### PR TITLE
[HUDI-1268] fix UpgradeDowngrade fs Rename issue for hdfs and aliyun oss

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -257,7 +257,26 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness im
     // Create a temp folder as the base path
     dfs = dfsCluster.getFileSystem();
     dfsBasePath = dfs.getWorkingDirectory().toString();
+    this.basePath = dfsBasePath;
+    this.hadoopConf = dfs.getConf();
     dfs.mkdirs(new Path(dfsBasePath));
+  }
+
+  /**
+   * Initializes an instance of {@link HoodieTableMetaClient} with a special table type specified by
+   * {@code getTableType()}.
+   *
+   * @throws IOException
+   */
+  protected void initDFSMetaClient() throws IOException {
+    if (dfsBasePath == null) {
+      throw new IllegalStateException("The base path has not been initialized.");
+    }
+
+    if (jsc == null) {
+      throw new IllegalStateException("The Spark context has not been initialized.");
+    }
+    metaClient = HoodieTestUtils.init(dfs.getConf(), dfsBasePath, getTableType());
   }
 
   /**


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
in UpgradeDowngrade.run()

fs.rename(updatedPropsFilePath, propsFilePath); 

the fs.rename have different action,such as:
// a) for hdfs : if propsFilePath already exist,fs.rename will not replace propsFilePath, but just return false
// b) for localfs: if propsFilePath already exist,fs.rename will replace propsFilePath, and return ture
// c) for aliyun ossfs: if propsFilePath already exist,will throw FileAlreadyExistsException
// so we should delete the old propsFilePath. also upgrade and downgrade is Idempotent


## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.