### PR TITLE
[WIP HUDI-53] Adding Record Level Index based on hoodie backed table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
@@ -133,10 +133,10 @@ public abstract class AbstractHoodieWriteClient<T extends HoodieRecordPayload, I
     super(context, writeConfig, timelineService);
     this.metrics = new HoodieMetrics(config, config.getTableName());
     this.rollbackPending = rollbackPending;
-    this.index = createIndex(writeConfig);
+    this.index = createIndex(writeConfig, context);
   }
 
-  protected abstract HoodieIndex<T, I, K, O> createIndex(HoodieWriteConfig writeConfig);
+  protected abstract HoodieIndex<T, I, K, O> createIndex(HoodieWriteConfig writeConfig, HoodieEngineContext context);
 
   public void setOperationType(WriteOperationType operationType) {
     this.operationType = operationType;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -90,6 +90,13 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
   public static final String SIMPLE_INDEX_INPUT_STORAGE_LEVEL = "hoodie.simple.index.input.storage.level";
   public static final String DEFAULT_SIMPLE_INDEX_INPUT_STORAGE_LEVEL = "MEMORY_AND_DISK_SER";
 
+  // Record level index configs
+  public static final String RECORD_LEVEL_INDEX_NUM_PARTITIONS = "hoodie.record.level.index.num.partitions";
+  public static final String DEFAULT_RECORD_LEVEL_INDEX_NUM_PARTITIONS = "1";
+
+  public static final String RECORD_LEVEL_INDEX_ENABLE_SEEK_PROP = "hoodie.record.level.index.enable.seek";
+  public static final String DEFAULT_RECORD_LEVEL_INDEX_ENABLE_SEEK = "false";
+
   /**
    * Only applies if index type is GLOBAL_BLOOM.
    * <p>
@@ -291,6 +298,10 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
           DEFAULT_GLOBAL_SIMPLE_INDEX_PARALLELISM);
       setDefaultOnCondition(props, !props.containsKey(SIMPLE_INDEX_UPDATE_PARTITION_PATH),
           SIMPLE_INDEX_UPDATE_PARTITION_PATH, DEFAULT_SIMPLE_INDEX_UPDATE_PARTITION_PATH);
+      setDefaultOnCondition(props, !props.containsKey(RECORD_LEVEL_INDEX_NUM_PARTITIONS), RECORD_LEVEL_INDEX_NUM_PARTITIONS,
+          DEFAULT_RECORD_LEVEL_INDEX_NUM_PARTITIONS);
+      setDefaultOnCondition(props, !props.containsKey(RECORD_LEVEL_INDEX_ENABLE_SEEK_PROP), RECORD_LEVEL_INDEX_ENABLE_SEEK_PROP,
+          DEFAULT_RECORD_LEVEL_INDEX_ENABLE_SEEK);
       // Throws IllegalArgumentException if the value set is not a known Hoodie Index Type
       HoodieIndex.IndexType.valueOf(props.getProperty(INDEX_TYPE_PROP));
       return config;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -923,6 +923,14 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
     return Integer.parseInt(props.getProperty(HoodieMetadataConfig.CLEANER_COMMITS_RETAINED_PROP));
   }
 
+  public int getNumPartitionsForRecordLevelIndex() {
+    return Integer.parseInt(props.getProperty(HoodieIndexConfig.RECORD_LEVEL_INDEX_NUM_PARTITIONS));
+  }
+
+  public boolean enableSeekForRecordLevelIndex() {
+    return Boolean.parseBoolean(props.getProperty(HoodieIndexConfig.RECORD_LEVEL_INDEX_ENABLE_SEEK_PROP));
+  }
+
   public static class Builder {
 
     protected final Properties props = new Properties();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java
@@ -61,9 +61,20 @@ public abstract class HoodieIndex<T extends HoodieRecordPayload, I, K, O> implem
    * <p>
    * TODO(vc): We may need to propagate the record as well in a WriteStatus class
    */
-  @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
+  @PublicAPIMethod(maturity = ApiMaturityLevel.DEPRECATED)
   public abstract O updateLocation(O writeStatuses, HoodieEngineContext context,
-                                   HoodieTable<T, I, K, O> hoodieTable) throws HoodieIndexException;
+      HoodieTable<T, I, K, O> hoodieTable) throws HoodieIndexException;
+
+  /**
+   * Extracts the location of written records, and updates the index.
+   * <p>
+   * TODO(vc): We may need to propagate the record as well in a WriteStatus class
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public O updateLocation(O writeStatuses, HoodieEngineContext context,
+      HoodieTable<T, I, K, O> hoodieTable, String instantTime) throws HoodieIndexException {
+    return updateLocation(writeStatuses, context, hoodieTable);
+  }
 
   /**
    * Rollback the effects of the commit made at instantTime.
@@ -104,6 +115,6 @@ public abstract class HoodieIndex<T extends HoodieRecordPayload, I, K, O> implem
   }
 
   public enum IndexType {
-    HBASE, INMEMORY, BLOOM, GLOBAL_BLOOM, SIMPLE, GLOBAL_SIMPLE
+    HBASE, INMEMORY, BLOOM, GLOBAL_BLOOM, SIMPLE, GLOBAL_SIMPLE, RECORD_LEVEL_INDEX
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -71,8 +71,8 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
    * Complete changes performed at the given instantTime marker with specified action.
    */
   @Override
