### PR TITLE
[DOCS] Fix hoodie.datasource.write.operation in pyspark example

### DIFF
--- a/docs/_docs/0.7.0/1_1_quick_start_guide.md
+++ b/docs/_docs/0.7.0/1_1_quick_start_guide.md
@@ -344,7 +344,7 @@ hudi_options = {
   'hoodie.datasource.write.recordkey.field': 'uuid',
   'hoodie.datasource.write.partitionpath.field': 'partitionpath',
   'hoodie.datasource.write.table.name': tableName,
-  'hoodie.datasource.write.operation': 'insert',
+  'hoodie.datasource.write.operation': 'upsert',
   'hoodie.datasource.write.precombine.field': 'ts',
   'hoodie.upsert.shuffle.parallelism': 2, 
   'hoodie.insert.shuffle.parallelism': 2

--- a/docs/_docs/1_1_quick_start_guide.md
+++ b/docs/_docs/1_1_quick_start_guide.md
@@ -343,7 +343,7 @@ hudi_options = {
   'hoodie.datasource.write.recordkey.field': 'uuid',
   'hoodie.datasource.write.partitionpath.field': 'partitionpath',
   'hoodie.datasource.write.table.name': tableName,
-  'hoodie.datasource.write.operation': 'insert',
+  'hoodie.datasource.write.operation': 'upsert',
   'hoodie.datasource.write.precombine.field': 'ts',
   'hoodie.upsert.shuffle.parallelism': 2, 
   'hoodie.insert.shuffle.parallelism': 2


### PR DESCRIPTION
The rest of the example in this section mentions "Here we are using the default write operation : upsert. If you have a workload without updates, you can also issue insert or bulk_insert operations which could be faster. "