### PR TITLE
[HUDI-1538] Try to init class trying different signatures instead of checking its name.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -18,6 +18,15 @@
 
 package org.apache.hudi.common.fs;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFileFormat;
@@ -31,16 +40,6 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.InvalidHoodiePathException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathFilter;
-import org.apache.hadoop.fs.RemoteIterator;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -50,11 +49,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Set;
-
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Matcher;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -289,7 +289,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
         eof = true;
       }
       long pos = Bytes.indexOf(dataBuf, HoodieLogFormat.MAGIC);
-      if (pos > 0) {
+      if (pos >= 0) {
         return currentPos + pos;
       }
       if (eof) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -43,8 +43,6 @@ import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaProviderWithPostProcessor;
 import org.apache.hudi.utilities.schema.SparkAvroPostProcessor;
 import org.apache.hudi.utilities.schema.RowBasedSchemaProvider;
-import org.apache.hudi.utilities.sources.AvroKafkaSource;
-import org.apache.hudi.utilities.sources.JsonKafkaSource;
 import org.apache.hudi.utilities.sources.Source;
 import org.apache.hudi.utilities.transform.ChainedTransformer;
 import org.apache.hudi.utilities.transform.Transformer;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -96,19 +96,22 @@ public class UtilHelpers {
   private static final Logger LOG = LogManager.getLogger(UtilHelpers.class);
 
   public static Source createSource(String sourceClass, TypedProperties cfg, JavaSparkContext jssc,
-                                    SparkSession sparkSession, SchemaProvider schemaProvider, HoodieDeltaStreamerMetrics metrics) throws IOException {
-
+                                    SparkSession sparkSession, SchemaProvider schemaProvider,
+                                    HoodieDeltaStreamerMetrics metrics) throws IOException {
     try {
-      if (JsonKafkaSource.class.getName().equals(sourceClass)
-              || AvroKafkaSource.class.getName().equals(sourceClass)) {
+      try {
         return (Source) ReflectionUtils.loadClass(sourceClass,
-                new Class<?>[]{TypedProperties.class, JavaSparkContext.class, SparkSession.class, SchemaProvider.class, HoodieDeltaStreamerMetrics.class}, cfg,
-                jssc, sparkSession, schemaProvider, metrics);
+            new Class<?>[]{TypedProperties.class, JavaSparkContext.class,
+                SparkSession.class, SchemaProvider.class,
+                HoodieDeltaStreamerMetrics.class}, cfg,
+            jssc, sparkSession, schemaProvider, metrics);
+      } catch (HoodieException e) {
+        return (Source) ReflectionUtils.loadClass(sourceClass,
+            new Class<?>[]{TypedProperties.class, JavaSparkContext.class,
+                SparkSession.class, SchemaProvider.class,
+                HoodieDeltaStreamerMetrics.class}, cfg,
+            jssc, sparkSession, schemaProvider);
       }
-
-      return (Source) ReflectionUtils.loadClass(sourceClass,
-          new Class<?>[] {TypedProperties.class, JavaSparkContext.class, SparkSession.class, SchemaProvider.class}, cfg,
-          jssc, sparkSession, schemaProvider);
     } catch (Throwable e) {
       throw new IOException("Could not load source class " + sourceClass, e);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -106,8 +106,7 @@ public class UtilHelpers {
       } catch (HoodieException e) {
         return (Source) ReflectionUtils.loadClass(sourceClass,
             new Class<?>[]{TypedProperties.class, JavaSparkContext.class,
-                SparkSession.class, SchemaProvider.class,
-                HoodieDeltaStreamerMetrics.class}, cfg,
+                SparkSession.class, SchemaProvider.class}, cfg,
             jssc, sparkSession, schemaProvider);
       }
     } catch (Throwable e) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -101,13 +101,13 @@ public class UtilHelpers {
         return (Source) ReflectionUtils.loadClass(sourceClass,
             new Class<?>[]{TypedProperties.class, JavaSparkContext.class,
                 SparkSession.class, SchemaProvider.class,
-                HoodieDeltaStreamerMetrics.class}, cfg,
-            jssc, sparkSession, schemaProvider, metrics);
+                HoodieDeltaStreamerMetrics.class},
+            cfg, jssc, sparkSession, schemaProvider, metrics);
       } catch (HoodieException e) {
         return (Source) ReflectionUtils.loadClass(sourceClass,
             new Class<?>[]{TypedProperties.class, JavaSparkContext.class,
-                SparkSession.class, SchemaProvider.class}, cfg,
-            jssc, sparkSession, schemaProvider);
+                SparkSession.class, SchemaProvider.class},
+            cfg, jssc, sparkSession, schemaProvider);
       }
     } catch (Throwable e) {
       throw new IOException("Could not load source class " + sourceClass, e);


### PR DESCRIPTION
## What is the purpose of the pull request
UtilHelpers.createSource had a hardcoded way of checking which
constructor signature needs to be used to instantiate a class
which makes it impossible to override those hardcoded classes outside of Hudi
and use them instead as their signature remains the same.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
