### PR TITLE
[HUDI-1597]remove deprecated spring repos from pom 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -948,14 +948,6 @@
       <id>confluent</id>
       <url>https://packages.confluent.io/maven/</url>
     </repository>
-    <repository>
-      <id>libs-milestone</id>
-      <url>https://repo.spring.io/libs-milestone/</url>
-    </repository>
-    <repository>
-      <id>libs-release</id>
-      <url>https://repo.spring.io/libs-release/</url>
-    </repository>
   </repositories>
 
   <profiles>


### PR DESCRIPTION
- maven build fail as spring repo no longer support anonymous download of 3rd-party Maven Central artifacts from repo.spring.io. backport the fix from master branch.


## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

remove deprecated spring repos from pom

## Brief change log

remove deprecated spring repos from pom.xml

## Verify this pull request

This change added tests and can be verified as follows:
  - run maven build successfully

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.