### PR TITLE
[HUDI-651] Fix incremental queries in hive for MOR tables

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -50,7 +50,7 @@ import java.util.List;
 
 import scala.Tuple2;
 
-import static org.apache.hudi.common.testutils.HoodieTestUtils.generateFakeHoodieWriteStat;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.generateFakeHoodieWriteStats;
 import static org.apache.hudi.table.action.commit.UpsertPartitioner.averageBytesPerRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -104,7 +104,7 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
   }
 
   private static List<HoodieWriteStat> generateCommitStatWith(int totalRecordsWritten, int totalBytesWritten) {
-    List<HoodieWriteStat> writeStatsList = generateFakeHoodieWriteStat(5);
+    List<HoodieWriteStat> writeStatsList = generateFakeHoodieWriteStats(5);
     // clear all record and byte stats except for last entry.
     for (int i = 0; i < writeStatsList.size() - 1; i++) {
       HoodieWriteStat writeStat = writeStatsList.get(i);
@@ -172,7 +172,7 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
 
   @Test
   public void testUpsertPartitioner() throws Exception {
-    final String testPartitionPath = "2016/09/26";
+    final String testPartitionPath = "1/09/26";
     // Inserts + Updates... Check all updates go together & inserts subsplit
     UpsertPartitioner partitioner = getUpsertPartitioner(0, 200, 100, 1024, testPartitionPath, false);
     List<InsertBucket> insertBuckets = partitioner.getInsertBuckets(testPartitionPath);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
@@ -18,13 +18,13 @@
 
 package org.apache.hudi.common.model;
 
-import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.apache.hudi.common.testutils.HoodieTestUtils.generateFakeHoodieWriteStats;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,7 +37,7 @@ public class TestHoodieCommitMetadata {
   @Test
   public void testPerfStatPresenceInHoodieMetadata() throws Exception {
 
-    List<HoodieWriteStat> fakeHoodieWriteStats = HoodieTestUtils.generateFakeHoodieWriteStat(100);
+    List<HoodieWriteStat> fakeHoodieWriteStats = generateFakeHoodieWriteStats(100);
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     fakeHoodieWriteStats.forEach(stat -> commitMetadata.addWriteStat(stat.getPartitionPath(), stat));
     assertTrue(commitMetadata.getTotalCreateTime() > 0);

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -505,24 +505,51 @@ public class HoodieTestUtils {
     return commits;
   }
 
-  public static List<HoodieWriteStat> generateFakeHoodieWriteStat(int limit) {
+  public static List<HoodieWriteStat> generateFakeHoodieWriteStats(int limit) {
+    return generateFakeHoodieWriteStats(limit, "/some/fake/path", "/some/fake/partition/path");
+  }
+
+  public static List<HoodieWriteStat> generateFakeHoodieWriteStats(int limit, String relFilePath, String relPartitionPath) {
     List<HoodieWriteStat> writeStatList = new ArrayList<>();
     for (int i = 0; i < limit; i++) {
-      HoodieWriteStat writeStat = new HoodieWriteStat();
-      writeStat.setFileId(UUID.randomUUID().toString());
-      writeStat.setNumDeletes(0);
-      writeStat.setNumUpdateWrites(100);
-      writeStat.setNumWrites(100);
-      writeStat.setPath("/some/fake/path" + i);
-      writeStat.setPartitionPath("/some/fake/partition/path" + i);
-      writeStat.setTotalLogFilesCompacted(100L);
-      RuntimeStats runtimeStats = new RuntimeStats();
-      runtimeStats.setTotalScanTime(100);
-      runtimeStats.setTotalCreateTime(100);
-      runtimeStats.setTotalUpsertTime(100);
-      writeStat.setRuntimeStats(runtimeStats);
-      writeStatList.add(writeStat);
+      writeStatList.add(generateFakeHoodieWriteStat(relFilePath + i, (relPartitionPath + i)));
     }
     return writeStatList;
+  }
+
+  public static HoodieWriteStat generateFakeHoodieWriteStat(String relFilePath, String relPartitionPath) {
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(UUID.randomUUID().toString());
+    writeStat.setNumDeletes(0);
+    writeStat.setNumUpdateWrites(100);
+    writeStat.setNumWrites(100);
+    writeStat.setPath(relFilePath);
+    writeStat.setPartitionPath(relPartitionPath);
+    writeStat.setTotalLogFilesCompacted(100L);
+    writeStat.setFileSizeInBytes(1024 * 10);
+    writeStat.setTotalWriteBytes(1024 * 10);
+    RuntimeStats runtimeStats = new RuntimeStats();
+    runtimeStats.setTotalScanTime(100);
+    runtimeStats.setTotalCreateTime(100);
+    runtimeStats.setTotalUpsertTime(100);
+    writeStat.setRuntimeStats(runtimeStats);
+    return writeStat;
+  }
+
+  public static HoodieWriteStat generateFakeHoodieWriteStats(java.nio.file.Path basePath, HoodieLogFile logFile) {
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(UUID.randomUUID().toString());
+    writeStat.setNumDeletes(0);
+    writeStat.setNumUpdateWrites(100);
+    writeStat.setNumWrites(100);
+    writeStat.setPath(logFile.getPath().toString().replaceFirst(basePath.toString() + "/", ""));
+    writeStat.setPartitionPath("/some/fake/partition/path");
+    writeStat.setTotalLogFilesCompacted(100L);
+    RuntimeStats runtimeStats = new RuntimeStats();
+    runtimeStats.setTotalScanTime(100);
+    runtimeStats.setTotalCreateTime(100);
+    runtimeStats.setTotalUpsertTime(100);
+    writeStat.setRuntimeStats(runtimeStats);
+    return writeStat;
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputPathHandler.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputPathHandler.java
@@ -51,7 +51,7 @@ public class InputPathHandler {
   private final List<Path> snapshotPaths;
   private final List<Path> nonHoodieInputPaths;
 
-  InputPathHandler(Configuration conf, Path[] inputPaths, List<String> incrementalTables) throws IOException {
+  public InputPathHandler(Configuration conf, Path[] inputPaths, List<String> incrementalTables) throws IOException {
     this.conf = conf;
     tableMetaClientMap = new HashMap<>();
     snapshotPaths = new ArrayList<>();

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMORIncrementalFileSplit.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMORIncrementalFileSplit.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileGroup;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.util.Option;
+
+/**
+ * Filesplit that wraps a HoodieFileGroup involved in Incremental queries.
+ */
+public class HoodieMORIncrementalFileSplit extends FileSplit {
+
+  private String basePath;
+  private HoodieFileGroupId fileGroupId;
+  private List<FileSlice> fileGroupSlices;
+  String maxCommitTime;
+
+  public HoodieMORIncrementalFileSplit(HoodieFileGroup hoodieFileGroup, String basePath, String maxCommitTime) {
+    this.fileGroupId = hoodieFileGroup.getFileGroupId();
+    this.fileGroupSlices = hoodieFileGroup.getAllFileSlices().collect(Collectors.toList());
+    this.basePath = basePath;
+    this.maxCommitTime = maxCommitTime;
+  }
+
+  public HoodieFileGroupId getFileGroupId() {
+    return fileGroupId;
+  }
+
+  public List<FileSlice> getFileSlices() {
+    return fileGroupSlices;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public String getMaxCommitTime() {
+    return maxCommitTime;
+  }
+
+  // returns the most recent Parquet file path from the group of file slices
+  public String getLatestBaseFilePath() {
+    Option<FileSlice> fileSlice = Option.fromJavaOptional(fileGroupSlices.stream().filter(slice -> slice.getBaseFile().isPresent()).findFirst());
+    return fileSlice.map(slice -> slice.getBaseFile().get().getPath()).orElse(null);
+  }
+
+  // returns the most recent log file paths from the group of file slices
+  public List<String> getLatestLogFilePaths() {
+    Option<FileSlice> fileSlice = Option.fromJavaOptional(fileGroupSlices.stream().filter(slice -> slice.getLogFiles().findAny().isPresent()).findFirst());
+    return fileSlice.map(slice -> slice.getLogFiles().map(logFile -> logFile.getPath().toString()).collect(Collectors.toList())).orElse(new ArrayList<>());
+  }
+
+  private static void writeString(String str, DataOutput out) throws IOException {
+    byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+    out.writeInt(bytes.length);
+    out.write(bytes);
+  }
+
+  private static void writeFileGroupId(HoodieFileGroupId fileGroupId, DataOutput out) throws IOException {
+    writeString(fileGroupId.getPartitionPath(), out);
+    writeString(fileGroupId.getFileId(), out);
+  }
+
+  private static void writeFileStatus(FileStatus fileStatus, DataOutput out) throws IOException {
+    out.writeLong(fileStatus.getLen());
+    writeString(fileStatus.getPath().toString(), out);
+  }
+
+  private static void writeFileSlice(FileSlice slice, DataOutput out) throws IOException {
+    boolean isBaseFilePresent = slice.getBaseFile().isPresent();
+    out.writeBoolean(isBaseFilePresent);
+    if (isBaseFilePresent) {
+      writeFileStatus(slice.getBaseFile().get().getFileStatus(), out);
+    }
+    List<String> logFilePaths = slice.getLogFiles()
+        .map(f -> f.getPath().toString())
+        .collect(Collectors.toList());
+    out.writeInt(logFilePaths.size());
+    for (String logFilePath : logFilePaths) {
+      writeString(logFilePath, out);
+    }
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    writeString(basePath, out);
+    writeString(maxCommitTime, out);
+    writeFileGroupId(fileGroupId, out);
+    out.writeInt(fileGroupSlices.size());
+    for (FileSlice fileSlice: fileGroupSlices) {
+      writeFileSlice(fileSlice, out);
+    }
+  }
+
+  private static String readString(DataInput in) throws IOException {
+    byte[] bytes = new byte[in.readInt()];
+    in.readFully(bytes);
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  private static HoodieFileGroupId readFileGroupId(DataInput in) throws IOException {
+    return new HoodieFileGroupId(readString(in), readString(in));
+  }
+
+  private static FileStatus readFileStatus(DataInput in) throws IOException {
+    return new FileStatus(in.readLong(), false, 0, 0, 0, new Path(readString(in)));
+  }
+
+  private static FileSlice readFileSlice(HoodieFileGroupId fileGroupId, DataInput in) throws IOException {
+    boolean isBaseFilePresent =  in.readBoolean();
+    Option<HoodieBaseFile> baseFile = isBaseFilePresent ? Option.of(new HoodieBaseFile(readFileStatus(in))) : Option.empty();
+    int numLogFiles = in.readInt();
+    List<HoodieLogFile> logFiles = new ArrayList<>();
+    Option<String> baseInstantTime = Option.empty();
+    for (int i = 0; i < numLogFiles; i++) {
+      HoodieLogFile logFile = new HoodieLogFile(readString(in));
+      logFiles.add(logFile);
+      if (!baseInstantTime.isPresent()) {
+        baseInstantTime = Option.of(logFile.getBaseCommitTime());
+      }
+    }
+    FileSlice fileSlice = new FileSlice(fileGroupId, baseInstantTime.get());
+    baseFile.ifPresent(fileSlice::setBaseFile);
+    for (HoodieLogFile logFile: logFiles) {
+      fileSlice.addLogFile(logFile);
+    }
+    return fileSlice;
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    basePath = readString(in);
+    maxCommitTime = readString(in);
+    fileGroupId = readFileGroupId(in);
+    int totalSlices = in.readInt();
+    fileGroupSlices = new ArrayList<>();
+    for (int i = 0; i < totalSlices; i++) {
+      fileGroupSlices.add(readFileSlice(fileGroupId, in));
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieMORIncrementalFileSplit{BasePath=" + basePath + ", FileGroupId=" + fileGroupId
+        + ", maxcommitTime='" + maxCommitTime
+        + ", numFileSlices='" + fileGroupSlices.size() + '}';
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMORIncrementalRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMORIncrementalRecordReader.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+/**
+ * Record Reader which can do compacted (merge-on-read) record reading to serve incremental queries.
+ */
+public class HoodieMORIncrementalRecordReader extends AbstractRealtimeRecordReader implements RecordReader<NullWritable, ArrayWritable> {
+  private static final Logger LOG = LogManager.getLogger(HoodieMORIncrementalRecordReader.class);
+  private final Map<String, ArrayWritable> records;
+  private final Iterator<ArrayWritable> iterator;
+
+  public HoodieMORIncrementalRecordReader(HoodieMORIncrementalFileSplit split, JobConf job, Reporter reporter) {
+    super(split, job);
+    HoodieMergedFileSlicesScanner fileSlicesScanner = new HoodieMergedFileSlicesScanner(split, job, reporter, this);
+    try {
+      fileSlicesScanner.scan();
+      this.records = fileSlicesScanner.getRecords();
+      this.iterator = records.values().iterator();
+    } catch (IOException e) {
+      throw new HoodieIOException("IOException when reading log file ");
+    }
+  }
+
+  @Override
+  public boolean next(NullWritable key, ArrayWritable value) throws IOException {
+    if (!iterator.hasNext()) {
+      return false;
+    }
+    value.set(iterator.next().get());
+    return true;
+  }
+
+  @Override
+  public NullWritable createKey() {
+    return null;
+  }
+
+  @Override
+  public ArrayWritable createValue() {
+    return new ArrayWritable(Writable.class);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    return 0;
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergedFileSlicesScanner.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergedFileSlicesScanner.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.COMPACTION_LAZY_BLOCK_READ_ENABLED_PROP;
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.DEFAULT_COMPACTION_LAZY_BLOCK_READ_ENABLED;
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.DEFAULT_MAX_DFS_STREAM_BUFFER_SIZE;
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.DEFAULT_SPILLABLE_MAP_BASE_PATH;
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.MAX_DFS_STREAM_BUFFER_SIZE_PROP;
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.SPILLABLE_MAP_BASE_PATH_PROP;
+import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.HOODIE_RECORD_KEY_COL_POS;
+import static org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils.arrayWritableToString;
+import static org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils.avroToArrayWritable;
+
+/**
+ * Scans through all files in a file slice. Constructs a map of records from Parquet file if present. Constructs merged
+ * log records if log files are present in the slice. Merges records from log files on top of records from base parquet
+ * file.
+ *
+ */
+public class HoodieMergedFileSlicesScanner {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieMergedFileSlicesScanner.class);
+
+  private final transient MapredParquetInputFormat mapredParquetInputFormat;
+  private final HoodieMORIncrementalFileSplit split;
+  private final List<FileSlice> fileSlices;
+
+  // Final map of compacted/merged records
+  // TODO change map to external spillable map. But ArrayWritable is not implementing Serializable
+  private final Map<String, ArrayWritable> records;
+
+  private final JobConf jobConf;
+  private final Reporter reporter;
+  private final HoodieMORIncrementalRecordReader recordReader;
+
+  public HoodieMergedFileSlicesScanner(
+          HoodieMORIncrementalFileSplit split,
+          JobConf jobConf,
+          Reporter reporter,
+          HoodieMORIncrementalRecordReader recordReader) {
+    this.split = split;
+    this.fileSlices = split.getFileSlices()
+        .stream()
+        .sorted(Comparator.comparing(FileSlice::getBaseInstantTime))
+        .collect(Collectors.toList());
+    this.mapredParquetInputFormat = new MapredParquetInputFormat();
+    this.records = new HashMap<>();
+    this.jobConf = jobConf;
+    this.reporter = reporter;
+    this.recordReader = recordReader;
+  }
+
+  public void scan() throws IOException {
+    for (FileSlice fileSlice: fileSlices) {
+      Map<String, ArrayWritable> newRecords = scanFileSlice(fileSlice);
+      mergeRecords(newRecords);
+    }
+  }
+
+  private void mergeRecords(Map<String, ArrayWritable> newFileSliceRecords) {
+    for (Entry<String, ArrayWritable> entry: newFileSliceRecords.entrySet()) {
+      records.put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  private Map<String, ArrayWritable> scanFileSlice(FileSlice fileSlice) throws IOException {
+    Map<String, ArrayWritable> baseFileRecords = fetchBaseFileRecordsMapForSlice(fileSlice);
+    Map<String, HoodieRecord<? extends HoodieRecordPayload>> deltaRecords = fetchDeltaRecordMapForSlice(fileSlice);
+    if ((baseFileRecords == null || baseFileRecords.isEmpty()) && deltaRecords != null) {
+      Map<String, ArrayWritable> result = new HashMap<>();
+      for (Entry<String, HoodieRecord<? extends HoodieRecordPayload>> entry: deltaRecords.entrySet()) {
+        Option<ArrayWritable> aWritable = hoodieRecordToArrayWritable(entry.getValue());
+        if (aWritable.isPresent()) {
+          result.put(entry.getKey(), aWritable.get());
+        }
+      }
+      return result;
+    }
+    if (deltaRecords == null && baseFileRecords != null) {
+      return baseFileRecords;
+    }
+    // Apply delta records on top of base file records
+    return applyUpdatesToBaseFile(baseFileRecords, deltaRecords);
+  }
+
+  private Map<String, ArrayWritable> applyUpdatesToBaseFile(
+      Map<String, ArrayWritable> baseFileRecords,
+      Map<String, HoodieRecord<? extends HoodieRecordPayload>> deltaRecords) throws IOException {
+    Iterator<Entry<String, ArrayWritable>> iterator = baseFileRecords.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Entry<String, ArrayWritable> entry = iterator.next();
+      if (deltaRecords.containsKey(entry.getKey())) {
+        Option<ArrayWritable> aWritable = hoodieRecordToArrayWritable(deltaRecords.get(entry.getKey()));
+        if (!aWritable.isPresent()) {
+          // case where a valid record in basefile is deleted later in log files
+          iterator.remove();
+        } else {
+          // replace original value with value from log file.
+          Writable[] originalValue = entry.getValue().get();
+          Writable[] replaceValue = aWritable.get().get();
+          try {
+            System.arraycopy(replaceValue, 0, originalValue, 0, originalValue.length);
+            entry.getValue().set(originalValue);
+          } catch (RuntimeException re) {
+            LOG.error("Got exception when doing array copy", re);
+            LOG.error("Base record :" + arrayWritableToString(entry.getValue()));
+            LOG.error("Log record :" + arrayWritableToString(aWritable.get()));
+            String errMsg = "Base-record :" + arrayWritableToString(entry.getValue())
+                + " ,Log-record :" + arrayWritableToString(aWritable.get()) + " ,Error :" + re.getMessage();
+            throw new RuntimeException(errMsg, re);
+          }
+        }
+      }
+    }
+    return baseFileRecords;
+  }
+
+  private Option<ArrayWritable> hoodieRecordToArrayWritable(
+      HoodieRecord<? extends HoodieRecordPayload> record) throws IOException {
+    Option<GenericRecord> rec;
+    if (recordReader.usesCustomPayload) {
+      rec = record.getData().getInsertValue(recordReader.getWriterSchema());
+    } else {
+      rec = record.getData().getInsertValue(recordReader.getReaderSchema());
+    }
+    if (!rec.isPresent()) {
+      // possibly the record is deleted
+      return Option.empty();
+    }
+    GenericRecord recordToReturn = rec.get();
+    if (recordReader.usesCustomPayload) {
+      // If using a custom payload, return only the projection fields. The readerSchema is a schema derived from
+      // the writerSchema with only the projection fields
+      recordToReturn = HoodieAvroUtils.rewriteRecordWithOnlyNewSchemaFields(rec.get(), recordReader.getReaderSchema());
+    }
+    return Option.of((ArrayWritable) avroToArrayWritable(recordToReturn, recordReader.getHiveSchema()));
+  }
+
+  private Map<String, ArrayWritable> fetchBaseFileRecordsMapForSlice(FileSlice fileSlice) throws IOException {
+    if (!fileSlice.getBaseFile().isPresent()) {
+      return null;
+    }
+
+    // create a single split from the base parquet file and read the records.
+    FileStatus baseFileStatus = fileSlice.getBaseFile().get().getFileStatus();
+    FileSplit fileSplit = new FileSplit(baseFileStatus.getPath(), 0, baseFileStatus.getLen(), (String[]) null);
+    Map<String, ArrayWritable> result = new HashMap<>();
+    RecordReader<NullWritable, ArrayWritable> recordReader  = null;
+    try {
+      recordReader = mapredParquetInputFormat.getRecordReader(fileSplit, jobConf, reporter);
+      NullWritable key = recordReader.createKey();
+      ArrayWritable value = recordReader.createValue();
+      boolean hasNext = recordReader.next(key, value);
+      while (hasNext) {
+        String hoodieRecordKey = value.get()[HOODIE_RECORD_KEY_COL_POS].toString();
+        result.put(hoodieRecordKey, value);
+        key = recordReader.createKey();
+        value = recordReader.createValue();
+        hasNext = recordReader.next(key, value);
+      }
+    } catch (IOException e) {
+      LOG.error("Got exception when iterating parquet file: " + baseFileStatus.getPath(), e);
+      throw new HoodieIOException("IO exception when reading parquet file");
+    } finally {
+      if (recordReader != null) {
+        recordReader.close();
+      }
+    }
+    return result;
+  }
+
+  private Map<String, HoodieRecord<? extends HoodieRecordPayload>> fetchDeltaRecordMapForSlice(FileSlice fileSlice) {
+    if (!fileSlice.getLogFiles().findAny().isPresent()) {
+      return null;
+    }
+    // reverse the log files to be in natural order
+    List<String> logFilesPath = fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator()).map(file -> file.getPath().toString()).collect(Collectors.toList());
+
+    return new HoodieMergedLogRecordScanner(
+        FSUtils.getFs(split.getBasePath(), jobConf),
+        split.getBasePath(),
+        logFilesPath,
+        recordReader.usesCustomPayload ? recordReader.getWriterSchema() : recordReader.getReaderSchema(),
+        split.getMaxCommitTime(),
+        recordReader.getMaxCompactionMemoryInBytes(),
+        Boolean
+            .parseBoolean(jobConf.get(COMPACTION_LAZY_BLOCK_READ_ENABLED_PROP, DEFAULT_COMPACTION_LAZY_BLOCK_READ_ENABLED)),
+        false,
+        jobConf.getInt(MAX_DFS_STREAM_BUFFER_SIZE_PROP, DEFAULT_MAX_DFS_STREAM_BUFFER_SIZE),
+        jobConf.get(SPILLABLE_MAP_BASE_PATH_PROP, DEFAULT_SPILLABLE_MAP_BASE_PATH)
+    ).getRecords();
+  }
+
+  public Map<String, ArrayWritable> getRecords() {
+    return records;
+  }
+}

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
 import org.apache.hudi.hadoop.utils.HoodieHiveUtils;
 
@@ -52,6 +51,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.hudi.common.testutils.HoodieTestUtils.generateFakeHoodieWriteStats;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.init;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,7 +103,7 @@ public class TestHoodieParquetInputFormat {
     instants.add(t4);
     instants.add(t5);
     instants.add(t6);
-    HoodieTableMetaClient metaClient = HoodieTestUtils.init(basePath.toString());
+    HoodieTableMetaClient metaClient = init(basePath.toString());
     HoodieActiveTimeline timeline = new HoodieActiveTimeline(metaClient);
     timeline.setInstants(instants);
 
@@ -239,7 +240,7 @@ public class TestHoodieParquetInputFormat {
 
   private void createCommitFile(java.nio.file.Path basePath, String commitNumber, String partitionPath)
       throws IOException {
-    List<HoodieWriteStat> writeStats = HoodieTestUtils.generateFakeHoodieWriteStat(1);
+    List<HoodieWriteStat> writeStats = generateFakeHoodieWriteStats(1);
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     writeStats.forEach(stat -> commitMetadata.addWriteStat(partitionPath, stat));
     File file = basePath.resolve(".hoodie").resolve(commitNumber + ".commit").toFile();

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieParquetRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieParquetRealtimeInputFormat.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.generateFakeHoodieWriteStats;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultHadoopConf;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.init;
+import static org.apache.hudi.common.testutils.SchemaTestUtil.generateAvroRecordFromJson;
+import static org.apache.hudi.common.testutils.SchemaTestUtil.getEvolvedSchema;
+import static org.apache.hudi.hadoop.config.HoodieRealtimeConfig.MAX_DFS_STREAM_BUFFER_SIZE_PROP;
+import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.HOODIE_COMMIT_TIME_COL_POS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestHoodieParquetRealtimeInputFormat {
+
+  private HoodieParquetRealtimeInputFormat inputFormat;
+  private JobConf jobConf;
+  private Configuration hadoopConf;
+  private FileSystem fs;
+  private Schema schema;
+  int numberOfRecords = 150;
+  int numRecordsPerBaseFile = numberOfRecords / 2;
+  int numberOfUniqueLogRecords = numberOfRecords / 6;
+  int numberOfFiles = 1;
+  String fileID = "fileid0";
+  String partitionPath = "2016/05/01";
+  String baseInstant1 = "100";
+  String deltaCommitTime1 = "101";
+  String deltaCommitTime2 = "102";
+  String deltaCommitTime3 = "103";
+  String baseInstant2 = "200";
+  String deltaCommitTime4 = "201";
+  String deltaCommitTime5 = "202";
+
+  @TempDir
+  public java.nio.file.Path basePath;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    inputFormat = new HoodieParquetRealtimeInputFormat();
+    jobConf = new JobConf();
+    jobConf.set(MAX_DFS_STREAM_BUFFER_SIZE_PROP, String.valueOf(1024 * 1024));
+    hadoopConf = getDefaultHadoopConf();
+    fs = FSUtils.getFs(basePath.toString(), hadoopConf);
+    schema = HoodieAvroUtils.addMetadataFields(getEvolvedSchema());
+    setPropsForInputFormat(inputFormat, jobConf, schema);
+  }
+
+  private static void setPropsForInputFormat(HoodieParquetRealtimeInputFormat inputFormat, JobConf jobConf,
+                                             Schema schema) {
+    List<Schema.Field> fields = schema.getFields();
+    String names = fields.stream().map(Schema.Field::name).collect(Collectors.joining(","));
+    String postions = fields.stream().map(f -> String.valueOf(f.pos())).collect(Collectors.joining(","));
+    Configuration conf = getDefaultHadoopConf();
+
+    String hiveColumnNames = fields.stream().filter(field -> !field.name().equalsIgnoreCase("datestr"))
+        .map(Schema.Field::name).collect(Collectors.joining(","));
+    hiveColumnNames = hiveColumnNames + ",datestr";
+
+    String hiveColumnTypes = HoodieAvroUtils.addMetadataColumnTypes("string,string,string,bigint,string,string");
+    hiveColumnTypes = hiveColumnTypes + ",string";
+    jobConf.set(hive_metastoreConstants.META_TABLE_COLUMNS, hiveColumnNames);
+    jobConf.set(hive_metastoreConstants.META_TABLE_COLUMN_TYPES, hiveColumnTypes);
+    jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);
+    jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, postions);
+    jobConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "datestr");
+    conf.set(hive_metastoreConstants.META_TABLE_COLUMNS, hiveColumnNames);
+    conf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);
+    conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, postions);
+    conf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "datestr");
+    conf.set(hive_metastoreConstants.META_TABLE_COLUMN_TYPES, hiveColumnTypes);
+    inputFormat.setConf(conf);
+    jobConf.addResource(conf);
+  }
+
+  private void prepareTestData() throws IOException, InterruptedException {
+    // [inserts][initial commit] => creates one parquet file
+    init(hadoopConf, basePath.toString(), HoodieTableType.MERGE_ON_READ);
+    File partitionDir = InputFormatTestUtil.prepareParquetTable(basePath, schema, numberOfFiles, numRecordsPerBaseFile, baseInstant1);
+    createCommitFile(basePath, baseInstant1, partitionPath);
+
+    moreUpdates(partitionDir, baseInstant1, deltaCommitTime1, 0);
+
+    moreUpdates(partitionDir, baseInstant1, deltaCommitTime2, 1 * numberOfUniqueLogRecords);
+
+    moreUpdates(partitionDir, baseInstant1, deltaCommitTime3, 2 * numberOfUniqueLogRecords);
+
+    InputFormatTestUtil.prepareParquetTable(basePath, schema, numberOfFiles, numRecordsPerBaseFile, baseInstant2);
+    createCommitFile(basePath, baseInstant2, partitionPath);
+
+    moreUpdates(partitionDir, baseInstant2, deltaCommitTime4, 0);
+
+    moreUpdates(partitionDir, baseInstant2, deltaCommitTime5, 1 * numberOfUniqueLogRecords);
+
+    // Add the paths to jobConf
+    FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+  }
+
+  // moreUpdates creates a new log file on top of latest FileSlice and publishes a new deltacommit
+  private void moreUpdates(File partitionDir, String baseCommit, String deltaCommit, int offset) throws IOException, InterruptedException {
+    HoodieLogFormat.Writer writer = writeLogFileWithUniqueUpdates(partitionDir, schema, fileID, baseCommit, deltaCommit,
+            numberOfUniqueLogRecords, offset);
+    long size = writer.getCurrentSize();
+    writer.close();
+    assertTrue(size > 0, "block - size should be > 0");
+    createDeltaCommitFile(basePath, deltaCommit, partitionPath, writer);
+  }
+
+  private HoodieLogFormat.Writer writeLogFileWithUniqueUpdates(
+          File partitionDir,
+          Schema schema,
+          String fileId,
+          String baseCommit,
+          String newCommit,
+          int numberOfRecords,
+          int offset) throws InterruptedException, IOException {
+    return writeDataBlockToLogFile(partitionDir, schema, fileId, baseCommit, newCommit, numberOfRecords, offset, 0);
+  }
+
+  private HoodieLogFormat.Writer writeDataBlockToLogFile(File partitionDir, Schema schema, String fileId,
+                                                         String baseCommit, String newCommit, int numberOfRecords, int offset, int logVersion)
+          throws InterruptedException, IOException {
+    HoodieLogFormat.Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(new Path(partitionDir.getPath()))
+            .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(fileId).withLogVersion(logVersion)
+            .withLogWriteToken("1-0-1").overBaseCommit(baseCommit).withFs(fs).build();
+    List<IndexedRecord> records = new ArrayList<>();
+    for (int i = offset; i < offset + numberOfRecords; i++) {
+      records.add(generateAvroRecordFromJson(schema, i, newCommit, fileID));
+    }
+    Schema writeSchema = records.get(0).getSchema();
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, newCommit);
+    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writeSchema.toString());
+    HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, header);
+    writer = writer.appendBlock(dataBlock);
+    return writer;
+  }
+
+  private void createCommitFile(java.nio.file.Path basePath, String commitNumber, String relativePartitionPath)
+          throws IOException {
+    String dataFileName = FSUtils.makeDataFileName(commitNumber, InputFormatTestUtil.TEST_WRITE_TOKEN, fileID);
+    java.nio.file.Path partitionPath = basePath.resolve(Paths.get("2016", "05", "01"));
+    Path fullPath = new Path(partitionPath.resolve(dataFileName).toString());
+    String relFilePath =  fullPath.toString().replaceFirst(basePath.toString() + "/", "");
+    HoodieWriteStat writeStat = HoodieTestUtils.generateFakeHoodieWriteStat(relFilePath, relativePartitionPath);
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.addWriteStat(relativePartitionPath, writeStat);
+    java.nio.file.Path file = Files.createFile(basePath.resolve(Paths.get(".hoodie", commitNumber + ".commit")));
+    FileOutputStream fileOutputStream = new FileOutputStream(file.toAbsolutePath().toString());
+    fileOutputStream.write(commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8));
+    fileOutputStream.flush();
+    fileOutputStream.close();
+  }
+
+  private void createDeltaCommitFile(java.nio.file.Path basePath, String commitNumber, String partitionPath, HoodieLogFormat.Writer writer)
+          throws IOException {
+    HoodieWriteStat writeStat = generateFakeHoodieWriteStats(basePath, writer.getLogFile());
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.addWriteStat(partitionPath, writeStat);
+    java.nio.file.Path file = Files.createFile(basePath.resolve(Paths.get(".hoodie/", commitNumber + ".deltacommit")));
+    FileOutputStream fileOutputStream = new FileOutputStream(file.toAbsolutePath().toString());
+    fileOutputStream.write(commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8));
+    fileOutputStream.flush();
+    fileOutputStream.close();
+  }
+
+  private void testIncrementalQuery(String msg, String endCommitTime, Option<String> beginCommitTime,
+                                    int expectedNumberOfRecordsInCommit) throws IOException {
+    int actualCount = 0;
+    InputSplit[] splits = inputFormat.getSplits(jobConf, 1);
+    assertEquals(1, splits.length);
+    for (InputSplit split : splits) {
+      RecordReader<NullWritable, ArrayWritable> recordReader = inputFormat.getRecordReader(split, jobConf, null);
+      NullWritable key = recordReader.createKey();
+      ArrayWritable writable = recordReader.createValue();
+
+      while (recordReader.next(key, writable)) {
+        // writable returns an array with schema like org.apache.hudi.common.util.TestRecord.java
+        // Take the commit time and compare with the one we are interested in
+        Writable[] values = writable.get();
+        String commitTime = values[HOODIE_COMMIT_TIME_COL_POS].toString();
+        boolean endCommitTimeMatches = HoodieTimeline.compareTimestamps(endCommitTime, HoodieTimeline.GREATER_THAN_OR_EQUALS, commitTime);
+        boolean beginCommitTimeMatches = !beginCommitTime.isPresent() || HoodieTimeline.compareTimestamps(beginCommitTime.get(), HoodieTimeline.LESSER_THAN, commitTime);
+        assertTrue(beginCommitTimeMatches && endCommitTimeMatches);
+        actualCount++;
+      }
+    }
+    assertEquals(expectedNumberOfRecordsInCommit, actualCount, msg);
+  }
+
+  private void ensureRecordsInCommitRange(InputSplit split, String beginCommitTime, String endCommitTime, int totalExpected)
+          throws IOException {
+    int actualCount = 0;
+    assertTrue(split instanceof HoodieRealtimeFileSplit);
+    RecordReader<NullWritable, ArrayWritable> recordReader = inputFormat.getRecordReader(split, jobConf, null);
+    NullWritable key = recordReader.createKey();
+    ArrayWritable writable = recordReader.createValue();
+
+    while (recordReader.next(key, writable)) {
+      // writable returns an array with schema like org.apache.hudi.common.util.TestRecord.java
+      // Take the commit time and compare with the one we are interested in
+      Writable[] values = writable.get();
+      String commitTime = values[HOODIE_COMMIT_TIME_COL_POS].toString();
+
+      // The begin and end commits are inclusive
+      boolean endCommitTimeMatches = HoodieTimeline.compareTimestamps(endCommitTime, HoodieTimeline.GREATER_THAN_OR_EQUALS, commitTime);
+      boolean beginCommitTimeMatches = HoodieTimeline.compareTimestamps(beginCommitTime, HoodieTimeline.LESSER_THAN_OR_EQUALS, commitTime);
+      assertTrue(beginCommitTimeMatches && endCommitTimeMatches);
+      actualCount++;
+    }
+    assertEquals(totalExpected, actualCount, "Expected num of records(" + totalExpected + ") do not match "
+            + "actual number of records(" + actualCount + ") for the split: " + ((HoodieRealtimeFileSplit)split).toString());
+  }
+
+  @Test // Simple querying on MOR table. Does not test incremental querying.
+  public void testInputFormatLoadAndUpdate() throws IOException, InterruptedException {
+    prepareTestData();
+
+    InputSplit[] inputSplits = inputFormat.getSplits(jobConf, 1);
+    assertEquals(1, inputSplits.length);
+
+    FileStatus[]  files = inputFormat.listStatus(jobConf);
+    assertEquals(1, files.length);
+
+    /*
+     * Since the begin and end commits are included the expected number of records is same as numRecordsPerBaseFile
+     * as the records in log files are really updates for existing keys and are merged by the RecordReader
+     */
+    ensureRecordsInCommitRange(inputSplits[0], baseInstant2, deltaCommitTime5, numRecordsPerBaseFile);
+  }
+
+  @Test
+  public void testIncrementalWithNoNewCommits() throws IOException, InterruptedException {
+    prepareTestData();
+    InputFormatTestUtil.setupIncremental(jobConf, deltaCommitTime5, 1);
+    FileStatus[] files = inputFormat.listStatus(jobConf);
+    assertEquals(0, files.length, "We should exclude commit 202 when returning incremental pull with start commit time as 202");
+  }
+
+  @Test
+  public void testChangesSinceLastCommit() throws IOException, InterruptedException {
+    prepareTestData();
+
+    // query for latest changes since (deltaCommitTime4,] (meaning > deltaCommitTime4 and <= deltaCommitTime5)
+    InputFormatTestUtil.setupIncremental(jobConf, deltaCommitTime4, 1);
+
+    /*
+    * Since the begin commit is not included in incremental query, here the expected output is the num of records that
+    * were updated in the one log file belonging to deltaCommitTime5
+    */
+    testIncrementalQuery("Number of actual records from Incremental querying does not match expected: " + numberOfUniqueLogRecords,
+            deltaCommitTime5, Option.of(deltaCommitTime4), numberOfUniqueLogRecords);
+  }
+
+  @Test
+  public void testChangesHappenedInTimePeriod() throws IOException, InterruptedException {
+    prepareTestData();
+
+    // query for changes in the period (baseInstant1,deltaCommitTime2] (meaning > baseInstant1 and <= deltaCommitTime2)
+    InputFormatTestUtil.setupIncremental(jobConf, baseInstant1, 2);
+    /*
+    * Since the begin commit is not included in incremental query, here the expected output is the num of records that
+    * were updated in the two log files belonging to deltaCommitTime1 and deltaCommitTime2. And we set up test data
+    * such that the log records belong to unique record keys. This might not be true in real world
+    */
+    testIncrementalQuery("Number of actual records from Incremental querying does not match expected: " + numberOfUniqueLogRecords * 2,
+            deltaCommitTime2, Option.of(baseInstant1), numberOfUniqueLogRecords * 2);
+
+    // query for changes in the period (deltaCommitTime1,deltaCommitTime4] meaning > deltaCommitTime1 and <= deltaCommitTime4
+    InputFormatTestUtil.setupIncremental(jobConf, deltaCommitTime1, 4);
+    /*
+     * Here the expected output is the num of records that matches the filter in first and second file slices. From
+     * first file slice records updated as part of deltaCommitTime2 and deltaCommitTime3 are considered
+     * (this would be 2 * 25 = 50 unique updates). From second file slice base file (75 records) and updates belonging to
+     * deltaCommitTime4 (25 updates to the baseInstant 2) would be considered. In total expected match would be 75 since
+     * the base file is the superset of all unique record keys and others are all updates.
+     */
+    testIncrementalQuery("Number of actual records from Incremental querying does not match expected: " + numRecordsPerBaseFile,
+            deltaCommitTime4, Option.of(deltaCommitTime1), numRecordsPerBaseFile);
+  }
+}

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/testutils/InputFormatTestUtil.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/testutils/InputFormatTestUtil.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 
 public class InputFormatTestUtil {
 
-  private static String TEST_WRITE_TOKEN = "1-0-1";
+  public static String TEST_WRITE_TOKEN = "1-0-1";
 
   public static File prepareTable(java.nio.file.Path basePath, HoodieFileFormat baseFileFormat, int numberOfFiles,
                                   String commitNumber)


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
This commit addresses two issues:
      1. Honors end time if less than the most recent completed commit time
      2. Doesnt require a base parquet file to be present in case when the begin and end times match only the the deltacommits.

    To achieve this:
    - Created a seperate FileSplit for handling incremental queries
    - New RecordReader to handle the new FileSplit
    - FileSlice Scanner to scan files in a File Slice. First takes base parquet file (if present) and applies merged records from all log files in that slice. If base file is not present returns merged records from log files on scanning
    - HoodieParquetRealtimeInputFormat modified to switch to this HoodieMORIncrementalFileSplit and HoodieMORIncrementalRecordReader from getSplit(..) and getRecordReader(..) in case of incremental queries.
    - Includes unit test to test different incremental queries
*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Pending action items before moving to full PR
- Noted a bunch of TODOs. will try to resolve them.
- Still working on testing this fix in an integrated environment. in the process, I plan to test in Docker Demo setup  that provides testing across all query engines.
- Needs changes to HoodieCombinedInputFormat
- May need changes in Spark as well. 

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*


## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.