### PR TITLE
[MINOR] check for table after creating db if auto create is true

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -114,8 +114,6 @@ public class HiveSyncTool extends AbstractSyncTool {
   private void syncHoodieTable(String tableName, boolean useRealtimeInputFormat) {
     LOG.info("Trying to sync hoodie table " + tableName + " with base path " + hoodieHiveClient.getBasePath()
         + " of type " + hoodieHiveClient.getTableType());
-    // Check if the necessary table exists
-    boolean tableExists = hoodieHiveClient.doesTableExist(tableName);
 
     // check if the database exists else create it
     if (cfg.autoCreateDatabase) {
@@ -130,6 +128,9 @@ public class HiveSyncTool extends AbstractSyncTool {
         throw new HoodieHiveSyncException("hive database does not exist " + cfg.databaseName);
       }
     }
+
+    // Check if the necessary table exists
+    boolean tableExists = hoodieHiveClient.doesTableExist(tableName);
 
     // Get the parquet schema for this table looking at the latest commit
     MessageType schema = hoodieHiveClient.getDataSchema();


### PR DESCRIPTION
## What is the purpose of the pull request

*with glue client if db does not exist, database not found exception is thrown while checking for table. This PR first check if database exists or autoCreateDatabase is true before checking for table*

## Verify this pull request

This file changed already has unit tests, the issue is that, with glue client it doesn't return false when checking table in non existing database.

![Screen Shot 2021-02-22 at 11 44 16 AM](https://user-images.githubusercontent.com/40214578/108761239-75677c00-7503-11eb-955f-a6062376d38d.jpg)


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.