### PR TITLE
HUDI-921 Remove inlineCompactionEvery method in HoodieCompactionConfig.Builder

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -147,11 +147,6 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
       return this;
     }
 
-    public Builder inlineCompactionEvery(int deltaCommits) {
-      props.setProperty(INLINE_COMPACT_PROP, String.valueOf(deltaCommits));
-      return this;
-    }
-
     public Builder withCleanerPolicy(HoodieCleaningPolicy policy) {
       props.setProperty(CLEANER_POLICY_PROP, policy.name());
       return this;


### PR DESCRIPTION
## What is the purpose of the pull request

inlineCompactionEvery method in HoodieCompactionConfig.Builder is incorrectly setting number of delta commits to INLINE_COMPACT_PROP property which is boolean variable
 
I think withMaxNumDeltaCommitsBeforeCompaction method is doing the purpose of setting num of delta commits before compaction. 

So, I am proposing to remove inlineCompactionEvery method, which is not used anywhere

## Brief change log

  - *Remove inlineCompactionEvery method from HoodieCompactionConfig.Builder*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.