### PR TITLE
[HUDI-1375] Fix bug for HoodieAvroUtils.removeMetadataFields() method

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -204,6 +204,7 @@ public class HoodieAvroUtils {
     List<Schema.Field> filteredFields = schema.getFields()
                                               .stream()
                                               .filter(field -> !HoodieRecord.HOODIE_META_COLUMNS.contains(field.name()))
+                                              .map(field -> new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal()))
                                               .collect(Collectors.toList());
     Schema filteredSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
     filteredSchema.setFields(filteredFields);

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -55,6 +55,8 @@ public class TestHoodieAvroUtils {
       + "{\"name\": \"non_pii_col\", \"type\": \"string\"},"
       + "{\"name\": \"pii_col\", \"type\": \"string\", \"column_category\": \"user_profile\"}]}";
 
+  private static int NUM_FIELDS_IN_EXAMPLE_SCHEMA = 4;
+
   private static String SCHEMA_WITH_METADATA_FIELD = "{\"type\": \"record\",\"name\": \"testrec2\",\"fields\": [ "
       + "{\"name\": \"timestamp\",\"type\": \"double\"},{\"name\": \"_row_key\", \"type\": \"string\"},"
       + "{\"name\": \"non_pii_col\", \"type\": \"string\"},"
@@ -196,5 +198,13 @@ public class TestHoodieAvroUtils {
     assertNull(rec1.get("evolved_field"));
     //evolvedField5.defaultVal() returns null.
     assertNull(rec1.get("evolved_field1"));
+  }
+
+  @Test
+  public void testAddingAndRemovingMetadataFields() {
+    Schema schemaWithMetaCols = HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(EXAMPLE_SCHEMA));
+    assertEquals(schemaWithMetaCols.getFields().size(), NUM_FIELDS_IN_EXAMPLE_SCHEMA + HoodieRecord.HOODIE_META_COLUMNS.size());
+    Schema schemaWithoutMetaCols = HoodieAvroUtils.removeMetadataFields(schemaWithMetaCols);
+    assertEquals(schemaWithoutMetaCols.getFields().size(), NUM_FIELDS_IN_EXAMPLE_SCHEMA);
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

JIRA https://issues.apache.org/jira/browse/HUDI-1375

This CR fix the bug in HoodieAvroUtils.removeMetadataFields() method.

The root cause for this bug is when using Schema$RecordSchema.setFields(), it requires the position of each field must be -1: https://github.com/apache/avro/blob/master/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L908. But filteredFields already set the position in each field. So that's why it throws the exception.

Looks like we cannot manually reset the position to -1. But when initializing a new Field, the position by default will be -1. So we can create a new field with the same value as before.

## Brief change log

Fix bug and add a test case to cover.

## Verify this pull request

This change added tests and can be verified as follows:

- w/o the code change in ```HoodieAvroUtils.java```, the unit test won't pass:

```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   TestHoodieAvroUtils.testAddingAndRemovingMetadataFields:207 » AvroRuntime Fiel...
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0

```
- with the code change in  ```HoodieAvroUtils.java```, the unit test could pass:

```
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hudi.avro.TestHoodieAvroUtils
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.346 s - in org.apache.hudi.avro.TestHoodieAvroUtils
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

```

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.