### PR TITLE
[HUDI-1222] Introduce MergeHelper.UpdateHandler as independent class

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/action/commit/MergeHelper.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/commit/MergeHelper.java
@@ -31,7 +31,6 @@ import org.apache.hudi.client.utils.MergingIterator;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.queue.BoundedInMemoryExecutor;
-import org.apache.hudi.common.util.queue.BoundedInMemoryQueueConsumer;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.execution.SparkBoundedInMemoryExecutor;
 import org.apache.hudi.io.HoodieMergeHandle;
@@ -158,28 +157,4 @@ public class MergeHelper {
         (inputRecordPair) -> HoodieAvroUtils.stitchRecords(inputRecordPair.getLeft(), inputRecordPair.getRight(), mergeHandle.getWriterSchemaWithMetafields()));
   }
 
-  /**
-   * Consumer that dequeues records from queue and sends to Merge Handle.
-   */
-  private static class UpdateHandler extends BoundedInMemoryQueueConsumer<GenericRecord, Void> {
-
-    private final HoodieMergeHandle upsertHandle;
-
-    private UpdateHandler(HoodieMergeHandle upsertHandle) {
-      this.upsertHandle = upsertHandle;
-    }
-
-    @Override
-    protected void consumeOneRecord(GenericRecord record) {
-      upsertHandle.write(record);
-    }
-
-    @Override
-    protected void finish() {}
-
-    @Override
-    protected Void getResult() {
-      return null;
-    }
-  }
 }

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/commit/UpdateHandler.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/commit/UpdateHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hudi.common.util.queue.BoundedInMemoryQueueConsumer;
+import org.apache.hudi.io.HoodieMergeHandle;
+
+/**
+ * Consumer that dequeues records from queue and sends to Merge Handle.
+ */
+public class UpdateHandler  extends BoundedInMemoryQueueConsumer<GenericRecord, Void> {
+
+  private final HoodieMergeHandle upsertHandle;
+
+  public UpdateHandler(HoodieMergeHandle upsertHandle) {
+    this.upsertHandle = upsertHandle;
+  }
+
+  @Override
+  protected void consumeOneRecord(GenericRecord record) {
+    upsertHandle.write(record);
+  }
+
+  @Override
+  protected void finish() {}
+
+  @Override
+  protected Void getResult() {
+    return null;
+  }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Introduce MergeHelper.UpdateHandler as independent class*

## Brief change log

Making UpdateHandler class independent helps reduce the workload of refactoring hudi-client

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.