### PR TITLE
[HUDI-539] Make HoodieROTablePathFilter implement Configurable

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hadoop;
 
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
@@ -50,7 +51,7 @@ import java.util.stream.Collectors;
  * hadoopConf.setClass("mapreduce.input.pathFilter.class", org.apache.hudi.hadoop .HoodieROTablePathFilter.class,
  * org.apache.hadoop.fs.PathFilter.class)
  */
-public class HoodieROTablePathFilter implements PathFilter, Serializable {
+public class HoodieROTablePathFilter implements Configurable, PathFilter, Serializable {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LogManager.getLogger(HoodieROTablePathFilter.class);
@@ -189,5 +190,15 @@ public class HoodieROTablePathFilter implements PathFilter, Serializable {
       LOG.error(msg, e);
       throw new HoodieException(msg, e);
     }
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = new SerializableConfiguration(conf);
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf.get();
   }
 }


### PR DESCRIPTION
## What is the purpose of this pull request

This pull request fixes [HUDI-539](https://issues.apache.org/jira/browse/HUDI-539).

## Brief change log
- Make `HoodieROTablePathFilter` implement `Configurable`

To follow through the code and see why the table filter needs to implement Configurable please go through the following links:
1. [This](https://github.com/apache/spark/blob/v2.4.4/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala#L125) is how Spark creates the filter
2. Filter is instantiated via [reflection](https://github.com/apache/hadoop-common/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/FileInputFormat.java#L159)
3. Which calls a [setConf](https://github.com/apache/hadoop-common/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ReflectionUtils.java#L133) method coming from the [Configurable](https://github.com/apache/hadoop-common/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ReflectionUtils.java#L72-L74) type

## Verify this pull request

This pull request is already covered by existing unit tests, such as TestHoodieROTablePathFilter. Apart from it, I've tested this change by writing data in Azure Datalake and then reading it in the following environment:

Databricks runtime: 6.6
Hudi version: 0.5.3
Spark version: 2.4.4

```scala

val stringData =
  """
    |id,ts,day
    | 0,0,2020-01-01
    | 1,1,2020-01-01
    | 2,1,2020-01-01
    | 3,2,2020-01-02
    | 4,2,2020-01-02
    |""".stripMargin

val data = spark.read
  .option("header", value = true)
  .csv(sc.parallelize(stringData.lines.toSeq)
  .toDS())

data.write
  .format("org.apache.hudi")
  .options(getQuickstartWriteConfigs)
  .option(PRECOMBINE_FIELD_OPT_KEY, "ts")
  .option(RECORDKEY_FIELD_OPT_KEY, "id")
  .option(PARTITIONPATH_FIELD_OPT_KEY, "day")
  .option(TABLE_NAME, "mytable")
  .mode(Overwrite)
  .save("adl://mystore.azuredatalakestore.net/hudi")

spark.read
  .format("org.apache.hudi")
  .load("adl://mystore.azuredatalakestore.net/hudi/*")
  .show()
```

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.