### PR TITLE
[HUDI-1129] Deltastreamer Add support for schema evolution

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
@@ -60,7 +60,7 @@ object AvroConversionUtils {
   def convertStructTypeToAvroSchema(structType: StructType,
                                     structName: String,
                                     recordNamespace: String): Schema = {
-    getAvroSchemaWithDefaults(SchemaConverters.toAvroType(structType, nullable = false, structName, recordNamespace))
+    AvroConversionHelper.removeNamespaceFromFixedFields(getAvroSchemaWithDefaults(SchemaConverters.toAvroType(structType, nullable = false, structName, recordNamespace)))
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayloadWithSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayloadWithSchema.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import java.io.Serializable;
+
+/**
+ * Base class for AVRO record based payloads, which stores writer schema as well.
+ */
+public abstract class BaseAvroPayloadWithSchema extends BaseAvroPayload implements Serializable {
+  /**
+   * Schema used to convert avro to bytes.
+   */
+  protected final Schema writerSchema;
+
+  /**
+   * Instantiate {@link BaseAvroPayloadWithSchema}.
+   *
+   * @param record      Generic record for the payload.
+   * @param orderingVal {@link Comparable} to be used in pre combine.
+   */
+  public BaseAvroPayloadWithSchema(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+    this.writerSchema = record != null ? record.getSchema() : null;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * <li> combineAndGetUpdateValue/getInsertValue - Simply overwrites storage with latest delta record
  * </ol>
  */
-public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
+public class OverwriteWithLatestAvroPayload extends BaseAvroPayloadWithSchema
     implements HoodieRecordPayload<OverwriteWithLatestAvroPayload> {
 
   public OverwriteWithLatestAvroPayload(GenericRecord record, Comparable orderingVal) {
@@ -66,7 +66,7 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
     if (recordBytes.length == 0) {
       return Option.empty();
     }
-    IndexedRecord indexedRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
+    IndexedRecord indexedRecord = HoodieAvroUtils.bytesToAvro(recordBytes, writerSchema, schema);
     if (isDeleteRecord((GenericRecord) indexedRecord)) {
       return Option.empty();
     } else {

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -46,8 +46,11 @@ public class TestHoodieAvroUtils {
       + "{\"name\": \"timestamp\",\"type\": \"double\"},{\"name\": \"_row_key\", \"type\": \"string\"},"
       + "{\"name\": \"non_pii_col\", \"type\": \"string\"},"
       + "{\"name\": \"pii_col\", \"type\": \"string\", \"column_category\": \"user_profile\"},"
-      + "{\"name\": \"new_col1\", \"type\": \"string\", \"default\": \"dummy_val\"},"
-      + "{\"name\": \"new_col2\", \"type\": [\"int\", \"null\"]}]}";
+      + "{\"name\": \"new_col_not_nullable_default_dummy_val\", \"type\": \"string\", \"default\": \"dummy_val\"},"
+      + "{\"name\": \"new_col_nullable_wo_default\", \"type\": [\"int\", \"null\"]},"
+      + "{\"name\": \"new_col_nullable_default_null\", \"type\": [\"null\" ,\"string\"],\"default\": null},"
+      + "{\"name\": \"new_col_nullable_default_dummy_val\", \"type\": [\"string\" ,\"null\"],\"default\": \"dummy_val\"}]}";
+
 
   private static String EXAMPLE_SCHEMA = "{\"type\": \"record\",\"name\": \"testrec\",\"fields\": [ "
       + "{\"name\": \"timestamp\",\"type\": \"double\"},{\"name\": \"_row_key\", \"type\": \"string\"},"
@@ -111,8 +114,10 @@ public class TestHoodieAvroUtils {
     rec.put("timestamp", 3.5);
     Schema schemaWithMetadata = HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(EVOLVED_SCHEMA));
     GenericRecord rec1 = HoodieAvroUtils.rewriteRecord(rec, schemaWithMetadata);
-    assertEquals(rec1.get("new_col1"), "dummy_val");
-    assertNull(rec1.get("new_col2"));
+    assertEquals(rec1.get("new_col_not_nullable_default_dummy_val"), "dummy_val");
+    assertNull(rec1.get("new_col_nullable_wo_default"));
+    assertNull(rec1.get("new_col_nullable_default_null"));
+    assertEquals(rec1.get("new_col_nullable_default_dummy_val"), "dummy_val");
     assertNull(rec1.get(HoodieRecord.RECORD_KEY_METADATA_FIELD));
   }
 
@@ -124,8 +129,8 @@ public class TestHoodieAvroUtils {
     rec.put("pii_col", "val2");
     rec.put("timestamp", 3.5);
     GenericRecord rec1 = HoodieAvroUtils.rewriteRecord(rec, new Schema.Parser().parse(EVOLVED_SCHEMA));
-    assertEquals(rec1.get("new_col1"), "dummy_val");
-    assertNull(rec1.get("new_col2"));
+    assertEquals(rec1.get("new_col_not_nullable_default_dummy_val"), "dummy_val");
+    assertNull(rec1.get("new_col_nullable_wo_default"));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -108,7 +108,7 @@ public class HoodieTestDataGenerator {
       + "{\"name\": \"nation\", \"type\": \"bytes\"},"
       + "{\"name\":\"current_date\",\"type\": {\"type\": \"int\", \"logicalType\": \"date\"}},"
       + "{\"name\":\"current_ts\",\"type\": {\"type\": \"long\"}},"
-      + "{\"name\":\"height\",\"type\":{\"type\":\"fixed\",\"name\":\"abc\",\"size\":5,\"logicalType\":\"decimal\",\"precision\":10,\"scale\":6}},";
+      + "{\"name\":\"height\",\"type\":{\"type\":\"fixed\",\"name\":\"fixed\",\"size\":5,\"logicalType\":\"decimal\",\"precision\":10,\"scale\":6}},";
 
   public static final String TRIP_EXAMPLE_SCHEMA =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;

--- a/hudi-utilities/src/test/resources/delta-streamer-config/source.avsc
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/source.avsc
@@ -70,7 +70,7 @@
     "name" : "height",
     "type" : {
       "type" : "fixed",
-      "name" : "abc",
+      "name" : "fixed",
       "size" : 5,
       "logicalType" : "decimal",
       "precision" : 10,

--- a/hudi-utilities/src/test/resources/delta-streamer-config/source_evolved.avsc
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/source_evolved.avsc
@@ -52,7 +52,7 @@
   }, {
     "name" : "weight",
     "type" : "float"
-  }, {
+  },{
     "name" : "nation",
     "type" : "bytes"
   },{
@@ -66,7 +66,7 @@
     "type" : {
       "type" : "long"
       }
-  }, {
+  },{
     "name" : "height",
     "type" : {
       "type" : "fixed",
@@ -82,12 +82,13 @@
       "type" : "map",
       "values": "string"
     }
-  }, {
+  },
+  {
     "name" : "fare",
     "type" : {
       "type" : "record",
       "name" : "fare",
-       "fields" : [
+      "fields" : [
         {
          "name" : "amount",
          "type" : "double"
@@ -96,8 +97,16 @@
          "name" : "currency",
          "type" : "string"
         }
-       ]
+      ]
     }
+  },
+  {
+      "name": "evoluted_optional_union_field",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
   },
   {
     "name" : "tip_history",
@@ -120,13 +129,9 @@
     }
   },
   {
-     "name" : "_hoodie_is_deleted",
-     "type" : "boolean",
-     "default" : false
-  },
-  {
-     "name" : "haversine_distance",
-     "type" : "double"
-  }]
+    "name" : "_hoodie_is_deleted",
+    "type" : "boolean",
+    "default" : false
+  } ]
 }
 


### PR DESCRIPTION
## What is the purpose of the pull request

When schema is evolved but producer is still producing events using older version of schema, Hudi delta streamer is failing. This fix is to make sure delta streamer works fine with schema evoluation.

Related issues #1845 #1971 #1972 

## Brief change log

  - Update avro to spark conversion method `AvroConversionHelper.createConverterToRow` to handle scenario when provided schema has more fields than data (scenario where producer is still sending events with old schema)
 -  Introduce new payload class called `BaseAvroPayloadWithSchema`. This is used to store the writer schema part of payload. Currently, `HoodieAvroUtils.avroToBytes` uses the schema of the data to convert to bytes, but `HoodieAvroUtils.bytesToAvro` uses provided schema. Since both may not match always, it results in error. By having data's schema as part of payload, we can ensure, same schema is used for converting avro to bytes and bytes back to avro. 


## Verify this pull request

This change added tests and can be verified as follows:

  - *Added unit test to verify schema evoluation* Thanks @sbernauer for unit test

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.