### PR TITLE
[WIP] Adding benchmark for some of the write operations in Hudi using jmh

### DIFF
--- a/hudi-spark/pom.xml
+++ b/hudi-spark/pom.xml
@@ -344,5 +344,16 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.19</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.19</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/hudi-spark/src/benchmark/README
+++ b/hudi-spark/src/benchmark/README
@@ -1,0 +1,91 @@
+jmh is used for benchmarking hudi operations.
+https://openjdk.java.net/projects/code-tools/jmh/
+
+To get benchmark numbers:
+Run BenchmarkRunner.java and you should see the output for all methods annotated with @Benchmark.
+In other words, annotate your method with @Benchmark if you want it to be included as part of BenchmarkRunner execution.
+
+Number of times each method will be executed as part of benchmarking is:
+X * Y * Z
+Z refers to one benchmark invocation of the method.
+Y refers to one benchmark iteration (or an iteration of invocations) and is the 2nd level.
+X refers to trials or an iteration of benchmark iterations and is the top most level. Each trial will have an output entry
+in the report generated.
+
+Y is set using @Measurement(iterations = N) with each method.
+X is set in execution plan using @Param(array of identifiers)
+
+Eg:
+
+@Benchmark
+@Measurement(iterations = 100)
+@BenchmarkMode(Mode.AverageTime)
+   void testMethod() {...}
+
+In execution plan : // more on this later
+  @Param({ "100", "200", "300"})
+  public int iterations;
+
+Sample Benchmark output
+
+Benchmark                                            (iterations)  Mode  Cnt  Score   Error  Units
+o.a.h.benchmark.HoodieWriteBenchmark.testMethod               100  avgt  100  6.922 ±  6.101   s/op
+o.a.h.benchmark.HoodieWriteBenchmark.testMethod               200  avgt  100  6.675 ±  5.686   s/op
+o.a.h.benchmark.HoodieWriteBenchmark.testMethod               300  avgt  100  6.870 ±  4.686   s/op
+
+As mentioned before, each trial will have an entry in the generated output. Each entry is the summary for N invocations
+as defined by @Measurement(iterations = N).
+Score refers to the avg time taken (since we have annotated with @BenchmarkMode(Mode.AverageTime)).
+Error shows the deviation.
+
+Here is what first entry in the output mean:
+For first benchmark iteration, (param value 100 in execution plan), avg time for 100 runs (Cnt) is 6.922 seconds.
+Range of avg time is 6.922 ± 6.101 seconds.
+
+Note: I have set up "/tmp/" as basePath for benchmarks (could be found in execution plan) for all runs. If you
+plan to run for larger size and your "tmp" may not have sufficient swap space, you migth want to change that value
+to some other location that might have sufficient space.
+
+Parameters:
+
+Will walk through the parameters involved.
+org.apache.hudi.benchmark.HoodieWriteBenchmark#benchmarkBulkInsert
+
+What does each annotation mean:
+@Fork(value = 1)
+refers to the number of threads used for benchmarking. 1 means sequential.
+
+Benchmark modes: eg @BenchmarkMode(Mode.AverageTime)
+Could be average time or throughput, sample time etc.
+
+@Warmup(iterations = 1)
+Refers to number of warm up iterations to run before actual runs. In the final report generated, warmup won't be
+reported.
+
+@Measurement(iterations = 10)
+Number of times the method to be benchmarked will run.
+
+@OutputTimeUnit(TimeUnit.SECONDS)
+To specify what time unit to be reported for benchmark report
+
+Here are the execution plan details:
+Each method can take in an execution plan as an argument. These execution plan can have set up methods that will be run
+according to the Levels defined. Also it could have some arguments which the method could access.
+For eg, total number of records to be generated could be set in an execution plan(using @Param) and all N
+(@Measurement(iterations = N)) invocations will be generating same number of records.
+We could have a set up where in records are generated once, and will be inserted N no of times based on
+@Measurement(iterations = N) if annotated with @Setup(Level.Iteration).
+
+Eg: org.apache.hudi.benchmark..WriteBenchmarkExecutionPlan
+
+@Levels annotations are used to have set up methods in the execution plan. Should be annotated as @Setup(Level.X)
+
+Bottommost level is Level.Invocation which refers to a single run of a method  or benchmark invocations.
+Next is Level.Iteration which refers to N iteration of invocations, where N is defined in @Measurement(iterations = N).
+Or called as benchmark iterations.
+Top most level if Level.Trial which refers to a set of benchmark iterations.
+
+Based on the tagging, the respective set up method will be executed accordingly.
+
+@Param
+These can act as arguments to the methods. You could provide different arguments for different benchmark iterations.

