### PR TITLE
Filtering abnormal data which the recordKeyField or precombineField is null in avro format

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.DataSourceUtils;
+import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.client.SparkRDDWriteClient;
@@ -365,7 +366,8 @@ public class DeltaSync implements Serializable {
     } else {
       // Pull the data from the source & prepare the write
       InputBatch<JavaRDD<GenericRecord>> dataAndCheckpoint =
-          formatAdapter.fetchNewDataInAvroFormat(resumeCheckpointStr, cfg.sourceLimit);
+          formatAdapter.fetchNewDataInAvroFormat(resumeCheckpointStr, cfg.sourceLimit,
+                  props.getString(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY()), cfg.sourceOrderingField);
       avroRDDOptional = dataAndCheckpoint.getBatch();
       checkpointStr = dataAndCheckpoint.getCheckpointForNextBatch();
       schemaProvider = dataAndCheckpoint.getSchemaProvider();


### PR DESCRIPTION
Filtering abnormal data which the recordKeyField or precombineField is null in avro format


## What is the purpose of the pull request

If the recordKey field or precombined field of the incoming data is null, the DeltaStreamer program will execute an error