### PR TITLE
[HUDI-1744][Rollback] rollback fail on mor table when the partition path hasn't any files

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackUtils.java
@@ -112,6 +112,9 @@ public class RollbackUtils {
     String commit = instantToRollback.getTimestamp();
     HoodieWriteConfig config = table.getConfig();
     List<String> partitions = FSUtils.getAllPartitionPaths(context, config.getMetadataConfig(), table.getMetaClient().getBasePath());
+    if (partitions.isEmpty()) {
+      return new ArrayList<>();
+    }
     int sparkPartitions = Math.max(Math.min(partitions.size(), config.getRollbackParallelism()), 1);
     context.setJobStatus(RollbackUtils.class.getSimpleName(), "Generate all rollback requests");
     return context.flatMap(partitions, partitionPath -> {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table.action.rollback;
 
 import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
+import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -154,5 +155,20 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
               true,
               true);
     });
+  }
+
+  /**
+   * Test Cases for rollbacking when has not base file.
+   */
+  @Test
+  public void testRollbackWhenFirstCommitFail() throws Exception {
+
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath).build();
+
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      client.startCommitWithTime("001");
+      client.insert(jsc.emptyRDD(), "001");
+      client.rollback("001");
+    }
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

for example, if someone write into a mor table and fail, and if this is the first commit, then the partition path is empty. then second time we submit a new write commit, it will fail because of rollback fail.
this pr use to solve this bug.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

add new ut

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.