### PR TITLE
[MINOR] Use skipTests flag for skip.hudi-spark2.unit.tests property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
     <skipUTs>${skipTests}</skipUTs>
     <skipFTs>${skipTests}</skipFTs>
     <skipITs>${skipTests}</skipITs>
+    <skip.hudi-spark2.unit.tests>${skipTests}</skip.hudi-spark2.unit.tests>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.basedir>${project.basedir}</main.basedir>
     <spark.bundle.hive.scope>provided</spark.bundle.hive.scope>
@@ -141,7 +142,6 @@
     <presto.bundle.bootstrap.scope>compile</presto.bundle.bootstrap.scope>
     <presto.bundle.bootstrap.shade.prefix>org.apache.hudi.</presto.bundle.bootstrap.shade.prefix>
     <shadeSources>true</shadeSources>
-    <skip.hudi-spark2.unit.tests>false</skip.hudi-spark2.unit.tests>
   </properties>
 
   <scm>


### PR DESCRIPTION
To control the property with master flag `skipTests`, which was used in `scripts/run_travis_tests.sh:25`.

Controlling this so that during mvn install before UT, tests under hudi-spark2 won't run.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.