### PR TITLE
[HUDI-783] Added python3 to the spark_base docker image to support pyspark

### DIFF
--- a/docker/hoodie/hadoop/spark_base/Dockerfile
+++ b/docker/hoodie/hadoop/spark_base/Dockerfile
@@ -40,6 +40,12 @@ RUN echo "Installing Spark-version (${SPARK_VERSION})" \
       && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       && cd /
 
+# Install python3 to enable and use pyspark shell
+RUN apt-get update \
+    && apt-get -yq install python3 \
+    && ln -sf $(which python3) /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
+
 #Give permission to execute scripts
 RUN chmod +x /wait-for-step.sh && chmod +x /execute-step.sh && chmod +x /finish-step.sh
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

This pull-request adds python3 to the apachehudi/sparkbase docker image, which is required to run pyspark shell command. This is part of the effort to add official python-support to hudi package.

We can run the following pyspark command on sparkmaster, sparkworker, sparkadhoc docker images after merging this pull request. 

## Brief change log

  - *Added python-support to the hudi demo docker images to enable pyspark shell*

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by building the docker image locally, registering with the local Docker registry, using the local docker image in the docker-compose file, started all the docker images and tested the change by invoking pyspark from the adhoc-1 machine via command-line.*

The details of the testing can be found in this gist: https://gist.github.com/vingov/347548f2df9af11892c8331123b42967

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.