### PR TITLE
[DOCS] UPSERT = no duplicates

### DIFF
--- a/docs/_docs/0.7.0/2_2_writing_data.md
+++ b/docs/_docs/0.7.0/2_2_writing_data.md
@@ -20,7 +20,7 @@ can be chosen/changed across each commit/deltacommit issued against the table.
 
  - **UPSERT** : This is the default operation where the input records are first tagged as inserts or updates by looking up the index. 
  The records are ultimately written after heuristics are run to determine how best to pack them on storage to optimize for things like file sizing. 
- This operation is recommended for use-cases like database change capture where the input almost certainly contains updates.
+ This operation is recommended for use-cases like database change capture where the input almost certainly contains updates. The target table will never show duplicates.
  - **INSERT** : This operation is very similar to upsert in terms of heuristics/file sizing but completely skips the index lookup step. Thus, it can be a lot faster than upserts 
  for use-cases like log de-duplication (in conjunction with options to filter duplicates mentioned below). This is also suitable for use-cases where the table can tolerate duplicates, but just 
  need the transactional writes/incremental pull/storage management capabilities of Hudi.

--- a/docs/_docs/2_2_writing_data.md
+++ b/docs/_docs/2_2_writing_data.md
@@ -19,7 +19,7 @@ can be chosen/changed across each commit/deltacommit issued against the table.
 
  - **UPSERT** : This is the default operation where the input records are first tagged as inserts or updates by looking up the index. 
  The records are ultimately written after heuristics are run to determine how best to pack them on storage to optimize for things like file sizing. 
- This operation is recommended for use-cases like database change capture where the input almost certainly contains updates.
+ This operation is recommended for use-cases like database change capture where the input almost certainly contains updates. The target table will never show duplicates.
  - **INSERT** : This operation is very similar to upsert in terms of heuristics/file sizing but completely skips the index lookup step. Thus, it can be a lot faster than upserts 
  for use-cases like log de-duplication (in conjunction with options to filter duplicates mentioned below). This is also suitable for use-cases where the table can tolerate duplicates, but just 
  need the transactional writes/incremental pull/storage management capabilities of Hudi.


### PR DESCRIPTION
Makes it clearer, ie for example when dealing with data like:

if record key is columnA then the table will get 2 rows if write mode is UPSERT for below incoming data:
row 1: columnA=abc,columnB=def
row 2: columnA=abc,columnB=xyx
row 3: columnA=jkl,columnB=rew

if record key is columnA then the table will get 3 rows if write mode is INSERT for below incoming data:
row 1: columnA=abc,columnB=def
row 2: columnA=abc,columnB=xyx
row 3: columnA=jkl,columnB=rew
