### PR TITLE
[HUDI-1731] Rename UpsertPartitioner in both hudi-java-client and hud…

### DIFF
--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/BaseJavaCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/BaseJavaCommitActionExecutor.java
@@ -228,8 +228,8 @@ public abstract class BaseJavaCommitActionExecutor<T extends HoodieRecordPayload
   @SuppressWarnings("unchecked")
   protected Iterator<List<WriteStatus>> handleUpsertPartition(String instantTime, Integer partition, Iterator recordItr,
                                                               Partitioner partitioner) {
-    UpsertPartitioner upsertPartitioner = (UpsertPartitioner) partitioner;
-    BucketInfo binfo = upsertPartitioner.getBucketInfo(partition);
+    JavaUpsertPartitioner javaUpsertPartitioner = (JavaUpsertPartitioner) partitioner;
+    BucketInfo binfo = javaUpsertPartitioner.getBucketInfo(partition);
     BucketType btype = binfo.bucketType;
     try {
       if (btype.equals(BucketType.INSERT)) {
@@ -314,7 +314,7 @@ public abstract class BaseJavaCommitActionExecutor<T extends HoodieRecordPayload
     if (profile == null) {
       throw new HoodieUpsertException("Need workload profile to construct the upsert partitioner.");
     }
-    return new UpsertPartitioner(profile, context, table, config);
+    return new JavaUpsertPartitioner(profile, context, table, config);
   }
 
   /**

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
@@ -51,9 +51,9 @@ import java.util.stream.Collectors;
 /**
  * Packs incoming records to be upserted, into buckets.
  */
-public class UpsertPartitioner<T extends HoodieRecordPayload<T>> implements Partitioner  {
+public class JavaUpsertPartitioner<T extends HoodieRecordPayload<T>> implements Partitioner  {
 
-  private static final Logger LOG = LogManager.getLogger(UpsertPartitioner.class);
+  private static final Logger LOG = LogManager.getLogger(JavaUpsertPartitioner.class);
 
   /**
    * List of all small files to be corrected.
@@ -84,8 +84,8 @@ public class UpsertPartitioner<T extends HoodieRecordPayload<T>> implements Part
 
   protected final HoodieWriteConfig config;
 
-  public UpsertPartitioner(WorkloadProfile profile, HoodieEngineContext context, HoodieTable table,
-                           HoodieWriteConfig config) {
+  public JavaUpsertPartitioner(WorkloadProfile profile, HoodieEngineContext context, HoodieTable table,
+                               HoodieWriteConfig config) {
     updateLocationToBucket = new HashMap<>();
     partitionPathToInsertBucketInfos = new HashMap<>();
     bucketInfoMap = new HashMap<>();


### PR DESCRIPTION
Add "Java" prefix for "UpsertPartitioner" in hudi-java-client to differentiate it from another same fully qualified name "UpsertPartitioner" in hudi-spark-client, otherwise when both modules are included in classpath, the two classes would conflict.