### PR TITLE
[HUDI-426][WIP] Initial implementation for Bootstrapping data source

### DIFF
--- a/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRDD.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRDD.scala
@@ -89,9 +89,6 @@ class HudiBootstrapRDD(@transient spark: SparkSession,
 
   override protected def getPartitions: Array[Partition] = {
     logInfo("Getting partitions..")
-    var conf = spark.sessionState.newHadoopConf()
-    conf = spark.sessionState.newHadoopConfWithOptions(Map.empty)
-    conf = spark.sparkContext.hadoopConfiguration
 
     tableState.files.zipWithIndex.map(file => {
       logInfo("Forming partition with => " + file._2 + "," + file._1.dataFile.filePath

--- a/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRDD.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRDD.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class HudiBootstrapRDD(@transient spark: SparkSession,
+                       dataReadFunction: PartitionedFile => Iterator[InternalRow],
+                       skeletonReadFunction: PartitionedFile => Iterator[InternalRow],
+                       dataSchema: StructType,
+                       skeletonSchema: StructType,
+                       tableState: HudiBootstrapTableState)
+  extends RDD[InternalRow](spark.sparkContext, Nil) {
+
+  override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
+    val bootstrapPartition = split.asInstanceOf[HudiBootstrapPartition]
+
+    logInfo("Got Split => " + bootstrapPartition.index + ","
+      + bootstrapPartition.split.dataFile.filePath + ","
+      + bootstrapPartition.split.skeletonFile.filePath)
+
+    val dataFileIterator = read(bootstrapPartition.split.dataFile, dataReadFunction)
+    val skeletonFileIterator = read(bootstrapPartition.split.skeletonFile, skeletonReadFunction)
+    merge(dataFileIterator, skeletonFileIterator)
+  }
+
+  def merge(left: Iterator[InternalRow], right: Iterator[InternalRow]): Iterator[InternalRow] = {
+    new Iterator[InternalRow] {
+      override def hasNext: Boolean = left.hasNext && right.hasNext
+
+      override def next(): InternalRow = {
+        val leftArr  = left.next().toSeq(dataSchema)
+        val rightArr = right.next().toSeq(skeletonSchema)
+        val merged  = leftArr ++ rightArr
+        val mergedRow = InternalRow.fromSeq(merged)
+        mergedRow
+      }
+    }
+  }
+
+  def read(partitionedFile: PartitionedFile, readFileFunction: PartitionedFile => Iterator[Any])
+    : Iterator[InternalRow] = {
+    val fileIterator = readFileFunction(partitionedFile)
+
+    import scala.collection.JavaConverters._
+
+    val rows = fileIterator.flatMap(_ match {
+      case r: InternalRow => Seq(r)
+      case b: ColumnarBatch => b.rowIterator().asScala
+    })
+    rows
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    logInfo("Getting partitions..")
+    var conf = spark.sessionState.newHadoopConf()
+    conf = spark.sessionState.newHadoopConfWithOptions(Map.empty)
+    conf = spark.sparkContext.hadoopConfiguration
+
+    tableState.files.zipWithIndex.map(file => {
+      logInfo("Forming partition with => " + file._2 + "," + file._1.dataFile.filePath
+        + "," + file._1.skeletonFile.filePath)
+      HudiBootstrapPartition(file._2, file._1)
+    }).toArray
+  }
+}
+
+case class HudiBootstrapPartition(index: Int, split: HudiBootstrapSplit) extends Partition

--- a/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRDD.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRDD.scala
@@ -67,6 +67,7 @@ class HudiBootstrapRDD(@transient spark: SparkSession,
           }
         })
 
+        logDebug("Merged data and skeleton values => " + mergedArr.mkString(","))
         val mergedRow = InternalRow.fromSeq(mergedArr)
         mergedRow
       }

--- a/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRelation.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRelation.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hudi.common.model.HoodieBaseFile
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView
+import org.apache.hudi.common.util.FSUtils
+import org.apache.hudi.hadoop.HoodieParquetInputFormat
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.sql.sources.{BaseRelation, PrunedScan}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+import scala.collection.JavaConverters._
+
+class HudiBootstrapRelation(@transient val _sqlContext: SQLContext,
+                            val userSchema: StructType,
+                            val basePath: String,
+                            val optParams: Map[String, String]) extends BaseRelation
+  with PrunedScan with Logging {
+
+  val fileIndex: HudiBootstrapFileIndex = buildFileIndex()
+
+  val skeletonSchema: StructType = StructType(Seq(
+    StructField("_hoodie_commit_time", StringType, nullable = true),
+    StructField("_hoodie_commit_seqno", StringType, nullable = true),
+    StructField("_hoodie_record_key", StringType, nullable = true),
+    StructField("_hoodie_partition_path", StringType, nullable = true),
+    StructField("_hoodie_file_name", StringType, nullable = true)
+  ))
+
+  var dataSchema: StructType = _
+
+  var completeSchema: StructType = null
+
+  override def sqlContext: SQLContext = _sqlContext
+
+  override def schema: StructType = {
+    if (completeSchema == null) {
+      logInfo("Inferring schema..")
+
+      // We need to infer schema from the external data files and then merge the skeleton schema which is fixed
+      // to get the complete schema
+      val conf = new Configuration()
+      val fs = FSUtils.getFs(basePath, conf)
+
+      val externalFileStatus = fs.listStatus(
+        fileIndex.files.map(file => new Path(file.getExternalDataFile.get())).toArray)
+
+      val inferredDataSchema = new ParquetFileFormat().inferSchema(
+        _sqlContext.sparkSession,
+        optParams,
+        externalFileStatus
+      )
+
+      logInfo("Inferred data schema => " + inferredDataSchema.get.toString())
+
+      dataSchema = inferredDataSchema.get
+      completeSchema = StructType(dataSchema.fields ++ skeletonSchema.fields)
+      logInfo("Complete schema => " + completeSchema.toString())
+    }
+    completeSchema
+  }
+
+  /**
+    * Implementing PrunedScan to support column pruning, by reading only the required columns from the parquet files
+    * instead by passing them down to the ParquetFileFormat.
+    *
+    * TODO: To get better performance with Filters we should implement PrunedFilteredScan push filters down to the
+    * parquet files. But this is much more tricky to implement because then with filters being pushed down, unequal
+    * number od rows may be returned by external data reader, and skeleton file readers. Merging in this scenario
+    * will become much more complicated.
+    *
+    * @param requiredColumns This contains the columns user has passed in select() or filter() operations on the
+    *                        dataframe
+    * @return
+    */
+  override def buildScan(requiredColumns: Array[String]): RDD[Row] = {
+
+    // Compute splits
+    val bootstrapSplits = fileIndex.files.map(hoodieBaseFile => {
+      val skeletonFile = PartitionedFile(InternalRow.empty, hoodieBaseFile.getPath, 0, hoodieBaseFile.getFileLen)
+      val dataFile = PartitionedFile(InternalRow.empty, hoodieBaseFile.getExternalDataFile.get(), 0,
+        hoodieBaseFile.getFileLen)
+      HudiBootstrapSplit(dataFile, skeletonFile)
+    })
+    val tableState = HudiBootstrapTableState(bootstrapSplits)
+
+    // Get required schemas for column pruning
+    val requiredDataSchema = StructType(dataSchema.filter(field => requiredColumns.contains(field.name)))
+    val requiredSkeletonSchema = StructType(skeletonSchema.filter(field => requiredColumns.contains(field.name)))
+
+    // Prepare readers for reading data file and skeleton files
+    val dataReadFunction = new ParquetFileFormat()
+        .buildReaderWithPartitionValues(
+          sparkSession = _sqlContext.sparkSession,
+          dataSchema = dataSchema,
+          partitionSchema = StructType(Seq.empty),
+          requiredSchema = requiredDataSchema,
+          filters = Nil,
+          options = Map.empty,
+          hadoopConf = _sqlContext.sparkSession.sessionState.newHadoopConf()
+        )
+
+    val skeletonReadFunction = new ParquetFileFormat()
+      .buildReaderWithPartitionValues(
+        sparkSession = _sqlContext.sparkSession,
+        dataSchema = skeletonSchema,
+        partitionSchema = StructType(Seq.empty),
+        requiredSchema = requiredSkeletonSchema,
+        filters = Nil,
+        options = Map.empty,
+        hadoopConf = _sqlContext.sparkSession.sessionState.newHadoopConf()
+      )
+
+    val rdd = new HudiBootstrapRDD(_sqlContext.sparkSession, dataReadFunction, skeletonReadFunction, requiredDataSchema,
+      requiredSkeletonSchema, tableState)
+
+    logInfo("RDD partitions size =>" + rdd.partitions.length)
+
+    val requiredSchema = StructType(requiredDataSchema.fields ++ requiredSkeletonSchema.fields)
+    val encoder = RowEncoder(requiredSchema).resolveAndBind()
+
+    logInfo("Row encoder using required schema => " + requiredSchema.toString())
+    rdd.map(x => encoder.fromRow(x))
+  }
+
+  def buildFileIndex() : HudiBootstrapFileIndex = {
+    logInfo("Building file index..")
+
+    val conf = new Configuration()
+    val fs = FSUtils.getFs(basePath, conf)
+
+    val metaClient = new HoodieTableMetaClient(fs.getConf, basePath)
+    val inputFormat = new HoodieParquetInputFormat()
+    inputFormat.setConf(conf)
+
+    val jobConf = new JobConf()
+    val partitionPaths = FSUtils.getAllPartitionPaths(fs, basePath, false)
+    val fullPartitionPaths = partitionPaths.asScala.map(partitionPath => {
+      val fullPartitionPath = basePath + "/" + partitionPath
+      fullPartitionPath
+    })
+    logInfo("Partition paths : " + fullPartitionPaths.mkString(","))
+
+    // Listing using input format listing api.
+    jobConf.set("mapreduce.input.fileinputformat.inputdir", fullPartitionPaths.mkString(","))
+    val fileStatuses = inputFormat.listStatus(jobConf)
+    fileStatuses.foreach(f => logInfo(f.getPath.toString))
+
+    val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitsTimeline
+      .filterCompletedInstants, fileStatuses)
+    val latestFiles: List[HoodieBaseFile] = fsView.getLatestBaseFiles.iterator().asScala.toList
+
+    latestFiles.foreach(file => logInfo("Skeleton file path: " + file.getPath))
+    latestFiles.foreach(file => logInfo("External data file path: " + file.getExternalDataFile.get()))
+
+    HudiBootstrapFileIndex(latestFiles)
+  }
+}
+
+case class HudiBootstrapFileIndex(files: List[HoodieBaseFile])
+
+case class HudiBootstrapTableState(files: List[HudiBootstrapSplit])
+
+case class HudiBootstrapSplit(dataFile: PartitionedFile, skeletonFile: PartitionedFile)

