### PR TITLE
[HUDI-1762] Added HiveStylePartitionExtractor to support Hive style partitions

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveStylePartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveStylePartitionValueExtractor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import java.util.Collections;
+import java.util.List;
+
+public class HiveStylePartitionValueExtractor implements PartitionValueExtractor {
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public List<String> extractPartitionValuesInPath(String partitionPath) {
+    // partition path is expected to be in this format partition_key=partition_value.
+    String[] splits = partitionPath.split("=");
+    if (splits.length != 2) {
+      throw new IllegalArgumentException(
+              "Partition path " + partitionPath + " is not in the form partition_key=partition_value.");
+    }
+    return Collections.singletonList(splits[1]);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveStylePartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveStylePartitionValueExtractor.java
@@ -21,6 +21,11 @@ package org.apache.hudi.hive;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Extractor for Hive Style Partitioned tables, when the parition folders are key value pairs.
+ *
+ * <p>This implementation extracts the partition value of yyyy-mm-dd from the path of type datestr=yyyy-mm-dd.
+ */
 public class HiveStylePartitionValueExtractor implements PartitionValueExtractor {
   private static final long serialVersionUID = 1L;
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.hive;
 
 import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,14 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TestPartitionValueExtractor {
   @Test
   public void testHourPartition() {
-    SlashEncodedHourPartitionValueExtractor hourPartition =
-        new SlashEncodedHourPartitionValueExtractor();
+    SlashEncodedHourPartitionValueExtractor hourPartition = new SlashEncodedHourPartitionValueExtractor();
     List<String> list = new ArrayList<>();
     list.add("2020-12-20-01");
     assertEquals(hourPartition.extractPartitionValuesInPath("2020/12/20/01"), list);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> hourPartition.extractPartitionValuesInPath("2020/12/20"));
+    assertThrows(IllegalArgumentException.class, () -> hourPartition.extractPartitionValuesInPath("2020/12/20"));
     assertEquals(hourPartition.extractPartitionValuesInPath("update_time=2020/12/20/01"), list);
   }
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive;
 
 import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,11 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TestPartitionValueExtractor {
   @Test
   public void testHourPartition() {
-    SlashEncodedHourPartitionValueExtractor hourPartition = new SlashEncodedHourPartitionValueExtractor();
+    SlashEncodedHourPartitionValueExtractor hourPartition =
+        new SlashEncodedHourPartitionValueExtractor();
     List<String> list = new ArrayList<>();
     list.add("2020-12-20-01");
     assertEquals(hourPartition.extractPartitionValuesInPath("2020/12/20/01"), list);
-    assertThrows(IllegalArgumentException.class, () -> hourPartition.extractPartitionValuesInPath("2020/12/20"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> hourPartition.extractPartitionValuesInPath("2020/12/20"));
     assertEquals(hourPartition.extractPartitionValuesInPath("update_time=2020/12/20/01"), list);
+  }
+
+  @Test
+  public void testHiveStylePartition() {
+    HiveStylePartitionValueExtractor hiveStylePartition = new HiveStylePartitionValueExtractor();
+    List<String> list = new ArrayList<>();
+    list.add("2021-04-02");
+    assertEquals(hiveStylePartition.extractPartitionValuesInPath("datestr=2021-04-02"), list);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> hiveStylePartition.extractPartitionValuesInPath("2021/04/02"));
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

*This pull request adds a new partition extractor class to support Hive style partitioning: HiveStylePartitionExtractor.*

## Brief change log

  - *Added HiveStylePartitionExtractor to support Hive style partitions.*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Added a new test method `testHiveStylePartition()` in the `TestPartitionValueExtractor` class to verify the change.*
  - *Manually verified the change by running a job locally.*

Before the fix:
`21/04/01 23:10:33 ERROR deltastreamer.HoodieDeltaStreamer: Got error running delta sync once. Shutting down
org.apache.hudi.exception.HoodieException: Got runtime exception when hive syncing delta_streamer_test
	at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:122)
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.syncMeta(DeltaSync.java:560)
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.writeToSink(DeltaSync.java:475)
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.syncOnce(DeltaSync.java:282)
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.lambda$sync$2(HoodieDeltaStreamer.java:170)
	at org.apache.hudi.common.util.Option.ifPresent(Option.java:96)
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.sync(HoodieDeltaStreamer.java:168)
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.main(HoodieDeltaStreamer.java:470)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:690)
Caused by: org.apache.hudi.hive.HoodieHiveSyncException: Failed to sync partitions for table fact_scheduled_trip__1pc_trip_uuid
	at org.apache.hudi.hive.HiveSyncTool.syncPartitions(HiveSyncTool.java:229)
	at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:166)
	at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:108)
	... 12 more
Caused by: java.lang.IllegalArgumentException: Partition path datestr=2021-03-28 is not in the form yyyy/mm/dd 
	at org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor.extractPartitionValuesInPath(SlashEncodedDayPartitionValueExtractor.java:55)
	at org.apache.hudi.hive.HoodieHiveClient.getPartitionEvents(HoodieHiveClient.java:220)
	at org.apache.hudi.hive.HiveSyncTool.syncPartitions(HiveSyncTool.java:221)`

After the fix:
`21/04/02 19:04:40 INFO hive.HiveSyncTool: No Schema difference for delta_streamer_test
21/04/02 19:04:40 INFO hive.HiveSyncTool: Schema sync complete. Syncing partitions for delta_streamer_test
21/04/02 19:04:41 INFO hive.HiveSyncTool: Last commit time synced was found to be null
21/04/02 19:04:41 INFO common.AbstractSyncHoodieClient: Last commit time synced is not known, listing all partitions in /tmp/delta_streamer_test,FS :DFS[DFSClient[clientName=DFSClient_NONMAPREDUCE_-2134537191_53, ugi=vinothg (auth:SIMPLE)]]
21/04/02 19:04:41 INFO hive.HiveSyncTool: Storage partitions scan complete. Found 6
21/04/02 19:04:41 INFO hive.HiveSyncTool: New Partitions [datestr=2021-03-28, datestr=2021-03-29, datestr=2021-03-30, datestr=2021-03-31, datestr=2021-04-01, datestr=2021-04-02]
21/04/02 19:04:41 INFO hive.HoodieHiveClient: Adding partitions 6 to table delta_streamer_test`


## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.