### PR TITLE
[HUDI-1540] Fixing commons codec shading in spark bundle

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -160,6 +160,10 @@
                   <shadedPattern>org.apache.hudi.com.codahale.metrics.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.commons.codec.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.commons.codec.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.eclipse.jetty.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.jetty.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
## What is the purpose of the pull request

Fixing commons codec shading in spark bundle.
Redo of https://github.com/apache/hudi/pull/2316
Fixes #2239 NoClassDefFoundError: org/apache/hudi/org/apache/commons/codec/binary/Base64

## Brief change log

Fixing commons codec shading in spark bundle

## Verify this pull request

Going to ask customer to verify the fix. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.