### PR TITLE
[HUDI-764] [HUDI-765] ORC reader and writer implementation

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieStorageConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieStorageConfig.java
@@ -39,10 +39,19 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
   public static final String DEFAULT_PARQUET_BLOCK_SIZE_BYTES = DEFAULT_PARQUET_FILE_MAX_BYTES;
   public static final String PARQUET_PAGE_SIZE_BYTES = "hoodie.parquet.page.size";
   public static final String DEFAULT_PARQUET_PAGE_SIZE_BYTES = String.valueOf(1 * 1024 * 1024);
+
   public static final String HFILE_FILE_MAX_BYTES = "hoodie.hfile.max.file.size";
   public static final String HFILE_BLOCK_SIZE_BYTES = "hoodie.hfile.block.size";
   public static final String DEFAULT_HFILE_BLOCK_SIZE_BYTES = String.valueOf(1 * 1024 * 1024);
   public static final String DEFAULT_HFILE_FILE_MAX_BYTES = String.valueOf(120 * 1024 * 1024);
+
+  public static final String ORC_FILE_MAX_BYTES = "hoodie.orc.max.file.size";
+  public static final String DEFAULT_ORC_FILE_MAX_BYTES = String.valueOf(120 * 1024 * 1024);
+  public static final String ORC_STRIPE_SIZE = "hoodie.orc.stripe.size";
+  public static final String DEFAULT_ORC_STRIPE_SIZE = String.valueOf(64 * 1024 * 1024);
+  public static final String ORC_BLOCK_SIZE = "hoodie.orc.block.size";
+  public static final String DEFAULT_ORC_BLOCK_SIZE = DEFAULT_ORC_FILE_MAX_BYTES;
+
   // used to size log files
   public static final String LOGFILE_SIZE_MAX_BYTES = "hoodie.logfile.max.size";
   public static final String DEFAULT_LOGFILE_SIZE_MAX_BYTES = String.valueOf(1024 * 1024 * 1024); // 1 GB
@@ -54,9 +63,11 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
   public static final String DEFAULT_STREAM_COMPRESSION_RATIO = String.valueOf(0.1);
   public static final String PARQUET_COMPRESSION_CODEC = "hoodie.parquet.compression.codec";
   public static final String HFILE_COMPRESSION_ALGORITHM = "hoodie.hfile.compression.algorithm";
+  public static final String ORC_COMPRESSION_CODEC = "hoodie.orc.compression.codec";
   // Default compression codec for parquet
   public static final String DEFAULT_PARQUET_COMPRESSION_CODEC = "gzip";
   public static final String DEFAULT_HFILE_COMPRESSION_ALGORITHM = "GZ";
+  public static final String DEFAULT_ORC_COMPRESSION_CODEC = "ZLIB";
   public static final String LOGFILE_TO_PARQUET_COMPRESSION_RATIO = "hoodie.logfile.to.parquet.compression.ratio";
   // Default compression ratio for log file to parquet, general 3x
   public static final String DEFAULT_LOGFILE_TO_PARQUET_COMPRESSION_RATIO = String.valueOf(0.35);
