### PR TITLE
[HUDI-1344] Documentation for IBM Cloud Object Storage Support 

### DIFF
--- a/docs/_docs/0_8_ibm_cos_filesystem.cn.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.cn.md
@@ -29,6 +29,11 @@ For example, using HMAC keys and service name `myCOS`:
   </property>
 
   <property>
+      <name>fs.cos.flat.list</name>
+      <value>true</value>
+  </property>
+
+  <property>
 	  <name>fs.stocator.scheme.list</name>
 	  <value>cos</value>
   </property>

--- a/docs/_docs/0_8_ibm_cos_filesystem.cn.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.cn.md
@@ -25,7 +25,7 @@ For example, using HMAC keys and service name `myCOS`:
 ```xml
   <property>
       <name>fs.defaultFS</name>
-      <value>cos://<my_bucket>.myCOS</value>
+      <value>cos://myBucket.myCOS</value>
   </property>
 
   <property>

--- a/docs/_docs/0_8_ibm_cos_filesystem.cn.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.cn.md
@@ -25,7 +25,7 @@ For example, using HMAC keys and service name `myCOS`:
 ```xml
   <property>
       <name>fs.defaultFS</name>
-      <value>cos://<my_bucket></value>
+      <value>cos://<my_bucket>.myCOS</value>
   </property>
 
   <property>

