### PR TITLE
[HUDI-593]Use scala_version placeholder to replace scala version hard code

### DIFF
--- a/hudi-test-suite/pom.xml
+++ b/hudi-test-suite/pom.xml
@@ -92,7 +92,7 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.mortbay.jetty</groupId>
@@ -222,14 +222,14 @@
         </exclusion>
         <exclusion>
           <groupId>com.databricks</groupId>
-          <artifactId>spark-avro_2.11</artifactId>
+          <artifactId>spark-avro_${scala.binary.version}</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-avro_2.11</artifactId>
+      <artifactId>spark-avro_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 

--- a/hudi-test-suite/prepare_integration_suite.sh
+++ b/hudi-test-suite/prepare_integration_suite.sh
@@ -78,7 +78,7 @@ while getopts ":h:s:p:a:i:l:" opt; do
     printf "Argument hive is %s\n" "$hive"
     ;;
     l) scala="$OPTARG"
-    printf "Argument scala is %s\n" "$hive"
+    printf "Argument scala is %s\n" "$scala"
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;

--- a/hudi-test-suite/prepare_integration_suite.sh
+++ b/hudi-test-suite/prepare_integration_suite.sh
@@ -15,12 +15,19 @@ usage() {
     echo "   -s, spark version"
     echo "   -p, parquet version"
     echo "   -a, avro version"
-    echo "   -s, hive version"
+    echo "   -i, hive version"
+    echo "   -l, scala version"
     exit 1
 }
 
 get_spark_command() {
-echo "spark-submit --packages org.apache.spark:spark-avro_2.11:2.4.4 \
+if [ -z "$scala" ]
+then
+  scala="2.11"
+else
+  scala=$1
+fi
+echo "spark-submit --packages org.apache.spark:spark-avro_${scala}:2.4.4 \
 --master $0 \
 --deploy-mode $1 \
 --properties-file $2 \
@@ -53,7 +60,7 @@ case "$1" in
        ;;
 esac
 
-while getopts ":h:s:p:a:s:" opt; do
+while getopts ":h:s:p:a:i:l:" opt; do
   case $opt in
     h) hadoop="$OPTARG"
     printf "Argument hadoop is %s\n" "$hadoop"
@@ -67,8 +74,11 @@ while getopts ":h:s:p:a:s:" opt; do
     a) avro="$OPTARG"
     printf "Argument avro is %s\n" "$avro"
     ;;
-    s) hive="$OPTARG"
+    i) hive="$OPTARG"
     printf "Argument hive is %s\n" "$hive"
+    ;;
+    l) scala="$OPTARG"
+    printf "Argument scala is %s\n" "$hive"
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;
@@ -93,10 +103,18 @@ get_versions () {
     hive=$2
     base_command+=' -Dhive.version='$hive
   fi
+
+  if [ -z "$scala" ]
+  then
+    base_command=$base_command
+  else
+    scala=$3
+    base_command+=' -Dscala-'$scala
+  fi
   echo $base_command
 }
 
-versions=$(get_versions $hadoop $hive)
+versions=$(get_versions $hadoop $hive $scala)
 
 final_command='mvn clean install -DskipTests '$versions
 printf "Final command $final_command \n"
@@ -109,4 +127,4 @@ $move_to_root && $final_command
 cd $_CALLING_DIR
 
 printf "A sample spark command to start the integration suite \n"
-get_spark_command
+get_spark_command $scala

--- a/packaging/hudi-test-suite-bundle/pom.xml
+++ b/packaging/hudi-test-suite-bundle/pom.xml
@@ -74,8 +74,8 @@
                   <include>org.apache.hudi:hudi-timeline-service</include>
                   <include>org.apache.hudi:hudi-test-suite</include>
                   <include>com.beust:jcommander</include>
-                  <include>com.twitter:bijection-avro_2.11</include>
-                  <include>com.twitter:bijection-core_2.11</include>
+                  <include>com.twitter:bijection-avro_${scala.binary.version}</include>
+                  <include>com.twitter:bijection-core_${scala.binary.version}</include>
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>com.twitter:parquet-avro</include>
                   <include>com.twitter.common:objectsize</include>
@@ -85,8 +85,8 @@
                   <include>io.confluent:kafka-schema-registry-client</include>
                   <include>io.dropwizard.metrics:metrics-core</include>
                   <include>io.dropwizard.metrics:metrics-graphite</include>
-                  <include>org.apache.spark:spark-streaming-kafka-0-8_2.11</include>
-                  <include>org.apache.kafka:kafka_2.11</include>
+                  <include>org.apache.spark:spark-streaming-kafka-0-10_${scala.binary.version}</include>
+                  <include>org.apache.kafka:kafka_${scala.binary.version}</include>
                   <include>com.101tec:zkclient</include>
                   <include>org.apache.kafka:kafka-clients</include>
                   <include>org.apache.hive:hive-common</include>
@@ -251,7 +251,7 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-scala_2.11</artifactId>
+      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
 
     <dependency>
@@ -447,12 +447,12 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
     </dependency>
 
     <dependency>
@@ -463,14 +463,14 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.11</artifactId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-kafka-0-8_2.11</artifactId>
+      <artifactId>spark-streaming-kafka-0-10_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
@@ -512,8 +512,8 @@
 
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>bijection-avro_2.11</artifactId>
-      <version>0.9.2</version>
+      <artifactId>bijection-avro_${scala.binary.version}</artifactId>
+      <version>0.9.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What is the purpose of the pull request

*After releasing Hudi v0.5.1, now Hudi supports scala 2.11/2.12. While the test suite still exists some hard code(2.11) of the Scala version. we can use ${scala_version} to replace them.*

## Brief change log

*(for example:)*
  - *Use scala_version placeholder to replace scala version hard code*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.