### PR TITLE
[HUDI-525] lack of insert info in delta_commit inflight

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -120,6 +120,12 @@ public abstract class BaseCommitActionExecutor<T extends HoodieRecordPayload<T>>
       HoodieCommitMetadata metadata = new HoodieCommitMetadata();
       profile.getPartitionPaths().forEach(path -> {
         WorkloadStat partitionStat = profile.getWorkloadStat(path.toString());
+        HoodieWriteStat insertStat = new HoodieWriteStat();
+        insertStat.setNumInserts(partitionStat.getNumInserts());
+        insertStat.setFileId("");
+        insertStat.setPrevCommit(HoodieWriteStat.NULL_COMMIT);
+        metadata.addWriteStat(path.toString(), insertStat);
+
         partitionStat.getUpdateLocationToCount().forEach((key, value) -> {
           HoodieWriteStat writeStat = new HoodieWriteStat();
           writeStat.setFileId(key);


### PR DESCRIPTION

add insert info with insert records num in the HoodieCommitMeta.
because of the file id is unknown, set it as empty string

testing result:


  "partitionToWriteStats" : {
    "americas/brazil/sao_paulo" : [ {
      "fileId" : "",
      "path" : null,
      "prevCommit" : null,
      "numWrites" : 0,
      "numDeletes" : 0,
      "numUpdateWrites" : 0,
      "numInserts" : 3,
      "totalWriteBytes" : 0,
      "totalWriteErrors" : 0,
      "tempPath" : null,
      "partitionPath" : null,
      "totalLogRecords" : 0,
      "totalLogFilesCompacted" : 0,
      "totalLogSizeCompacted" : 0,
      "totalUpdatedRecordsCompacted" : 0,
      "totalLogBlocks" : 0,
      "totalCorruptLogBlock" : 0,
      "totalRollbackBlocks" : 0,
      "fileSizeInBytes" : 0
    } ],