### PR TITLE
[MINOR] Ensure directory exists before listing all marker files.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/MarkerFiles.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/MarkerFiles.java
@@ -166,10 +166,12 @@ public class MarkerFiles implements Serializable {
 
   public List<String> allMarkerFilePaths() throws IOException {
     List<String> markerFiles = new ArrayList<>();
-    FSUtils.processFiles(fs, markerDirPath.toString(), fileStatus -> {
-      markerFiles.add(stripMarkerFolderPrefix(fileStatus.getPath().toString()));
-      return true;
-    }, false);
+    if (doesMarkerDirExist()) {
+      FSUtils.processFiles(fs, markerDirPath.toString(), fileStatus -> {
+        markerFiles.add(stripMarkerFolderPrefix(fileStatus.getPath().toString()));
+        return true;
+      }, false);
+    }
     return markerFiles;
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestMarkerFiles.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestMarkerFiles.java
@@ -119,6 +119,7 @@ public class TestMarkerFiles extends HoodieCommonTestHarness {
   public void testDeletionWhenMarkerDirNotExists() throws IOException {
     // then
     assertFalse(markerFiles.doesMarkerDirExist());
+    assertTrue(markerFiles.allMarkerFilePaths().isEmpty());
     assertFalse(markerFiles.deleteMarkerDir(context, 2));
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

The marker directory is created after a commit instance enters the inflight stage. If the process dies before the marker directory can be created, the next commit will encounter a .inflight instance and hence try to rollback. This rollback will try to list the marker directory to find the marker files. Since the marker directory was not created in the failed commit, the listing fails and leads to a FileSystem exception for FileNotFound.

Simple fix is to ensure marker directory exists before trying to list it.

## Brief change log

Simple check for marker directory existence.

## Verify this pull request

An existing unit test has been enhanced.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.