### PR TITLE
[HUDI-1211] clean up spark session for each test of FunctionalTestHar…

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/hbase/TestHBaseIndex.java
@@ -103,9 +103,6 @@ public class TestHBaseIndex extends FunctionalTestHarness {
       utility.deleteTable(TABLE_NAME);
       utility.shutdownMiniCluster();
     }
-    if (spark != null) {
-      spark.close();
-    }
   }
 
   @BeforeAll


### PR DESCRIPTION
…ness

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

To fix the issue of HUDI-1211, 

## Brief change log

* close spark session after each test in FunctionalTestHarness.java 

## Verify this pull request
* This change is only for tests

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.