### PR TITLE
[WIP] [HUDI-1072] Use replace metadata file to filter excluded files in views

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.io;
 
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -40,10 +42,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -206,6 +211,40 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
 
     // verify in-flight instants after archive
     verifyInflightInstants(metaClient, 2);
+  }
+
+  @Test
+  public void testArchiveTableWithReplacedFiles() throws IOException {
+    HoodieTestUtils.init(hadoopConf, basePath);
+    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2).forTable("test-trip-table")
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder().retainCommits(1).archiveCommitsWith(2, 3).build())
+        .build();
+
+    int numCommits = 4;
+    int commitInstant = 100;
+    for (int i = 0; i < numCommits; i++) {
+      createCommitAndReplaceMetadata(commitInstant);
+      commitInstant += 100;
+    }
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+    assertEquals(4, timeline.countInstants(), "Loaded 4 commits and the count should match");
+    HoodieTimelineArchiveLog archiveLog = new HoodieTimelineArchiveLog(cfg, metaClient);
+    boolean result = archiveLog.archiveIfRequired(hadoopConf);
+    assertTrue(result);
+
+    FileStatus[] allFiles = metaClient.getFs().listStatus(new Path(basePath + "/" + HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH));
+    Set<String> allFileIds = Arrays.stream(allFiles).map(fs -> FSUtils.getFileIdFromFilePath(fs.getPath())).collect(Collectors.toSet());
+
+    // verify 100-1,200-1 are deleted by archival
+    assertFalse(allFileIds.contains("file-100-1"));
+    assertFalse(allFileIds.contains("file-200-1"));
+    assertTrue(allFileIds.contains("file-100-2"));
+    assertTrue(allFileIds.contains("file-200-2"));
+    assertTrue(allFileIds.contains("file-300-1"));
+    assertTrue(allFileIds.contains("file-400-1"));
   }
 
   @Test
@@ -429,5 +468,20 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
 
     org.apache.hudi.avro.model.HoodieCommitMetadata expectedCommitMetadata = archiveLog.convertCommitMetadata(hoodieCommitMetadata);
     assertEquals(expectedCommitMetadata.getOperationType(), WriteOperationType.INSERT.toString());
+  }
+
+  private void createCommitAndReplaceMetadata(int commitInstant) throws IOException {
+    String commitTime = "" + commitInstant;
+    String fileId1 = "file-" + commitInstant + "-1";
+    String fileId2 = "file-" + commitInstant + "-2";
+
+    // create replace instant to mark fileId1 as deleted
+    Map<String, List<String>> partitionToReplaceFiles = new HashMap<>();
+    partitionToReplaceFiles.putIfAbsent(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, new ArrayList<>());
+    partitionToReplaceFiles.get(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH).add(fileId1);
+    HoodieTestUtils.createReplaceInstant(partitionToReplaceFiles, commitTime, metaClient);
+    HoodieTestDataGenerator.createCommitFile(basePath, commitTime, dfs.getConf());
+    HoodieTestDataGenerator.createDataFile(basePath, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, commitTime, fileId1, dfs.getConf());
+    HoodieTestDataGenerator.createDataFile(basePath, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, commitTime, fileId2, dfs.getConf());
   }
 }

--- a/hudi-client/src/test/java/org/apache/hudi/testutils/HoodieTestDataGenerator.java
+++ b/hudi-client/src/test/java/org/apache/hudi/testutils/HoodieTestDataGenerator.java
@@ -365,6 +365,14 @@ public class HoodieTestDataGenerator {
     createEmptyFile(basePath, commitFile, configuration);
   }
 
