### PR TITLE
[WIP] Externalize test classes' configs

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -81,7 +81,6 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
   public static final String HBASE_TABLENAME_PROP = "hoodie.index.hbase.table";
   public static final String HBASE_GET_BATCH_SIZE_PROP = "hoodie.index.hbase.get.batch.size";
   public static final String HBASE_PUT_BATCH_SIZE_PROP = "hoodie.index.hbase.put.batch.size";
-  public static final String DEFAULT_HBASE_BATCH_SIZE = "100";
 
 
   public static final String BLOOM_INDEX_INPUT_STORAGE_LEVEL = "hoodie.bloom.index.input.storage.level";
@@ -114,6 +113,7 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
   public static class Builder {
 
     private final Properties props = new Properties();
+    private boolean isHBaseIndexConfigSet = false;
 
     public Builder fromFile(File propertiesFile) throws IOException {
       try (FileReader reader = new FileReader(propertiesFile)) {
@@ -139,6 +139,7 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
 
     public Builder withHBaseIndexConfig(HoodieHBaseIndexConfig hBaseIndexConfig) {
       props.putAll(hBaseIndexConfig.getProps());
+      isHBaseIndexConfigSet = true;
       return this;
     }
 
@@ -274,6 +275,7 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
           DEFAULT_GLOBAL_SIMPLE_INDEX_PARALLELISM);
       setDefaultOnCondition(props, !props.containsKey(SIMPLE_INDEX_UPDATE_PARTITION_PATH),
           SIMPLE_INDEX_UPDATE_PARTITION_PATH, DEFAULT_SIMPLE_INDEX_UPDATE_PARTITION_PATH);
+      setDefaultOnCondition(props, !isHBaseIndexConfigSet, HoodieHBaseIndexConfig.newBuilder().fromProperties(props).build());
       // Throws IllegalArgumentException if the value set is not a known Hoodie Index Type
       HoodieIndex.IndexType.valueOf(props.getProperty(INDEX_TYPE_PROP));
       return config;

--- a/hudi-client/src/test/java/org/apache/hudi/testutils/FunctionalTestHarness.java
+++ b/hudi-client/src/test/java/org/apache/hudi/testutils/FunctionalTestHarness.java
@@ -24,6 +24,7 @@ import org.apache.hudi.client.HoodieWriteClient;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.ResourcesUtils;
 import org.apache.hudi.common.testutils.minicluster.HdfsTestService;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
@@ -120,6 +121,17 @@ public class FunctionalTestHarness implements SparkProvider, DFSProvider, Hoodie
   @Override
   public HoodieWriteClient getHoodieWriteClient(HoodieWriteConfig cfg) throws IOException {
     return new HoodieWriteClient(jsc, cfg, false, HoodieIndex.createIndex(cfg));
+  }
+
+  public HoodieWriteConfig getHoodieWriteConfig() {
+    return getHoodieWriteConfig(new Properties());
+  }
+
+  @Override
+  public HoodieWriteConfig getHoodieWriteConfig(Properties overwritingProps) {
+    Properties props = ResourcesUtils.getPropsForClass(getClass());
+    props.putAll(overwritingProps);
+    return new HoodieWriteConfig.Builder().withProps(props).build();
   }
 
   @BeforeEach

--- a/hudi-client/src/test/resources/org/apache/hudi/index/hbase/TestHBaseIndex.properties
+++ b/hudi-client/src/test/resources/org/apache/hudi/index/hbase/TestHBaseIndex.properties
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# HoodieWriteConfig
+hoodie.auto.commit=false
+hoodie.avro.schema=
+hoodie.base.path=/tmp
+hoodie.table.name=test-trip-table
+hoodie.insert.shuffle.parallelism=1
+hoodie.upsert.shuffle.parallelism=1
+# HoodieStorageConfig
+hoodie.parquet.max.file.size=1048576
+# HoodieIndexConfig
+hoodie.index.type=HBASE
+hoodie.index.hbase.table=test_table
+hoodie.index.hbase.zknode.path=/hudi-hbase-test
+hoodie.index.hbase.zkquorum=localhost
+hoodie.index.hbase.zkport=2181
+hoodie.index.hbase.put.batch.size.autocompute=true
+hoodie.index.hbase.get.batch.size=100
+# HoodieCompactionConfig
+hoodie.compact.inline=false
+hoodie.parquet.small.file.limit=1048576

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/ResourcesUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/ResourcesUtils.java
@@ -17,17 +17,23 @@
  * under the License.
  */
 
-package org.apache.hudi.testutils.providers;
-
-import org.apache.hudi.client.HoodieWriteClient;
-import org.apache.hudi.config.HoodieWriteConfig;
+package org.apache.hudi.common.testutils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
-public interface HoodieWriteClientProvider {
+public final class ResourcesUtils {
 
-  HoodieWriteClient getHoodieWriteClient(HoodieWriteConfig cfg) throws IOException;
-
-  HoodieWriteConfig getHoodieWriteConfig(Properties overwritingProps) throws IOException;
+  public static Properties getPropsForClass(Class<?> cls) {
+    Properties props = new Properties();
+    try {
+      String propsFileName = String.format("/%s.properties", cls.getName().replaceAll("\\.", "/"));
+      InputStream inputStream = cls.getResourceAsStream(propsFileName);
+      props.load(inputStream);
+    } catch (IOException e) {
+      throw new RuntimeException("Properties file not found in resources/ for class: " + cls.getName(), e);
+    }
+    return props;
+  }
 }


### PR DESCRIPTION
- Move getConfig() to properties
- Use common method to load configs for individual test class

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.