### PR TITLE
[HUDI-1032]Remove unused classes in HoodieCopyOnWriteTable and code clean

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieMergeOnReadTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieMergeOnReadTable.java
@@ -43,8 +43,6 @@ import org.apache.hudi.table.action.deltacommit.UpsertPreppedDeltaCommitActionEx
 import org.apache.hudi.table.action.compact.ScheduleCompactionActionExecutor;
 import org.apache.hudi.table.action.restore.MergeOnReadRestoreActionExecutor;
 import org.apache.hudi.table.action.rollback.MergeOnReadRollbackActionExecutor;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
@@ -68,8 +66,6 @@ import java.util.Map;
  * </p>
  */
 public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends HoodieCopyOnWriteTable<T> {
-
-  private static final Logger LOG = LogManager.getLogger(HoodieMergeOnReadTable.class);
 
   HoodieMergeOnReadTable(HoodieWriteConfig config, Configuration hadoopConf, HoodieTableMetaClient metaClient) {
     super(config, hadoopConf, metaClient);
@@ -137,6 +133,7 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends Hoodi
     return new MergeOnReadRollbackActionExecutor(jsc, config, this, rollbackInstantTime, commitInstant, deleteInstants).execute();
   }
 
+  @Override
   public HoodieRestoreMetadata restore(JavaSparkContext jsc, String restoreInstantTime, String instantToRestore) {
     return new MergeOnReadRestoreActionExecutor(jsc, config, this, restoreInstantTime, instantToRestore).execute();
   }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Currently, SmallFile, InsertBucket, BucketType and BucketInfo had been introduced as independent classes in path "src/main/java/org/apache/hudi/table/action/commit",  So the old ones can be removed now.

BTW, some code clean work is also done in HoodieMergeOnReadTable

## Brief change log

*Remove SmallFile, InsertBucket, BucketType and BucketInfo class in HoodieCopyOnWriteTable*
*Minor code clean in both HoodieCopyOnWriteTable and HoodieMergeOnReadTable*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.