### PR TITLE
[WIP][HUDI-797] Small performance improvement for rewriting records.

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
@@ -161,7 +161,7 @@ public abstract class HoodieWriteHandle<T extends HoodieRecordPayload> extends H
    * Rewrite the GenericRecord with the Schema containing the Hoodie Metadata fields.
    */
   protected GenericRecord rewriteRecord(GenericRecord record) {
-    return HoodieAvroUtils.rewriteRecord(record, writerSchema);
+    return HoodieAvroUtils.rewriteHoodieRecord(record, writerSchema);
   }
 
   public abstract WriteStatus close();

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -98,7 +99,8 @@ public class HoodieAvroUtils {
   }
 
   /**
-   * Adds the Hoodie metadata fields to the given schema.
+   * Adds the Hoodie metadata fields to the given schema. Retains the existing positions
+   * of fields in the schema.
    */
   public static Schema addMetadataFields(Schema schema) {
     List<Schema.Field> parentFields = new ArrayList<>();
@@ -114,23 +116,44 @@ public class HoodieAvroUtils {
     Schema.Field fileNameField =
         new Schema.Field(HoodieRecord.FILENAME_METADATA_FIELD, METADATA_FIELD_SCHEMA, "", (Object) null);
 
-    parentFields.add(commitTimeField);
-    parentFields.add(commitSeqnoField);
-    parentFields.add(recordKeyField);
-    parentFields.add(partitionPathField);
-    parentFields.add(fileNameField);
+    Map<String, Schema.Field> metadataFields = new HashMap<>();
+    metadataFields.put(commitTimeField.name(), commitTimeField);
+    metadataFields.put(commitSeqnoField.name(), commitSeqnoField);
+    metadataFields.put(recordKeyField.name(), recordKeyField);
+    metadataFields.put(partitionPathField.name(), partitionPathField);
+    metadataFields.put(fileNameField.name(), fileNameField);
+
+    int fieldPos = 0;
     for (Schema.Field field : schema.getFields()) {
+      // Fields should have sequentially assigned positions
+      assert field.pos() == fieldPos++;
       if (!isMetadataField(field.name())) {
         Schema.Field newField = new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
         for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
           newField.addProp(prop.getKey(), prop.getValue());
         }
         parentFields.add(newField);
+      } else {
+        Schema.Field newField = metadataFields.remove(field.name());
+        assert newField != null;
+        parentFields.add(newField);
       }
+    }
+
+    // Add the remaining metadata fields
+    for (Schema.Field newField : metadataFields.values()) {
+      parentFields.add(newField);
     }
 
     Schema mergedSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
     mergedSchema.setFields(parentFields);
+
+    // Ensure that the field positions remain the same in original and merged schemas
+    for (Schema.Field field : schema.getFields()) {
+      Schema.Field mergedField = mergedSchema.getField(field.name());
+      assert field.pos() == mergedField.pos();
+    }
+
     return mergedSchema;
   }
 
@@ -193,7 +216,7 @@ public class HoodieAvroUtils {
   public static GenericRecord rewriteRecord(GenericRecord record, Schema newSchema) {
     return rewrite(record, getCombinedFieldsToWrite(record.getSchema(), newSchema), newSchema);
   }
-
+ 
   /**
    * Given a avro record with a given schema, rewrites it into the new schema while setting fields only from the new
    * schema.
@@ -229,6 +252,36 @@ public class HoodieAvroUtils {
       }
     }
     return allFields;
+  }
+
+  /*
+   * Given a avro record with a given schema, rewrites it into the new schema while setting fields only from the old
+   * schema.
+   *
+   * NOTE: This function is only suitable if newSchema has fields with the same position as record's schema.
+   */
+  public static GenericRecord rewriteHoodieRecord(GenericRecord record, Schema newSchema) {
+    return rewriteHoodieRecord(record, record.getSchema(), newSchema);
+  }
+
+  /**
+   * Given a avro record with a given schema, rewrites it into the new schema while setting fields only from the old
+   * schema.
+   *
+   * This function has better performance than rewrite() even though it provides the same functionality.
+   *
+   * NOTE: This function is only suitable if newSchema has fields with the same position as schemaWithFields.
+   */
+  public static GenericRecord rewriteHoodieRecord(GenericRecord record, Schema schemaWithFields, Schema newSchema) {
+    GenericRecord newRecord = new GenericData.Record(newSchema);
+    for (Schema.Field f : schemaWithFields.getFields()) {
+      newRecord.put(f.pos(), record.get(f.pos()));
+    }
+    if (!GenericData.get().validate(newSchema, newRecord)) {
+      throw new SchemaCompatabilityException(
+          "Unable to validate the rewritten record " + record + " against schema " + newSchema);
+    }
+    return newRecord;
   }
 
   public static byte[] compress(String text) {


### PR DESCRIPTION
When adding HUDI metadata field to schema, the position of incoming schema fields is retained. This allows us to lookup fields in exiting record and assign to the new record using field positions (array index lookup). This is faster than looking up fields using name (HashMap based lookup).

## What is the purpose of the pull request

Small performance improvement for rewriting records during the ingestion phase. [HUDI-797](https://issues.apache.org/jira/browse/HUDI-797) as the details on the usecase and improvements. 

## Brief change log

1. Modified HoodieAvroUtils.addMetadataFields to retain the field positions.
2. Added a new rewriting function HoodieAvroUtils.rewriteHoodieRecord which rewrites using field positions rather than field names.

## Verify this pull request

This change is verified automatically by all the HUDI client tests which ingest data into HUDI.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.