### PR TITLE
[HUDI-786] Fixing read beyond inline length in InlineFS

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFsDataInputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFsDataInputStream.java
@@ -56,24 +56,29 @@ public class InLineFsDataInputStream extends FSDataInputStream {
 
   @Override
   public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+    if ((length - offset) > this.length) {
+      throw new IOException("Attempting to read past inline content");
+    }
     return outerStream.read(startOffset + position, buffer, offset, length);
   }
 
   @Override
   public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    if ((length - offset) > this.length) {
+      throw new IOException("Attempting to read past inline content");
+    }
     outerStream.readFully(startOffset + position, buffer, offset, length);
   }
 
   @Override
   public void readFully(long position, byte[] buffer)
       throws IOException {
-    outerStream.readFully(startOffset + position, buffer, 0, buffer.length);
+    readFully(position, buffer, 0, buffer.length);
   }
 
   @Override
   public boolean seekToNewSource(long targetPos) throws IOException {
-    boolean toReturn = outerStream.seekToNewSource(startOffset + targetPos);
-    return toReturn;
+    return outerStream.seekToNewSource(startOffset + targetPos);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFsDataInputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFsDataInputStream.java
@@ -37,15 +37,19 @@ public class InLineFsDataInputStream extends FSDataInputStream {
   private final FSDataInputStream outerStream;
   private final int length;
 
-  public InLineFsDataInputStream(int startOffset, FSDataInputStream outerStream, int length) {
+  public InLineFsDataInputStream(int startOffset, FSDataInputStream outerStream, int length) throws IOException {
     super(outerStream.getWrappedStream());
     this.startOffset = startOffset;
     this.outerStream = outerStream;
     this.length = length;
+    outerStream.seek(startOffset);
   }
 
   @Override
   public void seek(long desired) throws IOException {
+    if (desired > length) {
+      throw new IOException("Attempting to seek past inline content");
+    }
     outerStream.seek(startOffset + desired);
   }
 
@@ -56,7 +60,7 @@ public class InLineFsDataInputStream extends FSDataInputStream {
 
   @Override
   public int read(long position, byte[] buffer, int offset, int length) throws IOException {
-    if ((length - offset) > this.length) {
+    if ((length + offset) > this.length) {
       throw new IOException("Attempting to read past inline content");
     }
     return outerStream.read(startOffset + position, buffer, offset, length);
@@ -64,7 +68,7 @@ public class InLineFsDataInputStream extends FSDataInputStream {
 
   @Override
   public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
-    if ((length - offset) > this.length) {
+    if ((length + offset) > this.length) {
       throw new IOException("Attempting to read past inline content");
     }
     outerStream.readFully(startOffset + position, buffer, offset, length);
@@ -78,6 +82,9 @@ public class InLineFsDataInputStream extends FSDataInputStream {
 
   @Override
   public boolean seekToNewSource(long targetPos) throws IOException {
+    if (targetPos > this.length) {
+      throw new IOException("Attempting to seek past inline content");
+    }
     return outerStream.seekToNewSource(startOffset + targetPos);
   }
 
@@ -93,6 +100,9 @@ public class InLineFsDataInputStream extends FSDataInputStream {
 
   @Override
   public void setReadahead(Long readahead) throws IOException, UnsupportedOperationException {
+    if (readahead > this.length) {
+      throw new IOException("Attempting to set read ahead past inline content");
+    }
     outerStream.setReadahead(readahead);
   }
 
@@ -104,6 +114,9 @@ public class InLineFsDataInputStream extends FSDataInputStream {
   @Override
   public ByteBuffer read(ByteBufferPool bufferPool, int maxLength, EnumSet<ReadOption> opts)
       throws IOException, UnsupportedOperationException {
+    if (maxLength > this.length) {
+      throw new IOException("Attempting to read max length beyond inline content");
+    }
     return outerStream.read(bufferPool, maxLength, opts);
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/TestInLineFileSystem.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/TestInLineFileSystem.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -121,7 +120,6 @@ public class TestInLineFileSystem {
   }
 
   @Test
-  @Disabled("Disabling flaky test for now https://issues.apache.org/jira/browse/HUDI-786")
   public void testFileSystemApis() throws IOException {
     OuterPathInfo outerPathInfo = generateOuterFileAndGetInfo(1000);
     Path inlinePath = FileSystemTestUtils.getPhantomFile(outerPathInfo.outerPath, outerPathInfo.startOffset, outerPathInfo.length);
@@ -142,9 +140,9 @@ public class TestInLineFileSystem {
     fsDataInputStream.read(25, actualBytes, 100, 210);
     verifyArrayEquality(outerPathInfo.expectedBytes, 25, 210, actualBytes, 100, 210);
     // give length to read > than actual inline content
-    assertThrows(IndexOutOfBoundsException.class, () -> {
+    assertThrows(IOException.class, () -> {
       fsDataInputStream.read(0, new byte[1100], 0, 1101);
-    }, "Should have thrown IndexOutOfBoundsException");
+    }, "Should have thrown IOException");
 
     // test readFully(long position, byte[] buffer, int offset, int length)
     actualBytes = new byte[100];
@@ -154,9 +152,9 @@ public class TestInLineFileSystem {
     fsDataInputStream.readFully(25, actualBytes, 100, 210);
     verifyArrayEquality(outerPathInfo.expectedBytes, 25, 210, actualBytes, 100, 210);
     // give length to read > than actual inline content
-    assertThrows(IndexOutOfBoundsException.class, () -> {
+    assertThrows(IOException.class, () -> {
       fsDataInputStream.readFully(0, new byte[1100], 0, 1101);
-    }, "Should have thrown IndexOutOfBoundsException");
+    }, "Should have thrown IOException");
 
     // test readFully(long position, byte[] buffer)
     actualBytes = new byte[100];
@@ -166,9 +164,9 @@ public class TestInLineFileSystem {
     fsDataInputStream.readFully(25, actualBytes);
     verifyArrayEquality(outerPathInfo.expectedBytes, 25, 210, actualBytes, 0, 210);
     // give length to read > than actual inline content
-    actualBytes = new byte[1100];
-    fsDataInputStream.readFully(0, actualBytes);
-    verifyArrayEquality(outerPathInfo.expectedBytes, 0, 1000, actualBytes, 0, 1000);
+    assertThrows(IOException.class, () -> {
+      fsDataInputStream.readFully(0, new byte[1100]);
+    }, "Should have thrown IOException");
 
     // TODO. seek does not move the position. need to investigate.
     // test seekToNewSource(long targetPos)


### PR DESCRIPTION
Fixing read beyond inline length in InlineFS. 

  - Fix throws IOException when such read is attempted. 

## Verify this pull request

This pull request is already covered by existing tests, such as TestInlineFileSystem#testFileSystemApis()

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.