### PR TITLE
[HUDI-1662] Failed to query real-time view use hive/spark-sql when hudi mor table contains dateType

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -33,6 +33,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.HiveDecimalUtils;
@@ -166,6 +167,9 @@ public class HoodieRealtimeRecordReaderUtils {
       case BYTES:
         return new BytesWritable(((ByteBuffer)value).array());
       case INT:
+        if (schema.getLogicalType() != null && schema.getLogicalType().getName().equals("date")) {
+          return new DateWritable((Integer) value);
+        }
         return new IntWritable((Integer) value);
       case LONG:
         return new LongWritable((Long) value);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

fixed the bug that: Failed to query real-time view use hive/spark-sql when hudi mor table contains dateType
test step:
step1: prepare raw DataFrame with DateType, and insert it to HudiMorTable

df_raw.withColumn("date", lit(Date.valueOf("2020-11-10")))

merge(df_raw, "bulk_insert", "huditest.bulkinsert_mor_10g")

step2: prepare update DataFrame with DateType, and upsert into HudiMorTable

 df_update = sql("select * from huditest.bulkinsert_mor_10g_rt").withColumn("date", lit(Date.valueOf("2020-11-11")))

merge(df_update, "upsert", "huditest.bulkinsert_mor_10g")

step3: use hive-beeeline/ spark-sql query mor_rt table

use beeline/spark-sql   execute   statement select * from huditest.bulkinsert_mor_10g_rt where primary_key = 10000000;

then the follow error will occur:

java.lang.ClassCastExceoption: org.apache.hadoop.io.IntWritable cannot be cast to org.apache.hadoop.hive.serde2.io.DateWritableV2

## Brief change log
when hudi read log file and convert avro INT type record to writable，logicalType is not respected which lead the dateType will cast to IntWritable。so cast avro INT type  to writable,  logicalType must be  considered

## Verify this pull request
Existing UT tests
## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.