### PR TITLE
[HUDI-1582] Throw an exception when syncHoodieTable() fails, with RuntimeException

### DIFF
--- a/hudi-sync/hudi-dla-sync/src/main/java/org/apache/hudi/dla/DLASyncTool.java
+++ b/hudi-sync/hudi-dla-sync/src/main/java/org/apache/hudi/dla/DLASyncTool.java
@@ -102,7 +102,7 @@ public class DLASyncTool extends AbstractSyncTool {
           throw new InvalidTableException(hoodieDLAClient.getBasePath());
       }
     } catch (RuntimeException re) {
-      LOG.error("Got runtime exception when dla syncing", re);
+      throw new HoodieException("Got runtime exception when dla syncing " + cfg.tableName, re);
     } finally {
       hoodieDLAClient.close();
     }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -21,6 +21,7 @@ package org.apache.hudi.hive;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.hudi.sync.common.AbstractSyncHoodieClient.PartitionEvent;
@@ -104,7 +105,7 @@ public class HiveSyncTool extends AbstractSyncTool {
           throw new InvalidTableException(hoodieHiveClient.getBasePath());
       }
     } catch (RuntimeException re) {
-      LOG.error("Got runtime exception when hive syncing", re);
+      throw new HoodieException("Got runtime exception when hive syncing " + cfg.tableName, re);
     } finally {
       hoodieHiveClient.close();
     }


### PR DESCRIPTION
## What is the purpose of the pull request

Fixes the issue of silent failure from HiveSyncTool by throwing an exception, when syncHoodieTable() fails with RuntimeException (caused by an invalid schema).

## Brief change log
Modified syncHoodieTable() to throw a HoodieException, when hiveSync fails with RuntimeException.

## Verify this pull request

This change added tests and can be verified as follows:
  - Manually verified the change by running a job locally.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green
