### PR TITLE
[HUDI-1514] Avoid raw type use for parameter of Transformer interface

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/Transformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/Transformer.java
@@ -44,5 +44,5 @@ public interface Transformer {
    * @return Transformed Dataset
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
-  Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties);
+  Dataset<Row> apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties);
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
`Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties);`
*fix interface with raw type parameter cannot be reuse in scala, Dataset[T] is defined in scala, raw type use in java interface make this api impossible to extend by scala, while scala is so convenient to extend transform with udf*


## Brief change log

add a type parameter to transformer interface 

## Verify this pull request

this change does not affect any subclass ,which has overriden transformer api with a complete type parameter: Dataset<Row>
This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.