### PR TITLE
[HUDI-1353] add incremental timeline support for pending clustering ops

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/TestAsyncCompaction.java
@@ -376,6 +376,7 @@ public class TestAsyncCompaction extends CompactionTestBase {
       // make sure earlier file groups are not visible
       assertEquals(0, newFileGroups.stream().filter(fg -> fileGroupsBeforeReplace.contains(fg)).count());
 
+      assertTrue(newFileGroups.size() > 0, "Ensure latest file-slices are not empty");
       // compaction should run with associated file groups are replaced
       executeCompactionWithReplacedFiles(compactionInstantTime, client, hoodieTable, cfg, dataGen.getPartitionPaths(), fileGroupsBeforeReplace);
     }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/HoodieClientRollbackTestBase.java
@@ -80,11 +80,11 @@ public class HoodieClientRollbackTestBase extends HoodieClientTestBase {
     SyncableFileSystemView fsView = getFileSystemViewWithUnCommittedSlices(table.getMetaClient());
     List<HoodieFileGroup> firstPartitionCommit2FileGroups = fsView.getAllFileGroups(DEFAULT_FIRST_PARTITION_PATH).collect(Collectors.toList());
     assertEquals(1, firstPartitionCommit2FileGroups.size());
-    firstPartitionCommit2FileSlices.addAll(firstPartitionCommit2FileGroups.get(0).getAllFileSlices().collect(Collectors.toList()));
+    firstPartitionCommit2FileSlices.addAll(firstPartitionCommit2FileGroups.get(0).getAllRawFileSlices().collect(Collectors.toList()));
     //3. assert filegroup and get the second partition fileslice
     List<HoodieFileGroup> secondPartitionCommit2FileGroups = fsView.getAllFileGroups(DEFAULT_SECOND_PARTITION_PATH).collect(Collectors.toList());
     assertEquals(1, secondPartitionCommit2FileGroups.size());
-    secondPartitionCommit2FileSlices.addAll(secondPartitionCommit2FileGroups.get(0).getAllFileSlices().collect(Collectors.toList()));
+    secondPartitionCommit2FileSlices.addAll(secondPartitionCommit2FileGroups.get(0).getAllRawFileSlices().collect(Collectors.toList()));
 
     //4. assert fileslice
     HoodieTableType tableType = this.getTableType();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -376,11 +376,11 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     SyncableFileSystemView fsView = getFileSystemViewWithUnCommittedSlices(table.getMetaClient());
     List<HoodieFileGroup> firstPartitionCommit2FileGroups = fsView.getAllFileGroups(DEFAULT_FIRST_PARTITION_PATH).collect(Collectors.toList());
     assertEquals(1, firstPartitionCommit2FileGroups.size());
-    firstPartitionCommit2FileSlices.addAll(firstPartitionCommit2FileGroups.get(0).getAllFileSlices().collect(Collectors.toList()));
+    firstPartitionCommit2FileSlices.addAll(firstPartitionCommit2FileGroups.get(0).getAllRawFileSlices().collect(Collectors.toList()));
     //3. assert filegroup and get the second partition fileslice
     List<HoodieFileGroup> secondPartitionCommit2FileGroups = fsView.getAllFileGroups(DEFAULT_SECOND_PARTITION_PATH).collect(Collectors.toList());
     assertEquals(1, secondPartitionCommit2FileGroups.size());
-    secondPartitionCommit2FileSlices.addAll(secondPartitionCommit2FileGroups.get(0).getAllFileSlices().collect(Collectors.toList()));
+    secondPartitionCommit2FileSlices.addAll(secondPartitionCommit2FileGroups.get(0).getAllRawFileSlices().collect(Collectors.toList()));
 
     //4. assert fileslice
     HoodieTableType tableType = metaClient.getTableType();

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -77,7 +77,7 @@ public class HoodieFileGroup implements Serializable {
     this.fileGroupId = fileGroupId;
     this.fileSlices = new TreeMap<>(HoodieFileGroup.getReverseCommitTimeComparator());
     this.timeline = timeline;
-    this.lastInstant = timeline.lastInstant();
+    this.lastInstant = timeline.filterCompletedAndCompactionInstants().lastInstant();
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -105,6 +105,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
     return new HoodieDefaultTimeline(instants.stream().filter(s -> s.isCompleted()
             || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION)), details);
   }
