### PR TITLE
[HUDI-1540] Add commons-codec to spark and utilities bundle jars

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -157,6 +157,10 @@
                   <shadedPattern>org.apache.hudi.com.codahale.metrics.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.commons.codec.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.commons.codec.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.eclipse.jetty.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.jetty.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
## What is the purpose of the pull request
Fixes https://github.com/apache/hudi/issues/2239  NoClassDefFoundError: org/apache/hudi/org/apache/commons/codec/binary/Base64

## Brief change log
Included `commons-codec:commons-codec` in the spark and utilities bundle jars

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit -> NOTE: Doesnt exist
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.