### PR TITLE
[HUDI-1584] Modify maker file path, which should start with the target base path.

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -297,6 +297,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
       fs.delete(fileStatus.getPath(), true);
     }
   }
+
   private Path generateCurrentMakerPath() {
     String baseDir = cfg.targetBasePath.endsWith("/")
             ? cfg.targetBasePath.substring(0, cfg.targetBasePath.length() - 1)

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -298,15 +298,12 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
     }
   }
 
-  private Path generateCurrentMakerPath() {
-    String baseDir = cfg.targetBasePath.endsWith("/")
-            ? cfg.targetBasePath.substring(0, cfg.targetBasePath.length() - 1)
-            : cfg.targetBasePath;
-    Path auxPath = new Path(baseDir, HoodieTableMetaClient.AUXILIARYFOLDER_NAME);
+  private Path generateCurrentMakerDirPath() {
+    Path auxPath = new Path(cfg.targetBasePath, HoodieTableMetaClient.AUXILIARYFOLDER_NAME);
     return new Path(auxPath, INSTANT_MARKER_FOLDER_NAME);
   }
 
   private Path generateCurrentMakerFilePath(String instantMarkerFileName) {
-    return new Path(generateCurrentMakerPath(), instantMarkerFileName);
+    return new Path(generateCurrentMakerDirPath(), instantMarkerFileName);
   }
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -245,7 +245,7 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
   private boolean checkReceivedData(long checkpointId) throws InterruptedException, IOException {
     int numberOfParallelSubtasks = runtimeContext.getNumberOfParallelSubtasks();
     FileStatus[] fileStatuses;
-    Path instantMarkerPath = generateCurrentMakerPath();
+    Path instantMarkerPath = generateCurrentMakerDirPath();
     // waiting all subtask create marker file ready
     while (true) {
       Thread.sleep(500L);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

The maker file path should start with the target base path that was set by user.

## Brief change log

  - Add two functions to generate the path in `InstantGenerateOperator.java`.

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

This change added tests and can be verified as follows:

  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.