### PR TITLE
[HUDI-1488] Fix Test Case Failure in TestHBaseIndex

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBaseIndex.java
@@ -20,6 +20,7 @@ package org.apache.hudi.index.hbase;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -119,6 +120,8 @@ public class TestHBaseIndex extends FunctionalTestHarness {
   public void setUp() throws Exception {
     hadoopConf = jsc().hadoopConfiguration();
     hadoopConf.addResource(utility.getConfiguration());
+    // reInit the context here to keep the hadoopConf the same with that in this class
+    context = new HoodieSparkEngineContext(jsc());
     metaClient = getHoodieMetaClient(hadoopConf, basePath());
     dataGen = new HoodieTestDataGenerator();
   }


### PR DESCRIPTION
## *Tips*

## What is the purpose of the pull request

Fix the Test case failure in TestHBaseIndex

## Brief change log

The `hadoopConf` used by `metaClient` are different from that `SparkRDDWriteClient` use in `TestHBaseIndex`. They may have different namenode port. This will result in the `SparkRDDWriteClient` operate on different local NameNode with `metaClient`. And a hoodie table not exists exception will throw out for test case in `TestHBaseIndex`.
I fix this by reInit the `context`  with the `hadoopConf` in `TestHBaseIndex` to keep the conf consistent.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.