### PR TITLE
[HUDI-1694] Preparation for Avro update

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/index/simple/FlinkHoodieSimpleIndex.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/index/simple/FlinkHoodieSimpleIndex.java
@@ -34,8 +34,6 @@ import org.apache.hudi.index.HoodieIndexUtils;
 import org.apache.hudi.io.HoodieKeyLocationFetchHandle;
 import org.apache.hudi.table.HoodieTable;
 
-import avro.shaded.com.google.common.collect.Lists;
-
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -135,8 +133,8 @@ public class FlinkHoodieSimpleIndex<T extends HoodieRecordPayload> extends Flink
         context.map(latestBaseFiles, partitionPathBaseFile -> new HoodieKeyLocationFetchHandle<>(config, hoodieTable, partitionPathBaseFile), parallelism);
     Map<HoodieKey, HoodieRecordLocation> recordLocations = new HashMap<>();
     hoodieKeyLocationFetchHandles.stream()
-        .flatMap(handle -> Lists.newArrayList(handle.locations()).stream())
-        .forEach(x -> x.forEach(y -> recordLocations.put(y.getKey(), y.getRight())));
+        .flatMap(handle -> handle.locations())
+        .forEach(x -> recordLocations.put(x.getKey(), x.getRight()));
     return recordLocations;
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBaseIndex.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.index.hbase;
 
-import avro.shaded.com.google.common.collect.Maps;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
@@ -65,6 +64,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -469,7 +469,7 @@ public class TestHBaseIndex extends FunctionalTestHarness {
   @Test
   public void testHbaseTagLocationForArchivedCommits() throws Exception {
     // Load to memory
-    Map<String, String> params = Maps.newHashMap();
+    Map<String, String> params = new HashMap<String, String>();
     params.put(HoodieCompactionConfig.CLEANER_COMMITS_RETAINED_PROP, "1");
     params.put(HoodieCompactionConfig.MAX_COMMITS_TO_KEEP_PROP, "3");
     params.put(HoodieCompactionConfig.MIN_COMMITS_TO_KEEP_PROP, "2");

--- a/hudi-common/src/main/avro/HoodieClusteringPlan.avsc
+++ b/hudi-common/src/main/avro/HoodieClusteringPlan.avsc
@@ -30,7 +30,7 @@
     },
     {
        "name":"strategy",
-       "type":["HoodieClusteringStrategy", "null"],
+       "type":["null", "HoodieClusteringStrategy"],
        "default": null
     },
     {

--- a/hudi-common/src/main/avro/HoodieFSPermission.avsc
+++ b/hudi-common/src/main/avro/HoodieFSPermission.avsc
@@ -28,22 +28,22 @@
       {
         "name":"userAction",
         "type":[ "null", "string" ],
-        "default": "null"
+        "default": null
       },
       {
         "name":"groupAction",
         "type":[ "null", "string" ],
-        "default": "null"
+        "default": null
       },
       {
         "name":"otherAction",
         "type":[ "null", "string" ],
-        "default": "null"
+        "default": null
       },
       {
         "name":"stickyBit",
         "type":[ "null", "boolean" ],
-        "default": "null"
+        "default": null
       }
    ]
 }

--- a/hudi-common/src/main/avro/HoodieRequestedReplaceMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRequestedReplaceMetadata.avsc
@@ -23,11 +23,11 @@
      {
          "name":"operationType",
          "type":["null", "string"],
-         "default": ""
+         "default": null
     },
     {
        "name":"clusteringPlan", /* only set if operationType == clustering" */
-       "type":["HoodieClusteringPlan", "null"],
+       "type":["null", "HoodieClusteringPlan"],
        "default": null
     },
     {

--- a/hudi-common/src/main/avro/HoodieRestoreMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRestoreMetadata.avsc
@@ -38,7 +38,7 @@
      /* overlaps with 'instantsToRollback' field. Adding this to track action type for all the instants being rolled back. */
      {
        "name": "restoreInstantInfo",
-       "default": null,
+       "default": [],
        "type": {
          "type": "array",
          "default": null,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -330,7 +330,7 @@ public class TableSchemaResolver {
       for (final Field newSchemaField : newSchema.getFields()) {
         final Field oldSchemaField = SchemaCompatibility.lookupWriterField(oldSchema, newSchemaField);
         if (oldSchemaField == null) {
-          if (newSchemaField.defaultValue() == null) {
+          if (newSchemaField.defaultVal() == null) {
             // C3: newly added field in newSchema does not have a default value
             return false;
           }

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -25,7 +25,6 @@ import org.apache.hudi.exception.SchemaCompatibilityException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.codehaus.jackson.node.NullNode;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -184,7 +183,7 @@ public class TestHoodieAvroUtils {
     Schema.Field evolvedField1 = new Schema.Field("key", HoodieAvroUtils.METADATA_FIELD_SCHEMA, "", JsonProperties.NULL_VALUE);
     Schema.Field evolvedField2 = new Schema.Field("key1", HoodieAvroUtils.METADATA_FIELD_SCHEMA, "", JsonProperties.NULL_VALUE);
     Schema.Field evolvedField3 = new Schema.Field("key2", HoodieAvroUtils.METADATA_FIELD_SCHEMA, "", JsonProperties.NULL_VALUE);
-    Schema.Field evolvedField4 = new Schema.Field("evolved_field", HoodieAvroUtils.METADATA_FIELD_SCHEMA, "", NullNode.getInstance());
+    Schema.Field evolvedField4 = new Schema.Field("evolved_field", HoodieAvroUtils.METADATA_FIELD_SCHEMA, "", JsonProperties.NULL_VALUE);
     Schema.Field evolvedField5 = new Schema.Field("evolved_field1", HoodieAvroUtils.METADATA_FIELD_SCHEMA, "", JsonProperties.NULL_VALUE);
     evolvedFields.add(evolvedField1);
     evolvedFields.add(evolvedField2);


### PR DESCRIPTION
Hi Hudi team!

## What is the purpose of the pull request
We need to upgrade to at least Avro 1.9.x in production so i tried upgrading the avro version in the pom.xml of Hudi. Doing so i noticed some problems:

Upgrade to Avro 1.9.2:
- Renamed method defaultValue to defaultVal
- Moved NullNode.getInstance() to JsonProperties.NULL_VALUE
- Avro complains about invalid schemas/default values in hudi-common/src/main/avro/
- The shaded guava libs from Avro have been removed

Upgrade to Avro 1.10.1:
- Some more stuff (Not handled in this PR)

Spark 3.2.0 (we currently use 3.1.1) will contain Avro 1.10.1 (https://issues.apache.org/jira/browse/SPARK-27733).
Ín order to reduce the effort switching to a newer Avro version in the future i provided a patch that fixes the above mentioned issues.

## Brief change log
Fix the above mentioned issues

## Verify this pull request
Run Unit tests

Kind regards
Sebastian
