### PR TITLE
[MINOR] fix get classname for hive sync

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -99,9 +99,23 @@ public class HoodieInputFormatUtils {
     }
   }
 
-  public static String getInputFormatClassName(HoodieFileFormat baseFileFormat, boolean realtime, Configuration conf) {
-    FileInputFormat inputFormat = getInputFormat(baseFileFormat, realtime, conf);
-    return inputFormat.getClass().getName();
+  public static String getInputFormatClassName(HoodieFileFormat baseFileFormat, boolean realtime) {
+    switch (baseFileFormat) {
+      case PARQUET:
+        if (realtime) {
+          return HoodieParquetRealtimeInputFormat.class.getName();
+        } else {
+          return HoodieParquetInputFormat.class.getName();
+        }
+      case HFILE:
+        if (realtime) {
+          return HoodieHFileRealtimeInputFormat.class.getName();
+        } else {
+          return HoodieHFileInputFormat.class.getName();
+        }
+      default:
+        throw new HoodieIOException("Hoodie InputFormat not implemented for base file format " + baseFileFormat);
+    }
   }
 
   public static String getOutputFormatClassName(HoodieFileFormat baseFileFormat) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -157,8 +157,7 @@ public class HiveSyncTool extends AbstractSyncTool {
     if (!tableExists) {
       LOG.info("Hive table " + tableName + " is not found. Creating it");
       HoodieFileFormat baseFileFormat = HoodieFileFormat.valueOf(cfg.baseFileFormat.toUpperCase());
-      String inputFormatClassName = HoodieInputFormatUtils.getInputFormatClassName(baseFileFormat, useRealTimeInputFormat,
-          new Configuration());
+      String inputFormatClassName = HoodieInputFormatUtils.getInputFormatClassName(baseFileFormat, useRealTimeInputFormat);
 
       if (baseFileFormat.equals(HoodieFileFormat.PARQUET) && cfg.usePreApacheInputFormat) {
         // Parquet input format had an InputFormat class visible under the old naming scheme.


### PR DESCRIPTION
## What is the purpose of the pull request

Fix #2005 

## Brief change log

  - *avoid creating a new class when getting the class name in HoodieInputFormatUtils*

## Verify this pull request


This pull request is already covered by existing tests, such as *(please describe tests)*.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.