### PR TITLE
[HUDI-1188] Hbase index MOR tables records not being deduplicated

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/index/hbase/HBaseIndex.java
+++ b/hudi-client/src/main/java/org/apache/hudi/index/hbase/HBaseIndex.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
@@ -177,13 +176,11 @@ public class HBaseIndex<T extends HoodieRecordPayload> extends HoodieIndex<T> {
   }
 
   private boolean checkIfValidCommit(HoodieTableMetaClient metaClient, String commitTs) {
-    HoodieTimeline commitTimeline = metaClient.getActiveTimeline().filterCompletedInstants();
+    HoodieTimeline commitTimeline = metaClient.getCommitsTimeline().filterCompletedInstants();
     // Check if the last commit ts for this row is 1) present in the timeline or
     // 2) is less than the first commit ts in the timeline
     return !commitTimeline.empty()
-        && (commitTimeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, commitTs))
-            || HoodieTimeline.compareTimestamps(commitTimeline.firstInstant().get().getTimestamp(), HoodieTimeline.GREATER_THAN, commitTs
-    ));
+        && commitTimeline.containsOrBeforeTimelineStarts(commitTs);
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the pull request

After fetching hbase index for a record, Hudi performs validation that the commit timestamp stored in hbase for that record is a `commit` on the timeline. This makes any record that is stored to hbase index during a `deltacommit` considered an invalid index and treated as a new record. This causes the hbase index to be updated every time which leads to records being able to be in multiple partitions and even in different file groups within same partition.

## Brief change log

* Modify HbaseIndex.checkIfValidCommit to consider DELTA_COMMIT timestamp as valid index timestamp

## Verify this pull request

This change added tests and can be verified as follows:

  - Verified test failed on MOR table before change and succeeding now
  - Manually verified by:
       * Uploaded patched JAR to EMR 5.30.1 cluster
       * Create MOR table w/ HBASE index
       * Upsert record
       * Upsert record with new partition
       * Validate new partition was not created and existing partition displayed update to record