### PR TITLE
[HUDI-1539] Fix bug in HoodieCombineRealtimeRecordReader with reading…

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieCombineRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieCombineRealtimeRecordReader.java
@@ -71,7 +71,7 @@ public class HoodieCombineRealtimeRecordReader implements RecordReader<NullWrita
     } else if (recordReaders.size() > 0) {
       this.currentRecordReader.close();
       this.currentRecordReader = recordReaders.remove(0);
-      return this.currentRecordReader.next(key, value);
+      return next(key, value);
     } else {
       return false;
     }


### PR DESCRIPTION
… empty iterators

## What is the purpose of the pull request
Fix bug in HoodieCombineRealtimeRecordReader with reading empty iterators

## Brief change log
- CombineRealtimeRecordReader has a bug when there are more than two consecutive empty iterators (because of filtering by predicate for example). Fix it by calling next on combine record reader. https://github.com/apache/hudi/issues/2346#issuecomment-758591316 has additional details

## Verify this pull request
There are no existing tests to this module and looks like setup is quite involved. So I'm not able to add tests anytime soon. But this is a trivial fix and has been reported a while ago on support ticket. So sending PR for the fix.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.