### PR TITLE
[HUDI-1767] Add setter to HoodieKey and HoodieRecordLocation to have better SE/DE performance for Flink

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -29,17 +29,27 @@ import java.util.Objects;
  */
 public class HoodieKey implements Serializable {
 
-  private final String recordKey;
+  private String recordKey;
+  private String partitionPath;
 
-  private final String partitionPath;
+  public HoodieKey() {
+  }
 
   public HoodieKey(String recordKey, String partitionPath) {
     this.recordKey = recordKey;
     this.partitionPath = partitionPath;
   }
 
+  public void setRecordKey(String recordKey) {
+    this.recordKey = recordKey;
+  }
+
   public String getRecordKey() {
     return recordKey;
+  }
+
+  public void setPartitionPath(String partitionPath) {
+    this.partitionPath = partitionPath;
   }
 
   public String getPartitionPath() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
@@ -26,8 +26,11 @@ import java.util.Objects;
  */
 public class HoodieRecordLocation implements Serializable {
 
-  private final String instantTime;
-  private final String fileId;
+  private String instantTime;
+  private String fileId;
+
+  public HoodieRecordLocation() {
+  }
 
   public HoodieRecordLocation(String instantTime, String fileId) {
     this.instantTime = instantTime;
@@ -64,7 +67,15 @@ public class HoodieRecordLocation implements Serializable {
     return instantTime;
   }
 
+  public void setInstantTime(String instantTime) {
+    this.instantTime = instantTime;
+  }
+
   public String getFileId() {
     return fileId;
+  }
+
+  public void setFileId(String fileId) {
+    this.fileId = fileId;
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Currently the HoodieKey and HoodieRecordLocation do not implement the setters for the POJO member, the Flink TypeExtractor actually needs the setters for POJO SE/DE instead of generic type, the POJO SE/DE is more efficient.

## Brief change log

Add setter to HoodieKey and HoodieRecordLocation to have better SE/DE performance for Flink 
Add no arg constructor for HoodieKey and HoodieRecordLocation 

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.