### PR TITLE
[RFC-15] Fix partition key in metadata table when bootstrapping from file system

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -374,7 +374,8 @@ public class HoodieBackedTableMetadataWriter implements HoodieTableMetadataWrite
 
         if (p.getRight().length > filesInDir.size()) {
           // Is a partition. Add all data files to result.
-          partitionToFileStatus.put(p.getLeft().getName(), filesInDir);
+          String partitionName = FSUtils.getRelativePartitionPath(new Path(datasetMetaClient.getBasePath()), p.getLeft());
+          partitionToFileStatus.put(partitionName, filesInDir);
         } else {
           // Add sub-dirs to the queue
           pathsToList.addAll(Arrays.stream(p.getRight())

--- a/hudi-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
+++ b/hudi-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
@@ -73,7 +73,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
@@ -406,6 +405,7 @@ public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
   //@ParameterizedTest
   //@EnumSource(HoodieTableType.class)
   //public void testSync(HoodieTableType tableType) throws Exception {
+  @Test
   public void testSync() throws Exception {
     //FIXME(metadata): This is broken for MOR, until HUDI-1434 is fixed
     init(HoodieTableType.COPY_ON_WRITE);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

When bootstrapping metadata table from file system, for date partitioning i.e "2015/03/01", the key being placed in metadata is "01" rather than "2015/03/01"

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.