### PR TITLE
[HUDI-1152] Add option to skip syncing Hudi metadata columns

### DIFF
--- a/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -71,6 +71,9 @@ public class HiveSyncConfig implements Serializable {
   @Parameter(names = {"--use-jdbc"}, description = "Hive jdbc connect url")
   public Boolean useJdbc = true;
 
+  @Parameter(names = {"--skip-metadata-columns"}, description = "Skips syncing Hudi metadata columns from Hive for COW/RO tables")
+  public Boolean skipMetadataColumns = false;
+
   @Parameter(names = {"--skip-ro-suffix"}, description = "Skip the `_ro` suffix for Read optimized table, when registering")
   public Boolean skipROSuffix = false;
 
@@ -87,6 +90,7 @@ public class HiveSyncConfig implements Serializable {
     newConfig.partitionFields = cfg.partitionFields;
     newConfig.partitionValueExtractorClass = cfg.partitionValueExtractorClass;
     newConfig.jdbcUrl = cfg.jdbcUrl;
+    newConfig.skipMetadataColumns = cfg.skipMetadataColumns;
     newConfig.tableName = cfg.tableName;
     newConfig.usePreApacheInputFormat = cfg.usePreApacheInputFormat;
     return newConfig;

--- a/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -122,7 +122,8 @@ public class HiveSyncTool {
     }
 
     // Get the parquet schema for this table looking at the latest commit
-    MessageType schema = hoodieHiveClient.getDataSchema();
+    boolean skipMetadataColumns = cfg.skipMetadataColumns != null && cfg.skipMetadataColumns && !useRealtimeInputFormat;
+    MessageType schema = hoodieHiveClient.getDataSchema(skipMetadataColumns);
     // Sync schema if needed
     syncSchema(tableName, tableExists, useRealtimeInputFormat, schema);
 

--- a/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
+++ b/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
@@ -334,9 +334,13 @@ public class HoodieHiveClient {
    *
    * @return Parquet schema for this table
    */
-  public MessageType getDataSchema() {
+  public MessageType getDataSchema(boolean skipMetadataColumns) {
     try {
-      return new TableSchemaResolver(metaClient).getTableParquetSchema();
+      if (skipMetadataColumns) {
+        return new TableSchemaResolver(metaClient).getTableParquetSchemaWithoutMetadataFields();
+      } else {
+        return new TableSchemaResolver(metaClient).getTableParquetSchema();
+      }
     } catch (Exception e) {
       throw new HoodieHiveSyncException("Failed to read data schema", e);
     }

--- a/hudi-spark/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -323,6 +323,8 @@ public class DataSourceUtils {
         props.getString(DataSourceWriteOptions.HIVE_PASS_OPT_KEY(), DataSourceWriteOptions.DEFAULT_HIVE_PASS_OPT_VAL());
     hiveSyncConfig.jdbcUrl =
         props.getString(DataSourceWriteOptions.HIVE_URL_OPT_KEY(), DataSourceWriteOptions.DEFAULT_HIVE_URL_OPT_VAL());
+    hiveSyncConfig.skipMetadataColumns =
+        props.getBoolean(DataSourceWriteOptions.HIVE_SKIP_METADATA_COLS_OPT_KEY(), false);
     hiveSyncConfig.partitionFields =
         props.getStringList(DataSourceWriteOptions.HIVE_PARTITION_FIELDS_OPT_KEY(), ",", new ArrayList<>());
     hiveSyncConfig.partitionValueExtractorClass =

--- a/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -267,6 +267,7 @@ object DataSourceWriteOptions {
   val HIVE_ASSUME_DATE_PARTITION_OPT_KEY = "hoodie.datasource.hive_sync.assume_date_partitioning"
   val HIVE_USE_PRE_APACHE_INPUT_FORMAT_OPT_KEY = "hoodie.datasource.hive_sync.use_pre_apache_input_format"
   val HIVE_USE_JDBC_OPT_KEY = "hoodie.datasource.hive_sync.use_jdbc"
+  val HIVE_SKIP_METADATA_COLS_OPT_KEY = "hoodie.datasource.hive_sync.skip_metadata_cols"
 
   // DEFAULT FOR HIVE SPECIFIC CONFIGS
   val DEFAULT_HIVE_SYNC_ENABLED_OPT_VAL = "false"

--- a/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -280,6 +280,7 @@ private[hudi] object HoodieSparkSqlWriter {
     hiveSyncConfig.hiveUser = parameters(HIVE_USER_OPT_KEY)
     hiveSyncConfig.hivePass = parameters(HIVE_PASS_OPT_KEY)
     hiveSyncConfig.jdbcUrl = parameters(HIVE_URL_OPT_KEY)
+    hiveSyncConfig.skipMetadataColumns = parameters.get(HIVE_SKIP_METADATA_COLS_OPT_KEY).exists(r => r.toBoolean)
     hiveSyncConfig.partitionFields =
       ListBuffer(parameters(HIVE_PARTITION_FIELDS_OPT_KEY).split(",").map(_.trim).filter(!_.isEmpty).toList: _*)
     hiveSyncConfig.partitionValueExtractorClass = parameters(HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY)


### PR DESCRIPTION
## What is the purpose of the pull request
Add the option to skip syncing of Hudi metadata columns during hive sync. This is only applicable to Hudi COW/RO tables as these columns are required for use by Hudi RT.

## Brief change log
  - Add option to skip syncing Hudi metadata columns during hive-sync

## Verify this pull request
This change added tests and can be verified as follows:
  - New tests pass