-  protected HoodieIndex<T, List<HoodieRecord<T>>, List<HoodieKey>, List<WriteStatus>> createIndex(HoodieWriteConfig writeConfig) {
-    return FlinkHoodieIndex.createIndex((HoodieFlinkEngineContext) context, config);
+  protected HoodieIndex<T, List<HoodieRecord<T>>, List<HoodieKey>, List<WriteStatus>> createIndex(HoodieWriteConfig writeConfig, HoodieEngineContext context) {
+    return FlinkHoodieIndex.createIndex((HoodieFlinkEngineContext) this.context, config);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
@@ -71,7 +71,7 @@ public class HoodieJavaWriteClient<T extends HoodieRecordPayload> extends
   }
 
   @Override
-  protected HoodieIndex<T, List<HoodieRecord<T>>, List<HoodieKey>, List<WriteStatus>> createIndex(HoodieWriteConfig writeConfig) {
+  protected HoodieIndex<T, List<HoodieRecord<T>>, List<HoodieKey>, List<WriteStatus>> createIndex(HoodieWriteConfig writeConfig, HoodieEngineContext context) {
     return JavaHoodieIndex.createIndex(config);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
@@ -99,7 +99,7 @@ public class HoodieReadClient<T extends HoodieRecordPayload> implements Serializ
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(hadoopConf, basePath, true);
     this.hoodieTable = HoodieSparkTable.create(clientConfig, context, metaClient);
-    this.index = SparkHoodieIndex.createIndex(clientConfig);
+    this.index = SparkHoodieIndex.createIndex(clientConfig, context);
     this.sqlContextOpt = Option.empty();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -96,8 +96,8 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
   }
 
   @Override
-  protected HoodieIndex<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> createIndex(HoodieWriteConfig writeConfig) {
-    return SparkHoodieIndex.createIndex(config);
+  protected HoodieIndex<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> createIndex(HoodieWriteConfig writeConfig, HoodieEngineContext context) {
+    return SparkHoodieIndex.createIndex(config, context);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/SparkHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/SparkHoodieIndex.java
@@ -32,6 +32,7 @@ import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.index.bloom.SparkHoodieBloomIndex;
 import org.apache.hudi.index.bloom.SparkHoodieGlobalBloomIndex;
 import org.apache.hudi.index.hbase.SparkHoodieHBaseIndex;
+import org.apache.hudi.index.record.level.RecordLevelIndex;
 import org.apache.hudi.index.simple.SparkHoodieGlobalSimpleIndex;
 import org.apache.hudi.index.simple.SparkHoodieSimpleIndex;
 import org.apache.hudi.table.HoodieTable;
@@ -44,7 +45,7 @@ public abstract class SparkHoodieIndex<T extends HoodieRecordPayload> extends Ho
     super(config);
   }
 
-  public static SparkHoodieIndex createIndex(HoodieWriteConfig config) {
+  public static SparkHoodieIndex createIndex(HoodieWriteConfig config, HoodieEngineContext context) {
     // first use index class config to create index.
     if (!StringUtils.isNullOrEmpty(config.getIndexClass())) {
       Object instance = ReflectionUtils.loadClass(config.getIndexClass(), config);
@@ -66,6 +67,8 @@ public abstract class SparkHoodieIndex<T extends HoodieRecordPayload> extends Ho
         return new SparkHoodieSimpleIndex(config);
       case GLOBAL_SIMPLE:
         return new SparkHoodieGlobalSimpleIndex(config);
+      case RECORD_LEVEL_INDEX:
+        return new RecordLevelIndex(context.getHadoopConf(), config, context);
       default:
         throw new HoodieIndexException("Index type unspecified, set " + config.getIndexType());
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieKeyComparator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieKeyComparator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.record.level;
+
+import org.apache.hudi.common.model.HoodieKey;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * Record key comparator for HoodieKeys.
+ */
+public class HoodieKeyComparator implements Comparator<HoodieKey>, Serializable {
+
+  @Override
+  public int compare(HoodieKey o1, HoodieKey o2) {
+    return o1.toString().compareTo(o2.toString());
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieRecordLevelIndexLookupFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieRecordLevelIndexLookupFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.record.level;
+
+import org.apache.hudi.avro.model.HoodieRecordLevelIndexRecord;
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import org.apache.spark.api.java.function.Function2;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import scala.Tuple2;
+
+public class HoodieRecordLevelIndexLookupFunction<T extends HoodieRecordPayload> implements
+    Function2<Integer, Iterator<Tuple2<HoodieKey, HoodieRecord<T>>>, Iterator<Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>>> {
+
+  private final HoodieWriteConfig recordLevelIndexWriteConfig;
+  private final HoodieWriteConfig datasetWriteConfig;
+  private final HoodieTableMetaClient datasetMetaClient;
+  private final HoodieTableMetaClient indexMetaClient;
+  private final SerializableConfiguration serializableConfiguration;
+
+  public HoodieRecordLevelIndexLookupFunction(HoodieWriteConfig writeConfig, HoodieWriteConfig recordLevelIndexWriteConfig,
+      HoodieTableMetaClient datasetMetaClient, SerializableConfiguration serializableConfiguration) throws IOException {
+    this.datasetWriteConfig = writeConfig;
+    this.recordLevelIndexWriteConfig = recordLevelIndexWriteConfig;
+    this.datasetMetaClient = datasetMetaClient;
+    this.indexMetaClient = HoodieTableMetaClient.initTableType(serializableConfiguration.get(), recordLevelIndexWriteConfig.getBasePath(),
+        HoodieTableType.MERGE_ON_READ, recordLevelIndexWriteConfig.getTableName(), "archived", HoodieRecordLevelIndexRecord.class.getName(),
+        HoodieFileFormat.HFILE.toString());
+    this.serializableConfiguration = serializableConfiguration;
+  }
+
+  @Override
+  public Iterator<Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>> call(Integer partitionIndex, Iterator<Tuple2<HoodieKey, HoodieRecord<T>>> recordsToLookup) throws Exception {
+    return new RecordLevelIndexLazyLookupIterator(recordsToLookup, datasetWriteConfig, recordLevelIndexWriteConfig, datasetMetaClient, indexMetaClient, serializableConfiguration, partitionIndex);
+  }
+}
+
+

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieRecordLevelIndexScanner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieRecordLevelIndexScanner.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.record.level;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.avro.model.HoodieRecordLevelIndexRecord;
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.SpillableMapUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.index.HoodieRecordLevelIndexMergedLogRecordScanner;
+import org.apache.hudi.index.HoodieRecordLevelIndexPayload;
+import org.apache.hudi.io.storage.HoodieFileReader;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import scala.Tuple2;
+
+public class HoodieRecordLevelIndexScanner implements Serializable {
+
+  // Table name suffix
+  private static final String RECORD_LEVEL_INDEX_TABLE_NAME_SUFFIX = "index";
+
+  // Base path of the RecordLevelIndex Table relative to the dataset (.hoodie/index)
+  private static final String RECORD_LEVEL_INDEX_TABLE_REL_PATH = HoodieTableMetaClient.METAFOLDER_NAME + Path.SEPARATOR + RECORD_LEVEL_INDEX_TABLE_NAME_SUFFIX;
+
+  private static final Logger LOG = LogManager.getLogger(HoodieRecordLevelIndexScanner.class);
+
+  private HoodieWriteConfig datasetWriteConfig;
+  private HoodieTableMetaClient datasetMetaClient;
+  private HoodieTableMetaClient indexMetaClient;
+  private SerializableConfiguration serializableConfiguration;
+
+  private String indexBasePath;
+
+  // Readers for the base and log file which store the metadata
+  private HoodieFileReader<GenericRecord> baseFileReader;
+  private HoodieRecordLevelIndexMergedLogRecordScanner logRecordScanner;
+
+  private List<HoodieKey> recordKeys;
+  private int partitionIndex;
+
+  public HoodieRecordLevelIndexScanner(HoodieWriteConfig writeConfig, HoodieWriteConfig recordLevelIndexWriteConfig,
+      HoodieTableMetaClient datasetMetaClient, String indexTableName, SerializableConfiguration serializableConfiguration,
+      List<HoodieKey> recordKeys, int partitionIndex) throws IOException {
+    this.datasetWriteConfig = writeConfig;
+    this.datasetMetaClient = datasetMetaClient;
+    this.indexMetaClient = HoodieTableMetaClient.initTableType(serializableConfiguration.get(), recordLevelIndexWriteConfig.getBasePath(),
+        HoodieTableType.MERGE_ON_READ, indexTableName, "archived", HoodieRecordLevelIndexRecord.class.getName(),
+        HoodieFileFormat.HFILE.toString());
+    this.serializableConfiguration = serializableConfiguration;
+    this.indexBasePath = recordLevelIndexWriteConfig.getBasePath();
+    this.recordKeys = recordKeys;
+    this.partitionIndex = partitionIndex;
+  }
+
+  public List<Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>> getRecordLocations() {
+
+    Schema schema = HoodieAvroUtils.addMetadataFields(HoodieRecordLevelIndexRecord.getClassSchema());
+
+    try {
+      List<Long> timings = new ArrayList<>();
+      HoodieTimer timer = new HoodieTimer().startTimer();
+      Tuple2<HoodieFileReader<GenericRecord>, HoodieRecordLevelIndexMergedLogRecordScanner> baseLogFileReaders =
+          RecordLevelIndexUtils.openFileSlice(datasetMetaClient, indexMetaClient, serializableConfiguration, datasetWriteConfig.getSpillableMapBasePath(), indexBasePath, partitionIndex);
+      baseFileReader = baseLogFileReaders._1;
+      logRecordScanner = baseLogFileReaders._2;
+
+      timings.add(timer.endTimer());
+
+      timer.startTimer();
+
+      List<Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>> toReturn = new ArrayList<>();
+      List<String> keysToLookup = new ArrayList<>();
+      Map<String, HoodieKey> keyStringToHoodieKeyMap = new HashMap<>();
+      Set<String> matchedKeys = new HashSet<>();
+      // store map from key string to HoodieKey
+      recordKeys.forEach(entry -> {
+        keysToLookup.add(entry.getRecordKey() + "_" + entry.getPartitionPath());
+        keyStringToHoodieKeyMap.put(entry.getRecordKey() + "_" + entry.getPartitionPath(), entry);
+      });
+      // sort input keys since we are planning to scan base file and lookup as we go.
+      // we could avoid sort here since we do repartition and sort within partitions in the driver before calling into this.
+      Collections.sort(keysToLookup);
+
+      int curIndex = 0;
+      int totalSize = keysToLookup.size();
+
+      // Retrieve records from base file
+      Map<String, HoodieRecord<HoodieRecordLevelIndexPayload>> hoodieRecords = new HashMap<>();
+      if (baseFileReader != null) {
+        Iterator<GenericRecord> genericRecordIterator = baseFileReader.getRecordIterator();
+        // iterate all records from index base file and find matching records
+        while (genericRecordIterator.hasNext()) {
+          GenericRecord genericRecord = genericRecordIterator.next();
+          if (keysToLookup.get(curIndex).equals(genericRecord.get("key"))) {
+            hoodieRecords.put(keysToLookup.get(curIndex), SpillableMapUtils.convertToHoodieRecordPayload(genericRecord,
+                HoodieRecordLevelIndexPayload.class.getName()));
+            matchedKeys.add(keysToLookup.get(curIndex));
+            curIndex++;
+            if (curIndex >= totalSize) {
+              break;
+            }
+          }
+        }
+      }
+      timings.add(timer.endTimer());
+
+      // Retrieve record from log file
+      timer.startTimer();
+      if (logRecordScanner != null) {
+        Map<String, Option<HoodieRecord<HoodieRecordLevelIndexPayload>>> logHoodieRecords = logRecordScanner.getRecordsByKey(keysToLookup);
+        for (Map.Entry<String, Option<HoodieRecord<HoodieRecordLevelIndexPayload>>> entry : logHoodieRecords.entrySet()) {
+          String hoodieKeyStr = entry.getKey();
+          if (hoodieRecords.containsKey(hoodieKeyStr)) {
+            if (entry.getValue().isPresent()) { // record present in both base file and log file
+              HoodieRecordPayload mergedPayload = entry.getValue().get().getData().preCombine(hoodieRecords.get(hoodieKeyStr).getData());
+              Option<HoodieRecordLevelIndexRecord> mergedRecord = mergedPayload.getInsertValue(schema);
+              if (mergedRecord.isPresent()) {
+                toReturn.add(new Tuple2<>(keyStringToHoodieKeyMap.get(hoodieKeyStr), Option.of(new Tuple2<>(mergedRecord.get().getPartitionPath(),
+                    new HoodieRecordLocation(mergedRecord.get().getInstantTime(), mergedRecord.get().getFileId())))));
+              } else {
+                // do we need to do anything here? is this reachable?
+              }
+            } else { // record present only in base file
+              HoodieRecord<HoodieRecordLevelIndexPayload> baseRecord = hoodieRecords.get(hoodieKeyStr);
+              HoodieRecordLevelIndexPayload hoodieRecordLevelIndexPayload = baseRecord.getData();
+              toReturn.add(new Tuple2<>(keyStringToHoodieKeyMap.get(hoodieKeyStr), Option.of(new Tuple2<>(hoodieRecordLevelIndexPayload.getPartitionPath(),
+                  new HoodieRecordLocation(hoodieRecordLevelIndexPayload.getInstantTime(), hoodieRecordLevelIndexPayload.getFileId())))));
+            }
+          } else if (entry.getValue().isPresent()) { // record present only in log file
+            matchedKeys.add(hoodieKeyStr);
+            Option<HoodieRecord<HoodieRecordLevelIndexPayload>> logRecordOpt = entry.getValue();
+            if (logRecordOpt.isPresent()) {
+              HoodieRecordLevelIndexPayload logRecordPayload = logRecordOpt.get().getData();
+              toReturn.add(new Tuple2<>(keyStringToHoodieKeyMap.get(hoodieKeyStr), Option.of(new Tuple2<>(logRecordPayload.getPartitionPath(),
+                  new HoodieRecordLocation(logRecordPayload.getInstantTime(), logRecordPayload.getFileId())))));
+            }
+          }
+        }
+      } else {
+        for (Entry<String, HoodieRecord<HoodieRecordLevelIndexPayload>> record : hoodieRecords.entrySet()) {
+          HoodieRecordLevelIndexPayload hoodieRecordLevelIndexPayload = record.getValue().getData();
+          toReturn.add(new Tuple2<>(keyStringToHoodieKeyMap.get(record.getKey()), Option.of(new Tuple2<>(hoodieRecordLevelIndexPayload.getPartitionPath(),
+              new HoodieRecordLocation(hoodieRecordLevelIndexPayload.getInstantTime(), hoodieRecordLevelIndexPayload.getFileId())))));
+        }
+      }
+
+      // unmatched keys
+      for (String key : keysToLookup) {
+        if (!matchedKeys.contains(key)) {
+          toReturn.add(new Tuple2<>(keyStringToHoodieKeyMap.get(key), Option.empty()));
+        }
+      }
+
+      timings.add(timer.endTimer());
+      // LOG.info(String.format("Metadata read for key %s took [open, baseFileRead, logMerge] %s ms", key, timings));
+      return toReturn;
+    } catch (IOException ioe) {
+      throw new HoodieIOException("Error merging records from index table for key :" + Arrays.toString(recordKeys.toArray()), ioe);
+    } finally {
+      RecordLevelIndexUtils.close(baseFileReader, logRecordScanner);
+    }
+  }
+
+  /**
+   * Open readers to the base and log files.
+   */
+  /*private void openFileSlice(int partitionIndex) throws IOException {
+
+    // String partitionBasePath = indexBasePath + Path.SEPARATOR + Integer.toString(partitionIndex);
+
+    // HoodieTimer timer = new HoodieTimer().startTimer();
+    String latestInstantTime = getLatestDatasetInstantTime();
+
+    if (latestInstantTime != null) {
+      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(indexMetaClient, indexMetaClient.getActiveTimeline().filterCompletedInstants());
+      List<FileSlice> latestFileSystemMetadataSlices = fsView.getLatestFileSlices(Integer.toString(partitionIndex)).collect(Collectors.toList());
+
+      // If the base file is present then create a reader
+      Option<HoodieBaseFile> basefile = !latestFileSystemMetadataSlices.isEmpty() ? latestFileSystemMetadataSlices.get(0).getBaseFile() : Option.empty();
+      if (basefile.isPresent()) {
+        String basefilePath = basefile.get().getPath();
+        baseFileReader = HoodieFileReaderFactory.getFileReader(serializableConfiguration.get(), new Path(basefilePath));
+        LOG.info("Opened index base file from " + basefilePath + " at instant " + basefile.get().getCommitTime());
+      }
+
+      // Open the log record scanner using the log files from the latest file slice
+      List<String> logFilePaths = !latestFileSystemMetadataSlices.isEmpty() ? latestFileSystemMetadataSlices.get(0).getLogFiles()
+          .sorted(HoodieLogFile.getLogFileComparator())
+          .map(o -> o.getPath().toString())
+          .collect(Collectors.toList()) : Collections.emptyList();
+      Option<HoodieInstant> lastInstant = indexMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
+      String latestMetaInstantTimestamp = lastInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
+
+      // Load the schema
+      Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+      if (!logFilePaths.isEmpty()) {
+        logRecordScanner = new HoodieRecordLevelIndexMergedLogRecordScanner(indexMetaClient.getFs(), indexBasePath,
+            logFilePaths, schema, latestMetaInstantTimestamp, MAX_MEMORY_SIZE_IN_BYTES, BUFFER_SIZE,
+            datasetWriteConfig.getSpillableMapBasePath(), null);
+
+        LOG.info("Opened index log files from " + logFilePaths + " at instant " + latestInstantTime
+            + "(dataset instant=" + latestInstantTime + ", index instant=" + latestMetaInstantTimestamp + ")");
+      }
+    }
+  }
+
+  protected String getLatestDatasetInstantTime() {
+    if (datasetMetaClient.getActiveTimeline().filterCompletedInstants().empty()) {
+      return null;
+    } else {
+      return datasetMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant()
+          .map(HoodieInstant::getTimestamp).get();
+    }
+  } */
+
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndex.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.record.level;
+
+import org.apache.hudi.avro.model.HoodieRecordLevelIndexRecord;
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.fs.ConsistencyGuardConfig;
+import org.apache.hudi.common.model.HoodieCleaningPolicy;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieMetricsConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.index.HoodieIndexUtils;
+import org.apache.hudi.index.HoodieRecordLevelIndexPayload;
+import org.apache.hudi.index.SparkHoodieIndex;
+import org.apache.hudi.table.HoodieTable;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.HashPartitioner;
+import org.apache.spark.Partitioner;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.util.Utils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import scala.Tuple2;
+
+/**
+ * Record level index for Hoodie dataset. This index is backed by hoodie's MOR table.
+ * Base path of the RecordLevelIndex Table relative to the dataset is ".hoodie/index"
+ * Index information is stored in a hoodie table(index table) with statically allocated partitions.
+ * Tagging will look up the table and return the values
+ * UpdateLocation will ingest indexing information for records into index table.
+ *
+ * Record Key: {<data_record_key>_<data_partition_path>}
+ * Partition Path: index partition found by hash partitioning
+ * Data contains: key, partition_path, instantTime and fileId. Check {@link HoodieRecordLevelIndexRecord} for more info.
+ * Hashing is based on original HoodieKey.toString(). This hashing will assist in determining the partition in index table.
+ * @param <T>
+ */
+public class RecordLevelIndex<T extends HoodieRecordPayload> extends SparkHoodieIndex<T> {
+
+  // Table name suffix
+  private static final String RECORD_LEVEL_INDEX_TABLE_NAME_SUFFIX = "index";
+
+  // Base path of the RecordLevelIndex Table relative to the dataset (.hoodie/index)
+  private static final String RECORD_LEVEL_INDEX_TABLE_REL_PATH = HoodieTableMetaClient.METAFOLDER_NAME + Path.SEPARATOR + RECORD_LEVEL_INDEX_TABLE_NAME_SUFFIX;
+
+  private static final Logger LOG = LogManager.getLogger(RecordLevelIndex.class);
+
+  private final HoodieWriteConfig datasetWriteConfig;
+  private final HoodieWriteConfig recordLevelIndexWriteConfig;
+  private final SerializableConfiguration hadoopConf;
+  protected final transient HoodieEngineContext engineContext;
+  private HoodieTableMetaClient datasetMetaClient;
+
+  private String indexTableName;
+  private int numIndexPartitions = 1;
+
+  public RecordLevelIndex(SerializableConfiguration hadoopConf, HoodieWriteConfig writeConfig, HoodieEngineContext engineContext) {
+    super(writeConfig);
+    this.datasetWriteConfig = writeConfig;
+    this.engineContext = engineContext;
+    this.hadoopConf = hadoopConf;
+    this.indexTableName = writeConfig.getTableName() + RECORD_LEVEL_INDEX_TABLE_NAME_SUFFIX;
+    this.recordLevelIndexWriteConfig = createRecordLevelIndexWriteConfig(writeConfig);
+    this.numIndexPartitions = writeConfig.getNumPartitionsForRecordLevelIndex();
+    this.datasetMetaClient = new HoodieTableMetaClient(hadoopConf.get(), writeConfig.getBasePath());
+  }
+
+  @Override
+  public boolean rollbackCommit(String instantTime) {
+    try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, recordLevelIndexWriteConfig, true)) {
+      return writeClient.rollback(instantTime);
+    }
+  }
+
+  @Override
+  public boolean isGlobal() {
+    return false;
+  }
+
+  @Override
+  public boolean canIndexLogFiles() {
+    return false;
+  }
+
+  @Override
+  public boolean isImplicitWithStorage() {
+    return false;
+  }
+
+  @Override
+  public JavaRDD<WriteStatus> updateLocation(JavaRDD<WriteStatus> writeStatusRDD, HoodieEngineContext context,
+      HoodieTable<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> hoodieTable, String instantTime) throws HoodieIndexException {
+
+    // prepare records to be updated to index table
+
+    // fetch records from written records in write status.
+    // We need a pair of HoodieKey.toString() to IndexRecord. HoodieKey.toString to do hash partitioning
+    JavaPairRDD<String, HoodieRecord> recordsToBeUpdated =
+        writeStatusRDD.flatMapToPair((PairFlatMapFunction<WriteStatus, String, HoodieRecord>) writeStatus -> {
+          List<Tuple2<String, HoodieRecord>> toReturn = new ArrayList<>();
+          for (HoodieRecord record : writeStatus.getWrittenRecords()) {
+            // we need to update only written records from WriteStatus
+            if (!writeStatus.isErrored(record.getKey()) && record.getNewLocation().isPresent() && record.getCurrentLocation() == null) {
+              HoodieRecordLocation recordLocation = (HoodieRecordLocation) record.getNewLocation().get();
+              HoodieRecordLevelIndexRecord recordLevelIndexRecord =
+                  new HoodieRecordLevelIndexRecord((record.getRecordKey() + "_" + record.getPartitionPath()), record.getPartitionPath(), recordLocation.getInstantTime(), recordLocation.getFileId());
+              toReturn.add(new Tuple2(record.getKey().toString(), new HoodieRecord<>(record.getKey(), new HoodieRecordLevelIndexPayload(Option.of(recordLevelIndexRecord)))));
+            }
+          }
+          return toReturn.iterator();
+        });
+
+    // repartition with numBuckets and sort within partitions
+    JavaPairRDD<String, HoodieRecord> sortedRecordsRdd
+        = recordsToBeUpdated.repartitionAndSortWithinPartitions(new HashPartitioner(numIndexPartitions));
+
+    // Format of HoodieKey in index table ("<data_record_key>_<data_partition_path>", "<partitionPath in index table>"). so we fix hoodie key to have the right values.
+    // we can't avoid this mapPartitionsWithIndex call, since we need the partition index in index table to be injected into HoodieKey for every record.
+    JavaRDD<HoodieRecord> indexRecords =
+        sortedRecordsRdd.values().mapPartitionsWithIndex(new Function2<Integer, Iterator<HoodieRecord>, Iterator<HoodieRecord>>() {
+          @Override
+          public Iterator<HoodieRecord> call(Integer partitionIndex, Iterator<HoodieRecord> hoodieRecordIterator) throws Exception {
+            String partitionPath = Integer.toString(partitionIndex);
+            List<HoodieRecord> toReturn = new ArrayList<>();
+            while (hoodieRecordIterator.hasNext()) {
+              HoodieRecord incomingRecord = hoodieRecordIterator.next();
+              toReturn.add(new HoodieRecord(new HoodieKey((incomingRecord.getRecordKey() + "_" + incomingRecord.getPartitionPath()), partitionPath),
+                  incomingRecord.getData()));
+            }
+            return toReturn.iterator();
+          }
+        }, true);
+
+    // write to index table
+    try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, recordLevelIndexWriteConfig, true)) {
+      // start commit with same instant as data table
+      writeClient.startCommitWithTime(instantTime);
+      JavaRDD<WriteStatus> indexUpdateWriteStatuses = writeClient.upsert(indexRecords, instantTime);
+      List<WriteStatus> result = indexUpdateWriteStatuses.collect();
+      // TODO: what do we need to do w/ the result? parse and throw error if failed
+      // return original WriteStatus from data table)
+      return writeStatusRDD;
+    }
+  }
+
+  @Override
+  public JavaRDD<WriteStatus> updateLocation(JavaRDD<WriteStatus> writeStatusRDD, HoodieEngineContext context,
+      HoodieTable<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> hoodieTable) throws HoodieIndexException {
+    return updateLocation(writeStatusRDD, context, hoodieTable, null);
+  }
+
+  @Override
+  public JavaRDD<HoodieRecord<T>> tagLocation(JavaRDD<HoodieRecord<T>> records, HoodieEngineContext context,
+      HoodieTable<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> hoodieTable) throws HoodieIndexException {
+    datasetMetaClient = HoodieTableMetaClient.reload(datasetMetaClient);
+    // in the end, we need to join w/ incoming record to tag them, hence creating a map here.
+    JavaPairRDD<HoodieKey, HoodieRecord<T>> incomingRecords = records.mapToPair(entry -> new Tuple2<>(entry.getKey(), entry));
+    try {
+      // repartition with HoodieKey based partitioning and sort within each partition.
+      JavaPairRDD<HoodieKey, HoodieRecord<T>> partitionedSortedRDD = incomingRecords.repartitionAndSortWithinPartitions(new HoodieKeyHashPartitioner(numIndexPartitions), new HoodieKeyComparator());
+
+      JavaRDD<Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>> keyToLocationRdd = !datasetWriteConfig.enableSeekForRecordLevelIndex()
+          ? // if seek is not enabled, use HoodieRecordLevelIndexScanner which reads all records and looks up all keys together
+          partitionedSortedRDD.mapPartitionsWithIndex(
+              (Function2<Integer, Iterator<Tuple2<HoodieKey, HoodieRecord<T>>>, Iterator<Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>>>) (partitionIndex, recordItr) -> {
+                List<HoodieKey> keysToLookup = new ArrayList<>();
+                while (recordItr.hasNext()) {
+                  keysToLookup.add(recordItr.next()._1);
+                }
+                return new HoodieRecordLevelIndexScanner(datasetWriteConfig, recordLevelIndexWriteConfig, datasetMetaClient, indexTableName,
+                    hadoopConf, keysToLookup, partitionIndex).getRecordLocations().iterator();
+              }, true)
+          // if seek is enabled, use HoodieRecordLevelIndexLookupIterator which does per key lookup
+          : partitionedSortedRDD.mapPartitionsWithIndex(
+              new HoodieRecordLevelIndexLookupFunction(datasetWriteConfig, recordLevelIndexWriteConfig, datasetMetaClient, hadoopConf), true);
+
+      // conver to JavaPairRDD to join w/ incoming records
+      JavaPairRDD<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>> keyToLocationPairRdd = keyToLocationRdd.mapToPair(entry -> new Tuple2<>(entry._1, entry._2));
+
+      // join with incoming records to tag them.
+      return incomingRecords.join(keyToLocationPairRdd).values()
+          .map(v1 -> HoodieIndexUtils.getTaggedRecord(v1._1,
+              v1._2.isPresent() ? Option.ofNullable(v1._2.get()._2) : Option.empty()));
+    } catch (Exception e) {
+      throw new HoodieIndexException("Exception thrown while index lookup with RecordLevel Index ", e);
+    }
+  }
+
+  /**
+   * Create a {@code HoodieWriteConfig} to use for the Index Table. // TODO: copied from Metadata code w/ minimal changes required for index. Need to revisit every config set.
+   *
+   * @param writeConfig {@code HoodieWriteConfig} of the main dataset writer
+   */
+  private HoodieWriteConfig createRecordLevelIndexWriteConfig(HoodieWriteConfig writeConfig) {
+    int parallelism = writeConfig.getMetadataInsertParallelism();
+
+    // Create the write config for the record level index table by borrowing options from the main write config.
+    HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder()
+        .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
+        .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder()
+            .withConsistencyCheckEnabled(writeConfig.getConsistencyGuardConfig().isConsistencyCheckEnabled())
+            .withInitialConsistencyCheckIntervalMs(writeConfig.getConsistencyGuardConfig().getInitialConsistencyCheckIntervalMs())
+            .withMaxConsistencyCheckIntervalMs(writeConfig.getConsistencyGuardConfig().getMaxConsistencyCheckIntervalMs())
+            .withMaxConsistencyChecks(writeConfig.getConsistencyGuardConfig().getMaxConsistencyChecks())
+            .build())
+        .withAutoCommit(true)
+        .withAvroSchemaValidate(true)
+        .withEmbeddedTimelineServerEnabled(false)
+        .withPath(writeConfig.getBasePath() + Path.SEPARATOR + RECORD_LEVEL_INDEX_TABLE_REL_PATH)
+        .withSchema(HoodieRecordLevelIndexRecord.getClassSchema().toString())
+        .forTable(indexTableName)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withAsyncClean(writeConfig.isMetadataAsyncClean())
+            // we will trigger cleaning manually, to control the instant times
+            .withAutoClean(false)
+            .withCleanerParallelism(parallelism)
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
+            .retainCommits(writeConfig.getMetadataCleanerCommitsRetained())
+            .archiveCommitsWith(writeConfig.getMetadataMinCommitsToKeep(), writeConfig.getMetadataMaxCommitsToKeep())
+            // we will trigger compaction manually, to control the instant times
+            .withInlineCompaction(false)
+            .withMaxNumDeltaCommitsBeforeCompaction(writeConfig.getMetadataCompactDeltaCommitMax()).build())
+        .withParallelism(parallelism, parallelism)
+        .withDeleteParallelism(parallelism)
+        .withRollbackParallelism(parallelism)
+        .withFinalizeWriteParallelism(parallelism);
+
+    if (writeConfig.isMetricsOn()) {
+      HoodieMetricsConfig.Builder metricsConfig = HoodieMetricsConfig.newBuilder()
+          .withReporterType(writeConfig.getMetricsReporterType().toString())
+          .withExecutorMetrics(writeConfig.isExecutorMetricsEnabled())
+          .on(true);
+      switch (writeConfig.getMetricsReporterType()) {
+        case GRAPHITE:
+          metricsConfig.onGraphitePort(writeConfig.getGraphiteServerPort())
+              .toGraphiteHost(writeConfig.getGraphiteServerHost())
+              .usePrefix(writeConfig.getGraphiteMetricPrefix());
+          break;
+        case JMX:
+          metricsConfig.onJmxPort(writeConfig.getJmxPort())
+              .toJmxHost(writeConfig.getJmxHost());
+          break;
+        case DATADOG:
+          // TODO:
+          break;
+        case CONSOLE:
+        case INMEMORY:
+          break;
+        default:
+          throw new HoodieMetadataException("Unsupported Metrics Reporter type " + writeConfig.getMetricsReporterType());
+      }
+
+      builder.withMetricsConfig(metricsConfig.build());
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Hoodie key based hash Partitioner.
+   */
+  class HoodieKeyHashPartitioner extends Partitioner {
+
+    int numPartitions;
+
+    public HoodieKeyHashPartitioner(Integer partitions) {
+      this.numPartitions = partitions;
+    }
+
+    public boolean equals(HoodieKeyHashPartitioner other) {
+      return this.numPartitions == other.numPartitions;
+    }
+
+    public int hashCode() {
+      return numPartitions;
+    }
+
+    @Override
+    public int numPartitions() {
+      return numPartitions;
+    }
+
+    @Override
+    public int getPartition(Object key) {
+      if (key == null) {
+        return 0;
+      } else if (key instanceof HoodieKey) {
+        return Utils.nonNegativeMod(key.toString().hashCode(), numPartitions);
+      }
+      return 0;
+    }
+  }
+
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndexLazyLookupIterator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndexLazyLookupIterator.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.record.level;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.avro.model.HoodieRecordLevelIndexRecord;
+import org.apache.hudi.client.utils.LazyIterableIterator;
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.SpillableMapUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.index.HoodieRecordLevelIndexMergedLogRecordScanner;
+import org.apache.hudi.index.HoodieRecordLevelIndexPayload;
+import org.apache.hudi.io.storage.HoodieFileReader;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import scala.Tuple2;
+
+public class RecordLevelIndexLazyLookupIterator<T extends HoodieRecordPayload>
+    extends LazyIterableIterator<Tuple2<HoodieKey, HoodieRecord<T>>, Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>>> {
+
+  private static final Logger LOG = LogManager.getLogger(RecordLevelIndexLazyLookupIterator.class);
+
+  private HoodieWriteConfig datasetWriteConfig;
+  private HoodieTableMetaClient datasetMetaClient;
+  private HoodieTableMetaClient indexMetaClient;
+  private SerializableConfiguration serializableConfiguration;
+
+  private Schema schema;
+  private int partitionIndex;
+  private String indexBasePath;
+
+  // Readers for the base and log file which store the index
+  private HoodieFileReader<GenericRecord> baseFileReader;
+  private HoodieRecordLevelIndexMergedLogRecordScanner logRecordScanner;
+
+  RecordLevelIndexLazyLookupIterator(Iterator<Tuple2<HoodieKey, HoodieRecord<T>>> recordItr,
+      HoodieWriteConfig writeConfig, HoodieWriteConfig recordLevelIndexWriteConfig,
+      HoodieTableMetaClient datasetMetaClient, HoodieTableMetaClient indexMetaClient, SerializableConfiguration serializableConfiguration,
+      int partitionIndex) {
+    super(recordItr);
+    this.datasetWriteConfig = writeConfig;
+    this.datasetMetaClient = datasetMetaClient;
+    this.indexMetaClient = indexMetaClient;
+    this.serializableConfiguration = serializableConfiguration;
+    this.indexBasePath = recordLevelIndexWriteConfig.getBasePath();
+    this.partitionIndex = partitionIndex;
+    schema = HoodieAvroUtils.addMetadataFields(HoodieRecordLevelIndexRecord.getClassSchema());
+  }
+
+  @Override
+  protected void start() {
+    try {
+      Tuple2<HoodieFileReader<GenericRecord>, HoodieRecordLevelIndexMergedLogRecordScanner> baseLogFileReaders =
+          RecordLevelIndexUtils.openFileSlice(datasetMetaClient, indexMetaClient, serializableConfiguration, datasetWriteConfig.getSpillableMapBasePath(), indexBasePath, partitionIndex);
+      baseFileReader = baseLogFileReaders._1;
+      logRecordScanner = baseLogFileReaders._2;
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new HoodieException("Exception thrown while trying to load index partition files", e);
+    }
+  }
+
+  @Override
+  protected Tuple2<HoodieKey, Option<Tuple2<String, HoodieRecordLocation>>> computeNext() {
+
+    if (inputItr.hasNext()) {
+      Tuple2<HoodieKey, HoodieRecord<T>> recordToLookup = inputItr.next();
+      String keyToLookup = recordToLookup._1.getRecordKey() + "_" + recordToLookup._1.getPartitionPath();
+      HoodieRecord<HoodieRecordLevelIndexPayload> hoodieRecord = null;
+      try {
+        if (baseFileReader != null) {
+          Option<GenericRecord> baseRecord = baseFileReader.getRecordByKey(keyToLookup);
+          if (baseRecord.isPresent()) {
+            hoodieRecord = SpillableMapUtils.convertToHoodieRecordPayload(baseRecord.get(),
+                HoodieRecordLevelIndexPayload.class.getName());
+          }
+        }
+
+        if (logRecordScanner != null) {
+          Option<HoodieRecord<HoodieRecordLevelIndexPayload>> logRecord = logRecordScanner.getRecordByKey(keyToLookup);
+          if (logRecord.isPresent()) {
+            if (hoodieRecord != null) { // both log record and base record is present
+              HoodieRecordPayload mergedPayload = logRecord.get().getData().preCombine(hoodieRecord.getData());
+              Option<HoodieRecordLevelIndexRecord> mergedRecord = mergedPayload.getInsertValue(schema);
+              if (mergedRecord.isPresent()) { // both baseRecord and log record is present
+                return new Tuple2<>(recordToLookup._1, Option.of(new Tuple2<>(mergedRecord.get().getPartitionPath(),
+                    new HoodieRecordLocation(mergedRecord.get().getInstantTime(), mergedRecord.get().getFileId()))));
+              } else {
+                // not sure what needs to be done here.
+              }
+            } else { // only log record
+              HoodieRecordLevelIndexPayload logPayload = logRecord.get().getData();
+              return new Tuple2<>(recordToLookup._1, Option.of(new Tuple2<>(logPayload.getPartitionPath(),
+                  new HoodieRecordLocation(logPayload.getInstantTime(), logPayload.getFileId()))));
+            }
+          } else { // no log record
+            // no op
+          }
+        }
+        if (hoodieRecord != null) { // only base record
+          HoodieRecordLevelIndexPayload basePayload = hoodieRecord.getData();
+          return new Tuple2<>(recordToLookup._1, Option.of(new Tuple2<>(basePayload.getPartitionPath(),
+              new HoodieRecordLocation(basePayload.getInstantTime(), basePayload.getFileId()))));
+        } else { // not present in both
+          return new Tuple2<>(recordToLookup._1, Option.empty());
+        }
+      } catch (Exception e) {
+        throw new HoodieException("Index look up failed w/ exception ", e);
+      }
+    }
+    return null;
+  }
+
+  @Override
+  protected void end() {
+    RecordLevelIndexUtils.close(baseFileReader, logRecordScanner);
+  }
+
+  /**
+   * Open readers to the base and log files.
+   */
+  /*private void openFileSlice(int partitionIndex) throws IOException {
+    // String partitionBasePath = indexBasePath + Path.SEPARATOR + Integer.toString(partitionIndex);
+
+    String latestInstantTime = getLatestDatasetInstantTime();
+
+    if (latestInstantTime != null) {
+      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(indexMetaClient, indexMetaClient.getActiveTimeline().filterCompletedInstants());
+      List<FileSlice> latestFileSystemMetadataSlices = fsView.getLatestFileSlices(Integer.toString(partitionIndex)).collect(Collectors.toList());
+
+      // If the base file is present then create a reader
+      Option<HoodieBaseFile> basefile = !latestFileSystemMetadataSlices.isEmpty() ? latestFileSystemMetadataSlices.get(0).getBaseFile() : Option.empty();
+      if (basefile.isPresent()) {
+        String basefilePath = basefile.get().getPath();
+        baseFileReader = HoodieFileReaderFactory.getFileReader(serializableConfiguration.get(), new Path(basefilePath));
+        LOG.info("Opened index base file from " + basefilePath + " at instant " + basefile.get().getCommitTime());
+      }
+
+      // Open the log record scanner using the log files from the latest file slice
+      List<String> logFilePaths = !latestFileSystemMetadataSlices.isEmpty() ? latestFileSystemMetadataSlices.get(0).getLogFiles()
+          .sorted(HoodieLogFile.getLogFileComparator())
+          .map(o -> o.getPath().toString())
+          .collect(Collectors.toList()) : Collections.emptyList();
+      Option<HoodieInstant> lastInstant = indexMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
+      String latestMetaInstantTimestamp = lastInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
+
+      // Load the schema
+      Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+      if (!logFilePaths.isEmpty()) {
+        logRecordScanner = new HoodieRecordLevelIndexMergedLogRecordScanner(indexMetaClient.getFs(), indexBasePath,
+            logFilePaths, schema, latestMetaInstantTimestamp, MAX_MEMORY_SIZE_IN_BYTES, BUFFER_SIZE,
+            datasetWriteConfig.getSpillableMapBasePath(), null);
+
+        LOG.info("Opened index log files from " + logFilePaths + " at instant " + latestInstantTime
+            + "(dataset instant=" + latestInstantTime + ", index instant=" + latestMetaInstantTimestamp + ")");
+      }
+    }
+  }
+
+  protected String getLatestDatasetInstantTime() {
+    if (datasetMetaClient.getActiveTimeline().filterCompletedInstants().empty()) {
+      return null;
+    } else {
+      return datasetMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant()
+          .map(HoodieInstant::getTimestamp).get();
+    }
+  }*/
+}
+

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndexUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndexUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.record.level;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.avro.model.HoodieMetadataRecord;
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.index.HoodieRecordLevelIndexMergedLogRecordScanner;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieFileReaderFactory;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import scala.Tuple2;
+
+/**
+ * Utils for RecordKey Index.
+ */
+public class RecordLevelIndexUtils {
+
+  private static final Logger LOG = LogManager.getLogger(RecordLevelIndexUtils.class);
+
+  static final String SOLO_COMMIT_TIMESTAMP = "0000000000000";
+
+  static final long MAX_MEMORY_SIZE_IN_BYTES = 1024 * 1024 * 1024;
+  static final int BUFFER_SIZE = 10 * 1024 * 1024;
+
+  static Tuple2<HoodieFileReader<GenericRecord>, HoodieRecordLevelIndexMergedLogRecordScanner> openFileSlice(HoodieTableMetaClient datasetMetaClient, HoodieTableMetaClient indexMetaClient,
+      SerializableConfiguration serializableConfiguration, String spillableMapBaseDir, String indexBasePath, int partitionIndex) throws IOException {
+
+    HoodieFileReader<GenericRecord> baseFileReader = null;
+    HoodieRecordLevelIndexMergedLogRecordScanner logRecordScanner = null;
+
+    // String partitionBasePath = indexBasePath + Path.SEPARATOR + Integer.toString(partitionIndex);
+
+    // HoodieTimer timer = new HoodieTimer().startTimer();
+    String latestInstantTime = getLatestDatasetInstantTime(datasetMetaClient);
+
+    if (latestInstantTime != null) {
+      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(indexMetaClient, indexMetaClient.getActiveTimeline().filterCompletedInstants());
+      List<FileSlice> latestFileSystemMetadataSlices = fsView.getLatestFileSlices(Integer.toString(partitionIndex)).collect(Collectors.toList());
+
+      // If the base file is present then create a reader
+      Option<HoodieBaseFile> basefile = !latestFileSystemMetadataSlices.isEmpty() ? latestFileSystemMetadataSlices.get(0).getBaseFile() : Option.empty();
+      if (basefile.isPresent()) {
+        String basefilePath = basefile.get().getPath();
+        baseFileReader = HoodieFileReaderFactory.getFileReader(serializableConfiguration.get(), new Path(basefilePath));
+        LOG.info("Opened index base file from " + basefilePath + " at instant " + basefile.get().getCommitTime());
+      }
+
+      // Open the log record scanner using the log files from the latest file slice
+      List<String> logFilePaths = !latestFileSystemMetadataSlices.isEmpty() ? latestFileSystemMetadataSlices.get(0).getLogFiles()
+          .sorted(HoodieLogFile.getLogFileComparator())
+          .map(o -> o.getPath().toString())
+          .collect(Collectors.toList()) : Collections.emptyList();
+      Option<HoodieInstant> lastInstant = indexMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
+      String latestMetaInstantTimestamp = lastInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
+
+      // Load the schema
+      Schema schema = HoodieAvroUtils.addMetadataFields(HoodieMetadataRecord.getClassSchema());
+      if (!logFilePaths.isEmpty()) {
+        logRecordScanner = new HoodieRecordLevelIndexMergedLogRecordScanner(indexMetaClient.getFs(), indexBasePath,
+            logFilePaths, schema, latestMetaInstantTimestamp, MAX_MEMORY_SIZE_IN_BYTES, BUFFER_SIZE,
+            spillableMapBaseDir, null);
+
+        LOG.info("Opened index log files from " + logFilePaths + " at instant " + latestInstantTime
+            + "(dataset instant=" + latestInstantTime + ", index instant=" + latestMetaInstantTimestamp + ")");
+      }
+    }
+    return new Tuple2<>(baseFileReader, logRecordScanner);
+  }
+
+  static String getLatestDatasetInstantTime(HoodieTableMetaClient datasetMetaClient) {
+    if (datasetMetaClient.getActiveTimeline().filterCompletedInstants().empty()) {
+      return null;
+    } else {
+      return datasetMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant()
+          .map(HoodieInstant::getTimestamp).get();
+    }
+  }
+
+  static void close(HoodieFileReader<GenericRecord> baseFileReader, HoodieRecordLevelIndexMergedLogRecordScanner logRecordScanner) {
+    try {
+      if (baseFileReader != null) {
+        baseFileReader.close();
+        baseFileReader = null;
+      }
+      if (logRecordScanner != null) {
+        logRecordScanner.close();
+        logRecordScanner = null;
+      }
+    } catch (Exception e) {
+      throw new HoodieException("Error closing resources during metadata table merge", e);
+    }
+  }
+
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
@@ -67,6 +67,6 @@ public abstract class HoodieSparkTable<T extends HoodieRecordPayload>
 
   @Override
   protected HoodieIndex<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> getIndex(HoodieWriteConfig config, HoodieEngineContext context) {
-    return SparkHoodieIndex.createIndex(config);
+    return SparkHoodieIndex.createIndex(config, context);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
@@ -99,7 +99,7 @@ public class SparkExecuteClusteringCommitActionExecutor<T extends HoodieRecordPa
     }
 
     HoodieWriteMetadata<JavaRDD<WriteStatus>> writeMetadata = buildWriteMetadata(writeStatusRDD);
-    updateIndexAndCommitIfNeeded(writeStatusRDD, writeMetadata);
+    updateIndexAndCommitIfNeeded(writeStatusRDD, writeMetadata, instantTime);
     if (!writeMetadata.getCommitMetadata().isPresent()) {
       HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(writeStatusRDD.map(WriteStatus::getStat).collect(), writeMetadata.getPartitionToReplaceFileIds(),
           extraMetadata, operationType, getSchemaToStoreInCommit(), getCommitActionType());

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBulkInsertHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBulkInsertHelper.java
@@ -74,7 +74,7 @@ public class SparkBulkInsertHelper<T extends HoodieRecordPayload, R> extends Abs
     // write new files
     JavaRDD<WriteStatus> writeStatuses = bulkInsert(inputRecords, instantTime, table, config, performDedupe, userDefinedBulkInsertPartitioner, false, config.getBulkInsertShuffleParallelism());
     //update index
-    ((BaseSparkCommitActionExecutor) executor).updateIndexAndCommitIfNeeded(writeStatuses, result);
+    ((BaseSparkCommitActionExecutor) executor).updateIndexAndCommitIfNeeded(writeStatuses, result, instantTime);
     return result;
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/TestHoodieIndex.java
@@ -91,7 +91,7 @@ public class TestHoodieIndex extends HoodieClientTestHarness {
   }
 
   @ParameterizedTest
-  @EnumSource(value = IndexType.class, names = {"BLOOM", "GLOBAL_BLOOM", "SIMPLE", "GLOBAL_SIMPLE"})
+  @EnumSource(value = IndexType.class, names = {"RECORD_LEVEL_INDEX"})
   public void testSimpleTagLocationAndUpdate(IndexType indexType) throws Exception {
     setUp(indexType);
     String newCommitTime = "001";
@@ -141,7 +141,7 @@ public class TestHoodieIndex extends HoodieClientTestHarness {
   }
 
   @ParameterizedTest
-  @EnumSource(value = IndexType.class, names = {"BLOOM", "GLOBAL_BLOOM", "SIMPLE", "GLOBAL_SIMPLE"})
+  @EnumSource(value = IndexType.class, names = {"RECORD_LEVEL_INDEX"})
   public void testTagLocationAndDuplicateUpdate(IndexType indexType) throws Exception {
     setUp(indexType);
     String newCommitTime = "001";
@@ -160,6 +160,15 @@ public class TestHoodieIndex extends HoodieClientTestHarness {
     // recomputed. This includes the state transitions. We need to delete the inflight instance so that subsequent
     // upsert will not run into conflicts.
     metaClient.getFs().delete(new Path(metaClient.getMetaPath(), "001.inflight"));
+
+    metaClient.getFs().delete(new Path(metaClient.getMetaPath() + Path.SEPARATOR + "index" + Path.SEPARATOR
+        + HoodieTableMetaClient.METAFOLDER_NAME, "001.deltacommit.inflight"));
+    System.out.println("Deleted index delta commit " + (metaClient.getMetaPath() + Path.SEPARATOR + "index" + Path.SEPARATOR
+        + HoodieTableMetaClient.METAFOLDER_NAME));
+    metaClient.getFs().delete(new Path(metaClient.getMetaPath() + Path.SEPARATOR + "index" + Path.SEPARATOR
+        + HoodieTableMetaClient.METAFOLDER_NAME, "001.deltacommit.requested"));
+    metaClient.getFs().delete(new Path(metaClient.getMetaPath() + Path.SEPARATOR + "index" + Path.SEPARATOR
+        + HoodieTableMetaClient.METAFOLDER_NAME, "001.deltacommit"));
 
     writeClient.upsert(writeRecords, newCommitTime);
     Assertions.assertNoWriteErrors(writeStatues.collect());
@@ -191,7 +200,7 @@ public class TestHoodieIndex extends HoodieClientTestHarness {
   }
 
   @ParameterizedTest
-  @EnumSource(value = IndexType.class, names = {"BLOOM", "GLOBAL_BLOOM", "SIMPLE", "GLOBAL_SIMPLE"})
+  @EnumSource(value = IndexType.class, names = {"RECORD_LEVEL_INDEX"})
   public void testSimpleTagLocationAndUpdateWithRollback(IndexType indexType) throws Exception {
     setUp(indexType);
     String newCommitTime = writeClient.startCommit();
@@ -243,7 +252,7 @@ public class TestHoodieIndex extends HoodieClientTestHarness {
   }
 
   @ParameterizedTest
-  @EnumSource(value = IndexType.class, names = {"BLOOM", "SIMPLE",})
+  @EnumSource(value = IndexType.class, names = {"BLOOM"})
   public void testTagLocationAndFetchRecordLocations(IndexType indexType) throws Exception {
     setUp(indexType);
     String p1 = "2016/01/31";

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/TestHoodieIndexConfigs.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/TestHoodieIndexConfigs.java
@@ -68,29 +68,29 @@ public class TestHoodieIndexConfigs {
       case INMEMORY:
         config = clientConfigBuilder.withPath(basePath)
             .withIndexConfig(indexConfigBuilder.withIndexType(HoodieIndex.IndexType.INMEMORY).build()).build();
-        assertTrue(SparkHoodieIndex.createIndex(config) instanceof SparkInMemoryHashIndex);
+        assertTrue(SparkHoodieIndex.createIndex(config, null) instanceof SparkInMemoryHashIndex);
         break;
       case BLOOM:
         config = clientConfigBuilder.withPath(basePath)
             .withIndexConfig(indexConfigBuilder.withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();
-        assertTrue(SparkHoodieIndex.createIndex(config) instanceof SparkHoodieBloomIndex);
+        assertTrue(SparkHoodieIndex.createIndex(config, null) instanceof SparkHoodieBloomIndex);
         break;
       case GLOBAL_BLOOM:
         config = clientConfigBuilder.withPath(basePath)
             .withIndexConfig(indexConfigBuilder.withIndexType(IndexType.GLOBAL_BLOOM).build()).build();
-        assertTrue(SparkHoodieIndex.createIndex(config) instanceof SparkHoodieGlobalBloomIndex);
+        assertTrue(SparkHoodieIndex.createIndex(config, null) instanceof SparkHoodieGlobalBloomIndex);
         break;
       case SIMPLE:
         config = clientConfigBuilder.withPath(basePath)
             .withIndexConfig(indexConfigBuilder.withIndexType(IndexType.SIMPLE).build()).build();
-        assertTrue(SparkHoodieIndex.createIndex(config) instanceof SparkHoodieSimpleIndex);
+        assertTrue(SparkHoodieIndex.createIndex(config, null) instanceof SparkHoodieSimpleIndex);
         break;
       case HBASE:
         config = clientConfigBuilder.withPath(basePath)
             .withIndexConfig(indexConfigBuilder.withIndexType(HoodieIndex.IndexType.HBASE)
                 .withHBaseIndexConfig(new HoodieHBaseIndexConfig.Builder().build()).build())
             .build();
-        assertTrue(SparkHoodieIndex.createIndex(config) instanceof SparkHoodieHBaseIndex);
+        assertTrue(SparkHoodieIndex.createIndex(config, null) instanceof SparkHoodieHBaseIndex);
         break;
       default:
         // no -op. just for checkstyle errors
@@ -103,7 +103,7 @@ public class TestHoodieIndexConfigs {
     HoodieIndexConfig.Builder indexConfigBuilder = HoodieIndexConfig.newBuilder();
     HoodieWriteConfig config = clientConfigBuilder.withPath(basePath)
         .withIndexConfig(indexConfigBuilder.withIndexClass(DummyHoodieIndex.class.getName()).build()).build();
-    assertTrue(SparkHoodieIndex.createIndex(config) instanceof DummyHoodieIndex);
+    assertTrue(SparkHoodieIndex.createIndex(config, null) instanceof DummyHoodieIndex);
   }
 
   @Test
@@ -113,14 +113,14 @@ public class TestHoodieIndexConfigs {
     final HoodieWriteConfig config1 = clientConfigBuilder.withPath(basePath)
         .withIndexConfig(indexConfigBuilder.withIndexClass(IndexWithConstructor.class.getName()).build()).build();
     final Throwable thrown1 = assertThrows(HoodieException.class, () -> {
-      SparkHoodieIndex.createIndex(config1);
+      SparkHoodieIndex.createIndex(config1, null);
     }, "exception is expected");
     assertTrue(thrown1.getMessage().contains("is not a subclass of HoodieIndex"));
 
     final HoodieWriteConfig config2 = clientConfigBuilder.withPath(basePath)
         .withIndexConfig(indexConfigBuilder.withIndexClass(IndexWithoutConstructor.class.getName()).build()).build();
     final Throwable thrown2 = assertThrows(HoodieException.class, () -> {
-      SparkHoodieIndex.createIndex(config2);
+      SparkHoodieIndex.createIndex(config2, null);
     }, "exception is expected");
     assertTrue(thrown2.getMessage().contains("Unable to instantiate class"));
   }
@@ -133,8 +133,8 @@ public class TestHoodieIndexConfigs {
 
     @Override
     public JavaRDD<WriteStatus> updateLocation(JavaRDD<WriteStatus> writeStatusRDD,
-                                               HoodieEngineContext context,
-                                               HoodieTable<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> hoodieTable) throws HoodieIndexException {
+        HoodieEngineContext context,
+        HoodieTable<T, JavaRDD<HoodieRecord<T>>, JavaRDD<HoodieKey>, JavaRDD<WriteStatus>> hoodieTable) throws HoodieIndexException {
       return null;
     }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -155,7 +155,7 @@ public class TestCleaner extends HoodieClientTestBase {
     // We no longer write empty cleaner plans when there is nothing to be cleaned.
     assertTrue(table.getCompletedCleanTimeline().empty());
 
-    HoodieIndex index = SparkHoodieIndex.createIndex(cfg);
+    HoodieIndex index = SparkHoodieIndex.createIndex(cfg, context);
     List<HoodieRecord> taggedRecords = ((JavaRDD<HoodieRecord>) index.tagLocation(jsc.parallelize(records, 1), context, table)).collect();
     checkTaggedRecords(taggedRecords, newCommitTime);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
@@ -218,7 +218,7 @@ public class HoodieClientTestBase extends HoodieClientTestHarness {
   private Function2<List<HoodieRecord>, String, Integer> wrapRecordsGenFunctionForPreppedCalls(
       final HoodieWriteConfig writeConfig, final Function2<List<HoodieRecord>, String, Integer> recordGenFunction) {
     return (commit, numRecords) -> {
-      final SparkHoodieIndex index = SparkHoodieIndex.createIndex(writeConfig);
+      final SparkHoodieIndex index = SparkHoodieIndex.createIndex(writeConfig, context);
       List<HoodieRecord> records = recordGenFunction.apply(commit, numRecords);
       final HoodieTableMetaClient metaClient = new HoodieTableMetaClient(hadoopConf, basePath, true);
       HoodieSparkTable table = HoodieSparkTable.create(writeConfig, context, metaClient);
@@ -239,7 +239,7 @@ public class HoodieClientTestBase extends HoodieClientTestHarness {
   private Function<Integer, List<HoodieKey>> wrapDeleteKeysGenFunctionForPreppedCalls(
       final HoodieWriteConfig writeConfig, final Function<Integer, List<HoodieKey>> keyGenFunction) {
     return (numRecords) -> {
-      final SparkHoodieIndex index = SparkHoodieIndex.createIndex(writeConfig);
+      final SparkHoodieIndex index = SparkHoodieIndex.createIndex(writeConfig, context);
       List<HoodieKey> records = keyGenFunction.apply(numRecords);
       final HoodieTableMetaClient metaClient = new HoodieTableMetaClient(hadoopConf, basePath, true);
       HoodieSparkTable table = HoodieSparkTable.create(writeConfig, context, metaClient);

--- a/hudi-common/src/main/avro/HoodieRecodLevelIndex.avsc
+++ b/hudi-common/src/main/avro/HoodieRecodLevelIndex.avsc
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+    "namespace": "org.apache.hudi.avro.model",
+    "type": "record",
+    "name": "HoodieRecordLevelIndexRecord",
+    "doc": "A record saved within the RecordLevelIndex Table",
+    "fields": [
+        {
+            "name": "key",
+            "type": "string"
+        },
+        {
+            "name": "partitionPath",
+            "type": "string"
+        },
+        {
+            "name": "instantTime",
+            "type": "string"
+        },
+        {
+            "name": "fileId",
+            "type": "string"
+        }
+    ]
+}

--- a/hudi-common/src/main/java/org/apache/hudi/index/HoodieRecordLevelIndexMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/HoodieRecordLevelIndexMergedLogRecordScanner.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class HoodieRecordLevelIndexMergedLogRecordScanner extends HoodieMergedLogRecordScanner {
+
+  // Set of all record keys that are to be read in memory
+  private Set<String> mergeKeyFilter;
+
+  public HoodieRecordLevelIndexMergedLogRecordScanner(FileSystem fs, String basePath, List<String> logFilePaths,
+      Schema readerSchema, String latestInstantTime, Long maxMemorySizeInBytes, int bufferSize,
+      String spillableMapBasePath, Set<String> mergeKeyFilter) {
+    super(fs, basePath, logFilePaths, readerSchema, latestInstantTime, maxMemorySizeInBytes, false, false, bufferSize,
+        spillableMapBasePath, false);
+    this.mergeKeyFilter = mergeKeyFilter != null ? mergeKeyFilter : Collections.emptySet();
+
+    performScan();
+  }
+
+  @Override
+  protected void processNextRecord(HoodieRecord<? extends HoodieRecordPayload> hoodieRecord) throws IOException {
+    if (mergeKeyFilter.isEmpty() || mergeKeyFilter.contains(hoodieRecord.getRecordKey())) {
+      super.processNextRecord(hoodieRecord);
+    }
+  }
+
+  @Override
+  protected void processNextDeletedKey(HoodieKey hoodieKey) {
+    if (mergeKeyFilter.isEmpty() || mergeKeyFilter.contains(hoodieKey.getRecordKey())) {
+      super.processNextDeletedKey(hoodieKey);
+    }
+  }
+
+  /**
+   * Retrieve a record given its key.
+   *
+   * @param key Key of the record to retrieve
+   * @return {@code HoodieRecord} if key was found else {@code Option.empty()}
+   */
+  public Option<HoodieRecord<HoodieRecordLevelIndexPayload>> getRecordByKey(String key) {
+    return Option.ofNullable((HoodieRecord) records.get(key));
+  }
+
+  /**
+   * Retrieve a record given its key.
+   *
+   * @param key Key of the record to retrieve
+   * @return {@code HoodieRecord} if key was found else {@code Option.empty()}
+   */
+  public Map<String, Option<HoodieRecord<HoodieRecordLevelIndexPayload>>> getRecordsByKey(List<String> keys) {
+    Map<String, Option<HoodieRecord<HoodieRecordLevelIndexPayload>>> toReturn = new HashMap<>();
+    for (String key : keys) {
+      toReturn.put(key, Option.ofNullable((HoodieRecord) records.get(key)));
+    }
+    return toReturn;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/index/HoodieRecordLevelIndexPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/HoodieRecordLevelIndexPayload.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index;
+
+import org.apache.hudi.avro.model.HoodieRecordLevelIndexRecord;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.io.IOException;
+
+/**
+ * Payload used in index table for Hoodie Record level index.
+ */
+public class HoodieRecordLevelIndexPayload implements HoodieRecordPayload<HoodieRecordLevelIndexPayload> {
+
+  private String key;
+  private String partitionPath;
+  private String instantTime;
+  private String fileId;
+
+  public HoodieRecordLevelIndexPayload(Option<GenericRecord> record) {
+    if (record.isPresent()) {
+      // This can be simplified using SpecificData.deepcopy once this bug is fixed
+      // https://issues.apache.org/jira/browse/AVRO-1811
+      key = record.get().get("key").toString();
+      partitionPath = record.get().get("partitionPath").toString();
+      instantTime = record.get().get("instantTime").toString();
+      fileId = record.get().get("fileId").toString();
+    }
+  }
+
+  private HoodieRecordLevelIndexPayload(String key, String partitionPath, String instantTime, String fileId) {
+    this.key = key;
+    this.partitionPath = partitionPath;
+    this.instantTime = instantTime;
+    this.fileId = fileId;
+  }
+
+  @Override
+  public HoodieRecordLevelIndexPayload preCombine(HoodieRecordLevelIndexPayload another) {
+    if (this.instantTime.compareTo(another.instantTime) >= 0) {
+      return this;
+    } else {
+      return another;
+    }
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+    return getInsertValue(schema);
+  }
+
+  @Override
+  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+    if (key == null) {
+      return Option.empty();
+    }
+
+    HoodieRecordLevelIndexRecord record = new HoodieRecordLevelIndexRecord(key, partitionPath, instantTime, fileId);
+    return Option.of(record);
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public String getInstantTime() {
+    return instantTime;
+  }
+
+  public String getFileId() {
+    return fileId;
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Adding record level index based on hoodie backed table. 

## Brief change log

  - *Added RecordLevelIndex to hoodie that stores and exposes record level index info*
  - Had to change or evolve updateLocation api (to take in instant time) in [HoodieIndex](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java) as part of this new record level index. 

Review guide:
- Index class: [RecordLevelIndex](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndex.java)
- Classed used in read path for index table: // Supports read in two modes. either scan fully and fetch key locations. or look up one by one
a. [HoodieRecordLevelIndexScanner](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieRecordLevelIndexScanner.java)
b. [HoodieRecordLevelIndexLookupFunction](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/HoodieRecordLevelIndexLookupFunction.java) and [RecordLevelIndexLazyLookupIterator](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/record/level/RecordLevelIndexLazyLookupIterator.java)
- Record schema : [HoodieRecordLevelIndexRecord](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-common/src/main/avro/HoodieRecodLevelIndex.avsc)
- Payload to be used in Index table: [HoodieRecordLevelIndexPayload](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-common/src/main/java/org/apache/hudi/index/HoodieRecordLevelIndexPayload.java)
- [Configs added](https://github.com/apache/hudi/blob/8b07157d222a415db4f0d12fabb720cb4a37e28c/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java): hoodie.record.level.index.num.partitions and hoodie.record.level.index.enable.seek

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.