+  
+  @Override
+  public HoodieTimeline filterViewChangingInstants() {
+    return new HoodieDefaultTimeline(instants.stream().filter(s -> s.isCompleted()
+            || s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) || s.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION)), details);
+  }
 
   @Override
   public HoodieDefaultTimeline getCommitsAndCompactionTimeline() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -129,6 +129,19 @@ public interface HoodieTimeline extends Serializable {
    * @return New instance of HoodieTimeline with just completed instants
    */
   HoodieTimeline filterCompletedAndCompactionInstants();
+  
+  /**
+   *  Filter this timeline to just include the instants that are important for FileSystemViews. These include
+   *  a) all complete commits
+   *  b) pending compaction instants
+   *  c) pending replace commits
+   *  
+   *  A RT file-system view for reading must then merge the file-slices before and after pending 
+   *  compaction instant so that all delta-commits are read.
+   *  
+   * @return New instance of HoodieTimeline with just completed instants
+   */
+  HoodieTimeline filterViewChangingInstants();
 
   /**
    * Timeline to just include commits (commit/deltacommit) and compaction actions.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -1083,7 +1083,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   @Override
   public void sync() {
     HoodieTimeline oldTimeline = getTimeline();
-    HoodieTimeline newTimeline = metaClient.reloadActiveTimeline().filterCompletedAndCompactionInstants();
+    HoodieTimeline newTimeline = metaClient.reloadActiveTimeline().filterViewChangingInstants();
     try {
       writeLock.lock();
       runSync(oldTimeline, newTimeline);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
@@ -132,7 +132,7 @@ public class FileSystemViewManager {
    */
   private static RocksDbBasedFileSystemView createRocksDBBasedFileSystemView(SerializableConfiguration conf,
       FileSystemViewStorageConfig viewConf, HoodieTableMetaClient metaClient) {
-    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+    HoodieTimeline timeline = metaClient.getActiveTimeline().filterViewChangingInstants();
     return new RocksDbBasedFileSystemView(metaClient, timeline, viewConf);
   }
 
@@ -147,7 +147,7 @@ public class FileSystemViewManager {
   private static SpillableMapBasedFileSystemView createSpillableMapBasedFileSystemView(SerializableConfiguration conf,
       FileSystemViewStorageConfig viewConf, HoodieTableMetaClient metaClient) {
     LOG.info("Creating SpillableMap based view for basePath " + metaClient.getBasePath());
-    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+    HoodieTimeline timeline = metaClient.getActiveTimeline().filterViewChangingInstants();
     return new SpillableMapBasedFileSystemView(metaClient, timeline, viewConf);
   }
 
@@ -158,7 +158,7 @@ public class FileSystemViewManager {
   private static HoodieTableFileSystemView createInMemoryFileSystemView(HoodieMetadataConfig metadataConfig, FileSystemViewStorageConfig viewConf,
                                                                         HoodieTableMetaClient metaClient, SerializableSupplier<HoodieTableMetadata> metadataSupplier) {
     LOG.info("Creating InMemory based view for basePath " + metaClient.getBasePath());
-    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+    HoodieTimeline timeline = metaClient.getActiveTimeline().filterViewChangingInstants();
     if (metadataConfig.useFileListingMetadata()) {
       ValidationUtils.checkArgument(metadataSupplier != null, "Metadata supplier is null. Cannot instantiate metadata file system view");
       return new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -223,7 +223,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   @Override
   void addFileGroupsInPendingClustering(Stream<Pair<HoodieFileGroupId, HoodieInstant>> fileGroups) {
     fileGroups.forEach(fileGroupInstantPair -> {
-      ValidationUtils.checkArgument(fgIdToPendingClustering.containsKey(fileGroupInstantPair.getLeft()),
+      ValidationUtils.checkArgument(!fgIdToPendingClustering.containsKey(fileGroupInstantPair.getLeft()),
           "Trying to add a FileGroupId which is already in pending clustering operation. FgId :"
               + fileGroupInstantPair.getLeft() + ", new instant: " + fileGroupInstantPair.getRight() + ", existing instant "
               + fgIdToPendingClustering.get(fileGroupInstantPair.getLeft()));

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -161,7 +161,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
     // Adding mandatory parameters - Last instants affecting file-slice
     timeline.lastInstant().ifPresent(instant -> builder.addParameter(LAST_INSTANT_TS, instant.getTimestamp()));
-    builder.addParameter(TIMELINE_HASH, timeline.getTimelineHash());
+    builder.addParameter(TIMELINE_HASH, timeline.filterCompletedAndCompactionInstants().getTimelineHash());
 
     String url = builder.toString();
     LOG.info("Sending request : (" + url + ")");

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -69,7 +69,11 @@ public class ClusteringUtils {
         .filter(Option::isPresent).map(Option::get);
   }
 
-  public static Option<Pair<HoodieInstant, HoodieClusteringPlan>> getClusteringPlan(HoodieTableMetaClient metaClient, HoodieInstant pendingReplaceInstant) {
+  public static Option<Pair<HoodieInstant, HoodieClusteringPlan>> getClusteringPlan(HoodieTableMetaClient metaClient, HoodieInstant requestedReplaceInstant) {
+    return getClusteringPlan(metaClient.getActiveTimeline(), requestedReplaceInstant);
+  }
+
+  public static Option<Pair<HoodieInstant, HoodieClusteringPlan>> getClusteringPlan(HoodieTimeline timeline, HoodieInstant pendingReplaceInstant) {
     try {
       final HoodieInstant requestedInstant;
       if (!pendingReplaceInstant.isRequested()) {
@@ -80,7 +84,7 @@ public class ClusteringUtils {
       } else {
         requestedInstant = pendingReplaceInstant;
       }
-      Option<byte[]> content = metaClient.getActiveTimeline().getInstantDetails(requestedInstant);
+      Option<byte[]> content = timeline.getInstantDetails(requestedInstant);
       if (!content.isPresent() || content.get().length == 0) {
         // few operations create requested file without any content. Assume these are not clustering
         LOG.warn("No content found in requested file for instant " + pendingReplaceInstant);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -395,6 +395,16 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
         .forEach(i -> assertTrue(t1.containsInstant(i)));
     sup.get().filter(i -> !(states.contains(i.getState()) || actions.contains(i.getAction())))
         .forEach(i -> assertFalse(t1.containsInstant(i)));
+    
+    // filterViewChangingInstants
+    // This cannot be done using checkFilter as it involves both states and actions
+    final HoodieTimeline t11 = timeline.filterViewChangingInstants();
+    final Set<State> states11 = CollectionUtils.createSet(State.COMPLETED);
+    final Set<String> actions11 = CollectionUtils.createSet(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION);
+    sup.get().filter(i -> states11.contains(i.getState()) || actions11.contains(i.getAction()))
+        .forEach(i -> assertTrue(t11.containsInstant(i)));
+    sup.get().filter(i -> !(states11.contains(i.getState()) || actions11.contains(i.getAction())))
+        .forEach(i -> assertFalse(t11.containsInstant(i)));
 
     // filterPendingCompactionTimeline
     final HoodieTimeline t2 = timeline.filterPendingCompactionTimeline();


### PR DESCRIPTION
## What is the purpose of the pull request

* Add incremental timeline support to update pending clustering operations
* Fix timeline to include information in inflight clustering operations

## Brief change log
* Change timeline in filesystem views to include pending replacecommits (Previously it only included completed commits and pending compaction instants).
* Because filesystem view includes pending clustering operations, change HoodieFileGroup#lastInstant to track only completed instants. Note that this required changing some assumption in TestUpgradeDowngrade tests, please take a close look.
* Add incremental timeline support to refresh view based on pending clustering operations
* Change replacecommit.inflight file also to include clustering plan (Previously only requested file has clustering plan). This is needed to block updates on file groups in pending clustering correctly. One disadvantage is replacecommit.inflight has sometimes avro and sometimes json (WorkloadProfile used by insert_overwrite) structure. So there is a hack needed to figure out if a inflight file is created by insert_overwrite or clustering. 

Let me know if you have any suggestions . 

## Verify this pull request

This change added tests. See TestIncrementalFSViewSync.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.