### PR TITLE
[HUDI-1305] Added an API to shutdown and remove the metrics reporter.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/ConsoleMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/ConsoleMetricsReporter.java
@@ -68,5 +68,8 @@ public class ConsoleMetricsReporter extends MetricsReporter {
 
   @Override
   public void stop() {
+    if (consoleReporter != null) {
+      consoleReporter.stop();
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieConsoleMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieConsoleMetrics.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.metrics;
 
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,11 @@ public class TestHoodieConsoleMetrics {
     when(config.isMetricsOn()).thenReturn(true);
     when(config.getMetricsReporterType()).thenReturn(MetricsReporterType.CONSOLE);
     new HoodieMetrics(config, "raw_table");
+  }
+
+  @AfterEach
+  public void stop() {
+    Metrics.shutdown();
   }
 
   @Test


### PR DESCRIPTION
This helps in removing reporter once the test has complete. Prevents log pollution from un-necessary metric logs.

## What is the purpose of the pull request

Prevent log pollution from metrics printed to the console.

## Brief change log

Added an API to shutdown the metrics reporter after tests.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.