### PR TITLE
[HUDI-1252] Remove unused code in DataSourceTestUtils

### DIFF
--- a/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
+++ b/hudi-spark/src/test/java/org/apache/hudi/testutils/DataSourceTestUtils.java
@@ -18,16 +18,9 @@
 
 package org.apache.hudi.testutils;
 
-import org.apache.hudi.common.model.HoodieKey;
-import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.model.HoodieRecordPayload;
-import org.apache.hudi.common.testutils.RawTripTestPayload;
 import org.apache.hudi.common.util.FileIOUtils;
-import org.apache.hudi.common.util.Option;
-import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.avro.Schema;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 
@@ -38,7 +31,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
@@ -48,43 +40,6 @@ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_T
  * Test utils for data source tests.
  */
 public class DataSourceTestUtils {
-
-  public static Option<String> convertToString(HoodieRecord record) {
-    try {
-      String str = ((RawTripTestPayload) record.getData()).getJsonData();
-      str = "{" + str.substring(str.indexOf("\"timestamp\":"));
-      // Remove the last } bracket
-      str = str.substring(0, str.length() - 1);
-      return Option.of(str + ", \"partition\": \"" + record.getPartitionPath() + "\"}");
-    } catch (IOException e) {
-      return Option.empty();
-    }
-  }
-
-  public static List<String> convertToStringList(List<HoodieRecord> records) {
-    return records.stream().map(DataSourceTestUtils::convertToString).filter(Option::isPresent).map(Option::get)
-        .collect(Collectors.toList());
-  }
-
-  public static List<String> convertKeysToStringList(List<HoodieKey> keys) {
-    return keys.stream()
-        .map(hr -> "{\"_row_key\":\"" + hr.getRecordKey() + "\",\"partition\":\"" + hr.getPartitionPath() + "\"}")
-        .collect(Collectors.toList());
-  }
-
-  public static class NoOpBulkInsertPartitioner<T extends HoodieRecordPayload>
-      implements BulkInsertPartitioner<T> {
-
-    @Override
-    public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records, int outputSparkPartitions) {
-      return records;
-    }
-
-    @Override
-    public boolean arePartitionRecordsSorted() {
-      return false;
-    }
-  }
 
   public static Schema getStructTypeExampleSchema() throws IOException {
     return new Schema.Parser().parse(FileIOUtils.readAsUTFString(DataSourceTestUtils.class.getResourceAsStream("/exampleSchema.txt")));


### PR DESCRIPTION
…ceTestUtils

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*DataSourceTestUtils's inner class NoOpBulkInsertPartitioner was not used anywhere, we can remove it.*

## Brief change log

Remove unused class NoOpBulkInsertPartitioner in DataSourceTestUtils

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.