### PR TITLE
[HUDI-1025] Meter RPC calls in HoodieWrapperFileSystem

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieWrapperFileSystem.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieWrapperFileSystem.java
@@ -65,7 +65,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   public static final String HOODIE_SCHEME_PREFIX = "hoodie-";
 
-  private enum MetricNames {
+  private enum MetricName {
     create, rename, delete, listStatus, mkdirs, getFileStatus, globStatus, listFiles
   }
 
@@ -146,7 +146,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize,
       short replication, long blockSize, Progressable progress) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     final Path translatedPath = convertToDefaultPath(f);
     return wrapOutputStream(f,
         fileSystem.create(translatedPath, permission, overwrite, bufferSize, replication, blockSize, progress));
@@ -166,51 +166,51 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), overwrite));
   }
 
   @Override
   public FSDataOutputStream create(Path f) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f)));
   }
 
   @Override
   public FSDataOutputStream create(Path f, Progressable progress) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), progress));
   }
 
   @Override
   public FSDataOutputStream create(Path f, short replication) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), replication));
   }
 
   @Override
   public FSDataOutputStream create(Path f, short replication, Progressable progress) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), replication, progress));
   }
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize));
   }
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, Progressable progress)
       throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize, progress));
   }
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, short replication, long blockSize,
       Progressable progress) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f,
         fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize, replication, blockSize, progress));
   }
@@ -218,7 +218,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize,
       short replication, long blockSize, Progressable progress) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f,
         fileSystem.create(convertToDefaultPath(f), permission, flags, bufferSize, replication, blockSize, progress));
   }
@@ -226,7 +226,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize,
       short replication, long blockSize, Progressable progress, Options.ChecksumOpt checksumOpt) throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), permission, flags, bufferSize, replication,
         blockSize, progress, checksumOpt));
   }
@@ -234,7 +234,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, short replication, long blockSize)
       throws IOException {
-    this.metricsRegistry.increment(MetricNames.create.name());
+    this.metricsRegistry.increment(MetricName.create.name());
     return wrapOutputStream(f,
         fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize, replication, blockSize));
   }
