### PR TITLE
[HUDI-115] Enhance OverwriteWithLatestAvroPayload to also respect ordering value of record in storage

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -113,6 +113,9 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
   public static final String MAX_CONSISTENCY_CHECKS_PROP = "hoodie.consistency.check.max_checks";
   public static int DEFAULT_MAX_CONSISTENCY_CHECKS = 7;
 
+  private static final String PAYLOAD_ORDERING_FIELD_PROP = "hoodie.payload.ordering.field";
+  private static String DEFAULT_PAYLOAD_ORDERING_FIELD_VAL = "";
+
   /**
    * HUDI-858 : There are users who had been directly using RDD APIs and have relied on a behavior in 0.4.x to allow
    * multiple write operations (upsert/buk-insert/...) to be executed within a single commit.
@@ -272,6 +275,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
   public BulkInsertSortMode getBulkInsertSortMode() {
     String sortMode = props.getProperty(BULKINSERT_SORT_MODE);
     return BulkInsertSortMode.valueOf(sortMode.toUpperCase());
+  }
+
+  public String getPayloadOrderingField() {
+    return props.getProperty(PAYLOAD_ORDERING_FIELD_PROP, DEFAULT_PAYLOAD_ORDERING_FIELD_VAL);
   }
 
   /**
@@ -910,6 +917,11 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
 
     public Builder withProperties(Properties properties) {
       this.props.putAll(properties);
+      return this;
+    }
+
+    public Builder withPayloadOrderingField(String fieldName) {
+      props.setProperty(PAYLOAD_ORDERING_FIELD_PROP, fieldName);
       return this;
     }
 

--- a/hudi-client/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -22,6 +22,7 @@ import org.apache.hudi.client.SparkTaskContextSupplier;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.utils.SparkConfigUtils;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.BaseAvroPayload;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -47,6 +48,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -221,7 +223,8 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
       HoodieRecord<T> hoodieRecord = new HoodieRecord<>(keyToNewRecords.get(key));
       try {
         Option<IndexedRecord> combinedAvroRecord =
-            hoodieRecord.getData().combineAndGetUpdateValue(oldRecord, useWriterSchema ? writerSchemaWithMetafields : writerSchema);
+            hoodieRecord.getData().combineAndGetUpdateValue(oldRecord, useWriterSchema ? writerSchemaWithMetafields : writerSchema,
+                    Collections.singletonMap(BaseAvroPayload.ORDERING_FIELD_OPT_KEY, config.getPayloadOrderingField()));
         if (writeUpdateRecord(hoodieRecord, combinedAvroRecord)) {
           /*
            * ONLY WHEN 1) we have an update for this key AND 2) We are able to successfully write the the combined new

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -421,7 +421,7 @@ public class HoodieAvroUtils {
    * @param fieldValue avro field value
    * @return field value either converted (for certain data types) or as it is.
    */
-  private static Object convertValueForSpecificDataTypes(Schema fieldSchema, Object fieldValue) {
+  public static Object convertValueForSpecificDataTypes(Schema fieldSchema, Object fieldValue) {
     if (fieldSchema == null) {
       return fieldValue;
     }
@@ -438,7 +438,7 @@ public class HoodieAvroUtils {
    * @param fieldSchema avro field schema
    * @return boolean indicating whether fieldSchema is of Avro's Date Logical Type
    */
-  private static boolean isLogicalTypeDate(Schema fieldSchema) {
+  public static boolean isLogicalTypeDate(Schema fieldSchema) {
     if (fieldSchema.getType() == Schema.Type.UNION) {
       return fieldSchema.getTypes().stream().anyMatch(schema -> schema.getLogicalType() == LogicalTypes.date());
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -31,6 +31,8 @@ import java.io.Serializable;
  * Base class for all AVRO record based payloads, that can be ordered based on a field.
  */
 public abstract class BaseAvroPayload implements Serializable {
+
+  public static final String ORDERING_FIELD_OPT_KEY = "ordering.field";
   /**
    * Avro data extracted from the source converted to bytes.
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
@@ -50,7 +50,24 @@ public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Seri
    * @param schema Schema used for record
    * @return new combined/merged value to be written back to storage. EMPTY to skip writing this record.
    */
+  @Deprecated
   Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException;
+
+  /**
+   * This methods lets you write custom merging/combining logic to produce new values as a function of current value on
+   * storage and whats contained in this object.
+   * <p>
+   * eg: 1) You are updating counters, you may want to add counts to currentValue and write back updated counts 2) You
+   * may be reading DB redo logs, and merge them with current image for a database row on storage
+   *
+   * @param currentValue Current value in storage, to merge/combine this payload with
+   * @param schema Schema used for record
+   * @param props Payload related properties. For example pass the ordering field(s) name to extract from value in storage.
+   * @return new combined/merged value to be written back to storage. EMPTY to skip writing this record.
+   */
+  default Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Map<String, String> props) throws IOException {
+    return combineAndGetUpdateValue(currentValue, schema);
+  }
 
   /**
    * Generates an avro record out of the given HoodieRecordPayload, to be written out to storage. Called when writing a

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -82,6 +82,7 @@ import java.util.stream.Collectors;
 
 import scala.collection.JavaConversions;
 
+import static org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldVal;
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.CHECKPOINT_KEY;
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.CHECKPOINT_RESET_KEY;
 import static org.apache.hudi.config.HoodieCompactionConfig.INLINE_COMPACT_PROP;
@@ -349,7 +350,7 @@ public class DeltaSync implements Serializable {
     JavaRDD<GenericRecord> avroRDD = avroRDDOptional.get();
     JavaRDD<HoodieRecord> records = avroRDD.map(gr -> {
       HoodieRecordPayload payload = DataSourceUtils.createPayload(cfg.payloadClassName, gr,
-          (Comparable) DataSourceUtils.getNestedFieldVal(gr, cfg.sourceOrderingField, false));
+              (Comparable) getNestedFieldVal(gr, cfg.sourceOrderingField, false));
       return new HoodieRecord<>(keyGenerator.getKey(gr), payload);
     });
 
@@ -558,7 +559,7 @@ public class DeltaSync implements Serializable {
                 // Inline compaction is disabled for continuous mode. otherwise enabled for MOR
                 .withInlineCompaction(cfg.isInlineCompactionEnabled()).build())
             .forTable(cfg.targetTableName)
-            .withAutoCommit(autoCommit).withProps(props);
+            .withAutoCommit(autoCommit).withPayloadOrderingField(cfg.sourceOrderingField).withProps(props);
 
     if (null != schemaProvider && null != schemaProvider.getTargetSchema()) {
       builder = builder.withSchema(schemaProvider.getTargetSchema().toString());


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
This enhances the default payload class to respect records in disk when combining. If the records in disk is more recent they are rewritten with current commit time.

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

- [ ] This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

- [ ] This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

- [X] This change added tests and can be verified as follows:

*(example:)*

  - Added end-end test to TestDataSource to test writes from datasource
  -  Added unit tests to TestDataSourceDefaults 

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.