### PR TITLE
[HUDI-1087] Handle decimal type for realtime record reader with SparkSQL

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.HiveDecimalUtils;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.BytesWritable;
@@ -210,9 +212,8 @@ public class HoodieRealtimeRecordReaderUtils {
           LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) LogicalTypes.fromSchema(schema);
           HiveDecimalWritable writable = new HiveDecimalWritable(((GenericFixed) value).bytes(),
               decimal.getScale());
-          return HiveDecimalWritable.enforcePrecisionScale(writable,
-              decimal.getPrecision(),
-              decimal.getScale());
+          return HiveDecimalUtils.enforcePrecisionScale(writable,
+              new DecimalTypeInfo(decimal.getPrecision(), decimal.getScale()));
         }
         return new BytesWritable(((GenericFixed) value).bytes());
       default:


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

JIRA https://issues.apache.org/jira/browse/HUDI-1087  
ISSUE https://github.com/apache/hudi/issues/1790

This [pr](https://github.com/apache/hudi/pull/1677/files) calls ```HiveDecimalWritable.enforcePrecisionScale``` to handle decimal type for Hive realtime querying. But ```HiveDecimalWritable.enforcePrecisionScale``` is only available for Hive 2.x, so when using SparkSQL (which uses ```1.2.1.spark2``` version), it will throw a ```methodNotFound``` error.    

This PR replaces ```HiveDecimalWritable.enforcePrecisionScale``` with ```HiveDecimalUtils.enforcePrecisionScale``` which is compatible with both Hive 2.x and Hive 1.2.1.spark2.

## Brief change log

- Replaced ```HiveDecimalWritable.enforcePrecisionScale``` with ```HiveDecimalUtils.enforcePrecisionScale``` which is compatible with both Hive 2.x and Hive 1.2.1.spark2.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.