### PR TITLE
[HUDI-998] Introduce a robot to build testing website automatically

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,51 @@
+name: web sync
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  bot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.comment.body == 'sync testing site' }}
+
+    steps:
+      - name: clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: fetch pull request branch
+        run: |
+          git fetch origin +refs/pull/${{ github.event.issue.number }}/merge
+          git checkout FETCH_HEAD
+
+          siteRef=`git show-ref --hash --verify refs/remotes/origin/asf-site`
+          pullRef=`git log -1 --pretty=format:"%P" -1`
+          if [[ $pullRef =~ $siteRef ]]
+          then
+              exit 0;
+          else
+              exit -1;
+          fi
+
+      - name: jekyll docker build
+        run: |
+          docker run \
+          --privileged=true \
+          -v ${{ github.workspace }}/docs:/srv/jekyll/docs \
+          -v ${{ github.workspace }}/_site:/srv/jekyll/docs/_site \
+          jekyll/jekyll:3.8 \
+          /bin/bash -c "chmod 777 -R /srv/jekyll && cd /srv/jekyll/docs && gem sources -l && bundle install && bundle exec jekyll build --config _config.yml,_config.testing.yml"
+
+      - name: push test site
+        run: |
+          git clone https://${{ secrets.HUDI_GITHUB_WEB_TOKEN }}@github.com/ApacheHudi/hudi-testing-site
+          cd hudi-testing-site
+          mkdir -p docs
+          \cp -rf ../_site/* docs
+          git config user.name webbot
+          git config user.email webbot@hudi.apache.org
+          git add -A
+          git commit -am "push site"
+          git push origin master --force


### PR DESCRIPTION
## What is the purpose of the pull request

Based on #1698, if folks don't want to build staging site by themself, we can introduce a rebot which build testing website automatically.

Use command `sync testing site`, the rebot will fetch the repository and build site, then push the test site https://apachehudi.github.io/hudi-testing-site

## Brief change log

- Introduce a robot to build testing website automatically

## Verify this pull request

https://github.com/lamber-ken/hconfig/pull/7
https://apachehudi.github.io/hudi-testing-site

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.