--- a/hudi-spark/src/benchmark/java/org/apache/hudi/benchmark/BenchmarkRunner.java
+++ b/hudi-spark/src/benchmark/java/org/apache/hudi/benchmark/BenchmarkRunner.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.benchmark;
+
+/**
+ * Main class to run benchmarks
+ */
+public class BenchmarkRunner {
+  public static void main(String[] args) throws Exception {
+    org.openjdk.jmh.Main.main(args);
+  }
+}

--- a/hudi-spark/src/benchmark/java/org/apache/hudi/benchmark/HoodieWriteBenchmark.java
+++ b/hudi-spark/src/benchmark/java/org/apache/hudi/benchmark/HoodieWriteBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.benchmark;
+
+import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.keygen.SimpleKeyGenerator;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.File;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks some of the write operations using jmh
+ */
+public class HoodieWriteBenchmark {
+
+  private static final String pathPrefix = "hudi-benchmark";
+
+  /**
+   * Benchmarks insert in Hudi
+   */
+  @Fork(value = 1)
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @Warmup(iterations = 1)
+  @Measurement(iterations = 1)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  public void benchmarkInsert(WriteBenchmarkExecutionPlan plan) throws Exception {
+    try {
+      String randomPath = UUID.randomUUID().toString();
+      org.apache.hadoop.fs.Path tablePath = new org.apache.hadoop.fs.Path(plan.basePath + "/" + pathPrefix + "/" + randomPath);
+      plan.fs.mkdirs(tablePath);
+      doWrites(plan.inputDF, tablePath, plan.parallelism, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL());
+    } catch (Throwable e) {
+      e.printStackTrace();
+      throw new Exception("Exception thrown while running benchmark", e);
+    } finally {
+      FileUtils.deleteDirectory(new File(plan.basePath + "/" + pathPrefix));
+    }
+  }
+
+  /**
+   * Benchmarks bulk insert in Hudi
+   */
+  @Fork(value = 1)
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @Warmup(iterations = 1)
+  @Measurement(iterations = 1)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  public void benchmarkBulkInsert(WriteBenchmarkExecutionPlan plan) throws Exception {
+    try {
+      String randomPath = UUID.randomUUID().toString();
+      org.apache.hadoop.fs.Path tablePath = new org.apache.hadoop.fs.Path(plan.basePath + "/" + pathPrefix + "/" + randomPath);
+      plan.fs.mkdirs(tablePath);
+      doWrites(plan.inputDF, tablePath, plan.parallelism, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+    } catch (Throwable e) {
+      e.printStackTrace();
+      throw new Exception("Exception thrown while running benchmark", e);
+    } finally {
+      FileUtils.deleteDirectory(new File(plan.basePath + "/" + pathPrefix));
+    }
+  }
+
+  private void doWrites(Dataset<Row> inputDF1, org.apache.hadoop.fs.Path tablePath, int parallelism, String operation) {
+    DataFrameWriter<Row> writer = inputDF1.write().format("org.apache.hudi")
+        // set all parallelism for now
+        .option("hoodie.insert.shuffle.parallelism", parallelism)
+        .option("hoodie.bulkinsert.shuffle.parallelism", parallelism)
+        .option("hoodie.upsert.shuffle.parallelism", parallelism)
+        // Hoodie Table Type
+        .option(DataSourceWriteOptions.TABLE_TYPE_OPT_KEY(), HoodieTableType.COPY_ON_WRITE.name())
+        // operation type
+        .option(DataSourceWriteOptions.OPERATION_OPT_KEY(), operation)
+        // This is the record key
+        .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
+        // this is the partition to place it into
+        .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
+        // use to combine duplicate records in input/with disk val
+        .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
+        // Used by hive sync and queries
+        .option(HoodieWriteConfig.TABLE_NAME, "bulk_insert_test_tbl")
+        // Add Key Extractor
+        .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY(), SimpleKeyGenerator.class.getCanonicalName())
+        // This will remove any existing data at path below, and create a
+        .mode(SaveMode.Overwrite);
+    writer.save(tablePath.toString());
+  }
+
+}

