### PR TITLE
[MINOR] Update spark master default to yarn

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  */
 public class SparkUtil {
 
-  private static final String DEFAULT_SPARK_MASTER = "yarn-client";
+  private static final String DEFAULT_SPARK_MASTER = "yarn";
 
   /**
    * TODO: Need to fix a bunch of hardcoded stuff here eg: history server, spark distro.


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

* Hudi cli by default has spark master set to "yarn-client". In spark 2.x yarn-client was deprecated and in spark 3.x it was completely removed.

https://issues.apache.org/jira/browse/SPARK-13220

This causes following error when using hudi cli clean and compact commands running on spark 3

```
Exception in thread "main" org.apache.spark.SparkException: Could not parse Master URL: 'yarn-client'
hudi:basat org.apache.spark.SparkContext$.org$apache$spark$SparkContext$$createTaskScheduler(SparkContext.scala:2925)
hudi:basat org.apache.spark.SparkContext.<init>(SparkContext.scala:528)
hudi:basat org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
hudi:basat org.apache.hudi.cli.utils.SparkUtil.initJavaSparkConf(SparkUtil.java:95)
```

## Brief change log

* This updates default master set in spark configuration to "yarn". By default deploy mode is set to "client".

## Verify this pull request

* Validated hudi cli clean and compact commands run successfully on Spark 2 and 3

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.