### PR TITLE
[HUDI-1226] Fix ComplexKeyGenerator for non-partitioned tables

### DIFF
--- a/hudi-spark/src/main/java/org/apache/hudi/keygen/ComplexKeyGenerator.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/keygen/ComplexKeyGenerator.java
@@ -37,9 +37,9 @@ public class ComplexKeyGenerator extends BuiltinKeyGenerator {
   public ComplexKeyGenerator(TypedProperties props) {
     super(props);
     this.recordKeyFields = Arrays.stream(props.getString(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY())
-        .split(",")).map(String::trim).collect(Collectors.toList());
+        .split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());
     this.partitionPathFields = Arrays.stream(props.getString(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY())
-        .split(",")).map(String::trim).collect(Collectors.toList());
+        .split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());
   }
 
   @Override

--- a/hudi-spark/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -59,6 +59,10 @@ public class KeyGenUtils {
 
   public static String getRecordPartitionPath(GenericRecord record, List<String> partitionPathFields,
       boolean hiveStylePartitioning, boolean encodePartitionPath) {
+    if (partitionPathFields.isEmpty()) {
+      return "";
+    }
+
     StringBuilder partitionPath = new StringBuilder();
     for (String partitionPathField : partitionPathFields) {
       String fieldVal = HoodieAvroUtils.getNestedFieldValAsString(record, partitionPathField, true);

--- a/hudi-spark/src/test/java/TestComplexKeyGenerator.java
+++ b/hudi-spark/src/test/java/TestComplexKeyGenerator.java
@@ -64,4 +64,23 @@ public class TestComplexKeyGenerator {
     assertEquals(partitionPath, hoodieKey.getPartitionPath());
   }
 
+  @Test
+  public void testMultipleValueKeyGeneratorNonPartitioned() {
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key,timestamp");
+    properties.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "");
+    ComplexKeyGenerator compositeKeyGenerator = new ComplexKeyGenerator(properties);
+    assertEquals(compositeKeyGenerator.getRecordKeyFields().size(), 2);
+    assertEquals(compositeKeyGenerator.getPartitionPathFields().size(), 0);
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+    GenericRecord record = dataGenerator.generateGenericRecords(1).get(0);
+    String rowKey =
+        "_row_key" + ComplexKeyGenerator.DEFAULT_RECORD_KEY_SEPARATOR + record.get("_row_key").toString() + ","
+            + "timestamp" + ComplexKeyGenerator.DEFAULT_RECORD_KEY_SEPARATOR + record.get("timestamp").toString();
+    String partitionPath = "";
+    HoodieKey hoodieKey = compositeKeyGenerator.getKey(record);
+    assertEquals(rowKey, hoodieKey.getRecordKey());
+    assertEquals(partitionPath, hoodieKey.getPartitionPath());
+  }
+
 }


### PR DESCRIPTION

## What is the purpose of the pull request
ComplexKeyGenerator getPartitionPath doesnt seem to work well with non-partitioned tables. Fix it and add test case

## Brief change log
- Ignore empty string for partition path fields
- Return "" for partitionPath if there are no partition path fields defined

## Verify this pull request
This change added tests

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.