### PR TITLE
[HUDI-808] Support cleaning bootstrap source data

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -53,7 +53,7 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
   public static final String MIN_COMMITS_TO_KEEP_PROP = "hoodie.keep.min.commits";
   public static final String COMMITS_ARCHIVAL_BATCH_SIZE_PROP = "hoodie.commits.archival.batch";
   // Set true to clean bootstrap source files when necessary
-  public static final String CLEANER_BOOTSTRAP_BASE_FILE_ENABLED = "hoodie.cleaner.bootstrap.base.file";
+  public static final String CLEANER_BOOTSTRAP_BASE_FILE_ENABLED = "hoodie.cleaner.delete.bootstrap.base.file";
   // Upsert uses this file size to compact new data onto existing files..
   public static final String PARQUET_SMALL_FILE_LIMIT_BYTES = "hoodie.parquet.small.file.limit";
   // By default, treat any file <= 100MB as a small file.

--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -52,6 +52,8 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
   public static final String MAX_COMMITS_TO_KEEP_PROP = "hoodie.keep.max.commits";
   public static final String MIN_COMMITS_TO_KEEP_PROP = "hoodie.keep.min.commits";
   public static final String COMMITS_ARCHIVAL_BATCH_SIZE_PROP = "hoodie.commits.archival.batch";
+  // Set true to clean bootstrap source files when necessary
+  public static final String CLEANER_BOOTSTRAP_BASE_FILE_ENABLED = "hoodie.cleaner.bootstrap.base.file";
   // Upsert uses this file size to compact new data onto existing files..
   public static final String PARQUET_SMALL_FILE_LIMIT_BYTES = "hoodie.parquet.small.file.limit";
   // By default, treat any file <= 100MB as a small file.
@@ -112,6 +114,7 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
   private static final String DEFAULT_MAX_COMMITS_TO_KEEP = "30";
   private static final String DEFAULT_MIN_COMMITS_TO_KEEP = "20";
   private static final String DEFAULT_COMMITS_ARCHIVAL_BATCH_SIZE = String.valueOf(10);
+  private static final String DEFAULT_CLEANER_BOOTSTRAP_BASE_FILE_ENABLED = "false";
   public static final String TARGET_PARTITIONS_PER_DAYBASED_COMPACTION_PROP =
       "hoodie.compaction.daybased.target.partitions";
   // 500GB of target IO per compaction (both read and write)
@@ -252,6 +255,11 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder withCleanBootstrapBaseFileEnabled(Boolean cleanBootstrapSourceFileEnabled) {
+      props.setProperty(CLEANER_BOOTSTRAP_BASE_FILE_ENABLED, String.valueOf(cleanBootstrapSourceFileEnabled));
+      return this;
+    }
+
     public HoodieCompactionConfig build() {
       HoodieCompactionConfig config = new HoodieCompactionConfig(props);
       setDefaultOnCondition(props, !props.containsKey(AUTO_CLEAN_PROP), AUTO_CLEAN_PROP, DEFAULT_AUTO_CLEAN);
@@ -298,6 +306,8 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
           TARGET_PARTITIONS_PER_DAYBASED_COMPACTION_PROP, DEFAULT_TARGET_PARTITIONS_PER_DAYBASED_COMPACTION);
       setDefaultOnCondition(props, !props.containsKey(COMMITS_ARCHIVAL_BATCH_SIZE_PROP),
           COMMITS_ARCHIVAL_BATCH_SIZE_PROP, DEFAULT_COMMITS_ARCHIVAL_BATCH_SIZE);
+      setDefaultOnCondition(props, !props.containsKey(CLEANER_BOOTSTRAP_BASE_FILE_ENABLED),
+          CLEANER_BOOTSTRAP_BASE_FILE_ENABLED, DEFAULT_CLEANER_BOOTSTRAP_BASE_FILE_ENABLED);
 
       HoodieCleaningPolicy.valueOf(props.getProperty(CLEANER_POLICY_PROP));
 

--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -369,6 +369,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
     return Integer.parseInt(props.getProperty(HoodieCompactionConfig.COMMITS_ARCHIVAL_BATCH_SIZE_PROP));
   }
 
