### PR TITLE
[HUDI-1140] Fix Jcommander issue for --hoodie-conf in DeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
@@ -278,7 +278,8 @@ public class HDFSParquetImporter implements Serializable {
         + "hoodie client for importing")
     public String propsFilePath = null;
     @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
-        + "(using the CLI parameter \"--propsFilePath\") can also be passed command line using this parameter")
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+            splitter = IdentitySplitter.class)
     public List<String> configs = new ArrayList<>();
     @Parameter(names = {"--help", "-h"}, help = true)
     public Boolean help = false;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
@@ -88,7 +88,8 @@ public class HoodieCleaner {
     public String propsFilePath = null;
 
     @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
-        + "(using the CLI parameter \"--propsFilePath\") can also be passed command line using this parameter")
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+            splitter = IdentitySplitter.class)
     public List<String> configs = new ArrayList<>();
 
     @Parameter(names = {"--spark-master"}, description = "spark master to use.")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -90,7 +90,8 @@ public class HoodieCompactor {
     public String propsFilePath = null;
 
     @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
-        + "(using the CLI parameter \"--propsFilePath\") can also be passed command line using this parameter")
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+            splitter = IdentitySplitter.class)
     public List<String> configs = new ArrayList<>();
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/IdentitySplitter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/IdentitySplitter.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import com.beust.jcommander.converters.IParameterSplitter;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Splitter utility related to Jcommander usage of ArrayList parameters.
+ */
+public class IdentitySplitter implements IParameterSplitter {
+  public List<String> split(String value) {
+    return Collections.singletonList(value);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -18,8 +18,8 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
-import org.apache.hudi.async.AbstractAsyncService;
 import org.apache.hudi.client.HoodieWriteClient;
+import org.apache.hudi.async.AbstractAsyncService;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.bootstrap.index.HFileBootstrapIndex;
 import org.apache.hudi.common.config.TypedProperties;
@@ -33,6 +33,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.utilities.IdentitySplitter;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -60,6 +61,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -217,12 +219,14 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--props"}, description = "path to properties file on localfs or dfs, with configurations for "
         + "hoodie client, schema provider, key generator and data source. For hoodie client props, sane defaults are "
         + "used, but recommend use to provide basic things like metrics endpoints, hive configs etc. For sources, refer"
-        + "to individual classes, for supported properties.")
+        + "to individual classes, for supported properties."
+        + " Properties in this file can be overridden by \"--hoodie-conf\"")
     public String propsFilePath =
         "file://" + System.getProperty("user.dir") + "/src/test/resources/delta-streamer-config/dfs-source.properties";
 
     @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
