### PR TITLE
[WIP] [HUDI-1615] Fixing null schema for delete operation in spark datasource

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/RawTripTestPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/RawTripTestPayload.java
@@ -94,6 +94,11 @@ public class RawTripTestPayload implements HoodieRecordPayload<RawTripTestPayloa
     }
   }
 
+  public static List<String> recordsToDeleteStrings(List<HoodieRecord> records) {
+    return records.stream().map(entry -> "{\"_row_key\":\"" + entry.getRecordKey() + "\",\"partition\":\""
+        + entry.getPartitionPath() + "\"}").collect(Collectors.toList());
+  }
+
   public String getPartitionPath() {
     return partitionPath;
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -201,8 +201,7 @@ private[hudi] object HoodieSparkSqlWriter {
           }
 
           val tableMetaClient = HoodieTableMetaClient.builder.setConf(sparkContext.hadoopConfiguration).setBasePath(path.get).build()
-          val tableSchemaResolver = new TableSchemaResolver(tableMetaClient)
-          val tableSchema = tableSchemaResolver.getTableAvroSchemaWithoutMetadataFields
+          val tableSchema = new TableSchemaResolver(tableMetaClient).getTableAvroSchemaWithoutMetadataFields
 
           // Create a HoodieWriteClient & issue the delete.
           val client = hoodieWriteClient.getOrElse(DataSourceUtils.createHoodieClient(jsc,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
@@ -20,7 +20,6 @@ package org.apache.hudi.functional
 import java.time.Instant
 import java.util
 import java.util.{Collections, Date, UUID}
-
 import org.apache.commons.io.FileUtils
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.client.{SparkRDDWriteClient, TestBootstrap}
@@ -149,7 +148,7 @@ class HoodieSparkSqlWriterSuite extends FunSuite with Matchers {
       }
 
       // fetch all records from parquet files generated from write to hudi
-      val actualDf = sqlContext.read.parquet(fullPartitionPaths(0), fullPartitionPaths(1), fullPartitionPaths(2))
+      val actualDf = sqlContext.read.parquet(fullPartitionPaths:_*)
 
       // remove metadata columns so that expected and actual DFs can be compared as is
       val trimmedDf = actualDf.drop(HoodieRecord.HOODIE_META_COLUMNS.get(0)).drop(HoodieRecord.HOODIE_META_COLUMNS.get(1))


### PR DESCRIPTION
## What is the purpose of the pull request

With explicit "Delete" operation, Null schema is passed in to writeConfig. This in turn gets stored in extra metadata in commit metadata. This patch fixes the null schema for Delete operation. 

## Brief change log

  - *Setting table schema for delete operation*

## Verify this pull request

  - Could not verify that schema is written to extra metadata. But have written delete datasource tests to verify table schema. 
           TestCOWDataSource#testDeletes
  - But manually verified the extra metadata w/ hudi-cli. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.