### PR TITLE
[HUDI-1761] Adding support for Test your own Schema with QuickStart

### DIFF
--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -403,6 +403,12 @@
       <version>${zk-curator.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.confluent.avro</groupId>
+      <artifactId>avro-random-generator</artifactId>
+      <version>0.2.2</version>
+    </dependency>
+
     <!-- Hoodie - Test -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 
+import io.confluent.avro.random.generator.Generator;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -43,12 +44,12 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Class to be used in quickstart guide for generating inserts and updates against a corpus. Test data uses a toy Uber
- * trips, data model.
+ * Class to be used in quickstart guide for generating inserts and updates against a corpus. Test data uses a toy Uber trips, data model.
  */
 public class QuickstartUtils {
 
   public static class DataGenerator {
+
     private static final String DEFAULT_FIRST_PARTITION_PATH = "americas/united_states/san_francisco";
     private static final String DEFAULT_SECOND_PARTITION_PATH = "americas/brazil/sao_paulo";
     private static final String DEFAULT_THIRD_PARTITION_PATH = "asia/india/chennai";
@@ -68,6 +69,9 @@ public class QuickstartUtils {
     private final Map<Integer, HoodieKey> existingKeys;
     private final String[] partitionPaths;
     private int numExistingKeys;
+    private Generator randomAvroGenerator;
+    static Schema customSchema;
+    static String recordKeyField;
 
     public DataGenerator() {
       this(DEFAULT_PARTITION_PATHS, new HashMap<>());
@@ -113,19 +117,32 @@ public class QuickstartUtils {
       return rec;
     }
 
+    public void instantiateSchema(String schemaStr, String recordKeyField) {
+      Schema schema = new Schema.Parser().parse(schemaStr);
+      randomAvroGenerator = new Generator(schema, rand);
+      customSchema = schema;
+      this.recordKeyField = recordKeyField;
+    }
+
+    public static GenericRecord generateRandomGenRec(Generator randomAvroGenerator, String recordKeyField, String recordKeyValue) {
+      GenericRecord genericRecord = (GenericRecord) randomAvroGenerator.generate();
+      genericRecord.put(recordKeyField, recordKeyValue);
+      return genericRecord;
+    }
+
     /**
-     * Generates a new avro record of the above schema format, retaining the key if optionally provided. The
-     * riderDriverSuffix string is a random String to simulate updates by changing the rider driver fields for records
-     * belonging to the same commit. It is purely used for demo purposes. In real world, the actual updates are assumed
-     * to be provided based on the application requirements.
+     * Generates a new avro record of the above schema format, retaining the key if optionally provided. The riderDriverSuffix string is a random String to simulate updates by changing the rider
+     * driver fields for records belonging to the same commit. It is purely used for demo purposes. In real world, the actual updates are assumed to be provided based on the application requirements.
      */
-    public static OverwriteWithLatestAvroPayload generateRandomValue(HoodieKey key, String riderDriverSuffix)
+    public static OverwriteWithLatestAvroPayload generateRandomValue(HoodieKey key, String riderDriverSuffix, Schema schema,
+        Generator randomAvroGenerator, String recordKeyField)
         throws IOException {
       // The timestamp generated is limited to range from 7 days before to now, to avoid generating too many
       // partitionPaths when user use timestamp as partitionPath filed.
       GenericRecord rec =
-          generateGenericRecord(key.getRecordKey(), "rider-" + riderDriverSuffix, "driver-"
-              + riderDriverSuffix, generateRangeRandomTimestamp(7));
+          schema == null ? generateGenericRecord(key.getRecordKey(), "rider-" + riderDriverSuffix, "driver-"
+              + riderDriverSuffix, generateRangeRandomTimestamp(7)) : generateRandomGenRec(randomAvroGenerator,
+              recordKeyField, key.getRecordKey());
       return new OverwriteWithLatestAvroPayload(Option.of(rec));
     }
 
@@ -134,7 +151,7 @@ public class QuickstartUtils {
      */
     private static long generateRangeRandomTimestamp(int daysTillNow) {
       long maxIntervalMillis = daysTillNow * 24 * 60 * 60 * 1000L;
-      return System.currentTimeMillis() - (long)(Math.random() * maxIntervalMillis);
+      return System.currentTimeMillis() - (long) (Math.random() * maxIntervalMillis);
     }
 
     /**
@@ -149,7 +166,7 @@ public class QuickstartUtils {
         existingKeys.put(currSize + i, key);
         numExistingKeys++;
         try {
-          return new HoodieRecord(key, generateRandomValue(key, randomString));
+          return new HoodieRecord(key, generateRandomValue(key, randomString, customSchema, randomAvroGenerator, recordKeyField));
         } catch (IOException e) {
           throw new HoodieIOException(e.getMessage(), e);
         }
@@ -165,12 +182,11 @@ public class QuickstartUtils {
     }
 
     public HoodieRecord generateUpdateRecord(HoodieKey key, String randomString) throws IOException {
-      return new HoodieRecord(key, generateRandomValue(key, randomString));
+      return new HoodieRecord(key, generateRandomValue(key, randomString, customSchema, randomAvroGenerator, recordKeyField));
     }
 
     /**
-     * Generates new updates, randomly distributed across the keys above. There can be duplicates within the returned
-     * list
+     * Generates new updates, randomly distributed across the keys above. There can be duplicates within the returned list
      *
      * @param n Number of updates (including dups)
      * @return list of hoodie record updates
@@ -187,6 +203,21 @@ public class QuickstartUtils {
           throw new HoodieIOException(e.getMessage(), e);
         }
       }).collect(Collectors.toList());
+    }
+
+    /**
+     * Generates new updates, randomly distributed across the keys above. There can be duplicates within the returned list
+     *
+     * @param n Number of updates (including dups)
+     * @return list of hoodie record updates
+     */
+    public List<HoodieKey> generateDeletes(Integer n) {
+      if (numExistingKeys == 0) {
+        throw new HoodieException("Data must have been written before performing the update operation");
+      }
+      return IntStream.range(0, n).boxed().map(x ->
+          existingKeys.get(rand.nextInt(numExistingKeys))
+      ).collect(Collectors.toList());
     }
 
     /**
@@ -210,16 +241,24 @@ public class QuickstartUtils {
     }
   }
 
-  private static Option<String> convertToString(HoodieRecord record) {
+  private static Option<String> convertToString(HoodieRecord record, Schema schema) {
     try {
       String str = HoodieAvroUtils
-          .bytesToAvro(((OverwriteWithLatestAvroPayload) record.getData()).recordBytes, DataGenerator.avroSchema)
+          .bytesToAvro(((OverwriteWithLatestAvroPayload) record.getData()).recordBytes, schema)
           .toString();
-      str = "{" + str.substring(str.indexOf("\"ts\":"));
-      return Option.of(str.replaceAll("}", ", \"partitionpath\": \"" + record.getPartitionPath() + "\"}"));
+      return Option.of(str.substring(0, str.length() - 1) + ", \"partitionpath\": \"" + record.getPartitionPath() + "\"}");
     } catch (IOException e) {
       return Option.empty();
     }
+  }
+
+  private static Option<String> convertDeleteToString(HoodieKey record, String recordKeyField, String partitionPathField) {
+    StringBuffer stringBuffer = new StringBuffer();
+    stringBuffer.append("{");
+    stringBuffer.append("\"" + recordKeyField + "\": \"" + record.getRecordKey() + "\",");
+    stringBuffer.append("\"" + partitionPathField + "\": \"" + record.getPartitionPath() + "\"");
+    stringBuffer.append("}");
+    return Option.of(stringBuffer.toString());
   }
 
   private static Option<String> convertToString(String uuid, String partitionPath, Long ts) {
@@ -233,7 +272,25 @@ public class QuickstartUtils {
   }
 
   public static List<String> convertToStringList(List<HoodieRecord> records) {
-    return records.stream().map(hr -> convertToString(hr)).filter(os -> os.isPresent()).map(os -> os.get())
+    return convertToStringList(records,
+        DataGenerator.customSchema != null ? DataGenerator.customSchema : DataGenerator.avroSchema);
+  }
+
+  public static List<String> convertToStringList(List<HoodieRecord> records, Schema schema) {
+    return records.stream().map(hr -> convertToString(hr, schema)).filter(os -> os.isPresent()).map(os -> os.get())
+        .collect(Collectors.toList());
+  }
+
+  public static List<String> convertDeletesToStringList(List<HoodieKey> records) {
+    return convertDeletesToStringList(records, DataGenerator.customSchema == null ? "uuid" : DataGenerator.recordKeyField);
+  }
+
+  public static List<String> convertDeletesToStringList(List<HoodieKey> records, String recordKeyField) {
+    return convertDeletesToStringList(records, recordKeyField, "partitionpath");
+  }
+
+  public static List<String> convertDeletesToStringList(List<HoodieKey> records, String recordKeyField, String partitionPathField) {
+    return records.stream().map(hr -> convertDeleteToString(hr, recordKeyField, partitionPathField)).filter(os -> os.isPresent()).map(os -> os.get())
         .collect(Collectors.toList());
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestQuickstartUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestQuickstartUtils.java
@@ -19,6 +19,8 @@
 package org.apache.hudi;
 
 import org.apache.hudi.exception.HoodieException;
+
+import org.apache.avro.Schema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,5 +43,45 @@ public class TestQuickstartUtils {
     //Execute generateInserts before executing generateUpdates then no exception
     assertEquals(dataGenerator.generateInserts(10).size(), 10);
     assertEquals(dataGenerator.generateUpdates(10).size(), 10);
+    assertEquals(dataGenerator.generateDeletes(4).size(), 4);
+
+    QuickstartUtils.convertToStringList(dataGenerator.generateInserts(4)); // ensures no exception is thrown
+
+    QuickstartUtils.convertToStringList(dataGenerator.generateUpdates(2)); // ensure no exception is thrown
+
+    QuickstartUtils.convertDeletesToStringList(dataGenerator.generateDeletes(2)); // ensures no exception is thrown
   }
+
+  @Test
+  public void testGenerateUpdatesCustomSchema() throws Exception {
+    QuickstartUtils.DataGenerator dataGenerator = new QuickstartUtils.DataGenerator();
+
+    //Call generateUpdates directly then throws HoodieException
+    assertEquals(Assertions.assertThrows(HoodieException.class, () -> {
+      dataGenerator.generateUpdates(10);
+    }).getMessage(), "Data must have been written before performing the update operation");
+
+    Schema schema = createUserSchema();
+    dataGenerator.instantiateSchema(schema.toString(), "name");
+
+    assertEquals(dataGenerator.generateInserts(10).size(), 10);
+    assertEquals(dataGenerator.generateUpdates(10).size(), 10);
+    assertEquals(dataGenerator.generateDeletes(4).size(), 4);
+
+    QuickstartUtils.convertToStringList(dataGenerator.generateInserts(4)); // ensures no exception is thrown
+
+    QuickstartUtils.convertToStringList(dataGenerator.generateUpdates(2)); // ensure no exception is thrown
+
+    QuickstartUtils.convertDeletesToStringList(dataGenerator.generateDeletes(2)); // ensures no exception is thrown
+
+  }
+
+  private Schema createUserSchema() {
+    String userSchema = "{\"namespace\": \"example.avro\", \"type\": \"record\", "
+        + "\"name\": \"User\","
+        + "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}, {\"name\": \"strField\", \"type\": \"string\"}]}";
+    Schema.Parser parser = new Schema.Parser();
+    return parser.parse(userSchema);
+  }
+
 }

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -99,6 +99,7 @@
                   <include>io.prometheus:simpleclient_common</include>
                   <include>com.yammer.metrics:metrics-core</include>
                   <include>com.google.guava:guava</include>
+                  <include>io.confluent.avro:avro-random-generator</include>
 
                   <include>org.apache.spark:spark-avro_${scala.binary.version}</include>
                   <include>org.apache.hive:hive-common</include>
@@ -372,6 +373,12 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${zk-curator.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.confluent.avro</groupId>
+      <artifactId>avro-random-generator</artifactId>
+      <version>0.2.2</version>
     </dependency>
 
     <!-- TODO: Reinvestigate PR 633 -->


### PR DESCRIPTION
## What is the purpose of the pull request

Quick start in hudi has a statically defined schema. But it would be nice for users to try our their own schema with QuickStart. This patch adds such capability. User just need to provide toString representation of avroSchema and record key and the rest is taken care of(data generation, etc) by the datagen tool.

additional steps in Quick start to try out custom schema
```
val userSchema = // toString() of an avro schema
// ensure schema has the field for record key. partition path is added internally by the datagen tool and so not required to be part of the userSchema. As of now, only SimpleKeyGenerator is supported for both record key and partition path and partitionpath field is hardcoded. 

dataGen.instantiateSchema(userSchema, "rowKey") // replace "rowKey" with the field for record key
```
Sample run book: https://gist.github.com/nsivabalan/f47805e00996735a054d324a67d4296c

This patch adds dependency to io.confluent.avro:avro-random-generator to assist in generating random data for a given avro schema. Dependency is added to hudi-spark-bundle which needs discussion whether we need to keep it in this bundle or move it to a test module. But w/ test module, users will have to build locally before they can try it out. 

## Brief change log

*(for example:)*
  - Added support to test QuickStart w/ a custom avro schema. 

## Verify this pull request

- Added test to TestQuickstartUtils.
- Also, tested Quick start for inserts, updates and deletes. https://gist.github.com/nsivabalan/f47805e00996735a054d324a67d4296c

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.