### PR TITLE
[HUDI-1129]: AvroConversionUtils unable to handle avro to row transformation when passing evolved schema

### DIFF
--- a/hudi-spark/src/main/scala/org/apache/hudi/AvroConversionHelper.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/AvroConversionHelper.scala
@@ -136,7 +136,7 @@ object AvroConversionHelper {
         case (struct: StructType, RECORD) =>
           val length = struct.fields.length
           val converters = new Array[AnyRef => AnyRef](length)
-          val avroFieldIndexes = new Array[Int](length)
+          val avroFieldNames = new Array[String](length)
           var i = 0
           while (i < length) {
             val sqlField = struct.fields(i)
@@ -145,7 +145,7 @@ object AvroConversionHelper {
               val converter = createConverter(avroField.schema(), sqlField.dataType,
                 path :+ sqlField.name)
               converters(i) = converter
-              avroFieldIndexes(i) = avroField.pos()
+              avroFieldNames(i) = avroField.name()
             } else if (!sqlField.nullable) {
               throw new IncompatibleSchemaException(
                 s"Cannot find non-nullable field ${sqlField.name} at path ${path.mkString(".")} " +
@@ -167,7 +167,7 @@ object AvroConversionHelper {
               while (i < converters.length) {
                 if (converters(i) != null) {
                   val converter = converters(i)
-                  result(i) = converter(record.get(avroFieldIndexes(i)))
+                  result(i) = converter(record.get(avroFieldNames(i)))
                 }
                 i += 1
               }


### PR DESCRIPTION
## What is the purpose of the pull request

Specific fix this error: https://issues.apache.org/jira/browse/HUDI-1129
This is needed to partially fix https://github.com/apache/hudi/issues/1845

## Brief change log

- Use avro field names and not indices to convert from avro to GenericRow of catalyst at AvroConversionHelper

## Verify this pull request

Run maven test suite

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.