### PR TITLE
[hotfix] Add back dependency org.apache.flink:flink-connector-kafka-b…

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -104,6 +104,7 @@
                   <include>io.prometheus:simpleclient_common</include>
                   <include>com.yammer.metrics:metrics-core</include>
                   <include>org.apache.flink:flink-connector-kafka_${scala.binary.version}</include>
+                  <include>org.apache.flink:flink-connector-kafka-base_${scala.binary.version}</include>
                   <include>org.apache.kafka:kafka_${scala.binary.version}</include>
                   <include>com.101tec:zkclient</include>
                   <include>org.apache.kafka:kafka-clients</include>
@@ -187,6 +188,12 @@
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-kafka_${scala.binary.version}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-connector-kafka-base_${scala.binary.version}</artifactId>
+      <version>${flink11.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <prometheus.version>0.8.0</prometheus.version>
     <http.version>4.4.1</http.version>
     <spark.version>${spark2.version}</spark.version>
+    <flink11.version>1.11.2</flink11.version>
     <flink.version>1.12.0</flink.version>
     <spark2.version>2.4.4</spark2.version>
     <spark3.version>3.0.0</spark3.version>


### PR DESCRIPTION
…ase_2.11

## What is the purpose of the pull request

Add back the dependency because the `HoodieFlinkStreamer` needs that.

## Brief change log

  - Modify pom in hudi and hudi-flink-bundle module

## Verify this pull request

Build locally.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.