### PR TITLE
[HUDI-1153] Spark DataSource and Streaming Write must fail when operation type is misconfigured

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -41,10 +41,6 @@ public enum WriteOperationType {
   // used for old version
   UNKNOWN("unknown");
 
-  public String value() {
-    return value;
-  }
-
   private final String value;
 
   WriteOperationType(String value) {
@@ -73,6 +69,15 @@ public enum WriteOperationType {
       default:
         throw new HoodieException("Invalid value of Type.");
     }
+  }
+
+  /**
+   * Returns the name of this enum constant, as contained in the declaration.
+   * @return string form of WriteOperationType
+   */
+  @Override
+  public String toString() {
+    return value;
   }
 
   public static boolean isChangingRecords(WriteOperationType operationType) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -72,15 +72,6 @@ public enum WriteOperationType {
   }
 
   /**
-   * Returns the name of this enum constant, as contained in the declaration.
-   * @return string form of WriteOperationType
-   */
-  @Override
-  public String toString() {
-    return value();
-  }
-
-  /**
    * Getter for value.
    * @return string form of WriteOperationType
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -77,6 +77,14 @@ public enum WriteOperationType {
    */
   @Override
   public String toString() {
+    return value();
+  }
+
+  /**
+   * Getter for value
+   * @return string form of WriteOperationType
+   */
+  public String value() {
     return value;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -81,7 +81,7 @@ public enum WriteOperationType {
   }
 
   /**
-   * Getter for value
+   * Getter for value.
    * @return string form of WriteOperationType
    */
   public String value() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -41,6 +41,10 @@ public enum WriteOperationType {
   // used for old version
   UNKNOWN("unknown");
 
+  public String value() {
+    return value;
+  }
+
   private final String value;
 
   WriteOperationType(String value) {

--- a/hudi-spark/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -250,18 +250,17 @@ public class DataSourceUtils {
 
   public static JavaRDD<WriteStatus> doWriteOperation(HoodieWriteClient client, JavaRDD<HoodieRecord> hoodieRecords,
       String instantTime, WriteOperationType operation) throws HoodieException {
-    if (operation == WriteOperationType.BULK_INSERT) {
-      Option<BulkInsertPartitioner> userDefinedBulkInsertPartitioner =
-          createUserDefinedBulkInsertPartitioner(client.getConfig());
-      return client.bulkInsert(hoodieRecords, instantTime, userDefinedBulkInsertPartitioner);
-    } else if (operation == WriteOperationType.INSERT) {
-      return client.insert(hoodieRecords, instantTime);
-    } else {
-      // default is upsert
-      if (operation != WriteOperationType.UPSERT) {
-        LOG.warn("Not a valid operation type for doWriteOperation: " + operation.toString() + " using default operation: UPSERT instead");
-      }
-      return client.upsert(hoodieRecords, instantTime);
+    switch (operation) {
+      case BULK_INSERT:
+        Option<BulkInsertPartitioner> userDefinedBulkInsertPartitioner =
+                createUserDefinedBulkInsertPartitioner(client.getConfig());
+        return client.bulkInsert(hoodieRecords, instantTime, userDefinedBulkInsertPartitioner);
+      case INSERT:
+        return client.insert(hoodieRecords, instantTime);
+      case UPSERT:
+        return client.upsert(hoodieRecords, instantTime);
+      default:
+        throw new HoodieException("Not a valid operation type for doWriteOperation: " + operation.toString());
     }
   }
 

--- a/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -137,11 +137,11 @@ object DataSourceWriteOptions {
     * Default: upsert()
     */
   val OPERATION_OPT_KEY = "hoodie.datasource.write.operation"
-  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.value
-  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.value
-  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.value
-  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.value
-  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.value
+  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.toString
+  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.toString
+  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.toString
+  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.toString
+  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.toString
   val DEFAULT_OPERATION_OPT_VAL = UPSERT_OPERATION_OPT_VAL
 
   /**

--- a/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -137,11 +137,11 @@ object DataSourceWriteOptions {
     * Default: upsert()
     */
   val OPERATION_OPT_KEY = "hoodie.datasource.write.operation"
-  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.toString
-  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.toString
-  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.toString
-  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.toString
-  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.toString
+  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.value
+  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.value
+  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.value
+  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.value
+  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.value
   val DEFAULT_OPERATION_OPT_VAL = UPSERT_OPERATION_OPT_VAL
 
   /**

--- a/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -19,6 +19,7 @@ package org.apache.hudi
 
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload
+import org.apache.hudi.common.model.WriteOperationType
 import org.apache.hudi.hive.HiveSyncTool
 import org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor
 import org.apache.hudi.keygen.SimpleKeyGenerator
@@ -136,11 +137,11 @@ object DataSourceWriteOptions {
     * Default: upsert()
     */
   val OPERATION_OPT_KEY = "hoodie.datasource.write.operation"
-  val BULK_INSERT_OPERATION_OPT_VAL = "bulk_insert"
-  val INSERT_OPERATION_OPT_VAL = "insert"
-  val UPSERT_OPERATION_OPT_VAL = "upsert"
-  val DELETE_OPERATION_OPT_VAL = "delete"
-  val BOOTSTRAP_OPERATION_OPT_VAL = "bootstrap"
+  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.name
+  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.name
+  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.name
+  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.name
+  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.name
   val DEFAULT_OPERATION_OPT_VAL = UPSERT_OPERATION_OPT_VAL
 
   /**

--- a/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -137,11 +137,11 @@ object DataSourceWriteOptions {
     * Default: upsert()
     */
   val OPERATION_OPT_KEY = "hoodie.datasource.write.operation"
-  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.name
-  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.name
-  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.name
-  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.name
-  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.name
+  val BULK_INSERT_OPERATION_OPT_VAL = WriteOperationType.BULK_INSERT.value
+  val INSERT_OPERATION_OPT_VAL = WriteOperationType.INSERT.value
+  val UPSERT_OPERATION_OPT_VAL = WriteOperationType.UPSERT.value
+  val DELETE_OPERATION_OPT_VAL = WriteOperationType.DELETE.value
+  val BOOTSTRAP_OPERATION_OPT_VAL = WriteOperationType.BOOTSTRAP.value
   val DEFAULT_OPERATION_OPT_VAL = UPSERT_OPERATION_OPT_VAL
 
   /**

--- a/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
+++ b/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.HoodieWriteClient;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -108,7 +109,7 @@ public class TestDataSourceUtils {
     when(hoodieWriteClient.getConfig()).thenReturn(config);
 
     DataSourceUtils.doWriteOperation(hoodieWriteClient, hoodieRecords, "test-time",
-            DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+            WriteOperationType.BULK_INSERT);
 
     verify(hoodieWriteClient, times(1)).bulkInsert(any(hoodieRecords.getClass()), anyString(),
             optionCaptor.capture());
@@ -121,7 +122,7 @@ public class TestDataSourceUtils {
 
     Exception exception = assertThrows(HoodieException.class, () -> {
       DataSourceUtils.doWriteOperation(hoodieWriteClient, hoodieRecords, "test-time",
-              DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+              WriteOperationType.BULK_INSERT);
     });
 
     assertThat(exception.getMessage(), containsString("Could not create UserDefinedBulkInsertPartitioner"));
@@ -132,7 +133,7 @@ public class TestDataSourceUtils {
     setAndVerifyHoodieWriteClientWith(NoOpBulkInsertPartitioner.class.getName());
 
     DataSourceUtils.doWriteOperation(hoodieWriteClient, hoodieRecords, "test-time",
-        DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+            WriteOperationType.BULK_INSERT);
 
     verify(hoodieWriteClient, times(1)).bulkInsert(any(hoodieRecords.getClass()), anyString(),
         optionCaptor.capture());


### PR DESCRIPTION

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Currently for Spark Streaming Write operation is being manually string compared on usage in most of the code, we also silently swallow illegal operation types by defaulting to upsert. This addresses these issues

## Brief change log

- [HUDI-1153] Spark DataSource and Streaming Write must fail when operation type is misconfigured

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.
TestDataSourceUtils
* testDoWriteOperationWithoutUserDefinedBulkInsertPartitioner
* testDoWriteOperationWithNonExistUserDefinedBulkInsertPartitioner
* testDoWriteOperationWithUserDefinedBulkInsertPartitioner
If all existing tests pass. This should be good to review

 - [x] Existing tests pass 

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [x] Necessary doc changes done or have another open PR - None
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA- Not a large task