### PR TITLE
[HUDI-1552] Improve performance of key lookups from base file in Metadata Table.

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/MetadataCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/MetadataCommand.java
@@ -24,6 +24,7 @@ import org.apache.hudi.cli.HoodieCLI;
 import org.apache.hudi.cli.utils.SparkUtil;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -147,7 +148,8 @@ public class MetadataCommand implements CommandMarker {
   public String stats() throws IOException {
     HoodieCLI.getTableMetaClient();
     HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder().enable(true).build();
-    HoodieBackedTableMetadata metadata = new HoodieBackedTableMetadata(HoodieCLI.conf, config, HoodieCLI.basePath, "/tmp");
+    HoodieBackedTableMetadata metadata = new HoodieBackedTableMetadata(new HoodieLocalEngineContext(HoodieCLI.conf),
+        config, HoodieCLI.basePath, "/tmp");
     Map<String, String> stats = metadata.stats();
 
     StringBuffer out = new StringBuffer("\n");
@@ -197,7 +199,7 @@ public class MetadataCommand implements CommandMarker {
       final String partition) throws IOException {
     HoodieCLI.getTableMetaClient();
     HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder().enable(true).build();
-    HoodieBackedTableMetadata metaReader = new HoodieBackedTableMetadata(HoodieCLI.conf, config, HoodieCLI.basePath, "/tmp");
+    HoodieBackedTableMetadata metaReader = new HoodieBackedTableMetadata(new HoodieLocalEngineContext(HoodieCLI.conf), config, HoodieCLI.basePath, "/tmp");
 
     StringBuffer out = new StringBuffer("\n");
     if (!metaReader.enabled()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -107,7 +107,6 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
     this.hadoopConfiguration = context.getHadoopConf();
     this.context = context;
 
-    // disable reuse of resources, given there is no close() called on the executors ultimately
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().fromProperties(config.getMetadataConfig().getProps())
         .build();
     this.metadata = HoodieTableMetadata.create(context, metadataConfig, config.getBasePath(),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -109,7 +109,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
 
     // disable reuse of resources, given there is no close() called on the executors ultimately
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().fromProperties(config.getMetadataConfig().getProps())
-        .enableReuse(false).build();
+        .build();
     this.metadata = HoodieTableMetadata.create(context, metadataConfig, config.getBasePath(),
         FileSystemViewStorageConfig.DEFAULT_VIEW_SPILLABLE_DIR);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
@@ -973,7 +973,6 @@ public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(useFileListingMetadata)
-            .enableReuse(false)
             .enableMetrics(enableMetrics)
             .enableFallback(false).build())
         .withMetricsConfig(HoodieMetricsConfig.newBuilder().on(enableMetrics)

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -67,10 +67,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
   public static final String CLEANER_COMMITS_RETAINED_PROP = METADATA_PREFIX + ".cleaner.commits.retained";
   public static final int DEFAULT_CLEANER_COMMITS_RETAINED = 3;
 
-  // Controls whether or no the base file open/log merges are reused per API call
-  public static final String ENABLE_REUSE_PROP = METADATA_PREFIX + ".reuse.enable";
-  public static final String DEFAULT_ENABLE_REUSE = "true";
-
   // Controls whether or not, upon failure to fetch from metadata table, should fallback to listing.
   public static final String ENABLE_FALLBACK_PROP = METADATA_PREFIX + ".fallback.enable";
   public static final String DEFAULT_ENABLE_FALLBACK = "true";
@@ -103,10 +99,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
 
   public boolean useFileListingMetadata() {
     return Boolean.parseBoolean(props.getProperty(METADATA_ENABLE_PROP));
-  }
-
-  public boolean enableReuse() {
-    return Boolean.parseBoolean(props.getProperty(ENABLE_REUSE_PROP));
   }
 
   public boolean enableFallback() {
@@ -148,11 +140,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
 
     public Builder enableMetrics(boolean enableMetrics) {
       props.setProperty(METADATA_METRICS_ENABLE_PROP, String.valueOf(enableMetrics));
-      return this;
-    }
-
-    public Builder enableReuse(boolean reuse) {
-      props.setProperty(ENABLE_REUSE_PROP, String.valueOf(reuse));
       return this;
     }
 
@@ -233,8 +220,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
           HOODIE_ASSUME_DATE_PARTITIONING_PROP, DEFAULT_ASSUME_DATE_PARTITIONING);
       setDefaultOnCondition(props, !props.containsKey(ENABLE_FALLBACK_PROP), ENABLE_FALLBACK_PROP,
           DEFAULT_ENABLE_FALLBACK);
-      setDefaultOnCondition(props, !props.containsKey(ENABLE_REUSE_PROP), ENABLE_REUSE_PROP,
-          DEFAULT_ENABLE_REUSE);
       setDefaultOnCondition(props, !props.containsKey(DIRECTORY_FILTER_REGEX), DIRECTORY_FILTER_REGEX,
           DEFAULT_DIRECTORY_FILTER_REGEX);
       return config;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
@@ -214,7 +214,7 @@ public class FileSystemViewManager {
                                                         final FileSystemViewStorageConfig config,
                                                         final String basePath) {
     return createViewManager(context, metadataConfig, config,
-        () -> HoodieTableMetadata.create(context, metadataConfig, basePath, config.getSpillableDir()));
+        () -> HoodieTableMetadata.create(context, metadataConfig, basePath, config.getSpillableDir(), true));
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
@@ -56,6 +56,9 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
   private Configuration conf;
   private HFile.Reader reader;
   private Schema schema;
+  // Scanner used to read individual keys. This is cached to prevent the overhead of opening the scanner for each
+  // key retrieval.
+  private HFileScanner keyScanner;
 
   public static final String KEY_SCHEMA = "schema";
   public static final String KEY_BLOOM_FILTER_META_BLOCK = "bloomFilter";
@@ -140,7 +143,7 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
   public List<Pair<String, R>> readAllRecords(Schema writerSchema, Schema readerSchema) throws IOException {
     List<Pair<String, R>> recordList = new LinkedList<>();
     try {
-      HFileScanner scanner = reader.getScanner(false, false);
+      final HFileScanner scanner = reader.getScanner(false, false);
       if (scanner.seekTo()) {
         do {
           Cell c = scanner.getKeyValue();
@@ -174,7 +177,7 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
           // To handle when hasNext() is called multiple times for idempotency and/or the first time
           if (this.next == null && !this.eof) {
             if (!scanner.isSeeked() && scanner.seekTo()) {
-                this.next = (R)getRecordFromCell(scanner.getKeyValue(), getSchema(), readerSchema);
+                this.next = getRecordFromCell(scanner.getKeyValue(), getSchema(), readerSchema);
             }
           }
           return this.next != null;
@@ -194,7 +197,7 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
           }
           R retVal = this.next;
           if (scanner.next()) {
-            this.next = (R)getRecordFromCell(scanner.getKeyValue(), getSchema(), readerSchema);
+            this.next = getRecordFromCell(scanner.getKeyValue(), getSchema(), readerSchema);
           } else {
             this.next = null;
             this.eof = true;
@@ -209,12 +212,23 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
 
   @Override
   public Option getRecordByKey(String key, Schema readerSchema) throws IOException {
-    HFileScanner scanner = reader.getScanner(false, true);
+    byte[] value = null;
     KeyValue kv = new KeyValue(key.getBytes(), null, null, null);
-    if (scanner.seekTo(kv) == 0) {
-      Cell c = scanner.getKeyValue();
-      byte[] keyBytes = Arrays.copyOfRange(c.getRowArray(), c.getRowOffset(), c.getRowOffset() + c.getRowLength());
-      R record = getRecordFromCell(c, getSchema(), readerSchema);
+
+    synchronized (this) {
+      if (keyScanner == null) {
+        keyScanner = reader.getScanner(true, true);
+      }
+
+      if (keyScanner.seekTo(kv) == 0) {
+        Cell c = keyScanner.getKeyValue();
+        // Extract the byte value before releasing the lock since we cannot hold on to the returned cell afterwards
+        value = Arrays.copyOfRange(c.getValueArray(), c.getValueOffset(), c.getValueOffset() + c.getValueLength());
+      }
+    }
+
+    if (value != null) {
+      R record = (R)HoodieAvroUtils.bytesToAvro(value, getSchema(), readerSchema);
       return Option.of(record);
     }
 
@@ -232,10 +246,13 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     try {
       reader.close();
       reader = null;
+      if (keyScanner != null) {
+        keyScanner = null;
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
@@ -250,11 +250,9 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
     try {
       reader.close();
       reader = null;
-      if (keyScanner != null) {
-        keyScanner = null;
-      }
+      keyScanner = null;
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new HoodieIOException("Error closing the hfile reader", e);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -72,8 +72,13 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
 
   static HoodieTableMetadata create(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String datasetBasePath,
                                     String spillableMapPath) {
+    return create(engineContext, metadataConfig, datasetBasePath, spillableMapPath, false);
+  }
+
+  static HoodieTableMetadata create(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String datasetBasePath,
+                                    String spillableMapPath, boolean reuse) {
     if (metadataConfig.useFileListingMetadata()) {
-      return new HoodieBackedTableMetadata(engineContext, metadataConfig, datasetBasePath, spillableMapPath);
+      return new HoodieBackedTableMetadata(engineContext, metadataConfig, datasetBasePath, spillableMapPath, reuse);
     } else {
       return new FileSystemBackedTableMetadata(engineContext, new SerializableConfiguration(engineContext.getHadoopConf()),
           datasetBasePath, metadataConfig.shouldAssumeDatePartitioning());


### PR DESCRIPTION

## What is the purpose of the pull request

Improves the performance of key lookups from Metadata Table. 

In my scale testing with 150 partitions and 100K+ files on HDFS, the time to read the key was reduced (100ms avg -> 10ms) and the total data read from the HFile was reduced (85MB -> 3MB). The size of the base file was 3MB so this means that the in-memory HFile block caching was also working. 

## Brief change log

1. Cache the KeyScanner across lookups so that the HFile index does not have to be read for each lookup.
2. Enable block caching in KeyScanner.
3. Move the lock to a limited scope of the code to reduce lock contention.

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

mvn test -pl  hudi-client/hudi-spark-client -Dtest=TestHoodieBackedMetadata

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.