### PR TITLE
[MINOR] Add Databricks File System to StorageSchemes

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
@@ -49,7 +49,9 @@ public enum StorageSchemes {
   //ALLUXIO
   ALLUXIO("alluxio", false),
   // Tencent Cloud Object Storage
-  COSN("cosn", false);
+  COSN("cosn", false),
+  // Databricks file system
+  DBFS("dbfs", false);
 
   private String scheme;
   private boolean supportsAppend;

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
@@ -42,6 +42,7 @@ public class TestStorageSchemes {
     assertTrue(StorageSchemes.isAppendSupported("viewfs"));
     assertFalse(StorageSchemes.isAppendSupported("alluxio"));
     assertFalse(StorageSchemes.isAppendSupported("cosn"));
+    assertFalse(StorageSchemes.isAppendSupported("dbfs"));
     assertThrows(IllegalArgumentException.class, () -> {
       StorageSchemes.isAppendSupported("s2");
     }, "Should throw exception for unsupported schemes");


### PR DESCRIPTION
## What is the purpose of the pull request

*Add support to databricks file system as a mount point on top of Azure data lake*

## Brief change log

Add dbfs to StorageSchemes

## Verify this pull request

Tested on Databricks Spark 2.4.4 on top of Azure Data Lake Gen2.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.