+  public static void createDataFile(String basePath, String partitionPath, String instantTime, String fileID, Configuration configuration)
+      throws IOException {
+
+    Path dataFilePath = new Path(basePath + "/" + partitionPath + "/"
+        + FSUtils.makeDataFileName(instantTime, "1_0_1", fileID));
+    createEmptyFile(basePath, dataFilePath, configuration);
+  }
+
   private static void createEmptyFile(String basePath, Path filePath, Configuration configuration) throws IOException {
     FileSystem fs = FSUtils.getFs(basePath, configuration);
     FSDataOutputStream os = fs.create(filePath, true);

--- a/hudi-common/src/main/avro/HoodieReplaceMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieReplaceMetadata.avsc
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+  * Note that all 'replace' instants are read for every query
+  * So it is important to keep this small. Please be careful
+  * before tracking additional information in this file.
+  * This will be used for 'insert_overwrite' (RFC-18) and also 'clustering' (RFC-19)
+  */
+{"namespace": "org.apache.hudi.avro.model",
+ "type": "record",
+ "name": "HoodieReplaceMetadata",
+ "fields": [
+     {"name": "totalFileGroupsReplaced", "type": "int"},
+     {"name": "command", "type": "string"},
+     {"name": "partitionMetadata", "type": {
+     "type" : "map", "values" : {
+        "type": "array",
+        "items": "string"
+     }
+     }
+     },
+     {
+        "name":"version",
+        "type":["int", "null"],
+        "default": 1
+     }
+ ]
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -65,7 +65,8 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION, DELTA_COMMIT_EXTENSION,
       INFLIGHT_DELTA_COMMIT_EXTENSION, REQUESTED_DELTA_COMMIT_EXTENSION, SAVEPOINT_EXTENSION,
       INFLIGHT_SAVEPOINT_EXTENSION, CLEAN_EXTENSION, REQUESTED_CLEAN_EXTENSION, INFLIGHT_CLEAN_EXTENSION,
-      INFLIGHT_COMPACTION_EXTENSION, REQUESTED_COMPACTION_EXTENSION, INFLIGHT_RESTORE_EXTENSION, RESTORE_EXTENSION));
+      INFLIGHT_COMPACTION_EXTENSION, REQUESTED_COMPACTION_EXTENSION, INFLIGHT_RESTORE_EXTENSION, RESTORE_EXTENSION,
+      INFLIGHT_REPLACE_EXTENSION, REPLACE_EXTENSION));
 
   private static final Logger LOG = LogManager.getLogger(HoodieActiveTimeline.class);
   protected HoodieTableMetaClient metaClient;
@@ -302,6 +303,22 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     HoodieInstant inflight = new HoodieInstant(State.INFLIGHT, CLEAN_ACTION, requestedInstant.getTimestamp());
     transitionState(requestedInstant, inflight, data);
     return inflight;
