### PR TITLE
[HUDI-1611] Added a configuration to allow specific directories to be filtered out during Metadata Table bootstrap.

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
@@ -149,14 +149,22 @@ public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
     final String nonPartitionDirectory = HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[0] + "-nonpartition";
     Files.createDirectories(Paths.get(basePath, nonPartitionDirectory));
 
+    // Three directories which are partitions but will be ignored due to filter
+    final String filterDirRegex = ".*-filterDir\\d|\\..*";
+    final String filteredDirectoryOne = HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[0] + "-filterDir1";
+    final String filteredDirectoryTwo = HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[0] + "-filterDir2";
+    final String filteredDirectoryThree = ".backups";
+
     // Create some commits
     HoodieTestTable testTable = HoodieTestTable.of(metaClient);
-    testTable.withPartitionMetaFiles("p1", "p2")
+    testTable.withPartitionMetaFiles("p1", "p2", filteredDirectoryOne, filteredDirectoryTwo, filteredDirectoryThree)
         .addCommit("001").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10, 10)
         .addCommit("002").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10, 10, 10)
         .addInflightCommit("003").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10);
 
-    try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, getWriteConfig(true, true))) {
+    final HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withDirectoryFilterRegex(filterDirRegex).build()).build();
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       client.startCommitWithTime("005");
 
       List<String> partitions = metadataWriter(client).metadata().getAllPartitionPaths();
@@ -164,6 +172,13 @@ public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
           "Must not contain the non-partition " + nonPartitionDirectory);
       assertTrue(partitions.contains("p1"), "Must contain partition p1");
       assertTrue(partitions.contains("p2"), "Must contain partition p2");
+
+      assertFalse(partitions.contains(filteredDirectoryOne),
+          "Must not contain the filtered directory " + filteredDirectoryOne);
+      assertFalse(partitions.contains(filteredDirectoryTwo),
+          "Must not contain the filtered directory " + filteredDirectoryTwo);
+      assertFalse(partitions.contains(filteredDirectoryThree),
+          "Must not contain the filtered directory " + filteredDirectoryThree);
 
       FileStatus[] statuses = metadata(client).getAllFilesInPartition(new Path(basePath, "p1"));
       assertTrue(statuses.length == 2);

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -75,6 +75,10 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
   public static final String ENABLE_FALLBACK_PROP = METADATA_PREFIX + ".fallback.enable";
   public static final String DEFAULT_ENABLE_FALLBACK = "true";
 
+  // Regex to filter out matching directories during bootstrap
+  public static final String DIRECTORY_FILTER_REGEX = METADATA_PREFIX + ".dir.filter.regex";
+  public static final String DEFAULT_DIRECTORY_FILTER_REGEX = "";
+
   public static final String HOODIE_ASSUME_DATE_PARTITIONING_PROP = "hoodie.assume.date.partitioning";
   public static final String DEFAULT_ASSUME_DATE_PARTITIONING = "false";
 
@@ -115,6 +119,10 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
 
   public boolean enableMetrics() {
     return Boolean.parseBoolean(props.getProperty(METADATA_METRICS_ENABLE_PROP));
+  }
+
+  public String getDirectoryFilterRegex() {
+    return props.getProperty(DIRECTORY_FILTER_REGEX);
   }
 
   public static class Builder {
@@ -194,6 +202,11 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder withDirectoryFilterRegex(String regex) {
+      props.setProperty(DIRECTORY_FILTER_REGEX, regex);
+      return this;
+    }
+
     public HoodieMetadataConfig build() {
       HoodieMetadataConfig config = new HoodieMetadataConfig(props);
       setDefaultOnCondition(props, !props.containsKey(METADATA_ENABLE_PROP), METADATA_ENABLE_PROP,
@@ -222,6 +235,8 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
           DEFAULT_ENABLE_FALLBACK);
       setDefaultOnCondition(props, !props.containsKey(ENABLE_REUSE_PROP), ENABLE_REUSE_PROP,
           DEFAULT_ENABLE_REUSE);
+      setDefaultOnCondition(props, !props.containsKey(DIRECTORY_FILTER_REGEX), DIRECTORY_FILTER_REGEX,
+          DEFAULT_DIRECTORY_FILTER_REGEX);
       return config;
     }
   }


### PR DESCRIPTION

## What is the purpose of the pull request
During the bootstrap of the Metadata Table, all the directories which contain the partition metadata directory are assumed to be partitions and are added to the metadata table.

In our HDFS clusters, we have directories like .backup, .temp which are used by various teams for non-hoodie purposes (e.g. .backup may be keeping a snapshot of the dataset). During bootstrap, Metadata Table ends up containing all those paths also as partitions.

In this patch, I would like to introduce a configuration for HoodieMetadataConfig to filter out some directories based on a regular expression string. 

## Brief change log

Added a config to HoodieMetadataConfig.
Added a unit test.

## Verify this pull request

This change added tests and can be verified as follows:

Extended the unit test TestHoodieBackedMetadata#testOnlyValidPartitionsAdded 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.