### PR TITLE
[HUDI-1703] Fixing kafka auto.reset.offsets config param key

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -53,6 +53,7 @@ import org.apache.hudi.utilities.sources.InputBatch;
 import org.apache.hudi.utilities.sources.JsonKafkaSource;
 import org.apache.hudi.utilities.sources.ParquetDFSSource;
 import org.apache.hudi.utilities.sources.TestDataSource;
+import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.Config;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 import org.apache.hudi.utilities.testutils.sources.DistributedTestDataSource;
 import org.apache.hudi.utilities.testutils.sources.config.SourceConfigs;
@@ -259,7 +260,7 @@ public class TestHoodieDeltaStreamer extends UtilitiesTestBase {
   protected static void populateCommonKafkaProps(TypedProperties props) {
     //Kafka source properties
     props.setProperty("bootstrap.servers", testUtils.brokerAddress());
-    props.setProperty("hoodie.deltastreamer.source.kafka.auto.reset.offsets", "earliest");
+    props.setProperty(Config.KAFKA_AUTO_RESET_OFFSETS, "earliest");
     props.setProperty("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
     props.setProperty("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
     props.setProperty("hoodie.deltastreamer.kafka.source.maxEvents", String.valueOf(5000));
@@ -1344,7 +1345,7 @@ public class TestHoodieDeltaStreamer extends UtilitiesTestBase {
     props.setProperty("hoodie.deltastreamer.source.kafka.topic",topicName);
     props.setProperty("hoodie.deltastreamer.schemaprovider.source.schema.file", dfsBasePath + "/source_uber.avsc");
     props.setProperty("hoodie.deltastreamer.schemaprovider.target.schema.file", dfsBasePath + "/target_uber.avsc");
-    props.setProperty("hoodie.deltastreamer.source.kafka.auto.reset.offsets", autoResetValue);
+    props.setProperty(Config.KAFKA_AUTO_RESET_OFFSETS, autoResetValue);
 
     UtilitiesTestBase.Helpers.savePropsToDFS(props, dfs, dfsBasePath + "/" + propsFileName);
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestKafkaSource.java
@@ -88,7 +88,7 @@ public class TestKafkaSource extends UtilitiesTestBase {
     TypedProperties props = new TypedProperties();
     props.setProperty("hoodie.deltastreamer.source.kafka.topic", TEST_TOPIC_NAME);
     props.setProperty("bootstrap.servers", testUtils.brokerAddress());
-    props.setProperty("hoodie.deltastreamer.source.kafka.auto.reset.offsets", resetStrategy);
+    props.setProperty(Config.KAFKA_AUTO_RESET_OFFSETS, resetStrategy);
     props.setProperty("hoodie.deltastreamer.kafka.source.maxEvents",
         maxEventsToReadFromKafkaSource != null ? String.valueOf(maxEventsToReadFromKafkaSource) :
             String.valueOf(Config.maxEventsFromKafkaSource));


### PR DESCRIPTION
## What is the purpose of the pull request

In one of the [PRs](https://github.com/apache/hudi/commit/617cc24ad1a28196b872df5663e9e0f48cd7f0fa), we changed the kafka offset reset config param to be prefixed with "hoodie" w/o realizing that its native kafka config param. So, we need to revert that. 

## Brief change log

- Reverted Kafka config param key for auto reset offsets.
- Minor optimization in offset/checkpoint handling

## Verify this pull request

This pull request is already covered by existing tests, such as 
- TestKafkaSource
- Some tests in TestHoodieDeltaStreamer


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.