### PR TITLE
[HUDI-1453] Throw Exception when input data schema is not equal to th…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
@@ -178,7 +178,9 @@ public abstract class AbstractHoodieWriteClient<T extends HoodieRecordPayload, I
     HoodieTable table = createTable(config, hadoopConf);
 
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
-    HoodieCommitMetadata metadata = CommitUtils.buildMetadata(stats, partitionToReplaceFileIds, extraMetadata, operationType, config.getSchema(), commitActionType);
+    HoodieCommitMetadata metadata = CommitUtils.buildMetadata(stats, partitionToReplaceFileIds,
+        extraMetadata, operationType, table.getTableSchema(config, false).toString(),
+        commitActionType);
     // Finalize write
     finalizeWrite(table, instantTime, stats);
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -181,7 +181,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload, I, K, O> extends 
   private Option<IndexedRecord> getIndexedRecord(HoodieRecord<T> hoodieRecord) {
     Option<Map<String, String>> recordMetadata = hoodieRecord.getData().getMetadata();
     try {
-      Option<IndexedRecord> avroRecord = hoodieRecord.getData().getInsertValue(writerSchema);
+      Option<IndexedRecord> avroRecord = hoodieRecord.getData().getInsertValue(inputSchema);
       if (avroRecord.isPresent()) {
         // Convert GenericRecord to GenericRecord with hoodie commit metadata in schema
         avroRecord = Option.of(rewriteRecord((GenericRecord) avroRecord.get()));
@@ -327,7 +327,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload, I, K, O> extends 
   private void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header) {
     try {
       header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
-      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writerSchemaWithMetafields.toString());
+      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, inputSchemaWithMetaFields.toString());
       List<HoodieLogBlock> blocks = new ArrayList<>(2);
       if (recordList.size() > 0) {
         blocks.add(HoodieDataBlock.getBlock(hoodieTable.getLogDataBlockFormat(), recordList, header));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieBootstrapHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieBootstrapHandle.java
@@ -22,7 +22,7 @@ import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
-import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
 
@@ -38,8 +38,7 @@ public class HoodieBootstrapHandle<T extends HoodieRecordPayload, I, K, O> exten
   public HoodieBootstrapHandle(HoodieWriteConfig config, String commitTime, HoodieTable<T, I, K, O> hoodieTable,
       String partitionPath, String fileId, TaskContextSupplier taskContextSupplier) {
     super(config, commitTime, hoodieTable, partitionPath, fileId,
-        Pair.of(HoodieAvroUtils.RECORD_KEY_SCHEMA,
-            HoodieAvroUtils.addMetadataFields(HoodieAvroUtils.RECORD_KEY_SCHEMA)), taskContextSupplier);
+        Option.of(HoodieAvroUtils.RECORD_KEY_SCHEMA), taskContextSupplier);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
@@ -87,9 +87,9 @@ public class HoodieSortedMergeHandle<T extends HoodieRecordPayload, I, K, O> ext
       }
       try {
         if (useWriterSchema) {
-          writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(writerSchemaWithMetafields));
+          writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(inputSchemaWithMetaFields));
         } else {
-          writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(writerSchema));
+          writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(inputSchema));
         }
         insertRecordsWritten++;
         writtenRecordKeys.add(keyToPreWrite);
