### PR TITLE
[HUDI-1648] Added custom kafka meta fields and custom kafka avro decoder.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/decoders/KafkaAvroSchemaDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/decoders/KafkaAvroSchemaDeserializer.java
@@ -44,7 +44,6 @@ import java.util.Objects;
 public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
 
   private static final String SCHEMA_PROVIDER_CLASS_PROP = "hoodie.deltastreamer.schemaprovider.class";
-
   private final DecoderFactory decoderFactory = DecoderFactory.get();
   private Schema sourceSchema;
 
@@ -85,84 +84,7 @@ public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
       byte[] payload,
       Schema readerSchema)
       throws SerializationException {
-    // Even if the caller requests schema & version, if the payload is null we cannot include it.
-    // The caller must handle
-    // this case.
-    if (payload == null) {
-      return null;
-    }
-    int id = -1;
-    try {
-      ByteBuffer buffer = getByteBuffer(payload);
-      id = buffer.getInt();
-      Schema schema = schemaRegistry.getByID(id);
-
-      int length = buffer.limit() - 1 - idSize;
-      final Object result;
-      if (schema.getType().equals(Schema.Type.BYTES)) {
-        byte[] bytes = new byte[length];
-        buffer.get(bytes, 0, length);
-        result = bytes;
-      } else {
-        int start = buffer.position() + buffer.arrayOffset();
-        DatumReader reader = new GenericDatumReader(schema, sourceSchema);
-        Object object =
-            reader.read(null, decoderFactory.binaryDecoder(buffer.array(), start, length, null));
-
-        if (schema.getType().equals(Schema.Type.STRING)) {
-          object = object.toString(); // Utf8 -> String
-        }
-        result = object;
-      }
-
-      if (includeSchemaAndVersion) {
-        // Annotate the schema with the version. Note that we only do this if the schema +
-        // version are requested, i.e. in Kafka Connect converters. This is critical because that
-        // code *will not* rely on exact schema equality. Regular deserializers *must not* include
-        // this information because it would return schemas which are not equivalent.
-        //
-        // Note, however, that we also do not fill in the connect.version field. This allows the
-        // Converter to let a version provided by a Kafka Connect source take priority over the
-        // schema registry's ordering (which is implicit by auto-registration time rather than
-        // explicit from the Connector).
-        Integer version = schemaRegistry.getVersion(getSubjectName(topic, isKey), schema);
-        if (schema.getType() == Schema.Type.UNION) {
-          // Can't set additional properties on a union schema since it's just a list, so set it
-          // on the first non-null entry
-          for (Schema memberSchema : schema.getTypes()) {
-            if (memberSchema.getType() != Schema.Type.NULL) {
-              memberSchema.addProp(
-                  SCHEMA_REGISTRY_SCHEMA_VERSION_PROP,
-                  JsonNodeFactory.instance.numberNode(version));
-              break;
-            }
-          }
-        } else {
-          schema.addProp(
-              SCHEMA_REGISTRY_SCHEMA_VERSION_PROP, JsonNodeFactory.instance.numberNode(version));
-        }
-        if (schema.getType().equals(Schema.Type.RECORD)) {
-          return result;
-        } else {
-          return new NonRecordContainer(schema, result);
-        }
-      } else {
-        return result;
-      }
-    } catch (IOException | RuntimeException e) {
-      // avro deserialization may throw AvroRuntimeException, NullPointerException, etc
-      throw new SerializationException("Error deserializing Avro message for id " + id, e);
-    } catch (RestClientException e) {
-      throw new SerializationException("Error retrieving Avro schema for id " + id, e);
-    }
-  }
-
-  private ByteBuffer getByteBuffer(byte[] payload) {
-    ByteBuffer buffer = ByteBuffer.wrap(payload);
-    if (buffer.get() != MAGIC_BYTE) {
-      throw new SerializationException("Unknown magic byte!");
-    }
-    return buffer;
+    return super.deserialize(includeSchemaAndVersion, topic, isKey, payload, sourceSchema);
   }
 
   private TypedProperties getConvertToTypedProperties(Map<String, ?> configs) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/decoders/KafkaAvroSchemaDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/decoders/KafkaAvroSchemaDeserializer.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.decoders;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.NonRecordContainer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.kafka.common.errors.SerializationException;
