### PR TITLE
[HUDI-1772] HoodieFileGroupId compareTo logical error(fileId self compare)

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroupId.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroupId.java
@@ -69,7 +69,7 @@ public class HoodieFileGroupId implements Serializable, Comparable<HoodieFileGro
   public int compareTo(HoodieFileGroupId o) {
     int ret = partitionPath.compareTo(o.partitionPath);
     if (ret == 0) {
-      ret = fileId.compareTo(fileId);
+      ret = fileId.compareTo(o.fileId);
     }
     return ret;
   }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

fix error HoodieFileGroupId #compareTo logical 

## Brief change log

the compareTo method logical is error when partitionPath is equals. 
  @Override
  public int compareTo(HoodieFileGroupId o) {
    int ret = partitionPath.compareTo(o.partitionPath);
    if (ret == 0) {
      ret = fileId.compareTo(fileId);
    }
    return ret;
  }

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.