### PR TITLE
[HUDI-1606]align BaseJavaCommitActionExecuto#execute method with BaseSparkCommitActionExecutor

### DIFF
--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/BaseJavaCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/BaseJavaCommitActionExecutor.java
@@ -120,7 +120,7 @@ public abstract class BaseJavaCommitActionExecutor<T extends HoodieRecordPayload
         handleInsertPartition(instantTime, partition, records.iterator(), partitioner).forEachRemaining(writeStatuses::addAll);
       }
     });
-    updateIndex(writeStatuses, result);
+    updateIndexAndCommitIfNeeded(writeStatuses, result);
     return result;
   }
 
@@ -130,6 +130,11 @@ public abstract class BaseJavaCommitActionExecutor<T extends HoodieRecordPayload
     List<WriteStatus> statuses = table.getIndex().updateLocation(writeStatuses, context, table);
     result.setIndexUpdateDuration(Duration.between(indexStartTime, Instant.now()));
     result.setWriteStatuses(statuses);
+  }
+
+  protected void updateIndexAndCommitIfNeeded(List<WriteStatus> writeStatuses, HoodieWriteMetadata<List<WriteStatus>> result) {
+    updateIndex(writeStatuses, result);
+    commitOnAutoCommit(result);
   }
 
   @Override

--- a/hudi-examples/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
+++ b/hudi-examples/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
@@ -20,7 +20,6 @@ package org.apache.hudi.examples.java;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.client.HoodieJavaWriteClient;
-import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieAvroPayload;
@@ -94,8 +93,7 @@ public class HoodieJavaWriteClientExample {
     List<HoodieRecord<HoodieAvroPayload>> recordsSoFar = new ArrayList<>(records);
     List<HoodieRecord<HoodieAvroPayload>> writeRecords =
         recordsSoFar.stream().map(r -> new HoodieRecord<HoodieAvroPayload>(r)).collect(Collectors.toList());
-    List<WriteStatus> insertStatus = client.upsert(writeRecords, newCommitTime);
-    client.commit(newCommitTime,insertStatus);
+    client.upsert(writeRecords, newCommitTime);
 
     // updates
     newCommitTime = client.startCommit();

--- a/hudi-examples/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
+++ b/hudi-examples/src/main/java/org/apache/hudi/examples/java/HoodieJavaWriteClientExample.java
@@ -20,6 +20,7 @@ package org.apache.hudi.examples.java;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieAvroPayload;
@@ -93,7 +94,8 @@ public class HoodieJavaWriteClientExample {
     List<HoodieRecord<HoodieAvroPayload>> recordsSoFar = new ArrayList<>(records);
     List<HoodieRecord<HoodieAvroPayload>> writeRecords =
         recordsSoFar.stream().map(r -> new HoodieRecord<HoodieAvroPayload>(r)).collect(Collectors.toList());
-    client.upsert(writeRecords, newCommitTime);
+    List<WriteStatus> insertStatus = client.upsert(writeRecords, newCommitTime);
+    client.commit(newCommitTime,insertStatus);
 
     // updates
     newCommitTime = client.startCommit();


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

run HoodieJavaWriteClientExample locally ,the code fail with exception. The root cause is that BaseJavaCommitActionExecutor#execute method does not commit the index when it is needed. 
the PR is to fix the issue. 

## Brief change log
org.apache.hudi.table.action.commit.BaseJavaCommitActionExecutor

## Verify this pull request
This pull request is already covered by existing tests: HoodieJavaWriteClientExample.main()
I manually verified the change by running a job locally.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.