### PR TITLE
[RFC-15] Adding interfaces for HoodieMetadata, HoodieMetadataWriter

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/MetadataCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/MetadataCommand.java
@@ -22,12 +22,14 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.cli.HoodieCLI;
 import org.apache.hudi.cli.utils.SparkUtil;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieMetadataConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.metadata.HoodieMetadataReader;
-import org.apache.hudi.metadata.HoodieMetadataWriter;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataWriter;
+
 import org.apache.spark.api.java.JavaSparkContext;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
@@ -45,23 +47,45 @@ import java.util.Map;
  */
 @Component
 public class MetadataCommand implements CommandMarker {
+
   private JavaSparkContext jsc;
+  private static String metadataBaseDirectory;
+
+  /**
+   * Sets the directory to store/read Metadata Table.
+   *
+   * This can be used to store the metadata table away from the dataset directory.
+   *  - Useful for testing as well as for using via the HUDI CLI so that the actual dataset is not written to.
+   *  - Useful for testing Metadata Table performance and operations on existing datasets before enabling.
+   */
+  public static void setMetadataBaseDirectory(String metadataDir) {
+    ValidationUtils.checkState(metadataBaseDirectory == null,
+        "metadataBaseDirectory is already set to " + metadataBaseDirectory);
+    metadataBaseDirectory = metadataDir;
+  }
+
+  public static String getMetadataTableBasePath(String tableBasePath) {
+    if (metadataBaseDirectory != null) {
+      return metadataBaseDirectory;
+    }
+    return HoodieTableMetadata.getMetadataTableBasePath(tableBasePath);
+  }
 
   @CliCommand(value = "metadata set", help = "Set options for Metadata Table")
   public String set(@CliOption(key = {"metadataDir"},
       help = "Directory to read/write metadata table (can be different from dataset)", unspecifiedDefaultValue = "")
       final String metadataDir) {
     if (!metadataDir.isEmpty()) {
-      HoodieMetadataReader.setMetadataBaseDirectory(metadataDir);
+      setMetadataBaseDirectory(metadataDir);
     }
 
-    return String.format("Ok");
+    return "Ok";
   }
 
   @CliCommand(value = "metadata create", help = "Create the Metadata Table if it does not exist")
   public String create() throws IOException {
     HoodieCLI.getTableMetaClient();
-    Path metadataPath = new Path(HoodieMetadataReader.getMetadataTableBasePath(HoodieCLI.basePath));
+    Path metadataPath = new Path(getMetadataTableBasePath(HoodieCLI.basePath));
     try {
       FileStatus[] statuses = HoodieCLI.fs.listStatus(metadataPath);
       if (statuses.length > 0) {
@@ -75,15 +99,14 @@ public class MetadataCommand implements CommandMarker {
     HoodieTimer timer = new HoodieTimer().startTimer();
     HoodieWriteConfig writeConfig = getWriteConfig();
     initJavaSparkContext();
-    HoodieMetadataWriter.create(HoodieCLI.conf, writeConfig).initialize(jsc);
+    HoodieTableMetadataWriter.create(HoodieCLI.conf, writeConfig, jsc);
     return String.format("Created Metadata Table in %s (duration=%.2f secs)", metadataPath, timer.endTimer() / 1000.0);
   }
 
   @CliCommand(value = "metadata delete", help = "Remove the Metadata Table")
   public String delete() throws Exception {
     HoodieCLI.getTableMetaClient();
-    HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();
-    Path metadataPath = new Path(HoodieMetadataReader.getMetadataTableBasePath(HoodieCLI.basePath));
+    Path metadataPath = new Path(getMetadataTableBasePath(HoodieCLI.basePath));
     try {
       FileStatus[] statuses = HoodieCLI.fs.listStatus(metadataPath);
       if (statuses.length > 0) {
@@ -100,7 +123,7 @@ public class MetadataCommand implements CommandMarker {
   public String init(@CliOption(key = {"readonly"}, unspecifiedDefaultValue = "false",
       help = "Open in read-only mode") final boolean readOnly) throws Exception {
     HoodieCLI.getTableMetaClient();
-    Path metadataPath = new Path(HoodieMetadataReader.getMetadataTableBasePath(HoodieCLI.basePath));
+    Path metadataPath = new Path(getMetadataTableBasePath(HoodieCLI.basePath));
     try {
       HoodieCLI.fs.listStatus(metadataPath);
     } catch (FileNotFoundException e) {
@@ -114,7 +137,7 @@ public class MetadataCommand implements CommandMarker {
     } else {
       HoodieWriteConfig writeConfig = getWriteConfig();
       initJavaSparkContext();
-      HoodieMetadataWriter.create(HoodieCLI.conf, writeConfig).initialize(jsc);
+      HoodieTableMetadataWriter.create(HoodieCLI.conf, writeConfig, jsc);
     }
     long t2 = System.currentTimeMillis();
 
@@ -125,11 +148,11 @@ public class MetadataCommand implements CommandMarker {
   @CliCommand(value = "metadata stats", help = "Print stats about the metadata")
   public String stats() throws IOException {
     HoodieCLI.getTableMetaClient();
-    HoodieMetadataReader metaReader = new HoodieMetadataReader(HoodieCLI.conf, HoodieCLI.basePath, "/tmp", true, false);
-    Map<String, String> stats = metaReader.getStats(true);
+    HoodieBackedTableMetadata metadata = new HoodieBackedTableMetadata(HoodieCLI.conf, HoodieCLI.basePath, "/tmp", true, false, false);
+    Map<String, String> stats = metadata.stats();
 
     StringBuffer out = new StringBuffer("\n");
-    out.append(String.format("Base path: %s\n", HoodieMetadataReader.getMetadataTableBasePath(HoodieCLI.basePath)));
+    out.append(String.format("Base path: %s\n", getMetadataTableBasePath(HoodieCLI.basePath)));
     for (Map.Entry<String, String> entry : stats.entrySet()) {
       out.append(String.format("%s: %s\n", entry.getKey(), entry.getValue()));
     }
@@ -140,15 +163,15 @@ public class MetadataCommand implements CommandMarker {
   @CliCommand(value = "metadata list-partitions", help = "Print a list of all partitions from the metadata")
   public String listPartitions() throws IOException {
     HoodieCLI.getTableMetaClient();
-    HoodieMetadataReader metaReader = new HoodieMetadataReader(HoodieCLI.conf, HoodieCLI.basePath, "/tmp", true, false);
+    HoodieBackedTableMetadata metadata = new HoodieBackedTableMetadata(HoodieCLI.conf, HoodieCLI.basePath, "/tmp", true, false, false);
 
     StringBuffer out = new StringBuffer("\n");
-    if (!metaReader.enabled()) {
+    if (!metadata.enabled()) {
       out.append("=== Metadata Table not initilized. Using file listing to get list of partitions. ===\n\n");
     }
 
     long t1 = System.currentTimeMillis();
-    List<String> partitions = metaReader.getAllPartitionPaths(HoodieCLI.fs, HoodieCLI.basePath, false);
+    List<String> partitions = metadata.getAllPartitionPaths();
     long t2 = System.currentTimeMillis();
 
     int[] count = {0};
@@ -171,16 +194,15 @@ public class MetadataCommand implements CommandMarker {
       @CliOption(key = {"partition"}, help = "Name of the partition to list files", mandatory = true)
       final String partition) throws IOException {
     HoodieCLI.getTableMetaClient();
-    HoodieMetadataReader metaReader = new HoodieMetadataReader(HoodieCLI.conf, HoodieCLI.basePath, "/tmp", true, false);
+    HoodieBackedTableMetadata metaReader = new HoodieBackedTableMetadata(HoodieCLI.conf, HoodieCLI.basePath, "/tmp", true, false, false);
 
     StringBuffer out = new StringBuffer("\n");
     if (!metaReader.enabled()) {
-      out.append("=== Metadata Table not initilized. Using file listing to get list of files in partition. ===\n\n");
+      out.append("=== Metadata Table not initialized. Using file listing to get list of files in partition. ===\n\n");
     }
 
     long t1 = System.currentTimeMillis();
-    FileStatus[] statuses = metaReader.getAllFilesInPartition(HoodieCLI.conf, HoodieCLI.basePath,
-        new Path(HoodieCLI.basePath, partition));
+    FileStatus[] statuses = metaReader.getAllFilesInPartition(new Path(HoodieCLI.basePath, partition));
     long t2 = System.currentTimeMillis();
 
     Arrays.stream(statuses).sorted((p1, p2) -> p2.getPath().getName().compareTo(p1.getPath().getName())).forEach(p -> {

--- a/hudi-client/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
@@ -128,7 +128,7 @@ public abstract class AbstractHoodieWriteClient<T extends HoodieRecordPayload> e
     finalizeWrite(table, instantTime, stats);
 
     try {
-      table.metadata().update(jsc, metadata, instantTime);
+      table.metadataWriter(jsc).update(metadata, instantTime);
 
       activeTimeline.saveAsComplete(new HoodieInstant(true, commitActionType, instantTime),
           Option.of(metadata.toJsonString().getBytes(StandardCharsets.UTF_8)));

--- a/hudi-client/src/main/java/org/apache/hudi/client/HoodieWriteClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/HoodieWriteClient.java
@@ -44,7 +44,7 @@ import org.apache.hudi.exception.HoodieRestoreException;
 import org.apache.hudi.exception.HoodieRollbackException;
 import org.apache.hudi.exception.HoodieSavepointException;
 import org.apache.hudi.index.HoodieIndex;
-import org.apache.hudi.metadata.HoodieMetadataWriter;
+import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.metrics.HoodieMetrics;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.HoodieTimelineArchiveLog;
@@ -124,7 +124,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> extends AbstractHo
     this.rollbackPending = rollbackPending;
 
     // Initialize Metadata Table
-    HoodieMetadataWriter.create(hadoopConf, writeConfig).initialize(jsc);
+    HoodieTableMetadataWriter.create(hadoopConf, writeConfig, jsc);
   }
 
   /**
@@ -701,7 +701,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> extends AbstractHo
     finalizeWrite(table, compactionCommitTime, writeStats);
     LOG.info("Committing Compaction " + compactionCommitTime + ". Finished with result " + metadata);
 
-    table.metadata().update(jsc, metadata, compactionCommitTime);
+    table.metadataWriter(jsc).update(metadata, compactionCommitTime);
 
     CompactHelpers.completeInflightCompaction(table, compactionCommitTime, metadata);
 

--- a/hudi-client/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
@@ -47,9 +47,6 @@ public class HoodieMetadataFileSystemView extends HoodieTableFileSystemView {
    */
   @Override
   protected FileStatus[] listPartition(Path partitionPath) throws IOException {
-    FileStatus[] statuses = hoodieTable.metadata().getAllFilesInPartition(metaClient.getHadoopConf(),
-        metaClient.getBasePath(), partitionPath);
-
-    return statuses;
+    return hoodieTable.metadata().getAllFilesInPartition(partitionPath);
   }
 }

--- a/hudi-client/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.avro.model.HoodieRestoreMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.io.Serializable;
+
+/**
+ * Interface that supports updating metadata for a given table, as actions complete.
+ */
+public interface HoodieTableMetadataWriter extends Serializable {
+
+  static HoodieTableMetadataWriter create(Configuration conf, HoodieWriteConfig writeConfig, JavaSparkContext jsc) {
+    return new HoodieBackedTableMetadataWriter(conf, writeConfig, jsc);
+  }
+
+  void update(HoodieCommitMetadata commitMetadata, String instantTime);
+
+  void update(HoodieCleanerPlan cleanerPlan, String instantTime);
+
+  void update(HoodieCleanMetadata cleanMetadata, String instantTime);
+
+  void update(HoodieRestoreMetadata restoreMetadata, String instantTime);
+
+  void update(HoodieRollbackMetadata rollbackMetadata, String instantTime);
+}

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieTimelineArchiveLog.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieTimelineArchiveLog.java
@@ -53,6 +53,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieCommitException;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -216,7 +217,7 @@ public class HoodieTimelineArchiveLog {
 
     // For metadata tables, ensure commits >= latest compaction commit are retained. This is required for
     // metadata table sync.
-    if (table.metadata().isMetadataTable(config.getBasePath())) {
+    if (HoodieTableMetadata.isMetadataTable(config.getBasePath())) {
       Option<HoodieInstant> latestCompactionInstant =
           table.getActiveTimeline().filterPendingCompactionTimeline().lastInstant();
       if (latestCompactionInstant.isPresent()) {

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -256,7 +256,7 @@ public class CleanActionExecutor extends BaseActionExecutor<HoodieCleanMetadata>
           cleanStats
       );
 
-      table.metadata().update(jsc, cleanerPlan, cleanInstant.getTimestamp());
+      table.metadataWriter(jsc).update(cleanerPlan, cleanInstant.getTimestamp());
 
       table.getActiveTimeline().transitionCleanInflightToComplete(inflightInstant,
           TimelineMetadataUtils.serializeCleanMetadata(metadata));

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -185,8 +185,7 @@ public class CleanPlanner<T extends HoodieRecordPayload<T>> implements Serializa
    */
   private List<String> getPartitionPathsForFullCleaning() throws IOException {
     // Go to brute force mode of scanning all partitions
-    return hoodieTable.metadata().getAllPartitionPaths(hoodieTable.getMetaClient().getFs(),
-        hoodieTable.getMetaClient().getBasePath(), config.shouldAssumeDatePartitioning());
+    return hoodieTable.metadata().getAllPartitionPaths();
   }
 
   /**

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -226,7 +226,7 @@ public abstract class BaseCommitActionExecutor<T extends HoodieRecordPayload<T>,
       HoodieCommitMetadata metadata = CommitUtils.buildMetadata(writeStats, result.getPartitionToReplaceFileIds(),
           extraMetadata, operationType, getSchemaToStoreInCommit(), getCommitActionType());
 
-      table.metadata().update(jsc, metadata, instantTime);
+      table.metadataWriter(jsc).update(metadata, instantTime);
 
       activeTimeline.saveAsComplete(new HoodieInstant(true, getCommitActionType(), instantTime),
           Option.of(metadata.toJsonString().getBytes(StandardCharsets.UTF_8)));

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
@@ -93,7 +93,7 @@ public abstract class BaseRestoreActionExecutor extends BaseActionExecutor<Hoodi
     HoodieRestoreMetadata restoreMetadata = TimelineMetadataUtils.convertRestoreMetadata(
         instantTime, durationInMs, instantsRolledBack, instantToMetadata);
 
-    table.metadata().update(jsc, restoreMetadata, instantTime);
+    table.metadataWriter(jsc).update(restoreMetadata, instantTime);
 
     table.getActiveTimeline().saveAsComplete(new HoodieInstant(true, HoodieTimeline.RESTORE_ACTION, instantTime),
         TimelineMetadataUtils.serializeRestoreMetadata(restoreMetadata));

--- a/hudi-client/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -112,7 +112,7 @@ public abstract class BaseRollbackActionExecutor extends BaseActionExecutor<Hood
         Collections.singletonList(instantToRollback),
         stats);
     if (!skipTimelinePublish) {
-      table.metadata().update(jsc, rollbackMetadata, instantTime);
+      table.metadataWriter(jsc).update(rollbackMetadata, instantTime);
       finishRollback(rollbackMetadata);
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -19,11 +19,9 @@
 package org.apache.hudi.metadata;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +41,6 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
-import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
@@ -64,112 +61,68 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 /**
- * Reader for Metadata Table.
+ * Table metadata provided by an internal DFS backed Hudi metadata table.
  *
  * If the metadata table does not exist, RPC calls are used to retrieve file listings from the file system.
  * No updates are applied to the table and it is not synced.
  */
-public class HoodieMetadataReader implements Serializable {
-  private static final Logger LOG = LogManager.getLogger(HoodieMetadataReader.class);
+public class HoodieBackedTableMetadata implements HoodieTableMetadata {
 
-  // Base path of the Metadata Table relative to the dataset (.hoodie/metadata)
-  private static final String METADATA_TABLE_REL_PATH = HoodieTableMetaClient.METAFOLDER_NAME + Path.SEPARATOR
-      + "metadata";
+  private static final Logger LOG = LogManager.getLogger(HoodieBackedTableMetadata.class);
+  private static final long MAX_MEMORY_SIZE_IN_BYTES = 1024 * 1024 * 1024;
+  private static final int BUFFER_SIZE = 10 * 1024 * 1024;
 
-  // Table name suffix
-  protected static final String METADATA_TABLE_NAME_SUFFIX = "_metadata";
+  private final SerializableConfiguration hadoopConf;
+  private final String datasetBasePath;
+  private final String metadataBasePath;
+  private final Option<HoodieMetadataMetrics> metrics;
+  private HoodieTableMetaClient metaClient;
 
-  // Timestamp for a commit when the base dataset had not had any commits yet.
-  protected static final String SOLO_COMMIT_TIMESTAMP = "00000000000000";
-
-
-  // Name of partition which saves file listings
-  public static final String METADATA_PARTITION_NAME = "metadata_partition";
-  // List of all partitions
-  public static final String[] METADATA_ALL_PARTITIONS = {METADATA_PARTITION_NAME};
-  // Key for the record which saves list of all partitions
-  protected static final String RECORDKEY_PARTITION_LIST = "__all_partitions__";
-
-  // The partition name used for non-partitioned tables
-  protected static final String NON_PARTITIONED_NAME = ".";
-
-  // Metric names
-  public static final String LOOKUP_PARTITIONS_STR = "lookup_partitions";
-  public static final String LOOKUP_FILES_STR = "lookup_files";
-  public static final String VALIDATE_PARTITIONS_STR = "validate_partitions";
-  public static final String VALIDATE_FILES_STR = "validate_files";
-  public static final String VALIDATE_ERRORS_STR = "validate_errors";
-  public static final String SCAN_STR = "scan";
-  public static final String BASEFILE_READ_STR = "basefile_read";
-
-  // Stats names
-  public static final String STAT_TOTAL_BASE_FILE_SIZE = "totalBaseFileSizeInBytes";
-  public static final String STAT_TOTAL_LOG_FILE_SIZE = "totalLogFileSizeInBytes";
-  public static final String STAT_COUNT_BASE_FILES = "baseFileCount";
-  public static final String STAT_COUNT_LOG_FILES = "logFileCount";
-  public static final String STAT_COUNT_PARTITION = "partitionCount";
-  public static final String STAT_IN_SYNC = "isInSync";
-  public static final String STAT_LAST_COMPACTION_TIMESTAMP = "lastCompactionTimestamp";
-
-  // A base directory where the metadata tables should be saved outside the dataset directory.
-  // This is used in tests on existing datasets.
-  private static String metadataBaseDirectory;
-
-  protected final SerializableConfiguration hadoopConf;
-  protected final String datasetBasePath;
-  protected final String metadataBasePath;
-  protected Registry metricsRegistry;
-  protected HoodieTableMetaClient metaClient;
-  protected boolean enabled;
+  private boolean enabled;
   private final boolean validateLookups;
-  private long maxMemorySizeInBytes = 1024 * 1024 * 1024; // TODO
-  private int bufferSize = 10 * 1024 * 1024; // TODO
-
-  // Directory used for Splillable Map when merging records
-  private String spillableMapDirectory;
+  private final boolean assumeDatePartitioning;
+  // Directory used for Spillable Map when merging records
+  private final String spillableMapDirectory;
 
   // Readers for the base and log file which store the metadata
   private transient HoodieFileReader<GenericRecord> basefileReader;
   private transient HoodieMetadataMergedLogRecordScanner logRecordScanner;
 
-  /**
-   * Create a the Metadata Table in read-only mode.
-   */
-  public HoodieMetadataReader(Configuration conf, String datasetBasePath, String spillableMapDirectory,
-                              boolean enabled, boolean validateLookups) {
-    this(conf, datasetBasePath, spillableMapDirectory, enabled, validateLookups, false);
+  public HoodieBackedTableMetadata(Configuration conf, String datasetBasePath, String spillableMapDirectory,
+                                   boolean enabled, boolean validateLookups, boolean assumeDatePartitioning) {
+    this(conf, datasetBasePath, spillableMapDirectory, enabled, validateLookups, false, assumeDatePartitioning);
   }
 
-  /**
-   * Create a the Metadata Table in read-only mode.
-   */
-  public HoodieMetadataReader(Configuration conf, String datasetBasePath, String spillableMapDirectory,
-                              boolean enabled, boolean validateLookups, boolean enableMetrics) {
+  public HoodieBackedTableMetadata(Configuration conf, String datasetBasePath, String spillableMapDirectory,
+                                   boolean enabled, boolean validateLookups, boolean enableMetrics,
+                                   boolean assumeDatePartitioning) {
     this.hadoopConf = new SerializableConfiguration(conf);
     this.datasetBasePath = datasetBasePath;
-    this.metadataBasePath = getMetadataTableBasePath(datasetBasePath);
+    this.metadataBasePath = HoodieTableMetadata.getMetadataTableBasePath(datasetBasePath);
     this.validateLookups = validateLookups;
     this.spillableMapDirectory = spillableMapDirectory;
+    this.enabled = enabled;
+    this.assumeDatePartitioning = assumeDatePartitioning;
 
     if (enabled) {
       try {
-        metaClient = new HoodieTableMetaClient(hadoopConf.get(), metadataBasePath);
+        this.metaClient = new HoodieTableMetaClient(hadoopConf.get(), metadataBasePath);
       } catch (TableNotFoundException e) {
         LOG.error("Metadata table was not found at path " + metadataBasePath);
-        enabled = false;
+        this.enabled = false;
       } catch (Exception e) {
         LOG.error("Failed to initialize metadata table at path " + metadataBasePath, e);
-        enabled = false;
+        this.enabled = false;
       }
     } else {
       LOG.info("Metadata table is disabled.");
     }
 
     if (enableMetrics) {
-      metricsRegistry = Registry.getRegistry("HoodieMetadata");
+      this.metrics = Option.of(new HoodieMetadataMetrics(Registry.getRegistry("HoodieMetadata")));
+    } else {
+      this.metrics = Option.empty();
     }
-
-    this.enabled = enabled;
   }
 
   /**
@@ -180,21 +133,20 @@ public class HoodieMetadataReader implements Serializable {
    *
    * On any errors retrieving the listing from the metadata, defaults to using the file system listings.
    *
-   * @param fs The {@code FileSystem}
-   * @param basePath Base path of the dataset
-   * @param assumeDatePartitioning True if the dataset uses date based partitioning
    */
-  public List<String> getAllPartitionPaths(FileSystem fs, String basePath, boolean assumeDatePartitioning)
+  @Override
+  public List<String> getAllPartitionPaths()
       throws IOException {
     if (enabled) {
       try {
-        return getAllPartitionPaths();
+        return fetchAllPartitionPaths();
       } catch (Exception e) {
-        LOG.error("Failed to retrive list of partition from metadata", e);
+        LOG.error("Failed to retrieve list of partition from metadata", e);
       }
     }
 
-    return getAllPartitionPathsByListing(fs, basePath, assumeDatePartitioning);
+    FileSystem fs = FSUtils.getFs(datasetBasePath, hadoopConf.get());
+    return FSUtils.getAllPartitionPaths(fs, datasetBasePath, assumeDatePartitioning);
   }
 
   /**
@@ -205,29 +157,29 @@ public class HoodieMetadataReader implements Serializable {
    *
    * On any errors retrieving the listing from the metadata, defaults to using the file system listings.
    *
-   * @param hadoopConf {@code Configuration}
    * @param partitionPath The absolute path of the partition to list
    */
-  public FileStatus[] getAllFilesInPartition(Configuration hadoopConf, String basePath, Path partitionPath)
+  @Override
+  public FileStatus[] getAllFilesInPartition(Path partitionPath)
       throws IOException {
     if (enabled) {
       try {
-        return getAllFilesInPartition(partitionPath);
+        return fetchAllFilesInPartition(partitionPath);
       } catch (Exception e) {
         LOG.error("Failed to retrive files in partition " + partitionPath + " from metadata", e);
       }
     }
 
-    return getAllFilesInPartitionByListing(hadoopConf, basePath, partitionPath);
+    return FSUtils.getFs(partitionPath.toString(), hadoopConf.get()).listStatus(partitionPath);
   }
 
   /**
    * Returns a list of all partitions.
    */
-  protected List<String> getAllPartitionPaths() throws IOException {
+  protected List<String> fetchAllPartitionPaths() throws IOException {
     HoodieTimer timer = new HoodieTimer().startTimer();
     Option<HoodieRecord<HoodieMetadataPayload>> hoodieRecord = getMergedRecordByKey(RECORDKEY_PARTITION_LIST);
-    updateMetrics(LOOKUP_PARTITIONS_STR, timer.endTimer());
+    metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_PARTITIONS_STR, timer.endTimer()));
 
     List<String> partitions = Collections.emptyList();
     if (hoodieRecord.isPresent()) {
@@ -247,8 +199,8 @@ public class HoodieMetadataReader implements Serializable {
     if (validateLookups) {
       // Validate the Metadata Table data by listing the partitions from the file system
       timer.startTimer();
-      List<String> actualPartitions  = getAllPartitionPathsByListing(metaClient.getFs(), datasetBasePath, false);
-      updateMetrics(VALIDATE_PARTITIONS_STR, timer.endTimer());
+      List<String> actualPartitions  = FSUtils.getAllPartitionPaths(metaClient.getFs(), datasetBasePath, false);
+      metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.VALIDATE_PARTITIONS_STR, timer.endTimer()));
 
       Collections.sort(actualPartitions);
       Collections.sort(partitions);
@@ -257,7 +209,7 @@ public class HoodieMetadataReader implements Serializable {
         LOG.error("Partitions from metadata: " + Arrays.toString(partitions.toArray()));
         LOG.error("Partitions from file system: " + Arrays.toString(actualPartitions.toArray()));
 
-        updateMetrics(VALIDATE_ERRORS_STR, 0);
+        metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.VALIDATE_ERRORS_STR, 0));
       }
 
       // Return the direct listing as it should be correct
@@ -273,15 +225,15 @@ public class HoodieMetadataReader implements Serializable {
    *
    * @param partitionPath The absolute path of the partition
    */
-  FileStatus[] getAllFilesInPartition(Path partitionPath) throws IOException {
+  FileStatus[] fetchAllFilesInPartition(Path partitionPath) throws IOException {
     String partitionName = FSUtils.getRelativePartitionPath(new Path(datasetBasePath), partitionPath);
-    if (partitionName.equals("")) {
+    if (partitionName.isEmpty()) {
       partitionName = NON_PARTITIONED_NAME;
     }
 
     HoodieTimer timer = new HoodieTimer().startTimer();
     Option<HoodieRecord<HoodieMetadataPayload>> hoodieRecord = getMergedRecordByKey(partitionName);
-    updateMetrics(LOOKUP_FILES_STR, timer.endTimer());
+    metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_FILES_STR, timer.endTimer()));
 
     FileStatus[] statuses = {};
     if (hoodieRecord.isPresent()) {
@@ -299,7 +251,7 @@ public class HoodieMetadataReader implements Serializable {
       // Ignore partition metadata file
       FileStatus[] directStatuses = metaClient.getFs().listStatus(partitionPath,
           p -> !p.getName().equals(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
-      updateMetrics(VALIDATE_FILES_STR, timer.endTimer());
+      metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.VALIDATE_FILES_STR, timer.endTimer()));
 
       List<String> directFilenames = Arrays.stream(directStatuses)
           .map(s -> s.getPath().getName()).sorted()
@@ -314,7 +266,7 @@ public class HoodieMetadataReader implements Serializable {
         LOG.error("File list from metadata: " + Arrays.toString(metadataFilenames.toArray()));
         LOG.error("File list from direct listing: " + Arrays.toString(directFilenames.toArray()));
 
-        updateMetrics(VALIDATE_ERRORS_STR, 0);
+        metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.VALIDATE_ERRORS_STR, 0));
       }
 
       // Return the direct listing as it should be correct
@@ -323,16 +275,6 @@ public class HoodieMetadataReader implements Serializable {
 
     LOG.info("Listed file in partition from metadata: partition=" + partitionName + ", #files=" + statuses.length);
     return statuses;
-  }
-
-  private FileStatus[] getAllFilesInPartitionByListing(Configuration hadoopConf, String basePath, Path partitionPath)
-      throws IOException {
-    return FSUtils.getFs(partitionPath.toString(), hadoopConf).listStatus(partitionPath);
-  }
-
-  private List<String> getAllPartitionPathsByListing(FileSystem fs, String basePath, boolean assumeDatePartitioning)
-      throws IOException {
-    return FSUtils.getAllPartitionPaths(fs, basePath, assumeDatePartitioning);
   }
 
   /**
@@ -349,9 +291,9 @@ public class HoodieMetadataReader implements Serializable {
       HoodieTimer timer = new HoodieTimer().startTimer();
       Option<GenericRecord> baseRecord = basefileReader.getRecordByKey(key);
       if (baseRecord.isPresent()) {
-        hoodieRecord = SpillableMapUtils.convertToHoodieRecordPayload((GenericRecord) baseRecord.get(),
+        hoodieRecord = SpillableMapUtils.convertToHoodieRecordPayload(baseRecord.get(),
             metaClient.getTableConfig().getPayloadClass());
-        updateMetrics(BASEFILE_READ_STR, timer.endTimer());
+        metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.BASEFILE_READ_STR, timer.endTimer()));
       }
     }
 
@@ -379,19 +321,18 @@ public class HoodieMetadataReader implements Serializable {
       return;
     }
 
-    long t1 = System.currentTimeMillis();
+    HoodieTimer timer = new HoodieTimer().startTimer();
 
     // Metadata is in sync till the latest completed instant on the dataset
     HoodieTableMetaClient datasetMetaClient = new HoodieTableMetaClient(hadoopConf.get(), datasetBasePath);
     Option<HoodieInstant> datasetLatestInstant = datasetMetaClient.getActiveTimeline().filterCompletedInstants()
         .lastInstant();
-    String latestInstantTime = datasetLatestInstant.isPresent() ? datasetLatestInstant.get().getTimestamp()
-        : SOLO_COMMIT_TIMESTAMP;
+    String latestInstantTime = datasetLatestInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
 
     // Find the latest file slice
     HoodieTimeline timeline = metaClient.reloadActiveTimeline();
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
-    List<FileSlice> latestSlices = fsView.getLatestFileSlices(METADATA_PARTITION_NAME).collect(Collectors.toList());
+    List<FileSlice> latestSlices = fsView.getLatestFileSlices(MetadataPartitionType.FILES.partitionPath()).collect(Collectors.toList());
     ValidationUtils.checkArgument(latestSlices.size() == 1);
 
     // If the base file is present then create a reader
@@ -399,7 +340,6 @@ public class HoodieMetadataReader implements Serializable {
     if (basefile.isPresent()) {
       String basefilePath = basefile.get().getPath();
       basefileReader = HoodieFileReaderFactory.getFileReader(hadoopConf.get(), new Path(basefilePath));
-
       LOG.info("Opened metadata base file from " + basefilePath + " at instant " + basefile.get().getCommitTime());
     }
 
@@ -408,26 +348,26 @@ public class HoodieMetadataReader implements Serializable {
         .collect(Collectors.toList());
 
     Option<HoodieInstant> lastInstant = timeline.filterCompletedInstants().lastInstant();
-    String latestMetaInstantTimestamp = lastInstant.isPresent() ? lastInstant.get().getTimestamp()
-        : SOLO_COMMIT_TIMESTAMP;
+    String latestMetaInstantTimestamp = lastInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
+
     if (!HoodieTimeline.compareTimestamps(latestInstantTime, HoodieTimeline.EQUALS, latestMetaInstantTimestamp)) {
-      // TODO: This can be false positive if the metadata table had a compaction or clean
+      // TODO(metadata): This can be false positive if the metadata table had a compaction or clean
       LOG.warn("Metadata has more recent instant " + latestMetaInstantTimestamp + " than dataset " + latestInstantTime);
     }
 
     // Load the schema
     Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
 
-    // TODO: The below code may open the metadata to include incomplete instants on the dataset
+    // TODO(metadata): The below code may open the metadata to include incomplete instants on the dataset
     logRecordScanner =
         new HoodieMetadataMergedLogRecordScanner(metaClient.getFs(), metadataBasePath,
-            logFilePaths, schema, latestMetaInstantTimestamp, maxMemorySizeInBytes, bufferSize,
+            logFilePaths, schema, latestMetaInstantTimestamp, MAX_MEMORY_SIZE_IN_BYTES, BUFFER_SIZE,
             spillableMapDirectory, null);
 
     LOG.info("Opened metadata log files from " + logFilePaths + " at instant " + latestInstantTime
         + "(dataset instant=" + latestInstantTime + ", metadata instant=" + latestMetaInstantTimestamp + ")");
 
-    updateMetrics(SCAN_STR, System.currentTimeMillis() - t1);
+    metrics.ifPresent(metrics -> metrics.updateMetrics(HoodieMetadataMetrics.SCAN_STR, timer.endTimer()));
   }
 
   protected void closeReaders() {
@@ -441,8 +381,8 @@ public class HoodieMetadataReader implements Serializable {
   /**
    * Return {@code True} if all Instants from the dataset have been synced with the Metadata Table.
    */
+  @Override
   public boolean isInSync() {
-    // There should not be any instants to sync
     return enabled && findInstantsToSync().isEmpty();
   }
 
@@ -464,19 +404,22 @@ public class HoodieMetadataReader implements Serializable {
 
     // If there has not been any compaction then the first delta commit instant should be the one at which
     // the metadata table was created. We should not sync any instants before that creation time.
+    // FIXME(metadata): or it could be that compaction has not happened for a while, right.
     Option<HoodieInstant> oldestMetaInstant = Option.empty();
     if (!compactionTimestamp.isPresent()) {
       oldestMetaInstant = metaTimeline.getDeltaCommitTimeline().filterCompletedInstants().firstInstant();
       if (oldestMetaInstant.isPresent()) {
-        // TODO: Ensure this is the instant at which we created the metadata table
+        // FIXME(metadata): Ensure this is the instant at which we created the metadata table
       }
     }
 
-    String metaSyncTimestamp = compactionTimestamp.isPresent() ? compactionTimestamp.get()
-        : oldestMetaInstant.isPresent() ? oldestMetaInstant.get().getTimestamp() : SOLO_COMMIT_TIMESTAMP;
+    String metaSyncTimestamp = compactionTimestamp.orElse(
+        oldestMetaInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP)
+    );
 
     // Metadata table is updated when an instant is completed except for the following:
     //  CLEAN: metadata table is updated during inflight. So for CLEAN we accept inflight actions.
+    // FIXME(metadata): This need not be the case, right? It's risky to do this?
     List<HoodieInstant> datasetInstants = datasetMetaClient.getActiveTimeline().getInstants()
         .filter(i -> i.isCompleted() || (i.getAction().equals(HoodieTimeline.CLEAN_ACTION) && i.isInflight()))
         .filter(i -> metaSyncTimestamp.isEmpty()
@@ -495,7 +438,7 @@ public class HoodieMetadataReader implements Serializable {
       if (metadataInstantMap.containsKey(instant.getTimestamp())) {
         // instant already synced to metadata table
         if (!instantsToSync.isEmpty()) {
-          // TODO: async clean and async compaction are not yet handled. They have a timestamp which is in the past
+          // FIXME(metadata): async clean and async compaction are not yet handled. They have a timestamp which is in the past
           // (when the operation was scheduled) and even on completion they retain their old timestamp.
           LOG.warn("Found out-of-order already synced instant " + instant + ". Instants to sync=" + instantsToSync);
         }
@@ -509,11 +452,13 @@ public class HoodieMetadataReader implements Serializable {
   /**
    * Return the timestamp of the latest compaction instant.
    */
+  @Override
   public Option<String> getLatestCompactionTimestamp() {
     if (!enabled) {
       return Option.empty();
     }
 
+    //FIXME(metadata): should we really reload this?
     HoodieTimeline timeline = metaClient.reloadActiveTimeline();
     Option<HoodieInstant> lastCompactionInstant = timeline.filterCompletedInstants()
         .filter(i -> i.getAction().equals(HoodieTimeline.COMMIT_ACTION)).lastInstant();
@@ -525,114 +470,23 @@ public class HoodieMetadataReader implements Serializable {
     }
   }
 
-  public Map<String, String> getStats(boolean detailed) throws IOException {
-    metaClient.reloadActiveTimeline();
-    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
-    return getStats(fsView, detailed);
-  }
-
-  private Map<String, String> getStats(HoodieTableFileSystemView fsView, boolean detailed) throws IOException {
-    Map<String, String> stats = new HashMap<>();
-
-    // Total size of the metadata and count of base/log files
-    long totalBaseFileSizeInBytes = 0;
-    long totalLogFileSizeInBytes = 0;
-    int baseFileCount = 0;
-    int logFileCount = 0;
-    List<FileSlice> latestSlices = fsView.getLatestFileSlices(METADATA_PARTITION_NAME).collect(Collectors.toList());
-
-    for (FileSlice slice : latestSlices) {
-      if (slice.getBaseFile().isPresent()) {
-        totalBaseFileSizeInBytes += slice.getBaseFile().get().getFileStatus().getLen();
-        ++baseFileCount;
-      }
-      Iterator<HoodieLogFile> it = slice.getLogFiles().iterator();
-      while (it.hasNext()) {
-        totalLogFileSizeInBytes += it.next().getFileStatus().getLen();
-        ++logFileCount;
-      }
-    }
-
-    stats.put(STAT_TOTAL_BASE_FILE_SIZE, String.valueOf(totalBaseFileSizeInBytes));
-    stats.put(STAT_TOTAL_LOG_FILE_SIZE, String.valueOf(totalLogFileSizeInBytes));
-    stats.put(STAT_COUNT_BASE_FILES, String.valueOf(baseFileCount));
-    stats.put(STAT_COUNT_LOG_FILES, String.valueOf(logFileCount));
-
-    if (detailed) {
-      stats.put(STAT_COUNT_PARTITION, String.valueOf(getAllPartitionPaths().size()));
-      stats.put(STAT_IN_SYNC, String.valueOf(isInSync()));
-      stats.put(STAT_LAST_COMPACTION_TIMESTAMP, getLatestCompactionTimestamp().orElseGet(() -> "none"));
-    }
-
-    return stats;
-  }
-
-  protected void updateMetrics(String action, long durationInMs) {
-    if (metricsRegistry == null) {
-      return;
-    }
-
-    // Update sum of duration and total for count
-    String countKey = action + ".count";
-    String durationKey = action + ".totalDuration";
-    metricsRegistry.add(countKey, 1);
-    metricsRegistry.add(durationKey, durationInMs);
-
-    LOG.info(String.format("Updating metadata metrics (%s=%dms, %s=1)", durationKey, durationInMs, countKey));
-  }
-
-  protected void updateMetrics(long totalBaseFileSizeInBytes, long totalLogFileSizeInBytes, int baseFileCount,
-                               int logFileCount) {
-    if (metricsRegistry == null) {
-      return;
-    }
-
-    // Update sizes and count for metadata table's data files
-    metricsRegistry.add("basefile.size", totalBaseFileSizeInBytes);
-    metricsRegistry.add("logfile.size", totalLogFileSizeInBytes);
-    metricsRegistry.add("basefile.count", baseFileCount);
-    metricsRegistry.add("logfile.count", logFileCount);
-
-    LOG.info(String.format("Updating metadata size metrics (basefile.size=%d, logfile.size=%d, basefile.count=%d, "
-        + "logfile.count=%d)", totalBaseFileSizeInBytes, totalLogFileSizeInBytes, baseFileCount, logFileCount));
-  }
-
-  /**
-   * Return the base path of the Metadata Table.
-   *
-   * @param tableBasePath The base path of the dataset
-   */
-  public static String getMetadataTableBasePath(String tableBasePath) {
-    if (metadataBaseDirectory != null) {
-      return metadataBaseDirectory;
-    }
-
-    return tableBasePath + Path.SEPARATOR + METADATA_TABLE_REL_PATH;
-  }
-
-  /**
-   * Returns {@code True} if the given path contains a metadata table.
-   *
-   * @param basePath The base path to check
-   */
-  public static boolean isMetadataTable(String basePath) {
-    return basePath.endsWith(METADATA_TABLE_REL_PATH);
-  }
-
-  /**
-   * Sets the directory to store/read Metadata Table.
-   *
-   * This can be used to store the metadata table away from the dataset directory.
-   *  - Useful for testing as well as for using via the HUDI CLI so that the actual dataset is not written to.
-   *  - Useful for testing Metadata Table performance and operations on existing datasets before enabling.
-   */
-  public static void setMetadataBaseDirectory(String metadataDir) {
-    ValidationUtils.checkState(metadataBaseDirectory == null,
-        "metadataBaseDirectory is already set to " + metadataBaseDirectory);
-    metadataBaseDirectory = metadataDir;
-  }
-
   public boolean enabled() {
     return enabled;
+  }
+
+  public SerializableConfiguration getHadoopConf() {
+    return hadoopConf;
+  }
+
+  public String getDatasetBasePath() {
+    return datasetBasePath;
+  }
+
+  public HoodieTableMetaClient getMetaClient() {
+    return metaClient;
+  }
+
+  public Map<String, String> stats() {
+    return metrics.map(m -> m.getStats(true, metaClient, this)).orElse(new HashMap<>());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMergedLogRecordScanner.java
@@ -70,11 +70,6 @@ public class HoodieMetadataMergedLogRecordScanner extends HoodieMergedLogRecordS
    * @return {@code HoodieRecord} if key was found else {@code Option.empty()}
    */
   public Option<HoodieRecord<HoodieMetadataPayload>> getRecordByKey(String key) {
-    HoodieRecord record = records.get(key);
-    if (record == null) {
-      return Option.empty();
-    }
-
-    return Option.of(record);
+    return Option.ofNullable((HoodieRecord) records.get(key));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.metrics.Registry;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.exception.HoodieIOException;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class HoodieMetadataMetrics implements Serializable {
+
+  // Metric names
+  public static final String LOOKUP_PARTITIONS_STR = "lookup_partitions";
+  public static final String LOOKUP_FILES_STR = "lookup_files";
+  public static final String VALIDATE_PARTITIONS_STR = "validate_partitions";
+  public static final String VALIDATE_FILES_STR = "validate_files";
+  public static final String VALIDATE_ERRORS_STR = "validate_errors";
+  public static final String SCAN_STR = "scan";
+  public static final String BASEFILE_READ_STR = "basefile_read";
+  public static final String INITIALIZE_STR = "initialize";
+  public static final String SYNC_STR = "sync";
+
+  // Stats names
+  public static final String STAT_TOTAL_BASE_FILE_SIZE = "totalBaseFileSizeInBytes";
+  public static final String STAT_TOTAL_LOG_FILE_SIZE = "totalLogFileSizeInBytes";
+  public static final String STAT_COUNT_BASE_FILES = "baseFileCount";
+  public static final String STAT_COUNT_LOG_FILES = "logFileCount";
+  public static final String STAT_COUNT_PARTITION = "partitionCount";
+  public static final String STAT_IN_SYNC = "isInSync";
+  public static final String STAT_LAST_COMPACTION_TIMESTAMP = "lastCompactionTimestamp";
+
+  private static final Logger LOG = LogManager.getLogger(HoodieMetadataMetrics.class);
+
+  private final Registry metricsRegistry;
+
+  public HoodieMetadataMetrics(Registry metricsRegistry) {
+    this.metricsRegistry = metricsRegistry;
+  }
+
+  public Map<String, String> getStats(boolean detailed, HoodieTableMetaClient metaClient, HoodieTableMetadata metadata) {
+    try {
+      metaClient.reloadActiveTimeline();
+      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
+      return getStats(fsView, detailed, metadata);
+    } catch (IOException ioe) {
+      throw new HoodieIOException("Unable to get metadata stats.", ioe);
+    }
+  }
+
+  private Map<String, String> getStats(HoodieTableFileSystemView fsView, boolean detailed, HoodieTableMetadata tableMetadata) throws IOException {
+    Map<String, String> stats = new HashMap<>();
+
+    // Total size of the metadata and count of base/log files
+    long totalBaseFileSizeInBytes = 0;
+    long totalLogFileSizeInBytes = 0;
+    int baseFileCount = 0;
+    int logFileCount = 0;
+    List<FileSlice> latestSlices = fsView.getLatestFileSlices(MetadataPartitionType.FILES.partitionPath()).collect(Collectors.toList());
+
+    for (FileSlice slice : latestSlices) {
+      if (slice.getBaseFile().isPresent()) {
+        totalBaseFileSizeInBytes += slice.getBaseFile().get().getFileStatus().getLen();
+        ++baseFileCount;
+      }
+      Iterator<HoodieLogFile> it = slice.getLogFiles().iterator();
+      while (it.hasNext()) {
+        totalLogFileSizeInBytes += it.next().getFileStatus().getLen();
+        ++logFileCount;
+      }
+    }
+
+    stats.put(HoodieMetadataMetrics.STAT_TOTAL_BASE_FILE_SIZE, String.valueOf(totalBaseFileSizeInBytes));
+    stats.put(HoodieMetadataMetrics.STAT_TOTAL_LOG_FILE_SIZE, String.valueOf(totalLogFileSizeInBytes));
+    stats.put(HoodieMetadataMetrics.STAT_COUNT_BASE_FILES, String.valueOf(baseFileCount));
+    stats.put(HoodieMetadataMetrics.STAT_COUNT_LOG_FILES, String.valueOf(logFileCount));
+
+    if (detailed) {
+      stats.put(HoodieMetadataMetrics.STAT_COUNT_PARTITION, String.valueOf(tableMetadata.getAllPartitionPaths().size()));
+      stats.put(HoodieMetadataMetrics.STAT_IN_SYNC, String.valueOf(tableMetadata.isInSync()));
+      stats.put(HoodieMetadataMetrics.STAT_LAST_COMPACTION_TIMESTAMP, tableMetadata.getLatestCompactionTimestamp().orElseGet(() -> "none"));
+    }
+
+    return stats;
+  }
+
+  protected void updateMetrics(String action, long durationInMs) {
+    if (metricsRegistry == null) {
+      return;
+    }
+
+    // Update sum of duration and total for count
+    String countKey = action + ".count";
+    String durationKey = action + ".totalDuration";
+    metricsRegistry.add(countKey, 1);
+    metricsRegistry.add(durationKey, durationInMs);
+
+    LOG.info(String.format("Updating metadata metrics (%s=%dms, %s=1)", durationKey, durationInMs, countKey));
+  }
+
+  protected void updateMetrics(long totalBaseFileSizeInBytes, long totalLogFileSizeInBytes, int baseFileCount,
+                               int logFileCount) {
+    if (metricsRegistry == null) {
+      return;
+    }
+
+    // Update sizes and count for metadata table's data files
+    metricsRegistry.add("basefile.size", totalBaseFileSizeInBytes);
+    metricsRegistry.add("logfile.size", totalLogFileSizeInBytes);
+    metricsRegistry.add("basefile.count", baseFileCount);
+    metricsRegistry.add("logfile.count", logFileCount);
+
+    LOG.info(String.format("Updating metadata size metrics (basefile.size=%d, logfile.size=%d, basefile.count=%d, "
+        + "logfile.count=%d)", totalBaseFileSizeInBytes, totalLogFileSizeInBytes, baseFileCount, logFileCount));
+  }
+
+  public Registry registry() {
+    return metricsRegistry;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -40,8 +40,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.metadata.HoodieMetadataReader.METADATA_PARTITION_NAME;
-import static org.apache.hudi.metadata.HoodieMetadataReader.RECORDKEY_PARTITION_LIST;
+import static org.apache.hudi.metadata.HoodieTableMetadata.RECORDKEY_PARTITION_LIST;
 
 /**
  * This is a payload which saves information about a single entry in the Metadata Table.
@@ -100,7 +99,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
     partitions.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L,  false)));
 
-    HoodieKey key = new HoodieKey(RECORDKEY_PARTITION_LIST, METADATA_PARTITION_NAME);
+    HoodieKey key = new HoodieKey(RECORDKEY_PARTITION_LIST, MetadataPartitionType.FILES.partitionPath());
     HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), PARTITION_LIST, fileInfo);
     return new HoodieRecord<>(key, payload);
   }
@@ -120,7 +119,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     filesDeleted.ifPresent(
         m -> m.forEach(filename -> fileInfo.put(filename, new HoodieMetadataFileInfo(0L,  true))));
 
-    HoodieKey key = new HoodieKey(partition, METADATA_PARTITION_NAME);
+    HoodieKey key = new HoodieKey(partition, MetadataPartitionType.FILES.partitionPath());
     HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), FILE_LIST, fileInfo);
     return new HoodieRecord<>(key, payload);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Interface that supports querying various pieces of metadata about a hudi table.
+ */
+public interface HoodieTableMetadata extends Serializable {
+
+  // Table name suffix
+  String METADATA_TABLE_NAME_SUFFIX = "_metadata";
+  // Timestamp for a commit when the base dataset had not had any commits yet.
+  String SOLO_COMMIT_TIMESTAMP = "00000000000000";
+  // Key for the record which saves list of all partitions
+  String RECORDKEY_PARTITION_LIST = "__all_partitions__";
+  // The partition name used for non-partitioned tables
+  String NON_PARTITIONED_NAME = ".";
+
+  // Base path of the Metadata Table relative to the dataset (.hoodie/metadata)
+  static final String METADATA_TABLE_REL_PATH = HoodieTableMetaClient.METAFOLDER_NAME + Path.SEPARATOR + "metadata";
+
+  /**
+   * Return the base path of the Metadata Table.
+   *
+   * @param tableBasePath The base path of the dataset
+   */
+  static String getMetadataTableBasePath(String tableBasePath) {
+    return tableBasePath + Path.SEPARATOR + METADATA_TABLE_REL_PATH;
+  }
+
+  /**
+   * Returns {@code True} if the given path contains a metadata table.
+   *
+   * @param basePath The base path to check
+   */
+  static boolean isMetadataTable(String basePath) {
+    return basePath.endsWith(METADATA_TABLE_REL_PATH);
+  }
+
+  static HoodieTableMetadata create(Configuration conf, String datasetBasePath, String spillableMapPath, boolean useFileListingFromMetadata,
+                                    boolean verifyListings, boolean enableMetrics, boolean shouldAssumeDatePartitioning) {
+    return new HoodieBackedTableMetadata(conf, datasetBasePath, spillableMapPath, useFileListingFromMetadata, verifyListings,
+        enableMetrics, shouldAssumeDatePartitioning);
+  }
+
+  /**
+   * Fetch all the files at the given partition path, per the latest snapshot of the metadata.
+   */
+  FileStatus[] getAllFilesInPartition(Path partitionPath) throws IOException;
+
+  /**
+   * Fetch list of all partition paths, per the latest snapshot of the metadata.
+   */
+  List<String> getAllPartitionPaths() throws IOException;
+
+  Option<String> getLatestCompactionTimestamp();
+
+  boolean isInSync();
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+public enum MetadataPartitionType {
+  FILES("files");
+
+  private final String partitionPath;
+
+  MetadataPartitionType(String partitionPath) {
+    this.partitionPath = partitionPath;
+  }
+
+  public String partitionPath() {
+    return partitionPath;
+  }
+}


### PR DESCRIPTION
 - moved MetadataReader to FSBackedTableMetadata, under the HoodieTableMetadata interface
 - moved MetadataWriter to FSBackedTableMetadataWriter, under the HoodieTableMetadataWriter
 - Pulled all the metrics into HoodieMetadataMetrics
 - Writer now wraps the metadata, instead of extending it
 - New enum for MetadataPartitionType
 - Streamlined code flow inside FSBackedTableMetadataWriter w.r.t initializing metadata state

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.