### PR TITLE
[HUDI-995] Migrate HoodieTestUtils APIs to HoodieTestTable

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
@@ -54,7 +54,7 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
   private String tablePath;
 
   @BeforeEach
-  public void init() throws IOException {
+  public void init() throws Exception {
     initDFS();
     jsc.hadoopConfiguration().addResource(dfs.getConf());
     HoodieCLI.conf = dfs.getConf();
@@ -156,7 +156,7 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
    * Test for command: show archived commits.
    */
   @Test
-  public void testShowCommits() throws IOException {
+  public void testShowCommits() throws Exception {
     CommandResult cr = getShell().executeCommand("show archived commits");
     assertTrue(cr.isSuccess());
     final List<Comparable[]> rows = new ArrayList<>();

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCleansCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCleansCommand.java
@@ -62,7 +62,7 @@ public class TestCleansCommand extends AbstractShellIntegrationTest {
   private URL propsFilePath;
 
   @BeforeEach
-  public void init() throws IOException {
+  public void init() throws Exception {
     HoodieCLI.conf = jsc.hadoopConfiguration();
 
     String tableName = "test_table";

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -76,17 +76,19 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
         "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
   }
 
-  private LinkedHashMap<String, Integer[]> generateData() {
+  private LinkedHashMap<String, Integer[]> generateData() throws Exception {
     // generate data and metadata
     LinkedHashMap<String, Integer[]> data = new LinkedHashMap<>();
     data.put("102", new Integer[] {15, 10});
     data.put("101", new Integer[] {20, 10});
     data.put("100", new Integer[] {15, 15});
 
-    data.forEach((key, value) -> {
+    for (Map.Entry<String, Integer[]> entry : data.entrySet()) {
+      String key = entry.getKey();
+      Integer[] value = entry.getValue();
       HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath, key, jsc.hadoopConfiguration(),
           Option.of(value[0]), Option.of(value[1]));
-    });
+    }
 
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
     assertEquals(3, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
@@ -138,7 +140,7 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
    * Test case of 'commits show' command.
    */
   @Test
-  public void testShowCommits() throws IOException {
+  public void testShowCommits() throws Exception {
     Map<String, Integer[]> data = generateData();
 
     CommandResult cr = getShell().executeCommand("commits show");
@@ -154,7 +156,7 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
    * Test case of 'commits showarchived' command.
    */
   @Test
-  public void testShowArchivedCommits() throws IOException {
+  public void testShowArchivedCommits() throws Exception {
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath)
         .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
@@ -168,10 +170,12 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
     data.put("102", new Integer[] {25, 45});
     data.put("101", new Integer[] {35, 15});
 
-    data.forEach((key, value) -> {
+    for (Map.Entry<String, Integer[]> entry : data.entrySet()) {
+      String key = entry.getKey();
+      Integer[] value = entry.getValue();
       HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath, key, jsc.hadoopConfiguration(),
           Option.of(value[0]), Option.of(value[1]));
-    });
+    }
 
     // archive
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
@@ -198,7 +202,7 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
    * Test case of 'commit showpartitions' command.
    */
   @Test
-  public void testShowCommitPartitions() {
+  public void testShowCommitPartitions() throws Exception {
     Map<String, Integer[]> data = generateData();
 
     String commitInstant = "101";
@@ -235,7 +239,7 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
    * Test case of 'commit showfiles' command.
    */
   @Test
-  public void testShowCommitFiles() {
+  public void testShowCommitFiles() throws Exception {
     Map<String, Integer[]> data = generateData();
 
     String commitInstant = "101";
@@ -270,7 +274,7 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
    * Test case of 'commits compare' command.
    */
   @Test
-  public void testCompareCommits() throws IOException {
+  public void testCompareCommits() throws Exception {
     Map<String, Integer[]> data = generateData();
 
     String tableName2 = "test_table2";
@@ -278,10 +282,12 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
     HoodieTestUtils.init(jsc.hadoopConfiguration(), tablePath2, getTableType());
 
     data.remove("102");
-    data.forEach((key, value) -> {
+    for (Map.Entry<String, Integer[]> entry : data.entrySet()) {
+      String key = entry.getKey();
+      Integer[] value = entry.getValue();
       HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath2, key, jsc.hadoopConfiguration(),
           Option.of(value[0]), Option.of(value[1]));
-    });
+    }
 
     CommandResult cr = getShell().executeCommand(String.format("commits compare --path %s", tablePath2));
     assertTrue(cr.isSuccess());
@@ -298,7 +304,7 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
    * Test case of 'commits sync' command.
    */
   @Test
-  public void testSyncCommits() throws IOException {
+  public void testSyncCommits() throws Exception {
     Map<String, Integer[]> data = generateData();
 
     String tableName2 = "test_table2";
@@ -306,10 +312,12 @@ public class TestCommitsCommand extends AbstractShellIntegrationTest {
     HoodieTestUtils.init(jsc.hadoopConfiguration(), tablePath2, getTableType(), tableName2);
 
     data.remove("102");
-    data.forEach((key, value) -> {
+    for (Map.Entry<String, Integer[]> entry : data.entrySet()) {
+      String key = entry.getKey();
+      Integer[] value = entry.getValue();
       HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath2, key, jsc.hadoopConfiguration(),
           Option.of(value[0]), Option.of(value[1]));
-    });
+    }
 
     CommandResult cr = getShell().executeCommand(String.format("commits sync --path %s", tablePath2));
     assertTrue(cr.isSuccess());

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRollbacksCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRollbacksCommand.java
@@ -26,12 +26,12 @@ import org.apache.hudi.cli.TableHeader;
 import org.apache.hudi.cli.testutils.AbstractShellIntegrationTest;
 import org.apache.hudi.client.HoodieWriteClient;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
-import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
-import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -41,14 +41,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.shell.core.CommandResult;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,39 +63,37 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestRollbacksCommand extends AbstractShellIntegrationTest {
 
   @BeforeEach
-  public void init() throws IOException {
+  public void init() throws Exception {
     String tableName = "test_table";
-    String tablePath = basePath + File.separator + tableName;
+    String tablePath = Paths.get(basePath, tableName).toString();
     new TableCommand().createTable(
         tablePath, tableName, HoodieTableType.MERGE_ON_READ.name(),
         "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
-
+    metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
     //Create some commits files and parquet files
-    String commitTime1 = "100";
-    String commitTime2 = "101";
-    String commitTime3 = "102";
-    HoodieTestDataGenerator.writePartitionMetadata(fs, HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS, tablePath);
-
-    // two commit files
-    HoodieTestUtils.createCommitFiles(tablePath, commitTime1, commitTime2);
-    // one .inflight commit file
-    HoodieTestUtils.createInflightCommitFiles(tablePath, commitTime3);
-
-    // generate commit files for commits
-    for (String commitTime : Arrays.asList(commitTime1, commitTime2, commitTime3)) {
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, commitTime, "file-1");
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH, commitTime, "file-2");
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH, commitTime, "file-3");
-    }
-
+    Map<String, String> partitionAndFileId = new HashMap<String, String>() {
+      {
+        put(DEFAULT_FIRST_PARTITION_PATH, "file-1");
+        put(DEFAULT_SECOND_PARTITION_PATH, "file-2");
+        put(DEFAULT_THIRD_PARTITION_PATH, "file-3");
+      }
+    };
+    HoodieTestTable.of(metaClient)
+        .withPartitionMetaFiles(DEFAULT_PARTITION_PATHS)
+        .addCommit("100")
+        .withBaseFilesInPartitions(partitionAndFileId)
+        .addCommit("101")
+        .withBaseFilesInPartitions(partitionAndFileId)
+        .addInflightCommit("102")
+        .withBaseFilesInPartitions(partitionAndFileId);
     // generate two rollback
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build()).build();
 
     try (HoodieWriteClient client = getHoodieWriteClient(config)) {
       // Rollback inflight commit3 and commit2
-      client.rollback(commitTime3);
-      client.rollback(commitTime2);
+      client.rollback("102");
+      client.rollback("101");
     }
   }
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestStatsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestStatsCommand.java
@@ -73,17 +73,19 @@ public class TestStatsCommand extends AbstractShellIntegrationTest {
    * Test case for command 'stats wa'.
    */
   @Test
-  public void testWriteAmplificationStats() {
+  public void testWriteAmplificationStats() throws Exception {
     // generate data and metadata
     Map<String, Integer[]> data = new LinkedHashMap<>();
     data.put("100", new Integer[] {15, 10});
     data.put("101", new Integer[] {20, 10});
     data.put("102", new Integer[] {15, 15});
 
-    data.forEach((key, value) -> {
-      HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath, key, jsc.hadoopConfiguration(),
-          Option.of(value[0]), Option.of(value[1]));
-    });
+    for (Map.Entry<String, Integer[]> entry : data.entrySet()) {
+      String k = entry.getKey();
+      Integer[] v = entry.getValue();
+      HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath, k, jsc.hadoopConfiguration(),
+          Option.of(v[0]), Option.of(v[1]));
+    }
 
     CommandResult cr = getShell().executeCommand("stats wa");
     assertTrue(cr.isSuccess());
@@ -93,7 +95,7 @@ public class TestStatsCommand extends AbstractShellIntegrationTest {
     DecimalFormat df = new DecimalFormat("#.00");
     data.forEach((key, value) -> {
       // there are two partitions, so need to *2
-      rows.add(new Comparable[]{key, value[1] * 2, value[0] * 2, df.format((float) value[0] / value[1])});
+      rows.add(new Comparable[] {key, value[1] * 2, value[0] * 2, df.format((float) value[0] / value[1])});
     });
     int totalWrite = data.values().stream().map(integers -> integers[0] * 2).mapToInt(s -> s).sum();
     int totalUpdate = data.values().stream().map(integers -> integers[1] * 2).mapToInt(s -> s).sum();

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
@@ -27,8 +27,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.FileCreateUtils;
-import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
-import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.HoodieTestTable;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -36,11 +35,14 @@ import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
+import java.nio.file.Paths;
 import java.util.Properties;
 
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -51,45 +53,31 @@ public class TestUpgradeDowngradeCommand extends AbstractShellIntegrationTest {
   private String tablePath;
 
   @BeforeEach
-  public void init() throws IOException {
+  public void init() throws Exception {
     String tableName = "test_table";
-    tablePath = basePath + File.separator + tableName;
+    tablePath = Paths.get(basePath, tableName).toString();
     new TableCommand().createTable(
         tablePath, tableName, HoodieTableType.COPY_ON_WRITE.name(),
         "", TimelineLayoutVersion.VERSION_1, "org.apache.hudi.common.model.HoodieAvroPayload");
-
+    metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
     //Create some commits files and parquet files
-    String commitTime1 = "100";
-    String commitTime2 = "101";
-    HoodieTestDataGenerator.writePartitionMetadata(fs, HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS, tablePath);
-
-    // one commit file
-    HoodieTestUtils.createCommitFiles(tablePath, commitTime1);
-    // one .inflight commit file
-    HoodieTestUtils.createInflightCommitFiles(tablePath, commitTime2);
-
-    // generate commit files for commit 100
-    for (String commitTime : Arrays.asList(commitTime1)) {
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, commitTime, "file-1");
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH, commitTime, "file-2");
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH, commitTime, "file-3");
-    }
-
-    // generate commit and marker files for inflight commit 101
-    for (String commitTime : Arrays.asList(commitTime2)) {
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, commitTime, "file-1");
-      FileCreateUtils.createMarkerFile(tablePath, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, commitTime, "file-1", IOType.MERGE);
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH, commitTime, "file-2");
-      FileCreateUtils.createMarkerFile(tablePath, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH, commitTime, "file-2", IOType.MERGE);
-      HoodieTestUtils.createDataFile(tablePath, HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH, commitTime, "file-3");
-      FileCreateUtils.createMarkerFile(tablePath, HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH, commitTime, "file-3", IOType.MERGE);
-    }
+    HoodieTestTable.of(metaClient)
+        .withPartitionMetaFiles(DEFAULT_PARTITION_PATHS)
+        .addCommit("100")
+        .withBaseFilesInPartition(DEFAULT_FIRST_PARTITION_PATH, "file-1")
+        .withBaseFilesInPartition(DEFAULT_SECOND_PARTITION_PATH, "file-2")
+        .withBaseFilesInPartition(DEFAULT_THIRD_PARTITION_PATH, "file-3")
+        .addInflightCommit("101")
+        .withBaseFilesInPartition(DEFAULT_FIRST_PARTITION_PATH, "file-1")
+        .withBaseFilesInPartition(DEFAULT_SECOND_PARTITION_PATH, "file-2")
+        .withBaseFilesInPartition(DEFAULT_THIRD_PARTITION_PATH, "file-3")
+        .withMarkerFile(DEFAULT_FIRST_PARTITION_PATH, "file-1", IOType.MERGE)
+        .withMarkerFile(DEFAULT_SECOND_PARTITION_PATH, "file-2", IOType.MERGE)
+        .withMarkerFile(DEFAULT_THIRD_PARTITION_PATH, "file-3", IOType.MERGE);
   }
 
   @Test
   public void testDowngradeCommand() throws Exception {
-    metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
-
     // update hoodie.table.version to 1
     metaClient.getTableConfig().setTableVersion(HoodieTableVersion.ONE);
     try (FSDataOutputStream os = metaClient.getFs().create(new Path(metaClient.getMetaPath() + "/" + HoodieTableConfig.HOODIE_PROPERTIES_FILE), true)) {
@@ -98,7 +86,7 @@ public class TestUpgradeDowngradeCommand extends AbstractShellIntegrationTest {
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
 
     // verify marker files for inflight commit exists
-    for (String partitionPath : HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS) {
+    for (String partitionPath : DEFAULT_PARTITION_PATHS) {
       assertEquals(1, FileCreateUtils.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
     }
 
@@ -112,7 +100,7 @@ public class TestUpgradeDowngradeCommand extends AbstractShellIntegrationTest {
     assertTableVersionFromPropertyFile();
 
     // verify marker files are non existant
-    for (String partitionPath : HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS) {
+    for (String partitionPath : DEFAULT_PARTITION_PATHS) {
       assertEquals(0, FileCreateUtils.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -172,19 +172,6 @@ public class HoodieTestUtils {
     }
   }
 
-  /**
-   * @deprecated Use {@link HoodieTestTable} instead.
-   */
-  public static void createInflightCommitFiles(String basePath, String... instantTimes) throws IOException {
-
-    for (String instantTime : instantTimes) {
-      new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
-          + HoodieTimeline.makeRequestedCommitFileName(instantTime)).createNewFile();
-      new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline.makeInflightCommitFileName(
-          instantTime)).createNewFile();
-    }
-  }
-
   public static void createPendingCleanFiles(HoodieTableMetaClient metaClient, String... instantTimes) {
     for (String instantTime : instantTimes) {
       Arrays.asList(HoodieTimeline.makeRequestedCleanerFileName(instantTime),
@@ -255,22 +242,6 @@ public class HoodieTestUtils {
     HoodieInstant compactionInstant = new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, instant);
     metaClient.getActiveTimeline().saveToCompactionRequested(compactionInstant,
         TimelineMetadataUtils.serializeCompactionPlan(plan));
-  }
-
-  /**
-   * @deprecated Use {@link HoodieTestTable} instead.
-   */
-  public static String getCommitFilePath(String basePath, String instantTime) {
-    return basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + instantTime + HoodieTimeline.COMMIT_EXTENSION;
-  }
-
-  /**
-   * @deprecated Use {@link HoodieTestTable} instead.
-   */
-  public static boolean doesCommitExist(String basePath, String instantTime) {
-    return new File(
-        basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + instantTime + HoodieTimeline.COMMIT_EXTENSION)
-            .exists();
   }
 
   public static void createCleanFiles(HoodieTableMetaClient metaClient, String basePath,


### PR DESCRIPTION
Remove APIs in HoodieTestUtils
- HoodieTestUtils#createInflightCommitFiles
- HoodieTestUtils#getCommitFilePath
- HoodieTestUtils#doesCommitExist

and migrate usages to `HoodieTestTable` in
- hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRollbacksCommand.java
- hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
- hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
- hudi-cli/src/test/java/org/apache/hudi/cli/testutils/HoodieTestCommitMetadataGenerator.java
- hudi-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.