### PR TITLE
[MINOR] Fixing usage of right config value for parallelism to dedup in Bulk Insert

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/action/commit/BulkInsertHelper.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/commit/BulkInsertHelper.java
@@ -51,7 +51,7 @@ public class BulkInsertHelper<T extends HoodieRecordPayload<T>> {
 
     if (performDedupe) {
       dedupedRecords = WriteHelper.combineOnCondition(config.shouldCombineBeforeInsert(), inputRecords,
-          config.getInsertShuffleParallelism(), ((HoodieTable<T>)table));
+          config.getBulkInsertShuffleParallelism(), ((HoodieTable<T>)table));
     }
 
     final JavaRDD<HoodieRecord<T>> repartitionedRecords;


### PR DESCRIPTION
##  What is the purpose of the pull request

Fixing usage of right config value for parallelism to dedup in Bulk Insert

This pull request is a trivial fix.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.