### PR TITLE
[HUDI-1646] Provide mechanism to read uncommitted data through InputFormat

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -158,6 +158,13 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieDefaultTimeline findInstantsBeforeOrEquals(String instantTime) {
+    return new HoodieDefaultTimeline(instants.stream()
+        .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN_OR_EQUALS, instantTime)),
+        details);
+  }
+
+  @Override
   public HoodieTimeline filter(Predicate<HoodieInstant> filter) {
     return new HoodieDefaultTimeline(instants.stream().filter(filter), details);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -177,6 +177,11 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline findInstantsBefore(String instantTime);
 
   /**
+   * Create new timeline with all instants before or equals specified time.
+   */
+  HoodieTimeline findInstantsBeforeOrEquals(String instantTime);
+  
+  /**
    * Custom Filter of Instants.
    */
   HoodieTimeline filter(Predicate<HoodieInstant> filter);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
@@ -169,14 +169,21 @@ public class FileSystemViewManager {
 
   public static HoodieTableFileSystemView createInMemoryFileSystemView(HoodieEngineContext engineContext, HoodieTableMetaClient metaClient,
                                                                        HoodieMetadataConfig metadataConfig) {
+    
+    return createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig,
+        metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
+    
+  }
+  
+  public static HoodieTableFileSystemView createInMemoryFileSystemViewWithTimeline(HoodieEngineContext engineContext,
+                                                                                   HoodieTableMetaClient metaClient,
+                                                                                   HoodieMetadataConfig metadataConfig,
+                                                                                   HoodieTimeline timeline) {
     LOG.info("Creating InMemory based view for basePath " + metaClient.getBasePath());
     if (metadataConfig.useFileListingMetadata()) {
-      return new HoodieMetadataFileSystemView(engineContext, metaClient,
-          metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-          metadataConfig);
+      return new HoodieMetadataFileSystemView(engineContext, metaClient, timeline, metadataConfig);
     }
-    return new HoodieTableFileSystemView(metaClient,
-        metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
+    return new HoodieTableFileSystemView(metaClient, timeline);
   }
 
   /**

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -439,8 +439,9 @@ public class HoodieInputFormatUtils {
           LOG.debug("Hoodie Metadata initialized with completed commit instant as :" + metaClient);
         }
 
+        HoodieTimeline timeline = HoodieHiveUtils.getTableTimeline(metaClient.getTableConfig().getTableName(), job, metaClient);
         HoodieTableFileSystemView fsView = fsViewCache.computeIfAbsent(metaClient, tableMetaClient ->
-            FileSystemViewManager.createInMemoryFileSystemView(engineContext, tableMetaClient, buildMetadataConfig(job)));
+            FileSystemViewManager.createInMemoryFileSystemViewWithTimeline(engineContext, tableMetaClient, buildMetadataConfig(job), timeline));
         List<HoodieBaseFile> filteredBaseFiles = new ArrayList<>();
         for (Path p : entry.getValue()) {
           String relativePartitionPath = FSUtils.getRelativePartitionPath(new Path(metaClient.getBasePath()), p);

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -28,7 +28,9 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.testutils.FileCreateUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
 import org.apache.hudi.hadoop.utils.HoodieHiveUtils;
 
@@ -57,6 +59,7 @@ import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResou
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestHoodieParquetInputFormat {
 
@@ -427,6 +430,44 @@ public class TestHoodieParquetInputFormat {
     ensureFilesInCommit("Pulling all commit from beginning, should return instants after requested compaction",
         files, "400", 10);
 
+  }
+
+  @Test
+  public void testSnapshotPreCommitValidate() throws IOException {
+    // initial commit
+    File partitionDir = InputFormatTestUtil.prepareTable(basePath, baseFileFormat, 10, "100");
+    createCommitFile(basePath, "100", "2016/05/01");
+
+    // Add the paths
+    FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+    FileStatus[] files = inputFormat.listStatus(jobConf);
+    assertEquals(10, files.length, "Snapshot read must return all files in partition");
+
+    // add more files
+    InputFormatTestUtil.simulateInserts(partitionDir, baseFileExtension, "fileId2-", 5, "200");
+    FileCreateUtils.createInflightCommit(basePath.toString(), "200");
+
+    // Verify that validate mode reads uncommitted files
+    InputFormatTestUtil.setupSnapshotIncludePendingCommits(jobConf, "200");
+    files = inputFormat.listStatus(jobConf);
+    assertEquals(15, files.length, "Must return uncommitted files");
+    ensureFilesInCommit("Pulling 1 commit from 100, should get us the 5 files committed at 200", files, "200", 5);
+    ensureFilesInCommit("Pulling 1 commit from 100, should get us the 10 files committed at 100", files, "100", 10);
+
+    try {
+      // Verify that Validate mode throws error with invalid commit time
+      InputFormatTestUtil.setupSnapshotIncludePendingCommits(jobConf, "300"); 
+      inputFormat.listStatus(jobConf);
+      fail("Expected list status to fail when validate is called with unknown timestamp");
+    } catch (HoodieIOException e) {
+      // expected because validate is called with invalid instantTime
+    }
+    
+    // verify that snapshot mode skips uncommitted files
+    InputFormatTestUtil.setupSnapshotScanMode(jobConf);
+    files = inputFormat.listStatus(jobConf);
+    assertEquals(10, files.length, "snapshot scan mode must not return uncommitted files");
+    ensureFilesInCommit("Pulling 1 commit from 100, should get us the 10 files committed at 100", files, "100", 10);
   }
 
   private void ensureRecordsInCommit(String msg, String commit, int expectedNumberOfRecordsInCommit,

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/testutils/InputFormatTestUtil.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/testutils/InputFormatTestUtil.java
@@ -122,6 +122,26 @@ public class InputFormatTestUtil {
         String.format(HoodieHiveUtils.HOODIE_MAX_COMMIT_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
     jobConf.setInt(maxCommitPulls, numberOfCommitsToPull);
   }
+  
+  public static void setupSnapshotIncludePendingCommits(JobConf jobConf, String instantTime) {
+    setupSnapshotScanMode(jobConf, true);
+    String validateTimestampName =
+        String.format(HoodieHiveUtils.HOODIE_CONSUME_COMMIT, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.set(validateTimestampName, instantTime);
+  }
+
+  public static void setupSnapshotScanMode(JobConf jobConf) {
+    setupSnapshotScanMode(jobConf, false);
+  }
+  
+  private static void setupSnapshotScanMode(JobConf jobConf, boolean includePending) {
+    String modePropertyName =
+        String.format(HoodieHiveUtils.HOODIE_CONSUME_MODE_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.set(modePropertyName, HoodieHiveUtils.SNAPSHOT_SCAN_MODE);
+    String includePendingCommitsName =
+        String.format(HoodieHiveUtils.HOODIE_CONSUME_PENDING_COMMITS, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.setBoolean(includePendingCommitsName, includePending);
+  }
 
   public static File prepareParquetTable(java.nio.file.Path basePath, Schema schema, int numberOfFiles,
       int numberOfRecords, String commitNumber) throws IOException {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Add support for pre-commit validation hooks through hive/presto queries. We provide mechanism to read uncommitted data through InputFormat. If validation passes, we will promote the commit. Otherwise, rollback the commit.


## Brief change log

* Add new consume mode: validate. In this consume mode, we allow reading dirty data. Users can run hive/presto queries, validate data and then commit/abort. Note that users also need to explicitly specify dirty commit time to use this API. (We can consider making this optional)
* In the first version, only added support for COW tables and parquet format. If general approach looks good, i can extend support for other file formats/table types as a follow up.

## Verify this pull request

This change added tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.