@@ -109,9 +109,9 @@ public class HoodieSortedMergeHandle<T extends HoodieRecordPayload, I, K, O> ext
         HoodieRecord<T> hoodieRecord = keyToNewRecords.get(key);
         if (!writtenRecordKeys.contains(hoodieRecord.getRecordKey())) {
           if (useWriterSchema) {
-            writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(writerSchemaWithMetafields));
+            writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(inputSchemaWithMetaFields));
           } else {
-            writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(writerSchema));
+            writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(inputSchema));
           }
           insertRecordsWritten++;
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapRecordConsumer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapRecordConsumer.java
@@ -36,10 +36,12 @@ public class BootstrapRecordConsumer extends BoundedInMemoryQueueConsumer<Hoodie
     this.bootstrapHandle = bootstrapHandle;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   protected void consumeOneRecord(HoodieRecord record) {
     try {
-      bootstrapHandle.write(record, record.getData().getInsertValue(bootstrapHandle.getWriterSchemaWithMetafields()));
+      bootstrapHandle.write(record, record.getData()
+          .getInsertValue(bootstrapHandle.getInputSchemaWithMetaFields()));
     } catch (IOException e) {
       throw new HoodieIOException(e.getMessage(), e);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/AbstractMergeHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/AbstractMergeHelper.java
@@ -99,11 +99,12 @@ public abstract class AbstractMergeHelper<T extends HoodieRecordPayload, I, K, O
     if (externalSchemaTransformation) {
       bootstrapReadSchema = bootstrapReader.getSchema();
     } else {
-      bootstrapReadSchema = mergeHandle.getWriterSchema();
+      bootstrapReadSchema = mergeHandle.getReaderSchema();
     }
 
     return new MergingIterator<>(reader.getRecordIterator(readSchema), bootstrapReader.getRecordIterator(bootstrapReadSchema),
-        (inputRecordPair) -> HoodieAvroUtils.stitchRecords(inputRecordPair.getLeft(), inputRecordPair.getRight(), mergeHandle.getWriterSchemaWithMetafields()));
+        (inputRecordPair) -> HoodieAvroUtils.stitchRecords(inputRecordPair.getLeft(),
+          inputRecordPair.getRight(), mergeHandle.getTableSchemaWithMetaFields()));
   }
 
   /**

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkMergeHelper.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkMergeHelper.java
@@ -73,11 +73,11 @@ public class FlinkMergeHelper<T extends HoodieRecordPayload> extends AbstractMer
     if (externalSchemaTransformation || baseFile.getBootstrapBaseFile().isPresent()) {
       readSchema = HoodieFileReaderFactory.getFileReader(table.getHadoopConf(), mergeHandle.getOldFilePath()).getSchema();
       gWriter = new GenericDatumWriter<>(readSchema);
-      gReader = new GenericDatumReader<>(readSchema, mergeHandle.getWriterSchemaWithMetafields());
+      gReader = new GenericDatumReader<>(readSchema, mergeHandle.getTableSchemaWithMetaFields());
     } else {
       gReader = null;
       gWriter = null;
-      readSchema = mergeHandle.getWriterSchemaWithMetafields();
+      readSchema = mergeHandle.getTableSchemaWithMetaFields();
     }
 
     BoundedInMemoryExecutor<GenericRecord, GenericRecord, Void> wrapper = null;

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaMergeHelper.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaMergeHelper.java
@@ -72,11 +72,11 @@ public class JavaMergeHelper<T extends HoodieRecordPayload> extends AbstractMerg
     if (externalSchemaTransformation || baseFile.getBootstrapBaseFile().isPresent()) {
       readSchema = HoodieFileReaderFactory.getFileReader(table.getHadoopConf(), mergeHandle.getOldFilePath()).getSchema();
       gWriter = new GenericDatumWriter<>(readSchema);
-      gReader = new GenericDatumReader<>(readSchema, mergeHandle.getWriterSchemaWithMetafields());
+      gReader = new GenericDatumReader<>(readSchema, mergeHandle.getTableSchemaWithMetaFields());
     } else {
       gReader = null;
       gWriter = null;
-      readSchema = mergeHandle.getWriterSchemaWithMetafields();
+      readSchema = mergeHandle.getTableSchemaWithMetaFields();
     }
 
     BoundedInMemoryExecutor<GenericRecord, GenericRecord, Void> wrapper = null;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMergeHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkMergeHelper.java
@@ -71,11 +71,11 @@ public class SparkMergeHelper<T extends HoodieRecordPayload> extends AbstractMer
     if (externalSchemaTransformation || baseFile.getBootstrapBaseFile().isPresent()) {
       readSchema = HoodieFileReaderFactory.getFileReader(table.getHadoopConf(), mergeHandle.getOldFilePath()).getSchema();
       gWriter = new GenericDatumWriter<>(readSchema);
-      gReader = new GenericDatumReader<>(readSchema, mergeHandle.getWriterSchemaWithMetafields());
+      gReader = new GenericDatumReader<>(readSchema, mergeHandle.getTableSchemaWithMetaFields());
     } else {
       gReader = null;
       gWriter = null;
-      readSchema = mergeHandle.getWriterSchemaWithMetafields();
+      readSchema = mergeHandle.getTableSchemaWithMetaFields();
     }
 
     BoundedInMemoryExecutor<GenericRecord, GenericRecord, Void> wrapper = null;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestUpdateSchemaEvolution.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestUpdateSchemaEvolution.java
@@ -123,7 +123,7 @@ public class TestUpdateSchemaEvolution extends HoodieClientTestHarness {
       Executable executable = () -> {
         HoodieMergeHandle mergeHandle = new HoodieMergeHandle(updateTable.getConfig(), "101", updateTable,
             updateRecords.iterator(), updateRecords.get(0).getPartitionPath(), insertResult.getFileId(), supplier);
-        AvroReadSupport.setAvroReadSchema(updateTable.getHadoopConf(), mergeHandle.getWriterSchemaWithMetafields());
+        AvroReadSupport.setAvroReadSchema(updateTable.getHadoopConf(), mergeHandle.getTableSchemaWithMetaFields());
         List<GenericRecord> oldRecords = ParquetUtils.readAvroRecords(updateTable.getHadoopConf(),
             new Path(updateTable.getConfig().getBasePath() + "/" + insertResult.getStat().getPath()));
         for (GenericRecord rec : oldRecords) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -307,7 +307,7 @@ public class TableSchemaResolver {
   public static boolean isSchemaCompatible(Schema oldSchema, Schema newSchema) {
     if (oldSchema.getType() == newSchema.getType() && newSchema.getType() == Schema.Type.RECORD) {
       // record names must match:
-      if (!SchemaCompatibility.schemaNameEquals(newSchema, oldSchema)) {
+      if (!SchemaCompatibility.schemaNameEquals(oldSchema, newSchema)) {
         return false;
       }
 
@@ -344,7 +344,7 @@ public class TableSchemaResolver {
       // newSchema is the schema which will be used to read the records written earlier using oldSchema. Hence, in the
       // check below, use newSchema as the reader schema and oldSchema as the writer schema.
       org.apache.avro.SchemaCompatibility.SchemaPairCompatibility compatResult =
-          org.apache.avro.SchemaCompatibility.checkReaderWriterCompatibility(newSchema, oldSchema);
+          org.apache.avro.SchemaCompatibility.checkReaderWriterCompatibility(oldSchema, newSchema);
       return compatResult.getType() == org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE;
     }
   }


### PR DESCRIPTION
…e hoodie table schema

add test case

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Fix the bug when write  compatible data type to the hudi table, an exception throw out. For example when first write a double to the table, then write a int to the table, an exception throw out as the ISSUE [HUDI-1453] describe.


## Brief change log
Currently, Hudi will store the incoming record schema(we call it inputSchema here) in `HoodieWriteConfig`. In the write stage, Hoodie use the inputSchema to parse the incoming record and read&write record to the hoodie table.

In most case it works well.However when the incoming schema is compatible but not equal to the table schema(write a "int" to "long").It will throw an Exception in write stage as the ISSUE [HUDI-1453] describe. I fix this issue by distinguishing the two kind schemas(`inputSchema` and `tableSchema`). Here is the major change:

1. Divide `writerSchema` into `inputSchema` and `tableSchema` in `HoodieWriteHandle`.The `inputSchema` is used for `getInsertValue` to parse the incoming record.And the `tableSchema` is used for read/write data in/to the table which is the schema of  the hoodie table.
2. Change all references to `writerSchema` to `inputSchema` or `tableSchema`, according to the usage scenario. If parser the incoming record, we use the `inputSchema`. If we read/write data from the table, we use `tableSchema`. 
3. Add a `getTableSchema` method in `HoodieTable` to read the table schema. 
4. Refactoring the construct method for `HoodieWriteHandle`. Add an Option param to the construct method for `HoodieBootstrapHandle` to pass the specified schema.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - Added TestCOWDataSource#testWriteWithCompatibleType to verify the change

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.