### PR TITLE
[MINOR]Optimization for Option

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Option.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Option.java
@@ -98,6 +98,9 @@ public final class Option<T> implements Serializable {
   }
 
   public <U> Option<U> map(Function<? super T, ? extends U> mapper) {
+    if (null == mapper) {
+      throw new NullPointerException("mapper should not be null");
+    }
     if (!isPresent()) {
       return empty();
     } else {
@@ -140,6 +143,8 @@ public final class Option<T> implements Serializable {
 
   @Override
   public String toString() {
-    return "Option{val=" + val + '}';
+    return val != null
+            ? "Option{val=" + val + "}"
+            : "Optional.empty";
   }
 }


### PR DESCRIPTION
Two minor optimization for `Option`:

#### 1. Keep consistency with `map` method in `Optional` 

Ensure `mapper` is not null, even `val` is null and `mapper` will not be invoked.

#### 2. Rewrite `toString()` method

Code below will print same thing:
```java
        System.out.println(Option.of("null").toString());
        System.out.println(Option.empty().toString());

// Option{val=null}
// Option{val=null}
```
