### PR TITLE
[HUDI 1623] New Hoodie Instant on disk format with end time and milliseconds granularity

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -65,7 +65,7 @@ public class CommitsCommand {
     final List<Comparable[]> rows = new ArrayList<>();
 
     final List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
-        .getInstantsAsStream().sorted(HoodieInstant.COMPARATOR.reversed()).collect(Collectors.toList());
+        .getInstantsAsStream().sorted(HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed()).collect(Collectors.toList());
 
     for (final HoodieInstant commit : commits) {
       if (timeline.getInstantDetails(commit).isPresent()) {
@@ -103,7 +103,7 @@ public class CommitsCommand {
     final List<Comparable[]> rows = new ArrayList<>();
 
     final List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
-        .getInstantsAsStream().sorted(HoodieInstant.COMPARATOR.reversed()).collect(Collectors.toList());
+        .getInstantsAsStream().sorted(HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed()).collect(Collectors.toList());
 
     for (final HoodieInstant commit : commits) {
       if (timeline.getInstantDetails(commit).isPresent()) {

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
@@ -137,7 +137,7 @@ public class DiffCommand {
                                        BiFunction<HoodieWriteStat, String, Boolean> diffEntityChecker) throws IOException {
     List<Comparable[]> rows = new ArrayList<>();
     List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
-        .getInstantsAsStream().sorted(HoodieInstant.COMPARATOR.reversed()).collect(Collectors.toList());
+        .getInstantsAsStream().sorted(HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed()).collect(Collectors.toList());
 
     for (final HoodieInstant commit : commits) {
       Option<byte[]> instantDetails = timeline.getInstantDetails(commit);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
@@ -115,7 +115,7 @@ public class TestTableCommand extends CLIFunctionalTestHarness {
 
     // Check default values
     assertFalse(conf.isConsistencyCheckEnabled());
-    assertEquals(new Integer(1), HoodieCLI.layoutVersion.getVersion());
+    assertEquals(new Integer(2), HoodieCLI.layoutVersion.getVersion());
   }
 
   /**
@@ -132,7 +132,7 @@ public class TestTableCommand extends CLIFunctionalTestHarness {
     assertEquals(tablePath, client.getBasePath());
     assertEquals(metaPath, client.getMetaPath());
     assertEquals(HoodieTableType.COPY_ON_WRITE, client.getTableType());
-    assertEquals(new Integer(1), client.getTimelineLayoutVersion().getVersion());
+    assertEquals(new Integer(2), client.getTimelineLayoutVersion().getVersion());
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestBootstrapCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestBootstrapCommand.java
@@ -90,7 +90,7 @@ public class ITTestBootstrapCommand extends HoodieCLIIntegrationTestBase {
     assertTrue(ShellEvaluationResultUtil.isSuccess(resultForBootstrapRun));
 
     // Connect & check Hudi table exist
-    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(tablePath, TimelineLayoutVersion.VERSION_2, false, 2000, 300000, 7);
     metaClient = HoodieCLI.getTableMetaClient();
     assertEquals(1, metaClient.getActiveTimeline().getCommitsTimeline().countInstants(), "Should have 1 commit.");
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestHDFSParquetImportCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestHDFSParquetImportCommand.java
@@ -110,7 +110,7 @@ public class ITTestHDFSParquetImportCommand extends HoodieCLIIntegrationTestBase
     assertTrue(Files.exists(Paths.get(metaPath)), "Hoodie table not exist.");
 
     // Load meta data
-    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_2, false, 2000, 300000, 7);
     metaClient = HoodieCLI.getTableMetaClient();
 
     assertEquals(1, metaClient.getActiveTimeline().getCommitsTimeline().countInstants(), "Should only 1 commit.");
@@ -134,7 +134,7 @@ public class ITTestHDFSParquetImportCommand extends HoodieCLIIntegrationTestBase
     dataImporter.dataImport(jsc, 0);
 
     // Load meta data
-    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_1, false, 2000, 300000, 7);
+    new TableCommand().connect(targetPath.toString(), TimelineLayoutVersion.VERSION_2, false, 2000, 300000, 7);
     metaClient = HoodieCLI.getTableMetaClient();
 
     // check if insert instant exist

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.upgrade;
+
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SixToFiveDowngradeHandler implements DowngradeHandler {
+  @Override
+  public Map<ConfigProperty, String> downgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
+    HoodieTableMetaClient metaClient = upgradeDowngradeHelper.getTable(config, context).getMetaClient();
+    HoodieTimeline versionTwoActiveTimeline = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(config.getBasePath())
+        .setLoadActiveTimelineOnLoad(true).setConsistencyGuardConfig(config.getConsistencyGuardConfig())
+        .setLayoutVersion(Option.of(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_2))).build().getActiveTimeline();
+    HoodieTimeline versionOneActiveTimeline = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(config.getBasePath())
+        .setLoadActiveTimelineOnLoad(true).setConsistencyGuardConfig(config.getConsistencyGuardConfig())
+        .setLayoutVersion(Option.of(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_1))).build().getActiveTimeline();
+    List<HoodieInstant> versionTwoInstants = versionTwoActiveTimeline.getInstants();
+    List<HoodieInstant> versionOneInstants = versionOneActiveTimeline.getInstants();
+
+    for (HoodieInstant instant : versionTwoInstants) {
+      String versionOneFileName = instant.getFileName();
+      String versionTwoFileName = versionOneInstants.stream().filter(s -> s.getTimestamp()
+          .equals(instant.getTimestamp())).findFirst().get().getFileName();
+      String metaPath = metaClient.getMetaPath();
+      try {
+        metaClient.getFs().rename(new Path(metaPath, versionTwoFileName), new Path(metaPath, versionOneFileName));
+      } catch (IOException io) {
+        throw new HoodieUpgradeDowngradeException("Unable to rename instant filename ", io);
+      }
+    }
+    return Collections.EMPTY_MAP;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -2901,7 +2901,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withFailedWritesCleaningPolicy(cleaningPolicy)
             .withAutoClean(false).build())
-        .withTimelineLayoutVersion(1)
+        .withTimelineLayoutVersion(2)
         .withHeartbeatIntervalInMs(3 * 1000)
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.HoodieTimelineTimeZone;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantFormat;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
@@ -641,14 +642,14 @@ public class HoodieTableMetaClient implements Serializable {
         HoodieTableMetaClient
             .scanFiles(getFs(), timelinePath, path -> {
               // Include only the meta files with extensions that needs to be included
-              String extension = HoodieInstant.getTimelineFileExtension(path.getName());
+              String extension = HoodieInstantFormat.getInstantFormat(getTimelineLayoutVersion()).getTimelineFileExtension(path.getName());
               return includedExtensions.contains(extension);
-            })).map(HoodieInstant::new);
+            })).map(s -> new HoodieInstant(s, timelineLayoutVersion));
 
     if (applyLayoutVersionFilters) {
       instantStream = TimelineLayout.getLayout(getTimelineLayoutVersion()).filterHoodieInstants(instantStream);
     }
-    return instantStream.sorted().collect(Collectors.toList());
+    return TimelineLayout.getLayout(getTimelineLayoutVersion()).sortHoodieInstants(instantStream).collect(Collectors.toList());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
@@ -38,7 +38,9 @@ public enum HoodieTableVersion {
   // 0.11.0 onwards
   FOUR(4),
   // 0.12.0 onwards
-  FIVE(5);
+  FIVE(5),
+  // 0.14.0 onwards
+  SIX(6);
 
   private final int versionCode;
 
@@ -51,7 +53,7 @@ public enum HoodieTableVersion {
   }
 
   public static HoodieTableVersion current() {
-    return FIVE;
+    return SIX;
   }
 
   public static HoodieTableVersion versionFromCode(int versionCode) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimelineStateMachine.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimelineStateMachine.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+import org.apache.hudi.common.util.Option;
+
+/**
+ * In-Memory Timeline State Machine to hold all states for hoodie instants on the {@link HoodieActiveTimeline}.
+ * Provides APIs to be able to perform in memory create, delete, revert and transition of Action States.
+ * All writes to {@link HoodieActiveTimeline} go through this State Machine to ensure {@link HoodieInstant}s have
+ * {@link HoodieInstant#stateTransitionTime}.
+ */
+public class HoodieActiveTimelineStateMachine {
+
+  private Map<String, List<HoodieInstant>> actionStartTimeToInstantsMap = new ConcurrentHashMap<>();
+
+  private static HoodieActiveTimelineStateMachine instance;
+
+  /**
+   * Initialize State Machine from an instant stream.
+   * @param instantStream
+   */
+  public synchronized void initialize(Stream<HoodieInstant> instantStream) {
+    if (actionStartTimeToInstantsMap.size() > 0) {
+      throw new UnsupportedOperationException("call reset first");
+    }
+    instantStream.forEach(instant -> {
+      if (actionStartTimeToInstantsMap.containsKey(instant.getTimestamp())) {
+        appendToActionInstantList(instant);
+      } else {
+        addNewActionInstantInternal(instant);
+      }
+    });
+  }
+
+  /**
+   * Reset the current state machine.
+   */
+  public void reset() {
+    this.actionStartTimeToInstantsMap = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Get the current instance.
+   * @return
+   */
+  public static synchronized HoodieActiveTimelineStateMachine getInstance() {
+    if (instance == null) {
+      instance = new HoodieActiveTimelineStateMachine();
+    }
+    return instance;
+  }
+
+  /**
+   * Transition a {@link HoodieInstant} for an action from one state to another.
+   * @param fromInstant
+   * @param toInstant
+   * @return
+   */
+  public synchronized HoodieInstant transition(HoodieInstant fromInstant, HoodieInstant toInstant) {
+    if (actionStartTimeToInstantsMap.containsKey(fromInstant.getTimestamp())) {
+      HoodieInstant currentState = InstantTimeGenerator.setActionEndTimeIfNeeded(toInstant);
+      appendToActionInstantList(currentState);
+      return currentState;
+    } else {
+      HoodieInstant currentState = InstantTimeGenerator.setActionEndTimeIfNeeded(toInstant);
+      addNewActionInstantInternal(currentState);
+      return currentState;
+    }
+  }
+
+  /**
+   * Add a new {@link HoodieInstant} to the State Machine for a new action.
+   * @param instant
+   * @return
+   */
+  public synchronized HoodieInstant addNewActionInstant(HoodieInstant instant) {
+    if (!actionStartTimeToInstantsMap.containsKey(instant.getTimestamp())) {
+      HoodieInstant currentInstant = InstantTimeGenerator.setActionEndTimeIfNeeded(instant);
+      return addNewActionInstantInternal(currentInstant);
+    } else {
+      throw new IllegalArgumentException("This instant " + instant + " is not a new state for action " + instant.getAction());
+    }
+  }
+
+  /**
+   * Delete instant from the State Machine.
+   * @param instant
+   * @return
+   */
+  public synchronized HoodieInstant removeInstant(HoodieInstant instant) {
+    if (actionStartTimeToInstantsMap.containsKey(instant.getTimestamp())) {
+      actionStartTimeToInstantsMap.get(instant.getTimestamp()).remove(instant);
+      return instant;
+    }
+    throw new IllegalArgumentException(); // TODO: Not found exception
+  }
+
+  /**
+   * Find instant in the State Machine.
+   * @param instant
+   * @return
+   */
+  public Option<HoodieInstant> findInstant(HoodieInstant instant) {
+    if (actionStartTimeToInstantsMap.containsKey(instant.getTimestamp())) {
+      return Option.fromJavaOptional(actionStartTimeToInstantsMap.get(instant.getTimestamp()).stream()
+          .filter(instant1 -> instant1.getState().equals(instant.getState())
+              && instant1.getAction().equals(instant.getAction())).findFirst());
+    }
+    return Option.empty();
+  }
+
+  /**
+   * Get list of instants from State Machine for the given action start time.
+   * @param actionStartTime
+   * @return
+   */
+  public Option<List<HoodieInstant>> getInstants(String actionStartTime) {
+    return Option.of(actionStartTimeToInstantsMap.get(actionStartTime));
+  }
+
+  /**
+   * Get latest state instant from State Machine for the given action start time.
+   * @param actionStartTime
+   * @return
+   */
+  public Option<HoodieInstant> getLatestInstant(String actionStartTime) {
+    List<HoodieInstant> instants = actionStartTimeToInstantsMap.get(actionStartTime);
+    if (instants != null) {
+      return Option.of(instants.get(instants.size() - 1));
+    }
+    return Option.empty();
+  }
+
+  public Option<HoodieInstant> getInstant(String action, String actionStartTime, State actionState) {
+    List<HoodieInstant> instants = actionStartTimeToInstantsMap.get(actionStartTime);
+    if (instants != null) {
+      return Option.fromJavaOptional(instants.stream().filter(s -> s.getState().equals(actionState)).findFirst());
+    }
+    return Option.empty();
+  }
+
+  private HoodieInstant addNewActionInstantInternal(HoodieInstant instant) {
+    List<HoodieInstant> instants = new LinkedList<>();
+    instants.add(instant);
+    actionStartTimeToInstantsMap.put(instant.getTimestamp(), instants);
+    return instant;
+  }
+
+  private HoodieInstant appendToActionInstantList(HoodieInstant instant) {
+    List<HoodieInstant> instants = actionStartTimeToInstantsMap.get(instant.getTimestamp());
+    if (!instants.contains(instant)) {
+      instants.add(instant);
+    }
+    return instant;
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantFormat.java
@@ -1,0 +1,464 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import static org.apache.hudi.common.table.timeline.HoodieActiveTimeline.COMMIT_TIME_PATTERN;
+import static org.apache.hudi.common.table.timeline.HoodieInstant.DEFAULT_INIT_STATE;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hudi.common.table.timeline.HoodieInstant.InstantTime;
+import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+import org.apache.hudi.common.table.timeline.versioning.HoodieInstantVersion;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+
+/**
+ * TODO : Reduce code duplication in this class.
+ */
+public abstract class HoodieInstantFormat {
+
+  private static final Map<TimelineLayoutVersion, HoodieInstantFormat> FORMAT_MAP = new HashMap<>();
+
+  static {
+    FORMAT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_1), new HoodieInstantFormatV0());
+    FORMAT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION), new HoodieInstantFormatV1());
+  }
+
+  public static HoodieInstantFormat getInstantFormat(TimelineLayoutVersion version) {
+    return FORMAT_MAP.get(version);
+  }
+
+  public abstract String getAction(FileStatus fileStatus);
+
+  public abstract State getState(FileStatus fileStatus);
+
+  public abstract String getActionStartTime(FileStatus fileStatus);
+
+  public abstract String getStateTransitionTime(FileStatus fileStatus);
+
+  public abstract String getFileName(HoodieInstant instant);
+
+  public abstract String getTimelineFileExtension(String fileName);
+
+  public static class HoodieInstantFormatV0 extends HoodieInstantFormat {
+
+    private HoodieInstantVersion version = new HoodieInstantVersion(HoodieInstantVersion.VERSION_0);
+
+    @Override
+    public String getAction(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return action;
+    }
+
+    @Override
+    public State getState(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return state;
+    }
+
+    @Override
+    public String getActionStartTime(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return actionStartTimestamp;
+    }
+
+    @Override
+    public String getStateTransitionTime(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return stateTransitionTime;
+    }
+
+    @Override
+    public String getFileName(HoodieInstant instant) {
+      String action = instant.getAction();
+      InstantTime instantTime = instant.getInstantTime();
+
+      if (HoodieTimeline.COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightCommitFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedCommitFileName(instantTime)
+          : HoodieTimeline.makeCommitFileName(instantTime);
+      } else if (HoodieTimeline.CLEAN_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightCleanerFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedCleanerFileName(instantTime)
+          : HoodieTimeline.makeCleanerFileName(instantTime);
+      } else if (HoodieTimeline.ROLLBACK_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightRollbackFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedRollbackFileName(instantTime)
+          : HoodieTimeline.makeRollbackFileName(instantTime);
+      } else if (HoodieTimeline.SAVEPOINT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightSavePointFileName(instantTime)
+          : HoodieTimeline.makeSavePointFileName(instantTime);
+      } else if (HoodieTimeline.DELTA_COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightDeltaFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedDeltaFileName(instantTime)
+          : HoodieTimeline.makeDeltaFileName(instantTime);
+      } else if (HoodieTimeline.COMPACTION_ACTION.equals(action)) {
+        if (isInflight(instant)) {
+          return HoodieTimeline.makeInflightCompactionFileName(instantTime);
+        } else if (isRequested(instant)) {
+          return HoodieTimeline.makeRequestedCompactionFileName(instantTime);
+        } else {
+          return HoodieTimeline.makeCommitFileName(instantTime);
+        }
+      } else if (HoodieTimeline.LOG_COMPACTION_ACTION.equals(action)) {
+        if (isInflight(instant)) {
+          return HoodieTimeline.makeInflightLogCompactionFileName(instantTime);
+        } else if (isRequested(instant)) {
+          return HoodieTimeline.makeRequestedLogCompactionFileName(instantTime);
+        } else {
+          return HoodieTimeline.makeDeltaFileName(instantTime);
+        }
+      } else if (HoodieTimeline.RESTORE_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightRestoreFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedRestoreFileName(instantTime)
+          : HoodieTimeline.makeRestoreFileName(instantTime);
+      } else if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightReplaceFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedReplaceFileName(instantTime)
+          : HoodieTimeline.makeReplaceFileName(instantTime);
+      } else if (HoodieTimeline.INDEXING_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightIndexFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedIndexFileName(instantTime)
+          : HoodieTimeline.makeIndexCommitFileName(instantTime);
+      } else if (HoodieTimeline.SCHEMA_COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightSchemaFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestSchemaFileName(instantTime)
+          : HoodieTimeline.makeSchemaFileName(instantTime);
+      }
+      throw new IllegalArgumentException("Cannot get file name for unknown action " + action);
+    }
+
+    @Override
+    public String getTimelineFileExtension(String fileName) {
+      Objects.requireNonNull(fileName);
+      int dotIndex = fileName.indexOf('.');
+      return dotIndex == -1 ? "" : fileName.substring(dotIndex);
+    }
+
+    public String getActionStartTime(String fileExtensionPrefix) {
+      Objects.requireNonNull(fileExtensionPrefix);
+      int dotIndex = fileExtensionPrefix.indexOf('_');
+      return dotIndex == -1 ? fileExtensionPrefix : fileExtensionPrefix.substring(0, dotIndex);
+    }
+
+    public String getTransitionTime(FileStatus fileStatus, String startTimestamp) {
+      Objects.requireNonNull(fileStatus);
+      String endTimestamp = String.valueOf(fileStatus.getModificationTime());
+      return HoodieTimeline.LESSER_THAN_OR_EQUALS.test(endTimestamp, startTimestamp)
+          || !COMMIT_TIME_PATTERN.matcher(endTimestamp).matches() ? startTimestamp : endTimestamp;
+    }
+
+    public String getTransitionTime(String fileName, String startTimestamp) {
+      Objects.requireNonNull(fileName);
+      Objects.requireNonNull(startTimestamp);
+      int lastDotIndex = fileName.lastIndexOf(".");
+      String transitionTime = lastDotIndex == -1 ? "" : fileName.substring(lastDotIndex);
+      return COMMIT_TIME_PATTERN.matcher(transitionTime).matches() ? transitionTime : startTimestamp;
+    }
+
+    private Boolean isRequested(HoodieInstant instant) {
+      return instant.getState() == State.REQUESTED;
+    }
+
+    private Boolean isInflight(HoodieInstant instant) {
+      return instant.getState() == State.INFLIGHT;
+    }
+  }
+
+  public static class HoodieInstantFormatV1 extends HoodieInstantFormat {
+
+    private HoodieInstantVersion version = new HoodieInstantVersion(HoodieInstantVersion.VERSION_1);
+
+    @Override
+    public String getAction(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return action;
+    }
+
+    @Override
+    public State getState(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return state;
+    }
+
+    @Override
+    public String getActionStartTime(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return actionStartTimestamp;
+    }
+
+    @Override
+    public String getStateTransitionTime(FileStatus fileStatus) {
+      // First read the instant startTimestamp. [==>20170101193025<==].commit
+      String fileName = fileStatus.getPath().getName();
+      String fileExtension = getTimelineFileExtension(fileName);
+      String actionStartTimestamp = fileName.replace(fileExtension, "");
+      // Next read the action for this marker
+      String action = fileExtension.replaceFirst(".", "");
+      String stateTransitionTime = getTransitionTime(fileStatus, actionStartTimestamp);
+      State state = DEFAULT_INIT_STATE;
+      if (action.equals("inflight")) {
+        // This is to support backwards compatibility on how in-flight commit files were written
+        // General rule is inflight extension is .<action>.inflight, but for commit it is .inflight
+        action = "commit";
+        state = State.INFLIGHT;
+      } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
+        state = State.INFLIGHT;
+        action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+      } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
+        state = State.REQUESTED;
+        action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
+      }
+      return stateTransitionTime;
+    }
+
+    @Override
+    public String getFileName(HoodieInstant instant) {
+
+      String action = instant.getAction();
+      InstantTime instantTime = instant.getInstantTime();
+
+      if (HoodieTimeline.COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightCommitFileName(instantTime)
+            : isRequested(instant) ? HoodieTimeline.makeRequestedCommitFileName(instantTime)
+                : HoodieTimeline.makeCommitFileName(instantTime);
+      } else if (HoodieTimeline.CLEAN_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightCleanerFileName(instantTime)
+            : isRequested(instant) ? HoodieTimeline.makeRequestedCleanerFileName(instantTime)
+                : HoodieTimeline.makeCleanerFileName(instantTime);
+      } else if (HoodieTimeline.ROLLBACK_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightRollbackFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedRollbackFileName(instantTime)
+          : HoodieTimeline.makeRollbackFileName(instantTime);
+      } else if (HoodieTimeline.SAVEPOINT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightSavePointFileName(instantTime)
+            : HoodieTimeline.makeSavePointFileName(instantTime);
+      } else if (HoodieTimeline.DELTA_COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightDeltaFileName(instantTime)
+            : isRequested(instant) ? HoodieTimeline.makeRequestedDeltaFileName(instantTime)
+                : HoodieTimeline.makeDeltaFileName(instantTime);
+      } else if (HoodieTimeline.COMPACTION_ACTION.equals(action)) {
+        if (isInflight(instant)) {
+          return HoodieTimeline.makeInflightCompactionFileName(instantTime);
+        } else if (isRequested(instant)) {
+          return HoodieTimeline.makeRequestedCompactionFileName(instantTime);
+        } else {
+          return HoodieTimeline.makeCommitFileName(instantTime);
+        }
+      } else if (HoodieTimeline.LOG_COMPACTION_ACTION.equals(action)) {
+        if (isInflight(instant)) {
+          return HoodieTimeline.makeInflightLogCompactionFileName(instantTime);
+        } else if (isRequested(instant)) {
+          return HoodieTimeline.makeRequestedLogCompactionFileName(instantTime);
+        } else {
+          return HoodieTimeline.makeDeltaFileName(instantTime);
+        }
+      } else if (HoodieTimeline.RESTORE_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightRestoreFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedRestoreFileName(instantTime)
+          : HoodieTimeline.makeRestoreFileName(instantTime);
+      } else if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightReplaceFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedReplaceFileName(instantTime)
+          : HoodieTimeline.makeReplaceFileName(instantTime);
+      } else if (HoodieTimeline.INDEXING_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightIndexFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestedIndexFileName(instantTime)
+          : HoodieTimeline.makeIndexCommitFileName(instantTime);
+      } else if (HoodieTimeline.SCHEMA_COMMIT_ACTION.equals(action)) {
+        return isInflight(instant) ? HoodieTimeline.makeInflightSchemaFileName(instantTime)
+          : isRequested(instant) ? HoodieTimeline.makeRequestSchemaFileName(instantTime)
+          : HoodieTimeline.makeSchemaFileName(instantTime);
+      }
+      throw new IllegalArgumentException("Cannot get file name for unknown action " + action);
+    }
+
+    @Override
+    public String getTimelineFileExtension(String fileName) {
+      Objects.requireNonNull(fileName);
+      int dotIndex = fileName.indexOf('.');
+      return dotIndex == -1 ? "" : fileName.substring(dotIndex);
+    }
+
+    public String getActionStartTime(String fileExtensionPrefix) {
+      Objects.requireNonNull(fileExtensionPrefix);
+      int dotIndex = fileExtensionPrefix.indexOf('_');
+      return dotIndex == -1 ? fileExtensionPrefix : fileExtensionPrefix.substring(0, dotIndex);
+    }
+
+    public String getTransitionTime(FileStatus fileStatus, String startTimestamp) {
+      Objects.requireNonNull(fileStatus);
+      String endTimestamp = String.valueOf(fileStatus.getModificationTime());
+      return HoodieTimeline.LESSER_THAN_OR_EQUALS.test(endTimestamp, startTimestamp)
+          || !COMMIT_TIME_PATTERN.matcher(endTimestamp).matches() ? startTimestamp : endTimestamp;
+    }
+
+    public String getTransitionTime(String fileName, String startTimestamp) {
+      Objects.requireNonNull(fileName);
+      Objects.requireNonNull(startTimestamp);
+      int lastDotIndex = fileName.lastIndexOf(".");
+      String transitionTime = lastDotIndex == -1 ? "" : fileName.substring(lastDotIndex);
+      return COMMIT_TIME_PATTERN.matcher(transitionTime).matches() ? transitionTime : startTimestamp;
+    }
+
+    private Boolean isRequested(HoodieInstant instant) {
+      return instant.getState() == State.REQUESTED;
+    }
+
+    private Boolean isInflight(HoodieInstant instant) {
+      return instant.getState() == State.INFLIGHT;
+    }
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/InstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/InstantTimeGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+
+/**
+ * Generates final {@link HoodieInstant}s to write to the timeline.
+ */
+public class InstantTimeGenerator {
+
+  public static HoodieInstant setActionEndTimeIfNeeded(HoodieInstant instant) {
+    if (instant.getStateTransitionTime() != null) {
+      return new HoodieInstant(instant.getState(), instant.getAction(), instant.getTimestamp(),
+          HoodieActiveTimeline.createNewInstantTime());
+    }
+    return instant;
+  }
+
+  public static HoodieInstant createHoodieInstantWithActionEndTime(State state, String action, String actionStartTimestamp) {
+    return new HoodieInstant(state, action, actionStartTimestamp, HoodieActiveTimeline.createNewInstantTime());
+  }
+
+  public static HoodieInstant createHoodieInstant(State state, String action, String actionStartTimestamp, String actionEndTimestamp) {
+    return new HoodieInstant(state, action, actionStartTimestamp, actionEndTimestamp);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineLayout.java
@@ -37,6 +37,7 @@ public abstract class TimelineLayout implements Serializable {
   static {
     LAYOUT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_0), new TimelineLayoutV0());
     LAYOUT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_1), new TimelineLayoutV1());
+    LAYOUT_MAP.put(new TimelineLayoutVersion(TimelineLayoutVersion.VERSION_2), new TimelineLayoutV2());
   }
 
   public static TimelineLayout getLayout(TimelineLayoutVersion version) {
@@ -44,6 +45,8 @@ public abstract class TimelineLayout implements Serializable {
   }
 
   public abstract Stream<HoodieInstant> filterHoodieInstants(Stream<HoodieInstant> instantStream);
+
+  public abstract Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream);
 
   /**
    * Table Layout where state transitions are managed by renaming files.
@@ -53,6 +56,11 @@ public abstract class TimelineLayout implements Serializable {
     @Override
     public Stream<HoodieInstant> filterHoodieInstants(Stream<HoodieInstant> instantStream) {
       return instantStream;
+    }
+
+    @Override
+    public Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return instantStream.sorted();
     }
   }
 
@@ -72,6 +80,27 @@ public abstract class TimelineLayout implements Serializable {
             }
             return y;
           }).get());
+    }
+
+    @Override
+    public Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return instantStream.sorted();
+    }
+  }
+
+  /**
+   * Table Layout where state transitions are managed by creating new files with END_INSTANT_TIME.
+   */
+  private static class TimelineLayoutV2 extends TimelineLayoutV1 {
+
+    @Override
+    public Stream<HoodieInstant> filterHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return super.filterHoodieInstants(instantStream);
+    }
+
+    @Override
+    public Stream<HoodieInstant> sortHoodieInstants(Stream<HoodieInstant> instantStream) {
+      return instantStream.sorted(HoodieInstant.END_INSTANT_TIME_COMPARATOR);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/HoodieInstantVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/HoodieInstantVersion.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Hoodie Instant Disk Format Version. Add new version when instant format changes.
+ */
+public class HoodieInstantVersion implements Serializable, Comparable<HoodieInstantVersion> {
+
+  public static final Integer VERSION_0 = 0; // current version with state transition time
+  public static final Integer VERSION_1 = 1; // current version with state transition time
+
+  public static final Integer CURR_VERSION = VERSION_1;
+  public static final HoodieInstantVersion CURR_INSTANT_VERSION = new HoodieInstantVersion(CURR_VERSION);
+
+  private Integer version;
+
+  public HoodieInstantVersion(Integer version) {
+    this.version = version;
+  }
+
+  @Override
+  public int compareTo(HoodieInstantVersion o) {
+    return Integer.compare(version, o.version);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodieInstantVersion that = (HoodieInstantVersion) o;
+    return version.equals(that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/InstantTimeFormatter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This class wraps around the commit time generator and helps to handle version upgrade changes.
+ */
+public class InstantTimeFormatter {
+
+  public static final SimpleDateFormat COMMIT_FORMATTER_V1 = new SimpleDateFormat("yyyyMMddHHmmss");
+  public static final SimpleDateFormat COMMIT_FORMATTER_V2 = new SimpleDateFormat("yyyyMMddHHmmssSSS");
+  public static Integer latestVersion = TimelineLayoutVersion.CURR_VERSION;
+
+  public String format(Date date) {
+    switch (latestVersion) {
+      case 0:
+      case 1:
+        return COMMIT_FORMATTER_V1.format(date);
+      case 2:
+        return COMMIT_FORMATTER_V2.format(date);
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  public Date parse(String commitTime) throws ParseException {
+    int length = commitTime.length();
+    switch (length) {
+      // For second granularity instant times parsing in V1
+      /**
+       * 13 length is for {@link org.apache.hudi.metadata.HoodieTableMetadata#SOLO_COMMIT_TIMESTAMP}
+       * This value needs to be less than {@link org.apache.hudi.common.table.timeline.HoodieTimeline#INIT_INSTANT_TS}
+       * so we carry this logic forward.
+       */
+      case 13:
+      case 14:
+        return COMMIT_FORMATTER_V1.parse(commitTime);
+      case 17:
+        return COMMIT_FORMATTER_V2.parse(commitTime);
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/TimelineLayoutVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/TimelineLayoutVersion.java
@@ -29,9 +29,10 @@ import java.util.Objects;
 public class TimelineLayoutVersion implements Serializable, Comparable<TimelineLayoutVersion> {
 
   public static final Integer VERSION_0 = 0; // pre 0.5.1  version format
-  public static final Integer VERSION_1 = 1; // current version with no renames
+  public static final Integer VERSION_1 = 1; // new version with no renames
+  public static final Integer VERSION_2 = 2; // current version with no renames and end commit times
 
-  public static final Integer CURR_VERSION = VERSION_1;
+  public static final Integer CURR_VERSION = VERSION_2;
   public static final TimelineLayoutVersion CURR_LAYOUT_VERSION = new TimelineLayoutVersion(CURR_VERSION);
 
   private final Integer version;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
@@ -184,6 +184,7 @@ public class InternalSchemaCache {
     String avroSchema = "";
     Set<String> commitSet = Arrays.stream(validCommits.split(",")).collect(Collectors.toSet());
     List<String> validateCommitList = commitSet.stream().map(fileName -> {
+      // TODO: fetch extension based in HoodieInstantFormat
       String fileExtension = HoodieInstant.getTimelineFileExtension(fileName);
       return fileName.replace(fileExtension, "");
     }).collect(Collectors.toList());
@@ -192,6 +193,7 @@ public class InternalSchemaCache {
     Path hoodieMetaPath = new Path(tablePath, HoodieTableMetaClient.METAFOLDER_NAME);
     //step1:
     Path candidateCommitFile = commitSet.stream().filter(fileName -> {
+      // TODO: fetch extension based in HoodieInstantFormat
       String fileExtension = HoodieInstant.getTimelineFileExtension(fileName);
       return fileName.replace(fileExtension, "").equals(versionId + "");
     }).findFirst().map(f -> new Path(hoodieMetaPath, f)).orElse(null);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -488,11 +488,8 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     assertEquals(HoodieTimeline.getCommitFromCommitFile(instantInflight.getFileName()), "5");
     assertEquals(HoodieTimeline.getCommitFromCommitFile(instantComplete.getFileName()), "5");
 
-    assertEquals(HoodieTimeline.makeFileNameAsComplete(instantInflight.getFileName()),
-            instantComplete.getFileName());
-
-    assertEquals(HoodieTimeline.makeFileNameAsInflight(instantComplete.getFileName()),
-            instantInflight.getFileName());
+    assertEquals(instantInflight.getFileName(), instantComplete.getFileName());
+    assertEquals(instantComplete.getFileName(), instantInflight.getFileName());
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestTimelineLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestTimelineLayout.java
@@ -38,44 +38,53 @@ public class TestTimelineLayout  {
   @Test
   public void testTimelineLayoutFilter() {
     List<HoodieInstant> rawInstants = Arrays.asList(
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "001"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "001"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "002"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "002"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "003"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "003"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "004"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "004"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "005"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "005"),
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "006"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "006"),
-        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "007"),
-        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "007"));
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "001", "001"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "001", "001"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001", "002"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "002"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "002"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "009"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "003", "003"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "003", "003"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003", "004"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, "004", "004"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "004", "004"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "005"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "005"),
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "006"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "006", "006"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "006", "006"),
+        new HoodieInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, "007", "007"),
+        new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "007", "007"));
 
     List<HoodieInstant> layout0Instants = TimelineLayout.getLayout(new TimelineLayoutVersion(0))
         .filterHoodieInstants(rawInstants.stream()).collect(Collectors.toList());
     assertEquals(rawInstants, layout0Instants);
-    List<HoodieInstant> layout1Instants = TimelineLayout.getLayout(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
+    List<HoodieInstant> layout1Instants = TimelineLayout.getLayout(new TimelineLayoutVersion(1))
         .filterHoodieInstants(rawInstants.stream()).collect(Collectors.toList());
+    List<HoodieInstant> layout2Instants = TimelineLayout.getLayout(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
+        .filterHoodieInstants(rawInstants.stream()).sorted(HoodieInstant.END_INSTANT_TIME_COMPARATOR)
+        .collect(Collectors.toList());
+    assertEquals(7, layout2Instants.size());
+
     assertEquals(7, layout1Instants.size());
     assertTrue(layout1Instants.contains(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "007")));
     assertTrue(layout1Instants.contains(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "006")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "006")));
     assertTrue(layout1Instants.contains(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, "004")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003", "004")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "009")));
     assertTrue(layout1Instants.contains(
-        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001")));
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.CLEAN_ACTION, "001", "002")));
+
+    assertTrue(layout2Instants.indexOf(
+        new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "009"))
+        > layout2Instants.indexOf(new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "005", "006")));
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -300,7 +300,7 @@ public class HoodieInputFormatUtils {
     // Total number of commits to return in this batch. Set this to -1 to get all the commits.
     Integer maxCommits = HoodieHiveUtils.readMaxCommits(job, tableName);
     LOG.info("Last Incremental timestamp was set as " + lastIncrementalTs);
-    return timeline.findInstantsAfter(lastIncrementalTs, maxCommits);
+    return timeline.filterByFinishTs(HoodieTimeline.GREATER_THAN, lastIncrementalTs, maxCommits);
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -81,7 +81,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
 
   private val lastInstant = commitTimeline.lastInstant().get()
 
-  private val commitsTimelineToReturn = commitTimeline.findInstantsInRange(
+  private val commitsTimelineToReturn = commitTimeline.findInstantsInRangeByFinishTs(
     optParams(DataSourceReadOptions.BEGIN_INSTANTTIME.key),
     optParams.getOrElse(DataSourceReadOptions.END_INSTANTTIME.key(), lastInstant.getTimestamp))
   private val commitsToReturn = commitsTimelineToReturn.getInstantsAsStream.iterator().toList

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -62,7 +62,7 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
     if (fullTableScan) {
       metaClient.getCommitsAndCompactionTimeline
     } else {
-      metaClient.getCommitsAndCompactionTimeline.findInstantsInRange(startTimestamp, endTimestamp)
+      metaClient.getCommitsAndCompactionTimeline.findInstantsInRangeByFinishTs(startTimestamp, endTimestamp)
     }
   }
 
@@ -154,7 +154,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
     if (!startInstantArchived || !endInstantArchived) {
       // If endTimestamp commit is not archived, will filter instants
       // before endTimestamp.
-      super.timeline.findInstantsInRange(startTimestamp, endTimestamp).getInstants.asScala.toList
+      super.timeline.findInstantsInRangeByFinishTs(startTimestamp, endTimestamp).getInstants.asScala.toList
     } else {
       super.timeline.getInstants.asScala.toList
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
@@ -140,7 +140,7 @@ class ShowArchivedCommitsProcedure(includeExtraMetadata: Boolean) extends BasePr
     val commits: util.List[HoodieInstant] = timeline.getCommitsTimeline.filterCompletedInstants
       .getInstants.toArray().map(instant => instant.asInstanceOf[HoodieInstant]).toList.asJava
     val newCommits = new util.ArrayList[HoodieInstant](commits)
-    Collections.sort(newCommits, HoodieInstant.COMPARATOR.reversed)
+    Collections.sort(newCommits, HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed)
     (rows, newCommits)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
@@ -123,7 +123,7 @@ class ShowCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure 
     val commits: util.List[HoodieInstant] = timeline.getCommitsTimeline.filterCompletedInstants
       .getInstants.toArray().map(instant => instant.asInstanceOf[HoodieInstant]).toList.asJava
     val newCommits = new util.ArrayList[HoodieInstant](commits)
-    Collections.sort(newCommits, HoodieInstant.COMPARATOR.reversed)
+    Collections.sort(newCommits, HoodieInstant.START_INSTANT_TIME_COMPARATOR.reversed)
     (rows, newCommits)
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

1. Introducing start & end commit times to timeline filters            
2. Instant time granularity changed to milliseconds
3. Added versioning to HoodieInstant disk format

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.