-        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter")
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+            splitter = IdentitySplitter.class)
     public List<String> configs = new ArrayList<>();
 
     @Parameter(names = {"--source-class"},
@@ -343,16 +347,106 @@ public class HoodieDeltaStreamer implements Serializable {
       return !continuousMode && !forceDisableCompaction
           && HoodieTableType.MERGE_ON_READ.equals(HoodieTableType.valueOf(tableType));
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Config config = (Config) o;
+      return sourceLimit == config.sourceLimit
+              && Objects.equals(targetBasePath, config.targetBasePath)
+              && Objects.equals(targetTableName, config.targetTableName)
+              && Objects.equals(tableType, config.tableType)
+              && Objects.equals(baseFileFormat, config.baseFileFormat)
+              && Objects.equals(propsFilePath, config.propsFilePath)
+              && Objects.equals(configs, config.configs)
+              && Objects.equals(sourceClassName, config.sourceClassName)
+              && Objects.equals(sourceOrderingField, config.sourceOrderingField)
+              && Objects.equals(payloadClassName, config.payloadClassName)
+              && Objects.equals(schemaProviderClassName, config.schemaProviderClassName)
+              && Objects.equals(transformerClassNames, config.transformerClassNames)
+              && operation == config.operation
+              && Objects.equals(filterDupes, config.filterDupes)
+              && Objects.equals(enableHiveSync, config.enableHiveSync)
+              && Objects.equals(maxPendingCompactions, config.maxPendingCompactions)
+              && Objects.equals(continuousMode, config.continuousMode)
+              && Objects.equals(minSyncIntervalSeconds, config.minSyncIntervalSeconds)
+              && Objects.equals(sparkMaster, config.sparkMaster)
+              && Objects.equals(commitOnErrors, config.commitOnErrors)
+              && Objects.equals(deltaSyncSchedulingWeight, config.deltaSyncSchedulingWeight)
+              && Objects.equals(compactSchedulingWeight, config.compactSchedulingWeight)
+              && Objects.equals(deltaSyncSchedulingMinShare, config.deltaSyncSchedulingMinShare)
+              && Objects.equals(compactSchedulingMinShare, config.compactSchedulingMinShare)
+              && Objects.equals(forceDisableCompaction, config.forceDisableCompaction)
+              && Objects.equals(checkpoint, config.checkpoint)
+              && Objects.equals(initialCheckpointProvider, config.initialCheckpointProvider)
+              && Objects.equals(help, config.help);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(targetBasePath, targetTableName, tableType,
+              baseFileFormat, propsFilePath, configs, sourceClassName,
+              sourceOrderingField, payloadClassName, schemaProviderClassName,
+              transformerClassNames, sourceLimit, operation, filterDupes,
+              enableHiveSync, maxPendingCompactions, continuousMode,
+              minSyncIntervalSeconds, sparkMaster, commitOnErrors,
+              deltaSyncSchedulingWeight, compactSchedulingWeight, deltaSyncSchedulingMinShare,
+              compactSchedulingMinShare, forceDisableCompaction, checkpoint,
+              initialCheckpointProvider, help);
+    }
+  
+    @Override
+    public String toString() {
+      return "Config{"
+              + "targetBasePath='" + targetBasePath + '\''
+              + ", targetTableName='" + targetTableName + '\''
+              + ", tableType='" + tableType + '\''
+              + ", baseFileFormat='" + baseFileFormat + '\''
+              + ", propsFilePath='" + propsFilePath + '\''
+              + ", configs=" + configs
+              + ", sourceClassName='" + sourceClassName + '\''
+              + ", sourceOrderingField='" + sourceOrderingField + '\''
+              + ", payloadClassName='" + payloadClassName + '\''
+              + ", schemaProviderClassName='" + schemaProviderClassName + '\''
+              + ", transformerClassNames=" + transformerClassNames
+              + ", sourceLimit=" + sourceLimit
+              + ", operation=" + operation
+              + ", filterDupes=" + filterDupes
+              + ", enableHiveSync=" + enableHiveSync
+              + ", maxPendingCompactions=" + maxPendingCompactions
+              + ", continuousMode=" + continuousMode
+              + ", minSyncIntervalSeconds=" + minSyncIntervalSeconds
+              + ", sparkMaster='" + sparkMaster + '\''
+              + ", commitOnErrors=" + commitOnErrors
+              + ", deltaSyncSchedulingWeight=" + deltaSyncSchedulingWeight
+              + ", compactSchedulingWeight=" + compactSchedulingWeight
+              + ", deltaSyncSchedulingMinShare=" + deltaSyncSchedulingMinShare
+              + ", compactSchedulingMinShare=" + compactSchedulingMinShare
+              + ", forceDisableCompaction=" + forceDisableCompaction
+              + ", checkpoint='" + checkpoint + '\''
+              + ", initialCheckpointProvider='" + initialCheckpointProvider + '\''
+              + ", help=" + help
+              + '}';
+    }
   }
 
-  public static void main(String[] args) throws Exception {
-    final Config cfg = new Config();
+  public static final Config getConfig(String[] args) {
+    Config cfg = new Config();
     JCommander cmd = new JCommander(cfg, null, args);
     if (cfg.help || args.length == 0) {
       cmd.usage();
       System.exit(1);
     }
+    return cfg;
+  }
 
+  public static void main(String[] args) throws Exception {
+    final Config cfg = getConfig(args);
     Map<String, String> additionalSparkConfigs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
     JavaSparkContext jssc =
         UtilHelpers.buildSparkContext("delta-streamer-" + cfg.targetTableName, cfg.sparkMaster, additionalSparkConfigs);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.utilities.IdentitySplitter;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
@@ -226,7 +227,8 @@ public class HoodieMultiTableDeltaStreamer {
         "file://" + System.getProperty("user.dir") + "/src/test/resources/delta-streamer-config/dfs-source.properties";
 
     @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
-        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter")
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+            splitter = IdentitySplitter.class)
     public List<String> configs = new ArrayList<>();
 
     @Parameter(names = {"--source-class"},


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Attempt to fix this [issue](https://github.com/apache/hudi/issues/1586)

## Brief change log
Updating the way `--hoodie-conf` is parsed for `HoodieDeltaStreamer`. This also includes adding some functional tests for such command line argument parsing


## Verify this pull request

This change added tests and can be verified as follows:
  - * Added a functional test in code *
  - *Manually verified the change by running a job locally.*

Tried running 
```
mvn clean package -DskipITs
TestClientRollback>HoodieClientTestBase.setUp:78->HoodieClientTestHarness.initResources:100->HoodieClientTestHarness.initSparkContexts:139->HoodieClientTestHarness.initSparkContexts:126 » Spark
```

So planning to see if the same error happens in CI, if so attempt to fix it. Otherwise, something with my setup locally is wrong

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.