### PR TITLE
[HUDI-1579] Trying out github auto labelling for issues

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,15 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          labels-synonyms: '{"bug":["error","need fix","not working"],"enhancement":["upgrade"],"question":["help"]}'
+          labels-not-allowed: '["good first issue"]'
+          default-labels: '["help wanted"]'


### PR DESCRIPTION
## What is the purpose of the pull request

*Adding auto labelling actions to github issues
Reference: https://github.com/marketplace/actions/auto-label

## Brief change log

  - Adding auto labelling actions to github issues

## Verify this pull request

- have not verified. will verify once landed. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.