### PR TITLE
[HUDI-896] Parallelize CI tests by modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+os: linux
 language: java
 dist: trusty
 jdk:
   - openjdk8
-sudo: required
-env:
-  - HUDI_QUIETER_LOGGING=1 TEST_SUITE=unit
-  - TEST_SUITE=integration
+jobs:
+  include:
+    - name: "Unit test for hudi-client"
+      env: HUDI_QUIETER_LOGGING=1 TEST_SUITE=unit MODULES=hudi-client
+    - name: "Unit test excludes hudi-client"
+      env: HUDI_QUIETER_LOGGING=1 TEST_SUITE=unit MODULES='!hudi-client'
+    - name: "Integration test"
+      env: TEST_SUITE=integration
 install: true
 services:
   - docker
@@ -32,10 +37,11 @@ notifications:
     rooms:
       - secure: WNIZPBY//xf/xTJL1YUPzvPUDwjawaMM4IJ6IqxjRGcZCmuhNVu2XTJ3aL1g6X7ZcJKxJuwoU/TbSO8Dl6rgWSo/2OfyzBd4ks+hgeCsdycccTcvO8giQO1DOUGUSRdvUzOvKjWVK7iARYzQhoZawAYwI09UJLlwhYRCJ1IKc1ZksrEt964GeEmPyJbwMoZOJVUU84jJIAZPIpOFGTKM652FMermg9yaY2W5oSjDXaV98z0/mJV4Ry++J2v0fvoDs5HxkXYhZJP+dpWR82KDr6Q6LGL5/IlJ+b+IH3pF8LyKR4nCH6l1EZ8KpoFZapyYWYQpXMfQoF2K/JEQkpz1EqBCeEDSJ2+j1PPLhOWXd7ok4DsS26S8BP2ImvyXwua51THN1/r1fCGSIdxiQ5C8aeYmPCSr+oLChCVivEG2eeU34Z1nQJ5aDymNGeFE9qUUpjS0ETfFcjI/WQaA+FiYiPkDfeAoT1+6ySdY7l9gJhMygupILjq57IHbqx4nEr/8AB3Rqb8iIDTWDXgUBI9xKmty36zjIGcVOsCT/SGPccxvEJBXQk8uQqs/rDhaA/ErJPMLX/2b7ElSSObKFdjpMaxVvZIE6wvMLJpIYfChDoXwgfhN6zlAFZrEib7PFI4dGkS8u4wkkHkBS7C+uz2e92EhsAB+BIhUR1M3NQ33+Is=
     on_pull_requests: false
+before_script: mvn clean install -DskipTests -DskipITs -q
 script:
   # ping stdout every 9 minutes or Travis kills build
   # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
   - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
-  - scripts/run_travis_tests.sh $TEST_SUITE
+  - scripts/run_travis_tests.sh $TEST_SUITE $MODULES
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/scripts/run_travis_tests.sh
+++ b/scripts/run_travis_tests.sh
@@ -17,13 +17,14 @@
 # limitations under the License.
 
 mode=$1
+modules=$2
 sparkVersion=2.4.4
 hadoopVersion=2.7
 
 if [ "$mode" = "unit" ];
 then
   echo "Running Unit Tests"
-  mvn test -DskipITs=true -B
+  mvn test -DskipITs=true -pl "$modules" -B
 elif [ "$mode" = "integration" ];
 then
   echo "Downloading Apache Spark-${sparkVersion}-bin-hadoop${hadoopVersion}"


### PR DESCRIPTION
Unit tests in total takes ~40 min to finish and unit tests in `hudi-client` along takes 20 min. This parallelizing setup is to reduce CI wait time.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.