+  }
+
+  /**
+   * Transition Clean State from inflight to Committed.
+   *
+   * @param inflightInstant Inflight instant
+   * @param data Extra Metadata
+   * @return commit instant
+   */
+  public HoodieInstant transitionReplaceInflightToComplete(HoodieInstant inflightInstant, Option<byte[]> data) {
+    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.REPLACE_ACTION));
+    ValidationUtils.checkArgument(inflightInstant.isInflight());
+    HoodieInstant commitInstant = new HoodieInstant(State.COMPLETED, REPLACE_ACTION, inflightInstant.getTimestamp());
+    // Then write to timeline
+    transitionState(inflightInstant, commitInstant, data);
+    return commitInstant;
   }
 
   private void transitionState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -114,6 +114,24 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieDefaultTimeline getCommitsReplaceAndCompactionTimeline() {
+    Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, REPLACE_ACTION);
+    return new HoodieDefaultTimeline(instants.stream().filter(s -> validActions.contains(s.getAction())), details);
+  }
+
+  @Override
+  public HoodieTimeline getCompletedAndReplaceTimeline() {
+    Set<String> commitActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION);
+    Set<String> validCommitTimes = instants.stream().filter(s -> s.isCompleted())
+        .filter(s -> commitActions.contains(s.getAction()))
+        .map(s -> s.getTimestamp()).collect(Collectors.toSet());
+
+    return new HoodieDefaultTimeline(instants.stream().filter(s -> s.getAction().equals(REPLACE_ACTION))
+        .filter(s -> s.isCompleted())
+        .filter(instant -> validCommitTimes.contains(instant.getTimestamp())), details);
+  }
+
+  @Override
   public HoodieTimeline filterPendingCompactionTimeline() {
     return new HoodieDefaultTimeline(
         instants.stream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), details);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -162,6 +162,9 @@ public class HoodieInstant implements Serializable, Comparable<HoodieInstant> {
     } else if (HoodieTimeline.RESTORE_ACTION.equals(action)) {
       return isInflight() ? HoodieTimeline.makeInflightRestoreFileName(timestamp)
           : HoodieTimeline.makeRestoreFileName(timestamp);
+    } else if (HoodieTimeline.REPLACE_ACTION.equals(action)) {
+      return isInflight() ? HoodieTimeline.makeInflightReplaceFileName(timestamp)
+          : HoodieTimeline.makeReplaceFileName(timestamp);
     }
     throw new IllegalArgumentException("Cannot get file name for unknown action " + action);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -48,6 +48,7 @@ public interface HoodieTimeline extends Serializable {
   String CLEAN_ACTION = "clean";
   String ROLLBACK_ACTION = "rollback";
   String SAVEPOINT_ACTION = "savepoint";
+  String REPLACE_ACTION = "replace";
   String INFLIGHT_EXTENSION = ".inflight";
   // With Async Compaction, compaction instant can be in 3 states :
   // (compaction-requested), (compaction-inflight), (completed)
@@ -57,7 +58,7 @@ public interface HoodieTimeline extends Serializable {
 
   String[] VALID_ACTIONS_IN_TIMELINE = {COMMIT_ACTION, DELTA_COMMIT_ACTION,
       CLEAN_ACTION, SAVEPOINT_ACTION, RESTORE_ACTION, ROLLBACK_ACTION,
-      COMPACTION_ACTION};
+      COMPACTION_ACTION, REPLACE_ACTION};
 
   String COMMIT_EXTENSION = "." + COMMIT_ACTION;
   String DELTA_COMMIT_EXTENSION = "." + DELTA_COMMIT_ACTION;
@@ -78,6 +79,8 @@ public interface HoodieTimeline extends Serializable {
   String INFLIGHT_COMPACTION_EXTENSION = StringUtils.join(".", COMPACTION_ACTION, INFLIGHT_EXTENSION);
   String INFLIGHT_RESTORE_EXTENSION = "." + RESTORE_ACTION + INFLIGHT_EXTENSION;
   String RESTORE_EXTENSION = "." + RESTORE_ACTION;
+  String INFLIGHT_REPLACE_EXTENSION = "." + REPLACE_ACTION + INFLIGHT_EXTENSION;
+  String REPLACE_EXTENSION = "." + REPLACE_ACTION;
 
   String INVALID_INSTANT_TS = "0";
 
@@ -125,6 +128,21 @@ public interface HoodieTimeline extends Serializable {
    * @return
    */
   HoodieTimeline getCommitsAndCompactionTimeline();
+
+  /**
+   * Timeline to just include commits (commit/deltacommit), replace and compaction actions.
+   *
+   * @return
+   */
+  HoodieDefaultTimeline getCommitsReplaceAndCompactionTimeline();
+
+
+  /**
+   * Timeline to just include replace instants that have valid (commit/deltacommit) actions.
+   *
+   * @return
+   */
+  HoodieTimeline getCompletedAndReplaceTimeline();
 
   /**
    * Filter this timeline to just include requested and inflight compaction instants.
@@ -346,6 +364,14 @@ public interface HoodieTimeline extends Serializable {
 
   static String makeInflightRestoreFileName(String instant) {
     return StringUtils.join(instant, HoodieTimeline.INFLIGHT_RESTORE_EXTENSION);
+  }
+
+  static String makeReplaceFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REPLACE_EXTENSION);
+  }
+
+  static String makeInflightReplaceFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_REPLACE_EXTENSION);
   }
 
   static String makeDeltaFileName(String instantTime) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.timeline;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieReplaceMetadata;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
@@ -109,6 +110,10 @@ public class TimelineMetadataUtils {
     return serializeAvroMetadata(restoreMetadata, HoodieRestoreMetadata.class);
   }
 
+  public static Option<byte[]> serializeReplaceMetadata(HoodieReplaceMetadata metadata) throws IOException {
+    return serializeAvroMetadata(metadata, HoodieReplaceMetadata.class);
+  }
+
   public static <T extends SpecificRecordBase> Option<byte[]> serializeAvroMetadata(T metadata, Class<T> clazz)
       throws IOException {
     DatumWriter<T> datumWriter = new SpecificDatumWriter<>(clazz);
@@ -138,6 +143,10 @@ public class TimelineMetadataUtils {
 
   public static HoodieSavepointMetadata deserializeHoodieSavepointMetadata(byte[] bytes) throws IOException {
     return deserializeAvroMetadata(bytes, HoodieSavepointMetadata.class);
+  }
+
+  public static HoodieReplaceMetadata deserializeHoodieReplaceMetadata(byte[] bytes) throws IOException {
+    return deserializeAvroMetadata(bytes, HoodieReplaceMetadata.class);
   }
 
   public static <T extends SpecificRecordBase> T deserializeAvroMetadata(byte[] bytes, Class<T> clazz)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -34,8 +34,10 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,6 +54,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
 
   // mapping from partition paths to file groups contained within them
   protected Map<String, List<HoodieFileGroup>> partitionToFileGroupsMap;
+  protected Map<String, Set<String>> partitionToExcludeFileGroupsMap;
 
   /**
    * PartitionPath + File-Id to pending compaction instant time.
@@ -86,6 +89,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   @Override
   public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline) {
     this.partitionToFileGroupsMap = createPartitionToFileGroups();
+    this.partitionToExcludeFileGroupsMap = createPartitionToExcludeFileGroups();
     super.init(metaClient, visibleActiveTimeline);
   }
 
@@ -99,9 +103,14 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   protected void resetViewState() {
     this.fgIdToPendingCompaction = null;
     this.partitionToFileGroupsMap = null;
+    this.partitionToExcludeFileGroupsMap = null;
   }
 
   protected Map<String, List<HoodieFileGroup>> createPartitionToFileGroups() {
+    return new ConcurrentHashMap<>();
+  }
+
+  protected Map<String, Set<String>> createPartitionToExcludeFileGroups() {
     return new ConcurrentHashMap<>();
   }
 
@@ -203,8 +212,24 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   }
 
   @Override
+  protected void storePartitionExcludedFiles(final String partition, final Set<String> fileIdsToExclude) {
+    LOG.info("Ignore file-ids for partition :" + partition + ", #FileGroups=" + fileIdsToExclude.size());
+    partitionToExcludeFileGroupsMap.put(partition, fileIdsToExclude);
+  }
+
+  @Override
   public Stream<HoodieFileGroup> fetchAllStoredFileGroups() {
     return partitionToFileGroupsMap.values().stream().flatMap(Collection::stream);
+  }
+
+  @Override
+  public boolean isExcludeFileGroup(String partitionPath, String fileId) {
+    return partitionToExcludeFileGroupsMap.getOrDefault(partitionPath, Collections.emptySet()).contains(fileId);
+  }
+
+  @Override
+  public Stream<String> getAllExcludeFileGroups(String partitionPath) {
+    return partitionToExcludeFileGroupsMap.getOrDefault(partitionPath, Collections.emptySet()).stream();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/PriorityBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/PriorityBasedFileSystemView.java
@@ -194,6 +194,11 @@ public class PriorityBasedFileSystemView implements SyncableFileSystemView, Seri
   }
 
   @Override
+  public Stream<String> getAllExcludeFileGroups(final String partitionPath) {
+    return execute(partitionPath, preferredView::getAllExcludeFileGroups, secondaryView::getAllExcludeFileGroups);
+  }
+
+  @Override
   public Stream<Pair<String, CompactionOperation>> getPendingCompactionOperations() {
     return execute(preferredView::getPendingCompactionOperations, secondaryView::getPendingCompactionOperations);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -18,6 +18,11 @@
 
 package org.apache.hudi.common.table.view;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.hudi.common.model.CompactionOperation;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -36,12 +41,6 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieRemoteException;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.client.fluent.Request;
-import org.apache.http.client.fluent.Response;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -86,6 +85,9 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
   public static final String ALL_FILEGROUPS_FOR_PARTITION_URL =
       String.format("%s/%s", BASE_URL, "filegroups/all/partition/");
+
+  public static final String ALL_EXCLUDE_FILEGROUPS_FOR_PARTITION_URL =
+      String.format("%s/%s", BASE_URL, "filegroups/exclude/partition/");
 
   public static final String LAST_INSTANT = String.format("%s/%s", BASE_URL, "timeline/instant/last");
   public static final String LAST_INSTANTS = String.format("%s/%s", BASE_URL, "timeline/instants/last");
@@ -350,6 +352,18 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
       List<FileGroupDTO> fileGroups = executeRequest(ALL_FILEGROUPS_FOR_PARTITION_URL, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
       return fileGroups.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient));
+    } catch (IOException e) {
+      throw new HoodieRemoteException(e);
+    }
+  }
+
+  @Override
+  public Stream<String> getAllExcludeFileGroups(final String partitionPath) {
+    Map<String, String> paramsMap = getParamsWithPartitionPath(partitionPath);
+    try {
+      List<String> fileGroups = executeRequest(ALL_EXCLUDE_FILEGROUPS_FOR_PARTITION_URL, paramsMap,
+          new TypeReference<List<String>>() {}, RequestMethod.GET);
+      return fileGroups.stream();
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -74,6 +75,13 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  protected Map<String, Set<String>> createPartitionToExcludeFileGroups() {
+    // TODO should we create another spillable directory under baseStoreDir?
+    // the exclude file group is expected to be small, so use parent class in-memory representation
+    return super.createPartitionToExcludeFileGroups();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/TableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/TableFileSystemView.java
@@ -148,6 +148,9 @@ public interface TableFileSystemView {
    */
   Stream<HoodieFileGroup> getAllFileGroups(String partitionPath);
 
+  Stream<String> getAllExcludeFileGroups(String partitionPath);
+
+
   /**
    * Return Pending Compaction Operations.
    *

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieActionInstant;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieReplaceMetadata;
 import org.apache.hudi.common.HoodieCleanStat;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
@@ -203,6 +204,21 @@ public class HoodieTestUtils {
       new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline.makeInflightCommitFileName(
           instantTime)).createNewFile();
     }
+  }
+
+  public static void createReplaceInstant(Map<String, List<String>> partitionToReplaceFiles,
+                                          String instantTime,
+                                          HoodieTableMetaClient metaClient) throws IOException {
+    HoodieReplaceMetadata replaceMetadata = new HoodieReplaceMetadata();
+    replaceMetadata.setVersion(1);
+    replaceMetadata.setPartitionMetadata(partitionToReplaceFiles);
+    replaceMetadata.setTotalFileGroupsReplaced(1);
+    replaceMetadata.setCommand("test");
+
+    HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
+    HoodieInstant replaceInstant = new HoodieInstant(true, HoodieTimeline.REPLACE_ACTION, instantTime);
+    commitTimeline.createNewInstant(replaceInstant);
+    commitTimeline.transitionReplaceInflightToComplete(replaceInstant, TimelineMetadataUtils.serializeReplaceMetadata(replaceMetadata));
   }
 
   public static void createPendingCleanFiles(HoodieTableMetaClient metaClient, String... instantTimes) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestSerializationUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestSerializationUtils.java
@@ -19,12 +19,23 @@
 package org.apache.hudi.common.util;
 
 import org.apache.avro.util.Utf8;
+import org.apache.hudi.avro.model.HoodieReplaceMetadata;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.junit.jupiter.api.Test;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -50,6 +61,38 @@ public class TestSerializationUtils {
     verifyObject(new Utf8("test-key"));
     // Verify serialization of list.
     verifyObject(new LinkedList<>(Arrays.asList(2, 3, 5)));
+  }
+
+  @Test
+  public void testSerDeserReplaceMetadata() throws Exception {
+    Random  r = new Random();
+    int numPartitions = 1;
+    HoodieReplaceMetadata replaceMetadata = new HoodieReplaceMetadata();
+    int numFiles = 30;
+    Map<String, List<String>> partitionToReplaceFileId = new HashMap<>();
+
+    for (int i = 0; i < numFiles; i++) {
+      int partition = r.nextInt(numPartitions);
+      String partitionStr = "2020/07/0" + partition;
+      partitionToReplaceFileId.putIfAbsent(partitionStr, new ArrayList<>());
+      partitionToReplaceFileId.get(partitionStr).add(FSUtils.createNewFileIdPfx());
+    }
+    String command = "clustering";
+    replaceMetadata.setVersion(1);
+    replaceMetadata.setTotalFileGroupsReplaced(numFiles);
+    replaceMetadata.setCommand(command);
+    replaceMetadata.setPartitionMetadata(partitionToReplaceFileId);
+    String filePath = "/tmp/myreplacetest";
+    byte[] data = TimelineMetadataUtils.serializeReplaceMetadata(replaceMetadata).get();
+    FileOutputStream fos = new FileOutputStream(filePath);
+    fos.write(data);
+    fos.close();
+
+    data = Files.readAllBytes(Paths.get(filePath));
+    HoodieReplaceMetadata replaceMetadataD = TimelineMetadataUtils.deserializeHoodieReplaceMetadata(data);
+    assertEquals(replaceMetadataD.getTotalFileGroupsReplaced(), numFiles);
+    assertEquals(command, replaceMetadataD.getCommand());
+    assertEquals(partitionToReplaceFileId, replaceMetadataD.getPartitionMetadata());
   }
 
   private <T> void verifyObject(T expectedValue) throws IOException {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/FileSystemViewHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/FileSystemViewHandler.java
@@ -284,6 +284,13 @@ public class FileSystemViewHandler {
       writeValueAsString(ctx, dtos);
     }, true));
 
+    app.get(RemoteHoodieTableFileSystemView.ALL_EXCLUDE_FILEGROUPS_FOR_PARTITION_URL, new ViewHandler(ctx -> {
+      List<String> excludeFileGroups = sliceHandler.getExcludeFileGroups(
+          ctx.validatedQueryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM).getOrThrow(),
+          ctx.queryParam(RemoteHoodieTableFileSystemView.PARTITION_PARAM,""));
+      writeValueAsString(ctx, excludeFileGroups);
+    }, true));
+
     app.post(RemoteHoodieTableFileSystemView.REFRESH_TABLE, new ViewHandler(ctx -> {
       boolean success = sliceHandler
           .refreshTable(ctx.validatedQueryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM).getOrThrow());

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
@@ -89,6 +89,10 @@ public class FileSliceHandler extends Handler {
         .collect(Collectors.toList());
   }
 
+  public List<String> getExcludeFileGroups(String basePath, String partitionPath) {
+    return viewManager.getFileSystemView(basePath).getAllExcludeFileGroups(partitionPath).collect(Collectors.toList());
+  }
+
   public boolean refreshTable(String basePath) {
     viewManager.clearFileSystemView(basePath);
     return true;


### PR DESCRIPTION


## What is the purpose of the pull request
Follow up on #1853 
Use metadata and filter excluded files from views.

Changed base views. If general approach looks good, I can update RocksDB and spillable view implementations

## Brief change log
Add new methods in Abstract view to filter files excluded by replace commits

## Verify this pull request
Added unit tests

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.