### PR TITLE
Add HIVE_STYLE_PARTITIONING_OPT_KEY to Config doc

### DIFF
--- a/docs/_docs/2_4_configurations.cn.md
+++ b/docs/_docs/2_4_configurations.cn.md
@@ -90,6 +90,10 @@ inputDF.write()
   <span style="color:grey">分区路径字段。用作`HoodieKey`中`partitionPath`部分的值。
   通过调用.toString()获得实际的值</span>
 
+#### HIVE_STYLE_PARTITIONING_OPT_KEY {#HIVE_STYLE_PARTITIONING_OPT_KEY}
+  属性：`hoodie.datasource.write.hive_style_partitioning`, 默认值：`false` <br/>
+  <span style="color:grey">如果设置为true，则生成基于Hive格式的partition目录：<partition_column_name>=<partition_value></span>
+
 #### KEYGENERATOR_CLASS_OPT_KEY {#KEYGENERATOR_CLASS_OPT_KEY}
   属性：`hoodie.datasource.write.keygenerator.class`, 默认值：`org.apache.hudi.SimpleKeyGenerator` <br/>
   <span style="color:grey">键生成器类，实现从输入的`Row`对象中提取键</span>

--- a/docs/_docs/2_4_configurations.md
+++ b/docs/_docs/2_4_configurations.md
@@ -89,6 +89,10 @@ the dot notation eg: `a.b.c`</span>
   <span style="color:grey">Partition path field. Value to be used at the `partitionPath` component of `HoodieKey`.
 Actual value ontained by invoking .toString()</span>
 
+#### HIVE_STYLE_PARTITIONING_OPT_KEY {#HIVE_STYLE_PARTITIONING_OPT_KEY}
+  Property: `hoodie.datasource.write.hive_style_partitioning`, Default: `false` <br/>
+  <span style="color:grey">When set to true, partition folder names follow the format of Hive partitions: <partition_column_name>=<partition_value></span>
+
 #### KEYGENERATOR_CLASS_OPT_KEY {#KEYGENERATOR_CLASS_OPT_KEY}
   Property: `hoodie.datasource.write.keygenerator.class`, Default: `org.apache.hudi.SimpleKeyGenerator` <br/>
   <span style="color:grey">Key generator class, that implements will extract the key out of incoming `Row` object</span>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Added HIVE_STYLE_PARTITIONING_OPT_KEY to Config doc.

HIVE_STYLE_PARTITIONING_OPT_KEY is an option we introduced in this pr: https://github.com/apache/hudi/pull/1036. However, this option does not show up in the config doc, many people don't aware of this option.

Added this option in this PR.
## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.