@@ -246,7 +246,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
-    this.metricsRegistry.increment(MetricNames.rename.name());
+    this.metricsRegistry.increment(MetricName.rename.name());
     try {
       consistencyGuard.waitTillFileAppears(convertToDefaultPath(src));
     } catch (TimeoutException e) {
@@ -273,7 +273,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
-    this.metricsRegistry.increment(MetricNames.delete.name());
+    this.metricsRegistry.increment(MetricName.delete.name());
     boolean success = fileSystem.delete(convertToDefaultPath(f), recursive);
 
     if (success) {
@@ -288,7 +288,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f) throws IOException {
-    this.metricsRegistry.increment(MetricNames.listStatus.name());
+    this.metricsRegistry.increment(MetricName.listStatus.name());
     return fileSystem.listStatus(convertToDefaultPath(f));
   }
 
@@ -304,7 +304,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean mkdirs(Path f, FsPermission permission) throws IOException {
-    this.metricsRegistry.increment(MetricNames.mkdirs.name());
+    this.metricsRegistry.increment(MetricName.mkdirs.name());
     boolean success = fileSystem.mkdirs(convertToDefaultPath(f), permission);
     if (success) {
       try {
@@ -318,7 +318,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
-    this.metricsRegistry.increment(MetricNames.getFileStatus.name());
+    this.metricsRegistry.increment(MetricName.getFileStatus.name());
     try {
       consistencyGuard.waitTillFileAppears(convertToDefaultPath(f));
     } catch (TimeoutException e) {
@@ -462,7 +462,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path f) throws IOException {
-    this.metricsRegistry.increment(MetricNames.delete.name());
+    this.metricsRegistry.increment(MetricName.delete.name());
     return delete(f, true);
   }
 
@@ -508,31 +508,31 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f, PathFilter filter) throws IOException {
-    this.metricsRegistry.increment(MetricNames.listStatus.name());
+    this.metricsRegistry.increment(MetricName.listStatus.name());
     return fileSystem.listStatus(convertToDefaultPath(f), filter);
   }
 
   @Override
   public FileStatus[] listStatus(Path[] files) throws IOException {
-    this.metricsRegistry.increment(MetricNames.listStatus.name());
+    this.metricsRegistry.increment(MetricName.listStatus.name());
     return fileSystem.listStatus(convertDefaults(files));
   }
 
   @Override
   public FileStatus[] listStatus(Path[] files, PathFilter filter) throws IOException {
-    this.metricsRegistry.increment(MetricNames.listStatus.name());
+    this.metricsRegistry.increment(MetricName.listStatus.name());
     return fileSystem.listStatus(convertDefaults(files), filter);
   }
 
   @Override
   public FileStatus[] globStatus(Path pathPattern) throws IOException {
-    this.metricsRegistry.increment(MetricNames.globStatus.name());
+    this.metricsRegistry.increment(MetricName.globStatus.name());
     return fileSystem.globStatus(convertToDefaultPath(pathPattern));
   }
 
   @Override
   public FileStatus[] globStatus(Path pathPattern, PathFilter filter) throws IOException {
-    this.metricsRegistry.increment(MetricNames.globStatus.name());
+    this.metricsRegistry.increment(MetricName.globStatus.name());
     return fileSystem.globStatus(convertToDefaultPath(pathPattern), filter);
   }
 
@@ -543,7 +543,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public RemoteIterator<LocatedFileStatus> listFiles(Path f, boolean recursive) throws IOException {
-    this.metricsRegistry.increment(MetricNames.listFiles.name());
+    this.metricsRegistry.increment(MetricName.listFiles.name());
     return fileSystem.listFiles(convertToDefaultPath(f), recursive);
   }
 
@@ -554,7 +554,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean mkdirs(Path f) throws IOException {
-    this.metricsRegistry.increment(MetricNames.mkdirs.name());
+    this.metricsRegistry.increment(MetricName.mkdirs.name());
     boolean success = fileSystem.mkdirs(convertToDefaultPath(f));
     if (success) {
       try {

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieWrapperFileSystem.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieWrapperFileSystem.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.fs;
 
+import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 
@@ -64,10 +65,15 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   public static final String HOODIE_SCHEME_PREFIX = "hoodie-";
 
+  private enum MetricNames {
+    create, rename, delete, listStatus, mkdirs, getFileStatus, globStatus, listFiles
+  }
+
   private ConcurrentMap<String, SizeAwareFSDataOutputStream> openStreams = new ConcurrentHashMap<>();
   private FileSystem fileSystem;
   private URI uri;
   private ConsistencyGuard consistencyGuard = new NoOpConsistencyGuard();
+  private Registry metricsRegistry = Registry.getRegistry(this.getClass().getSimpleName());
 
   public HoodieWrapperFileSystem() {}
 
@@ -140,6 +146,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize,
       short replication, long blockSize, Progressable progress) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     final Path translatedPath = convertToDefaultPath(f);
     return wrapOutputStream(f,
         fileSystem.create(translatedPath, permission, overwrite, bufferSize, replication, blockSize, progress));
@@ -159,43 +166,51 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), overwrite));
   }
 
   @Override
   public FSDataOutputStream create(Path f) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f)));
   }
 
   @Override
   public FSDataOutputStream create(Path f, Progressable progress) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), progress));
   }
 
   @Override
   public FSDataOutputStream create(Path f, short replication) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), replication));
   }
 
   @Override
   public FSDataOutputStream create(Path f, short replication, Progressable progress) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), replication, progress));
   }
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize));
   }
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, Progressable progress)
       throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize, progress));
   }
 
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, short replication, long blockSize,
       Progressable progress) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f,
         fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize, replication, blockSize, progress));
   }
@@ -203,6 +218,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize,
       short replication, long blockSize, Progressable progress) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f,
         fileSystem.create(convertToDefaultPath(f), permission, flags, bufferSize, replication, blockSize, progress));
   }
@@ -210,6 +226,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize,
       short replication, long blockSize, Progressable progress, Options.ChecksumOpt checksumOpt) throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f, fileSystem.create(convertToDefaultPath(f), permission, flags, bufferSize, replication,
         blockSize, progress, checksumOpt));
   }
@@ -217,6 +234,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
   @Override
   public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, short replication, long blockSize)
       throws IOException {
+    this.metricsRegistry.increment(MetricNames.create.name());
     return wrapOutputStream(f,
         fileSystem.create(convertToDefaultPath(f), overwrite, bufferSize, replication, blockSize));
   }
