### PR TITLE
[HUDI-603]: DeltaStreamer can now fetch schema before every run in continuous mode

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
@@ -161,4 +161,8 @@ public abstract class AsyncCompactService extends HoodieAsyncService {
   protected boolean shouldStopCompactor() {
     return false;
   }
+
+  public synchronized void updateWriteClient(AbstractHoodieWriteClient writeClient) {
+    this.compactor.updateWriteClient(writeClient);
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieClient.java
@@ -18,9 +18,7 @@
 
 package org.apache.hudi.client;
 
-import org.apache.hadoop.conf.Configuration;
-
-import org.apache.hudi.client.common.EngineProperty;
+import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.common.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -29,6 +27,7 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -100,14 +99,8 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
     if (config.isEmbeddedTimelineServerEnabled()) {
       if (!timelineServer.isPresent()) {
         // Run Embedded Timeline Server
-        LOG.info("Starting Timeline service !!");
-        Option<String> hostAddr = context.getProperty(EngineProperty.EMBEDDED_SERVER_HOST);
-        timelineServer = Option.of(new EmbeddedTimelineService(context, hostAddr.orElse(null),
-            config.getEmbeddedTimelineServerPort(), config.getClientSpecifiedViewStorageConfig()));
         try {
-          timelineServer.get().startServer();
-          // Allow executor to find this newly instantiated timeline service
-          config.setViewStorageConfig(timelineServer.get().getRemoteFileSystemViewConfig());
+          timelineServer = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(context, config);
         } catch (IOException e) {
           LOG.warn("Unable to start timeline service. Proceeding as if embedded server is disabled", e);
           stopEmbeddedServerView(false);
@@ -128,5 +121,9 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
     return new HoodieTableMetaClient(hadoopConf, config.getBasePath(), loadActiveTimelineOnLoad,
         config.getConsistencyGuardConfig(),
         Option.of(new TimelineLayoutVersion(config.getTimelineLayoutVersion())));
+  }
+
+  public Option<EmbeddedTimelineService> getTimelineServer() {
+    return timelineServer;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.embedded;
+
+import org.apache.hudi.client.common.EngineProperty;
+import org.apache.hudi.client.common.HoodieEngineContext;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * Helper class to instantiate embedded timeline service.
+ */
+public class EmbeddedTimelineServerHelper {
+
+  private static final Logger LOG = LogManager.getLogger(EmbeddedTimelineService.class);
+
+  /**
+   * Instantiate Embedded Timeline Server.
+   * @param context Hoodie Engine Context
+   * @param config     Hoodie Write Config
+   * @return TimelineServer if configured to run
+   * @throws IOException
+   */
+  public static Option<EmbeddedTimelineService> createEmbeddedTimelineService(
+      HoodieEngineContext context, HoodieWriteConfig config) throws IOException {
+    Option<EmbeddedTimelineService> timelineServer = Option.empty();
+    if (config.isEmbeddedTimelineServerEnabled()) {
+      // Run Embedded Timeline Server
+      LOG.info("Starting Timeline service !!");
+      Option<String> hostAddr = context.getProperty(EngineProperty.EMBEDDED_SERVER_HOST);
+      timelineServer = Option.of(new EmbeddedTimelineService(context, hostAddr.orElse(null),
+          config.getEmbeddedTimelineServerPort(), config.getClientSpecifiedViewStorageConfig()));
+      timelineServer.get().startServer();
+      updateWriteConfigWithTimelineServer(timelineServer.get(), config);
+    }
+    return timelineServer;
+  }
+
+  /**
+   * Adjusts hoodie write config with timeline server settings.
+   * @param timelineServer Embedded Timeline Server
+   * @param config  Hoodie Write Config
+   */
+  public static void updateWriteConfigWithTimelineServer(EmbeddedTimelineService timelineServer,
+      HoodieWriteConfig config) {
+    // Allow executor to find this newly instantiated timeline service
+    if (config.isEmbeddedTimelineServerEnabled()) {
+      config.setViewStorageConfig(timelineServer.getRemoteFileSystemViewConfig());
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieSparkCompactor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieSparkCompactor.java
@@ -41,7 +41,8 @@ public class HoodieSparkCompactor<T extends HoodieRecordPayload> extends Abstrac
   @Override
   public void compact(HoodieInstant instant) throws IOException {
     LOG.info("Compactor executing compaction " + instant);
-    JavaRDD<WriteStatus> res = compactionClient.compact(instant.getTimestamp());
+    SparkRDDWriteClient<T> writeClient = (SparkRDDWriteClient<T>)compactionClient;
+    JavaRDD<WriteStatus> res = writeClient.compact(instant.getTimestamp());
     long numWriteErrors = res.collect().stream().filter(WriteStatus::hasErrors).count();
     if (numWriteErrors != 0) {
       // We treat even a single error in compaction as fatal
@@ -50,6 +51,6 @@ public class HoodieSparkCompactor<T extends HoodieRecordPayload> extends Abstrac
           "Compaction for instant (" + instant + ") failed with write errors. Errors :" + numWriteErrors);
     }
     // Commit compaction
-    compactionClient.commitCompaction(instant.getTimestamp(), res, Option.empty());
+    writeClient.commitCompaction(instant.getTimestamp(), res, Option.empty());
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaSet.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaSet.java
@@ -16,31 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.client;
+package org.apache.hudi.utilities.schema;
 
-import org.apache.hudi.common.model.HoodieRecordPayload;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-
-import java.io.IOException;
 import java.io.Serializable;
+import java.util.HashSet;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaNormalization;
+
+import java.util.Set;
 
 /**
- * Run one round of compaction.
+ * Tracks already processed schemas.
  */
-public abstract class AbstractCompactor<T extends HoodieRecordPayload, I, K, O> implements Serializable {
+public class SchemaSet implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private final Set<Long> processedSchema = new HashSet<>();
 
-  protected transient AbstractHoodieWriteClient<T, I, K, O> compactionClient;
-
-  public AbstractCompactor(AbstractHoodieWriteClient<T, I, K, O> compactionClient) {
-    this.compactionClient = compactionClient;
+  public boolean isSchemaPresent(Schema schema) {
+    long schemaKey = SchemaNormalization.parsingFingerprint64(schema);
+    return processedSchema.contains(schemaKey);
   }
 
-  public abstract void compact(HoodieInstant instant) throws IOException;
-
-  public void updateWriteClient(AbstractHoodieWriteClient<T, I, K, O> writeClient) {
-    this.compactionClient = writeClient;
+  public void addSchema(Schema schema) {
+    long schemaKey = SchemaNormalization.parsingFingerprint64(schema);
+    processedSchema.add(schemaKey);
   }
-
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

HoodieDeltaStreamer create SchemaProvider instance and delegate to DeltaSync for periodical sync. However, default implementation of SchemaProvider does not refresh schema, which can change due to schema evolution. DeltaSync snapshot the schema when it creates writeClient, using the SchemaProvider instance or pick up from source, and the schema for writeClient is not refreshed during the loop of Sync.

## Brief change log

- Introduced a function to refresh schema after every run of DeltaSync.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.