### PR TITLE
[HUDI-1506] Fix wrong exception thrown in HoodieAvroUtils

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -428,10 +428,12 @@ public class HoodieAvroUtils {
 
     if (returnNullIfNotFound) {
       return null;
-    } else {
+    } else if (valueNode.getSchema().getField(parts[i]) == null) {
       throw new HoodieException(
           fieldName + "(Part -" + parts[i] + ") field not found in record. Acceptable fields were :"
               + valueNode.getSchema().getFields().stream().map(Field::name).collect(Collectors.toList()));
+    } else {
+      throw new HoodieException("The value of " + parts[i] + " can not be null");
     }
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Fix wrong exception thrown in HoodieAvroUtils*
error stack
```
org.apache.hudi.exception.HoodieException: etlDatetime(Part -etlDatetime) field not found in record. Acceptable fields were :[vin, uuid, commercialType, businessType, vehicleNo, plateColor, vehicleColor, engineId, nextFixDate, feePrintId, transArea, createTime, updateTime, registerDate, curVehicleNo, reportVehicleNo, model, checkDate, certifyDateA, certifyDateB, certificate, transAgency, transAgencyNet, transDateStart, transDateStop, insurCom, insurNum, insurType, insurCount, insurEff, insurExp, insurCreateTime, insurUpdateTime, curVehicleCertno, reportVehicleCertno, seats, brand, vehicleType, fuelType, engineDisplace, photo, enginePower, gpsBrand, gpsModel, gpsImei, gpsInstallDate, curDriverUuid, reportDrivers, curTimeOn, curTimeOff, timeFrom, timeTo, ownerName, fixState, checkState, photoId, photoIdUrl, fareType, wheelBase, vehicleTec, vehicleSafe, lesseeName, lesseeCode, sdcOperationType, hivePartition, etlDatetime]
```
we can see the `etlDatetime` do exist. it is caused by null value actually

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

This pull request is already covered by org.apache.hudi.avro.TestHoodieAvroUtils#testGetNestedFieldVal.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.