### PR TITLE
[HUDI-1643] Hudi observability - framework to report stats from execu…

### DIFF
--- a/hudi-client/hudi-client-common/pom.xml
+++ b/hudi-client/hudi-client-common/pom.xml
@@ -218,7 +218,6 @@
       <version>${zk-curator.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
@@ -197,6 +197,7 @@ public class HoodieCreateHandle<T extends HoodieRecordPayload, I, K, O> extends 
    * @throws IOException if error occurs
    */
   protected void setupWriteStatus() throws IOException {
+    long fileSizeInBytes = computeFileSizeInBytes();
     HoodieWriteStat stat = new HoodieWriteStat();
     stat.setPartitionPath(writeStatus.getPartitionPath());
     stat.setNumWrites(recordsWritten);
@@ -206,12 +207,15 @@ public class HoodieCreateHandle<T extends HoodieRecordPayload, I, K, O> extends 
     stat.setFileId(writeStatus.getFileId());
     stat.setPath(new Path(config.getBasePath()), path);
     stat.setTotalWriteBytes(computeTotalWriteBytes());
-    stat.setFileSizeInBytes(computeFileSizeInBytes());
+    stat.setFileSizeInBytes(fileSizeInBytes);
     stat.setTotalWriteErrors(writeStatus.getTotalErrorRecords());
     RuntimeStats runtimeStats = new RuntimeStats();
     runtimeStats.setTotalCreateTime(timer.endTimer());
     stat.setRuntimeStats(runtimeStats);
     writeStatus.setStat(stat);
+
+    // record write metrics
+    reportWriteMetrics(recordsWritten, runtimeStats.getTotalCreateTime(), fileSizeInBytes);
   }
 
   protected long computeTotalWriteBytes() throws IOException {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -336,8 +336,8 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload, I, K, O> extends H
       }
 
       long fileSizeInBytes = FSUtils.getFileSize(fs, newFilePath);
-      HoodieWriteStat stat = writeStatus.getStat();
 
+      HoodieWriteStat stat = writeStatus.getStat();
       stat.setTotalWriteBytes(fileSizeInBytes);
       stat.setFileSizeInBytes(fileSizeInBytes);
       stat.setNumWrites(recordsWritten);
@@ -345,11 +345,15 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload, I, K, O> extends H
       stat.setNumUpdateWrites(updatedRecordsWritten);
       stat.setNumInserts(insertRecordsWritten);
       stat.setTotalWriteErrors(writeStatus.getTotalErrorRecords());
+
+      performMergeDataValidationCheck(writeStatus);
+
       RuntimeStats runtimeStats = new RuntimeStats();
       runtimeStats.setTotalUpsertTime(timer.endTimer());
       stat.setRuntimeStats(runtimeStats);
 
-      performMergeDataValidationCheck(writeStatus);
+      // report write metrics
+      reportWriteMetrics(recordsWritten, runtimeStats.getTotalUpsertTime(), fileSizeInBytes);
 
       LOG.info(String.format("MergeHandle for partitionPath %s fileID %s, took %d ms.", stat.getPartitionPath(),
           stat.getFileId(), runtimeStats.getTotalUpsertTime()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -40,6 +40,7 @@ import org.apache.hudi.common.fs.ConsistencyGuard.FileVisibility;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.fs.FailSafeConsistencyGuard;
 import org.apache.hudi.common.fs.OptimisticConsistencyGuard;
+import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecordPayload;
@@ -74,6 +75,7 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,6 +104,9 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
 
   private transient FileSystemViewManager viewManager;
   protected final transient HoodieEngineContext context;
+
+  // Metric registries to be sent to executors
+  private Map<String, Registry> distributedMetricsRegistryMap = new HashMap<>();
 
   protected HoodieTable(HoodieWriteConfig config, HoodieEngineContext context, HoodieTableMetaClient metaClient) {
     this.config = config;
@@ -670,5 +675,13 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
     // This is to handle scenarios where this is called at the executor tasks which do not have access
     // to engine context, and it ends up being null (as its not serializable and marked transient here).
     return context == null ? new HoodieLocalEngineContext(hadoopConfiguration.get()) : context;
+  }
+
+  public final void setDistributedMetricsRegistry(String name, Registry registry) {
+    distributedMetricsRegistryMap.put(name,  registry);
+  }
+
+  public final Option<Registry> getDistributedMetricsRegistry(String name) {
+    return Option.ofNullable(distributedMetricsRegistryMap.get(name));
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metrics/HoodieDistributedMetrics.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metrics/HoodieDistributedMetrics.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.metrics.Registry;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.io.Serializable;
+
+import static org.apache.hudi.common.model.DistributedMetricsReporter.DISTRIBUTED_METRICS_REGISTRY_NAME;
+
+public class HoodieDistributedMetrics extends DistributedRegistry implements Registry, Serializable {
+
+  public HoodieDistributedMetrics() {
+    super(DISTRIBUTED_METRICS_REGISTRY_NAME);
+  }
+
+  public HoodieDistributedMetrics(String name) {
+    super(name);
+  }
+
+  public void registerWithSpark(HoodieEngineContext context, HoodieWriteConfig config) {
+    if (config.isMetricsOn() && config.isExecutorMetricsEnabled()) {
+      Metrics.init(config);
+
+      // register with spark
+      JavaSparkContext jsc = ((HoodieSparkEngineContext) context).getJavaSparkContext();
+      register(jsc);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -32,11 +32,14 @@ import org.apache.hudi.common.testutils.Transformations;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieMetricsConfig;
 import org.apache.hudi.config.HoodieStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.utils.HoodieHiveUtils;
 import org.apache.hudi.io.HoodieCreateHandle;
+import org.apache.hudi.metrics.HoodieDistributedMetrics;
+import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.table.HoodieSparkCopyOnWriteTable;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
@@ -456,5 +459,74 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
   @ValueSource(strings = {"global_sort", "partition_sort", "none"})
   public void testBulkInsertRecordsWithGlobalSort(String bulkInsertMode) throws Exception {
     testBulkInsertRecords(bulkInsertMode);
+  }
+
+  @Test
+  public void testDistributedMetricsOnCOW() throws Exception {
+    // config with metrics enabled
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(SCHEMA.toString())
+        .withMetricsConfig(HoodieMetricsConfig.newBuilder().on(true).withExecutorMetrics(true).build()).build();
+    Metrics.flush(); // flush outstanding stats accumulated so far, if any
+    String firstCommitTime = makeNewCommitTime();
+    SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
+    writeClient.startCommitWithTime(firstCommitTime);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+
+    String partitionPath = "2016/01/31";
+    HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
+
+    // Get some records belong to the same partition (2016/01/31)
+    String recordStr1 = "{\"_row_key\":\"8eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
+        + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}";
+    String recordStr2 = "{\"_row_key\":\"8eb5b87b-1feu-4edd-87b4-6ec96dc405a0\","
+        + "\"time\":\"2016-01-31T03:20:41.415Z\",\"number\":100}";
+    String recordStr3 = "{\"_row_key\":\"8eb5b87c-1fej-4edd-87b4-6ec96dc405a0\","
+        + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":15}";
+    String recordStr4 = "{\"_row_key\":\"8eb5b87d-1fej-4edd-87b4-6ec96dc405a0\","
+        + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":51}";
+
+    List<HoodieRecord> records = new ArrayList<>();
+    RawTripTestPayload rowChange1 = new RawTripTestPayload(recordStr1);
+    records.add(new HoodieRecord(new HoodieKey(rowChange1.getRowKey(), rowChange1.getPartitionPath()), rowChange1));
+    RawTripTestPayload rowChange2 = new RawTripTestPayload(recordStr2);
+    records.add(new HoodieRecord(new HoodieKey(rowChange2.getRowKey(), rowChange2.getPartitionPath()), rowChange2));
+    RawTripTestPayload rowChange3 = new RawTripTestPayload(recordStr3);
+    records.add(new HoodieRecord(new HoodieKey(rowChange3.getRowKey(), rowChange3.getPartitionPath()), rowChange3));
+
+    // Insert new records
+    final HoodieSparkCopyOnWriteTable cowTable = table;
+    writeClient.insert(jsc.parallelize(records, 1), firstCommitTime);
+
+    FileStatus[] allFiles = getIncrementalFiles(partitionPath, "0", -1);
+    assertEquals(1, allFiles.length);
+
+    // Check Stats are reported to registry
+    Option<HoodieDistributedMetrics> distributedRegistry = writeClient.getHoodieDistributedMetrics();
+    assertEquals(true, distributedRegistry.isPresent());
+    Map<String, Long> metrics = distributedRegistry.get().getAllCounts();
+    assertEquals(3, metrics.get("raw_trips.consolidated.totalRecordsWritten.CREATE"));
+
+    // We update the 1st record & add a new record
+    String updateRecordStr1 = "{\"_row_key\":\"8eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
+        + "\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":15}";
+    RawTripTestPayload updateRowChanges1 = new RawTripTestPayload(updateRecordStr1);
+    HoodieRecord updatedRecord1 = new HoodieRecord(
+        new HoodieKey(updateRowChanges1.getRowKey(), updateRowChanges1.getPartitionPath()), updateRowChanges1);
+
+    RawTripTestPayload rowChange4 = new RawTripTestPayload(recordStr4);
+    HoodieRecord insertedRecord1 =
+        new HoodieRecord(new HoodieKey(rowChange4.getRowKey(), rowChange4.getPartitionPath()), rowChange4);
+
+    List<HoodieRecord> updatedRecords = Arrays.asList(updatedRecord1, insertedRecord1);
+
+    Thread.sleep(1000);
+    String newCommitTime = makeNewCommitTime();
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    writeClient.startCommitWithTime(newCommitTime);
+    List<WriteStatus> statuses = writeClient.upsert(jsc.parallelize(updatedRecords), newCommitTime).collect();
+
+    metrics = distributedRegistry.get().getAllCounts();
+    assertEquals(4, metrics.get("raw_trips.consolidated.totalRecordsWritten.MERGE"));
+    assertEquals(2, metrics.get("raw_trips.consolidated.bloomIndexFileRecords"));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DistributedMetricsReporter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DistributedMetricsReporter.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.metrics.Registry;
+import org.apache.hudi.common.util.Option;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+
+/**
+ * Observability related metrics collection operations.
+ */
+public class DistributedMetricsReporter implements Serializable {
+  public static long ONE_MB = 1024 * 1024;
+  public static long USEC_PER_SEC = 1000 * 1000;
+
+  public static final String DISTRIBUTED_METRICS_REGISTRY_NAME = "DistributedMetrics";
+  public static final String TABLE_NAME = "tableName";
+  public static final String STAGE_ID = "stageId";
+  public static final String PARTITION_ID = "partitionId";
+  public static final String IO_TYPE = "IoType";
+  public static final String HOST_NAME = "hostName";
+  private HashMap<String, Object> props = new HashMap<>();
+  public DistributedMetricsReporter(Option<Registry> registry, String tableName, long stageId, long partitionId) {
+    props.put(DISTRIBUTED_METRICS_REGISTRY_NAME, registry);
+    props.put(TABLE_NAME, tableName);
+    props.put(STAGE_ID, stageId);
+    props.put(PARTITION_ID, partitionId);
+    props.put(HOST_NAME, getHostName());
+  }
+
+  private String getHostName() {
+    String host = "Unknown";
+    try {
+      host = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      // use "unknown"
+    }
+    return host;
+  }
+
+  public HashMap<String, Object> getPropertiesMap() {
+    return props;
+  }
+
+  public void reportWriteMetrics() {
+    WriteMetrics.reportWriteStats(props);
+  }
+
+  public void reportBloomIndexMetrics() {
+    BloomIndexMetrics.reportBloomIndexStats(props);
+  }
+
+  public static class WriteMetrics {
+    // define a unique metric name string for each metric to be collected.
+    public static final String PARQUET_NORMALIZED_WRITE_TIME = "writeTimePerRecordInUSec";
+    public static final String PARQUET_CUMULATIVE_WRITE_TIME_IN_USEC = "cumulativeParquetWriteTimeInUSec";
+    public static final String PARQUET_WRITE_TIME_PER_MB_IN_USEC = "writeTimePerMBInUSec";
+    public static final String PARQUET_WRITE_THROUGHPUT_MBPS = "writeThroughputMBps";
+    public static final String TOTAL_RECORDS_WRITTEN = "totalRecordsWritten";
+    public static final String TOTAL_BYTES_WRITTEN = "totalBytesWritten";
+
+    private static String getWriteMetricKey(String metric, HashMap<String, Object> props) {
+      return String.format("%s.%s.%s.%s.%d", props.get(TABLE_NAME), metric, props.get(IO_TYPE),
+          props.get(HOST_NAME), props.get(PARTITION_ID));
+    }
+
+    private static String getConsolidatedWriteMetricKey(String metric, HashMap<String, Object> params) {
+      return String.format("%s.consolidated.%s.%s", params.get(TABLE_NAME), metric, params.get(IO_TYPE));
+    }
+
+    public static void reportWriteStats(HashMap<String, Object> props) {
+
+      Option<Registry> registry = (Option<Registry>) props.get(DISTRIBUTED_METRICS_REGISTRY_NAME);
+      long cumulativeWriteTimeInUsec = (Long)props.get(PARQUET_CUMULATIVE_WRITE_TIME_IN_USEC);
+      long totalRecs = (Long) props.get(TOTAL_RECORDS_WRITTEN);
+      long writeTimePerRecordInUSec = cumulativeWriteTimeInUsec / Math.max(totalRecs, 1);
+      long writeTimePerMBInUSec = (long) (cumulativeWriteTimeInUsec
+          * ((double) ONE_MB / (double) Math.max((Long)props.get(TOTAL_BYTES_WRITTEN), 1)));
+      long writeThroughputMBps = (USEC_PER_SEC / Math.max(writeTimePerMBInUSec, 1));
+
+      if (registry.isPresent()) {
+        // executor specific stats
+        registry.get().add(getWriteMetricKey(PARQUET_NORMALIZED_WRITE_TIME, props), writeTimePerRecordInUSec);
+        registry.get().add(getWriteMetricKey(PARQUET_CUMULATIVE_WRITE_TIME_IN_USEC, props), cumulativeWriteTimeInUsec);
+        registry.get().add(getWriteMetricKey(TOTAL_RECORDS_WRITTEN, props), totalRecs);
+        registry.get().add(getWriteMetricKey(PARQUET_WRITE_TIME_PER_MB_IN_USEC, props), writeTimePerMBInUSec);
+        registry.get().add(getWriteMetricKey(PARQUET_WRITE_THROUGHPUT_MBPS,props), writeThroughputMBps);
+
+        // stats consolidated from all executors
+        registry.get().add(getConsolidatedWriteMetricKey(TOTAL_RECORDS_WRITTEN, props), totalRecs);
+        registry.get().add(getConsolidatedWriteMetricKey(PARQUET_CUMULATIVE_WRITE_TIME_IN_USEC, props),
+            cumulativeWriteTimeInUsec);
+      }
+    }
+  }
+
+  public static class BloomIndexMetrics {
+    public static final String SEARCH_TIME_IN_USEC = "bloomIndexSearchTime";
+    public static final String CANDIDATE_RECORDS = "bloomIndexCandidateRecords";
+    public static final String FILE_RECORDS = "bloomIndexFileRecords";
+    public static final String MATCHING_RECORDS = "bloomIndexMatchingRecords";
+    public static final String HIT_RATIO_AGAINST_FILE_RECORDS = "bloomIndexHitRatioVsFileRecords";
+    public static final String HIT_RATIO_AGAINST_CANDIDATE_RECORDS = "bloomIndexHitRatioVsCandidateRecords";
+    public static final String CANDIDATE_TO_FILE_RECORDS_RATIO = "bloomIndexCandidatesToFileRecordsRatio";
+    public static final String SEARCH_TIME_PER_MATCHING_RECORD = "bloomIndexSearchTimePerMatchingRecord";
+    public static final String TIME_TAKEN_PER_INSPECTION = "bloomIndexTimeTakenPerInspection";
+
+    private static String getBloomIndexMetricKey(String metric, HashMap<String, Object> props) {
+      return String.format("%s.%s.%s.%d", props.get(TABLE_NAME), metric, props.get(HOST_NAME), props.get(PARTITION_ID));
+    }
+
+    private static String getConsolidatedBloomIndexMetricKey(String metric, HashMap<String, Object> props) {
+      return String.format("%s.consolidated.%s", props.get(TABLE_NAME), metric);
+    }
+
+    // inputs:
+    // searchTimeInUSecs (total time taken for the search)
+    // candidateRecords (needles being searched)
+    // fileRecords  (haystack in consideration)
+    // matchingRecords (needles found)
+    //
+    // metrics:
+    // hitRatioAgainstFileRecords  = matchingRecords / fileRecords  (needles found to haystack ratio)
+    // hitRatioAgainstCandidateRecords = matchingRecords / candidateRecords (percentage needles found)
+    // candidateToFileRatio = candidateRecords / FileRecords (needles to haystack ratio)
+    // numInspections  (number of needle/hay items inspected)
+    // perMatchingRecordSearchTime = SearchTimeInUsec / matchingRecords (search time per needle found)
+    // timeTakenPerInspection = SearchTimeInUsec / numInspections
+
+    public static void reportBloomIndexStats(HashMap<String, Object> props) {
+
+      Option<Registry> registry = (Option<Registry>) props.get(DISTRIBUTED_METRICS_REGISTRY_NAME);
+      long cumulativeSearchTimeInUsec = (Long)props.get(SEARCH_TIME_IN_USEC);
+      long matchingRecords = (Long) props.get(MATCHING_RECORDS);
+      long fileRecords = (Long) props.get(FILE_RECORDS);
+      long candidateRecords = (Long) props.get(CANDIDATE_RECORDS);
+
+      long searchTimePerMatchingRecord = cumulativeSearchTimeInUsec / Math.max(matchingRecords, 1);
+      long timeTakenPerInspection = cumulativeSearchTimeInUsec / Math.max(fileRecords, 1);
+      long candidateToFileRatio = candidateRecords / Math.max(fileRecords, 1);
+      long hitRatioAgainstCandidateRecords = matchingRecords / Math.max(candidateRecords, 1);
+      long hitRatioAgainstFileRecords = matchingRecords / Math.max(fileRecords, 1);
+
+      if (registry.isPresent()) {
+        // executor specific stats
+        registry.get().add(getBloomIndexMetricKey(SEARCH_TIME_IN_USEC, props), cumulativeSearchTimeInUsec);
+        registry.get().add(getBloomIndexMetricKey(CANDIDATE_RECORDS, props), candidateRecords);
+        registry.get().add(getBloomIndexMetricKey(FILE_RECORDS, props), fileRecords);
+        registry.get().add(getBloomIndexMetricKey(MATCHING_RECORDS, props), matchingRecords);
+        registry.get().add(getBloomIndexMetricKey(HIT_RATIO_AGAINST_FILE_RECORDS, props), hitRatioAgainstFileRecords);
+        registry.get().add(getBloomIndexMetricKey(HIT_RATIO_AGAINST_CANDIDATE_RECORDS, props), hitRatioAgainstCandidateRecords);
+        registry.get().add(getBloomIndexMetricKey(CANDIDATE_TO_FILE_RECORDS_RATIO, props), candidateToFileRatio);
+        registry.get().add(getBloomIndexMetricKey(SEARCH_TIME_PER_MATCHING_RECORD, props), searchTimePerMatchingRecord);
+        registry.get().add(getBloomIndexMetricKey(TIME_TAKEN_PER_INSPECTION, props), timeTakenPerInspection);
+
+        // stats consolidated from all executors
+        registry.get().add(getConsolidatedBloomIndexMetricKey(FILE_RECORDS, props), fileRecords);
+        registry.get().add(getConsolidatedBloomIndexMetricKey(SEARCH_TIME_IN_USEC, props), cumulativeSearchTimeInUsec);
+      }
+    }
+  }
+}


### PR DESCRIPTION
…tors

## What is the purpose of the pull request
Frame work for collecting Hudi Observability stats from the executors.

## Brief change log

- Using distributed registry, report stats from the executors to the driver, to be published using the Graphite reporter.
- Report Hudi Write stage performance stats.
- Report Hudi BoomIndex stage stats.

## Verify this pull request

This change added tests and can be verified as follows:

  -  Added a unit testcase testObservabilityMetricsOnCOW
  -  Manually verified the change by running a job locally.

## Committer checklist

 - [ x] Has a corresponding JIRA in PR title & commit
 
 - [ x] Commit message is descriptive of the change
 
 - [ x] CI is green

 - [x ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.