### PR TITLE
[MINOR] Fix default value for hoodie.deltastreamer.source.kafka.auto.reset.offsets

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -177,7 +177,7 @@ public class KafkaOffsetGen {
     }
     DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(Config.KAFKA_TOPIC_NAME));
     topicName = props.getString(Config.KAFKA_TOPIC_NAME);
-    String kafkaAutoResetOffsetsStr = props.getString(Config.KAFKA_AUTO_RESET_OFFSETS, Config.DEFAULT_KAFKA_AUTO_RESET_OFFSETS.name());
+    String kafkaAutoResetOffsetsStr = props.getString(Config.KAFKA_AUTO_RESET_OFFSETS, Config.DEFAULT_KAFKA_AUTO_RESET_OFFSETS.name().toLowerCase());
     boolean found = false;
     for (KafkaResetOffsetStrategies entry: KafkaResetOffsetStrategies.values()) {
       if (entry.name().toLowerCase().equals(kafkaAutoResetOffsetsStr)) {


### PR DESCRIPTION
## What is the purpose of the pull request

This pull requests fixes a minor bug in default value of `hoodie.deltastreamer.source.kafka.auto.reset.offsets`.
It gives following error otherwise.
```
Caused by: org.apache.hudi.exception.HoodieDeltaStreamerException: hoodie.deltastreamer.source.kafka.auto.reset.offsets config set to unknown value LATEST
	at org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.<init>(KafkaOffsetGen.java:190)
	at org.apache.hudi.utilities.sources.AvroKafkaSource.<init>(AvroKafkaSource.java:57)
	... 23 more
```

## Brief change log



## Verify this pull request

*(Please pick either of the following options)*

- [x] This pull request is a trivial rework / code cleanup without any test coverage. 

*(or)*

- [ ] This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

- [ ] This change added tests and can be verified as follows:

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.