### PR TITLE
[HUDI-980] Fixing dir path for metastore_db and derby.logs generated in hive tests

### DIFF
--- a/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestService.java
+++ b/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestService.java
@@ -154,6 +154,7 @@ public class HiveTestService {
     File derbyLogFile = new File(localHiveDir, "derby.log");
     derbyLogFile.createNewFile();
     setSystemProperty("derby.stream.error.file", derbyLogFile.getPath());
+    setSystemProperty("derby.system.home", localHiveDir.getAbsolutePath());
     conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
         Files.createTempDirectory(System.currentTimeMillis() + "-").toFile().getAbsolutePath());
     conf.set("datanucleus.schema.autoCreateTables", "true");


### PR DESCRIPTION
After running TestHiveSyncTool, some remnants are found in source dir(hudi-hive-sync). Eg, metastore_db and derby.logs. This patch fixes the same. This indirectly causes compilation of hudi to fail. Once you run unit tests, if you try to compile, it may complain about license headers in these generated files. 

Source: https://stackoverflow.com/questions/38377188/how-to-get-rid-of-derby-log-metastore-db-from-spark-shell

Verification: 
- Verified that these are created in the temp dir created as part of tests and no remnants are found in hudi-hive-sync. 
- Ran entire TestHiveSyncTool. All passed. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.