### PR TITLE
[HUDI-1421] Improvement of failure recovery for HoodieFlinkStreamer.

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -215,4 +215,23 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
     return unCompletedTimeline.getInstants().filter(x -> x.getAction().equals(commitType)).map(HoodieInstant::getTimestamp)
         .collect(Collectors.toList());
   }
+
+  public HoodieInstant.State getInstantTimeState(String instantTime){
+    HoodieTableMetaClient metaClient = createMetaClient(true);
+    Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(x -> instantTime.equals(x.getTimestamp())).lastInstant();
+    if(instantOption.isPresent()){
+      return instantOption.get().getState();
+    }
+    return null;
+  }
+
+  public String getLatestCompletedInstanTime(){
+    HoodieTableMetaClient metaClient = createMetaClient(true);
+    Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(HoodieInstant::isCompleted).lastInstant();
+    if(instantOption.isPresent()){
+      return instantOption.get().getTimestamp();
+    }
+    return null;
+  }
+
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -216,22 +216,22 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
         .collect(Collectors.toList());
   }
 
-  public HoodieInstant.State getInstantTimeState(String instantTime){
+  public Option<HoodieInstant.State> getInstantTimeState(String instantTime){
     HoodieTableMetaClient metaClient = createMetaClient(true);
     Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(x -> instantTime.equals(x.getTimestamp())).lastInstant();
     if(instantOption.isPresent()){
-      return instantOption.get().getState();
+      return Option.of(instantOption.get().getState());
     }
-    return null;
+    return Option.empty();
   }
 
-  public String getLatestCompletedInstanTime(){
+  public Option<String> getLatestCompletedInstanTime(){
     HoodieTableMetaClient metaClient = createMetaClient(true);
     Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(HoodieInstant::isCompleted).lastInstant();
     if(instantOption.isPresent()){
-      return instantOption.get().getTimestamp();
+      return Option.of(instantOption.get().getTimestamp());
     }
-    return null;
+    return Option.empty();
   }
 
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -216,19 +216,19 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
         .collect(Collectors.toList());
   }
 
-  public Option<HoodieInstant.State> getInstantTimeState(String instantTime){
+  public Option<HoodieInstant.State> getInstantTimeState(String instantTime) {
     HoodieTableMetaClient metaClient = createMetaClient(true);
     Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(x -> instantTime.equals(x.getTimestamp())).lastInstant();
-    if(instantOption.isPresent()){
+    if (instantOption.isPresent()) {
       return Option.of(instantOption.get().getState());
     }
     return Option.empty();
   }
 
-  public Option<String> getLatestCompletedInstanTime(){
+  public Option<String> getLatestCompletedInstanTime() {
     HoodieTableMetaClient metaClient = createMetaClient(true);
     Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(HoodieInstant::isCompleted).lastInstant();
-    if(instantOption.isPresent()){
+    if (instantOption.isPresent()) {
       return Option.of(instantOption.get().getTimestamp());
     }
     return Option.empty();

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
@@ -70,6 +70,11 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
   private String latestInstant;
 
   /**
+   * Tuple3<latestInstant, upsert result, indexOfThisSubtask>
+   */
+  private Tuple3<String, List<WriteStatus>, Integer> latestOutputResult;
+
+  /**
    * Flag indicate whether this subtask has records in.
    */
   private boolean hasRecordsIn;
@@ -123,7 +128,7 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
           default:
             throw new HoodieFlinkStreamerException("Unknown operation : " + cfg.operation);
         }
-        output.collect(new Tuple3<>(instantTimestamp, writeStatus, indexOfThisSubtask));
+        latestOutputResult = new Tuple3<>(instantTimestamp, writeStatus, indexOfThisSubtask);
         bufferedRecords.clear();
       }
     } else {
@@ -153,6 +158,14 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
 
   public String getLatestInstant() {
     return latestInstant;
+  }
+
+  public HoodieFlinkWriteClient getWriteClient() {
+    return writeClient;
+  }
+
+  public Tuple3<String, List<WriteStatus>, Integer> getLatestOutputResult() {
+    return latestOutputResult;
   }
 
   @Override

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
@@ -70,7 +70,7 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
   private String latestInstant;
 
   /**
-   * Tuple3<latestInstant, upsert result, indexOfThisSubtask>
+   * Tuple3<latestInstant, upsert result, indexOfThisSubtask>.
    */
   private Tuple3<String, List<WriteStatus>, Integer> latestOutputResult;
 

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
@@ -18,6 +18,11 @@
 
 package org.apache.hudi.operator;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieRecord;
 
@@ -27,10 +32,13 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -41,6 +49,12 @@ public class KeyedWriteProcessOperator extends KeyedProcessOperator<String, Hood
   public static final String NAME = "WriteProcessOperator";
   private static final Logger LOG = LoggerFactory.getLogger(KeyedWriteProcessOperator.class);
   private KeyedWriteProcessFunction writeProcessFunction;
+
+  private List<String> latestInstantList = new ArrayList<>(1);
+  private transient ListState<String> latestInstantState;
+
+  private List<Tuple3<String, List<WriteStatus>, Integer>> latestOutputResultList = new ArrayList<>(1);
+  private transient ListState<Tuple3<String, List<WriteStatus>, Integer>> latestOutputResultState;
 
   public KeyedWriteProcessOperator(KeyedProcessFunction<String, HoodieRecord, Tuple3<String, List<WriteStatus>, Integer>> function) {
     super(function);
@@ -56,12 +70,101 @@ public class KeyedWriteProcessOperator extends KeyedProcessOperator<String, Hood
     // sure each subtask will send a write status downstream, we implement this operator`s snapshotState() to mock empty
     // write status and send it downstream when there is no data flows in some subtask.
     super.snapshotState(context);
-
+    Tuple3<String, List<WriteStatus>, Integer> outputResult;
     // make up an empty result and send downstream
-    if (!writeProcessFunction.hasRecordsIn() && writeProcessFunction.getLatestInstant() != null) {
-      String instantTime = writeProcessFunction.getLatestInstant();
+    String instantTime = writeProcessFunction.getLatestInstant();
+    if (!writeProcessFunction.hasRecordsIn() && instantTime != null) {
+      outputResult = new Tuple3(instantTime, new ArrayList<WriteStatus>(), getRuntimeContext().getIndexOfThisSubtask());
       LOG.info("Mock empty writeStatus, subtaskId = [{}], instant = [{}]", getRuntimeContext().getIndexOfThisSubtask(), instantTime);
-      output.collect(new StreamRecord<>(new Tuple3(instantTime, new ArrayList<WriteStatus>(), getRuntimeContext().getIndexOfThisSubtask())));
+    }else {
+      outputResult = writeProcessFunction.getLatestOutputResult();
     }
+
+    // update state
+    if(instantTime != null){
+      if (latestInstantList.isEmpty()) {
+        latestInstantList.add(instantTime);
+      } else {
+        latestInstantList.set(0, instantTime);
+      }
+      latestInstantState.update(latestInstantList);
+      LOG.info("Update latest instant [{}]", latestInstantList);
+
+      if (latestOutputResultList.isEmpty()) {
+        latestOutputResultList.add(outputResult);
+      } else {
+        latestOutputResultList.set(0, outputResult);
+      }
+      latestOutputResultState.update(latestOutputResultList);
+      LOG.info("Update latest output result [{}]", outputResult);
+    }
+
+    output.collect(new StreamRecord<>(outputResult));
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    // instantState
+    ListStateDescriptor<String> latestInstantStateDescriptor = new ListStateDescriptor<String>("latestInstant", String.class);
+    latestInstantState = context.getOperatorStateStore().getListState(latestInstantStateDescriptor);
+    // recordState
+    ListStateDescriptor<Tuple3<String, List<WriteStatus>, Integer>> latestOutputResultDescriptor = new ListStateDescriptor<>("latestOutputResult", new TypeHint<Tuple3<String, List<WriteStatus>, Integer>>() {}.getTypeInfo());
+    latestOutputResultState = context.getOperatorStateStore().getListState(latestOutputResultDescriptor);
+
+    if (context.isRestored()) {
+      Iterator<String> latestInstantIterator = latestInstantState.get().iterator();
+      if(latestInstantIterator.hasNext()){
+        String latestInstant = latestInstantIterator.next();
+        if(StringUtils.isNullOrEmpty(latestInstant)){
+          LOG.info("KeyedWriteProcessOperator initializeState get latestInstant [{}] is empty !", latestInstant);
+          return;
+        }
+
+        // get hudi instant status
+        // HoodieFlinkEngineContext hoodieFlinkEngineContext =
+        // new HoodieFlinkEngineContext(new SerializableConfiguration(new org.apache.hadoop.conf.Configuration()), new FlinkTaskContextSupplier(getRuntimeContext()));
+        // HoodieFlinkStreamer.Config cfg = (HoodieFlinkStreamer.Config) getRuntimeContext().getExecutionConfig().getGlobalJobParameters();
+        // HoodieFlinkWriteClient writeClient = new HoodieFlinkWriteClient(hoodieFlinkEngineContext, StreamerUtil.getHoodieClientConfig(cfg));
+
+        HoodieFlinkWriteClient writeClient = writeProcessFunction.getWriteClient();
+        HoodieInstant.State instantTimeState = writeClient.getInstantTimeState(latestInstant);
+        LOG.info("KeyedWriteProcessOperator initializeState get latestInstant [{}] state [{}]", latestInstant,instantTimeState);
+
+        // maybe instant was archived and removed from hdfs
+        if(instantTimeState == null){
+          String latestCompletedInstanTime = writeClient.getLatestCompletedInstanTime();
+          if(latestCompletedInstanTime == null || Long.parseLong(latestCompletedInstanTime) < Long.parseLong(latestInstant)){
+            throw new RuntimeException("KeyedWriteProcessOperator initializeState get latestInstant is null ! latestCompletedInstanTime ["+latestCompletedInstanTime+"]");
+          }
+        }else {
+          switch (instantTimeState){
+            // upsert success but commit failed
+            case INFLIGHT:
+              LOG.info("KeyedWriteProcessOperator initializeState get latestInstant [{}] state [{}] need to output data again.", latestInstant,instantTimeState);
+              handleInflightState();
+              break;
+            // restored from a success checkpoint or a success savepoint
+            case COMPLETED: break;
+            default:break;
+          }
+        }
+      }
+    }
+    
+  }
+
+  private void handleInflightState() throws Exception {
+    Iterator<Tuple3<String, List<WriteStatus>, Integer>> iterator = latestOutputResultState.get().iterator();
+    if(iterator.hasNext()){
+      Tuple3<String, List<WriteStatus>, Integer> next = iterator.next();
+      List<WriteStatus> writeStatuses = next.f1;
+      writeStatuses.forEach(x->{
+        LOG.info("KeyedWriteProcessOperator initializeState output writeStatus [{}]",x);
+      });
+      output.collect(new StreamRecord<>(next));
+    }
+
   }
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
@@ -54,7 +54,7 @@ public class KeyedWriteProcessOperator extends KeyedProcessOperator<String, Hood
 
     // If there is no data flows in `writeProcessFunction`, it will never send anything downstream. so, in order to make
     // sure each subtask will send a write status downstream, we implement this operator`s snapshotState() to mock empty
-    // write status and send it downstream when there is no data flows in some subtasks.
+    // write status and send it downstream when there is no data flows in some subtask.
     super.snapshotState(context);
 
     // make up an empty result and send downstream


### PR DESCRIPTION
Improvement of failure recovery for HoodieFlinkStreamer.

When HoodieFlinkStreamer failure recovery from a checkpoint or savepoint KeyedWriteProcessOperator will get an instant time from flink state, if instant state is INFLIGHT indicate KeyedWriteProcessFunction operator snapshot successed but CommitSink operator do commit failed, so need to get the writeStatus from state and send to sink operator again.