### PR TITLE
[WIP] Add test case for syncing non-parititioned table to hive

### DIFF
--- a/hudi-spark/pom.xml
+++ b/hudi-spark/pom.xml
@@ -348,6 +348,14 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hive-sync</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
+++ b/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
@@ -20,10 +20,18 @@ package org.apache.hudi.functional
 import java.util.{Date, UUID}
 
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.metastore.IMetaStoreClient
+import org.apache.hadoop.hive.ql.metadata.Hive
+import org.apache.hive.jdbc.HiveDriver
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieSparkSqlWriter
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.testutils.minicluster.MiniClusterUtil
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.hive.HoodieHiveSyncException
+import org.apache.hudi.hive.testutils.HiveTestService
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.scalatest.{FunSuite, Matchers}
 
@@ -102,4 +110,91 @@ class HoodieSparkSqlWriterSuite extends FunSuite with Matchers {
 
   case class Test(uuid: String, ts: Long)
 
+  test("Table can be created normally without partition keys, when sync non-parititioned table to hive") {
+    // MiniCluster
+    MiniClusterUtil.setUp()
+
+    val hadoopConf = MiniClusterUtil.configuration
+
+    // Hive
+    val hiveTestService = new HiveTestService(hadoopConf)
+    val hiveServer = hiveTestService.start()
+
+    val session = SparkSession.builder()
+      .appName("test_hoodie_trips_hive_non_partitioned")
+      .master("local[*]")
+      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .getOrCreate()
+
+    try {
+
+      val sqlContext = session.sqlContext
+      val tableName = "hoodie_trips_hive_non_partitioned"
+      val path = hadoopConf.getRaw("fs.defaultFS") + "/hoodie_test_path"
+
+      import session.implicits._
+      val df = Seq(
+        (100, "name_1", "2020-01-01 13:51:39", 1.32, "type1"),
+        (101, "name_2", "2020-01-01 12:14:58", 2.57, "type2"),
+        (102, "name_3", "2020-01-01 12:15:00", 3.45, "type1"),
+        (103, "name_4", "2020-01-01 13:51:42", 6.78, "type2")
+      )
+        .toDF("id", "name", "ts", "value", "type")
+
+      val tableOptions = Map("path" -> path,
+        HoodieWriteConfig.TABLE_NAME -> tableName,
+        RECORDKEY_FIELD_OPT_KEY -> "id",
+        PRECOMBINE_FIELD_OPT_KEY -> "ts",
+        PARTITIONPATH_FIELD_OPT_KEY -> "type",
+        // enable Hive Sync
+        HIVE_SYNC_ENABLED_OPT_KEY -> "true",
+        HIVE_TABLE_OPT_KEY -> tableName,
+        // HIVE_PARTITION_FIELDS_OPT_KEY should be ignored when sync non-parititioned table to hive
+        HIVE_PARTITION_FIELDS_OPT_KEY -> "type",
+        HIVE_URL_OPT_KEY -> "jdbc:hive2://127.0.0.1:9999",
+        // Set partition value extractor to NonPartitionedExtractor
+        HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY -> "org.apache.hudi.hive.NonPartitionedExtractor",
+        KEYGENERATOR_CLASS_OPT_KEY -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator"
+      )
+      val tableParams = HoodieSparkSqlWriter.parametersWithWriteDefaults(tableOptions)
+
+      // do the write and sync
+      HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, tableParams, df)
+
+      // validate
+      val hiveMSClient = getHiveMetaStoreClient(hiveServer.getHiveConf)
+
+      // table should exist and have no partitions
+      assert(hiveMSClient.tableExists(tableParams(HIVE_DATABASE_OPT_KEY), tableName), s"Table $tableName should exist after sync complete")
+      assert(hiveMSClient.listPartitions(tableParams(HIVE_DATABASE_OPT_KEY), tableName, -1).size() == 0,
+        "Table should not have partitions because of NonPartitionedExtractor")
+
+      // table create DDL should not contain 'PARTITIONED BY'
+      assert(hiveMSClient.getTable(tableParams(HIVE_DATABASE_OPT_KEY), tableName).getPartitionKeys.size() == 0,
+        "Table create DDL should not contain 'PARTITIONED BY'")
+
+      // finally the total number of fields should be equal
+      assert(hiveMSClient.getTable(tableParams(HIVE_DATABASE_OPT_KEY), tableName)
+        .getSd().getCols().size() == (df.columns.length + HoodieRecord.HOODIE_META_COLUMNS.size()),
+        "Table schema should contain all the fields")
+
+    } finally {
+      session.stop()
+      hiveServer.stop()
+      hiveTestService.stop()
+      MiniClusterUtil.shutdown()
+    }
+  }
+
+  def getHiveMetaStoreClient(hiveConf: HiveConf): IMetaStoreClient ={
+    try {
+      Class.forName(classOf[HiveDriver].getName)
+      Hive.get(hiveConf).getMSC()
+    } catch {
+      case e: ClassNotFoundException =>
+        throw new IllegalStateException("Could not find HiveDriver in classpath. ", e)
+      case _ =>
+        throw new HoodieHiveSyncException("Failed to create HiveMetaStoreClient")
+    }
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -761,10 +761,10 @@
         <version>${hive.version}</version>
         <scope>provided</scope>
         <exclusions>
-          <exclusion>
+          <!--<exclusion>
             <groupId>javax.transaction</groupId>
             <artifactId>jta</artifactId>
-          </exclusion>
+          </exclusion>-->
           <exclusion>
             <groupId>javax.transaction</groupId>
             <artifactId>transaction-api</artifactId>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Relates to #1720 
This pull request adds test case to verify table can be created normally without partition keys, when sync non-parititioned table to hive.

## Brief change log

- *Add test code in HoodieSparkSqlWriterSuite.*
- *Two pom.xml involved. One is hudi-spark/pom.xml, adding the tests dependency of hudi-hive-sync module, because of HiveTestService. The other is for the parent pom.xml, I free the JTA dependency. The test seem to rely on the jta package, which can lead to a test failure. I  wonder if these changes have any impact.*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.