+  public Boolean shouldCleanBootstrapBaseFile() {
+    return Boolean.valueOf(props.getProperty(HoodieCompactionConfig.CLEANER_BOOTSTRAP_BASE_FILE_ENABLED));
+  }
+
   /**
    * index properties.
    */

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/clean/PartitionCleanStat.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/clean/PartitionCleanStat.java
@@ -28,21 +28,36 @@ class PartitionCleanStat implements Serializable {
   private final List<String> deletePathPatterns = new ArrayList<>();
   private final List<String> successDeleteFiles = new ArrayList<>();
   private final List<String> failedDeleteFiles = new ArrayList<>();
+  private final List<String> deleteBootstrapBasePathPatterns = new ArrayList<>();
+  private final List<String> successfulDeleteBootstrapBaseFiles = new ArrayList<>();
+  private final List<String> failedDeleteBootstrapBaseFiles = new ArrayList<>();
 
   PartitionCleanStat(String partitionPath) {
     this.partitionPath = partitionPath;
   }
 
-  void addDeletedFileResult(String deletePathStr, Boolean deletedFileResult) {
-    if (deletedFileResult) {
-      successDeleteFiles.add(deletePathStr);
+  void addDeletedFileResult(String deletePathStr, boolean success, boolean isBootstrapBasePath) {
+    if (success) {
+      if (isBootstrapBasePath) {
+        successfulDeleteBootstrapBaseFiles.add(deletePathStr);
+      } else {
+        successDeleteFiles.add(deletePathStr);
+      }
     } else {
-      failedDeleteFiles.add(deletePathStr);
+      if (isBootstrapBasePath) {
+        failedDeleteBootstrapBaseFiles.add(deletePathStr);
+      } else {
+        failedDeleteFiles.add(deletePathStr);
+      }
     }
   }
 
-  void addDeleteFilePatterns(String deletePathStr) {
-    deletePathPatterns.add(deletePathStr);
+  void addDeleteFilePatterns(String deletePathStr, boolean isBootstrapBasePath) {
+    if (isBootstrapBasePath) {
+      deleteBootstrapBasePathPatterns.add(deletePathStr);
+    } else {
+      deletePathPatterns.add(deletePathStr);
+    }
   }
 
   PartitionCleanStat merge(PartitionCleanStat other) {
@@ -53,6 +68,9 @@ class PartitionCleanStat implements Serializable {
     successDeleteFiles.addAll(other.successDeleteFiles);
     deletePathPatterns.addAll(other.deletePathPatterns);
     failedDeleteFiles.addAll(other.failedDeleteFiles);
+    deleteBootstrapBasePathPatterns.addAll(other.deleteBootstrapBasePathPatterns);
+    successfulDeleteBootstrapBaseFiles.addAll(other.successfulDeleteBootstrapBaseFiles);
+    failedDeleteBootstrapBaseFiles.addAll(other.failedDeleteBootstrapBaseFiles);
     return this;
   }
 
@@ -66,5 +84,17 @@ class PartitionCleanStat implements Serializable {
 
   public List<String> failedDeleteFiles() {
     return failedDeleteFiles;
+  }
+
+  public List<String> getDeleteBootstrapBasePathPatterns() {
+    return deleteBootstrapBasePathPatterns;
+  }
+
+  public List<String> getSuccessfulDeleteBootstrapBaseFiles() {
+    return successfulDeleteBootstrapBaseFiles;
+  }
+
+  public List<String> getFailedDeleteBootstrapBaseFiles() {
+    return failedDeleteBootstrapBaseFiles;
   }
 }

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -817,7 +817,7 @@ public class TestCleaner extends HoodieClientTestBase {
         gotVersion1Plan.getFilesToBeDeletedPerPartition().get(partition1).get(0));
     assertEquals(version1Plan.getFilesToBeDeletedPerPartition().get(partition2).get(0),
         gotVersion1Plan.getFilesToBeDeletedPerPartition().get(partition2).get(0));
-    assertNull(gotVersion1Plan.getFilePathsToBeDeletedPerPartition());
+    assertTrue(gotVersion1Plan.getFilePathsToBeDeletedPerPartition().isEmpty());
     assertNull(version1Plan.getFilePathsToBeDeletedPerPartition());
   }
 

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -70,6 +70,7 @@
             <import>${basedir}/src/main/avro/HoodieCompactionOperation.avsc</import>
             <import>${basedir}/src/main/avro/HoodieSavePointMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieCompactionMetadata.avsc</import>
+            <import>${basedir}/src/main/avro/HoodieCleanPartitionMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieCleanMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieCleanerPlan.avsc</import>
             <import>${basedir}/src/main/avro/HoodieRollbackMetadata.avsc</import>

--- a/hudi-common/src/main/avro/HoodieCleanMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCleanMetadata.avsc
@@ -24,23 +24,22 @@
      {"name": "totalFilesDeleted", "type": "int"},
      {"name": "earliestCommitToRetain", "type": "string"},
      {"name": "partitionMetadata", "type": {
-     "type" : "map", "values" : {
-        "type": "record",
-        "name": "HoodieCleanPartitionMetadata",
-        "fields": [
-            {"name": "partitionPath", "type": "string"},
-            {"name": "policy", "type": "string"},
-            {"name": "deletePathPatterns", "type": {"type": "array", "items": "string"}},
-            {"name": "successDeleteFiles", "type": {"type": "array", "items": "string"}},
-            {"name": "failedDeleteFiles", "type": {"type": "array", "items": "string"}}
-        ]
-     }
-     }
+        "type" : "map", "values" : "HoodieCleanPartitionMetadata"
+      }
      },
      {
         "name":"version",
         "type":["int", "null"],
         "default": 1
+     },
+     {
+        "name": "bootstrapPartitionMetadata",
+        "type": [ "null", {
+          "type" : "map", 
+          "values" : "HoodieCleanPartitionMetadata",
+          "default" : null
+        }],
+        "default" : null
      }
  ]
 }

--- a/hudi-common/src/main/avro/HoodieCleanPartitionMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCleanPartitionMetadata.avsc
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,21 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.hudi.common.table.timeline.versioning.clean;
-
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.versioning.MetadataMigrator;
-
-import java.util.Arrays;
-
-public class CleanMetadataMigrator extends MetadataMigrator<HoodieCleanMetadata> {
-
-  public CleanMetadataMigrator(HoodieTableMetaClient metaClient) {
-    super(metaClient,
-        Arrays
-            .asList(new CleanMetadataV1MigrationHandler(metaClient),
-                new CleanMetadataV2MigrationHandler(metaClient)));
-  }
+{
+  "namespace": "org.apache.hudi.avro.model",
+  "type": "record",
+  "name": "HoodieCleanPartitionMetadata",
+  "fields": [
+     {"name": "partitionPath", "type": "string"},
+     {"name": "policy", "type": "string"},
+     {"name": "deletePathPatterns", "type": {"type": "array", "items": "string"}},
+     {"name": "successDeleteFiles", "type": {"type": "array", "items": "string"}},
+     {"name": "failedDeleteFiles", "type": {"type": "array", "items": "string"}}
+  ] 
 }

--- a/hudi-common/src/main/avro/HoodieCleanerPlan.avsc
+++ b/hudi-common/src/main/avro/HoodieCleanerPlan.avsc
@@ -47,6 +47,7 @@
       "type": "string"
     },
     {
+      /** This is deprecated and replaced by the field filePathsToBeDeletedPerPartition **/
       "name": "filesToBeDeletedPerPartition",
       "type": [
         "null", {
@@ -64,6 +65,33 @@
       "name":"version",
       "type":["int", "null"],
       "default": 1
+    },
+    {
+      "name": "filePathsToBeDeletedPerPartition",
+      "doc": "This field replaces the field filesToBeDeletedPerPartition",
+      "type": [
+        "null", {
+        "type":"map",
+        "values": {
+          "type":"array",
+          "items":{
+            "name":"HoodieCleanFileInfo",
+            "type": "record",
+            "fields":[
+                     {
+                        "name":"filePath",
+                        "type":["null","string"],
+                        "default": null
+                     },
+                     {
+                        "name":"isBootstrapBaseFile",
+                        "type":["null","boolean"],
+                        "default": null
+                     }
+                ]
+          }
+      }}],
+      "default" : null
     }
   ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/HoodieCleanStat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/HoodieCleanStat.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common;
 
+import java.util.ArrayList;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
@@ -39,17 +40,34 @@ public class HoodieCleanStat implements Serializable {
   private final List<String> successDeleteFiles;
   // Files that could not be deleted
   private final List<String> failedDeleteFiles;
+  // Boostrap Base Path patterns that were generated for the delete operation
+  private final List<String> deleteBootstrapBasePathPatterns;
+  private final List<String> successDeleteBootstrapBaseFiles;
+  // Files that could not be deleted
+  private final List<String> failedDeleteBootstrapBaseFiles;
   // Earliest commit that was retained in this clean
   private final String earliestCommitToRetain;
 
   public HoodieCleanStat(HoodieCleaningPolicy policy, String partitionPath, List<String> deletePathPatterns,
       List<String> successDeleteFiles, List<String> failedDeleteFiles, String earliestCommitToRetain) {
+    this(policy, partitionPath, deletePathPatterns, successDeleteFiles, failedDeleteFiles, earliestCommitToRetain,
+        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+  }
+
+  public HoodieCleanStat(HoodieCleaningPolicy policy, String partitionPath, List<String> deletePathPatterns,
+                         List<String> successDeleteFiles, List<String> failedDeleteFiles,
+                         String earliestCommitToRetain, List<String> deleteBootstrapBasePathPatterns,
+                         List<String> successDeleteBootstrapBaseFiles,
+                         List<String> failedDeleteBootstrapBaseFiles) {
     this.policy = policy;
     this.partitionPath = partitionPath;
     this.deletePathPatterns = deletePathPatterns;
     this.successDeleteFiles = successDeleteFiles;
     this.failedDeleteFiles = failedDeleteFiles;
     this.earliestCommitToRetain = earliestCommitToRetain;
+    this.deleteBootstrapBasePathPatterns = deleteBootstrapBasePathPatterns;
+    this.successDeleteBootstrapBaseFiles = successDeleteBootstrapBaseFiles;
+    this.failedDeleteBootstrapBaseFiles = failedDeleteBootstrapBaseFiles;
   }
 
   public HoodieCleaningPolicy getPolicy() {
@@ -72,6 +90,18 @@ public class HoodieCleanStat implements Serializable {
     return failedDeleteFiles;
   }
 
+  public List<String> getDeleteBootstrapBasePathPatterns() {
+    return deleteBootstrapBasePathPatterns;
+  }
+
+  public List<String> getSuccessDeleteBootstrapBaseFiles() {
+    return successDeleteBootstrapBaseFiles;
+  }
+
+  public List<String> getFailedDeleteBootstrapBaseFiles() {
+    return failedDeleteBootstrapBaseFiles;
+  }
+
   public String getEarliestCommitToRetain() {
     return earliestCommitToRetain;
   }
@@ -91,6 +121,9 @@ public class HoodieCleanStat implements Serializable {
     private List<String> failedDeleteFiles;
     private String partitionPath;
     private String earliestCommitToRetain;
+    private List<String> deleteBootstrapBasePathPatterns;
+    private List<String> successDeleteBootstrapBaseFiles;
+    private List<String> failedDeleteBootstrapBaseFiles;
 
     public Builder withPolicy(HoodieCleaningPolicy policy) {
       this.policy = policy;
@@ -112,6 +145,21 @@ public class HoodieCleanStat implements Serializable {
       return this;
     }
 
+    public Builder withDeleteBootstrapBasePathPatterns(List<String> deletePathPatterns) {
+      this.deleteBootstrapBasePathPatterns = deletePathPatterns;
+      return this;
+    }
+
+    public Builder withSuccessfulDeleteBootstrapBaseFiles(List<String> successDeleteFiles) {
+      this.successDeleteBootstrapBaseFiles = successDeleteFiles;
+      return this;
+    }
+
+    public Builder withFailedDeleteBootstrapBaseFiles(List<String> failedDeleteFiles) {
+      this.failedDeleteBootstrapBaseFiles = failedDeleteFiles;
+      return this;
+    }
+
     public Builder withPartitionPath(String partitionPath) {
       this.partitionPath = partitionPath;
       return this;
@@ -125,7 +173,8 @@ public class HoodieCleanStat implements Serializable {
 
     public HoodieCleanStat build() {
       return new HoodieCleanStat(policy, partitionPath, deletePathPatterns, successDeleteFiles, failedDeleteFiles,
-          earliestCommitToRetain);
+          earliestCommitToRetain, deleteBootstrapBasePathPatterns, successDeleteBootstrapBaseFiles,
+        failedDeleteBootstrapBaseFiles);
     }
   }
 
@@ -137,7 +186,10 @@ public class HoodieCleanStat implements Serializable {
         + ", deletePathPatterns=" + deletePathPatterns
         + ", successDeleteFiles=" + successDeleteFiles
         + ", failedDeleteFiles=" + failedDeleteFiles
-        + ", earliestCommitToRetain='" + earliestCommitToRetain + '\''
+        + ", earliestCommitToRetain='" + earliestCommitToRetain
+        + ", deleteBootstrapBasePathPatterns=" + deleteBootstrapBasePathPatterns
+        + ", successDeleteBootstrapBaseFiles=" + successDeleteBootstrapBaseFiles
+        + ", failedDeleteBootstrapBaseFiles=" + failedDeleteBootstrapBaseFiles + '\''
         + '}';
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/HoodieCleanStat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/HoodieCleanStat.java
@@ -18,9 +18,9 @@
 
 package org.apache.hudi.common;
 
-import java.util.ArrayList;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 
 import java.io.Serializable;
@@ -40,7 +40,7 @@ public class HoodieCleanStat implements Serializable {
   private final List<String> successDeleteFiles;
   // Files that could not be deleted
   private final List<String> failedDeleteFiles;
-  // Boostrap Base Path patterns that were generated for the delete operation
+  // Bootstrap Base Path patterns that were generated for the delete operation
   private final List<String> deleteBootstrapBasePathPatterns;
   private final List<String> successDeleteBootstrapBaseFiles;
   // Files that could not be deleted
@@ -51,7 +51,8 @@ public class HoodieCleanStat implements Serializable {
   public HoodieCleanStat(HoodieCleaningPolicy policy, String partitionPath, List<String> deletePathPatterns,
       List<String> successDeleteFiles, List<String> failedDeleteFiles, String earliestCommitToRetain) {
     this(policy, partitionPath, deletePathPatterns, successDeleteFiles, failedDeleteFiles, earliestCommitToRetain,
-        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        CollectionUtils.createImmutableList(), CollectionUtils.createImmutableList(),
+        CollectionUtils.createImmutableList());
   }
 
   public HoodieCleanStat(HoodieCleaningPolicy policy, String partitionPath, List<String> deletePathPatterns,

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/CleanFileInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/CleanFileInfo.java
@@ -16,20 +16,32 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.common.table.timeline.versioning.clean;
+package org.apache.hudi.common.model;
 
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.versioning.MetadataMigrator;
+import org.apache.hudi.avro.model.HoodieCleanFileInfo;
 
-import java.util.Arrays;
+import java.io.Serializable;
 
-public class CleanMetadataMigrator extends MetadataMigrator<HoodieCleanMetadata> {
+public class CleanFileInfo implements Serializable {
 
-  public CleanMetadataMigrator(HoodieTableMetaClient metaClient) {
-    super(metaClient,
-        Arrays
-            .asList(new CleanMetadataV1MigrationHandler(metaClient),
-                new CleanMetadataV2MigrationHandler(metaClient)));
+  private final String filePath;
+  private final boolean isBootstrapBaseFile;
+
+  public CleanFileInfo(String filePath, boolean isBootstrapBaseFile) {
+    this.filePath = filePath;
+    this.isBootstrapBaseFile = isBootstrapBaseFile;
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  public boolean isBootstrapBaseFile() {
+    return isBootstrapBaseFile;
+  }
+
+  public HoodieCleanFileInfo toHoodieFileCleanInfo() {
+    return new HoodieCleanFileInfo(filePath, isBootstrapBaseFile);
   }
 }
+

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanMetadataV1MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanMetadataV1MigrationHandler.java
@@ -31,11 +31,11 @@ import org.apache.hadoop.fs.Path;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class CleanV1MigrationHandler extends AbstractMigratorBase<HoodieCleanMetadata> {
+public class CleanMetadataV1MigrationHandler extends AbstractMigratorBase<HoodieCleanMetadata> {
 
   public static final Integer VERSION = 1;
 
-  public CleanV1MigrationHandler(HoodieTableMetaClient metaClient) {
+  public CleanMetadataV1MigrationHandler(HoodieTableMetaClient metaClient) {
     super(metaClient);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanMetadataV2MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanMetadataV2MigrationHandler.java
@@ -31,11 +31,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class CleanV2MigrationHandler extends AbstractMigratorBase<HoodieCleanMetadata> {
+public class CleanMetadataV2MigrationHandler extends AbstractMigratorBase<HoodieCleanMetadata> {
 
   public static final Integer VERSION = 2;
 
-  public CleanV2MigrationHandler(HoodieTableMetaClient metaClient) {
+  public CleanMetadataV2MigrationHandler(HoodieTableMetaClient metaClient) {
     super(metaClient);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanMigrator.java
@@ -18,18 +18,19 @@
 
 package org.apache.hudi.common.table.timeline.versioning.clean;
 
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.versioning.MetadataMigrator;
 
 import java.util.Arrays;
 
-public class CleanMetadataMigrator extends MetadataMigrator<HoodieCleanMetadata> {
+/**
+ * Manages upgrade/downgrade of cleaner plan.
+ */
+public class CleanPlanMigrator extends MetadataMigrator<HoodieCleanerPlan> {
 
-  public CleanMetadataMigrator(HoodieTableMetaClient metaClient) {
+  public CleanPlanMigrator(HoodieTableMetaClient metaClient) {
     super(metaClient,
-        Arrays
-            .asList(new CleanMetadataV1MigrationHandler(metaClient),
-                new CleanMetadataV2MigrationHandler(metaClient)));
+        Arrays.asList(new CleanPlanV1MigrationHandler(metaClient), new CleanPlanV2MigrationHandler(metaClient)));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV1MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV1MigrationHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.timeline.versioning.clean;
 
+import java.util.HashMap;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.versioning.AbstractMigratorBase;
@@ -59,6 +60,7 @@ public class CleanPlanV1MigrationHandler extends AbstractMigratorBase<HoodieClea
           return Pair.of(e.getKey(), e.getValue().stream().map(v -> new Path(v.getFilePath()).getName())
             .collect(Collectors.toList()));
         }).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
-    return new HoodieCleanerPlan(plan.getEarliestInstantToRetain(), plan.getPolicy(), filesPerPartition, VERSION, null);
+    return new HoodieCleanerPlan(plan.getEarliestInstantToRetain(), plan.getPolicy(), filesPerPartition, VERSION,
+        new HashMap<>());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV1MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV1MigrationHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning.clean;
+
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.versioning.AbstractMigratorBase;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CleanPlanV1MigrationHandler extends AbstractMigratorBase<HoodieCleanerPlan> {
+
+  public static final Integer VERSION = 1;
+
+  public CleanPlanV1MigrationHandler(HoodieTableMetaClient metaClient) {
+    super(metaClient);
+  }
+
+  @Override
+  public Integer getManagedVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public HoodieCleanerPlan upgradeFrom(HoodieCleanerPlan plan) {
+    throw new IllegalArgumentException(
+      "This is the lowest version. Plan cannot be any lower version");
+  }
+
+  @Override
+  public HoodieCleanerPlan downgradeFrom(HoodieCleanerPlan plan) {
+    if (metaClient.getTableConfig().getBootstrapBasePath().isPresent()) {
+      throw new IllegalArgumentException(
+        "This version do not support METADATA_ONLY bootstrapped tables. Failed to downgrade.");
+    }
+    Map<String, List<String>> filesPerPartition = plan.getFilePathsToBeDeletedPerPartition().entrySet().stream()
+        .map(e -> {
+          return Pair.of(e.getKey(), e.getValue().stream().map(v -> new Path(v.getFilePath()).getName())
+            .collect(Collectors.toList()));
+        }).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    return new HoodieCleanerPlan(plan.getEarliestInstantToRetain(), plan.getPolicy(), filesPerPartition, VERSION, null);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV2MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV2MigrationHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning.clean;
+
+import java.util.HashMap;
+import org.apache.hudi.avro.model.HoodieCleanFileInfo;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.versioning.AbstractMigratorBase;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CleanPlanV2MigrationHandler extends AbstractMigratorBase<HoodieCleanerPlan> {
+
+  public static final Integer VERSION = 2;
+
+  public CleanPlanV2MigrationHandler(HoodieTableMetaClient metaClient) {
+    super(metaClient);
+  }
+
+  @Override
+  public Integer getManagedVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public HoodieCleanerPlan upgradeFrom(HoodieCleanerPlan plan) {
+    Map<String, List<HoodieCleanFileInfo>> filePathsPerPartition =
+        plan.getFilesToBeDeletedPerPartition().entrySet().stream().map(e -> Pair.of(e.getKey(), e.getValue().stream()
+          .map(v -> new HoodieCleanFileInfo(
+            new Path(FSUtils.getPartitionPath(metaClient.getBasePath(), e.getKey()), v).toString(), false))
+          .collect(Collectors.toList()))).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    return new HoodieCleanerPlan(plan.getEarliestInstantToRetain(), plan.getPolicy(), new HashMap<>(), VERSION, filePathsPerPartition);
+  }
+
+  @Override
+  public HoodieCleanerPlan downgradeFrom(HoodieCleanerPlan input) {
+    throw new IllegalArgumentException(
+      "This is the current highest version. Plan cannot be any higher version");
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV2MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/clean/CleanPlanV2MigrationHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.table.timeline.versioning.clean;
 
-import java.util.HashMap;
 import org.apache.hudi.avro.model.HoodieCleanFileInfo;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.fs.FSUtils;
@@ -28,6 +27,7 @@ import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.hadoop.fs.Path;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,7 +52,8 @@ public class CleanPlanV2MigrationHandler extends AbstractMigratorBase<HoodieClea
           .map(v -> new HoodieCleanFileInfo(
             new Path(FSUtils.getPartitionPath(metaClient.getBasePath(), e.getKey()), v).toString(), false))
           .collect(Collectors.toList()))).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
-    return new HoodieCleanerPlan(plan.getEarliestInstantToRetain(), plan.getPolicy(), new HashMap<>(), VERSION, filePathsPerPartition);
+    return new HoodieCleanerPlan(plan.getEarliestInstantToRetain(), plan.getPolicy(), new HashMap<>(), VERSION,
+        filePathsPerPartition);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/IncrementalTimelineSyncFileSystemView.java
@@ -252,7 +252,8 @@ public abstract class IncrementalTimelineSyncFileSystemView extends AbstractTabl
   }
 
   /**
-   * Add newly found clean instant.
+   * Add newly found clean instant. Note that cleaner metadata (.clean.completed)
+   * contains only relative paths unlike clean plans (.clean.requested) which contains absolute paths.
    *
    * @param timeline Timeline
    * @param instant Clean instant

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -26,23 +26,26 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataMigrator;
-import org.apache.hudi.common.table.timeline.versioning.clean.CleanV1MigrationHandler;
-import org.apache.hudi.common.table.timeline.versioning.clean.CleanV2MigrationHandler;
+import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataV1MigrationHandler;
+import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataV2MigrationHandler;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanMigrator;
 
 public class CleanerUtils {
-  public static final Integer CLEAN_METADATA_VERSION_1 = CleanV1MigrationHandler.VERSION;
-  public static final Integer CLEAN_METADATA_VERSION_2 = CleanV2MigrationHandler.VERSION;
+  public static final Integer CLEAN_METADATA_VERSION_1 = CleanMetadataV1MigrationHandler.VERSION;
+  public static final Integer CLEAN_METADATA_VERSION_2 = CleanMetadataV2MigrationHandler.VERSION;
   public static final Integer LATEST_CLEAN_METADATA_VERSION = CLEAN_METADATA_VERSION_2;
 
   public static HoodieCleanMetadata convertCleanMetadata(String startCleanTime,
                                                          Option<Long> durationInMs,
                                                          List<HoodieCleanStat> cleanStats) {
     Map<String, HoodieCleanPartitionMetadata> partitionMetadataMap = new HashMap<>();
+    Map<String, HoodieCleanPartitionMetadata> partitionBootstrapMetadataMap = new HashMap<>();
+
     int totalDeleted = 0;
     String earliestCommitToRetain = null;
     for (HoodieCleanStat stat : cleanStats) {
@@ -50,6 +53,13 @@ public class CleanerUtils {
           new HoodieCleanPartitionMetadata(stat.getPartitionPath(), stat.getPolicy().name(),
               stat.getDeletePathPatterns(), stat.getSuccessDeleteFiles(), stat.getFailedDeleteFiles());
       partitionMetadataMap.put(stat.getPartitionPath(), metadata);
+      if ((null != stat.getDeleteBootstrapBasePathPatterns())
+          && (!stat.getDeleteBootstrapBasePathPatterns().isEmpty())) {
+        HoodieCleanPartitionMetadata bootstrapMetadata = new HoodieCleanPartitionMetadata(stat.getPartitionPath(),
+            stat.getPolicy().name(), stat.getDeleteBootstrapBasePathPatterns(), stat.getSuccessDeleteBootstrapBaseFiles(),
+            stat.getFailedDeleteBootstrapBaseFiles());
+        partitionBootstrapMetadataMap.put(stat.getPartitionPath(), bootstrapMetadata);
+      }
       totalDeleted += stat.getSuccessDeleteFiles().size();
       if (earliestCommitToRetain == null) {
         // This will be the same for all partitions
@@ -57,8 +67,8 @@ public class CleanerUtils {
       }
     }
 
-    return new HoodieCleanMetadata(startCleanTime,
-        durationInMs.orElseGet(() -> -1L), totalDeleted, earliestCommitToRetain, partitionMetadataMap, CLEAN_METADATA_VERSION_2);
+    return new HoodieCleanMetadata(startCleanTime, durationInMs.orElseGet(() -> -1L), totalDeleted,
+      earliestCommitToRetain, partitionMetadataMap, CLEAN_METADATA_VERSION_2, partitionBootstrapMetadataMap);
   }
 
   /**
@@ -77,7 +87,7 @@ public class CleanerUtils {
   }
 
   /**
-   * Get Cleaner Plan corresponding to a clean instant.
+   * Get Latest version of cleaner plan corresponding to a clean instant.
    * @param metaClient  Hoodie Table Meta Client
    * @param cleanInstant Instant referring to clean action
    * @return Cleaner plan corresponding to clean instant
@@ -85,7 +95,9 @@ public class CleanerUtils {
    */
   public static HoodieCleanerPlan getCleanerPlan(HoodieTableMetaClient metaClient, HoodieInstant cleanInstant)
       throws IOException {
-    return TimelineMetadataUtils.deserializeAvroMetadata(metaClient.getActiveTimeline().readCleanerInfoAsBytes(cleanInstant).get(),
-        HoodieCleanerPlan.class);
+    CleanPlanMigrator cleanPlanMigrator = new CleanPlanMigrator(metaClient);
+    HoodieCleanerPlan cleanerPlan = TimelineMetadataUtils.deserializeAvroMetadata(
+        metaClient.getActiveTimeline().readCleanerInfoAsBytes(cleanInstant).get(), HoodieCleanerPlan.class);
+    return cleanPlanMigrator.upgradeToLatest(cleanerPlan, cleanerPlan.getVersion());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -18,22 +18,25 @@
 
 package org.apache.hudi.common.util;
 
+import java.util.stream.Collectors;
+import org.apache.hudi.avro.model.HoodieCleanFileInfo;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.common.HoodieCleanStat;
+import org.apache.hudi.common.model.CleanFileInfo;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataMigrator;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataV1MigrationHandler;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanMetadataV2MigrationHandler;
+import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanMigrator;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanMigrator;
 
 public class CleanerUtils {
   public static final Integer CLEAN_METADATA_VERSION_1 = CleanMetadataV1MigrationHandler.VERSION;
@@ -99,5 +102,14 @@ public class CleanerUtils {
     HoodieCleanerPlan cleanerPlan = TimelineMetadataUtils.deserializeAvroMetadata(
         metaClient.getActiveTimeline().readCleanerInfoAsBytes(cleanInstant).get(), HoodieCleanerPlan.class);
     return cleanPlanMigrator.upgradeToLatest(cleanerPlan, cleanerPlan.getVersion());
+  }
+
+  /**
+   * Convert list of cleanFileInfo instances to list of avro-generated HoodieCleanFileInfo instances.
+   * @param cleanFileInfoList
+   * @return
+   */
+  public static List<HoodieCleanFileInfo> convertToHoodieCleanFileInfoList(List<CleanFileInfo> cleanFileInfoList) {
+    return cleanFileInfoList.stream().map(CleanFileInfo::toHoodieFileCleanInfo).collect(Collectors.toList());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -45,6 +45,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
@@ -219,7 +220,8 @@ public class HoodieTestUtils {
               os = metaClient.getFs().create(commitFile, true);
               // Write empty clean metadata
               os.write(TimelineMetadataUtils.serializeCleanerPlan(
-                  new HoodieCleanerPlan(new HoodieActionInstant("", "", ""), "", new HashMap<>(), 1)).get());
+                  new HoodieCleanerPlan(new HoodieActionInstant("", "", ""), "", new HashMap<>(),
+                      CleanPlanV2MigrationHandler.VERSION, new HashMap<>())).get());
             } catch (IOException ioe) {
               throw new HoodieIOException(ioe.getMessage(), ioe);
             } finally {

--- a/hudi-spark/src/test/java/org/apache/hudi/client/TestBootstrap.java
+++ b/hudi-spark/src/test/java/org/apache/hudi/client/TestBootstrap.java
@@ -551,7 +551,7 @@ public class TestBootstrap extends HoodieClientTestBase {
   }
 
   public static Dataset<Row> generateTestRawTripDataset(double timestamp, int from, int to, List<String> partitionPaths,
-                                                         JavaSparkContext jsc, SQLContext sqlContext) {
+                                                        JavaSparkContext jsc, SQLContext sqlContext) {
     boolean isPartitioned = partitionPaths != null && !partitionPaths.isEmpty();
     final List<String> records = new ArrayList<>();
     IntStream.range(from, to).forEach(i -> {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

JIRA https://issues.apache.org/jira/browse/HUDI-808

This is an important requirement from GDPR perspective. When performing deletion on a metadata only bootstrapped partition, users should have the ability to tell to clean up the original data from the source location because as per this new bootstrapping mechanism the original data serves as the data in original commit for Hudi.

Create an option named ```hoodie.cleaner.bootstrap.source.file```, when set it to true, users have the ability to clean the original source data for the bootstrap table. By default, it is false.

## Brief change log

Create an option named ```hoodie.cleaner.bootstrap.source.file```, when set it to true, users have the ability to clean the original source data for the bootstrap table. By default, it is false.

Also added corresponding unit tests for this option in TestCleaner.java.

## Verify this pull request

This change added tests and can be verified as follows:
  - *Added two test case in ```TestCleaner.java``` to verify the change.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.