@@ -140,6 +151,26 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder orcMaxFileSize(long maxFileSize) {
+      props.setProperty(ORC_FILE_MAX_BYTES, String.valueOf(maxFileSize));
+      return this;
+    }
+
+    public Builder orcStripeSize(int orcStripeSize) {
+      props.setProperty(ORC_STRIPE_SIZE, String.valueOf(orcStripeSize));
+      return this;
+    }
+
+    public Builder orcBlockSize(int orcBlockSize) {
+      props.setProperty(ORC_BLOCK_SIZE, String.valueOf(orcBlockSize));
+      return this;
+    }
+
+    public Builder orcCompressionCodec(String orcCompressionCodec) {
+      props.setProperty(ORC_COMPRESSION_CODEC, orcCompressionCodec);
+      return this;
+    }
+
     public HoodieStorageConfig build() {
       HoodieStorageConfig config = new HoodieStorageConfig(props);
       setDefaultOnCondition(props, !props.containsKey(PARQUET_FILE_MAX_BYTES), PARQUET_FILE_MAX_BYTES,
@@ -165,6 +196,15 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
           DEFAULT_HFILE_COMPRESSION_ALGORITHM);
       setDefaultOnCondition(props, !props.containsKey(HFILE_FILE_MAX_BYTES), HFILE_FILE_MAX_BYTES,
           DEFAULT_HFILE_FILE_MAX_BYTES);
+
+      setDefaultOnCondition(props, !props.containsKey(ORC_FILE_MAX_BYTES), ORC_FILE_MAX_BYTES,
+          DEFAULT_ORC_FILE_MAX_BYTES);
+      setDefaultOnCondition(props, !props.containsKey(ORC_STRIPE_SIZE), ORC_STRIPE_SIZE,
+          DEFAULT_ORC_STRIPE_SIZE);
+      setDefaultOnCondition(props, !props.containsKey(ORC_BLOCK_SIZE), ORC_BLOCK_SIZE,
+          DEFAULT_ORC_BLOCK_SIZE);
+      setDefaultOnCondition(props, !props.containsKey(ORC_COMPRESSION_CODEC), ORC_COMPRESSION_CODEC,
+          DEFAULT_ORC_COMPRESSION_CODEC);
 
       return config;
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieStorageConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieStorageConfig.java
@@ -47,8 +47,10 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
 
   public static final String ORC_FILE_MAX_BYTES = "hoodie.orc.max.file.size";
   public static final String DEFAULT_ORC_FILE_MAX_BYTES = String.valueOf(120 * 1024 * 1024);
+  // size of the memory buffer in bytes for writing
   public static final String ORC_STRIPE_SIZE = "hoodie.orc.stripe.size";
   public static final String DEFAULT_ORC_STRIPE_SIZE = String.valueOf(64 * 1024 * 1024);
+  // file system block size
   public static final String ORC_BLOCK_SIZE = "hoodie.orc.block.size";
   public static final String DEFAULT_ORC_BLOCK_SIZE = DEFAULT_ORC_FILE_MAX_BYTES;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -42,6 +42,7 @@ import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.metrics.datadog.DatadogHttpClient.ApiSite;
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.action.compact.strategy.CompactionStrategy;
+import org.apache.orc.CompressionKind;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import javax.annotation.concurrent.Immutable;
@@ -750,6 +751,22 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
 
   public Compression.Algorithm getHFileCompressionAlgorithm() {
     return Compression.Algorithm.valueOf(props.getProperty(HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM));
+  }
+
+  public long getOrcMaxFileSize() {
+    return Long.parseLong(props.getProperty(HoodieStorageConfig.ORC_FILE_MAX_BYTES));
+  }
+
+  public int getOrcStripeSize() {
+    return Integer.parseInt(props.getProperty(HoodieStorageConfig.ORC_STRIPE_SIZE));
+  }
+
+  public int getOrcBlockSize() {
+    return Integer.parseInt(props.getProperty(HoodieStorageConfig.ORC_BLOCK_SIZE));
+  }
+
+  public CompressionKind getOrcCompressionCodec() {
+    return CompressionKind.valueOf(props.getProperty(HoodieStorageConfig.ORC_COMPRESSION_CODEC));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriter.java
@@ -18,6 +18,9 @@
 
 package org.apache.hudi.io.storage;
 
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieRecord;
 
 import org.apache.avro.generic.IndexedRecord;
@@ -35,4 +38,11 @@ public interface HoodieFileWriter<R extends IndexedRecord> {
   void writeAvro(String key, R oldRecord) throws IOException;
 
   long getBytesWritten();
+
+  default void prepRecordWithMetadata(R avroRecord, HoodieRecord record, String instantTime, Integer partitionId, AtomicLong recordIndex, String fileName) {
+    String seqId = HoodieRecord.generateSequenceId(instantTime, partitionId, recordIndex.getAndIncrement());
+    HoodieAvroUtils.addHoodieKeyToRecord((GenericRecord) avroRecord, record.getRecordKey(), record.getPartitionPath(), fileName);
+    HoodieAvroUtils.addCommitMetadataToRecord((GenericRecord) avroRecord, instantTime, seqId);
+    return;
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -34,6 +34,7 @@ import org.apache.parquet.avro.AvroSchemaConverter;
 
 import java.io.IOException;
 
+import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
 import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
 
@@ -48,6 +49,9 @@ public class HoodieFileWriterFactory {
     }
     if (HFILE.getFileExtension().equals(extension)) {
       return newHFileFileWriter(instantTime, path, config, schema, hoodieTable, taskContextSupplier);
+    }
+    if (ORC.getFileExtension().equals(extension)) {
+      return newOrcFileWriter(instantTime, path, config, schema, hoodieTable, taskContextSupplier);
     }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
@@ -75,6 +79,15 @@ public class HoodieFileWriterFactory {
         config.getHFileCompressionAlgorithm(), config.getHFileBlockSize(), config.getHFileMaxFileSize(), filter);
 
     return new HoodieHFileWriter<>(instantTime, path, hfileConfig, schema, taskContextSupplier);
+  }
+
+  private static <T extends HoodieRecordPayload, R extends IndexedRecord> HoodieFileWriter<R> newOrcFileWriter(
+      String instantTime, Path path, HoodieWriteConfig config, Schema schema, HoodieTable hoodieTable,
+      TaskContextSupplier taskContextSupplier) throws IOException {
+    BloomFilter filter = createBloomFilter(config);
+    HoodieOrcConfig orcConfig = new HoodieOrcConfig(hoodieTable.getHadoopConf(), config.getOrcCompressionCodec(),
+        config.getOrcStripeSize(), config.getOrcBlockSize(), config.getOrcMaxFileSize(), filter);
+    return new HoodieOrcWriter<>(instantTime, path, orcConfig, schema, taskContextSupplier);
   }
 
   private static BloomFilter createBloomFilter(HoodieWriteConfig config) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileWriter.java
@@ -99,13 +99,9 @@ public class HoodieHFileWriter<T extends HoodieRecordPayload, R extends IndexedR
 
   @Override
   public void writeAvroWithMetadata(R avroRecord, HoodieRecord record) throws IOException {
-    String seqId =
-        HoodieRecord.generateSequenceId(instantTime, taskContextSupplier.getPartitionIdSupplier().get(), recordIndex.getAndIncrement());
-    HoodieAvroUtils.addHoodieKeyToRecord((GenericRecord) avroRecord, record.getRecordKey(), record.getPartitionPath(),
-        file.getName());
-    HoodieAvroUtils.addCommitMetadataToRecord((GenericRecord) avroRecord, instantTime, seqId);
-
-    writeAvro(record.getRecordKey(), (IndexedRecord)avroRecord);
+    prepRecordWithMetadata(avroRecord, record, instantTime,
+        taskContextSupplier.getPartitionIdSupplier().get(), recordIndex, file.getName());
+    writeAvro(record.getRecordKey(), (IndexedRecord) avroRecord);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieOrcConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieOrcConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.orc.CompressionKind;
+
+public class HoodieOrcConfig {
+  static final String AVRO_SCHEMA_METADATA_KEY = "orc.avro.schema";
+
+  private final CompressionKind compressionKind;
+  private final int stripeSize;
+  private final int blockSize;
+  private final long maxFileSize;
+  private final Configuration hadoopConf;
+  private final BloomFilter bloomFilter;
+
+  public HoodieOrcConfig(Configuration hadoopConf, CompressionKind compressionKind, int stripeSize,
+      int blockSize, long maxFileSize, BloomFilter bloomFilter) {
+    this.hadoopConf = hadoopConf;
+    this.compressionKind = compressionKind;
+    this.stripeSize = stripeSize;
+    this.blockSize = blockSize;
+    this.maxFileSize = maxFileSize;
+    this.bloomFilter = bloomFilter;
+  }
+
+  public Configuration getHadoopConf() {
+    return hadoopConf;
+  }
+
+  public CompressionKind getCompressionKind() {
+    return compressionKind;
+  }
+
+  public int getStripeSize() {
+    return stripeSize;
+  }
+
+  public int getBlockSize() {
+    return blockSize;
+  }
+
+  public long getMaxFileSize() {
+    return maxFileSize;
+  }
+
+  public boolean useBloomFilter() {
+    return bloomFilter != null;
+  }
+
+  public BloomFilter getBloomFilter() {
+    return bloomFilter;
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieOrcWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieOrcWriter.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import static org.apache.hudi.avro.HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY;
+import static org.apache.hudi.avro.HoodieAvroWriteSupport.HOODIE_BLOOM_FILTER_TYPE_CODE;
+import static org.apache.hudi.avro.HoodieAvroWriteSupport.HOODIE_MAX_RECORD_KEY_FOOTER;
+import static org.apache.hudi.avro.HoodieAvroWriteSupport.HOODIE_MIN_RECORD_KEY_FOOTER;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.fs.HoodieWrapperFileSystem;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.AvroOrcUtils;
+
+public class HoodieOrcWriter<T extends HoodieRecordPayload, R extends IndexedRecord>
+    implements HoodieFileWriter<R> {
+  private static final AtomicLong RECORD_INDEX = new AtomicLong(1);
+
+  private final long maxFileSize;
+  private final Schema avroSchema;
+  private final List<TypeDescription> fieldTypes;
+  private final List<String> fieldNames;
+  private final VectorizedRowBatch batch;
+  private final Writer writer;
+
+  private final Path file;
+  private final HoodieWrapperFileSystem fs;
+  private final String instantTime;
+  private final TaskContextSupplier taskContextSupplier;
+
+  private HoodieOrcConfig orcConfig;
+  private String minRecordKey;
+  private String maxRecordKey;
+
+  public HoodieOrcWriter(String instantTime, Path file, HoodieOrcConfig config, Schema schema,
+      TaskContextSupplier taskContextSupplier) throws IOException {
+
+    Configuration conf = FSUtils.registerFileSystem(file, config.getHadoopConf());
+    this.file = HoodieWrapperFileSystem.convertToHoodiePath(file, conf);
+    this.fs = (HoodieWrapperFileSystem) this.file.getFileSystem(conf);
+    this.instantTime = instantTime;
+    this.taskContextSupplier = taskContextSupplier;
+
+    this.avroSchema = schema;
+    final TypeDescription orcSchema = AvroOrcUtils.createOrcSchema(avroSchema);
+    this.fieldTypes = orcSchema.getChildren();
+    this.fieldNames = orcSchema.getFieldNames();
+    this.maxFileSize = config.getMaxFileSize();
+    this.batch = orcSchema.createRowBatch();
+    OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(conf)
+        .blockSize(config.getBlockSize())
+        .stripeSize(config.getStripeSize())
+        .compress(config.getCompressionKind())
+        .bufferSize(config.getBlockSize())
+        .fileSystem(fs)
+        .setSchema(orcSchema);
+    this.writer = OrcFile.createWriter(this.file, writerOptions);
+    this.orcConfig = config;
+  }
+
+  @Override
+  public void writeAvroWithMetadata(R avroRecord, HoodieRecord record) throws IOException {
+    String seqId = HoodieRecord.generateSequenceId(instantTime, taskContextSupplier.getPartitionIdSupplier().get(),
+        RECORD_INDEX.getAndIncrement());
+    HoodieAvroUtils.addHoodieKeyToRecord((GenericRecord) avroRecord, record.getRecordKey(),
+        record.getPartitionPath(), file.getName());
+    HoodieAvroUtils
+        .addCommitMetadataToRecord((GenericRecord) avroRecord, instantTime, seqId);
+
+    writeAvro(record.getRecordKey(), avroRecord);
+  }
+
+  @Override
+  public boolean canWrite() {
+    return fs.getBytesWritten(file) < maxFileSize;
+  }
+
+  @Override
+  public void writeAvro(String recordKey, IndexedRecord object) throws IOException {
+    for (int col = 0; col < batch.numCols; col++) {
+      ColumnVector colVector = batch.cols[col];
+      final String thisField = fieldNames.get(col);
+      final TypeDescription type = fieldTypes.get(col);
+
+      Object fieldValue = ((GenericRecord) object).get(thisField);
+      Schema.Field avroField = avroSchema.getField(thisField);
+      AvroOrcUtils.addToVector(type, colVector, avroField.schema(), fieldValue, batch.size);
+    }
+
+    batch.size++;
+
+    if (batch.size == batch.getMaxSize()) {
+      writer.addRowBatch(batch);
+      batch.reset();
+      batch.size = 0;
+    }
+
+    if (orcConfig.useBloomFilter()) {
+      orcConfig.getBloomFilter().add(recordKey);
+      if (minRecordKey != null) {
+        minRecordKey = minRecordKey.compareTo(recordKey) <= 0 ? minRecordKey : recordKey;
+      } else {
+        minRecordKey = recordKey;
+      }
+
+      if (maxRecordKey != null) {
+        maxRecordKey = maxRecordKey.compareTo(recordKey) >= 0 ? maxRecordKey : recordKey;
+      } else {
+        maxRecordKey = recordKey;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (batch.size != 0) {
+      writer.addRowBatch(batch);
+      batch.reset();
+    }
+
+    if (orcConfig.useBloomFilter()) {
+      final BloomFilter bloomFilter = orcConfig.getBloomFilter();
+      writer.addUserMetadata(HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY, ByteBuffer.wrap(bloomFilter.serializeToString().getBytes()));
+      if (minRecordKey != null && maxRecordKey != null) {
+        writer.addUserMetadata(HOODIE_MIN_RECORD_KEY_FOOTER, ByteBuffer.wrap(minRecordKey.getBytes()));
+        writer.addUserMetadata(HOODIE_MAX_RECORD_KEY_FOOTER, ByteBuffer.wrap(maxRecordKey.getBytes()));
+      }
+      if (bloomFilter.getBloomFilterTypeCode().name().contains(HoodieDynamicBoundedBloomFilter.TYPE_CODE_PREFIX)) {
+        writer.addUserMetadata(HOODIE_BLOOM_FILTER_TYPE_CODE, ByteBuffer.wrap(bloomFilter.getBloomFilterTypeCode().name().getBytes()));
+      }
+    }
+    writer.addUserMetadata(HoodieOrcConfig.AVRO_SCHEMA_METADATA_KEY, ByteBuffer.wrap(avroSchema.toString().getBytes()));
+
+    writer.close();
+  }
+
+  @Override
+  public long getBytesWritten() {
+    return fs.getBytesWritten(file);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.io.storage;
 
-import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
@@ -27,7 +26,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileWriter;
@@ -75,11 +73,8 @@ public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends Indexe
 
   @Override
   public void writeAvroWithMetadata(R avroRecord, HoodieRecord record) throws IOException {
-    String seqId =
-        HoodieRecord.generateSequenceId(instantTime, taskContextSupplier.getPartitionIdSupplier().get(), recordIndex.getAndIncrement());
-    HoodieAvroUtils.addHoodieKeyToRecord((GenericRecord) avroRecord, record.getRecordKey(), record.getPartitionPath(),
-        file.getName());
-    HoodieAvroUtils.addCommitMetadataToRecord((GenericRecord) avroRecord, instantTime, seqId);
+    prepRecordWithMetadata(avroRecord, record, instantTime,
+        taskContextSupplier.getPartitionIdSupplier().get(), recordIndex, file.getName());
     super.write(avroRecord);
     writeSupport.add(record.getRecordKey());
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -649,6 +649,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
   public HoodieLogBlockType getLogDataBlockFormat() {
     switch (getBaseFileFormat()) {
       case PARQUET:
+      case ORC:
         return HoodieLogBlockType.AVRO_DATA_BLOCK;
       case HFILE:
         return HoodieLogBlockType.HFILE_DATA_BLOCK;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/TestHoodieFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/TestHoodieFileWriterFactory.java
@@ -51,10 +51,17 @@ public class TestHoodieFileWriterFactory extends HoodieClientTestBase {
         parquetPath, table, cfg, HoodieTestDataGenerator.AVRO_SCHEMA, supplier);
     assertTrue(parquetWriter instanceof HoodieParquetWriter);
 
+    // hfile format.
     final Path hfilePath = new Path(basePath + "/partition/path/f1_1-0-1_000.hfile");
     HoodieFileWriter<IndexedRecord> hfileWriter = HoodieFileWriterFactory.getFileWriter(instantTime,
         hfilePath, table, cfg, HoodieTestDataGenerator.AVRO_SCHEMA, supplier);
     assertTrue(hfileWriter instanceof HoodieHFileWriter);
+
+    // orc file format.
+    final Path orcPath = new Path(basePath + "/partition/path/f1_1-0-1_000.orc");
+    HoodieFileWriter<IndexedRecord> orcFileWriter = HoodieFileWriterFactory.getFileWriter(instantTime,
+        orcPath, table, cfg, HoodieTestDataGenerator.AVRO_SCHEMA, supplier);
+    assertTrue(orcFileWriter instanceof HoodieOrcWriter);
 
     // other file format exception.
     final Path logPath = new Path(basePath + "/partition/path/f.b51192a8-574b-4a85-b246-bcfec03ac8bf_100.log.2_1-0-1");

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -126,16 +126,6 @@
       <version>${orc.version}</version>
       <classifier>nohive</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.apache.orc</groupId>
-      <artifactId>orc-shims</artifactId>
-      <version>${orc.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.airlift</groupId>
-      <artifactId>aircompressor</artifactId>
-      <version>${airlift.version}</version>
-    </dependency>
 
     <!-- Httpcomponents -->
     <dependency>

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -119,6 +119,24 @@
       <artifactId>parquet-avro</artifactId>
     </dependency>
 
+    <!-- ORC -->
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-core</artifactId>
+      <version>${orc.version}</version>
+      <classifier>nohive</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-shims</artifactId>
+      <version>${orc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+      <version>${airlift.version}</version>
+    </dependency>
+
     <!-- Httpcomponents -->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -24,7 +24,8 @@ package org.apache.hudi.common.model;
 public enum HoodieFileFormat {
   PARQUET(".parquet"),
   HOODIE_LOG(".log"),
-  HFILE(".hfile");
+  HFILE(".hfile"),
+  ORC(".orc");
 
   private final String extension;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
@@ -1,0 +1,598 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Conversions;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.generic.GenericData;
+import java.nio.charset.StandardCharsets;
+import org.apache.avro.Schema;
+import org.apache.avro.util.Utf8;
+import org.apache.orc.storage.common.type.HiveDecimal;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
+import org.apache.orc.storage.ql.exec.vector.DoubleColumnVector;
+import org.apache.orc.storage.ql.exec.vector.ListColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.MapColumnVector;
+import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
+import org.apache.orc.storage.ql.exec.vector.TimestampColumnVector;
+import org.apache.orc.storage.ql.exec.vector.UnionColumnVector;
+import org.apache.orc.storage.serde2.io.DateWritable;
+import org.apache.orc.TypeDescription;
+
+/**
+ * This file is originally from https://github.com/streamsets/datacollector.
+ * Source classes:
+ * - com.streamsets.pipeline.lib.util.avroorc.AvroToOrcRecordConverter
+ * - com.streamsets.pipeline.lib.util.avroorc.AvroToOrcSchemaConverter
+ *
+ * Changes made:
+ * 1. Flatten nullable Avro schema type when the value if not null in `addToVector`.
+ * 2. Use getLogicalType(), constants from LogicalTypes instead of getJsonProp() to handle Avro logical types.
+ */
+public class AvroOrcUtils {
+
+  private static final int MICROS_PER_MILLI = 1000;
+  private static final int NANOS_PER_MICRO = 1000;
+
+  /**
+   * Add an object (of a given ORC type) to the column vector at a given position.
+   *
+   * @param type        ORC schema of the value Object.
+   * @param colVector   The column vector to store the value Object.
+   * @param avroSchema  Avro schema of the value Object.
+   *                    Only used to check logical types for timestamp unit conversion.
+   * @param value       Object to be added to the column vector
+   * @param vectorPos   The position in the vector where value will be stored at.
+   */
+  public static void addToVector(TypeDescription type, ColumnVector colVector, Schema avroSchema, Object value, int vectorPos) {
+
+    final int currentVecLength = colVector.isNull.length;
+    if (vectorPos >= currentVecLength) {
+      colVector.ensureSize(2 * currentVecLength, true);
+    }
+    if (value == null) {
+      colVector.isNull[vectorPos] = true;
+      colVector.noNulls = false;
+      return;
+    }
+
+    if (avroSchema.getType().equals(Schema.Type.UNION)) {
+      avroSchema = getActualSchemaType(avroSchema);
+    }
+
+    LogicalType logicalType = avroSchema != null ? avroSchema.getLogicalType() : null;
+
+    switch (type.getCategory()) {
+      case BOOLEAN:
+        LongColumnVector boolVec = (LongColumnVector) colVector;
+        boolVec.vector[vectorPos] = (boolean) value ? 1 : 0;
+        break;
+      case BYTE:
+        LongColumnVector byteColVec = (LongColumnVector) colVector;
+        byteColVec.vector[vectorPos] = (byte) value;
+        break;
+      case SHORT:
+        LongColumnVector shortColVec = (LongColumnVector) colVector;
+        shortColVec.vector[vectorPos] = (short) value;
+        break;
+      case INT:
+        // the Avro logical type could be AvroTypeUtil.LOGICAL_TYPE_TIME_MILLIS, but we will ignore that fact here
+        // since Orc has no way to represent a time in the way Avro defines it; we will simply preserve the int value
+        LongColumnVector intColVec = (LongColumnVector) colVector;
+        intColVec.vector[vectorPos] = (int) value;
+        break;
+      case LONG:
+        // the Avro logical type could be AvroTypeUtil.LOGICAL_TYPE_TIME_MICROS, but we will ignore that fact here
+        // since Orc has no way to represent a time in the way Avro defines it; we will simply preserve the long value
+        LongColumnVector longColVec = (LongColumnVector) colVector;
+        longColVec.vector[vectorPos] = (long) value;
+        break;
+      case FLOAT:
+        DoubleColumnVector floatColVec = (DoubleColumnVector) colVector;
+        floatColVec.vector[vectorPos] = (float) value;
+        break;
+      case DOUBLE:
+        DoubleColumnVector doubleColVec = (DoubleColumnVector) colVector;
+        doubleColVec.vector[vectorPos] = (double) value;
+        break;
+      case VARCHAR:
+      case CHAR:
+      case STRING:
+        BytesColumnVector bytesColVec = (BytesColumnVector) colVector;
+        byte[] bytes = null;
+
+        if (value instanceof String) {
+          bytes = ((String) value).getBytes(StandardCharsets.UTF_8);
+        } else if (value instanceof Utf8) {
+          final Utf8 utf8 = (Utf8) value;
+          bytes = utf8.getBytes();
+        } else if (value instanceof GenericData.EnumSymbol) {
+          bytes = ((GenericData.EnumSymbol) value).toString().getBytes(StandardCharsets.UTF_8);
+        } else {
+          throw new IllegalStateException(String.format(
+              "Unrecognized type for Avro %s field value, which has type %s, value %s",
+              type.getCategory().getName(),
+              value.getClass().getName(),
+              value.toString()
+          ));
+        }
+
+        if (bytes == null) {
+          bytesColVec.isNull[vectorPos] = true;
+          bytesColVec.noNulls = false;
+        } else {
+          bytesColVec.setRef(vectorPos, bytes, 0, bytes.length);
+        }
+        break;
+      case DATE:
+        LongColumnVector dateColVec = (LongColumnVector) colVector;
+        int daysSinceEpoch;
+        if (logicalType instanceof LogicalTypes.Date) {
+          daysSinceEpoch = (int) value;
+        } else if (value instanceof java.sql.Date) {
+          daysSinceEpoch = DateWritable.dateToDays((java.sql.Date) value);
+        } else if (value instanceof Date) {
+          daysSinceEpoch = DateWritable.millisToDays(((Date) value).getTime());
+        } else {
+          throw new IllegalStateException(String.format(
+              "Unrecognized type for Avro DATE field value, which has type %s, value %s",
+              value.getClass().getName(),
+              value.toString()
+          ));
+        }
+        dateColVec.vector[vectorPos] = daysSinceEpoch;
+        break;
+      case TIMESTAMP:
+        TimestampColumnVector tsColVec = (TimestampColumnVector) colVector;
+
+        long time;
+        int nanos = 0;
+
+        if (logicalType instanceof LogicalTypes.TimestampMillis) {
+          time = (long) value;
+        } else if (logicalType instanceof LogicalTypes.TimestampMicros) {
+          final long logicalTsValue = (long) value;
+          time = logicalTsValue / MICROS_PER_MILLI;
+          nanos = NANOS_PER_MICRO * ((int)(logicalTsValue % MICROS_PER_MILLI));
+        } else if (value instanceof Timestamp) {
+          Timestamp tsValue = (Timestamp) value;
+          time = tsValue.getTime();
+          nanos = tsValue.getNanos();
+        } else if (value instanceof java.sql.Date) {
+          java.sql.Date sqlDateValue = (java.sql.Date) value;
+          time = sqlDateValue.getTime();
+        } else if (value instanceof Date) {
+          Date dateValue = (Date) value;
+          time = dateValue.getTime();
+        } else {
+          throw new IllegalStateException(String.format(
+              "Unrecognized type for Avro TIMESTAMP field value, which has type %s, value %s",
+              value.getClass().getName(),
+              value.toString()
+          ));
+        }
+
+        final long millis = time % 1000;
+        if (millis > 0) {
+          // need to account for millis in the nanos portion
+          nanos += NANOS_PER_MICRO * MICROS_PER_MILLI * millis;
+        }
+
+        tsColVec.time[vectorPos] = time;
+        tsColVec.nanos[vectorPos] = nanos;
+        break;
+      case BINARY:
+        BytesColumnVector binaryColVec = (BytesColumnVector) colVector;
+
+        byte[] binaryBytes;
+        if (value instanceof GenericData.Fixed) {
+          binaryBytes = ((GenericData.Fixed)value).bytes();
+        }  else if (value instanceof ByteBuffer) {
+          final ByteBuffer byteBuffer = (ByteBuffer) value;
+          binaryBytes = new byte[byteBuffer.remaining()];
+          byteBuffer.get(binaryBytes);
+        } else if (value instanceof byte[]) {
+          binaryBytes = (byte[]) value;
+        } else {
+          throw new IllegalStateException(String.format(
+              "Unrecognized type for Avro BINARY field value, which has type %s, value %s",
+              value.getClass().getName(),
+              value.toString()
+          ));
+        }
+        binaryColVec.setRef(vectorPos, binaryBytes, 0, binaryBytes.length);
+        break;
+      case DECIMAL:
+        DecimalColumnVector decimalColVec = (DecimalColumnVector) colVector;
+        HiveDecimal decimalValue;
+        if (value instanceof BigDecimal) {
+          final BigDecimal decimal = (BigDecimal) value;
+          decimalValue = HiveDecimal.create(decimal);
+        } else if (value instanceof ByteBuffer) {
+          final ByteBuffer byteBuffer = (ByteBuffer) value;
+          final byte[] decimalBytes = new byte[byteBuffer.remaining()];
+          byteBuffer.get(decimalBytes);
+          final BigInteger bigInt = new BigInteger(decimalBytes);
+          final int scale = type.getScale();
+          BigDecimal bigDecVal =  new BigDecimal(bigInt, scale);
+
+          decimalValue = HiveDecimal.create(bigDecVal);
+          if (decimalValue == null && decimalBytes.length > 0) {
+            throw new IllegalStateException(
+                "Unexpected read null HiveDecimal from bytes (base-64 encoded): "
+                    + Base64.getEncoder().encodeToString(decimalBytes)
+            );
+          }
+        } else if (value instanceof GenericData.Fixed) {
+          final BigDecimal decimal = new Conversions.DecimalConversion()
+              .fromFixed((GenericData.Fixed) value, avroSchema, logicalType);
+          decimalValue = HiveDecimal.create(decimal);
+        } else {
+          throw new IllegalStateException(String.format(
+              "Unexpected type for decimal (%s), cannot convert from Avro value",
+              value.getClass().getCanonicalName()
+          ));
+        }
+        if (decimalValue == null) {
+          decimalColVec.isNull[vectorPos] = true;
+          decimalColVec.noNulls = false;
+        } else {
+          decimalColVec.set(vectorPos, decimalValue);
+        }
+        break;
+      case LIST:
+        List<?> list = (List<?>) value;
+        ListColumnVector listColVec = (ListColumnVector) colVector;
+        listColVec.offsets[vectorPos] = listColVec.childCount;
+        listColVec.lengths[vectorPos] = list.size();
+
+        TypeDescription listType = type.getChildren().get(0);
+        for (Object listItem : list) {
+          addToVector(listType, listColVec.child, avroSchema.getElementType(), listItem, listColVec.childCount++);
+        }
+        break;
+      case MAP:
+        Map<String, ?> mapValue = (Map<String, ?>) value;
+
+        MapColumnVector mapColumnVector = (MapColumnVector) colVector;
+        mapColumnVector.offsets[vectorPos] = mapColumnVector.childCount;
+        mapColumnVector.lengths[vectorPos] = mapValue.size();
+
+        // keys are always strings
+        Schema keySchema = Schema.create(Schema.Type.STRING);
+        for (Map.Entry<String, ?> entry : mapValue.entrySet()) {
+          addToVector(
+              type.getChildren().get(0),
+              mapColumnVector.keys,
+              keySchema,
+              entry.getKey(),
+              mapColumnVector.childCount
+          );
+
+          addToVector(
+              type.getChildren().get(1),
+              mapColumnVector.values,
+              avroSchema.getValueType(),
+              entry.getValue(),
+              mapColumnVector.childCount
+          );
+
+          mapColumnVector.childCount++;
+        }
+
+        break;
+      case STRUCT:
+        StructColumnVector structColVec = (StructColumnVector) colVector;
+
+        GenericData.Record record = (GenericData.Record) value;
+
+        for (int i = 0; i < type.getFieldNames().size(); i++) {
+          String fieldName = type.getFieldNames().get(i);
+          Object fieldValue = record.get(fieldName);
+          TypeDescription fieldType = type.getChildren().get(i);
+          addToVector(fieldType, structColVec.fields[i], avroSchema.getFields().get(i).schema(), fieldValue, vectorPos);
+        }
+
+        break;
+      case UNION:
+        UnionColumnVector unionColVec = (UnionColumnVector) colVector;
+
+        List<TypeDescription> childTypes = type.getChildren();
+        boolean added = addUnionValue(unionColVec, childTypes, avroSchema, value, vectorPos);
+
+        if (!added) {
+          throw new IllegalStateException(String.format(
+              "Failed to add value %s to union with type %s",
+              value == null ? "null" : value.toString(),
+              type.toString()
+          ));
+        }
+
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid TypeDescription " + type.toString() + ".");
+    }
+  }
+
+  /**
+   * Match value with its ORC type and add to the union vector at a given position.
+   *
+   * @param unionVector       The vector to store value.
+   * @param unionChildTypes   All possible types for the value Object.
+   * @param avroSchema        Avro union schema for the value Object.
+   * @param value             Object to be added to the unionVector
+   * @param vectorPos         The position in the vector where value will be stored at.
+   * @return                  succeeded or failed
+   */
+  public static boolean addUnionValue(
+      UnionColumnVector unionVector,
+      List<TypeDescription> unionChildTypes,
+      Schema avroSchema,
+      Object value,
+      int vectorPos
+  ) {
+    int matchIndex = -1;
+    TypeDescription matchType = null;
+    Object matchValue = null;
+
+    for (int t = 0; t < unionChildTypes.size(); t++) {
+      TypeDescription childType = unionChildTypes.get(t);
+      boolean matches = false;
+
+      switch (childType.getCategory()) {
+        case BOOLEAN:
+          matches = value instanceof Boolean;
+          break;
+        case BYTE:
+          matches = value instanceof Byte;
+          break;
+        case SHORT:
+          matches = value instanceof Short;
+          break;
+        case INT:
+          matches = value instanceof Integer;
+          break;
+        case LONG:
+          matches = value instanceof Long;
+          break;
+        case FLOAT:
+          matches = value instanceof Float;
+          break;
+        case DOUBLE:
+          matches = value instanceof Double;
+          break;
+        case STRING:
+        case VARCHAR:
+        case CHAR:
+          if (value instanceof String) {
+            matches = true;
+            matchValue = ((String) value).getBytes(StandardCharsets.UTF_8);
+          } else if (value instanceof Utf8) {
+            matches = true;
+            matchValue = ((Utf8) value).getBytes();
+          }
+          break;
+        case DATE:
+          matches = value instanceof Date;
+          break;
+        case TIMESTAMP:
+          matches = value instanceof Timestamp;
+          break;
+        case BINARY:
+          matches = value instanceof byte[] || value instanceof GenericData.Fixed;
+          break;
+        case DECIMAL:
+          matches = value instanceof BigDecimal;
+          break;
+        case LIST:
+          matches = value instanceof List;
+          break;
+        case MAP:
+          matches = value instanceof Map;
+          break;
+        case STRUCT:
+          throw new UnsupportedOperationException("Cannot handle STRUCT within UNION.");
+        case UNION:
+          List<TypeDescription> children = childType.getChildren();
+          if (value == null) {
+            matches = children == null || children.size() == 0;
+          } else {
+            matches = addUnionValue(unionVector, children, avroSchema, value, vectorPos);
+          }
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid TypeDescription " + childType.getCategory().toString() + ".");
+      }
+
+      if (matches) {
+        matchIndex = t;
+        matchType = childType;
+        break;
+      }
+    }
+
+    if (value == null && matchValue != null) {
+      value = matchValue;
+    }
+
+    if (matchIndex >= 0) {
+      unionVector.tags[vectorPos] = matchIndex;
+      if (value == null) {
+        unionVector.isNull[vectorPos] = true;
+        unionVector.noNulls = false;
+      } else {
+        addToVector(matchType, unionVector.fields[matchIndex], avroSchema.getTypes().get(matchIndex), value, vectorPos);
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public static TypeDescription createOrcSchema(Schema avroSchema) {
+
+    LogicalType logicalType = avroSchema.getLogicalType();
+
+    if (logicalType != null) {
+      if (logicalType instanceof LogicalTypes.Decimal) {
+        return TypeDescription.createDecimal()
+            .withPrecision(((LogicalTypes.Decimal) logicalType).getPrecision())
+            .withScale(((LogicalTypes.Decimal) logicalType).getScale());
+      } else if (logicalType instanceof LogicalTypes.Date) {
+        // The date logical type represents a date within the calendar, with no reference to a particular time zone
+        // or time of day.
+        //
+        // A date logical type annotates an Avro int, where the int stores the number of days from the unix epoch, 1
+        // January 1970 (ISO calendar).
+        return TypeDescription.createDate();
+      } else if (logicalType instanceof LogicalTypes.TimeMillis) {
+        // The time-millis logical type represents a time of day, with no reference to a particular calendar, time
+        // zone or date, with a precision of one millisecond.
+        //
+        // A time-millis logical type annotates an Avro int, where the int stores the number of milliseconds after
+        // midnight, 00:00:00.000.
+        return TypeDescription.createInt();
+      } else if (logicalType instanceof LogicalTypes.TimeMicros) {
+        // The time-micros logical type represents a time of day, with no reference to a particular calendar, time
+        // zone or date, with a precision of one microsecond.
+        //
+        // A time-micros logical type annotates an Avro long, where the long stores the number of microseconds after
+        // midnight, 00:00:00.000000.
+        return TypeDescription.createLong();
+      } else if (logicalType instanceof LogicalTypes.TimestampMillis) {
+        // The timestamp-millis logical type represents an instant on the global timeline, independent of a
+        // particular time zone or calendar, with a precision of one millisecond.
+        //
+        // A timestamp-millis logical type annotates an Avro long, where the long stores the number of milliseconds
+        // from the unix epoch, 1 January 1970 00:00:00.000 UTC.
+        return TypeDescription.createTimestamp();
+      } else if (logicalType instanceof LogicalTypes.TimestampMicros) {
+        // The timestamp-micros logical type represents an instant on the global timeline, independent of a
+        // particular time zone or calendar, with a precision of one microsecond.
+        //
+        // A timestamp-micros logical type annotates an Avro long, where the long stores the number of microseconds
+        // from the unix epoch, 1 January 1970 00:00:00.000000 UTC.
+        return TypeDescription.createTimestamp();
+      }
+    }
+
+    final Schema.Type type = avroSchema.getType();
+    switch (type) {
+      case NULL:
+        // empty union represents null type
+        final TypeDescription nullUnion = TypeDescription.createUnion();
+        return nullUnion;
+      case LONG:
+        return TypeDescription.createLong();
+      case INT:
+        return TypeDescription.createInt();
+      case BYTES:
+        return TypeDescription.createBinary();
+      case ARRAY:
+        return TypeDescription.createList(createOrcSchema(avroSchema.getElementType()));
+      case RECORD:
+        final TypeDescription recordStruct = TypeDescription.createStruct();
+        for (Schema.Field field : avroSchema.getFields()) {
+          final Schema fieldSchema = field.schema();
+          final TypeDescription fieldType = createOrcSchema(fieldSchema);
+          if (fieldType != null) {
+            recordStruct.addField(field.name(), fieldType);
+          }
+        }
+        return recordStruct;
+      case MAP:
+        return TypeDescription.createMap(
+            // in Avro maps, keys are always strings
+            TypeDescription.createString(),
+            createOrcSchema(avroSchema.getValueType())
+        );
+      case UNION:
+        final List<Schema> nonNullMembers = avroSchema.getTypes().stream().filter(
+            schema -> !Schema.Type.NULL.equals(schema.getType())
+        ).collect(Collectors.toList());
+
+        if (nonNullMembers.isEmpty()) {
+          // no non-null union members; represent as an ORC empty union
+          return TypeDescription.createUnion();
+        } else if (nonNullMembers.size() == 1) {
+          // a single non-null union member
+          // this is how Avro represents "nullable" types; as a union of the NULL type with another
+          // since ORC already supports nullability of all types, just use the child type directly
+          return createOrcSchema(nonNullMembers.get(0));
+        } else {
+          // more than one non-null type; represent as an actual ORC union of them
+          final TypeDescription union = TypeDescription.createUnion();
+          for (final Schema childSchema : nonNullMembers) {
+            union.addUnionChild(createOrcSchema(childSchema));
+          }
+          return union;
+        }
+      case STRING:
+        return TypeDescription.createString();
+      case FLOAT:
+        return TypeDescription.createFloat();
+      case DOUBLE:
+        return TypeDescription.createDouble();
+      case BOOLEAN:
+        return TypeDescription.createBoolean();
+      case ENUM:
+        // represent as String for now
+        return TypeDescription.createString();
+      case FIXED:
+        return TypeDescription.createBinary();
+      default:
+        throw new IllegalStateException(String.format("Unrecognized Avro type: %s", type.getName()));
+    }
+  }
+
+  /**
+   * Returns the actual schema of a field.
+   *
+   * All types in ORC is nullable whereas Avro uses a union that contains the NULL type to imply
+   * the nullability of an Avro type. To achieve consistency between the Avro and ORC schema,
+   * non-NULL types are extracted from the union type.
+   * @param unionSchema       A schema of union type.
+   * @return  An Avro schema that is either NULL or a UNION without NULL fields.
+   */
+  private static Schema getActualSchemaType(Schema unionSchema) {
+    final List<Schema> nonNullMembers = unionSchema.getTypes().stream().filter(
+        schema -> !Schema.Type.NULL.equals(schema.getType())
+    ).collect(Collectors.toList());
+    if (nonNullMembers.isEmpty()) {
+      return Schema.create(Schema.Type.NULL);
+    } else if (nonNullMembers.size() == 1) {
+      return nonNullMembers.get(0);
+    } else {
+      return Schema.createUnion(nonNullMembers);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
@@ -208,12 +208,6 @@ public class AvroOrcUtils {
           ));
         }
 
-        final long millis = time % 1000;
-        if (millis > 0) {
-          // need to account for millis in the nanos portion
-          nanos += NANOS_PER_MICRO * MICROS_PER_MILLI * millis;
-        }
-
         tsColVec.time[vectorPos] = time;
         tsColVec.nanos[vectorPos] = nanos;
         break;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/OrcReaderIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/OrcReaderIterator.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hudi.exception.HoodieIOException;
+
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * This class wraps a ORC reader and provides an iterator based api to read from an ORC file.
+ */
+public class OrcReaderIterator<T> implements Iterator<T> {
+
+  private final RecordReader recordReader;
+  private final Schema avroSchema;
+  List<String> fieldNames;
+  List<TypeDescription> orcFieldTypes;
+  Schema[] avroFieldSchemas;
+  private VectorizedRowBatch batch;
+  private int rowInBatch;
+  private T next;
+
+  public OrcReaderIterator(RecordReader recordReader, Schema schema, TypeDescription orcSchema) {
+    this.recordReader = recordReader;
+    this.avroSchema = schema;
+    this.fieldNames = orcSchema.getFieldNames();
+    this.orcFieldTypes = orcSchema.getChildren();
+    this.avroFieldSchemas = fieldNames.stream()
+        .map(fieldName -> avroSchema.getField(fieldName).schema())
+        .toArray(size -> new Schema[size]);
+    this.batch = orcSchema.createRowBatch();
+    this.rowInBatch = 0;
+  }
+
+  /**
+   * If the current batch is empty, get a new one.
+   * @return true if we have rows available.
+   * @throws IOException
+   */
+  private boolean ensureBatch() throws IOException {
+    if (rowInBatch >= batch.size) {
+      rowInBatch = 0;
+      return recordReader.nextBatch(batch);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean hasNext() {
+    try {
+      ensureBatch();
+      if (this.next == null) {
+        this.next = (T) readRecordFromBatch();
+      }
+      return this.next != null;
+    } catch (IOException io) {
+      throw new HoodieIOException("unable to read next record from ORC file ", io);
+    }
+  }
+
+  @Override
+  public T next() {
+    try {
+      // To handle case when next() is called before hasNext()
+      if (this.next == null) {
+        if (!hasNext()) {
+          throw new HoodieIOException("No more records left to read from ORC file");
+        }
+      }
+      T retVal = this.next;
+      this.next = (T) readRecordFromBatch();
+      return retVal;
+    } catch (IOException io) {
+      throw new HoodieIOException("unable to read next record from ORC file ", io);
+    }
+  }
+
+  private GenericData.Record readRecordFromBatch() throws IOException {
+    // No more records left to read from ORC file
+    if (!ensureBatch()) {
+      return null;
+    }
+
+    GenericData.Record record = new Record(avroSchema);
+    int numFields = orcFieldTypes.size();
+    for (int i = 0; i < numFields; i++) {
+      record.put(fieldNames.get(i),
+          AvroOrcUtils.readFromVector(orcFieldTypes.get(i), batch.cols[i], avroFieldSchemas[i], rowInBatch));
+    }
+    rowInBatch++;
+    return record;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hudi.avro.HoodieAvroWriteSupport;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.BloomFilterFactory;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.MetadataNotFoundException;
+import org.apache.orc.OrcFile;
+import org.apache.orc.OrcProto.UserMetadataItem;
+import org.apache.orc.Reader;
+import org.apache.orc.Reader.Options;
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+
+/**
+ * Utility functions for ORC files.
+ */
+public class OrcUtils {
+  /**
+   * Read the rowKey list matching the given filter, from the given ORC file. If the filter is empty, then this will
+   * return all the rowkeys.
+   *
+   * @param conf configuration to build fs object.
+   * @param filePath      The ORC file path.
+   * @param filter        record keys filter
+   * @return Set Set of row keys matching candidateRecordKeys
+   */
+  public static Set<String> filterOrcRowKeys(Configuration conf,
+      Path filePath, Set<String> filter) throws HoodieIOException {
+    try {
+      Reader reader = OrcFile.createReader(filePath, OrcFile.readerOptions(conf));
+      Set<String> filteredRowKeys = new HashSet<>();
+      TypeDescription schema = reader.getSchema();
+      List<String> fieldNames = schema.getFieldNames();
+      VectorizedRowBatch batch = schema.createRowBatch();
+      RecordReader recordReader = reader.rows(new Options(conf).schema(schema));
+
+      // column index for the RECORD_KEY_METADATA_FIELD field
+      int colIndex = -1;
+      for (int i = 0; i < fieldNames.size(); i++) {
+        if (fieldNames.get(i).equals(HoodieRecord.RECORD_KEY_METADATA_FIELD)) {
+          colIndex = i;
+          break;
+        }
+      }
+      if (colIndex == -1) {
+        throw new HoodieException(String.format("Couldn't find row keys in %s.", filePath));
+      }
+      while (recordReader.nextBatch(batch)) {
+        BytesColumnVector rowKeys = (BytesColumnVector) batch.cols[colIndex];
+        for (int i = 0; i < batch.size; i++) {
+          String rowKey = rowKeys.toString(i);
+          if (filter.isEmpty() || filter.contains(rowKey)) {
+            filteredRowKeys.add(rowKey);
+          }
+        }
+      }
+      return filteredRowKeys;
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to read next batch from ORC file ", io);
+    }
+  }
+
+  /**
+   * Read out the bloom filter from the ORC file meta data.
+   */
+  public static BloomFilter readBloomFilterFromOrcMetadata(Configuration conf, Path orcFilePath) {
+    Map<String, String> footerVals =
+        readOrcFooter(conf, orcFilePath, false,
+            HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY,
+            HoodieAvroWriteSupport.HOODIE_BLOOM_FILTER_TYPE_CODE);
+    String footerVal = footerVals.get(HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY);
+    BloomFilter toReturn = null;
+    if (footerVal != null) {
+      if (footerVals.containsKey(HoodieAvroWriteSupport.HOODIE_BLOOM_FILTER_TYPE_CODE)) {
+        toReturn = BloomFilterFactory.fromString(footerVal,
+            footerVals.get(HoodieAvroWriteSupport.HOODIE_BLOOM_FILTER_TYPE_CODE));
+      } else {
+        toReturn = BloomFilterFactory.fromString(footerVal, BloomFilterTypeCode.SIMPLE.name());
+      }
+    }
+    return toReturn;
+  }
+
+  public static String[] readMinMaxRecordKeys(Configuration conf, Path orcFilePath) {
+    Map<String, String> minMaxKeys = readOrcFooter(conf, orcFilePath, true,
+        HoodieAvroWriteSupport.HOODIE_MIN_RECORD_KEY_FOOTER, HoodieAvroWriteSupport.HOODIE_MAX_RECORD_KEY_FOOTER);
+    if (minMaxKeys.size() != 2) {
+      throw new HoodieException(
+          String.format("Could not read min/max record key out of footer correctly from %s. read) : %s",
+              orcFilePath, minMaxKeys));
+    }
+    return new String[] {minMaxKeys.get(HoodieAvroWriteSupport.HOODIE_MIN_RECORD_KEY_FOOTER),
+        minMaxKeys.get(HoodieAvroWriteSupport.HOODIE_MAX_RECORD_KEY_FOOTER)};
+  }
+
+  private static Map<String, String> readOrcFooter(Configuration conf, Path orcFilePath,
+                                                   boolean required, String... footerNames) {
+    try {
+      Reader reader = OrcFile.createReader(orcFilePath, OrcFile.readerOptions(conf));
+      Map<String, String> footerVals = new HashMap<>();
+      List<UserMetadataItem> metadataItemList = reader.getFileTail().getFooter().getMetadataList();
+      Map<String, String> metadata = metadataItemList.stream().collect(Collectors.toMap(
+          UserMetadataItem::getName,
+          metadataItem -> metadataItem.getValue().toStringUtf8()));
+      for (String footerName : footerNames) {
+        if (metadata.containsKey(footerName)) {
+          footerVals.put(footerName, metadata.get(footerName));
+        } else if (required) {
+          throw new MetadataNotFoundException(
+              "Could not find index in ORC footer. Looked for key " + footerName + " in "
+                  + orcFilePath);
+        }
+      }
+      return footerVals;
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to create an ORC reader.", io);
+    }
+  }
+
+  public static Schema getAvroSchema(Configuration conf, Path orcFilePath) {
+    try {
+      Reader reader = OrcFile.createReader(orcFilePath, OrcFile.readerOptions(conf));
+      TypeDescription orcSchema = reader.getSchema();
+      return AvroOrcUtils.createAvroSchema(orcSchema);
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to create an ORC reader.", io);
+    }
+  }
+
+  public static long getRowCount(Configuration conf, Path orcFilePath) {
+    try {
+      Reader reader = OrcFile.createReader(orcFilePath, OrcFile.readerOptions(conf));
+      return reader.getNumberOfRows();
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to create an ORC reader.", io);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
@@ -90,7 +90,7 @@ public class OrcUtils {
       }
       return filteredRowKeys;
     } catch (IOException io) {
-      throw new HoodieIOException("Unable to read next batch from ORC file ", io);
+      throw new HoodieIOException("Unable to read row keys for ORC file" + filePath.getName(), io);
     }
   }
 
@@ -147,7 +147,7 @@ public class OrcUtils {
       }
       return footerVals;
     } catch (IOException io) {
-      throw new HoodieIOException("Unable to create an ORC reader.", io);
+      throw new HoodieIOException("Unable to read footer for ORC file" + orcFilePath.getName(), io);
     }
   }
 
@@ -157,7 +157,7 @@ public class OrcUtils {
       TypeDescription orcSchema = reader.getSchema();
       return AvroOrcUtils.createAvroSchema(orcSchema);
     } catch (IOException io) {
-      throw new HoodieIOException("Unable to create an ORC reader.", io);
+      throw new HoodieIOException("Unable to get Avro schema for ORC file" + orcFilePath.getName(), io);
     }
   }
 
@@ -166,7 +166,7 @@ public class OrcUtils {
       Reader reader = OrcFile.createReader(orcFilePath, OrcFile.readerOptions(conf));
       return reader.getNumberOfRows();
     } catch (IOException io) {
-      throw new HoodieIOException("Unable to create an ORC reader.", io);
+      throw new HoodieIOException("Unable to get row count for ORC file" + orcFilePath.getName(), io);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 
 import java.io.IOException;
 
+import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
 import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
 
@@ -40,6 +41,9 @@ public class HoodieFileReaderFactory {
     if (HFILE.getFileExtension().equals(extension)) {
       return newHFileFileReader(conf, path);
     }
+    if (ORC.getFileExtension().equals(extension)) {
+      return newOrcFileReader(conf, path);
+    }
 
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
@@ -51,5 +55,9 @@ public class HoodieFileReaderFactory {
   private static <R extends IndexedRecord> HoodieFileReader<R> newHFileFileReader(Configuration conf, Path path) throws IOException {
     CacheConfig cacheConfig = new CacheConfig(conf);
     return new HoodieHFileReader<>(conf, path, cacheConfig);
+  }
+
+  private static <R extends IndexedRecord> HoodieFileReader<R> newOrcFileReader(Configuration conf, Path path) {
+    return new HoodieOrcReader<>(conf, path);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieOrcReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieOrcReader.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.util.AvroOrcUtils;
+import org.apache.hudi.common.util.OrcReaderIterator;
+import org.apache.hudi.common.util.OrcUtils;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.Reader.Options;
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+
+public class HoodieOrcReader<R extends IndexedRecord> implements HoodieFileReader {
+  private Path path;
+  private Configuration conf;
+
+  public HoodieOrcReader(Configuration configuration, Path path) {
+    this.conf = configuration;
+    this.path = path;
+  }
+
+  @Override
+  public String[] readMinMaxRecordKeys() {
+    return OrcUtils.readMinMaxRecordKeys(conf, path);
+  }
+
+  @Override
+  public BloomFilter readBloomFilter() {
+    return OrcUtils.readBloomFilterFromOrcMetadata(conf, path);
+  }
+
+  @Override
+  public Set<String> filterRowKeys(Set candidateRowKeys) {
+    return OrcUtils.filterOrcRowKeys(conf, path, candidateRowKeys);
+  }
+
+  @Override
+  public Iterator<R> getRecordIterator(Schema schema) throws IOException {
+    try {
+      Reader reader = OrcFile.createReader(path, OrcFile.readerOptions(conf));
+      TypeDescription orcSchema = AvroOrcUtils.createOrcSchema(schema);
+      RecordReader recordReader = reader.rows(new Options(conf).schema(orcSchema));
+      return new OrcReaderIterator(recordReader, schema, orcSchema);
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to create an ORC reader.", io);
+    }
+  }
+
+  @Override
+  public Schema getSchema() {
+    return OrcUtils.getAvroSchema(conf, path);
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public long getTotalRecords() {
+    return OrcUtils.getRowCount(conf, path);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestAvroOrcUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestAvroOrcUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.orc.TypeDescription;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestAvroOrcUtils extends HoodieCommonTestHarness {
+
+  public static List<Arguments> testCreateOrcSchemaArgs() {
+    // the ORC schema is constructed in the order as AVRO_SCHEMA:
+    // TRIP_SCHEMA_PREFIX, EXTRA_TYPE_SCHEMA, MAP_TYPE_SCHEMA, FARE_NESTED_SCHEMA, TIP_NESTED_SCHEMA, TRIP_SCHEMA_SUFFIX
+    // The following types are tested:
+    // DATE, DECIMAL, LONG, INT, BYTES, ARRAY, RECORD, MAP, STRING, FLOAT, DOUBLE
+    TypeDescription orcSchema = TypeDescription.fromString("struct<"
+        + "timestamp:bigint,_row_key:string,rider:string,driver:string,begin_lat:double,"
+        + "begin_lon:double,end_lat:double,end_lon:double,"
+        + "distance_in_meters:int,seconds_since_epoch:bigint,weight:float,nation:binary,"
+        + "current_date:date,current_ts:bigint,height:decimal(10,6),"
+        + "city_to_state:map<string,string>,"
+        + "fare:struct<amount:double,currency:string>,"
+        + "tip_history:array<struct<amount:double,currency:string>>,"
+        + "_hoodie_is_deleted:boolean>");
+
+    // Tests the types FIXED, UNION
+    String structField = "{\"type\":\"record\", \"name\":\"fare\",\"fields\": "
+        + "[{\"name\": \"amount\",\"type\": \"double\"},{\"name\": \"currency\", \"type\": \"string\"}]}";
+    Schema avroSchemaWithMoreTypes = new Schema.Parser().parse(
+        "{\"type\": \"record\"," + "\"name\": \"triprec\"," + "\"fields\": [ "
+            + "{\"name\" : \"age\", \"type\":{\"type\": \"fixed\", \"size\": 16, \"name\": \"fixedField\" }},"
+            + "{\"name\" : \"height\", \"type\": [\"int\", \"null\"] },"
+            + "{\"name\" : \"id\", \"type\": [\"int\", \"string\"] },"
+            + "{\"name\" : \"fare\", \"type\": [" + structField + ", \"null\"] }]}");
+    TypeDescription orcSchemaWithMoreTypes = TypeDescription.fromString(
+        "struct<age:binary,height:int,id:uniontype<int,string>,fare:struct<amount:double,currency:string>>");
+
+    return Arrays.asList(
+        Arguments.of(AVRO_SCHEMA, orcSchema),
+        Arguments.of(avroSchemaWithMoreTypes, orcSchemaWithMoreTypes)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCreateOrcSchemaArgs")
+  public void testCreateOrcSchema(Schema avroSchema, TypeDescription orcSchema) {
+    TypeDescription convertedSchema = AvroOrcUtils.createOrcSchema(avroSchema);
+    assertEquals(orcSchema, convertedSchema);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/io/storage/TestHoodieFileReaderFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/io/storage/TestHoodieFileReaderFactory.java
@@ -44,11 +44,16 @@ public class TestHoodieFileReaderFactory {
     HoodieFileReader<IndexedRecord> parquetReader = HoodieFileReaderFactory.getFileReader(hadoopConf, parquetPath);
     assertTrue(parquetReader instanceof HoodieParquetReader);
 
-    // other file format exception.
+    // log file format.
     final Path logPath = new Path("/partition/path/f.b51192a8-574b-4a85-b246-bcfec03ac8bf_100.log.2_1-0-1");
     final Throwable thrown = assertThrows(UnsupportedOperationException.class, () -> {
       HoodieFileReader<IndexedRecord> logWriter = HoodieFileReaderFactory.getFileReader(hadoopConf, logPath);
     }, "should fail since log storage reader is not supported yet.");
     assertTrue(thrown.getMessage().contains("format not supported yet."));
+
+    // Orc file format.
+    final Path orcPath = new Path("/partition/path/f1_1-0-1_000.orc");
+    HoodieFileReader<IndexedRecord> orcReader = HoodieFileReaderFactory.getFileReader(hadoopConf, orcPath);
+    assertTrue(orcReader instanceof HoodieOrcReader);
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -18,6 +18,9 @@
 
 package org.apache.hudi.hadoop.utils;
 
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -123,6 +126,8 @@ public class HoodieInputFormatUtils {
         } else {
           return HoodieHFileInputFormat.class.getName();
         }
+      case ORC:
+        return OrcInputFormat.class.getName();
       default:
         throw new HoodieIOException("Hoodie InputFormat not implemented for base file format " + baseFileFormat);
     }
@@ -134,6 +139,8 @@ public class HoodieInputFormatUtils {
         return MapredParquetOutputFormat.class.getName();
       case HFILE:
         return MapredParquetOutputFormat.class.getName();
+      case ORC:
+        return OrcOutputFormat.class.getName();
       default:
         throw new HoodieIOException("No OutputFormat for base file format " + baseFileFormat);
     }
@@ -145,6 +152,8 @@ public class HoodieInputFormatUtils {
         return ParquetHiveSerDe.class.getName();
       case HFILE:
         return ParquetHiveSerDe.class.getName();
+      case ORC:
+        return OrcSerde.class.getName();
       default:
         throw new HoodieIOException("No SerDe for base file format " + baseFileFormat);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,8 @@
     <hive.version>2.3.1</hive.version>
     <hive.exec.classifier>core</hive.exec.classifier>
     <metrics.version>4.1.1</metrics.version>
+    <orc.version>1.6.0</orc.version>
+    <airlift.version>0.16</airlift.version>
     <prometheus.version>0.8.0</prometheus.version>
     <http.version>4.4.1</http.version>
     <spark.version>${spark2.version}</spark.version>


### PR DESCRIPTION
## What is the purpose of the pull request

This pull request supports ORC storage in hudi.

## Brief change log

In two separate commits:
- Implemented HoodieOrcWriter
  - Added HoodieOrcConfigs
  - Added AvroOrcUtils that writes Avro record **to** VectorizedRowBatch
  - Used orc-core:no-hive module (`no-hive` is needed because spark-sql uses no-hive version of orc and it would become easier for spark integration)
- Implemented HoodieOrcReader
  - Read Avro records **from** VectorizedRowBatch
  - Implemented OrcReaderIterator
  - Implemented ORC utility functions 

## Verify this pull request

- Added unit tests for 
  - reader/writer creation
  - AvroOrcUtils
- (local) Wrote a small tool that reads from ORC/Parquet files and writes to ORC/Parquet files, verified that the records in the input/output files are identical using spark.read.orc/spark.read.parquet.
- (local) Changed the HoodieTableConfig.DEFAULT_BASE_FILE_FORMAT  to force the tests to run with ORC as the base format. Some changes need to be made, but I'm leaving it out of this PR to get some initial feedback on the reader/writer implementation first.
  For all tests to pass with ORC as the base file format:
  - Understand schema evolution in ORC (ref TestUpdateSchemaEvolution)
  - Add ORC support for places that have hardcoded ParquetReader or sqlContext.read().parquet() 
  - Add ORC support for bootstrap op
  - Hive engine integration with ORC (implement HoodieOrcInputFormat, and more)
  - Spark engine integration with ORC (implement HoodieInternalRowOrcWriter, and more)
  - Add ORC support for HoodieSnapshotExporter
  - Implement HDFSOrcImporter
  - and possibly more.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.