### PR TITLE
[HUDI-1067]Replace the integer version field with HoodieLogBlockVersion data structure

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlockVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlockVersion.java
@@ -22,7 +22,7 @@ abstract class HoodieLogBlockVersion {
 
   private final int currentVersion;
 
-  public static final int DEFAULT_VERSION = 0;
+  public static final int DEFAULT_VERSION = Integer.parseInt("hoodie.logblock.default.version");
 
   HoodieLogBlockVersion(int version) {
     this.currentVersion = version;

--- a/hudi-common/src/main/resources/HoodieLogBlockVersion.properties
+++ b/hudi-common/src/main/resources/HoodieLogBlockVersion.properties
@@ -1,0 +1,18 @@
+###
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+###
+hoodie.logblock.default.version=0


### PR DESCRIPTION
Replace the integer version field with HoodieLogBlockVersion data structure

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

_Replace the integer version field with HoodieLogBlockVersion data structure_

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.