### PR TITLE
[HUDI-1511] InstantGenerateOperator support multiple parallelism

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -215,4 +215,23 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
     return unCompletedTimeline.getInstants().filter(x -> x.getAction().equals(commitType)).map(HoodieInstant::getTimestamp)
         .collect(Collectors.toList());
   }
+
+  public HoodieInstant.State getInstantTimeState(String instantTime){
+    HoodieTableMetaClient metaClient = createMetaClient(true);
+    Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(x -> instantTime.equals(x.getTimestamp())).lastInstant();
+    if(instantOption.isPresent()){
+      return instantOption.get().getState();
+    }
+    return null;
+  }
+
+  public String getLatestCompletedInstanTime(){
+    HoodieTableMetaClient metaClient = createMetaClient(true);
+    Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(HoodieInstant::isCompleted).lastInstant();
+    if(instantOption.isPresent()){
+      return instantOption.get().getTimestamp();
+    }
+    return null;
+  }
+
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -216,22 +216,22 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
         .collect(Collectors.toList());
   }
 
-  public HoodieInstant.State getInstantTimeState(String instantTime){
+  public Option<HoodieInstant.State> getInstantTimeState(String instantTime){
     HoodieTableMetaClient metaClient = createMetaClient(true);
     Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(x -> instantTime.equals(x.getTimestamp())).lastInstant();
     if(instantOption.isPresent()){
-      return instantOption.get().getState();
+      return Option.of(instantOption.get().getState());
     }
-    return null;
+    return Option.empty();
   }
 
-  public String getLatestCompletedInstanTime(){
+  public Option<String> getLatestCompletedInstanTime(){
     HoodieTableMetaClient metaClient = createMetaClient(true);
     Option<HoodieInstant> instantOption = metaClient.getActiveTimeline().filter(HoodieInstant::isCompleted).lastInstant();
     if(instantOption.isPresent()){
-      return instantOption.get().getTimestamp();
+      return Option.of(instantOption.get().getTimestamp());
     }
-    return null;
+    return Option.empty();
   }
 
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -72,6 +72,7 @@ public class HoodieTableMetaClient implements Serializable {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LogManager.getLogger(HoodieTableMetaClient.class);
   public static final String METAFOLDER_NAME = ".hoodie";
+  public static final String INSTANT_GENERATE_FOLDER_NAME = "instant_generate";
   public static final String TEMPFOLDER_NAME = METAFOLDER_NAME + File.separator + ".temp";
   public static final String AUXILIARYFOLDER_NAME = METAFOLDER_NAME + File.separator + ".aux";
   public static final String BOOTSTRAP_INDEX_ROOT_FOLDER_PATH = AUXILIARYFOLDER_NAME + File.separator + ".bootstrap";
@@ -202,7 +203,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Returns Marker folder path.
-   * 
+   *
    * @param instantTs Instant Timestamp
    * @return
    */
@@ -272,7 +273,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Return raw file-system.
-   * 
+   *
    * @return fs
    */
   public FileSystem getRawFs() {
@@ -418,6 +419,12 @@ public class HoodieTableMetaClient implements Serializable {
       if (!fs.exists(archiveLogDir)) {
         fs.mkdirs(archiveLogDir);
       }
+    }
+
+    // Always create instantGenerateFolder which is needed for InstantGenerateOperator
+    final Path instantGenerateFolder = new Path(basePath, HoodieTableMetaClient.INSTANT_GENERATE_FOLDER_NAME);
+    if (!fs.exists(instantGenerateFolder)) {
+      fs.mkdirs(instantGenerateFolder);
     }
 
     // Always create temporaryFolder which is needed for finalizeWrite for Hoodie tables

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.operator;
 
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.hudi.HoodieFlinkStreamer;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
@@ -46,6 +48,8 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -63,7 +67,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
 
   private static final Logger LOG = LoggerFactory.getLogger(InstantGenerateOperator.class);
   public static final String NAME = "InstantGenerateOperator";
-
+  private static final String UNDERLINE = "_";
   private HoodieFlinkStreamer.Config cfg;
   private HoodieFlinkWriteClient writeClient;
   private SerializableConfiguration serializableHadoopConf;
@@ -71,30 +75,26 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
   private String latestInstant = "";
   private List<String> latestInstantList = new ArrayList<>(1);
   private transient ListState<String> latestInstantState;
-  private List<StreamRecord> bufferedRecords = new LinkedList();
-  private transient ListState<StreamRecord> recordsState;
   private Integer retryTimes;
   private Integer retryInterval;
+  private transient boolean isMain = false;
+  private volatile transient long batchSize = 0;
 
   @Override
   public void processElement(StreamRecord<HoodieRecord> streamRecord) throws Exception {
     if (streamRecord.getValue() != null) {
-      bufferedRecords.add(streamRecord);
       output.collect(streamRecord);
+      batchSize ++;
     }
   }
 
   @Override
   public void open() throws Exception {
     super.open();
+    isMain = getRuntimeContext().getIndexOfThisSubtask() == 0;
+
     // get configs from runtimeContext
     cfg = (HoodieFlinkStreamer.Config) getRuntimeContext().getExecutionConfig().getGlobalJobParameters();
-
-    // retry times
-    retryTimes = Integer.valueOf(cfg.blockRetryTime);
-
-    // retry interval
-    retryInterval = Integer.valueOf(cfg.blockRetryInterval);
 
     // hadoopConf
     serializableHadoopConf = new SerializableConfiguration(StreamerUtil.getHadoopConf());
@@ -102,65 +102,124 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
     // Hadoop FileSystem
     fs = FSUtils.getFs(cfg.targetBasePath, serializableHadoopConf.get());
 
-    TaskContextSupplier taskContextSupplier = new FlinkTaskContextSupplier(null);
+    if(isMain){
+      // retry times
+      retryTimes = Integer.valueOf(cfg.blockRetryTime);
 
-    // writeClient
-    writeClient = new HoodieFlinkWriteClient(new HoodieFlinkEngineContext(taskContextSupplier), StreamerUtil.getHoodieClientConfig(cfg), true);
+      // retry interval
+      retryInterval = Integer.valueOf(cfg.blockRetryInterval);
 
-    // init table, create it if not exists.
-    initTable();
+      TaskContextSupplier taskContextSupplier = new FlinkTaskContextSupplier(null);
+
+      // writeClient
+      writeClient = new HoodieFlinkWriteClient(new HoodieFlinkEngineContext(taskContextSupplier), StreamerUtil.getHoodieClientConfig(cfg), true);
+
+      // init table, create it if not exists.
+      initTable();
+    }
   }
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
     super.prepareSnapshotPreBarrier(checkpointId);
-    // check whether the last instant is completed, if not, wait 10s and then throws an exception
-    if (!StringUtils.isNullOrEmpty(latestInstant)) {
-      doCheck();
-      // last instant completed, set it empty
-      latestInstant = "";
+    int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
+    String instantGenerateInfoFileName = indexOfThisSubtask + UNDERLINE + checkpointId + UNDERLINE + batchSize;
+    Path path = new Path(HoodieTableMetaClient.INSTANT_GENERATE_FOLDER_NAME,instantGenerateInfoFileName);
+    // mk generate file by each subtask
+    fs.create(path,true);
+    LOG.info("subtask [{}] at checkpoint [{}] created generate file [{}]",indexOfThisSubtask,checkpointId,instantGenerateInfoFileName);
+    if(isMain){
+      boolean hasData = generateFilePasre(checkpointId);
+      // check whether the last instant is completed, if not, wait 10s and then throws an exception
+      if (!StringUtils.isNullOrEmpty(latestInstant)) {
+        doCheck();
+        // last instant completed, set it empty
+        latestInstant = "";
+      }
+
+      // no data no new instant
+      if (hasData) {
+        latestInstant = startNewInstant(checkpointId);
+      }
     }
 
-    // no data no new instant
-    if (!bufferedRecords.isEmpty()) {
-      latestInstant = startNewInstant(checkpointId);
+  }
+
+  private boolean generateFilePasre(long checkpointId) throws InterruptedException, IOException {
+    int numberOfParallelSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+    FileStatus[] fileStatuses = null;
+    Path generatePath = new Path(HoodieTableMetaClient.INSTANT_GENERATE_FOLDER_NAME);
+    int tryTimes = 1;
+    // waiting all subtask create generate file ready
+    while (true){
+      Thread.sleep(500L);
+      fileStatuses = fs.listStatus(generatePath, new PathFilter() {
+        @Override
+        public boolean accept(Path pathname) {
+          return pathname.getName().contains(UNDERLINE + checkpointId + UNDERLINE);
+        }
+      });
+
+      // is ready
+      if(fileStatuses != null && fileStatuses.length == numberOfParallelSubtasks){
+        break;
+      }
+
+      if(tryTimes >= 5){
+        LOG.warn("waiting generate file, checkpointId [{}]",checkpointId);
+        tryTimes = 0;
+      }
     }
+
+    boolean hasData = false;
+    // judge whether has data in this checkpoint and delete tmp file.
+    for(FileStatus fileStatus : fileStatuses){
+      Path path = fileStatus.getPath();
+      String name = path.getName();
+      // has data
+      if(Long.parseLong(name.split(UNDERLINE)[2]) > 0){
+        hasData = true;
+        break;
+      }
+    }
+
+    // delete all tmp file
+    fileStatuses = fs.listStatus(generatePath);
+    for(FileStatus fileStatus : fileStatuses){
+      fs.delete(fileStatus.getPath());
+    }
+
+    return hasData;
   }
 
   @Override
   public void initializeState(StateInitializationContext context) throws Exception {
-    // instantState
-    ListStateDescriptor<String> latestInstantStateDescriptor = new ListStateDescriptor<String>("latestInstant", String.class);
-    latestInstantState = context.getOperatorStateStore().getListState(latestInstantStateDescriptor);
+    isMain = getRuntimeContext().getIndexOfThisSubtask() == 0;
+    if(isMain){
+      // instantState
+      ListStateDescriptor<String> latestInstantStateDescriptor = new ListStateDescriptor<String>("latestInstant", String.class);
+      latestInstantState = context.getOperatorStateStore().getListState(latestInstantStateDescriptor);
 
-    // recordState
-    ListStateDescriptor<StreamRecord> recordsStateDescriptor = new ListStateDescriptor<StreamRecord>("recordsState", StreamRecord.class);
-    recordsState = context.getOperatorStateStore().getListState(recordsStateDescriptor);
-
-    if (context.isRestored()) {
-      Iterator<String> latestInstantIterator = latestInstantState.get().iterator();
-      latestInstantIterator.forEachRemaining(x -> latestInstant = x);
-      LOG.info("InstantGenerateOperator initializeState get latestInstant [{}]", latestInstant);
-
-      Iterator<StreamRecord> recordIterator = recordsState.get().iterator();
-      bufferedRecords.clear();
-      recordIterator.forEachRemaining(x -> bufferedRecords.add(x));
+      if (context.isRestored()) {
+        Iterator<String> latestInstantIterator = latestInstantState.get().iterator();
+        latestInstantIterator.forEachRemaining(x -> latestInstant = x);
+        LOG.info("InstantGenerateOperator initializeState get latestInstant [{}]", latestInstant);
+      }
     }
   }
 
   @Override
   public void snapshotState(StateSnapshotContext functionSnapshotContext) throws Exception {
-    if (latestInstantList.isEmpty()) {
-      latestInstantList.add(latestInstant);
-    } else {
-      latestInstantList.set(0, latestInstant);
+    LOG.info("Update latest instant [{}] records size [{}]", latestInstant,batchSize);
+    batchSize = 0;
+    if(isMain){
+      if (latestInstantList.isEmpty()) {
+        latestInstantList.add(latestInstant);
+      } else {
+        latestInstantList.set(0, latestInstant);
+      }
+      latestInstantState.update(latestInstantList);
     }
-    latestInstantState.update(latestInstantList);
-    LOG.info("Update latest instant [{}]", latestInstant);
-
-    recordsState.update(bufferedRecords);
-    LOG.info("Update records state size = [{}]", bufferedRecords.size());
-    bufferedRecords.clear();
   }
 
   /**
@@ -196,7 +255,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
         return;
       }
     }
-    throw new InterruptedException("Last instant costs more than ten second, stop task now");
+    throw new InterruptedException(String.format("Last instant costs more than %s second, stop task now", retryTimes * retryInterval));
   }
 
 

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
@@ -70,6 +70,11 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
   private String latestInstant;
 
   /**
+   * Tuple3<latestInstant, upsert result, indexOfThisSubtask>
+   */
+  private Tuple3<String, List<WriteStatus>, Integer> latestOutputResult;
+
+  /**
    * Flag indicate whether this subtask has records in.
    */
   private boolean hasRecordsIn;
@@ -123,7 +128,7 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
           default:
             throw new HoodieFlinkStreamerException("Unknown operation : " + cfg.operation);
         }
-        output.collect(new Tuple3<>(instantTimestamp, writeStatus, indexOfThisSubtask));
+        latestOutputResult = new Tuple3<>(instantTimestamp, writeStatus, indexOfThisSubtask);
         bufferedRecords.clear();
       }
     } else {
@@ -153,6 +158,14 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
 
   public String getLatestInstant() {
     return latestInstant;
+  }
+
+  public HoodieFlinkWriteClient getWriteClient() {
+    return writeClient;
+  }
+
+  public Tuple3<String, List<WriteStatus>, Integer> getLatestOutputResult() {
+    return latestOutputResult;
   }
 
   @Override

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
@@ -18,6 +18,11 @@
 
 package org.apache.hudi.operator;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieRecord;
 
@@ -27,10 +32,13 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -41,6 +49,12 @@ public class KeyedWriteProcessOperator extends KeyedProcessOperator<String, Hood
   public static final String NAME = "WriteProcessOperator";
   private static final Logger LOG = LoggerFactory.getLogger(KeyedWriteProcessOperator.class);
   private KeyedWriteProcessFunction writeProcessFunction;
+
+  private List<String> latestInstantList = new ArrayList<>(1);
+  private transient ListState<String> latestInstantState;
+
+  private List<Tuple3<String, List<WriteStatus>, Integer>> latestOutputResultList = new ArrayList<>(1);
+  private transient ListState<Tuple3<String, List<WriteStatus>, Integer>> latestOutputResultState;
 
   public KeyedWriteProcessOperator(KeyedProcessFunction<String, HoodieRecord, Tuple3<String, List<WriteStatus>, Integer>> function) {
     super(function);
@@ -56,12 +70,101 @@ public class KeyedWriteProcessOperator extends KeyedProcessOperator<String, Hood
     // sure each subtask will send a write status downstream, we implement this operator`s snapshotState() to mock empty
     // write status and send it downstream when there is no data flows in some subtask.
     super.snapshotState(context);
-
+    Tuple3<String, List<WriteStatus>, Integer> outputResult;
     // make up an empty result and send downstream
-    if (!writeProcessFunction.hasRecordsIn() && writeProcessFunction.getLatestInstant() != null) {
-      String instantTime = writeProcessFunction.getLatestInstant();
+    String instantTime = writeProcessFunction.getLatestInstant();
+    if (!writeProcessFunction.hasRecordsIn() && instantTime != null) {
+      outputResult = new Tuple3(instantTime, new ArrayList<WriteStatus>(), getRuntimeContext().getIndexOfThisSubtask());
       LOG.info("Mock empty writeStatus, subtaskId = [{}], instant = [{}]", getRuntimeContext().getIndexOfThisSubtask(), instantTime);
-      output.collect(new StreamRecord<>(new Tuple3(instantTime, new ArrayList<WriteStatus>(), getRuntimeContext().getIndexOfThisSubtask())));
+    }else {
+      outputResult = writeProcessFunction.getLatestOutputResult();
     }
+
+    // update state
+    if(instantTime != null){
+      if (latestInstantList.isEmpty()) {
+        latestInstantList.add(instantTime);
+      } else {
+        latestInstantList.set(0, instantTime);
+      }
+      latestInstantState.update(latestInstantList);
+      LOG.info("Update latest instant [{}]", latestInstantList);
+
+      if (latestOutputResultList.isEmpty()) {
+        latestOutputResultList.add(outputResult);
+      } else {
+        latestOutputResultList.set(0, outputResult);
+      }
+      latestOutputResultState.update(latestOutputResultList);
+      LOG.info("Update latest output result [{}]", outputResult);
+    }
+
+    output.collect(new StreamRecord<>(outputResult));
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    // instantState
+    ListStateDescriptor<String> latestInstantStateDescriptor = new ListStateDescriptor<String>("latestInstant", String.class);
+    latestInstantState = context.getOperatorStateStore().getListState(latestInstantStateDescriptor);
+    // recordState
+    ListStateDescriptor<Tuple3<String, List<WriteStatus>, Integer>> latestOutputResultDescriptor = new ListStateDescriptor<>("latestOutputResult", new TypeHint<Tuple3<String, List<WriteStatus>, Integer>>() {}.getTypeInfo());
+    latestOutputResultState = context.getOperatorStateStore().getListState(latestOutputResultDescriptor);
+
+    if (context.isRestored()) {
+      Iterator<String> latestInstantIterator = latestInstantState.get().iterator();
+      if(latestInstantIterator.hasNext()){
+        String latestInstant = latestInstantIterator.next();
+        if(StringUtils.isNullOrEmpty(latestInstant)){
+          LOG.info("KeyedWriteProcessOperator initializeState get latestInstant [{}] is empty !", latestInstant);
+          return;
+        }
+
+        // get hudi instant status
+        // HoodieFlinkEngineContext hoodieFlinkEngineContext =
+        // new HoodieFlinkEngineContext(new SerializableConfiguration(new org.apache.hadoop.conf.Configuration()), new FlinkTaskContextSupplier(getRuntimeContext()));
+        // HoodieFlinkStreamer.Config cfg = (HoodieFlinkStreamer.Config) getRuntimeContext().getExecutionConfig().getGlobalJobParameters();
+        // HoodieFlinkWriteClient writeClient = new HoodieFlinkWriteClient(hoodieFlinkEngineContext, StreamerUtil.getHoodieClientConfig(cfg));
+
+        HoodieFlinkWriteClient writeClient = writeProcessFunction.getWriteClient();
+        HoodieInstant.State instantTimeState = writeClient.getInstantTimeState(latestInstant);
+        LOG.info("KeyedWriteProcessOperator initializeState get latestInstant [{}] state [{}]", latestInstant,instantTimeState);
+
+        // maybe instant was archived and removed from hdfs
+        if(instantTimeState == null){
+          String latestCompletedInstanTime = writeClient.getLatestCompletedInstanTime();
+          if(latestCompletedInstanTime == null || Long.parseLong(latestCompletedInstanTime) < Long.parseLong(latestInstant)){
+            throw new RuntimeException("KeyedWriteProcessOperator initializeState get latestInstant is null ! latestCompletedInstanTime ["+latestCompletedInstanTime+"]");
+          }
+        }else {
+          switch (instantTimeState){
+            // upsert success but commit failed
+            case INFLIGHT:
+              LOG.info("KeyedWriteProcessOperator initializeState get latestInstant [{}] state [{}] need to output data again.", latestInstant,instantTimeState);
+              handleInflightState();
+              break;
+            // restored from a success checkpoint or a success savepoint
+            case COMPLETED: break;
+            default:break;
+          }
+        }
+      }
+    }
+    
+  }
+
+  private void handleInflightState() throws Exception {
+    Iterator<Tuple3<String, List<WriteStatus>, Integer>> iterator = latestOutputResultState.get().iterator();
+    if(iterator.hasNext()){
+      Tuple3<String, List<WriteStatus>, Integer> next = iterator.next();
+      List<WriteStatus> writeStatuses = next.f1;
+      writeStatuses.forEach(x->{
+        LOG.info("KeyedWriteProcessOperator initializeState output writeStatus [{}]",x);
+      });
+      output.collect(new StreamRecord<>(next));
+    }
+
   }
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessOperator.java
@@ -54,7 +54,7 @@ public class KeyedWriteProcessOperator extends KeyedProcessOperator<String, Hood
 
     // If there is no data flows in `writeProcessFunction`, it will never send anything downstream. so, in order to make
     // sure each subtask will send a write status downstream, we implement this operator`s snapshotState() to mock empty
-    // write status and send it downstream when there is no data flows in some subtasks.
+    // write status and send it downstream when there is no data flows in some subtask.
     super.snapshotState(context);
 
     // make up an empty result and send downstream


### PR DESCRIPTION
InstantGenerateOperator support multiple parallelism.
When InstantGenerateOperator subtask size greater than 1 we can set subtask 0 as a main subtask, only main task create new instant.
The prerequisite of create new instant is exist subtask received data in current checkpoint. Every subtask will create a tmp file,
flie name is make up by checkpointid,subtask index and received records size. 
The main subtask will check every subtask file and parse file to make sure is shuold to create new instant. 