### PR TITLE
[HUDI-867]: fixed IllegalArgumentException from graphite metrics in deltaStreamer continuous mode

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -653,24 +653,9 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
       return this;
     }
 
-    public Builder withRollbackParallelism(int rollbackParallelism) {
-      props.setProperty(ROLLBACK_PARALLELISM, String.valueOf(rollbackParallelism));
-      return this;
-    }
-
-    public Builder withWriteBufferLimitBytes(int writeBufferLimit) {
-      props.setProperty(WRITE_BUFFER_LIMIT_BYTES, String.valueOf(writeBufferLimit));
-      return this;
-    }
-
     public Builder combineInput(boolean onInsert, boolean onUpsert) {
       props.setProperty(COMBINE_BEFORE_INSERT_PROP, String.valueOf(onInsert));
       props.setProperty(COMBINE_BEFORE_UPSERT_PROP, String.valueOf(onUpsert));
-      return this;
-    }
-
-    public Builder withWriteStatusStorageLevel(String level) {
-      props.setProperty(WRITE_STATUS_STORAGE_LEVEL, level);
       return this;
     }
 
@@ -689,12 +674,6 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
     public Builder withCompactionConfig(HoodieCompactionConfig compactionConfig) {
       props.putAll(compactionConfig.getProps());
       isCompactionConfigSet = true;
-      return this;
-    }
-
-    public Builder withMetricsConfig(HoodieMetricsConfig metricsConfig) {
-      props.putAll(metricsConfig.getProps());
-      isMetricsConfigSet = true;
       return this;
     }
 

--- a/hudi-client/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -41,7 +41,7 @@ public class HoodieMetrics {
   public String compactionTimerName = null;
   public String indexTimerName = null;
   private HoodieWriteConfig config;
-  private String tableName;
+  private static String tableName;
   private Timer rollbackTimer = null;
   private Timer cleanTimer = null;
   private Timer commitTimer = null;
@@ -63,6 +63,10 @@ public class HoodieMetrics {
       this.compactionTimerName = getMetricsName("timer", HoodieTimeline.COMPACTION_ACTION);
       this.indexTimerName = getMetricsName("timer", "index");
     }
+  }
+
+  public static void setTableName(String name) {
+    tableName = name;
   }
 
   private Timer createTimer(String name) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -210,9 +210,9 @@ public class DeltaSync implements Serializable {
   /**
    * Run one round of delta sync and return new compaction instant if one got scheduled.
    */
-  public Option<String> syncOnce() throws Exception {
+  public Option<String> syncOnce(String tableName) throws Exception {
     Option<String> scheduledCompaction = Option.empty();
-    HoodieDeltaStreamerMetrics metrics = new HoodieDeltaStreamerMetrics(getHoodieClientConfig(schemaProvider));
+    HoodieDeltaStreamerMetrics metrics = new HoodieDeltaStreamerMetrics(getHoodieClientConfig(schemaProvider), tableName);
     Timer.Context overallTimerContext = metrics.getOverallTimerContext();
 
     // Refresh Timeline
@@ -351,7 +351,7 @@ public class DeltaSync implements Serializable {
    * @return Option Compaction instant if one is scheduled
    */
   private Option<String> writeToSink(JavaRDD<HoodieRecord> records, String checkpointStr,
-                                     HoodieDeltaStreamerMetrics metrics, Timer.Context overallTimerContext) throws Exception {
+                                     HoodieDeltaStreamerMetrics metrics, Timer.Context overallTimerContext) {
 
     Option<String> scheduledCompactionInstant = Option.empty();
     // filter dupes if needed

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
@@ -33,9 +33,9 @@ public class HoodieDeltaStreamerMetrics {
   private Timer overallTimer = null;
   public Timer hiveSyncTimer = null;
 
-  public HoodieDeltaStreamerMetrics(HoodieWriteConfig config) {
+  public HoodieDeltaStreamerMetrics(HoodieWriteConfig config, String tableName) {
     this.config = config;
-    this.tableName = config.getTableName();
+    this.tableName = tableName;
     if (config.isMetricsOn()) {
       Metrics.init(config);
       this.overallTimerName = getMetricsName("timer", "deltastreamer");


### PR DESCRIPTION

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Added a way to create metric names with updated table name in every iteration so that IllegalArgumentException does not comes up. 

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.