--- a/docs/_docs/0_8_ibm_cos_filesystem.cn.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.cn.md
@@ -1,0 +1,74 @@
+---
+title: IBM Cloud Object Storage Filesystem
+keywords: hudi, hive, ibm, cos, spark, presto
+permalink: /cn/docs/ibm_cos_hoodie.html
+summary: In this page, we go over how to configure Hudi with IBM Cloud Object Storage filesystem.
+last_modified_at: 2020-10-01T11:38:24-10:00
+language: cn
+---
+In this page, we explain how to get your Hudi spark job to store into IBM Cloud Object Storage.
+
+## IBM COS configs
+
+There are two configurations required for Hudi-IBM Cloud Object Storage compatibility:
+
+- Adding IBM COS Credentials for Hudi
+- Adding required Jars to classpath
+
+### IBM Cloud Object Storage Credentials
+
+Simplest way to use Hudi with IBM Cloud Object Storage, is to configure your `SparkSession` or `SparkContext` with IBM Cloud Object Storage credentials using [Stocator](https://github.com/CODAIT/stocator) storage connector for Spark. Hudi will automatically pick this up and talk to IBM Cloud Object Storage.
+
+Alternatively, add the required configs in your core-site.xml from where Hudi can fetch them. Replace the `fs.defaultFS` with your IBM Cloud Object Storage bucket name and Hudi should be able to read/write from the bucket.
+
+For example, using HMAC keys and service name `myCOS`:
+```xml
+  <property>
+      <name>fs.defaultFS</name>
+      <value>cos://<my_bucket></value>
+  </property>
+
+  <property>
+	  <name>fs.stocator.scheme.list</name>
+	  <value>cos</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.impl</name>
+	  <value>com.ibm.stocator.fs.ObjectStoreFileSystem</value>
+  </property>
+
+  <property>
+	  <name>fs.stocator.cos.impl</name>
+	  <value>com.ibm.stocator.fs.cos.COSAPIClient</value>
+  </property>
+
+  <property>
+	  <name>fs.stocator.cos.scheme</name>
+	  <value>cos</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.myCos.access.key</name>
+	  <value>ACCESS KEY</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.myCos.endpoint</name>
+	  <value>http://s3-api.us-geo.objectstorage.softlayer.net</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.myCos.secret.key</name>
+	  <value>SECRET KEY</value>
+  </property>
+
+```
+
+For more options see Stocator [documentation](https://github.com/CODAIT/stocator/blob/master/README.md).
+
+### IBM Cloud Object Storage Libs
+
+IBM Cloud Object Storage hadoop libraries to add to our classpath
+
+ - com.ibm.stocator:stocator:1.1.3

--- a/docs/_docs/0_8_ibm_cos_filesystem.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.md
@@ -28,6 +28,11 @@ For example, using HMAC keys and service name `myCOS`:
   </property>
 
   <property>
+      <name>fs.cos.flat.list</name>
+      <value>true</value>
+  </property>
+
+  <property>
 	  <name>fs.stocator.scheme.list</name>
 	  <value>cos</value>
   </property>

--- a/docs/_docs/0_8_ibm_cos_filesystem.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.md
@@ -1,0 +1,73 @@
+---
+title: IBM Cloud Object Storage Filesystem
+keywords: hudi, hive, ibm, cos, spark, presto
+permalink: /docs/ibm_cos_hoodie.html
+summary: In this page, we go over how to configure Hudi with IBM Cloud Object Storage filesystem.
+last_modified_at: 2020-10-01T11:38:24-10:00
+---
+In this page, we explain how to get your Hudi spark job to store into IBM Cloud Object Storage.
+
+## IBM COS configs
+
+There are two configurations required for Hudi-IBM Cloud Object Storage compatibility:
+
+- Adding IBM COS Credentials for Hudi
+- Adding required Jars to classpath
+
+### IBM Cloud Object Storage Credentials
+
+Simplest way to use Hudi with IBM Cloud Object Storage, is to configure your `SparkSession` or `SparkContext` with IBM Cloud Object Storage credentials using [Stocator](https://github.com/CODAIT/stocator) storage connector for Spark. Hudi will automatically pick this up and talk to IBM Cloud Object Storage.
+
+Alternatively, add the required configs in your `core-site.xml` from where Hudi can fetch them. Replace the `fs.defaultFS` with your IBM Cloud Object Storage bucket name and Hudi should be able to read/write from the bucket.
+
+For example, using HMAC keys and service name `myCOS`:
+```xml
+  <property>
+      <name>fs.defaultFS</name>
+      <value>cos://<my_bucket></value>
+  </property>
+
+  <property>
+	  <name>fs.stocator.scheme.list</name>
+	  <value>cos</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.impl</name>
+	  <value>com.ibm.stocator.fs.ObjectStoreFileSystem</value>
+  </property>
+
+  <property>
+	  <name>fs.stocator.cos.impl</name>
+	  <value>com.ibm.stocator.fs.cos.COSAPIClient</value>
+  </property>
+
+  <property>
+	  <name>fs.stocator.cos.scheme</name>
+	  <value>cos</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.myCos.access.key</name>
+	  <value>ACCESS KEY</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.myCos.endpoint</name>
+	  <value>http://s3-api.us-geo.objectstorage.softlayer.net</value>
+  </property>
+
+  <property>
+	  <name>fs.cos.myCos.secret.key</name>
+	  <value>SECRET KEY</value>
+  </property>
+
+```
+
+For more options see Stocator [documentation](https://github.com/CODAIT/stocator/blob/master/README.md).
+
+### IBM Cloud Object Storage Libs
+
+IBM Cloud Object Storage hadoop libraries to add to our classpath
+
+ - com.ibm.stocator:stocator:1.1.3

--- a/docs/_docs/0_8_ibm_cos_filesystem.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.md
@@ -24,7 +24,7 @@ For example, using HMAC keys and service name `myCOS`:
 ```xml
   <property>
       <name>fs.defaultFS</name>
-      <value>cos://<my_bucket>.myCOS</value>
+      <value>cos://myBucket.myCOS</value>
   </property>
 
   <property>

--- a/docs/_docs/0_8_ibm_cos_filesystem.md
+++ b/docs/_docs/0_8_ibm_cos_filesystem.md
@@ -24,7 +24,7 @@ For example, using HMAC keys and service name `myCOS`:
 ```xml
   <property>
       <name>fs.defaultFS</name>
-      <value>cos://<my_bucket></value>
+      <value>cos://<my_bucket>.myCOS</value>
   </property>
 
   <property>

--- a/docs/_docs/2_7_cloud.cn.md
+++ b/docs/_docs/2_7_cloud.cn.md
@@ -22,3 +22,5 @@ language: cn
    Azure和Hudi协同工作所需的配置。
  * [Tencent Cloud Object Storage](/cn/docs/cos_hoodie.html) <br/>
    COS和Hudi协同工作所需的配置。
+ * [IBM Cloud Object Storage](/cn/docs/ibm_cos_hoodie.html) <br/>
+   IBM Cloud Object Storage和Hudi协同工作所需的配置。

--- a/docs/_docs/2_7_cloud.md
+++ b/docs/_docs/2_7_cloud.md
@@ -22,3 +22,5 @@ to cloud stores.
    Configurations required for Azure and Hudi co-operability.
 * [Tencent Cloud Object Storage](/docs/cos_hoodie.html) <br/>
    Configurations required for COS and Hudi co-operability.
+* [IBM Cloud Object Storage](/docs/ibm_cos_hoodie.html) <br/>
+   Configurations required for IBM Cloud Object Storage and Hudi co-operability.


### PR DESCRIPTION
## What is the purpose of the pull request

* Add Documentation for Hudi support for IBM Cloud Object Storage
Hudi Support for IBM Cloud is introduced in this [PR](https://github.com/apache/hudi/pull/2182)

## Brief change log

- Add documentation for IBM Cloud Object Storage support

## Verify this pull request

Built the docs locally and checked the documentation looks fine.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.