### PR TITLE
[HUDI-1133] Tune buffer sizes for the diskbased external spillable map

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/BufferedRandomAccessFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/BufferedRandomAccessFile.java
@@ -79,7 +79,7 @@ public final class BufferedRandomAccessFile extends RandomAccessFile {
    */
   public BufferedRandomAccessFile(File file, String mode) throws IOException {
     super(file, mode);
-    this.init(0);
+    this.init(DEFAULT_BUFFER_SIZE);
   }
 
   /**
@@ -102,7 +102,7 @@ public final class BufferedRandomAccessFile extends RandomAccessFile {
    */
   public BufferedRandomAccessFile(String name, String mode) throws IOException {
     super(name, mode);
-    this.init(0);
+    this.init(DEFAULT_BUFFER_SIZE);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
@@ -93,7 +93,7 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
     try {
       BufferedRandomAccessFile readHandle = randomAccessFile.get();
       if (readHandle == null) {
-        readHandle = new BufferedRandomAccessFile(filePath, "r");
+        readHandle = new BufferedRandomAccessFile(filePath, "r", BUFFER_SIZE);
         readHandle.seek(0);
         randomAccessFile.set(readHandle);
         openedAccessFiles.offer(readHandle);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
Tune buffer sizes for the diskbased external spillable map

## Brief change log

When bootstrapping large tables, external spill-able map is heavily used.  Increasing the buffer size used for BufferedRandomAccessFile, for non-default values.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [x ] Has a corresponding JIRA in PR title & commit
 
 - [ x] Commit message is descriptive of the change
 
 - [x ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.