@@ -228,6 +246,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
+    this.metricsRegistry.increment(MetricNames.rename.name());
     try {
       consistencyGuard.waitTillFileAppears(convertToDefaultPath(src));
     } catch (TimeoutException e) {
@@ -254,6 +273,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
+    this.metricsRegistry.increment(MetricNames.delete.name());
     boolean success = fileSystem.delete(convertToDefaultPath(f), recursive);
 
     if (success) {
@@ -268,6 +288,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f) throws IOException {
+    this.metricsRegistry.increment(MetricNames.listStatus.name());
     return fileSystem.listStatus(convertToDefaultPath(f));
   }
 
@@ -283,6 +304,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+    this.metricsRegistry.increment(MetricNames.mkdirs.name());
     boolean success = fileSystem.mkdirs(convertToDefaultPath(f), permission);
     if (success) {
       try {
@@ -296,6 +318,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
+    this.metricsRegistry.increment(MetricNames.getFileStatus.name());
     try {
       consistencyGuard.waitTillFileAppears(convertToDefaultPath(f));
     } catch (TimeoutException e) {
@@ -439,6 +462,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path f) throws IOException {
+    this.metricsRegistry.increment(MetricNames.delete.name());
     return delete(f, true);
   }
 
@@ -484,26 +508,31 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f, PathFilter filter) throws IOException {
+    this.metricsRegistry.increment(MetricNames.listStatus.name());
     return fileSystem.listStatus(convertToDefaultPath(f), filter);
   }
 
   @Override
   public FileStatus[] listStatus(Path[] files) throws IOException {
+    this.metricsRegistry.increment(MetricNames.listStatus.name());
     return fileSystem.listStatus(convertDefaults(files));
   }
 
   @Override
   public FileStatus[] listStatus(Path[] files, PathFilter filter) throws IOException {
+    this.metricsRegistry.increment(MetricNames.listStatus.name());
     return fileSystem.listStatus(convertDefaults(files), filter);
   }
 
   @Override
   public FileStatus[] globStatus(Path pathPattern) throws IOException {
+    this.metricsRegistry.increment(MetricNames.globStatus.name());
     return fileSystem.globStatus(convertToDefaultPath(pathPattern));
   }
 
   @Override
   public FileStatus[] globStatus(Path pathPattern, PathFilter filter) throws IOException {
+    this.metricsRegistry.increment(MetricNames.globStatus.name());
     return fileSystem.globStatus(convertToDefaultPath(pathPattern), filter);
   }
 
@@ -514,6 +543,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public RemoteIterator<LocatedFileStatus> listFiles(Path f, boolean recursive) throws IOException {
+    this.metricsRegistry.increment(MetricNames.listFiles.name());
     return fileSystem.listFiles(convertToDefaultPath(f), recursive);
   }
 
@@ -524,6 +554,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   @Override
   public boolean mkdirs(Path f) throws IOException {
+    this.metricsRegistry.increment(MetricNames.mkdirs.name());
     boolean success = fileSystem.mkdirs(convertToDefaultPath(f));
     if (success) {
       try {

--- a/hudi-common/src/main/java/org/apache/hudi/common/metrics/Counter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/metrics/Counter.java
@@ -35,6 +35,7 @@ public class Counter implements Metric {
     this.count.addAndGet(n);
   }
 
+  @Override
   public Long getValue() {
     return count.get();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/metrics/Counter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/metrics/Counter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Lightweight Counter for Hudi Metrics.
+ */
+public class Counter implements Metric {
+
+  private final AtomicLong count = new AtomicLong();
+
+  public void increment() {
+    this.add(1);
+  }
+
+  public void add(long n) {
+    this.count.addAndGet(n);
+  }
+
+  public Long getValue() {
+    return count.get();
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/metrics/Metric.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/metrics/Metric.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.metrics;
+
+/**
+ * Interface for Hudi Metric Types.
+ */
+public interface Metric {
+  Long getValue();
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/metrics/Registry.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/metrics/Registry.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+/**
+ * Lightweight Metrics Registry to track Hudi events.
+ */
+public class Registry {
+  ConcurrentHashMap<String, Counter> counters = new ConcurrentHashMap<>();
+  final String name;
+
+  private static ConcurrentHashMap<String, Registry> registryMap = new ConcurrentHashMap<>();
+
+  private Registry(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Get (or create) the registry for a provided name.
+   */
+  public static synchronized Registry getRegistry(String registryName) {
+    if (!registryMap.containsKey(registryName)) {
+      registryMap.put(registryName, new Registry(registryName));
+    }
+    return registryMap.get(registryName);
+  }
+
+  /**
+   * Get all registered metrics.
+   * @param flush clean all metrics as part of this operation.
+   * @param prefixWithRegistryName prefix each metric name with the registry name.
+   * @return
+   */
+  public static synchronized Map<String, Long> getAllMetrics(boolean flush, boolean prefixWithRegistryName) {
+    HashMap allMetrics = new HashMap<String, Long>();
+    registryMap.forEach((registryName, registry) -> {
+      allMetrics.putAll(registry.getAllCounts(prefixWithRegistryName));
+      if (flush) {
+        registry.flush();
+      }
+    });
+    return allMetrics;
+  }
+
+  public void flush() {
+    counters.clear();
+  }
+
+  public void increment(String name) {
+    getCounter(name).increment();
+  }
+
+  public void add(String name, long value) {
+    getCounter(name).add(value);
+  }
+
+  private synchronized Counter getCounter(String name) {
+    if (!counters.containsKey(name)) {
+      counters.put(name, new Counter());
+    }
+    return counters.get(name);
+  }
+
+  /**
+   * Get all Counter type metrics.
+   */
+  public Map<String, Long> getAllCounts() {
+    return getAllCounts(false);
+  }
+
+  /**
+   * Get all Counter type metrics.
+   */
+  public Map<String, Long> getAllCounts(boolean prefixWithRegistryName) {
+    HashMap<String, Long> countersMap = new HashMap<>();
+    counters.forEach((k, v) -> {
+      String key = prefixWithRegistryName ? name + "." + k : k;
+      countersMap.put(key, v.getValue());
+    });
+    return countersMap;
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/metrics/Registry.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/metrics/Registry.java
@@ -53,17 +53,17 @@ public class Registry {
    * @return
    */
   public static synchronized Map<String, Long> getAllMetrics(boolean flush, boolean prefixWithRegistryName) {
-    HashMap allMetrics = new HashMap<String, Long>();
+    HashMap<String, Long> allMetrics = new HashMap<>();
     registryMap.forEach((registryName, registry) -> {
       allMetrics.putAll(registry.getAllCounts(prefixWithRegistryName));
       if (flush) {
-        registry.flush();
+        registry.clear();
       }
     });
     return allMetrics;
   }
 
-  public void flush() {
+  public void clear() {
     counters.clear();
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/TestRegistry.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/TestRegistry.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common;
+
+import org.apache.hudi.common.metrics.Registry;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestRegistry {
+
+  @Test
+  public void testGetRegistry() throws Exception {
+    Registry r = Registry.getRegistry("testGetRegistry_1");
+    assertEquals(r, Registry.getRegistry("testGetRegistry_1"));
+  }
+
+  private void registerMetrics(Map<String, Long> map, Registry registry) {
+    map.forEach((k, v) -> registry.add(k, v));
+  }
+
+  @Test
+  public void testGetAllMetrics() throws Exception {
+    String registryName = "testGetAllMetrics";
+    Registry r = Registry.getRegistry(registryName);
+    Map<String, Long> countsMap = new HashMap<>();
+
+    countsMap.put("one", 1L);
+    registerMetrics(countsMap, r);
+    Map<String, Long> allMetrics1 = Registry.getAllMetrics(false, true);
+    assertTrue(allMetrics1.containsKey(registryName + ".one"));
+
+    countsMap.remove("one");
+    countsMap.put("two", 2L);
+    registerMetrics(countsMap, r);
+    Map<String, Long> allMetrics2 = Registry.getAllMetrics(true, true);
+    assertTrue(allMetrics2.containsKey(registryName + ".one"));
+    assertTrue(allMetrics2.containsKey(registryName + ".two"));
+
+    Map<String, Long> allMetrics3 = Registry.getAllMetrics(false, true);
+    assertTrue(allMetrics3.isEmpty());
+  }
+
+  @Test
+  public void testCounts() throws Exception {
+    Registry r = Registry.getRegistry("testCounts");
+    Map<String, Long> countsMap = new HashMap<>();
+    countsMap.put("one", 1L);
+    countsMap.put("two", 2L);
+
+    registerMetrics(countsMap, r);
+    assertEquals(countsMap, r.getAllCounts());
+  }
+
+}


### PR DESCRIPTION
##  What is the purpose of the pull request

This diff adds a lightweight metrics registry (based on codahale metrics) for Hudi Common. Other modules can use this registry to track their metrics as well. The Hudi Client has been modified to collect and emit the metrics from this registry.


## Verify this pull request

This change added tests and can be verified as follows:

  - Added unit tests in `org.apache.hudi.common.TestRegistry`. 
  - Verified change using console logger metrics in Hudi Demo Docker.
  - These changes have been tested in production at Uber. 

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.