### PR TITLE
[HUDI-1446] Support skip bootstrapIndex's init in abstract fs view init

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.bootstrap.selector.MetadataOnlyBootstrapModeSelect
 import org.apache.hudi.client.bootstrap.translator.IdentityBootstrapPartitionPathTranslator;
 import org.apache.hudi.common.bootstrap.index.HFileBootstrapIndex;
 import org.apache.hudi.common.config.DefaultHoodieConfig;
+import org.apache.hudi.common.table.HoodieTableConfig;
 
 import java.io.File;
 import java.io.FileReader;
@@ -135,7 +136,7 @@ public class HoodieBootstrapConfig extends DefaultHoodieConfig {
           BOOTSTRAP_MODE_SELECTOR_REGEX_MODE, DEFAULT_BOOTSTRAP_MODE_SELECTOR_REGEX_MODE);
       BootstrapMode.valueOf(props.getProperty(BOOTSTRAP_MODE_SELECTOR_REGEX_MODE));
       setDefaultOnCondition(props, !props.containsKey(BOOTSTRAP_INDEX_CLASS_PROP), BOOTSTRAP_INDEX_CLASS_PROP,
-          DEFAULT_BOOTSTRAP_INDEX_CLASS);
+          HoodieTableConfig.getDefaultBootstrapIndexClass(props));
       setDefaultOnCondition(props, !props.containsKey(FULL_BOOTSTRAP_INPUT_PROVIDER), FULL_BOOTSTRAP_INPUT_PROVIDER,
           DEFAULT_FULL_BOOTSTRAP_INPUT_PROVIDER);
       return config;

--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/BootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/BootstrapIndex.java
@@ -64,10 +64,14 @@ public abstract class BootstrapIndex implements Serializable {
    * @return
    */
   public final boolean useIndex() {
-    boolean validInstantTime = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().lastInstant()
-        .map(i -> HoodieTimeline.compareTimestamps(i.getTimestamp(), HoodieTimeline.GREATER_THAN_OR_EQUALS,
-            HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS)).orElse(false);
-    return  validInstantTime && metaClient.getTableConfig().getBootstrapBasePath().isPresent() && isPresent();
+    if (isPresent()) {
+      boolean validInstantTime = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().lastInstant()
+          .map(i -> HoodieTimeline.compareTimestamps(i.getTimestamp(), HoodieTimeline.GREATER_THAN_OR_EQUALS,
+              HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS)).orElse(false);
+      return validInstantTime && metaClient.getTableConfig().getBootstrapBasePath().isPresent();
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/NoOpBootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/NoOpBootstrapIndex.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.bootstrap.index;
+
+import org.apache.hudi.common.model.BootstrapFileMapping;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+
+import java.util.List;
+
+/**
+ * No Op Bootstrap Index , which is a empty implement and not do anything.
+ */
+public class NoOpBootstrapIndex extends BootstrapIndex {
+
+  public NoOpBootstrapIndex(HoodieTableMetaClient metaClient) {
+    super(metaClient);
+  }
+
+  @Override
+  public IndexReader createReader() {
+    throw new RuntimeException("DefaultBootstrapIndex not support create reader!");
+  }
+
+  @Override
+  public IndexWriter createWriter(String sourceBasePath) {
+    throw new RuntimeException("DefaultBootstrapIndex not support create writer!");
+  }
+
+  @Override
+  public void dropIndex() {
+    throw new RuntimeException("DefaultBootstrapIndex not support drop index!");
+  }
+
+  @Override
+  protected boolean isPresent() {
+    return false;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/NoOpBootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/NoOpBootstrapIndex.java
@@ -18,10 +18,7 @@
 
 package org.apache.hudi.common.bootstrap.index;
 
-import org.apache.hudi.common.model.BootstrapFileMapping;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-
-import java.util.List;
 
 /**
  * No Op Bootstrap Index , which is a empty implement and not do anything.

--- a/hudi-common/src/test/java/org/apache/hudi/common/bootstrap/TestBootstrapIndex.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/bootstrap/TestBootstrapIndex.java
@@ -24,12 +24,15 @@ import org.apache.hudi.avro.model.HoodiePath;
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex;
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex.IndexWriter;
 import org.apache.hudi.common.bootstrap.index.HFileBootstrapIndex;
+import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
 import org.apache.hudi.common.model.BootstrapFileMapping;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.collection.Pair;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 
 import java.io.IOException;
@@ -40,6 +43,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -83,6 +87,21 @@ public class TestBootstrapIndex extends HoodieCommonTestHarness {
 
     // Run again this time recreating bootstrap index
     testBootstrapIndexOneRound(5);
+  }
+
+  @Test
+  public void testNoOpBootstrapIndex() throws IOException {
+    Map<String, String> props = metaClient.getTableConfig().getProps();
+    props.put(HoodieTableConfig.HOODIE_BOOTSTRAP_INDEX_ENABLE, "false");
+    Properties properties = new Properties();
+    for (Map.Entry<String, String> prop : props.entrySet()) {
+      properties.setProperty(prop.getKey(), prop.getValue());
+    }
+    HoodieTableConfig.createHoodieProperties(metaClient.getFs(), new Path(metaClient.getMetaPath()), properties);
+
+    metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).build();
+    BootstrapIndex bootstrapIndex = BootstrapIndex.getBootstrapIndex(metaClient);
+    assert (bootstrapIndex instanceof NoOpBootstrapIndex);
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
@@ -411,7 +411,7 @@ class HoodieSparkSqlWriterSuite extends FunSuite with Matchers {
         initSparkContext("test_schema_evolution")
         val path = java.nio.file.Files.createTempDirectory("hoodie_test_path")
         try {
-          val hoodieFooTableName = "hoodie_foo_tbl"
+          val hoodieFooTableName = "hoodie_foo_tbl_" + tableType
           //create a new table
           val fooTableModifier = Map("path" -> path.toAbsolutePath.toString,
             HoodieWriteConfig.TABLE_NAME -> hoodieFooTableName,


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Support skip bootstrapIndex's init in abstract fs view init

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.