### PR TITLE
[HUDI-995] Use HoodieTestTable in more classes

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestStatsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestStatsCommand.java
@@ -27,7 +27,7 @@ import org.apache.hudi.cli.testutils.HoodieTestCommitMetadataGenerator;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
-import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
 
 import com.codahale.metrics.Histogram;
@@ -66,6 +66,7 @@ public class TestStatsCommand extends AbstractShellIntegrationTest {
     new TableCommand().createTable(
         tablePath, tableName, HoodieTableType.COPY_ON_WRITE.name(),
         "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
+    metaClient = HoodieCLI.getTableMetaClient();
   }
 
   /**
@@ -112,7 +113,7 @@ public class TestStatsCommand extends AbstractShellIntegrationTest {
    * Test case for command 'stats filesizes'.
    */
   @Test
-  public void testFileSizeStats() throws IOException {
+  public void testFileSizeStats() throws Exception {
     String commit1 = "100";
     String commit2 = "101";
     Map<String, Integer[]> data = new LinkedHashMap<>();
@@ -124,18 +125,20 @@ public class TestStatsCommand extends AbstractShellIntegrationTest {
     String partition2 = HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
     String partition3 = HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
 
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
     Integer[] data1 = data.get(commit1);
     assertTrue(3 <= data1.length);
-    HoodieTestUtils.createNewDataFile(tablePath, partition1, commit1, data1[0]);
-    HoodieTestUtils.createNewDataFile(tablePath, partition2, commit1, data1[1]);
-    HoodieTestUtils.createNewDataFile(tablePath, partition3, commit1, data1[2]);
+    testTable.addCommit(commit1)
+        .withBaseFilesInPartition(partition1, data1[0])
+        .withBaseFilesInPartition(partition2, data1[1])
+        .withBaseFilesInPartition(partition3, data1[2]);
 
     Integer[] data2 = data.get(commit2);
     assertTrue(4 <= data2.length);
-    HoodieTestUtils.createNewDataFile(tablePath, partition1, commit2, data2[0]);
-    HoodieTestUtils.createNewDataFile(tablePath, partition2, commit2, data2[1]);
-    HoodieTestUtils.createNewDataFile(tablePath, partition2, commit2, data2[2]);
-    HoodieTestUtils.createNewDataFile(tablePath, partition3, commit2, data2[3]);
+    testTable.addCommit(commit2)
+        .withBaseFilesInPartition(partition1, data2[0])
+        .withBaseFilesInPartition(partition2, data2[1], data2[2])
+        .withBaseFilesInPartition(partition3, data2[3]);
 
     CommandResult cr = getShell().executeCommand("stats filesizes");
     assertTrue(cr.isSuccess());

--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieKeyLocationFetchHandle.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieKeyLocationFetchHandle.java
@@ -53,7 +53,7 @@ import scala.Tuple2;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA_WITH_METADATA_FIELDS;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestUtils.makeNewCommitTime;
+import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.common.testutils.Transformations.recordsToPartitionRecordsMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -98,8 +98,8 @@ import java.util.stream.Stream;
 
 import scala.Tuple3;
 
+import static org.apache.hudi.common.testutils.HoodieTestTable.makeIncrementalCommitTimes;
 import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
-import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTimes;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.DEFAULT_PARTITION_PATHS;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -244,7 +244,7 @@ public class TestCleaner extends HoodieClientTestBase {
           .map(e -> Pair.of(e.getKey().getPartitionPath(), e.getValue())).collect(Collectors.toList());
       HoodieCompactionPlan compactionPlan =
           CompactionUtils.buildFromFileSlices(partitionFileSlicePairs, Option.empty(), Option.empty());
-      List<String> instantTimes = makeNewCommitTimes(9);
+      List<String> instantTimes = makeIncrementalCommitTimes(9);
       String compactionTime = instantTimes.get(0);
       table.getActiveTimeline().saveToCompactionRequested(
           new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, compactionTime),
@@ -386,7 +386,7 @@ public class TestCleaner extends HoodieClientTestBase {
         HoodieCleaningPolicy.KEEP_LATEST_COMMITS);
 
     // Keep doing some writes and clean inline. Make sure we have expected number of files remaining.
-    makeNewCommitTimes(8).forEach(newCommitTime -> {
+    makeIncrementalCommitTimes(8).forEach(newCommitTime -> {
       try {
         client.startCommitWithTime(newCommitTime);
         List<HoodieRecord> records = recordUpsertGenWrappedFunction.apply(newCommitTime, 100);

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -1069,7 +1069,7 @@ public class TestCleaner extends HoodieClientTestBase {
         HoodieWriteConfig.newBuilder()
             .withPath(basePath).withAssumeDatePartitioning(true)
             .withCompactionConfig(HoodieCompactionConfig.newBuilder()
-                .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS).retainFileVersions(1).build())
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS).retainFileVersions(1).build())
             .build();
 
     String commitTime = makeNewCommitTime(1);

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -66,6 +66,7 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.action.clean.CleanPlanner;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -97,6 +98,8 @@ import java.util.stream.Stream;
 
 import scala.Tuple3;
 
+import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
+import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTimes;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.DEFAULT_PARTITION_PATHS;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -241,7 +244,7 @@ public class TestCleaner extends HoodieClientTestBase {
           .map(e -> Pair.of(e.getKey().getPartitionPath(), e.getValue())).collect(Collectors.toList());
       HoodieCompactionPlan compactionPlan =
           CompactionUtils.buildFromFileSlices(partitionFileSlicePairs, Option.empty(), Option.empty());
-      List<String> instantTimes = HoodieTestUtils.monotonicIncreasingCommitTimestamps(9, 1);
+      List<String> instantTimes = makeNewCommitTimes(9);
       String compactionTime = instantTimes.get(0);
       table.getActiveTimeline().saveToCompactionRequested(
           new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, compactionTime),
@@ -383,7 +386,7 @@ public class TestCleaner extends HoodieClientTestBase {
         HoodieCleaningPolicy.KEEP_LATEST_COMMITS);
 
     // Keep doing some writes and clean inline. Make sure we have expected number of files remaining.
-    HoodieTestUtils.monotonicIncreasingCommitTimestamps(8, 1).forEach(newCommitTime -> {
+    makeNewCommitTimes(8).forEach(newCommitTime -> {
       try {
         client.startCommitWithTime(newCommitTime);
         List<HoodieRecord> records = recordUpsertGenWrappedFunction.apply(newCommitTime, 100);
@@ -432,7 +435,15 @@ public class TestCleaner extends HoodieClientTestBase {
    * @param config HoodieWriteConfig
    */
   private List<HoodieCleanStat> runCleaner(HoodieWriteConfig config) throws IOException {
-    return runCleaner(config, false);
+    return runCleaner(config, false, 1);
+  }
+
+  private List<HoodieCleanStat> runCleaner(HoodieWriteConfig config, int firstCommitSequence) throws IOException {
+    return runCleaner(config, false, firstCommitSequence);
+  }
+
+  private List<HoodieCleanStat> runCleaner(HoodieWriteConfig config, boolean simulateRetryFailure) throws IOException {
+    return runCleaner(config, simulateRetryFailure, 1);
   }
 
   /**
@@ -440,9 +451,9 @@ public class TestCleaner extends HoodieClientTestBase {
    *
    * @param config HoodieWriteConfig
    */
-  private List<HoodieCleanStat> runCleaner(HoodieWriteConfig config, boolean simulateRetryFailure) throws IOException {
+  private List<HoodieCleanStat> runCleaner(HoodieWriteConfig config, boolean simulateRetryFailure, int firstCommitSequence) throws IOException {
     HoodieWriteClient<?> writeClient = getHoodieWriteClient(config);
-    String cleanInstantTs = getNextInstant();
+    String cleanInstantTs = makeNewCommitTime(firstCommitSequence);
     HoodieCleanMetadata cleanMetadata1 = writeClient.clean(cleanInstantTs);
 
     if (null == cleanMetadata1) {
@@ -463,7 +474,7 @@ public class TestCleaner extends HoodieClientTestBase {
         });
       });
       metaClient.reloadActiveTimeline().revertToInflight(completedCleanInstant);
-      HoodieCleanMetadata newCleanMetadata = writeClient.clean(getNextInstant());
+      HoodieCleanMetadata newCleanMetadata = writeClient.clean(makeNewCommitTime(firstCommitSequence + 1));
       // No new clean metadata would be created. Only the previous one will be retried
       assertNull(newCleanMetadata);
       HoodieCleanMetadata cleanMetadata2 = CleanerUtils.getCleanerMetadata(metaClient, completedCleanInstant);
@@ -540,7 +551,7 @@ public class TestCleaner extends HoodieClientTestBase {
         .withBaseFilesInPartition(p1, file1P1C0)
         .withBaseFilesInPartitions(p0, p1);
 
-    List<HoodieCleanStat> hoodieCleanStatsTwo = runCleaner(config);
+    List<HoodieCleanStat> hoodieCleanStatsTwo = runCleaner(config, 1);
     // enableBootstrapSourceClean would delete the bootstrap base file as the same time
     HoodieCleanStat cleanStat = getCleanStat(hoodieCleanStatsTwo, p0);
     assertEquals(enableBootstrapSourceClean ? 2 : 1, cleanStat.getSuccessDeleteFiles().size()
@@ -581,7 +592,7 @@ public class TestCleaner extends HoodieClientTestBase {
     String file3P0C2 = testTable.addCommit("00000000000003")
         .withBaseFilesInPartition(p0, file1P0C0, file2P0C1)
         .withBaseFilesInPartitions(p0).get(p0);
-    List<HoodieCleanStat> hoodieCleanStatsThree = runCleaner(config);
+    List<HoodieCleanStat> hoodieCleanStatsThree = runCleaner(config, 3);
     assertEquals(2,
         getCleanStat(hoodieCleanStatsThree, p0)
             .getSuccessDeleteFiles().size(), "Must clean two files");
@@ -1058,10 +1069,21 @@ public class TestCleaner extends HoodieClientTestBase {
         HoodieWriteConfig.newBuilder()
             .withPath(basePath).withAssumeDatePartitioning(true)
             .withCompactionConfig(HoodieCompactionConfig.newBuilder()
-            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS).retainFileVersions(1).build())
+                .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS).retainFileVersions(1).build())
             .build();
 
-    HoodieTestUtils.createCorruptedPendingCleanFiles(metaClient, getNextInstant());
+    String commitTime = makeNewCommitTime(1);
+    List<String> cleanerFileNames = Arrays.asList(
+        HoodieTimeline.makeRequestedCleanerFileName(commitTime),
+        HoodieTimeline.makeInflightCleanerFileName(commitTime));
+    for (String f : cleanerFileNames) {
+      Path commitFile = new Path(Paths
+          .get(metaClient.getBasePath(), HoodieTableMetaClient.METAFOLDER_NAME, f).toString());
+      try (FSDataOutputStream os = metaClient.getFs().create(commitFile, true)) {
+        // Write empty clean metadata
+        os.write(new byte[0]);
+      }
+    }
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
     List<HoodieCleanStat> cleanStats = runCleaner(config);

--- a/hudi-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
 import static org.apache.hudi.execution.bulkinsert.TestBulkInsertInternalPartitioner.generateExpectedPartitionNumRecords;
 import static org.apache.hudi.execution.bulkinsert.TestBulkInsertInternalPartitioner.generateTestRecordsForBulkInsert;
@@ -86,7 +87,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     String fileName = UUID.randomUUID().toString();
     String partitionPath = "2016/05/04";
 
-    String instantTime = HoodieTestUtils.makeNewCommitTime();
+    String instantTime = makeNewCommitTime();
     HoodieWriteConfig config = makeHoodieClientConfig();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieTable.create(metaClient, config, hadoopConf);
@@ -118,7 +119,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
   public void testUpdateRecords() throws Exception {
     // Prepare the AvroParquetIO
     HoodieWriteConfig config = makeHoodieClientConfig();
-    String firstCommitTime = HoodieTestUtils.makeNewCommitTime();
+    String firstCommitTime = makeNewCommitTime();
     HoodieWriteClient writeClient = getHoodieWriteClient(config);
     writeClient.startCommitWithTime(firstCommitTime);
     metaClient = HoodieTableMetaClient.reload(metaClient);
@@ -182,7 +183,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     List<HoodieRecord> updatedRecords = Arrays.asList(updatedRecord1, insertedRecord1);
 
     Thread.sleep(1000);
-    String newCommitTime = HoodieTestUtils.makeNewCommitTime();
+    String newCommitTime = makeNewCommitTime();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     writeClient.startCommitWithTime(newCommitTime);
     List<WriteStatus> statuses = writeClient.upsert(jsc.parallelize(updatedRecords), newCommitTime).collect();
@@ -263,7 +264,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     // Prepare the AvroParquetIO
     HoodieWriteConfig config =
         makeHoodieClientConfigBuilder().withWriteStatusClass(MetadataMergeWriteStatus.class).build();
-    String firstCommitTime = HoodieTestUtils.makeNewCommitTime();
+    String firstCommitTime = makeNewCommitTime();
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
     HoodieCopyOnWriteTable table = (HoodieCopyOnWriteTable) HoodieTable.create(metaClient, config, hadoopConf);
@@ -317,7 +318,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
   @Test
   public void testInsertRecords() throws Exception {
     HoodieWriteConfig config = makeHoodieClientConfig();
-    String instantTime = HoodieTestUtils.makeNewCommitTime();
+    String instantTime = makeNewCommitTime();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieCopyOnWriteTable table = (HoodieCopyOnWriteTable) HoodieTable.create(metaClient, config, hadoopConf);
 
@@ -368,7 +369,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     HoodieWriteConfig config = makeHoodieClientConfigBuilder().withStorageConfig(HoodieStorageConfig.newBuilder()
         .parquetMaxFileSize(64 * 1024).hfileMaxFileSize(64 * 1024)
         .parquetBlockSize(64 * 1024).parquetPageSize(64 * 1024).build()).build();
-    String instantTime = HoodieTestUtils.makeNewCommitTime();
+    String instantTime = makeNewCommitTime();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieCopyOnWriteTable table = (HoodieCopyOnWriteTable) HoodieTable.create(metaClient, config, hadoopConf);
 
@@ -434,7 +435,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
         .withBulkInsertParallelism(2).withBulkInsertSortMode(bulkInsertMode).build();
-    String instantTime = HoodieTestUtils.makeNewCommitTime();
+    String instantTime = makeNewCommitTime();
     HoodieWriteClient writeClient = getHoodieWriteClient(config);
     writeClient.startCommitWithTime(instantTime);
     metaClient = HoodieTableMetaClient.reload(metaClient);

--- a/hudi-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -38,18 +38,17 @@ import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SQLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
-import org.apache.log4j.Logger;
-import org.apache.log4j.LogManager;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The test harness for resource initialization and cleanup.
@@ -66,16 +65,11 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness im
   protected transient HoodieTestDataGenerator dataGen = null;
   protected transient ExecutorService executorService;
   protected transient HoodieTableMetaClient metaClient;
-  private static AtomicInteger instantGen = new AtomicInteger(1);
   protected transient HoodieWriteClient writeClient;
   protected transient HoodieReadClient readClient;
   protected transient HoodieTableFileSystemView tableView;
 
   protected final SparkTaskContextSupplier supplier = new SparkTaskContextSupplier();
-
-  public String getNextInstant() {
-    return String.format("%09d", instantGen.getAndIncrement());
-  }
 
   // dfs
   protected String dfsBasePath;

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -100,6 +100,23 @@ public class FileCreateUtils {
     createMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION);
   }
 
+  private static void createAuxiliaryMetaFile(String basePath, String instantTime, String suffix) throws IOException {
+    Path parentPath = Paths.get(basePath, HoodieTableMetaClient.AUXILIARYFOLDER_NAME);
+    Files.createDirectories(parentPath);
+    Path metaFilePath = parentPath.resolve(instantTime + suffix);
+    if (Files.notExists(metaFilePath)) {
+      Files.createFile(metaFilePath);
+    }
+  }
+
+  public static void createRequestedCompaction(String basePath, String instantTime) throws IOException {
+    createAuxiliaryMetaFile(basePath, instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
+  }
+
+  public static void createInflightCompaction(String basePath, String instantTime) throws IOException {
+    createAuxiliaryMetaFile(basePath, instantTime, HoodieTimeline.INFLIGHT_COMPACTION_EXTENSION);
+  }
+
   public static void createPartitionMetaFile(String basePath, String partitionPath) throws IOException {
     Path parentPath = Paths.get(basePath, partitionPath);
     Files.createDirectories(parentPath);

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ValidationUtils;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -29,21 +30,28 @@ import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.apache.hudi.common.table.timeline.HoodieActiveTimeline.COMMIT_FORMATTER;
 import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createCommit;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createDeltaCommit;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightCompaction;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createInflightDeltaCommit;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createMarkerFile;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedCommit;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedCompaction;
 import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedDeltaCommit;
 import static org.apache.hudi.common.testutils.FileCreateUtils.logFileName;
 
@@ -64,6 +72,30 @@ public class HoodieTestTable {
 
   public static HoodieTestTable of(HoodieTableMetaClient metaClient) {
     return new HoodieTestTable(metaClient.getBasePath(), metaClient.getRawFs(), metaClient);
+  }
+
+  public static String makeNewCommitTime(int sequence) {
+    return String.format("%09d", sequence);
+  }
+
+  public static String makeNewCommitTime() {
+    return makeNewCommitTime(Instant.now());
+  }
+
+  public static String makeNewCommitTime(Instant dateTime) {
+    return COMMIT_FORMATTER.format(Date.from(dateTime));
+  }
+
+  public static List<String> makeNewCommitTimes(int num) {
+    return makeNewCommitTimes(num, 1);
+  }
+
+  public static List<String> makeNewCommitTimes(int num, int firstOffsetSeconds) {
+    final Instant now = Instant.now();
+    return IntStream.range(0, num)
+        .mapToObj(i ->
+            makeNewCommitTime(now.plus(i == 0 ? firstOffsetSeconds : firstOffsetSeconds + i, SECONDS)))
+        .collect(Collectors.toList());
   }
 
   public HoodieTestTable addRequestedCommit(String instantTime) throws Exception {
@@ -114,12 +146,32 @@ public class HoodieTestTable {
     return this;
   }
 
+  public HoodieTestTable addRequestedCompaction(String instantTime) throws IOException {
+    createRequestedCompaction(basePath, instantTime);
+    currentInstantTime = instantTime;
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    return this;
+  }
+
+  public HoodieTestTable addCompaction(String instantTime) throws IOException {
+    createRequestedCompaction(basePath, instantTime);
+    createInflightCompaction(basePath, instantTime);
+    currentInstantTime = instantTime;
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    return this;
+  }
+
   public HoodieTestTable forCommit(String instantTime) {
     currentInstantTime = instantTime;
     return this;
   }
 
   public HoodieTestTable forDeltaCommit(String instantTime) {
+    currentInstantTime = instantTime;
+    return this;
+  }
+
+  public HoodieTestTable forCompaction(String instantTime) {
     currentInstantTime = instantTime;
     return this;
   }
@@ -174,6 +226,14 @@ public class HoodieTestTable {
     return this;
   }
 
+  public HoodieTestTable withBaseFilesInPartition(String partition, int... lengths) throws Exception {
+    for (int l : lengths) {
+      String fileId = UUID.randomUUID().toString();
+      FileCreateUtils.createBaseFile(basePath, partition, currentInstantTime, fileId, l);
+    }
+    return this;
+  }
+
   public String withLogFile(String partitionPath) throws Exception {
     String fileId = UUID.randomUUID().toString();
     withLogFile(partitionPath, fileId);
@@ -209,8 +269,28 @@ public class HoodieTestTable {
     }
   }
 
+  public Path getPartitionPath(String partition) {
+    return new Path(Paths.get(basePath, partition).toUri());
+  }
+
   public String getBaseFileNameById(String fileId) {
     return baseFileName(currentInstantTime, fileId);
+  }
+
+  public Path getBaseFilePath(String partition, String fileId) {
+    return new Path(Paths.get(basePath, partition, getBaseFileNameById(fileId)).toUri());
+  }
+
+  public Path getInflightCommitFilePath(String instantTime) {
+    return new Path(Paths.get(basePath, HoodieTableMetaClient.METAFOLDER_NAME, instantTime + HoodieTimeline.INFLIGHT_COMMIT_EXTENSION).toUri());
+  }
+
+  public Path getCommitFilePath(String instantTime) {
+    return new Path(Paths.get(basePath, HoodieTableMetaClient.METAFOLDER_NAME, instantTime + HoodieTimeline.COMMIT_EXTENSION).toUri());
+  }
+
+  public Path getRequestedCompactionFilePath(String instantTime) {
+    return new Path(Paths.get(basePath, HoodieTableMetaClient.AUXILIARYFOLDER_NAME, instantTime + HoodieTimeline.REQUESTED_COMPACTION_EXTENSION).toUri());
   }
 
   public boolean logFilesExist(String partition, String instantTime, String fileId, int... versions) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -86,11 +86,11 @@ public class HoodieTestTable {
     return COMMIT_FORMATTER.format(Date.from(dateTime));
   }
 
-  public static List<String> makeNewCommitTimes(int num) {
-    return makeNewCommitTimes(num, 1);
+  public static List<String> makeIncrementalCommitTimes(int num) {
+    return makeIncrementalCommitTimes(num, 1);
   }
 
-  public static List<String> makeNewCommitTimes(int num, int firstOffsetSeconds) {
+  public static List<String> makeIncrementalCommitTimes(int num, int firstOffsetSeconds) {
     final Instant now = Instant.now();
     return IntStream.range(0, num)
         .mapToObj(i ->

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -93,8 +93,7 @@ public class HoodieTestTable {
   public static List<String> makeIncrementalCommitTimes(int num, int firstOffsetSeconds) {
     final Instant now = Instant.now();
     return IntStream.range(0, num)
-        .mapToObj(i ->
-            makeNewCommitTime(now.plus(i == 0 ? firstOffsetSeconds : firstOffsetSeconds + i, SECONDS)))
+        .mapToObj(i -> makeNewCommitTime(now.plus(firstOffsetSeconds + i, SECONDS)))
         .collect(Collectors.toList());
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -291,7 +291,7 @@ public class HoodieTestUtils {
   public static boolean doesCommitExist(String basePath, String instantTime) {
     return new File(
         basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + instantTime + HoodieTimeline.COMMIT_EXTENSION)
-        .exists();
+            .exists();
   }
 
   /**
@@ -353,8 +353,8 @@ public class HoodieTestUtils {
       Writer logWriter;
       try {
         logWriter = HoodieLogFormat.newWriterBuilder().onParentPath(new Path(basePath, partitionPath))
-            .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(location.getFileId())
-            .overBaseCommit(location.getInstantTime()).withFs(fs).build();
+          .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(location.getFileId())
+          .overBaseCommit(location.getInstantTime()).withFs(fs).build();
 
         Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
         header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, location.getInstantTime());

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -71,18 +71,12 @@ import org.apache.hadoop.util.StringUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +86,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.table.timeline.HoodieActiveTimeline.COMMIT_FORMATTER;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -162,10 +155,6 @@ public class HoodieTestUtils {
     return HoodieTableMetaClient.initTableAndGetMetaClient(hadoopConf, basePath, properties);
   }
 
-  public static String makeNewCommitTime() {
-    return COMMIT_FORMATTER.format(new Date());
-  }
-
   /**
    * @deprecated Use {@link HoodieTestTable} instead.
    */
@@ -181,10 +170,6 @@ public class HoodieTestUtils {
           basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline.makeCommitFileName(instantTime))
           .createNewFile();
     }
-  }
-
-  public static void createMetadataFolder(String basePath) {
-    new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME).mkdirs();
   }
 
   /**
@@ -229,40 +214,6 @@ public class HoodieTestUtils {
     }
   }
 
-  public static void createCorruptedPendingCleanFiles(HoodieTableMetaClient metaClient, String commitTime) {
-    Arrays.asList(HoodieTimeline.makeRequestedCleanerFileName(commitTime),
-        HoodieTimeline.makeInflightCleanerFileName(commitTime))
-        .forEach(f -> {
-          FSDataOutputStream os = null;
-          try {
-            Path commitFile = new Path(Paths
-                .get(metaClient.getBasePath(), HoodieTableMetaClient.METAFOLDER_NAME, f).toString());
-            os = metaClient.getFs().create(commitFile, true);
-            // Write empty clean metadata
-            os.write(new byte[0]);
-          } catch (IOException ioe) {
-            throw new HoodieIOException(ioe.getMessage(), ioe);
-          } finally {
-            if (null != os) {
-              try {
-                os.close();
-              } catch (IOException e) {
-                throw new HoodieIOException(e.getMessage(), e);
-              }
-            }
-          }
-        });
-  }
-
-  /**
-   * @deprecated Use {@link HoodieTestTable} instead.
-   */
-  public static String createNewDataFile(String basePath, String partitionPath, String instantTime, long length)
-      throws IOException {
-    String fileID = UUID.randomUUID().toString();
-    return createDataFileFixLength(basePath, partitionPath, instantTime, fileID, length);
-  }
-
   /**
    * @deprecated Use {@link HoodieTestTable} instead.
    */
@@ -271,18 +222,6 @@ public class HoodieTestUtils {
     String folderPath = basePath + "/" + partitionPath + "/";
     new File(folderPath).mkdirs();
     new File(folderPath + FSUtils.makeDataFileName(instantTime, DEFAULT_WRITE_TOKEN, fileID)).createNewFile();
-    return fileID;
-  }
-
-  private static String createDataFileFixLength(String basePath, String partitionPath, String instantTime, String fileID,
-      long length) throws IOException {
-    String folderPath = basePath + "/" + partitionPath + "/";
-    Files.createDirectories(Paths.get(folderPath));
-    String filePath = folderPath + FSUtils.makeDataFileName(instantTime, DEFAULT_WRITE_TOKEN, fileID);
-    Files.createFile(Paths.get(filePath));
-    try (FileChannel output = new FileOutputStream(new File(filePath)).getChannel()) {
-      output.write(ByteBuffer.allocate(1), length - 1);
-    }
     return fileID;
   }
 
@@ -305,6 +244,11 @@ public class HoodieTestUtils {
     return fileID;
   }
 
+  /**
+   * TODO: incorporate into {@link HoodieTestTable}.
+   *
+   * @deprecated Use {@link HoodieTestTable} instead.
+   */
   public static void createCompactionRequest(HoodieTableMetaClient metaClient, String instant,
       List<Pair<String, FileSlice>> fileSliceList) throws IOException {
     HoodieCompactionPlan plan = CompactionUtils.buildFromFileSlices(fileSliceList, Option.empty(), Option.empty());
@@ -336,31 +280,18 @@ public class HoodieTestUtils {
   /**
    * @deprecated Use {@link HoodieTestTable} instead.
    */
-  public static String getInflightCommitFilePath(String basePath, String instantTime) {
-    return basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + instantTime
-        + HoodieTimeline.INFLIGHT_COMMIT_EXTENSION;
-  }
-
-  /**
-   * @deprecated Use {@link HoodieTestTable} instead.
-   */
-  public static String getRequestedCompactionFilePath(String basePath, String instantTime) {
-    return basePath + "/" + HoodieTableMetaClient.AUXILIARYFOLDER_NAME + "/" + instantTime
-        + HoodieTimeline.INFLIGHT_COMMIT_EXTENSION;
-  }
-
-  /**
-   * @deprecated Use {@link HoodieTestTable} instead.
-   */
   public static boolean doesDataFileExist(String basePath, String partitionPath, String instantTime,
       String fileID) {
     return new File(getDataFilePath(basePath, partitionPath, instantTime, fileID)).exists();
   }
 
+  /**
+   * @deprecated Use {@link HoodieTestTable} instead.
+   */
   public static boolean doesCommitExist(String basePath, String instantTime) {
     return new File(
         basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + instantTime + HoodieTimeline.COMMIT_EXTENSION)
-            .exists();
+        .exists();
   }
 
   /**
@@ -408,6 +339,9 @@ public class HoodieTestUtils {
     return deseralizedObject;
   }
 
+  /**
+   * @deprecated Use {@link HoodieTestTable} instead.
+   */
   public static void writeRecordsToLogFiles(FileSystem fs, String basePath, Schema schema,
       List<HoodieRecord> updatedRecords) {
     Map<HoodieRecordLocation, List<HoodieRecord>> groupedUpdated =
@@ -419,8 +353,8 @@ public class HoodieTestUtils {
       Writer logWriter;
       try {
         logWriter = HoodieLogFormat.newWriterBuilder().onParentPath(new Path(basePath, partitionPath))
-          .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(location.getFileId())
-          .overBaseCommit(location.getInstantTime()).withFs(fs).build();
+            .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(location.getFileId())
+            .overBaseCommit(location.getInstantTime()).withFs(fs).build();
 
         Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
         header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, location.getInstantTime());
@@ -475,17 +409,6 @@ public class HoodieTestUtils {
   public static FileStatus[] listAllDataFilesAndLogFilesInPath(FileSystem fs, String basePath) throws IOException {
     return Stream.concat(Arrays.stream(listAllDataFilesInPath(fs, basePath)), Arrays.stream(listAllLogFilesInPath(fs, basePath)))
             .toArray(FileStatus[]::new);
-  }
-
-  public static List<String> monotonicIncreasingCommitTimestamps(int numTimestamps, int startSecsDelta) {
-    Calendar cal = Calendar.getInstance();
-    cal.add(Calendar.SECOND, startSecsDelta);
-    List<String> commits = new ArrayList<>();
-    for (int i = 0; i < numTimestamps; i++) {
-      commits.add(COMMIT_FORMATTER.format(cal.getTime()));
-      cal.add(Calendar.SECOND, 1);
-    }
-    return commits;
   }
 
   public static List<HoodieWriteStat> generateFakeHoodieWriteStat(int limit) {


### PR DESCRIPTION
Migrate test data prep logic in
- TestStatsCommand
- TestHoodieROTablePathFilter

Re-implement methods for create new commit times in HoodieTestUtils and HoodieClientTestHarness
- Move relevant APIs to HoodieTestTable
- Migrate usages

After changing to HoodieTestTable APIs, removed unused deprecated APIs in HoodieTestUtils

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.