### PR TITLE
[HUDI-1667]: Fix bug when HoodieMergeOnReadRDD read record from base …

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDD.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDD.scala
@@ -281,7 +281,7 @@ class HoodieMergeOnReadRDD(@transient sc: SparkContext,
         tableState.requiredStructSchema.foreach(
           f => {
             val curPos = posIterator.next()
-            val curField = row.get(curPos, f.dataType)
+            val curField = if (row.isNullAt(curPos)) null else row.get(curPos, f.dataType)
             rowToReturn.update(curIndex, curField)
             curIndex = curIndex + 1
           }


### PR DESCRIPTION
…file, Hoodie may set non-null value in field which is null if vectorization is enabled.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

* Fix bug when HoodieMergeOnReadRDD read record from base file, Hoodie may set non-null value in field which is null if vectorization is enabled.*

## Brief change log

  - When HoodieMergeOnReadRDD read record from base file,  will create new InternalRow base on requiredStructSchema.
  - Hoodie doesn't check isNull when get value from all fields.
If vectorization is enabled, which  means row is ColumnarBatchRow.  ColumnarBatchRow may return non-null value even if value of field is null. So, hoodie may set non-null value in field which is null.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.