### PR TITLE
[HUDI-865] Improve Hive Syncing by directly translating avro schema to Hive types

### DIFF
--- a/hudi-sync/hudi-dla-sync/src/main/java/org/apache/hudi/dla/DLASyncTool.java
+++ b/hudi-sync/hudi-dla-sync/src/main/java/org/apache/hudi/dla/DLASyncTool.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.dla;
 
 import com.beust.jcommander.JCommander;
+import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
@@ -36,7 +37,6 @@ import org.apache.hudi.sync.common.AbstractSyncHoodieClient;
 import org.apache.hudi.sync.common.AbstractSyncTool;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.parquet.schema.MessageType;
 
 import java.util.List;
 import java.util.Map;
@@ -112,7 +112,7 @@ public class DLASyncTool extends AbstractSyncTool {
     // Check if the necessary table exists
     boolean tableExists = hoodieDLAClient.doesTableExist(tableName);
     // Get the parquet schema for this table looking at the latest commit
-    MessageType schema = hoodieDLAClient.getDataSchema();
+    Schema schema = hoodieDLAClient.getDataSchema();
     // Sync schema if needed
     syncSchema(tableName, tableExists, useRealtimeInputFormat, schema);
 
@@ -140,7 +140,7 @@ public class DLASyncTool extends AbstractSyncTool {
    * @param tableExists - does table exist
    * @param schema - extracted schema
    */
-  private void syncSchema(String tableName, boolean tableExists, boolean useRealTimeInputFormat, MessageType schema) {
+  private void syncSchema(String tableName, boolean tableExists, boolean useRealTimeInputFormat, Schema schema) {
     // Check and sync schema
     if (!tableExists) {
       LOG.info("DLA table " + tableName + " is not found. Creating it");

--- a/hudi-sync/hudi-dla-sync/src/main/java/org/apache/hudi/dla/HoodieDLAClient.java
+++ b/hudi-sync/hudi-dla-sync/src/main/java/org/apache/hudi/dla/HoodieDLAClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.dla;
 
+import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.fs.FSUtils;
@@ -33,7 +34,6 @@ import org.apache.hudi.hive.util.HiveSchemaUtil;
 import org.apache.hudi.sync.common.AbstractSyncHoodieClient;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.parquet.schema.MessageType;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -100,7 +100,7 @@ public class HoodieDLAClient extends AbstractSyncHoodieClient {
   }
 
   @Override
-  public void createTable(String tableName, MessageType storageSchema, String inputFormatClass, String outputFormatClass, String serdeClass) {
+  public void createTable(String tableName, Schema storageSchema, String inputFormatClass, String outputFormatClass, String serdeClass) {
     try {
       String createSQLQuery = HiveSchemaUtil.generateCreateDDL(tableName, storageSchema, toHiveSyncConfig(), inputFormatClass, outputFormatClass, serdeClass);
       LOG.info("Creating table with " + createSQLQuery);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.avro.Schema;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.util.Option;
@@ -35,7 +36,6 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hudi.sync.common.AbstractSyncTool;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.parquet.schema.MessageType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -131,7 +131,7 @@ public class HiveSyncTool extends AbstractSyncTool {
     }
 
     // Get the parquet schema for this table looking at the latest commit
-    MessageType schema = hoodieHiveClient.getDataSchema();
+    Schema schema = hoodieHiveClient.getDataSchema();
     // Sync schema if needed
     syncSchema(tableName, tableExists, useRealtimeInputFormat, schema);
 
@@ -158,7 +158,7 @@ public class HiveSyncTool extends AbstractSyncTool {
    * @param tableExists - does table exist
    * @param schema - extracted schema
    */
-  private void syncSchema(String tableName, boolean tableExists, boolean useRealTimeInputFormat, MessageType schema) {
+  private void syncSchema(String tableName, boolean tableExists, boolean useRealTimeInputFormat, Schema schema) {
     // Check and sync schema
     if (!tableExists) {
       LOG.info("Hive table " + tableName + " is not found. Creating it");

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.avro.Schema;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -42,7 +43,6 @@ import org.apache.hive.jdbc.HiveDriver;
 import org.apache.hudi.sync.common.AbstractSyncHoodieClient;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.parquet.schema.MessageType;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
@@ -237,7 +237,7 @@ public class HoodieHiveClient extends AbstractSyncHoodieClient {
     return client.listPartitions(syncConfig.databaseName, tableName, (short) -1);
   }
 
-  void updateTableDefinition(String tableName, MessageType newSchema) {
+  void updateTableDefinition(String tableName, Schema newSchema) {
     try {
       String newSchemaStr = HiveSchemaUtil.generateSchemaString(newSchema, syncConfig.partitionFields);
       // Cascade clause should not be present for non-partitioned tables
@@ -255,7 +255,7 @@ public class HoodieHiveClient extends AbstractSyncHoodieClient {
   }
 
   @Override
-  public void createTable(String tableName, MessageType storageSchema, String inputFormatClass, String outputFormatClass, String serdeClass) {
+  public void createTable(String tableName, Schema storageSchema, String inputFormatClass, String outputFormatClass, String serdeClass) {
     try {
       String createSQLQuery =
           HiveSchemaUtil.generateCreateDDL(tableName, storageSchema, syncConfig, inputFormatClass, outputFormatClass, serdeClass);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SchemaDifference.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SchemaDifference.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.hive;
 
-import org.apache.parquet.schema.MessageType;
+import org.apache.avro.Schema;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,13 +34,13 @@ import java.util.StringJoiner;
  */
 public class SchemaDifference {
 
-  private final MessageType storageSchema;
+  private final Schema storageSchema;
   private final Map<String, String> tableSchema;
   private final List<String> deleteColumns;
   private final Map<String, String> updateColumnTypes;
   private final Map<String, String> addColumnTypes;
 
-  private SchemaDifference(MessageType storageSchema, Map<String, String> tableSchema, List<String> deleteColumns,
+  private SchemaDifference(Schema storageSchema, Map<String, String> tableSchema, List<String> deleteColumns,
       Map<String, String> updateColumnTypes, Map<String, String> addColumnTypes) {
     this.storageSchema = storageSchema;
     this.tableSchema = tableSchema;
@@ -61,7 +61,7 @@ public class SchemaDifference {
     return addColumnTypes;
   }
 
-  public static Builder newBuilder(MessageType storageSchema, Map<String, String> tableSchema) {
+  public static Builder newBuilder(Schema storageSchema, Map<String, String> tableSchema) {
     return new Builder(storageSchema, tableSchema);
   }
 
@@ -82,13 +82,13 @@ public class SchemaDifference {
 
   public static class Builder {
 
-    private final MessageType storageSchema;
+    private final Schema storageSchema;
     private final Map<String, String> tableSchema;
     private List<String> deleteColumns;
     private Map<String, String> updateColumnTypes;
     private Map<String, String> addColumnTypes;
 
-    public Builder(MessageType storageSchema, Map<String, String> tableSchema) {
+    public Builder(Schema storageSchema, Map<String, String> tableSchema) {
       this.storageSchema = storageSchema;
       this.tableSchema = tableSchema;
       deleteColumns = new ArrayList<>();

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/AbstractSyncHoodieClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/AbstractSyncHoodieClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sync.common;
 
+import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.fs.FSUtils;
@@ -55,7 +56,7 @@ public abstract class AbstractSyncHoodieClient {
     this.fs = fs;
   }
 
-  public abstract void createTable(String tableName, MessageType storageSchema,
+  public abstract void createTable(String tableName, Schema storageSchema,
                                    String inputFormatClass, String outputFormatClass, String serdeClass);
 
   public abstract boolean doesTableExist(String tableName);
@@ -107,9 +108,9 @@ public abstract class AbstractSyncHoodieClient {
    *
    * @return Parquet schema for this table
    */
-  public MessageType getDataSchema() {
+  public Schema getDataSchema() {
     try {
-      return new TableSchemaResolver(metaClient).getTableParquetSchema();
+      return new TableSchemaResolver(metaClient).getTableAvroSchema();
     } catch (Exception e) {
       throw new HoodieSyncException("Failed to read data schema", e);
     }


### PR DESCRIPTION
…Schema transformations,skip the extra hop to parquet schema

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Hive Sync integration would resort to the following translations for finding table schema 
Avro-Schema to Parquet-Schema to Hive Schema transformations
We need to implement logic to skip the extra hop to parquet schema when generating hive schema. 

This is more as a cleanup and  to standardize hive schema syncing.
It also helps to keep hive schema syncing standardized in future when we support other types like ORC.



## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.