### PR TITLE
[HUDI-1554] Introduced buffering for streams in HUDI.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieClient.java
@@ -20,6 +20,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
+import org.apache.hudi.common.config.HoodieWrapperFileSystemConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.common.fs.FSUtils;
@@ -76,6 +77,13 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
         clientConfig.getHoodieClientHeartbeatIntervalInMs(), clientConfig.getHoodieClientHeartbeatTolerableMisses());
     startEmbeddedServerView();
     initWrapperFSMetrics();
+
+    // File system IO buffering configs are propagated via Hadoop Configuration
+    context.setHadoopConfig(HoodieWrapperFileSystemConfig.FILE_IO_BUFFER_ENABLED, Boolean.toString(clientConfig.isFileIOBufferingEnabled()));
+    context.setHadoopConfig(HoodieWrapperFileSystemConfig.MIN_FILE_IO_BUFFER_SIZE,
+        Integer.toString(clientConfig.getFileIOBufferMinSize()));
+    context.setHadoopConfig(HoodieWrapperFileSystemConfig.MIN_DATA_FILE_IO_BUFFER_SIZE,
+        Integer.toString(clientConfig.getDataFileIOBufferMinSize()));
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -64,6 +64,12 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
     return sqlContext;
   }
 
+  @Override
+  public void setHadoopConfig(String name, String value) {
+    super.setHadoopConfig(name, value);
+    javaSparkContext.hadoopConfiguration().set(name, value);
+  }
+
   public static JavaSparkContext getSparkContext(HoodieEngineContext context) {
     return ((HoodieSparkEngineContext) context).getJavaSparkContext();
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -375,8 +375,8 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
 
     List<HoodieRecord> records = new ArrayList<>();
-    // Approx 1150 records are written for block size of 64KB
-    for (int i = 0; i < 2000; i++) {
+    // Approx 1400 records are written for block size of 64KB
+    for (int i = 0; i < 3000; i++) {
       String recordStr = "{\"_row_key\":\"" + UUID.randomUUID().toString()
           + "\",\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":" + i + "}";
       RawTripTestPayload rowChange = new RawTripTestPayload(recordStr);
@@ -398,7 +398,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
         counts++;
       }
     }
