### PR TITLE
[HUDI-1596] NPE while getting option PATH from configuration.

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/InstantGenerateOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.operator;
 
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.streamer.FlinkStreamerConfig;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
@@ -112,7 +113,9 @@ public class InstantGenerateOperator extends AbstractStreamOperator<HoodieRecord
       TaskContextSupplier taskContextSupplier = new FlinkTaskContextSupplier(null);
 
       // writeClient
-      writeClient = new HoodieFlinkWriteClient(new HoodieFlinkEngineContext(taskContextSupplier), StreamerUtil.getHoodieClientConfig(cfg), true);
+      final org.apache.flink.configuration.Configuration conf = FlinkOptions.fromStreamerConfig(cfg);
+      final HoodieWriteConfig hoodieClientConfig = StreamerUtil.getHoodieClientConfig(conf);
+      writeClient = new HoodieFlinkWriteClient(new HoodieFlinkEngineContext(taskContextSupplier), hoodieClientConfig, true);
 
       // init table, create it if not exists.
       initTable();

--- a/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/operator/KeyedWriteProcessFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.operator;
 
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.streamer.FlinkStreamerConfig;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
@@ -95,7 +96,9 @@ public class KeyedWriteProcessFunction extends KeyedProcessFunction<String, Hood
     HoodieFlinkEngineContext context =
         new HoodieFlinkEngineContext(new SerializableConfiguration(new org.apache.hadoop.conf.Configuration()), new FlinkTaskContextSupplier(getRuntimeContext()));
 
-    writeClient = new HoodieFlinkWriteClient<>(context, StreamerUtil.getHoodieClientConfig(cfg));
+    final Configuration conf = FlinkOptions.fromStreamerConfig(cfg);
+    final HoodieWriteConfig hoodieClientConfig = StreamerUtil.getHoodieClientConfig(conf);
+    writeClient = new HoodieFlinkWriteClient<>(context, hoodieClientConfig);
   }
 
   @Override

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/CommitSink.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/CommitSink.java
@@ -23,8 +23,10 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieFlinkStreamerException;
+import org.apache.hudi.operator.FlinkOptions;
 import org.apache.hudi.streamer.FlinkStreamerConfig;
 import org.apache.hudi.util.StreamerUtil;
 
@@ -77,7 +79,11 @@ public class CommitSink extends RichSinkFunction<Tuple3<String, List<WriteStatus
     writeParallelSize = getRuntimeContext().getExecutionConfig().getParallelism();
 
     // writeClient
-    writeClient = new HoodieFlinkWriteClient<>(new HoodieFlinkEngineContext(new FlinkTaskContextSupplier(null)), StreamerUtil.getHoodieClientConfig(cfg));
+    final Configuration conf = FlinkOptions.fromStreamerConfig(cfg);
+    final HoodieWriteConfig hoodieClientConfig = StreamerUtil.getHoodieClientConfig(conf);
+    final HoodieFlinkEngineContext context = new HoodieFlinkEngineContext(new FlinkTaskContextSupplier(null));
+
+    writeClient = new HoodieFlinkWriteClient<>(context, hoodieClientConfig);
   }
 
   @Override

--- a/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -220,6 +220,7 @@ public class StreamerUtil {
                     .build())
             .forTable(conf.getString(FlinkOptions.TABLE_NAME))
             .withAutoCommit(false)
+            .withEmbeddedTimelineServerEnabled(conf.getBoolean(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLED, true))
             .withProps(flinkConf2TypedProperties(FlinkOptions.flatOptions(conf)));
 
     builder = builder.withSchema(getSourceSchema(conf).toString());


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

 This pull request fixes the bug that throwing NPE while getting option PATH from configuration and adds the embedded time line server option.

## Brief change log

  - *Modify the configuration for `writeClient` during flink operator initialization.*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.