### PR TITLE
[HUDI-1147] Modify GenericRecordFullPayloadGenerator to generate vali…

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/DeltaGenerator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/DeltaGenerator.java
@@ -129,7 +129,7 @@ public class DeltaGenerator implements Serializable {
 
   public JavaRDD<GenericRecord> generateInserts(Config operation) {
     int numPartitions = operation.getNumInsertPartitions();
-    long recordsPerPartition = operation.getNumRecordsInsert() / numPartitions;
+    long recordsPerPartition = operation.getNumRecordsInsert();
     int minPayloadSize = operation.getRecordSize();
     int startPartition = operation.getStartPartition();
 
@@ -140,7 +140,7 @@ public class DeltaGenerator implements Serializable {
     JavaRDD<GenericRecord> inputBatch = jsc.parallelize(partitionIndexes, numPartitions)
         .mapPartitionsWithIndex((index, p) -> {
           return new LazyRecordGeneratorIterator(new FlexibleSchemaRecordGenerationIterator(recordsPerPartition,
-            minPayloadSize, schemaStr, partitionPathFieldNames, (Integer)index));
+              minPayloadSize, schemaStr, partitionPathFieldNames, numPartitions));
         }, true);
 
     if (deltaOutputConfig.getInputParallelism() < numPartitions) {

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/FlexibleSchemaRecordGenerationIterator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/FlexibleSchemaRecordGenerationIterator.java
@@ -66,14 +66,15 @@ public class FlexibleSchemaRecordGenerationIterator implements Iterator<GenericR
   @Override
   public GenericRecord next() {
     this.counter--;
+    boolean partitionPathsNonEmpty = partitionPathFieldNames != null && partitionPathFieldNames.size() > 0;
     if (lastRecord == null) {
-      GenericRecord record = this.partitionPathFieldNames != null && this.partitionPathFieldNames.size() > 0
-          ? this.generator.getNewPayloadWithTimestamp(firstPartitionPathField)
+      GenericRecord record = partitionPathsNonEmpty
+          ? this.generator.getNewPayloadWithTimestamp(this.firstPartitionPathField)
           : this.generator.getNewPayload();
       lastRecord = record;
       return record;
     } else {
-      return this.partitionPathFieldNames != null && this.partitionPathFieldNames.size() > 0
+      return partitionPathsNonEmpty
           ? this.generator.getUpdatePayloadWithTimestamp(lastRecord,
           this.partitionPathFieldNames, firstPartitionPathField)
           : this.generator.getUpdatePayload(lastRecord, this.partitionPathFieldNames);

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/FlexibleSchemaRecordGenerationIterator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/FlexibleSchemaRecordGenerationIterator.java
@@ -20,11 +20,6 @@ package org.apache.hudi.integ.testsuite.generator;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Iterator;
-import java.util.List;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,17 +41,21 @@ public class FlexibleSchemaRecordGenerationIterator implements Iterator<GenericR
   private GenericRecord lastRecord;
   // Partition path field name
   private Set<String> partitionPathFieldNames;
+  private String firstPartitionPathField;
 
   public FlexibleSchemaRecordGenerationIterator(long maxEntriesToProduce, String schema) {
     this(maxEntriesToProduce, GenericRecordFullPayloadGenerator.DEFAULT_PAYLOAD_SIZE, schema, null, 0);
   }
 
   public FlexibleSchemaRecordGenerationIterator(long maxEntriesToProduce, int minPayloadSize, String schemaStr,
-      List<String> partitionPathFieldNames, int partitionIndex) {
+      List<String> partitionPathFieldNames, int numPartitions) {
     this.counter = maxEntriesToProduce;
     this.partitionPathFieldNames = new HashSet<>(partitionPathFieldNames);
+    if(partitionPathFieldNames != null && partitionPathFieldNames.size() > 0) {
+      this.firstPartitionPathField = partitionPathFieldNames.get(0);
+    }
     Schema schema = new Schema.Parser().parse(schemaStr);
-    this.generator = new GenericRecordFullPayloadGenerator(schema, minPayloadSize, partitionIndex);
+    this.generator = new GenericRecordFullPayloadGenerator(schema, minPayloadSize, numPartitions);
   }
 
   @Override
@@ -68,11 +67,16 @@ public class FlexibleSchemaRecordGenerationIterator implements Iterator<GenericR
   public GenericRecord next() {
     this.counter--;
     if (lastRecord == null) {
-      GenericRecord record = this.generator.getNewPayload(partitionPathFieldNames);
+      GenericRecord record = this.partitionPathFieldNames != null && this.partitionPathFieldNames.size() > 0
+          ? this.generator.getNewPayloadWithTimestamp(firstPartitionPathField)
+          : this.generator.getNewPayload();
       lastRecord = record;
       return record;
     } else {
-      return this.generator.randomize(lastRecord, this.partitionPathFieldNames);
+      return this.partitionPathFieldNames != null && this.partitionPathFieldNames.size() > 0
+          ? this.generator.getUpdatePayloadWithTimestamp(lastRecord,
+          this.partitionPathFieldNames, firstPartitionPathField)
+          : this.generator.getUpdatePayload(lastRecord, this.partitionPathFieldNames);
     }
   }
 }

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordFullPayloadGenerator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordFullPayloadGenerator.java
@@ -46,8 +46,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class GenericRecordFullPayloadGenerator implements Serializable {
 
-  private static Logger LOG = LoggerFactory.getLogger(GenericRecordFullPayloadGenerator.class);
-
+  private static final Logger LOG = LoggerFactory.getLogger(GenericRecordFullPayloadGenerator.class);
   public static final int DEFAULT_PAYLOAD_SIZE = 1024 * 10; // 10 KB
   public static final int DEFAULT_NUM_DATE_PARTITIONS = 50;
   public static final String DEFAULT_HOODIE_IS_DELETED_COL = "_hoodie_is_deleted";
@@ -70,14 +69,7 @@ public class GenericRecordFullPayloadGenerator implements Serializable {
   // The index of partition for which records are being generated
   private int partitionIndex = 0;
   // The size of a full record where every field of a generic record created contains 1 random value
-<<<<<<< HEAD
-  private final int estimatedFullPayloadSize;
-
-=======
   private int estimatedFullPayloadSize;
-  // Index to cycle through numDatePartitions, for timestamp generation.
-  private long partitionIndex = 0;
->>>>>>> 666d71d5... merge conflicts
   // LogicalTypes in Avro 1.8.2
   private static final String DECIMAL = "decimal";
   private static final String UUID_NAME = "uuid";
@@ -104,10 +96,9 @@ public class GenericRecordFullPayloadGenerator implements Serializable {
     if (estimatedFullPayloadSize < minPayloadSize) {
       int numberOfComplexFields = sizeInfo.getRight();
       if (numberOfComplexFields < 1) {
-        LOG.warn("The schema does not have any collections/complex fields. "
-            + "Cannot achieve minPayloadSize => " + minPayloadSize);
+        LOG.warn("The schema does not have any collections/complex fields. Cannot achieve minPayloadSize : {}",
+            minPayloadSize);
       }
-
       determineExtraEntriesRequired(numberOfComplexFields, minPayloadSize - estimatedFullPayloadSize);
     }
   }

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordFullPayloadGenerator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordFullPayloadGenerator.java
@@ -70,8 +70,14 @@ public class GenericRecordFullPayloadGenerator implements Serializable {
   // The index of partition for which records are being generated
   private int partitionIndex = 0;
   // The size of a full record where every field of a generic record created contains 1 random value
+<<<<<<< HEAD
   private final int estimatedFullPayloadSize;
 
+=======
+  private int estimatedFullPayloadSize;
+  // Index to cycle through numDatePartitions, for timestamp generation.
+  private long partitionIndex = 0;
+>>>>>>> 666d71d5... merge conflicts
   // LogicalTypes in Avro 1.8.2
   private static final String DECIMAL = "decimal";
   private static final String UUID_NAME = "uuid";
@@ -86,7 +92,7 @@ public class GenericRecordFullPayloadGenerator implements Serializable {
   }
 
   public GenericRecordFullPayloadGenerator(Schema schema, int minPayloadSize, int numDatePartitions) {
-    this(schema, DEFAULT_PAYLOAD_SIZE);
+    this(schema, minPayloadSize);
     this.numDatePartitions = numDatePartitions;
   }
 

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordFullPayloadGenerator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordFullPayloadGenerator.java
@@ -55,21 +55,15 @@ public class GenericRecordFullPayloadGenerator implements Serializable {
   private final transient Schema baseSchema;
   // Used to validate a generic record
   private final transient GenericData genericData = new GenericData();
+  // The index of partition for which records are being generated
+  private int partitionIndex = 0;
+  // The size of a full record where every field of a generic record created contains 1 random value
+  private int estimatedFullPayloadSize;
   // Number of extra entries to add in a complex/collection field to achieve the desired record size
   Map<String, Integer> extraEntriesMap = new HashMap<>();
 
   // The number of unique dates to create
   private int numDatePartitions = DEFAULT_NUM_DATE_PARTITIONS;
-  // Number of more bytes to add based on the estimated full record payload size and min payload size
-  private int numberOfBytesToAdd;
-  // If more elements should be packed to meet the minPayloadSize
-  private boolean shouldAddMore;
-  // How many complex fields have we visited that can help us pack more entries and increase the size of the record
-  private int numberOfComplexFields;
-  // The index of partition for which records are being generated
-  private int partitionIndex = 0;
-  // The size of a full record where every field of a generic record created contains 1 random value
-  private int estimatedFullPayloadSize;
   // LogicalTypes in Avro 1.8.2
   private static final String DECIMAL = "decimal";
   private static final String UUID_NAME = "uuid";

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/generator/TestGenericRecordPayloadGenerator.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/generator/TestGenericRecordPayloadGenerator.java
@@ -33,8 +33,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
-
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -164,10 +162,10 @@ public class TestGenericRecordPayloadGenerator {
       updateTimeStamps.add((Long) record.get("timestamp"));
     });
     // The row keys from insert payloads should match all the row keys from the update payloads
-    Assert.assertTrue(insertRowKeys.containsAll(updateRowKeys));
+    assertTrue(insertRowKeys.containsAll(updateRowKeys));
     // The timestamp field for the insert payloads should not all match with the update payloads
-    Assert.assertFalse(insertTimeStamps.containsAll(updateTimeStamps));
+    assertFalse(insertTimeStamps.containsAll(updateTimeStamps));
     Long currentMillis = System.currentTimeMillis();
-    Assert.assertTrue(insertTimeStamps.stream().allMatch(t -> t >= startMillis  && t <= currentMillis));
+    assertTrue(insertTimeStamps.stream().allMatch(t -> t >= startMillis  && t <= currentMillis));
   }
 }

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/generator/TestGenericRecordPayloadGenerator.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/generator/TestGenericRecordPayloadGenerator.java
@@ -27,11 +27,14 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -133,4 +136,38 @@ public class TestGenericRecordPayloadGenerator {
     assertTrue(HoodieAvroUtils.avroToBytes(record).length < minPayloadSize + 0.1 * minPayloadSize);
   }
 
+  @Test
+  public void testUpdatePayloadGeneratorWithTimestamp() throws IOException {
+    Schema schema = new Schema.Parser().parse(UtilitiesTestBase.Helpers
+        .readFileFromAbsolutePath(System.getProperty("user.dir") + "/.." + SOURCE_SCHEMA_DOCKER_DEMO_RELATIVE_PATH));
+    GenericRecordFullPayloadGenerator payloadGenerator = new GenericRecordFullPayloadGenerator(schema);
+    List<String> insertRowKeys = new ArrayList<>();
+    List<String> updateRowKeys = new ArrayList<>();
+    List<Long> insertTimeStamps = new ArrayList<>();
+    List<Long> updateTimeStamps = new ArrayList<>();
+    List<GenericRecord> records = new ArrayList<>();
+    Long startMillis = System.currentTimeMillis() - TimeUnit.MILLISECONDS
+        .convert(GenericRecordFullPayloadGenerator.DEFAULT_NUM_DATE_PARTITIONS, TimeUnit.DAYS);
+
+    // Generate 10 new records
+    IntStream.range(0, 10).forEach(a -> {
+      GenericRecord record = payloadGenerator.getNewPayloadWithTimestamp("timestamp");
+      records.add(record);
+      insertRowKeys.add(record.get("_row_key").toString());
+      insertTimeStamps.add((Long) record.get("timestamp"));
+    });
+    Set<String> blacklistFields = new HashSet<>(Arrays.asList("_row_key"));
+    records.stream().forEach(a -> {
+      // Generate 10 updated records
+      GenericRecord record = payloadGenerator.getUpdatePayloadWithTimestamp(a, blacklistFields, "timestamp");
+      updateRowKeys.add(record.get("_row_key").toString());
+      updateTimeStamps.add((Long) record.get("timestamp"));
+    });
+    // The row keys from insert payloads should match all the row keys from the update payloads
+    Assert.assertTrue(insertRowKeys.containsAll(updateRowKeys));
+    // The timestamp field for the insert payloads should not all match with the update payloads
+    Assert.assertFalse(insertTimeStamps.containsAll(updateTimeStamps));
+    Long currentMillis = System.currentTimeMillis();
+    Assert.assertTrue(insertTimeStamps.stream().allMatch(t -> t >= startMillis  && t <= currentMillis));
+  }
 }


### PR DESCRIPTION
…d timestamps

## What is the purpose of the pull request
Modify GenericRecordFullPayloadGenerator to generate valid timestamps

## Brief change log
- Hudi-test-suite uses the GenericRecordFullPayloadGenerator for generating test data at scale.  With this change, 
number of partitions to use during test data generation is configurable.   Generated records are distributed among 
the requested number of partitions, equally.

## Verify this pull request

This change added  tests and can be verified as follows:
- Added testUpdatePayloadGeneratorWithTimestamp to verify the scenario.

## Committer checklist

 - [ x] Has a corresponding JIRA in PR title & commit
 
 - [ x] Commit message is descriptive of the change
 
 - [ x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.