-    assertEquals(3, counts, "If the number of records are more than 1150, then there should be a new file");
+    assertEquals(3, counts, "If the number of records are more than 1400, then there should be a new file");
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieWrapperFileSystemConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieWrapperFileSystemConfig.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Hoodie payload related configs.
+ */
+public class HoodieWrapperFileSystemConfig extends DefaultHoodieConfig {
+
+  // Buffering for IO streams
+  private static final String CONFIG_IO_BUFFER_PREFIX = "hoodie.fs.io.buffer";
+  public static final String FILE_IO_BUFFER_ENABLED = CONFIG_IO_BUFFER_PREFIX + ".enabled";
+  private static final String DEFAULT_FILE_IO_BUFFER_ENABLED = "true";
+
+  // Minimum buffer size of data files and log files which are generally large in size
+  public static final String MIN_DATA_FILE_IO_BUFFER_SIZE = CONFIG_IO_BUFFER_PREFIX + ".data.min.size";
+  private static final String DEFAULT_MIN_DATA_FILE_IO_BUFFER_SIZE_BYTES = String.valueOf(16 * 1024 * 1024); // 16MB;
+
+  // Minimum size of IO buffer for non-data files
+  public static final String MIN_FILE_IO_BUFFER_SIZE = CONFIG_IO_BUFFER_PREFIX + ".min.size";
+  public static final String DEFAULT_MIN_FILE_IO_BUFFER_SIZE_BYTES = String.valueOf(1 * 1024 * 1024); // 1 MB
+
+  public HoodieWrapperFileSystemConfig(Properties props) {
+    super(props);
+  }
+
+  public static HoodieWrapperFileSystemConfig.Builder newBuilder() {
+    return new HoodieWrapperFileSystemConfig.Builder();
+  }
+
+  public boolean isFileIOBufferingEnabled() {
+    return Boolean.parseBoolean(props.getProperty(FILE_IO_BUFFER_ENABLED, DEFAULT_FILE_IO_BUFFER_ENABLED));
+  }
+
+  public int getFileIOBufferMinSize() {
+    return Integer.parseInt(props.getProperty(MIN_FILE_IO_BUFFER_SIZE, DEFAULT_MIN_FILE_IO_BUFFER_SIZE_BYTES));
+  }
+
+  public int getDataFileIOBufferMinSize() {
+    return Integer.parseInt(props.getProperty(MIN_DATA_FILE_IO_BUFFER_SIZE, DEFAULT_MIN_DATA_FILE_IO_BUFFER_SIZE_BYTES));
+  }
+
+  public static class Builder {
+
+    private final Properties props = new Properties();
+
+    public Builder fromFile(File propertiesFile) throws IOException {
+      try (FileReader reader = new FileReader(propertiesFile)) {
+        this.props.load(reader);
+        return this;
+      }
+    }
+
+    public Builder fromProperties(Properties props) {
+      this.props.putAll(props);
+      return this;
+    }
+
+    public Builder withFileIOBufferingEnabled(boolean enabled) {
+      props.setProperty(FILE_IO_BUFFER_ENABLED, String.valueOf(enabled));
+      return this;
+    }
+
+    public Builder withMinDataFileIOBufferSize(int sizeInBytes) {
+      props.setProperty(MIN_DATA_FILE_IO_BUFFER_SIZE, String.valueOf(sizeInBytes));
+      return this;
+    }
+
+    public Builder withMinFileIOBufferSize(int sizeInBytes) {
+      props.setProperty(MIN_FILE_IO_BUFFER_SIZE, String.valueOf(sizeInBytes));
+      return this;
+    }
+
+    public HoodieWrapperFileSystemConfig build() {
+      HoodieWrapperFileSystemConfig config = new HoodieWrapperFileSystemConfig(props);
+      setDefaultOnCondition(props, !props.containsKey(FILE_IO_BUFFER_ENABLED), FILE_IO_BUFFER_ENABLED,
+          String.valueOf(DEFAULT_FILE_IO_BUFFER_ENABLED));
+      setDefaultOnCondition(props, !props.containsKey(MIN_DATA_FILE_IO_BUFFER_SIZE), MIN_DATA_FILE_IO_BUFFER_SIZE,
+          String.valueOf(DEFAULT_MIN_DATA_FILE_IO_BUFFER_SIZE_BYTES));
+      setDefaultOnCondition(props, !props.containsKey(MIN_FILE_IO_BUFFER_SIZE), MIN_FILE_IO_BUFFER_SIZE,
+          String.valueOf(DEFAULT_MIN_FILE_IO_BUFFER_SIZE_BYTES));
+      return config;
+    }
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
@@ -54,6 +54,10 @@ public abstract class HoodieEngineContext {
     return taskContextSupplier;
   }
 
+  public void setHadoopConfig(String name, String value) {
+    getHadoopConf().get().set(name, value);
+  }
+
   public abstract <I, O> List<O> map(List<I> data, SerializableFunction<I, O> func, int parallelism);
 
   public abstract <I, O> List<O> flatMap(List<I> data, SerializableFunction<I, Stream<O>> func, int parallelism);

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/BufferedSizeAwareOutputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/BufferedSizeAwareOutputStream.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.fs;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+
+/**
+ * Wrapper over <code>BufferedOutputStream</code> which can return the number of buffered bytes.
+ */
+public class BufferedSizeAwareOutputStream extends BufferedOutputStream {
+
+  public BufferedSizeAwareOutputStream(OutputStream out, int size) {
+    super(out, size);
+  }
+
+  public long getBytesBuffered() {
+    return count;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/TimedFSInputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/TimedFSInputStream.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.fs;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSInputStream;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * A wrapper over <code>FSInputStream</code> that also times the operations.
+ */
+public class TimedFSInputStream extends FSInputStream {
+
+  private FSDataInputStream in;
+  private Path path;
+
+  public TimedFSInputStream(Path p, FSDataInputStream in) {
+    this.in = in;
+    this.path = p;
+  }
+
+  @Override
+  public int read() throws IOException {
+    return HoodieWrapperFileSystem.executeFuncWithTimeAndByteMetrics(HoodieWrapperFileSystem.MetricName.read.name(),
+        path, 4, () -> {
+          return in.read();
+        });
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return HoodieWrapperFileSystem.executeFuncWithTimeAndByteMetrics(HoodieWrapperFileSystem.MetricName.read.name(),
+        path, () -> {
+          return in.read(b, off, len);
+        });
+  }
+
+  @Override
+  public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+    return HoodieWrapperFileSystem.executeFuncWithTimeAndByteMetrics(HoodieWrapperFileSystem.MetricName.read.name(),
+        path, () -> {
+          return in.read(position, buffer, offset, length);
+        });
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    HoodieWrapperFileSystem.executeFuncWithTimeAndByteMetrics(HoodieWrapperFileSystem.MetricName.read.name(),
+        path, length, () -> {
+          in.readFully(position, buffer, offset, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer) throws IOException {
+    HoodieWrapperFileSystem.executeFuncWithTimeAndByteMetrics(HoodieWrapperFileSystem.MetricName.read.name(),
+        path, buffer.length, () -> {
+          in.readFully(position, buffer);
+          return null;
+        });
+  }
+
+  @Override
+  public void seek(long pos) throws IOException {
+    in.seek(pos);
+  }
+
+  @Override
+  public long skip(long pos) throws IOException {
+    return in.skip(pos);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return in.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return in.getPos();
+  }
+
+  @Override
+  public boolean seekToNewSource(long targetPos) throws IOException {
+    return in.seekToNewSource(targetPos);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -18,6 +18,14 @@
 
 package org.apache.hudi.common.model;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.fs.FSUtils;
+
 /**
  * Hoodie file format.
  */
@@ -27,6 +35,10 @@ public enum HoodieFileFormat {
   HFILE(".hfile");
 
   private final String extension;
+  private static final Set<String> BASE_FILE_EXTENSIONS = Arrays.stream(HoodieFileFormat.values())
+      .map(HoodieFileFormat::getFileExtension)
+      .filter(x -> !x.equals(HoodieFileFormat.HOODIE_LOG.getFileExtension()))
+      .collect(Collectors.toCollection(HashSet::new));
 
   HoodieFileFormat(String extension) {
     this.extension = extension;
@@ -34,5 +46,10 @@ public enum HoodieFileFormat {
 
   public String getFileExtension() {
     return extension;
+  }
+
+  public static boolean isBaseFile(Path path) {
+    String extension = FSUtils.getFileExtension(path.getName());
+    return BASE_FILE_EXTENSIONS.contains(extension);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -79,15 +79,12 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       this.inputStream = new TimedFSDataInputStream(logFile.getPath(), new FSDataInputStream(
           new BufferedFSInputStream((FSInputStream) ((
               (FSDataInputStream) fsDataInputStream.getWrappedStream()).getWrappedStream()), bufferSize)));
-    } else if (fsDataInputStream.getWrappedStream() instanceof FSInputStream) {
-      this.inputStream = new TimedFSDataInputStream(logFile.getPath(), new FSDataInputStream(
-          new BufferedFSInputStream((FSInputStream) fsDataInputStream.getWrappedStream(), bufferSize)));
     } else {
-      // fsDataInputStream.getWrappedStream() maybe a BufferedFSInputStream
-      // need to wrap in another BufferedFSInputStream the make bufferSize work?
       this.inputStream = fsDataInputStream;
     }
 
+    LOG.info("Opened inputstream of type " + this.inputStream.getClass().getName() + "  wrapping over "
+        + inputStream.getWrappedStream().getClass().getName() + " with buffersize " + bufferSize);
     this.logFile = logFile;
     this.readerSchema = readerSchema;
     this.readBlockLazily = readBlockLazily;


### PR DESCRIPTION

## What is the purpose of the pull request

Input and Output streams created in HUDI through calls to HoodieWrapperFileSystem do not include any buffering unless the underlying file system implements buffering.

This patch introduces buffering at the HoodieWrapperFileSystem level so that all types of reads and writes benefit from buffering.

## Brief change log

HoodieWrapperFileSystem changed to introduce BufferedStreams.

## Verify this pull request

This pull request is already covered by existing tests.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.