### PR TITLE
[MINOR] Fix release script for onetime uploading of gpgkeys

### DIFF
--- a/scripts/release/preparation_before_release.sh
+++ b/scripts/release/preparation_before_release.sh
@@ -61,34 +61,43 @@ if [[ $confirmation != "y" ]]; then
   else
     echo "Please input your name: "
     read name
+    echo "Please input you Apache account creds for checking out ${ROOT_SVN_URL} and adding your key to KEYS file"
+    echo "username: "
+    read apache_username
+    echo "password: "
+    read passowrd
     echo "======Starting updating KEYS file in dev repo===="
     if [[ -d ${LOCAL_SVN_DIR} ]]; then
       rm -rf ${LOCAL_SVN_DIR}
     fi
     mkdir ${LOCAL_SVN_DIR}
     cd ${LOCAL_SVN_DIR}
-    svn co ${ROOT_SVN_URL}/${DEV_REPO}/${HUDI_REPO}
+    svn --username=${apache_username} --password=${passowrd} co ${ROOT_SVN_URL}/${DEV_REPO}/${HUDI_REPO}
     cd ${HUDI_REPO}
     (gpg --list-sigs ${name} && gpg --armor --export ${name}) >> KEYS
     svn status
     echo "Please review all changes. Do you confirm to commit? [y|N]"
     read commit_confirmation
     if [[ $commit_confirmation = "y" ]]; then
-      svn commit --no-auth-cache KEYS
+      svn --username=${apache_username} --password=${passowrd} commit --no-auth-cache KEYS
     else
       echo "Not commit new changes into ${ROOT_SVN_URL}/${DEV_REPO}/${HUDI_REPO}${DEV_REPO}/KEYS"
     fi
-
-    cd ~/${LOCAL_SVN_DIR}
+    cd ~
+    if [[ -d ${LOCAL_SVN_DIR} ]]; then
+      rm -rf ${LOCAL_SVN_DIR}
+    fi
+    mkdir ${LOCAL_SVN_DIR}
+    cd ${LOCAL_SVN_DIR}
     echo "===Starting updating KEYS file in release repo==="
-    svn co ${ROOT_SVN_URL}/${RELEASE_REPO}/${HUDI_REPO}
+    svn --username=${apache_username} --password=${passowrd} co ${ROOT_SVN_URL}/${RELEASE_REPO}/${HUDI_REPO}
     cd ${HUDI_REPO}
     (gpg --list-sigs ${name} && gpg --armor --export ${name}) >> KEYS
     svn status
     echo "Please review all changes. Do you confirm to commit? [y|N]"
     read commit_confirmation
     if [[ $commit_confirmation = "y" ]]; then
-      svn commit --no-auth-cache KEYS
+      svn --username=${apache_username} --password=${passowrd} commit --no-auth-cache KEYS
     else
       echo "Not commit new changes into ${ROOT_SVN_URL}/${DEV_REPO}/${HUDI_REPO}${RELEASE_REPO}/KEYS"
     fi


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

This fixes the `preparation_before_release.sh` to take in apache account creds for  svn checkout and commit operations. 

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.