### PR TITLE
[HUDI-1511] InstantGenerateOperator support multiple parallelism

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -71,6 +71,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LogManager.getLogger(HoodieTableMetaClient.class);
+  public static final String INSTANT_GENERATE_FOLDER_NAME = "instant_generate";
   public static final String METAFOLDER_NAME = ".hoodie";
   public static final String TEMPFOLDER_NAME = METAFOLDER_NAME + File.separator + ".temp";
   public static final String AUXILIARYFOLDER_NAME = METAFOLDER_NAME + File.separator + ".aux";
@@ -202,7 +203,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Returns Marker folder path.
-   * 
+   *
    * @param instantTs Instant Timestamp
    * @return
    */
@@ -272,7 +273,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Return raw file-system.
-   * 
+   *
    * @return fs
    */
   public FileSystem getRawFs() {
@@ -418,6 +419,12 @@ public class HoodieTableMetaClient implements Serializable {
       if (!fs.exists(archiveLogDir)) {
         fs.mkdirs(archiveLogDir);
       }
+    }
+
+    // Always create instantGenerateFolder which is needed for InstantGenerateOperator
+    final Path instantGenerateFolder = new Path(basePath, HoodieTableMetaClient.INSTANT_GENERATE_FOLDER_NAME);
+    if (!fs.exists(instantGenerateFolder)) {
+      fs.mkdirs(instantGenerateFolder);
     }
 
     // Always create temporaryFolder which is needed for finalizeWrite for Hoodie tables

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -71,7 +71,6 @@ public class HoodieTableMetaClient implements Serializable {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LogManager.getLogger(HoodieTableMetaClient.class);
-  public static final String INSTANT_GENERATE_FOLDER_NAME = "instant_generate";
   public static final String METAFOLDER_NAME = ".hoodie";
   public static final String TEMPFOLDER_NAME = METAFOLDER_NAME + File.separator + ".temp";
   public static final String AUXILIARYFOLDER_NAME = METAFOLDER_NAME + File.separator + ".aux";
@@ -419,12 +418,6 @@ public class HoodieTableMetaClient implements Serializable {
       if (!fs.exists(archiveLogDir)) {
         fs.mkdirs(archiveLogDir);
       }
-    }
-
-    // Always create instantGenerateFolder which is needed for InstantGenerateOperator
-    final Path instantGenerateFolder = new Path(basePath, HoodieTableMetaClient.INSTANT_GENERATE_FOLDER_NAME);
-    if (!fs.exists(instantGenerateFolder)) {
-      fs.mkdirs(instantGenerateFolder);
     }
 
     // Always create temporaryFolder which is needed for finalizeWrite for Hoodie tables

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -202,7 +202,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Returns Marker folder path.
-   *
+   * 
    * @param instantTs Instant Timestamp
    * @return
    */
@@ -272,7 +272,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Return raw file-system.
-   *
+   * 
    * @return fs
    */
   public FileSystem getRawFs() {

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -128,18 +128,17 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
     super.prepareSnapshotPreBarrier(checkpointId);
     String instantMarkerFileName = String.format("%d%s%d%s%d", indexOfThisSubtask, DELIMITER, checkpointId, DELIMITER, recordCounter.get());
     Path path = new Path(new Path(HoodieTableMetaClient.AUXILIARYFOLDER_NAME, INSTANT_MARKER_FOLDER_NAME), instantMarkerFileName);
-    // mk generate file by each subtask
+    // mk marker file by each subtask
     fs.create(path, true);
-    LOG.info("Subtask [{}] at checkpoint [{}] created generate file [{}]", indexOfThisSubtask, checkpointId, instantMarkerFileName);
+    LOG.info("Subtask [{}] at checkpoint [{}] created marker file [{}]", indexOfThisSubtask, checkpointId, instantMarkerFileName);
     if (isMain) {
-      boolean receivedDataInCurrentCP = checkReceivedData(checkpointId);
       // check whether the last instant is completed, if not, wait 10s and then throws an exception
       if (!StringUtils.isNullOrEmpty(latestInstant)) {
         doCheck();
         // last instant completed, set it empty
         latestInstant = "";
       }
-
+      boolean receivedDataInCurrentCP = checkReceivedData(checkpointId);
       // no data no new instant
       if (receivedDataInCurrentCP) {
         latestInstant = startNewInstant(checkpointId);
@@ -265,7 +264,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
       }
 
       if (tryTimes >= 5) {
-        LOG.warn("waiting generate file, checkpointId [{}]", checkpointId);
+        LOG.warn("waiting marker file, checkpointId [{}]", checkpointId);
         tryTimes = 0;
       }
       tryTimes++;

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -150,7 +150,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
     isMain = getRuntimeContext().getIndexOfThisSubtask() == 0;
     if (isMain) {
       // instantState
-      ListStateDescriptor<String> latestInstantStateDescriptor = new ListStateDescriptor<String>("latestInstant", String.class);
+      ListStateDescriptor<String> latestInstantStateDescriptor = new ListStateDescriptor<>("latestInstant", String.class);
       latestInstantState = context.getOperatorStateStore().getListState(latestInstantStateDescriptor);
 
       if (context.isRestored()) {
@@ -203,7 +203,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
       StringBuilder sb = new StringBuilder();
       if (rollbackPendingCommits.contains(latestInstant)) {
         rollbackPendingCommits.forEach(x -> sb.append(x).append(","));
-        LOG.warn("Latest transaction [{}] is not completed! unCompleted transaction:[{}],try times [{}]", latestInstant, sb.toString(), tryTimes);
+        LOG.warn("Latest transaction [{}] is not completed! unCompleted transaction:[{}],try times [{}]", latestInstant, sb, tryTimes);
         TimeUnit.SECONDS.sleep(retryInterval);
         rollbackPendingCommits = writeClient.getInflightsAndRequestedInstants(commitType);
       } else {


### PR DESCRIPTION
 InstantGenerateOperator support multiple parallelism.
When InstantGenerateOperator subtask size greater than 1 we can set subtask 0 as a main subtask, only main task create new instant.
The prerequisite of create new instant is exist subtask received data in current checkpoint. Every subtask will create a tmp file,
flie name is make up by checkpointid,subtask index and received records size. 
The main subtask will check every subtask file and parse file to make sure is shuold to create new instant. 