### PR TITLE
[MINOR] Remove useless config for bootstrap integ testing

### DIFF
--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
@@ -209,7 +209,6 @@ public class ITTestHoodieDemo extends ITTestBase {
         + " --initial-checkpoint-provider"
         + " org.apache.hudi.utilities.checkpointing.InitialCheckpointFromAnotherHoodieTimelineProvider"
         + " --hoodie-conf hoodie.bootstrap.base.path=" + BOOTSTRAPPED_SRC_PATH
-        + " --hoodie-conf hoodie.bootstrap.recordkey.columns=key"
         + " --hoodie-conf hoodie.deltastreamer.checkpoint.provider.path=" + COW_BASE_PATH
         + " --hoodie-conf hoodie.bootstrap.parallelism=2 "
         + " --hoodie-conf hoodie.bootstrap.keygen.class=" + SimpleKeyGenerator.class.getName()
@@ -224,7 +223,6 @@ public class ITTestHoodieDemo extends ITTestBase {
         + " --initial-checkpoint-provider"
         + " org.apache.hudi.utilities.checkpointing.InitialCheckpointFromAnotherHoodieTimelineProvider"
         + " --hoodie-conf hoodie.bootstrap.base.path=" + BOOTSTRAPPED_SRC_PATH
-        + " --hoodie-conf hoodie.bootstrap.recordkey.columns=key"
         + " --hoodie-conf hoodie.deltastreamer.checkpoint.provider.path=" + COW_BASE_PATH
         + " --hoodie-conf hoodie.bootstrap.parallelism=2 "
         + " --hoodie-conf hoodie.bootstrap.keygen.class=" + SimpleKeyGenerator.class.getName()


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

This is minor CR which removes a useless config for bootstrap integ test. This useless config may cause misleading for customers who see that part of code as a bootstrap example.

```hoodie.bootstrap.recordkey.columns``` is not valid parameter and you cannot find any definition in the Hudi package. The record key for bootstrap table is actually defined by ```hoodie.datasource.write.recordkey.field```. In ```ITTestHoodieDemo.java```, it is defined in the ```dfs-source.properties```: https://github.com/apache/hudi/blob/master/docker/demo/config/dfs-source.properties#L20, that's why even with this useless config, the integ testing still works.

## Brief change log

Remove ```hoodie.bootstrap.recordkey.columns```.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.