+import org.codehaus.jackson.node.JsonNodeFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Extending {@link KafkaAvroSchemaDeserializer} as we need to be able to inject reader schema during deserialization.
+ */
+public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
+
+  private static final String SCHEMA_PROVIDER_CLASS_PROP = "hoodie.deltastreamer.schemaprovider.class";
+
+  private final DecoderFactory decoderFactory = DecoderFactory.get();
+  private Schema sourceSchema;
+
+  public KafkaAvroSchemaDeserializer() {}
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    super.configure(configs, isKey);
+    try {
+      TypedProperties props = getConvertToTypedProperties(configs);
+      SchemaProvider schemaProvider = UtilHelpers.createSchemaProvider(
+          props.getString(SCHEMA_PROVIDER_CLASS_PROP), props, null);
+      sourceSchema = Objects.requireNonNull(schemaProvider).getSourceSchema();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Pretty much copy-paste from the {@link AbstractKafkaAvroDeserializer} except line 87:
+   * DatumReader reader = new GenericDatumReader(schema, sourceSchema);
+   * <p>
+   * We need to inject reader schema during deserialization or later stages of the pipeline break.
+   *
+   * @param includeSchemaAndVersion
+   * @param topic
+   * @param isKey
+   * @param payload
+   * @param readerSchema
+   * @return
+   * @throws SerializationException
+   */
+  @Override
+  protected Object deserialize(
+      boolean includeSchemaAndVersion,
+      String topic,
+      Boolean isKey,
+      byte[] payload,
+      Schema readerSchema)
+      throws SerializationException {
+    // Even if the caller requests schema & version, if the payload is null we cannot include it.
+    // The caller must handle
+    // this case.
+    if (payload == null) {
+      return null;
+    }
+    int id = -1;
+    try {
+      ByteBuffer buffer = getByteBuffer(payload);
+      id = buffer.getInt();
+      Schema schema = schemaRegistry.getByID(id);
+
+      int length = buffer.limit() - 1 - idSize;
+      final Object result;
+      if (schema.getType().equals(Schema.Type.BYTES)) {
+        byte[] bytes = new byte[length];
+        buffer.get(bytes, 0, length);
+        result = bytes;
+      } else {
+        int start = buffer.position() + buffer.arrayOffset();
+        DatumReader reader = new GenericDatumReader(schema, sourceSchema);
+        Object object =
+            reader.read(null, decoderFactory.binaryDecoder(buffer.array(), start, length, null));
+
+        if (schema.getType().equals(Schema.Type.STRING)) {
+          object = object.toString(); // Utf8 -> String
+        }
+        result = object;
+      }
+
+      if (includeSchemaAndVersion) {
+        // Annotate the schema with the version. Note that we only do this if the schema +
+        // version are requested, i.e. in Kafka Connect converters. This is critical because that
+        // code *will not* rely on exact schema equality. Regular deserializers *must not* include
+        // this information because it would return schemas which are not equivalent.
+        //
+        // Note, however, that we also do not fill in the connect.version field. This allows the
+        // Converter to let a version provided by a Kafka Connect source take priority over the
+        // schema registry's ordering (which is implicit by auto-registration time rather than
+        // explicit from the Connector).
+        Integer version = schemaRegistry.getVersion(getSubjectName(topic, isKey), schema);
+        if (schema.getType() == Schema.Type.UNION) {
+          // Can't set additional properties on a union schema since it's just a list, so set it
+          // on the first non-null entry
+          for (Schema memberSchema : schema.getTypes()) {
+            if (memberSchema.getType() != Schema.Type.NULL) {
+              memberSchema.addProp(
+                  SCHEMA_REGISTRY_SCHEMA_VERSION_PROP,
+                  JsonNodeFactory.instance.numberNode(version));
+              break;
+            }
+          }
+        } else {
+          schema.addProp(
+              SCHEMA_REGISTRY_SCHEMA_VERSION_PROP, JsonNodeFactory.instance.numberNode(version));
+        }
+        if (schema.getType().equals(Schema.Type.RECORD)) {
+          return result;
+        } else {
+          return new NonRecordContainer(schema, result);
+        }
+      } else {
+        return result;
+      }
+    } catch (IOException | RuntimeException e) {
+      // avro deserialization may throw AvroRuntimeException, NullPointerException, etc
+      throw new SerializationException("Error deserializing Avro message for id " + id, e);
+    } catch (RestClientException e) {
+      throw new SerializationException("Error retrieving Avro schema for id " + id, e);
+    }
+  }
+
+  private ByteBuffer getByteBuffer(byte[] payload) {
+    ByteBuffer buffer = ByteBuffer.wrap(payload);
+    if (buffer.get() != MAGIC_BYTE) {
+      throw new SerializationException("Unknown magic byte!");
+    }
+    return buffer;
+  }
+
+  private TypedProperties getConvertToTypedProperties(Map<String, ?> configs) {
+    TypedProperties typedProperties = new TypedProperties();
+    for (Entry<String, ?> entry : configs.entrySet()) {
+      typedProperties.put(entry.getKey(), entry.getValue());
+    }
+    return typedProperties;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java
@@ -16,24 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.utilities.decoders;
+package org.apache.hudi.utilities.deser;
 
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.kafka.serializers.NonRecordContainer;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DecoderFactory;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.kafka.common.errors.SerializationException;
-import org.codehaus.jackson.node.JsonNodeFactory;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -44,7 +38,6 @@ import java.util.Objects;
 public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
 
   private static final String SCHEMA_PROVIDER_CLASS_PROP = "hoodie.deltastreamer.schemaprovider.class";
-  private final DecoderFactory decoderFactory = DecoderFactory.get();
   private Schema sourceSchema;
 
   public KafkaAvroSchemaDeserializer() {}
@@ -58,7 +51,7 @@ public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
           props.getString(SCHEMA_PROVIDER_CLASS_PROP), props, null);
       sourceSchema = Objects.requireNonNull(schemaProvider).getSourceSchema();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new HoodieException(e);
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java
@@ -22,12 +22,11 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.apache.avro.Schema;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -47,10 +46,10 @@ public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
     super.configure(configs, isKey);
     try {
       TypedProperties props = getConvertToTypedProperties(configs);
-      SchemaProvider schemaProvider = UtilHelpers.createSchemaProvider(
-          props.getString(SCHEMA_PROVIDER_CLASS_PROP), props, null);
+      String className = props.getString(SCHEMA_PROVIDER_CLASS_PROP);
+      SchemaProvider schemaProvider = (SchemaProvider) ReflectionUtils.loadClass(className, props);
       sourceSchema = Objects.requireNonNull(schemaProvider).getSourceSchema();
-    } catch (IOException e) {
+    } catch (Throwable e) {
       throw new HoodieException(e);
     }
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -56,11 +56,8 @@ public class SchemaRegistryProvider extends SchemaProvider {
   private final String targetRegistryUrl;
   private final boolean noTargetSchema;
 
-  public String fetchSchemaFromRegistry(String registryUrl) throws IOException {
-    URL registry = new URL(registryUrl);
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode node = mapper.readTree(registry.openStream());
-    return node.get("schema").asText();
+  public SchemaRegistryProvider(TypedProperties props) {
+    this(props, null);
   }
 
   public SchemaRegistryProvider(TypedProperties props, JavaSparkContext jssc) {
@@ -71,6 +68,13 @@ public class SchemaRegistryProvider extends SchemaProvider {
     this.registryUrl = config.getString(Config.SRC_SCHEMA_REGISTRY_URL_PROP);
     this.targetRegistryUrl = config.getString(Config.TARGET_SCHEMA_REGISTRY_URL_PROP, registryUrl);
     this.noTargetSchema = targetRegistryUrl.equals("null");
+  }
+
+  public String fetchSchemaFromRegistry(String registryUrl) throws IOException {
+    URL registry = new URL(registryUrl);
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode node = mapper.readTree(registry.openStream());
+    return node.get("schema").asText();
   }
 
   private Schema getSchema(String registryUrl) throws IOException {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -67,7 +67,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
     super(props, jssc);
     DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(Config.SRC_SCHEMA_REGISTRY_URL_PROP));
     this.cacheDisabled = !props.getBoolean(Config.CACHE_SCHEMAS, false);
-    this.injectKafkaFieldSchema = props.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_FIELDS, false);
+    this.injectKafkaFieldSchema = props.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, false);
     this.registryUrl = config.getString(Config.SRC_SCHEMA_REGISTRY_URL_PROP);
     this.targetRegistryUrl = config.getString(Config.TARGET_SCHEMA_REGISTRY_URL_PROP, registryUrl);
     this.noTargetSchema = targetRegistryUrl.equals("null");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -56,7 +56,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
   private final String targetRegistryUrl;
   private final boolean noTargetSchema;
 
-  private static String fetchSchemaFromRegistry(String registryUrl) throws IOException {
+  public String fetchSchemaFromRegistry(String registryUrl) throws IOException {
     URL registry = new URL(registryUrl);
     ObjectMapper mapper = new ObjectMapper();
     JsonNode node = mapper.readTree(registry.openStream());
@@ -73,10 +73,10 @@ public class SchemaRegistryProvider extends SchemaProvider {
     this.noTargetSchema = targetRegistryUrl.equals("null");
   }
 
-  private static Schema getSchema(String registryUrl, boolean injectKafkaFieldSchema) throws IOException {
+  private Schema getSchema(String registryUrl) throws IOException {
     Schema schema = new Schema.Parser().parse(fetchSchemaFromRegistry(registryUrl));
     if (injectKafkaFieldSchema) {
-      return AvroKafkaSourceHelpers.addKafkaMetadataFields(schema);
+      schema = AvroKafkaSourceHelpers.addKafkaMetadataFields(schema);
     }
     return schema;
   }
@@ -116,7 +116,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
 
   private Schema getSourceSchemaFromRegistry() {
     try {
-      return getSchema(registryUrl, injectKafkaFieldSchema);
+      return getSchema(registryUrl);
     } catch (IOException ioe) {
       throw new HoodieIOException("Error reading source schema from registry :" + registryUrl, ioe);
     }
@@ -124,7 +124,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
 
   private Schema getTargetSchemaFromRegistry() {
     try {
-      return getSchema(targetRegistryUrl, injectKafkaFieldSchema);
+      return getSchema(targetRegistryUrl);
     } catch (IOException ioe) {
       throw new HoodieIOException("Error reading target schema from registry :" + targetRegistryUrl, ioe);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -21,13 +21,13 @@ package org.apache.hudi.utilities.sources;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.utilities.deser.KafkaAvroSchemaDeserializer;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.AvroKafkaSourceHelpers;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen;
 import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
 
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.log4j.LogManager;
@@ -58,7 +58,7 @@ public class AvroKafkaSource extends AvroSource {
     String deserializerClassName = props.getString(KAFKA_AVRO_VALUE_DESERIALIZER, "");
 
     if (deserializerClassName.isEmpty()) {
-      props.put("value.deserializer", KafkaAvroDeserializer.class);
+      props.put("value.deserializer", KafkaAvroSchemaDeserializer.class);
     } else {
       try {
         props.put("value.deserializer", Class.forName(deserializerClassName));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -44,7 +44,7 @@ import org.apache.spark.streaming.kafka010.OffsetRange;
  */
 public class AvroKafkaSource extends AvroSource {
 
-  private static final String KAFKA_AVRO_VALUE_DESERIALIZER = "hoodie.deltastreamer.source.value.deserializer";
+  private static final String KAFKA_AVRO_VALUE_DESERIALIZER = "hoodie.deltastreamer.source.value.deserializer.class";
   private static final Logger LOG = LogManager.getLogger(AvroKafkaSource.class);
   private final KafkaOffsetGen offsetGen;
   private final HoodieDeltaStreamerMetrics metrics;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -70,7 +70,7 @@ public class AvroKafkaSource extends AvroSource {
     }
 
     this.metrics = metrics;
-    this.injectKafkaData = props.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_FIELDS, false);
+    this.injectKafkaData = props.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, false);
 
     offsetGen = new KafkaOffsetGen(props);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroKafkaSourceHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroKafkaSourceHelpers.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class AvroKafkaSourceHelpers {
+
+  public static final String INJECT_KAFKA_FIELDS = "hoodie.deltastreamer.source.inject_kafka_fields";
+
+  public static final String KAFKA_PARTITION = "_hudi_kafka_partition";
+  public static final String KAFKA_OFFSET = "_hudi_kafka_offset";
+  public static final String KAFKA_TOPIC = "_hudi_kafka_topic";
+  public static final String KAFKA_KEY = "_hudi_kafka_key";
+  private static final String KAFKA_FIELDS_PATTERN = "<KAFKA_FIELDS>";
+
+  private static final String ALL_KAFKA_FIELDS = String.join(
+      ",",
+      AvroKafkaSourceHelpers.KAFKA_PARTITION,
+      AvroKafkaSourceHelpers.KAFKA_OFFSET,
+      AvroKafkaSourceHelpers.KAFKA_TOPIC,
+      AvroKafkaSourceHelpers.KAFKA_KEY);
+
+  public static String transform(String sql) {
+    return sql.replaceAll(KAFKA_FIELDS_PATTERN, ALL_KAFKA_FIELDS);
+  }
+
+  public static GenericRecord addKafkaFields(ConsumerRecord<Object, Object> obj) {
+    GenericRecord record = (GenericRecord) obj.value();
+    record.put(AvroKafkaSourceHelpers.KAFKA_OFFSET, obj.offset());
+    record.put(AvroKafkaSourceHelpers.KAFKA_PARTITION, obj.partition());
+    record.put(AvroKafkaSourceHelpers.KAFKA_TOPIC, obj.topic());
+    record.put(AvroKafkaSourceHelpers.KAFKA_KEY, obj.key());
+    return record;
+  }
+
+  private static boolean isKafkaMetadataField(String fieldName) {
+    return AvroKafkaSourceHelpers.KAFKA_PARTITION.equals(fieldName)
+        || AvroKafkaSourceHelpers.KAFKA_OFFSET.equals(fieldName)
+        || AvroKafkaSourceHelpers.KAFKA_TOPIC.equals(fieldName)
+        || AvroKafkaSourceHelpers.KAFKA_KEY.equals(fieldName);
+  }
+
+  /**
+   * Adds the Kafka metadata fields to the given schema, so later on the appropriate data can be injected.
+   */
+  public static Schema addKafkaMetadataFields(Schema schema) {
+
+    final List<Schema.Field> parentFields = new ArrayList<>();
+    final List<Schema.Field> schemaFields = schema.getFields();
+
+    for (Schema.Field field : schemaFields) {
+      if (!isKafkaMetadataField(field.name())) {
+        Schema.Field newField = new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
+        for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
+          newField.addProp(prop.getKey(), prop.getValue());
+        }
+        parentFields.add(newField);
+      }
+    }
+
+    final Schema.Field partitionField =
+        new Schema.Field(
+            AvroKafkaSourceHelpers.KAFKA_PARTITION,
+            Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT))),
+            "",
+            Schema.NULL_VALUE);
+    final Schema.Field offsetField =
+        new Schema.Field(
+            AvroKafkaSourceHelpers.KAFKA_OFFSET,
+            Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG))),
+            "",
+            Schema.NULL_VALUE);
+    final Schema.Field topicField =
+        new Schema.Field(
+            AvroKafkaSourceHelpers.KAFKA_TOPIC,
+            Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING))),
+            "",
+            Schema.NULL_VALUE);
+    final Schema.Field keyField =
+        new Schema.Field(
+            AvroKafkaSourceHelpers.KAFKA_KEY,
+            Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING))),
+            "",
+            Schema.NULL_VALUE);
+
+    parentFields.add(partitionField);
+    parentFields.add(offsetField);
+    parentFields.add(topicField);
+    parentFields.add(keyField);
+
+    final Schema mergedSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
+    mergedSchema.setFields(parentFields);
+    return mergedSchema;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroKafkaSourceHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroKafkaSourceHelpers.java
@@ -35,9 +35,9 @@ public class AvroKafkaSourceHelpers {
   public static final String KAFKA_OFFSET_META_FIELD = "_hudi_kafka_offset";
   public static final String KAFKA_TOPIC_META_FIELD = "_hudi_kafka_topic";
   public static final String KAFKA_KEY_META_FIELD = "_hudi_kafka_key";
-  private static final String KAFKA_META_FIELDS_PATTERN = "<KAFKA_FIELDS>";
+  public static final String KAFKA_META_FIELDS_PATTERN = "<KAFKA_FIELDS>";
 
-  private static final String ALL_KAFKA_META_FIELDS = String.join(
+  public static final String ALL_KAFKA_META_FIELDS = String.join(
       ",",
       AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD,
       AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD,

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroKafkaSourceHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroKafkaSourceHelpers.java
@@ -29,39 +29,39 @@ import java.util.Map;
 
 public class AvroKafkaSourceHelpers {
 
-  public static final String INJECT_KAFKA_FIELDS = "hoodie.deltastreamer.source.inject_kafka_fields";
+  public static final String INJECT_KAFKA_META_FIELDS = "hoodie.deltastreamer.source.inject_kafka_fields";
 
-  public static final String KAFKA_PARTITION = "_hudi_kafka_partition";
-  public static final String KAFKA_OFFSET = "_hudi_kafka_offset";
-  public static final String KAFKA_TOPIC = "_hudi_kafka_topic";
-  public static final String KAFKA_KEY = "_hudi_kafka_key";
-  private static final String KAFKA_FIELDS_PATTERN = "<KAFKA_FIELDS>";
+  public static final String KAFKA_PARTITION_META_FIELD = "_hudi_kafka_partition";
+  public static final String KAFKA_OFFSET_META_FIELD = "_hudi_kafka_offset";
+  public static final String KAFKA_TOPIC_META_FIELD = "_hudi_kafka_topic";
+  public static final String KAFKA_KEY_META_FIELD = "_hudi_kafka_key";
+  private static final String KAFKA_META_FIELDS_PATTERN = "<KAFKA_FIELDS>";
 
-  private static final String ALL_KAFKA_FIELDS = String.join(
+  private static final String ALL_KAFKA_META_FIELDS = String.join(
       ",",
-      AvroKafkaSourceHelpers.KAFKA_PARTITION,
-      AvroKafkaSourceHelpers.KAFKA_OFFSET,
-      AvroKafkaSourceHelpers.KAFKA_TOPIC,
-      AvroKafkaSourceHelpers.KAFKA_KEY);
+      AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD,
+      AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD,
+      AvroKafkaSourceHelpers.KAFKA_TOPIC_META_FIELD,
+      AvroKafkaSourceHelpers.KAFKA_KEY_META_FIELD);
 
   public static String transform(String sql) {
-    return sql.replaceAll(KAFKA_FIELDS_PATTERN, ALL_KAFKA_FIELDS);
+    return sql.replaceAll(KAFKA_META_FIELDS_PATTERN, ALL_KAFKA_META_FIELDS);
   }
 
   public static GenericRecord addKafkaFields(ConsumerRecord<Object, Object> obj) {
     GenericRecord record = (GenericRecord) obj.value();
-    record.put(AvroKafkaSourceHelpers.KAFKA_OFFSET, obj.offset());
-    record.put(AvroKafkaSourceHelpers.KAFKA_PARTITION, obj.partition());
-    record.put(AvroKafkaSourceHelpers.KAFKA_TOPIC, obj.topic());
-    record.put(AvroKafkaSourceHelpers.KAFKA_KEY, obj.key());
+    record.put(AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD, obj.offset());
+    record.put(AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD, obj.partition());
+    record.put(AvroKafkaSourceHelpers.KAFKA_TOPIC_META_FIELD, obj.topic());
+    record.put(AvroKafkaSourceHelpers.KAFKA_KEY_META_FIELD, obj.key());
     return record;
   }
 
   private static boolean isKafkaMetadataField(String fieldName) {
-    return AvroKafkaSourceHelpers.KAFKA_PARTITION.equals(fieldName)
-        || AvroKafkaSourceHelpers.KAFKA_OFFSET.equals(fieldName)
-        || AvroKafkaSourceHelpers.KAFKA_TOPIC.equals(fieldName)
-        || AvroKafkaSourceHelpers.KAFKA_KEY.equals(fieldName);
+    return AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD.equals(fieldName)
+        || AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD.equals(fieldName)
+        || AvroKafkaSourceHelpers.KAFKA_TOPIC_META_FIELD.equals(fieldName)
+        || AvroKafkaSourceHelpers.KAFKA_KEY_META_FIELD.equals(fieldName);
   }
 
   /**
@@ -84,25 +84,25 @@ public class AvroKafkaSourceHelpers {
 
     final Schema.Field partitionField =
         new Schema.Field(
-            AvroKafkaSourceHelpers.KAFKA_PARTITION,
+            AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD,
             Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT))),
             "",
             Schema.NULL_VALUE);
     final Schema.Field offsetField =
         new Schema.Field(
-            AvroKafkaSourceHelpers.KAFKA_OFFSET,
+            AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD,
             Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG))),
             "",
             Schema.NULL_VALUE);
     final Schema.Field topicField =
         new Schema.Field(
-            AvroKafkaSourceHelpers.KAFKA_TOPIC,
+            AvroKafkaSourceHelpers.KAFKA_TOPIC_META_FIELD,
             Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING))),
             "",
             Schema.NULL_VALUE);
     final Schema.Field keyField =
         new Schema.Field(
-            AvroKafkaSourceHelpers.KAFKA_KEY,
+            AvroKafkaSourceHelpers.KAFKA_KEY_META_FIELD,
             Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING))),
             "",
             Schema.NULL_VALUE);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
@@ -63,7 +63,7 @@ public class SqlQueryBasedTransformer implements Transformer {
     LOG.info("Registering tmp table : " + tmpTable);
     rowDataset.registerTempTable(tmpTable);
     String sqlStr = transformerSQL.replaceAll(SRC_PATTERN, tmpTable);
-    if (properties.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_FIELDS, false)) {
+    if (properties.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, false)) {
       sqlStr = AvroKafkaSourceHelpers.transform(sqlStr);
     }
     LOG.info("SQL Query for transformation : (" + sqlStr + ")");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.transform;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.sources.helpers.AvroKafkaSourceHelpers;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -62,6 +63,9 @@ public class SqlQueryBasedTransformer implements Transformer {
     LOG.info("Registering tmp table : " + tmpTable);
     rowDataset.registerTempTable(tmpTable);
     String sqlStr = transformerSQL.replaceAll(SRC_PATTERN, tmpTable);
+    if (properties.getBoolean(AvroKafkaSourceHelpers.INJECT_KAFKA_FIELDS, false)) {
+      sqlStr = AvroKafkaSourceHelpers.transform(sqlStr);
+    }
     LOG.info("SQL Query for transformation : (" + sqlStr + ")");
     return sparkSession.sql(sqlStr);
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/SchemaRegistryProviderTest.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/SchemaRegistryProviderTest.java
@@ -25,23 +25,25 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.junit.jupiter.api.Assertions.*;
 
 class SchemaRegistryProviderTest {
 
-  final static String AVRO_SCHEMA = "{\n" +
-      "     \"type\": \"record\",\n" +
-      "     \"namespace\": \"com.example\",\n" +
-      "     \"name\": \"FullName\",\n" +
-      "     \"fields\": [\n" +
-      "       { \"name\": \"first\", \"type\": \"string\" },\n" +
-      "       { \"name\": \"last\", \"type\": \"string\" }\n" +
-      "     ]\n" +
-      "}";
+  private static final String AVRO_SCHEMA = "{\n"
+      + "     \"type\": \"record\",\n"
+      + "     \"namespace\": \"com.example\",\n"
+      + "     \"name\": \"FullName\",\n"
+      + "     \"fields\": [\n"
+      + "       { \"name\": \"first\", \"type\": \"string\" },\n"
+      + "       { \"name\": \"last\", \"type\": \"string\" }\n"
+      + "     ]\n"
+      + "}";
 
   TypedProperties initProps() {
     TypedProperties tp = new TypedProperties();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/SchemaRegistryProviderTest.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/SchemaRegistryProviderTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.schema;
+
+import org.apache.avro.Schema;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.sources.helpers.AvroKafkaSourceHelpers;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchemaRegistryProviderTest {
+
+  final static String AVRO_SCHEMA = "{\n" +
+      "     \"type\": \"record\",\n" +
+      "     \"namespace\": \"com.example\",\n" +
+      "     \"name\": \"FullName\",\n" +
+      "     \"fields\": [\n" +
+      "       { \"name\": \"first\", \"type\": \"string\" },\n" +
+      "       { \"name\": \"last\", \"type\": \"string\" }\n" +
+      "     ]\n" +
+      "}";
+
+  TypedProperties initProps() {
+    TypedProperties tp = new TypedProperties();
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.url", "sourceUrl");
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.targetUrl", "targetUrl");
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.cache_enabled", "false");
+    tp.put(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, "false");
+    return tp;
+  }
+
+  @Test
+  void getSourceSchemaNoCacheNoKafka() throws IOException {
+    TypedProperties tp = initProps();
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+    doReturn(AVRO_SCHEMA).when(srp).fetchSchemaFromRegistry("sourceUrl");
+    Schema sc1 = srp.getSourceSchema();
+    Schema sc2 = srp.getSourceSchema();
+    verify(srp, times(2)).fetchSchemaFromRegistry("sourceUrl");
+    assertEquals(sc1, sc2);
+  }
+
+  @Test
+  void getTargetSchemaNoCacheNoKafka() throws IOException {
+    TypedProperties tp = initProps();
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+    doReturn(AVRO_SCHEMA).when(srp).fetchSchemaFromRegistry("targetUrl");
+    Schema sc1 = srp.getTargetSchema();
+    Schema sc2 = srp.getTargetSchema();
+    verify(srp, times(2)).fetchSchemaFromRegistry("targetUrl");
+    assertEquals(sc1, sc2);
+  }
+
+  @Test
+  void getSourceSchemaWithCacheNoKafka() throws IOException {
+    TypedProperties tp = initProps();
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.cache_enabled", "true");
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+    doReturn(AVRO_SCHEMA).when(srp).fetchSchemaFromRegistry("sourceUrl");
+    Schema sc1 = srp.getSourceSchema();
+    Schema sc2 = srp.getSourceSchema();
+    verify(srp, times(1)).fetchSchemaFromRegistry("sourceUrl");
+    assertEquals(sc1, sc2);
+  }
+
+  @Test
+  void getTargetSchemaWithCacheNoKafka() throws IOException {
+    TypedProperties tp = initProps();
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.cache_enabled", "true");
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+    doReturn(AVRO_SCHEMA).when(srp).fetchSchemaFromRegistry("targetUrl");
+    Schema sc1 = srp.getTargetSchema();
+    Schema sc2 = srp.getTargetSchema();
+    verify(srp, times(1)).fetchSchemaFromRegistry("targetUrl");
+    assertEquals(sc1, sc2);
+  }
+
+  void assertFieldExistsInSchema(Schema sc, String fieldName) {
+    for (Schema.Field f : sc.getFields()) {
+      if (f.name().equals(fieldName)) {
+        return;
+      }
+    }
+    fail(String.format("No '%s' field found in schema %s", fieldName, sc));
+  }
+
+  @Test
+  void getSourceSchemaWithCacheAndKafka() throws IOException {
+    TypedProperties tp = initProps();
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.cache_enabled", "true");
+    tp.put(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, "true");
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+    doReturn(AVRO_SCHEMA).when(srp).fetchSchemaFromRegistry("sourceUrl");
+    Schema sc1 = srp.getSourceSchema();
+    Schema sc2 = srp.getSourceSchema();
+    assertEquals(sc1, sc2);
+    System.out.println(sc1);
+    verify(srp, times(1)).fetchSchemaFromRegistry("sourceUrl");
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_KEY_META_FIELD);
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD);
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD);
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_TOPIC_META_FIELD);
+  }
+
+  @Test
+  void getTargetSchemaWithCacheAndKafka() throws IOException {
+    TypedProperties tp = initProps();
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.cache_enabled", "true");
+    tp.put(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, "true");
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+    doReturn(AVRO_SCHEMA).when(srp).fetchSchemaFromRegistry("targetUrl");
+    Schema sc1 = srp.getTargetSchema();
+    Schema sc2 = srp.getTargetSchema();
+    assertEquals(sc1, sc2);
+    System.out.println(sc1);
+    verify(srp, times(1)).fetchSchemaFromRegistry("targetUrl");
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_KEY_META_FIELD);
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_OFFSET_META_FIELD);
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_PARTITION_META_FIELD);
+    assertFieldExistsInSchema(sc1, AvroKafkaSourceHelpers.KAFKA_TOPIC_META_FIELD);
+  }
+
+  @Test
+  void getNullTargetSchema() throws IOException {
+    TypedProperties tp = initProps();
+    tp.put("hoodie.deltastreamer.schemaprovider.registry.targetUrl", "null");
+    SchemaRegistryProvider srp = spy(new SchemaRegistryProvider(tp, null));
+
+    Schema sc = srp.getTargetSchema();
+    assertNull(sc);
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformerTest.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.sources.helpers.AvroKafkaSourceHelpers;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.anyString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SqlQueryBasedTransformerTest {
+
+  @Test
+  void applyNoKafkaFieldsAreInjected() {
+    Dataset<Row> dataset = mock(Dataset.class);
+    dataset.registerTempTable(anyString());
+
+    SparkSession sparkSession = mock(SparkSession.class);
+    ArgumentCaptor<String> ac = ArgumentCaptor.forClass(String.class);
+
+    SqlQueryBasedTransformer t = new SqlQueryBasedTransformer();
+    TypedProperties props = new TypedProperties();
+    props.put("hoodie.deltastreamer.transformer.sql", "sql query <SRC> <KAFKA_FIELDS>");
+    props.put(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, "false");
+    Dataset<Row> res = t.apply(null, sparkSession, dataset, props);
+    verify(sparkSession, times(1)).sql(ac.capture());
+
+    assertTrue(ac.getValue().startsWith("sql query HOODIE_SRC_TMP_TABLE_"));
+    assertTrue(ac.getValue().endsWith(AvroKafkaSourceHelpers.KAFKA_META_FIELDS_PATTERN));
+  }
+
+  @Test
+  void applyKafkaFieldsAreInjected() {
+    Dataset<Row> dataset = mock(Dataset.class);
+    dataset.registerTempTable(anyString());
+
+    SparkSession sparkSession = mock(SparkSession.class);
+    ArgumentCaptor<String> ac = ArgumentCaptor.forClass(String.class);
+
+    SqlQueryBasedTransformer t = new SqlQueryBasedTransformer();
+    TypedProperties props = new TypedProperties();
+    props.put("hoodie.deltastreamer.transformer.sql", "sql query <SRC> <KAFKA_FIELDS>");
+    props.put(AvroKafkaSourceHelpers.INJECT_KAFKA_META_FIELDS, "true");
+
+    Dataset<Row> res = t.apply(null, sparkSession, dataset, props);
+    verify(sparkSession, times(1)).sql(ac.capture());
+    assertTrue(ac.getValue().startsWith("sql query HOODIE_SRC_TMP_TABLE_"));
+    assertTrue(ac.getValue().endsWith(AvroKafkaSourceHelpers.ALL_KAFKA_META_FIELDS));
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request
This PR adds ability to:
 - Inject kafka meta information into the received data from avro kafka source, so users can track which kafka topic, partition, offset and the key delivered a specific record (super useful for debugging consistency issues). In SQL query user would need to specify <KAFKA_FIELDS> and enable appropriate options to enable the injection.
 - specify custom kafka avro data decoder that takes into account source latest schema and different schema versions.
 - cache retrieved source and target latest schemas
 - return null for the target schema if it is not in use by specifying "null" as a target schema url. (I know, there is NullTargetSchemaProvider, however it looks redundant).

## Brief change log

 - Added kafka meta info injection
 - Kafka data deserializer can be swapped with a custom one.
 - source and target latest schema are optionally can being cached
 - if target schema url is set to "null", target schema will return null as a value forcing Hudi to infer the schema from the source one.


## Verify this pull request

This change added tests and can be verified as follows:

  - Added unit tests for the components that were not originally covered.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.