### PR TITLE
[HUDI-1326] Added an API to force publish metrics and flush them.

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/dag/scheduler/DagScheduler.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/dag/scheduler/DagScheduler.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.integ.testsuite.dag.nodes.DagNode;
+import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.integ.testsuite.dag.ExecutionContext;
 import org.apache.hudi.integ.testsuite.dag.WorkflowDag;
 import org.apache.hudi.integ.testsuite.dag.WriterContext;
@@ -95,6 +96,9 @@ public class DagScheduler {
       for (Future future : futures) {
         future.get(1, TimeUnit.HOURS);
       }
+
+      // After each level, report and flush the metrics
+      Metrics.flush();
     } while (queue.size() > 0);
     log.info("Finished workloads");
   }


### PR DESCRIPTION
Using the added API, publish metrics after each level of the DAG completed in hudi-test-suite.


## What is the purpose of the pull request

HUDI metrics are published at two stages:
1. When an action completed (e.g. HoodieMetrics.updateCommitMetrics)
2. When the JVM is shutdown (Metrics.java addShutdownHook)

hudi-test-suite includes multiple jobs each of which is an action on the table. All these jobs are run in a single JVM. Hence, currently some metrics are not published till the entire hudi-test-suite run is over.

Enhancements:
1. Allow metrics to be published after each job
2. Flush metrics so redundant metrics (from the last job) are not published again.

## Brief change log

Added Metrics.flush()

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.