### PR TITLE
[HUDI-1589] Fix Rollback Metadata AVRO backwards incompatiblity

### DIFF
--- a/hudi-common/src/main/avro/HoodieRollbackMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRollbackMetadata.avsc
@@ -31,22 +31,22 @@
             {"name": "partitionPath", "type": "string"},
             {"name": "successDeleteFiles", "type": {"type": "array", "items": "string"}},
             {"name": "failedDeleteFiles", "type": {"type": "array", "items": "string"}},
-            {"name": "rollbackLogFiles", "type": {
+            {"name": "rollbackLogFiles", "type": ["null", {
                 "type": "map",
                 "doc": "Files to which append blocks were written to capture rollback commit",
                 "values": {
                     "type": "long",
                     "doc": "Size of this file in bytes"
                 }
-            }},
-            {"name": "writtenLogFiles", "type": {
+            }], "default":null },
+            {"name": "writtenLogFiles", "type": ["null", {
                 "type": "map",
                 "doc": "Log files written that were expected to be rolledback",
                  "values": {
                     "type": "long",
                     "doc": "Size of this file in bytes"
                 }
-            }}
+            }], "default":null }
         ]
      }}},
      {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Fix Rollback Metadata AVRO backwards incompatiblity, this was introduced in https://github.com/apache/hudi/commit/e3d3677b7e7899705b624925666317f0c074f7c7#diff-9f6615efb217f3b41c27bb6d95ad5c034393002ed1b9778925ef9d22bdbbc7e3

## Brief change log

- Add default value "null" for new introduced fields

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.