### PR TITLE
[HUDI-1080] Fix backward compatibility for com.uber inputformats

### DIFF
--- a/hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop.hive;
+
+import com.uber.hoodie.hadoop.HoodieInputFormat;
+import com.uber.hoodie.hadoop.realtime.HoodieRealtimeInputFormat;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hudi.hadoop.HoodieParquetInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
+
+public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extends Writable>
+    extends org.apache.hudi.hadoop.hive.HoodieCombineHiveInputFormat<K, V> {
+
+  @Override
+  protected String getParquetInputFormatClassName() {
+    return HoodieInputFormat.class.getName();
+  }
+
+  @Override
+  protected String getParquetRealtimeInputFormatClassName() {
+    return HoodieRealtimeInputFormat.class.getName();
+  }
+
+  @Override
+  protected org.apache.hudi.hadoop.hive.HoodieCombineHiveInputFormat.HoodieCombineFileInputFormatShim
+      createInputFormatShim() {
+    return new HoodieCombineFileInputFormatShim<>();
+  }
+
+  public static class HoodieCombineFileInputFormatShim<K, V>
+      extends org.apache.hudi.hadoop.hive.HoodieCombineHiveInputFormat.HoodieCombineFileInputFormatShim {
+
+    @Override
+    protected HoodieParquetInputFormat createParquetInputFormat() {
+      return new HoodieInputFormat();
+    }
+
+    @Override
+    protected HoodieParquetRealtimeInputFormat createParquetRealtimeInputFormat() {
+      return new HoodieRealtimeInputFormat();
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

1) InputFormat backward compatibility is broken in several places because equality check is done including package name in multiple places https://github.com/apache/hudi/blob/master/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java#L154. Fix this by using inheritance and using appropriate package name.

2) For 0.4.x versions, reading worked with ORCInputFormat as well. For 0.4.x, we used shim to read as opposed to throwing error for non-hoodie formats. Bring back same functionality to master.

## Brief change log

- Fix InputFormat class lookup based on package name of source inputformat.
- Do not throw error for non-hoodie input format and delegate reading to shim loader

## Verify this pull request
Verified end-to-end in uber internal hive service deployment.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.