--- a/hudi-spark/src/benchmark/java/org/apache/hudi/benchmark/WriteBenchmarkExecutionPlan.java
+++ b/hudi-spark/src/benchmark/java/org/apache/hudi/benchmark/WriteBenchmarkExecutionPlan.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.benchmark;
+
+import org.apache.hudi.common.HoodieTestDataGenerator;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.testutils.DataSourceTestUtils;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Execution plan for benchmarking. This has set up methods and acts as arguments to benchmark methods
+ */
+@State(Scope.Benchmark)
+public class WriteBenchmarkExecutionPlan {
+
+  @Param( {"100"})
+  public int iterations;
+
+  String basePath = "/tmp/";
+  int totalRecordsToTest = 10000;
+  int parallelism = 10;
+  SparkSession spark;
+  JavaSparkContext jssc;
+  FileSystem fs;
+  HoodieTestDataGenerator dataGen;
+  Dataset<Row> inputDF;
+
+  @Setup(Level.Iteration)
+  public void doSetup() throws Exception {
+    try {
+      spark = SparkSession.builder().appName("Hoodie Write Benchmark")
+          .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer").master("local[2]").getOrCreate();
+      jssc = new JavaSparkContext(spark.sparkContext());
+      spark.sparkContext().setLogLevel("WARN");
+      fs = FileSystem.get(jssc.hadoopConfiguration());
+      dataGen = new HoodieTestDataGenerator();
+      List<HoodieRecord> recordsSoFar = new ArrayList<>(dataGen.generateInserts("001", totalRecordsToTest));
+      List<String> records = DataSourceTestUtils.convertToStringList(recordsSoFar);
+      inputDF = spark.read().json(jssc.parallelize(records, 10));
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new Exception("Exception thrown while generating records to write ", e);
+    }
+  }
+}

--- a/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
+++ b/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
@@ -106,10 +106,10 @@ public class TestDataSourceUtils {
     when(hoodieWriteClient.getConfig()).thenReturn(config);
 
     DataSourceUtils.doWriteOperation(hoodieWriteClient, hoodieRecords, "test-time",
-            DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+        DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
 
     verify(hoodieWriteClient, times(1)).bulkInsert(any(hoodieRecords.getClass()), anyString(),
-            optionCaptor.capture());
+        optionCaptor.capture());
     assertThat(optionCaptor.getValue(), is(equalTo(Option.empty())));
   }
 
@@ -119,7 +119,7 @@ public class TestDataSourceUtils {
 
     Exception exception = assertThrows(HoodieException.class, () -> {
       DataSourceUtils.doWriteOperation(hoodieWriteClient, hoodieRecords, "test-time",
-              DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+          DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
     });
 
     assertThat(exception.getMessage(), containsString("Could not create UserDefinedBulkInsertPartitioner"));
@@ -130,17 +130,17 @@ public class TestDataSourceUtils {
     setAndVerifyHoodieWriteClientWith(DataSourceTestUtils.NoOpBulkInsertPartitioner.class.getName());
 
     DataSourceUtils.doWriteOperation(hoodieWriteClient, hoodieRecords, "test-time",
-            DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+        DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
 
     verify(hoodieWriteClient, times(1)).bulkInsert(any(hoodieRecords.getClass()), anyString(),
-            optionCaptor.capture());
+        optionCaptor.capture());
     assertThat(optionCaptor.getValue().get(), is(instanceOf(DataSourceTestUtils.NoOpBulkInsertPartitioner.class)));
   }
 
   private void setAndVerifyHoodieWriteClientWith(final String partitionerClassName) {
     config = HoodieWriteConfig.newBuilder().withPath(config.getBasePath())
-            .withUserDefinedBulkInsertPartitionerClass(partitionerClassName)
-            .build();
+        .withUserDefinedBulkInsertPartitionerClass(partitionerClassName)
+        .build();
     when(hoodieWriteClient.getConfig()).thenReturn(config);
 
     assertThat(config.getUserDefinedBulkInsertPartitionerClass(), is(equalTo(partitionerClassName)));


### PR DESCRIPTION
Adding benchmark for some of the write operations in Hudi using jmh

## Brief change log
- Added simple benchmarking for insert and bulk insert for hudi

Verification: 
- These are benchmarking code. Need to be run manually locally. So, not tests per se. I ran locally to ensure that benchmarking is running fine w/o any issues. 

Here is a sample output from running in my mac laptop. 

100k records. 100 parallelism. 50 iterations. 

|Benchmark                  |               Mode|  Cnt|   Score|   Error|  Units|
|--------------------|---------------|------|------|------|------|
|HoodieWriteBenchmark.benchmarkBulkInsert|          avgt|   50|  51.704| ± 2.838|   s/op|
|HoodieWriteBenchmark.benchmarkInsert|             avgt|   50|   9.633| ± 0.400|   s/op|

500k records. 100 parallelism. 10 iterations. 

|Benchmark                  |               Mode|  Cnt|   Score|   Error|  Units|
|--------------------|------------------|------|------|------|------|
|HoodieWriteBenchmark.benchmarkBulkInsert|           avgt|   10|  66.124| ± 14.443|   s/op|
|HoodieWriteBenchmark.benchmarkInsert|               avgt|   10|   29.792| ± 18.107|   s/op|

// Probably Insert benchmark for 500k has some issues. Might have to re-run since the range is way off. 


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.