### PR TITLE
[MINOR] Fixing the default value for source ordering field in payload config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
@@ -65,7 +65,7 @@ public class HoodiePayloadConfig extends DefaultHoodieConfig {
 
     public HoodiePayloadConfig build() {
       HoodiePayloadConfig config = new HoodiePayloadConfig(props);
-      setDefaultOnCondition(props, !props.containsKey(PAYLOAD_ORDERING_FIELD_PROP), DEFAULT_PAYLOAD_ORDERING_FIELD_VAL,
+      setDefaultOnCondition(props, !props.containsKey(PAYLOAD_ORDERING_FIELD_PROP), PAYLOAD_ORDERING_FIELD_PROP,
           String.valueOf(DEFAULT_PAYLOAD_ORDERING_FIELD_VAL));
       return config;
     }


### PR DESCRIPTION
## What is the purpose of the pull request

Fixing the default value for source ordering field for payload config

## Brief change log

*(for example:)*
  - Fixing the default value for source ordering field for payload config

## Verify this pull request
Fix is wrt default and should not affect is users are setting it explicitly. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.