### PR TITLE
[Hudi-1583]: Fix bug that Hudi will skip remaining log files if there is logFile with zero size in logFileList when merge on read.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReader.java
@@ -104,7 +104,7 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
         throw new HoodieIOException("unable to initialize read with log file ", io);
       }
       LOG.info("Moving to the next reader for logfile " + currentReader.getLogFile());
-      return this.currentReader.hasNext();
+      return hasNext();
     }
     return false;
   }


### PR DESCRIPTION
…When merge on read, hudi would skip remaining logFiles if encounter logFiles with zero size.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Fix bug in HoodieLogFormatReader when read logFileList including logFile with zero size.

## Brief change log
- HoodieLogFormatReader has a bug that Hudi will skip remaining log files if there is logFile with zero size in logFileList when merge on read.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.