### PR TITLE
[MINOR] Make QuickstartUtil generate random timestamp instead of 0

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java
@@ -121,9 +121,20 @@ public class QuickstartUtils {
      */
     public static OverwriteWithLatestAvroPayload generateRandomValue(HoodieKey key, String riderDriverSuffix)
         throws IOException {
+      // The timestamp generated is limited to range from 7 days before to now, to avoid generating too many
+      // partitionPaths when user use timestamp as partitionPath filed.
       GenericRecord rec =
-          generateGenericRecord(key.getRecordKey(), "rider-" + riderDriverSuffix, "driver-" + riderDriverSuffix, 0);
+          generateGenericRecord(key.getRecordKey(), "rider-" + riderDriverSuffix, "driver-"
+              + riderDriverSuffix, generateRangeRandomTimestamp(7));
       return new OverwriteWithLatestAvroPayload(Option.of(rec));
+    }
+
+    /**
+     * Generate timestamp range from {@param daysTillNow} before to now.
+     */
+    private static long generateRangeRandomTimestamp(int daysTillNow) {
+      long maxIntervalMillis = daysTillNow * 24 * 60 * 60 * 1000L;
+      return System.currentTimeMillis() - (long)(Math.random() * maxIntervalMillis);
     }
 
     /**


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Make QuickstartUtil generate random timestamp instead of 0*
 timestamp generated by `QuickstartUtil` is always 0, which is inconvenient to test `TimestampBasedKeyGenerator`

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.