### PR TITLE
Fixed invalid avro schemas in hudi-common/src/main/avro/

### DIFF
--- a/hudi-common/src/main/avro/HoodieClusteringPlan.avsc
+++ b/hudi-common/src/main/avro/HoodieClusteringPlan.avsc
@@ -30,7 +30,7 @@
     },
     {
        "name":"strategy",
-       "type":["HoodieClusteringStrategy", "null"],
+       "type":["null", "HoodieClusteringStrategy"],
        "default": null
     },
     {

--- a/hudi-common/src/main/avro/HoodieFSPermission.avsc
+++ b/hudi-common/src/main/avro/HoodieFSPermission.avsc
@@ -28,22 +28,22 @@
       {
         "name":"userAction",
         "type":[ "null", "string" ],
-        "default": "null"
+        "default": null
       },
       {
         "name":"groupAction",
         "type":[ "null", "string" ],
-        "default": "null"
+        "default": null
       },
       {
         "name":"otherAction",
         "type":[ "null", "string" ],
-        "default": "null"
+        "default": null
       },
       {
         "name":"stickyBit",
         "type":[ "null", "boolean" ],
-        "default": "null"
+        "default": null
       }
    ]
 }

--- a/hudi-common/src/main/avro/HoodieRequestedReplaceMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRequestedReplaceMetadata.avsc
@@ -23,11 +23,11 @@
      {
          "name":"operationType",
          "type":["null", "string"],
-         "default": ""
+         "default": null
     },
     {
        "name":"clusteringPlan", /* only set if operationType == clustering" */
-       "type":["HoodieClusteringPlan", "null"],
+       "type":["null", "HoodieClusteringPlan"],
        "default": null
     },
     {

--- a/hudi-common/src/main/avro/HoodieRestoreMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRestoreMetadata.avsc
@@ -38,7 +38,6 @@
      /* overlaps with 'instantsToRollback' field. Adding this to track action type for all the instants being rolled back. */
      {
        "name": "restoreInstantInfo",
-       "default": null,
        "type": {
          "type": "array",
          "default": null,


### PR DESCRIPTION
Hi Hudi team!

## What is the purpose of the pull request
We need to upgrade to at least Avro 1.9.x in production so i tried upgrading the avro version in the pom.xml of Hudi. Doing so i noticed some problems:

Upgrade to Avro 1.9.2:
- Renamed method defaultValue to defaultVal ==> #TODO
- Avro complains about invalid schemas/default values in hudi-common/src/main/avro/ ==> #2649
- The shaded guava libs from Avro have been removed ==> #TODO

Upgrade to Avro 1.10.1:
- Some more stuff

Spark 3.2.0 (we currently use 3.1.1) will contain Avro 1.10.1 (https://issues.apache.org/jira/browse/SPARK-27733).
Ín order to reduce the effort switching to a newer Avro version in the future i provided some patches that fixes the above mentioned issues.

## Brief change log
This PR addresses the following issues:
- Avro complains about invalid schemas/default values in hudi-common/src/main/avro/ ==> #2649

## Verify this pull request
Run Unit tests

Kind regards
Sebastian