--- a/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRelation.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HudiBootstrapRelation.scala
@@ -155,15 +155,10 @@ class HudiBootstrapRelation(@transient val _sqlContext: SQLContext,
     try {
       metaClient = new HoodieTableMetaClient(fs.getConf, path)
       logInfo("Found Hudi table at path => " + path)
-      val partitionPaths = FSUtils.getAllPartitionPaths(fs, path, false)
-      val fullPartitionPaths = partitionPaths.asScala.map(partitionPath => {
-        val fullPartitionPath = path + "/" + partitionPath
-        fullPartitionPath
-      })
-      logInfo("Partition paths : " + fullPartitionPaths.mkString(","))
 
       // Listing using input format listing api.
-      jobConf.set("mapreduce.input.fileinputformat.inputdir", fullPartitionPaths.mkString(","))
+      jobConf.set("mapreduce.input.fileinputformat.inputdir", path)
+      jobConf.set("mapreduce.input.fileinputformat.input.dir.recursive", "true")
     } catch {
       case ex: TableNotFoundException => {
         val partitionPath = new Path(path)


### PR DESCRIPTION
## What is the purpose of the pull request

This is a first draft of spark data source implementation for bootstrapped tables. This work is currently in progress, and I have put this WIP PR out to gather feedback feedback early. l will continue to work on this and push to this PR.  Currently this implementation is able to infer schema, merge skeleton and data files and perform column pruning.

Note: This depends on the PR by @bvaradar https://github.com/apache/incubator-hudi/pull/1112 for getting the file system view of external data files.

Feedback is welcome.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.