### PR TITLE
[HUDI 1623] Introduce start & end commit times to timeline

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -67,7 +67,7 @@ public class CommitsCommand implements CommandMarker {
     final List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
             .getInstants().collect(Collectors.toList());
     // timeline can be read from multiple files. So sort is needed instead of reversing the collection
-    Collections.sort(commits, HoodieInstant.COMPARATOR.reversed());
+    Collections.sort(commits, HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed());
 
     for (int i = 0; i < commits.size(); i++) {
       final HoodieInstant commit = commits.get(i);
@@ -113,7 +113,7 @@ public class CommitsCommand implements CommandMarker {
     final List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
             .getInstants().collect(Collectors.toList());
     // timeline can be read from multiple files. So sort is needed instead of reversing the collection
-    Collections.sort(commits, HoodieInstant.COMPARATOR.reversed());
+    Collections.sort(commits, HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed());
 
     for (int i = 0; i < commits.size(); i++) {
       final HoodieInstant commit = commits.get(i);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
@@ -92,7 +92,7 @@ public class TestTableCommand extends AbstractShellIntegrationTest {
 
     // Check default values
     assertFalse(conf.isConsistencyCheckEnabled());
-    assertEquals(new Integer(1), HoodieCLI.layoutVersion.getVersion());
+    assertEquals(new Integer(2), HoodieCLI.layoutVersion.getVersion());
   }
 
   /**
@@ -109,7 +109,7 @@ public class TestTableCommand extends AbstractShellIntegrationTest {
     assertEquals(tablePath, client.getBasePath());
     assertEquals(metaPath, client.getMetaPath());
     assertEquals(HoodieTableType.COPY_ON_WRITE, client.getTableType());
-    assertEquals(new Integer(1), client.getTimelineLayoutVersion().getVersion());
+    assertEquals(new Integer(2), client.getTimelineLayoutVersion().getVersion());
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestBootstrapCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestBootstrapCommand.java
@@ -85,7 +85,7 @@ public class ITTestBootstrapCommand extends AbstractShellIntegrationTest {
     assertTrue(cr.isSuccess());
 
     // Connect & check Hudi table exist
-    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_2, false, 2000, 300000, 7);
     metaClient = HoodieCLI.getTableMetaClient();
     assertEquals(1, metaClient.getActiveTimeline().getCommitsTimeline().countInstants(), "Should have 1 commit.");
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestHDFSParquetImportCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestHDFSParquetImportCommand.java
@@ -103,7 +103,7 @@ public class ITTestHDFSParquetImportCommand extends AbstractShellIntegrationTest
     assertTrue(Files.exists(Paths.get(metaPath)), "Hoodie table not exist.");
 
     // Load meta data
-    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_2, false, 2000, 300000, 7);
     metaClient = HoodieCLI.getTableMetaClient();
 
     assertEquals(1, metaClient.getActiveTimeline().getCommitsTimeline().countInstants(), "Should only 1 commit.");
@@ -127,7 +127,7 @@ public class ITTestHDFSParquetImportCommand extends AbstractShellIntegrationTest
     dataImporter.dataImport(jsc, 0);
 
     // Load meta data
-    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_2, false, 2000, 300000, 7);
     metaClient = HoodieCLI.getTableMetaClient();
 
     // check if insert instant exist

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1958,7 +1958,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .withFailedWritesCleaningPolicy(cleaningPolicy)
             .withAutoClean(false).build())
-        .withTimelineLayoutVersion(1)
+        .withTimelineLayoutVersion(2)
         .withHeartbeatIntervalInMs(3 * 1000)
         .withAutoCommit(false).build();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -588,7 +588,7 @@ public class HoodieTableMetaClient implements Serializable {
     if (applyLayoutVersionFilters) {
       instantStream = TimelineLayout.getLayout(getTimelineLayoutVersion()).filterHoodieInstants(instantStream);
     }
-    return instantStream.sorted().collect(Collectors.toList());
+    return TimelineLayout.getLayout(getTimelineLayoutVersion()).sortHoodieInstants(instantStream).collect(Collectors.toList());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+import org.apache.hudi.common.table.timeline.versioning.InstantTimeFormatter;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -34,7 +35,6 @@ import org.apache.log4j.Logger;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -59,7 +60,8 @@ import java.util.stream.Collectors;
  */
 public class HoodieActiveTimeline extends HoodieDefaultTimeline {
 
-  public static final SimpleDateFormat COMMIT_FORMATTER = new SimpleDateFormat("yyyyMMddHHmmss");
+  public static final InstantTimeFormatter COMMIT_FORMATTER = new InstantTimeFormatter();
+  public static final Pattern COMMIT_TIME_PATTERN = Pattern.compile("^[0-9]{14}$ | ^[0-9]{17}$");
 
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, REQUESTED_COMMIT_EXTENSION,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -29,6 +29,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -137,6 +138,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieDefaultTimeline findInstantsInRangeByFinishTs(String startTs, String endTs) {
+    return new HoodieDefaultTimeline(
+            instants.stream().filter(s -> HoodieTimeline.isInRange(s.getActionEndTimestamp(), startTs, endTs)), details);
+  }
+
+  @Override
   public HoodieDefaultTimeline findInstantsAfter(String instantTime, int numCommits) {
     return new HoodieDefaultTimeline(instants.stream()
         .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), GREATER_THAN, instantTime)).limit(numCommits),
@@ -160,6 +167,11 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline filter(Predicate<HoodieInstant> filter) {
     return new HoodieDefaultTimeline(instants.stream().filter(filter), details);
+  }
+
+  @Override
+  public HoodieTimeline filterByFinishTs(BiPredicate<String, String> filter, String ts) {
+    return new HoodieDefaultTimeline(instants.stream().filter(s -> filter.test(s.getActionEndTimestamp(), ts)), details);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -167,6 +167,11 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline findInstantsInRange(String startTs, String endTs);
 
   /**
+   * Create a new Timeline with instants after startTs and before or on endTs by finished timestamp of actions.
+   */
+  HoodieTimeline findInstantsInRangeByFinishTs(String first, String endTs);
+
+  /**
    * Create a new Timeline with all the instants after startTs.
    */
   HoodieTimeline findInstantsAfter(String instantTime, int numCommits);
@@ -180,6 +185,11 @@ public interface HoodieTimeline extends Serializable {
    * Custom Filter of Instants.
    */
   HoodieTimeline filter(Predicate<HoodieInstant> filter);
+
+  /**
+   * Custom Filter of instants by their finished Timestamps.
+   */
+  HoodieTimeline filterByFinishTs(BiPredicate<String, String> filter, String ts);
 
   /**
    * If the timeline has any instants.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -86,11 +86,11 @@ public interface HoodieTimeline extends Serializable {
   String INVALID_INSTANT_TS = "0";
 
   // Instant corresponding to pristine state of the table after its creation
-  String INIT_INSTANT_TS = "00000000000000";
+  String INIT_INSTANT_TS = "00000000000000000";
   // Instant corresponding to METADATA bootstrapping of table/partitions
-  String METADATA_BOOTSTRAP_INSTANT_TS = "00000000000001";
+  String METADATA_BOOTSTRAP_INSTANT_TS = "00000000000001000";
   // Instant corresponding to full bootstrapping of table/partitions
-  String FULL_BOOTSTRAP_INSTANT_TS = "00000000000002";
+  String FULL_BOOTSTRAP_INSTANT_TS = "00000000000002000";
 
   /**
    * Filter this timeline to just include the in-flights.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -86,11 +86,11 @@ public interface HoodieTimeline extends Serializable {
   String INVALID_INSTANT_TS = "0";
 
   // Instant corresponding to pristine state of the table after its creation
-  String INIT_INSTANT_TS = "00000000000000000";
+  String INIT_INSTANT_TS = "00000000000000";
   // Instant corresponding to METADATA bootstrapping of table/partitions
-  String METADATA_BOOTSTRAP_INSTANT_TS = "00000000000001000";
+  String METADATA_BOOTSTRAP_INSTANT_TS = "00000000000001";
   // Instant corresponding to full bootstrapping of table/partitions
-  String FULL_BOOTSTRAP_INSTANT_TS = "00000000000002000";
+  String FULL_BOOTSTRAP_INSTANT_TS = "00000000000002";
 
   /**
    * Filter this timeline to just include the in-flights.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineLayout.java
@@ -38,6 +38,7 @@ public abstract class TimelineLayout implements Serializable {
   static {
     LAYOUT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_0), new TimelineLayoutV0());
     LAYOUT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_1), new TimelineLayoutV1());
+    LAYOUT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_2), new TimelineLayoutV2());
   }
 
   public static TimelineLayout getLayout(TimelineLayoutVersion version) {
@@ -45,6 +46,8 @@ public abstract class TimelineLayout implements Serializable {
   }
 
   public abstract Stream<HoodieInstant> filterHoodieInstants(Stream<HoodieInstant> instantStream);
+
+  public abstract Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream);
 
   /**
    * Table Layout where state transitions are managed by renaming files.
@@ -54,6 +57,11 @@ public abstract class TimelineLayout implements Serializable {
     @Override
     public Stream<HoodieInstant> filterHoodieInstants(Stream<HoodieInstant> instantStream) {
       return instantStream;
+    }
+
+    @Override
+    public Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return instantStream.sorted();
     }
   }
 
@@ -73,6 +81,27 @@ public abstract class TimelineLayout implements Serializable {
             }
             return y;
           }).get());
+    }
+
+    @Override
+    public Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return instantStream.sorted();
+    }
+  }
+
+  /**
+   * Table Layout where state transitions are managed by creating new files with END_INSTANT_TIME.
+   */
+  private static class TimelineLayoutV2 extends TimelineLayoutV1 {
+
+    @Override
+    public Stream<HoodieInstant> filterHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return super.filterHoodieInstants(instantStream);
+    }
+
+    @Override
+    public Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return instantStream.sorted(HoodieInstant.END_INSTANT_TIME_COMPARATOR);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This class wraps around the commit time generator and helps to handle version upgrade changes.
+ */
+public class InstantTimeFormatter {
+
+  public static final SimpleDateFormat COMMIT_FORMATTER_V1 = new SimpleDateFormat("yyyyMMddHHmmss");
+  public static final SimpleDateFormat COMMIT_FORMATTER_V2 = new SimpleDateFormat("yyyyMMddHHmmssSSS");
+  public static Integer latestVersion = TimelineLayoutVersion.CURR_VERSION;
+
+  public String format(Date date) {
+    switch (latestVersion) {
+      case 0:
+      case 1:
+        return COMMIT_FORMATTER_V1.format(date);
+      case 2:
+        return COMMIT_FORMATTER_V2.format(date);
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  public Date parse(String commitTime) throws ParseException {
+    int length = commitTime.length();
+    switch (length) {
+      // For second granularity instant times parsing in V1
+      case 14:
+        return COMMIT_FORMATTER_V1.parse(commitTime);
+      // For milliseconds granularity instant times parsing in V2
+      case 17:
+        return COMMIT_FORMATTER_V2.parse(commitTime);
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
@@ -28,16 +28,14 @@ import java.util.Date;
 public class InstantTimeFormatter {
 
   public static final SimpleDateFormat COMMIT_FORMATTER_V1 = new SimpleDateFormat("yyyyMMddHHmmss");
-  public static final SimpleDateFormat COMMIT_FORMATTER_V2 = new SimpleDateFormat("yyyyMMddHHmmssSSS");
   public static Integer latestVersion = TimelineLayoutVersion.CURR_VERSION;
 
   public String format(Date date) {
     switch (latestVersion) {
       case 0:
       case 1:
-        return COMMIT_FORMATTER_V1.format(date);
       case 2:
-        return COMMIT_FORMATTER_V2.format(date);
+        return COMMIT_FORMATTER_V1.format(date);
       default:
         throw new UnsupportedOperationException();
     }
@@ -55,9 +53,6 @@ public class InstantTimeFormatter {
       case 13:
       case 14:
         return COMMIT_FORMATTER_V1.parse(commitTime);
-      // For milliseconds granularity instant times parsing in V2
-      case 17:
-        return COMMIT_FORMATTER_V2.parse(commitTime);
       default:
         throw new UnsupportedOperationException();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
@@ -47,6 +47,12 @@ public class InstantTimeFormatter {
     int length = commitTime.length();
     switch (length) {
       // For second granularity instant times parsing in V1
+      /**
+       * 13 length is for {@link org.apache.hudi.metadata.HoodieTableMetadata#SOLO_COMMIT_TIMESTAMP}
+       * This value needs to be less than {@link org.apache.hudi.common.table.timeline.HoodieTimeline#INIT_INSTANT_TS}
+       * so we carry this logic forward.
+       */
+      case 13:
       case 14:
         return COMMIT_FORMATTER_V1.parse(commitTime);
       // For milliseconds granularity instant times parsing in V2

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/TimelineLayoutVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/TimelineLayoutVersion.java
@@ -29,9 +29,10 @@ import java.util.Objects;
 public class TimelineLayoutVersion implements Serializable, Comparable<TimelineLayoutVersion> {
 
   public static final Integer VERSION_0 = 0; // pre 0.5.1  version format
-  public static final Integer VERSION_1 = 1; // current version with no renames
+  public static final Integer VERSION_1 = 1; // new version with no renames
+  public static final Integer VERSION_2 = 2; // current version with no renames and end commit times
 
-  public static final Integer CURR_VERSION = VERSION_1;
+  public static final Integer CURR_VERSION = VERSION_2;
   public static final TimelineLayoutVersion CURR_LAYOUT_VERSION = new TimelineLayoutVersion(CURR_VERSION);
 
   private Integer version;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -43,7 +43,7 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * {@link org.apache.hudi.common.table.timeline.HoodieTimeline#INIT_INSTANT_TS}, such that the metadata table
    * can be prepped even before bootstrap is done.
    */
-  String SOLO_COMMIT_TIMESTAMP = "0000000000000";
+  String SOLO_COMMIT_TIMESTAMP = "00000000000000";
   // Key for the record which saves list of all partitions
   String RECORDKEY_PARTITION_LIST = "__all_partitions__";
   // The partition name used for non-partitioned tables

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -43,7 +43,7 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * {@link org.apache.hudi.common.table.timeline.HoodieTimeline#INIT_INSTANT_TS}, such that the metadata table
    * can be prepped even before bootstrap is done.
    */
-  String SOLO_COMMIT_TIMESTAMP = "000000000000000";
+  String SOLO_COMMIT_TIMESTAMP = "0000000000000";
   // Key for the record which saves list of all partitions
   String RECORDKEY_PARTITION_LIST = "__all_partitions__";
   // The partition name used for non-partitioned tables

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -43,7 +43,7 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * {@link org.apache.hudi.common.table.timeline.HoodieTimeline#INIT_INSTANT_TS}, such that the metadata table
    * can be prepped even before bootstrap is done.
    */
-  String SOLO_COMMIT_TIMESTAMP = "00000000000000";
+  String SOLO_COMMIT_TIMESTAMP = "000000000000000";
   // Key for the record which saves list of all partitions
   String RECORDKEY_PARTITION_LIST = "__all_partitions__";
   // The partition name used for non-partitioned tables

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestTimelineLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestTimelineLayout.java
@@ -35,44 +35,53 @@ public class TestTimelineLayout  {
   @Test
   public void testTimelineLayoutFilter() {
     List<HoodieInstant> rawInstants = Arrays.asList(
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "001"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "001"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "002"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "002"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "003"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "003"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "004"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "004"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "005"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "005"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "006"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "006"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "007"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "007"));
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "001", "001"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "001", "001"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001", "002"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "002"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "002"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "009"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "003", "003"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "003", "003"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003", "004"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "004", "004"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "004", "004"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "005"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "005"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "006"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "006", "006"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "006", "006"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "007", "007"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "007", "007"));
 
     List<HoodieInstant> layout0Instants = TimelineLayout.getLayout(new TimelineLayoutVersion(0))
         .filterHoodieInstants(rawInstants.stream()).collect(Collectors.toList());
     assertEquals(rawInstants, layout0Instants);
-    List<HoodieInstant> layout1Instants = TimelineLayout.getLayout(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
+    List<HoodieInstant> layout1Instants = TimelineLayout.getLayout(new TimelineLayoutVersion(1))
         .filterHoodieInstants(rawInstants.stream()).collect(Collectors.toList());
+    List<HoodieInstant> layout2Instants = TimelineLayout.getLayout(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
+        .filterHoodieInstants(rawInstants.stream()).sorted(HoodieInstant.END_INSTANT_TIME_COMPARATOR)
+        .collect(Collectors.toList());
+    assertEquals(7, layout2Instants.size());
+
     assertEquals(7, layout1Instants.size());
     assertTrue(layout1Instants.contains(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "007")));
     assertTrue(layout1Instants.contains(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "006")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "006")));
     assertTrue(layout1Instants.contains(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "004")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003", "004")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "009")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001", "002")));
+
+    assertTrue(layout2Instants.indexOf(
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "009"))
+        > layout2Instants.indexOf(new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "006")));
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -278,8 +278,8 @@ public class HoodieInputFormatUtils {
     // Total number of commits to return in this batch. Set this to -1 to get all the commits.
     Integer maxCommits = HoodieHiveUtils.readMaxCommits(job, tableName);
     LOG.info("Last Incremental timestamp was set as " + lastIncrementalTs);
-    return Option.of(timeline.findInstantsAfter(lastIncrementalTs, maxCommits)
-        .getInstants().collect(Collectors.toList()));
+    return Option.of(timeline.filterByFinishTs(HoodieTimeline.GREATER_THAN, lastIncrementalTs)
+            .getInstants().limit(maxCommits).collect(Collectors.toList()));
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -68,7 +68,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
 
   private val lastInstant = commitTimeline.lastInstant().get()
 
-  private val commitsToReturn = commitTimeline.findInstantsInRange(
+  private val commitsToReturn = commitTimeline.findInstantsInRangeByFinishTs(
     optParams(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY),
     optParams.getOrElse(DataSourceReadOptions.END_INSTANTTIME_OPT_KEY, lastInstant.getTimestamp))
     .getInstants.iterator().toList

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -67,7 +67,7 @@ class MergeOnReadIncrementalRelation(val sqlContext: SQLContext,
     DataSourceReadOptions.REALTIME_MERGE_OPT_KEY,
     DataSourceReadOptions.DEFAULT_REALTIME_MERGE_OPT_VAL)
 
-  private val commitsTimelineToReturn = commitTimeline.findInstantsInRange(
+  private val commitsTimelineToReturn = commitTimeline.findInstantsInRangeByFinishTs(
     optParams(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY),
     optParams.getOrElse(DataSourceReadOptions.END_INSTANTTIME_OPT_KEY, lastInstant.getTimestamp))
   log.debug(s"${commitsTimelineToReturn.getInstants.iterator().toList.map(f => f.toString).mkString(",")}")


### PR DESCRIPTION
## What is the purpose of the pull request

*This PR adds support to be able to consume the Hudi Timeline based on finish times of commits. This helps to order incremental pulls, snapshot reads based on the end commit time, especially when multiple writers are working on the same table*

## Brief change log

  - *Introduce the notion of end commit time to the timeline filters*
  - *Alter instant time generation to milliseconds*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.