### PR TITLE
[HUDI-1540] Fixing commons codec depedency in bundle jars

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -112,6 +112,7 @@
                   <include>org.apache.hbase:hbase-protocol</include>
                   <include>org.apache.hbase:hbase-server</include>
                   <include>org.apache.htrace:htrace-core</include>
+                  <include>commons-codec:commons-codec</include> 
                 </includes>
               </artifactSet>
               <relocations>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -123,6 +123,7 @@
                   <include>org.apache.hbase:hbase-protocol</include>
                   <include>org.apache.hbase:hbase-server</include>
                   <include>org.apache.htrace:htrace-core</include>
+                  <include>commons-codec:commons-codec</include>
                 </includes>
               </artifactSet>
               <relocations>


### PR DESCRIPTION
## What is the purpose of the pull request

*commons-codec wasn't pulled in from any of the dep. So had to explicitly add it in our bundles*

## Brief change log

*(for example:)*
  - *Added commons-codec dependency to spark and utilities bundle*

## Verify this pull request

manually verified. 
```
tar -tvf packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.11-0.8.0-SNAPSHOT.jar | grep commons-codec
drwxrwxr-x  0 0      0           0 Feb 10 07:59 META-INF/maven/commons-codec/
drwxrwxr-x  0 0      0           0 Feb 10 07:59 META-INF/maven/commons-codec/commons-codec/
-rw-rw-r--  0 0      0       10494 Aug  6  2009 META-INF/maven/commons-codec/commons-codec/pom.xml
-rw-rw-r--  0 0      0         114 Aug  6  2009 META-INF/maven/commons-codec/commons-codec/pom.properties
sivabala-C02XG219JGH6:hudi sivabala$ tar -tvf packaging/hudi-spark-bundle/target/hudi-spark-bundle_2.11-0.8.0-SNAPSHOT.jar | grep commons-codec
drwxrwxr-x  0 0      0           0 Feb 10 08:00 META-INF/maven/commons-codec/
drwxrwxr-x  0 0      0           0 Feb 10 08:00 META-INF/maven/commons-codec/commons-codec/
-rw-rw-r--  0 0      0       10494 Aug  6  2009 META-INF/maven/commons-codec/commons-codec/pom.xml
-rw-rw-r--  0 0      0         114 Aug  6  2009 META-INF/maven/commons-codec/commons-codec/pom.properties
```


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.