### PR TITLE
[HUDI-1527] automatically infer the data directory, users only need to specify the table directory

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -84,6 +84,30 @@ public class DataSourceUtils {
     throw new TableNotFoundException("Unable to find a hudi table for the user provided paths.");
   }
 
+<<<<<<< HEAD
+=======
+  public static Option<String> getOnePartitionPath(FileSystem fs, Path tablePath) throws IOException {
+    // When the table is not partitioned
+    if (HoodiePartitionMetadata.hasPartitionMetadata(fs, tablePath)) {
+      return Option.of(tablePath.toString());
+    }
+    FileStatus[] statuses = fs.listStatus(tablePath);
+    for (FileStatus status : statuses) {
+      if (status.isDirectory()) {
+        if (HoodiePartitionMetadata.hasPartitionMetadata(fs, status.getPath())) {
+          return Option.of(status.getPath().toString());
+        } else {
+          Option<String> partitionPath = getOnePartitionPath(fs, status.getPath());
+          if (partitionPath.isPresent()) {
+            return partitionPath;
+          }
+        }
+      }
+    }
+    return Option.empty();
+  }
+
+>>>>>>> [HUDI-1527] automatically infer the data directory, users only need to specify the table directory [adapt no partition]
   public static String getDataPath(String tablePath, String partitionPath) {
     // When the table is not partitioned
     if (tablePath.equals(partitionPath)) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -84,30 +84,6 @@ public class DataSourceUtils {
     throw new TableNotFoundException("Unable to find a hudi table for the user provided paths.");
   }
 
-<<<<<<< HEAD
-=======
-  public static Option<String> getOnePartitionPath(FileSystem fs, Path tablePath) throws IOException {
-    // When the table is not partitioned
-    if (HoodiePartitionMetadata.hasPartitionMetadata(fs, tablePath)) {
-      return Option.of(tablePath.toString());
-    }
-    FileStatus[] statuses = fs.listStatus(tablePath);
-    for (FileStatus status : statuses) {
-      if (status.isDirectory()) {
-        if (HoodiePartitionMetadata.hasPartitionMetadata(fs, status.getPath())) {
-          return Option.of(status.getPath().toString());
-        } else {
-          Option<String> partitionPath = getOnePartitionPath(fs, status.getPath());
-          if (partitionPath.isPresent()) {
-            return partitionPath;
-          }
-        }
-      }
-    }
-    return Option.empty();
-  }
-
->>>>>>> [HUDI-1527] automatically infer the data directory, users only need to specify the table directory [adapt no partition]
   public static String getDataPath(String tablePath, String partitionPath) {
     // When the table is not partitioned
     if (tablePath.equals(partitionPath)) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -84,6 +84,19 @@ public class DataSourceUtils {
     throw new TableNotFoundException("Unable to find a hudi table for the user provided paths.");
   }
 
+  public static String getDataPath(String tablePath, String partitionPath) {
+    // When the table is not partitioned
+    if (tablePath.equals(partitionPath)) {
+      return tablePath + "/*";
+    }
+    assert partitionPath.length() > tablePath.length();
+    assert partitionPath.startsWith(tablePath);
+    int n = partitionPath.substring(tablePath.length()).split("/").length;
+    String dataPathSuffix = String.join("/*", Collections.nCopies(n + 1, ""));
+    return tablePath + dataPathSuffix;
+  }
+
+
   /**
    * Create a key generator class via reflection, passing in any configs needed.
    * <p>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -32,9 +32,11 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDat
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, concat, lit, udf}
 import org.apache.spark.sql.types._
+import org.junit.jupiter.api.Assertions.fail
+import org.apache.spark.sql.types.{DataTypes => _, DateType => _, IntegerType => _, StringType => _, TimestampType => _, _}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -587,17 +587,17 @@ class TestCOWDataSource extends HoodieClientTestBase {
   @Test def testAutoInferDataPath(): Unit = {
     val records1 = recordsToStrings(dataGen.generateInserts("000", 100)).toList
     val inputDF1 = spark.read.json(spark.sparkContext.parallelize(records1, 2))
-    // default partition
+    // Default partition
     inputDF1.write.format("org.apache.hudi")
       .options(commonOpts)
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
-    // no need to specify basePath/*/*
+    // No need to specify basePath/*/*
     spark.read.format("org.apache.hudi")
       .load(basePath).show()
 
-    // partition with org.apache.hudi.keygen.CustomKeyGenerator
+    // Partition with org.apache.hudi.keygen.CustomKeyGenerator
     inputDF1.write.format("org.apache.hudi")
       .options(commonOpts)
       .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY, "org.apache.hudi.keygen.CustomKeyGenerator")
@@ -605,11 +605,11 @@ class TestCOWDataSource extends HoodieClientTestBase {
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
-    // no need to specify basePath/*/*/*/*
+    // No need to specify basePath/*/*/*/*
     spark.read.format("org.apache.hudi")
       .load(basePath).show()
 
-    // no partition
+    // No partition
     inputDF1.write.format("org.apache.hudi")
       .options(commonOpts)
       .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY, "org.apache.hudi.keygen.NonpartitionedKeyGenerator")
@@ -617,7 +617,7 @@ class TestCOWDataSource extends HoodieClientTestBase {
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
-    // no need to specify basePath/*
+    // No need to specify basePath/*
     spark.read.format("org.apache.hudi")
       .load(basePath).show()
 
@@ -630,7 +630,7 @@ class TestCOWDataSource extends HoodieClientTestBase {
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
-    // specify basePath/yyyyMMdd/*
+    // Specify basePath/yyyyMMdd/*
     val date = new DateTime().toString(DateTimeFormat.forPattern("yyyyMMdd"))
     spark.read.format("org.apache.hudi")
       .load(basePath + s"/$date/*").show()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -626,7 +626,7 @@ class TestCOWDataSource extends HoodieClientTestBase {
     inputDF1.write.format("org.apache.hudi")
       .options(commonOpts)
       .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY, "org.apache.hudi.keygen.CustomKeyGenerator")
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY, "current_ts:SIMPLE")
+      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY, "current_ts:TIMESTAMP")
       .option(Config.TIMESTAMP_TYPE_FIELD_PROP, "EPOCHMILLISECONDS")
       .option(Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, "yyyyMMdd")
       .mode(SaveMode.Overwrite)


### PR DESCRIPTION

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

To read the hudi table, you need to specify the path, but the path is not only the tablePath corresponding to the table, but needs to be determined by the partition directory structure. Different keyGenerators correspond to different partition directory structures. The first-level partition directory uses path=```.../table/*/*```, the secondary partition directory path=```.../table/*/*/*```，so it is troublesome to let the user specify the data path, the user only needs to specify the tablePath:  ```.../table```

At the same time, after reading the hudi table by configuring path=```.../table```, it is more convenient to use sparksql to query the hudi table. You only need to add tabproperties to the hive table metadata: ```spark.sql.sources.provider= hudi```, you can automatically convert the hive table to the hudi table.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.