### PR TITLE
[HUDI-1470] In the hudi-test-suite, use the latest writer schema, when reading from existing parquet files

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
@@ -52,6 +52,7 @@ import org.apache.hudi.common.util.ParquetReaderIterator;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieMemoryConfig;
 import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -243,6 +244,9 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
 
   private Iterator<IndexedRecord> readParquetOrLogFiles(FileSlice fileSlice) throws IOException {
     if (fileSlice.getBaseFile().isPresent()) {
+      // Read the parquet files using the latest writer schema.
+      Schema schema = new Schema.Parser().parse(schemaStr);
+      AvroReadSupport.setAvroReadSchema(metaClient.getHadoopConf(), HoodieAvroUtils.addMetadataFields(schema));
       Iterator<IndexedRecord> itr =
           new ParquetReaderIterator<IndexedRecord>(AvroParquetReader.<IndexedRecord>builder(new
               Path(fileSlice.getBaseFile().get().getPath())).withConf(metaClient.getHadoopConf()).build());


### PR DESCRIPTION

## What is the purpose of the pull request
When hudi-test-suite is reading records from the existing parquet files, it is using the reader schema (original schema used to write the parquet file).  Hudi writer core uses the evolved/latest writer schema when reading the existing parquet files.  (Difference is visible only when testing schema evolution, with an evolved schema).

To mimic the Hudi writer core behavior, with this change latest writer schema is used for reading the parquet files.

## Brief change log

- Modified DFSHoodieDatasetInputReader, readParquetOrLogFiles() to use writer schema.
- 
## Verify this pull request

This pull request is already covered by existing tests, such as testSimpleHoodieDatasetReader().

## Committer checklist

 - [ x] Has a corresponding JIRA in PR title & commit
 
 - [x ] Commit message is descriptive of the change
 
 - [x ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.