### PR TITLE
[Hudi 73] Adding support for vanilla AvroKafkaSource

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -287,7 +287,6 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_${scala.binary.version}</artifactId>
       <version>${kafka.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- Httpcomponents -->

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -40,8 +40,9 @@ public class FilebasedSchemaProvider extends SchemaProvider {
    * Configs supported.
    */
   public static class Config {
-    private static final String SOURCE_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.source.schema.file";
+    public static final String SOURCE_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.source.schema.file";
     private static final String TARGET_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.target.schema.file";
+    public static final String SOURCE_SCHEMA_PROP = "hoodie.deltastreamer.schemaprovider.source.schema";
   }
 
   private final FileSystem fs;
@@ -49,14 +50,17 @@ public class FilebasedSchemaProvider extends SchemaProvider {
   private final Schema sourceSchema;
 
   private Schema targetSchema;
+  private TypedProperties props;
 
   public FilebasedSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
     super(props, jssc);
+    this.props = props;
     DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(Config.SOURCE_SCHEMA_FILE_PROP));
     String sourceFile = props.getString(Config.SOURCE_SCHEMA_FILE_PROP);
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
     try {
       this.sourceSchema = new Schema.Parser().parse(this.fs.open(new Path(sourceFile)));
+      props.setProperty(Config.SOURCE_SCHEMA_PROP, sourceSchema.toString());
       if (props.containsKey(Config.TARGET_SCHEMA_FILE_PROP)) {
         this.targetSchema =
             new Schema.Parser().parse(fs.open(new Path(props.getString(Config.TARGET_SCHEMA_FILE_PROP))));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -40,9 +40,10 @@ public class FilebasedSchemaProvider extends SchemaProvider {
    * Configs supported.
    */
   public static class Config {
+
     public static final String SOURCE_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.source.schema.file";
     private static final String TARGET_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.target.schema.file";
-    public static final String SOURCE_SCHEMA_PROP = "hoodie.deltastreamer.schemaprovider.source.schema";
+    // public static final String SOURCE_SCHEMA_PROP = "hoodie.deltastreamer.schemaprovider.source.schema";
   }
 
   private final FileSystem fs;
@@ -60,7 +61,7 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
     try {
       this.sourceSchema = new Schema.Parser().parse(this.fs.open(new Path(sourceFile)));
-      props.setProperty(Config.SOURCE_SCHEMA_PROP, sourceSchema.toString());
+      // props.setProperty(Config.SOURCE_SCHEMA_PROP, sourceSchema.toString());
       if (props.containsKey(Config.TARGET_SCHEMA_FILE_PROP)) {
         this.targetSchema =
             new Schema.Parser().parse(fs.open(new Path(props.getString(Config.TARGET_SCHEMA_FILE_PROP))));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/AbstractHoodieKafkaAvroDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/AbstractHoodieKafkaAvroDeserializer.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.serde;
+
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+import org.apache.hudi.utilities.serde.config.HoodieKafkaAvroDeserializationConfig;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import kafka.utils.VerifiableProperties;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.kafka.common.errors.SerializationException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class AbstractHoodieKafkaAvroDeserializer {
+
+  private final DecoderFactory decoderFactory = DecoderFactory.get();
+  private boolean useSpecificAvroReader = false;
+  private Schema sourceSchema;
+
+  public AbstractHoodieKafkaAvroDeserializer(VerifiableProperties properties) {
+    this.sourceSchema = new Schema.Parser().parse(properties.props().getProperty(FilebasedSchemaProvider.Config.SOURCE_SCHEMA_PROP));
+  }
+
+  protected void configure(HoodieKafkaAvroDeserializationConfig config) {
+    useSpecificAvroReader = config
+      .getBoolean(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG);
+  }
+
+  protected Object deserialize(byte[] payload) throws SerializationException {
+    return deserialize(null, null, payload, sourceSchema);
+  }
+
+  protected Object deserialize(String topic, Boolean isKey, byte[] payload, Schema readerSchema) {
+    try {
+      ByteBuffer buffer = this.getByteBuffer(payload);
+      int id = buffer.getInt();
+      int length = buffer.limit() - 1 - 4;
+      Object result;
+      if (sourceSchema.getType().equals(Schema.Type.BYTES)) {
+        byte[] bytes = new byte[length];
+        buffer.get(bytes, 0, length);
+        result = bytes;
+      } else {
+        int start = buffer.position() + buffer.arrayOffset();
+        DatumReader reader = this.getDatumReader(sourceSchema, readerSchema);
+        Object object = reader.read(null, this.decoderFactory.binaryDecoder(buffer.array(), start, length, null));
+        if (sourceSchema.getType().equals(Schema.Type.STRING)) {
+          object = object.toString();
+        }
+
+        result = object;
+      }
+      return result;
+    } catch (IOException ioe) {
+      throw new SerializationException("Error deserializing payload: ", ioe);
+    }
+  }
+
+  private ByteBuffer getByteBuffer(byte[] payload) {
+    ByteBuffer buffer = ByteBuffer.wrap(payload);
+    if (buffer.get() != 0) {
+      throw new SerializationException("Unknown magic byte!");
+    } else {
+      return buffer;
+    }
+  }
+
+  private DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {
+    if (this.useSpecificAvroReader) {
+      return new SpecificDatumReader(writerSchema, readerSchema);
+    } else {
+      return new GenericDatumReader(writerSchema, readerSchema);
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/AbstractHoodieKafkaAvroDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/AbstractHoodieKafkaAvroDeserializer.java
@@ -21,7 +21,6 @@ package org.apache.hudi.utilities.serde;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 import org.apache.hudi.utilities.serde.config.HoodieKafkaAvroDeserializationConfig;
 
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import kafka.utils.VerifiableProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
@@ -45,7 +44,7 @@ public class AbstractHoodieKafkaAvroDeserializer {
 
   protected void configure(HoodieKafkaAvroDeserializationConfig config) {
     useSpecificAvroReader = config
-      .getBoolean(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG);
+      .getBoolean(HoodieKafkaAvroDeserializationConfig.SPECIFIC_AVRO_READER_CONFIG);
   }
 
   protected Object deserialize(byte[] payload) throws SerializationException {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/HoodieKafkaAvroDecoder.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/HoodieKafkaAvroDecoder.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.serde;
+
+import org.apache.hudi.utilities.serde.config.HoodieKafkaAvroDeserializationConfig;
+
+import kafka.serializer.Decoder;
+import kafka.utils.VerifiableProperties;
+
+public class HoodieKafkaAvroDecoder extends AbstractHoodieKafkaAvroDeserializer implements Decoder<Object> {
+
+  public HoodieKafkaAvroDecoder(VerifiableProperties properties) {
+    super(properties);
+    configure(new HoodieKafkaAvroDeserializationConfig(properties.props()));
+  }
+
+  @Override
+  public Object fromBytes(byte[] bytes) {
+    return deserialize(bytes);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/HoodieKafkaAvroDecoder.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/HoodieKafkaAvroDecoder.java
@@ -22,6 +22,8 @@ import org.apache.hudi.utilities.serde.config.HoodieKafkaAvroDeserializationConf
 
 import kafka.serializer.Decoder;
 import kafka.utils.VerifiableProperties;
+import org.apache.avro.Schema;
+import org.apache.kafka.common.errors.SerializationException;
 
 public class HoodieKafkaAvroDecoder extends AbstractHoodieKafkaAvroDeserializer implements Decoder<Object> {
 
@@ -33,5 +35,10 @@ public class HoodieKafkaAvroDecoder extends AbstractHoodieKafkaAvroDeserializer 
   @Override
   public Object fromBytes(byte[] bytes) {
     return deserialize(bytes);
+  }
+
+  @Override
+  protected Object deserialize(String topic, Boolean isKey, byte[] payload, Schema readerSchema) throws SerializationException {
+    return super.deserialize(topic, isKey, payload, readerSchema);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/config/HoodieKafkaAvroDeserializationConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/config/HoodieKafkaAvroDeserializationConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.serde.config;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+public class HoodieKafkaAvroDeserializationConfig extends AbstractConfig {
+
+  public static final String SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader";
+  public static final boolean SPECIFIC_AVRO_READER_DEFAULT = false;
+  public static final String SPECIFIC_AVRO_READER_DOC = "If true, tries to look up the SpecificRecord class ";
+
+  private static ConfigDef config;
+
+  static {
+    config = new ConfigDef()
+      .define(SPECIFIC_AVRO_READER_CONFIG, ConfigDef.Type.BOOLEAN, SPECIFIC_AVRO_READER_DEFAULT,
+        ConfigDef.Importance.LOW, SPECIFIC_AVRO_READER_DOC);
+  }
+
+  public HoodieKafkaAvroDeserializationConfig(Map<?,?> props) {
+    super(config, props);
+  }
+
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/config/HoodieKafkaAvroDeserializationConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/serde/config/HoodieKafkaAvroDeserializationConfig.java
@@ -29,6 +29,8 @@ public class HoodieKafkaAvroDeserializationConfig extends AbstractConfig {
   public static final boolean SPECIFIC_AVRO_READER_DEFAULT = false;
   public static final String SPECIFIC_AVRO_READER_DOC = "If true, tries to look up the SpecificRecord class ";
 
+  public static final String SCHEMA_PROVIDER_CLASS_PROP = "hoodie.deltastreamer.schemaprovider.class";
+
   private static ConfigDef config;
 
   static {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -18,10 +18,13 @@
 
 package org.apache.hudi.utilities.sources;
 
+import org.apache.hudi.DataSourceUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.serde.HoodieKafkaAvroDecoder;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
 
@@ -37,6 +40,8 @@ import org.apache.spark.streaming.kafka010.KafkaUtils;
 import org.apache.spark.streaming.kafka010.LocationStrategies;
 import org.apache.spark.streaming.kafka010.OffsetRange;
 
+import java.util.Collections;
+
 /**
  * Reads avro serialized Kafka data, based on the confluent schema-registry.
  */
@@ -45,15 +50,21 @@ public class AvroKafkaSource extends AvroSource {
   private static final Logger LOG = LogManager.getLogger(AvroKafkaSource.class);
 
   private final KafkaOffsetGen offsetGen;
-
   private final HoodieDeltaStreamerMetrics metrics;
+  private final String useSchemaRegistry = "hoodie.deltastreamer.source.avro.serde.useSchemaRegistry";
 
   public AvroKafkaSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
       SchemaProvider schemaProvider, HoodieDeltaStreamerMetrics metrics) {
     super(props, sparkContext, sparkSession, schemaProvider);
     this.metrics = metrics;
+    boolean useSchemaRegistryForDeserialization = props.getBoolean(useSchemaRegistry, true);
     props.put("key.deserializer", StringDeserializer.class);
-    props.put("value.deserializer", KafkaAvroDeserializer.class);
+    if (useSchemaRegistryForDeserialization) {
+      props.put("value.deserializer", KafkaAvroDeserializer.class);
+    } else {
+      DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(FilebasedSchemaProvider.Config.SOURCE_SCHEMA_FILE_PROP));
+      props.put("value.deserializer", HoodieKafkaAvroDecoder.class);
+    }
     offsetGen = new KafkaOffsetGen(props);
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/serde/TestHoodieKafkaAvroDecoder.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/serde/TestHoodieKafkaAvroDecoder.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.serde;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.UtilitiesTestBase;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import kafka.utils.VerifiableProperties;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+public class TestHoodieKafkaAvroDecoder extends UtilitiesTestBase {
+
+  private static KafkaAvroSerializer avroSerializer;
+  private static KafkaAvroDeserializer avroDeserializer;
+  private static String topic;
+
+  @BeforeAll
+  public static void init() throws Exception {
+    UtilitiesTestBase.initClass();
+    Properties defaultConfig = new Properties();
+    defaultConfig.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    avroDeserializer = new KafkaAvroDeserializer(schemaRegistryClient);
+    avroSerializer = new KafkaAvroSerializer(schemaRegistryClient, new HashMap(defaultConfig));
+    topic = "test_topic";
+
+    UtilitiesTestBase.Helpers.copyToDFS("delta-streamer-config/source_uber.avsc", dfs, dfsBasePath + "/source_uber.avsc");
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    super.setup();
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    super.teardown();
+  }
+
+  private GenericRecord createAvroRecord(Schema schema) {
+    GenericRecord avroRecord = new GenericData.Record(schema);
+    avroRecord.put("_row_key", "testUser");
+    avroRecord.put("timestamp", 0.0);
+    avroRecord.put("rider", "dummy_rider");
+    avroRecord.put("driver", "dummy_driver");
+    avroRecord.put("fare", 50.0);
+    avroRecord.put("_hoodie_is_deleted", false);
+    return avroRecord;
+  }
+
+  @Test
+  public void testKafkaDeserializer() {
+    TypedProperties typedProperties = new TypedProperties();
+    typedProperties.setProperty(FilebasedSchemaProvider.Config.SOURCE_SCHEMA_FILE_PROP, dfsBasePath + "/source_uber.avsc");
+    VerifiableProperties verifiableProperties = new VerifiableProperties(typedProperties);
+    FilebasedSchemaProvider schemaProvider = new FilebasedSchemaProvider(typedProperties, jsc);
+    byte[] bytes;
+    GenericRecord record = createAvroRecord(schemaProvider.getSourceSchema());
+    bytes = avroSerializer.serialize(topic, record);
+    HoodieKafkaAvroDecoder kafkaAvroDecoder = new HoodieKafkaAvroDecoder(verifiableProperties);
+    Assertions.assertEquals(record, avroDeserializer.deserialize(topic, bytes));
+    Assertions.assertEquals(record, kafkaAvroDecoder.deserialize(bytes));
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Redo of https://github.com/apache/hudi/pull/1565

## Brief change log

- Added HoodieKafkaAvroDecoder and AbstractHoodieKafkaAvroDeserializer to assist in deserializing kafka avro data.
- Introduced a property for configuring AvroKafkaSource with or without schema-registry setup.

## Verify this pull request

This change added tests and can be verified as follows:

  - *Added TestHoodieKafkaAvroDecoder to verify the change.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.