### PR TITLE
[HUDI-1196] Update HoodieKey when deduplicating records

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkWriteHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkWriteHelper.java
@@ -59,10 +59,9 @@ public class SparkWriteHelper<T extends HoodieRecordPayload,R> extends AbstractW
     }).reduceByKey((rec1, rec2) -> {
       @SuppressWarnings("unchecked")
       T reducedData = (T) rec1.getData().preCombine(rec2.getData());
-      // we cannot allow the user to change the key or partitionPath, since that will affect
-      // everything
-      // so pick it from one of the records.
-      return new HoodieRecord<T>(rec1.getKey(), reducedData);
+      HoodieKey reducedKey = rec1.getData().equals(reducedData) ? rec1.getKey() : rec2.getKey();
+
+      return new HoodieRecord<T>(reducedKey, reducedData);
     }, parallelism).map(Tuple2::_2);
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java
@@ -241,6 +241,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     when(index.isGlobal()).thenReturn(true);
     List<HoodieRecord<RawTripTestPayload>> dedupedRecs = SparkWriteHelper.newInstance().deduplicateRecords(records, index, 1).collect();
     assertEquals(1, dedupedRecs.size());
+    assertEquals(dedupedRecs.get(0).getPartitionPath(), recordThree.getPartitionPath());
     assertNodupesWithinPartition(dedupedRecs);
 
     // non-Global dedup should be done based on both recordKey and partitionPath


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Currently when records are deduplicated HoodieKey is chosen without respect to results of precombine method. This creates issues when using global index if partition values are different in a batch. The record can be placed in the incorrect partition since `partitionPath` in HoodieKey does not correspond to data returned by `precombine()`.

https://issues.apache.org/jira/browse/HUDI-1196

## Brief change log

This change checks to see whether data returned by `precombine()` corresponds to `record1` or `record2` and creates HoodieRecord with the proper HoodieKey 

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.