### PR TITLE
[HUDI-1778] Add setter to CompactionPlanEvent and CompactionCommitEvent to have better SE/DE performance for Flink

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitEvent.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitEvent.java
@@ -32,19 +32,34 @@ public class CompactionCommitEvent implements Serializable {
   /**
    * The compaction commit instant time.
    */
-  private final String instant;
+  private String instant;
   /**
    * The write statuses.
    */
-  private final List<WriteStatus> writeStatuses;
+  private List<WriteStatus> writeStatuses;
   /**
    * The compaction task identifier.
    */
-  private final int taskID;
+  private int taskID;
+
+  public CompactionCommitEvent() {
+  }
 
   public CompactionCommitEvent(String instant, List<WriteStatus> writeStatuses, int taskID) {
     this.instant = instant;
     this.writeStatuses = writeStatuses;
+    this.taskID = taskID;
+  }
+
+  public void setInstant(String instant) {
+    this.instant = instant;
+  }
+
+  public void setWriteStatuses(List<WriteStatus> writeStatuses) {
+    this.writeStatuses = writeStatuses;
+  }
+
+  public void setTaskID(int taskID) {
     this.taskID = taskID;
   }
 

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanEvent.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanEvent.java
@@ -28,12 +28,23 @@ import java.io.Serializable;
 public class CompactionPlanEvent implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final String compactionInstantTime;
+  private String compactionInstantTime;
 
-  private final CompactionOperation operation;
+  private CompactionOperation operation;
+
+  public CompactionPlanEvent() {
+  }
 
   public CompactionPlanEvent(String instantTime, CompactionOperation operation) {
     this.compactionInstantTime = instantTime;
+    this.operation = operation;
+  }
+
+  public void setCompactionInstantTime(String compactionInstantTime) {
+    this.compactionInstantTime = compactionInstantTime;
+  }
+
+  public void setOperation(CompactionOperation operation) {
     this.operation = operation;
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Add setter to CompactionPlanEvent and CompactionCommitEvent to have better SE/DE performance for Flink

## Brief change log

  - *Modify CompactionPlanEvent  add setter and no arg constructor*
  - *Modify CompactionCommitEvent add setter and no arg constructor*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.