### PR TITLE
[HUDI-1206]Remove unused variable in Compactor

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/async/AsyncCompactService.java
+++ b/hudi-client/src/main/java/org/apache/hudi/async/AsyncCompactService.java
@@ -64,7 +64,7 @@ public class AsyncCompactService extends AbstractAsyncService {
   public AsyncCompactService(JavaSparkContext jssc, HoodieWriteClient client, boolean runInDaemonMode) {
     super(runInDaemonMode);
     this.jssc = jssc;
-    this.compactor = new Compactor(client, jssc);
+    this.compactor = new Compactor(client);
     this.maxConcurrentCompaction = 1;
   }
 

--- a/hudi-client/src/main/java/org/apache/hudi/client/Compactor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/Compactor.java
@@ -25,7 +25,6 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -39,10 +38,8 @@ public class Compactor implements Serializable {
   private static final Logger LOG = LogManager.getLogger(Compactor.class);
 
   private transient HoodieWriteClient compactionClient;
-  private transient JavaSparkContext jssc;
 
-  public Compactor(HoodieWriteClient compactionClient, JavaSparkContext jssc) {
-    this.jssc = jssc;
+  public Compactor(HoodieWriteClient compactionClient) {
     this.compactionClient = compactionClient;
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Remove unused variable in Compactor*

JavaSparkContext jssc in Compactor class was not used anywhere, we can remove it.


## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.