### PR TITLE
[MINOR] Relocate jetty during shading/packaging for Databricks runtime

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -52,10 +52,9 @@
               <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
               </dependencyReducedPomLocation>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
-                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"></transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                    <addHeader>true</addHeader>
+                  <addHeader>true</addHeader>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                   <resource>META-INF/LICENSE</resource>
@@ -142,9 +141,13 @@
                   <pattern>org.apache.commons.codec.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.commons.codec.</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.eclipse.jetty.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.jetty.</shadedPattern>
+                </relocation>
                 <!-- TODO: Revisit GH ISSUE #533 & PR#633-->
               </relocations>
-             <filters>
+              <filters>
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
@@ -161,14 +164,14 @@
         </executions>
       </plugin>
     </plugins>
-     <resources>
-       <resource>
-         <directory>src/main/resources</directory>
-       </resource>
-       <resource>
-         <directory>src/test/resources</directory>
-       </resource>
-     </resources>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/test/resources</directory>
+      </resource>
+    </resources>
   </build>
 
   <dependencies>


### PR DESCRIPTION
## What is the purpose of the pull request

This pull-request relocates jetty during the packaging of `hudi-spark-bundle`.

I'm testing Hudi in Databricks and found there is a transitive dependency conflict around Jetty.  (Databricks runtime 6.6)[https://docs.databricks.com/release-notes/runtime/6.6.html] provides Jetty 9.3; Hudi has a dependency on Jetty 9.4 (specifically, `SessionHandler.setHttpOnly()` doesn't exist in 9.3).  (Databricks runtime 7.0)[https://docs.databricks.com/release-notes/runtime/7.0.html) includes Jetty 9.4, but it also includes Spark 3.0.0; Hudi requires 2.x.

Relocating Jetty during packaging solves the problem and allows Hudi to operate with its own version, independent of what Databricks provides.  This allows `hudi-spark-bundle` to work within Databricks out-of-the-box with no further alterations.

## Brief change log

  - Modify `packaging/hudi-spark-bundle/pom.xml` to relocate Jetty during packaging

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.  There are no modifications to code functionality.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit (used `[MINOR]` tag due to simple nature of the change)
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.