### PR TITLE
[HUDI-1735] Add hive-exec  dependency for hudi-examples

### DIFF
--- a/hudi-examples/pom.xml
+++ b/hudi-examples/pom.xml
@@ -206,6 +206,23 @@
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${hive.groupid}</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive.version}</version>
+      <scope>provided</scope>
+      <classifier>${hive.exec.classifier}</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
   </dependencies>
 </project>


### PR DESCRIPTION


## What is the purpose of the pull request

*hudi-examples missed MapredParquetInputFormat class*

## Brief change log

  - *Add hive-exec  dependency for hudi-examples*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.