### PR TITLE
[HUDI-1784]  Added print detailed stack log when hbase connection error

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieDependentSystemUnavailableException.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/exception/HoodieDependentSystemUnavailableException.java
@@ -27,8 +27,8 @@ public class HoodieDependentSystemUnavailableException extends HoodieException {
 
   public static final String HBASE = "HBASE";
 
-  public HoodieDependentSystemUnavailableException(String system, String connectURL) {
-    super(getLogMessage(system, connectURL));
+  public HoodieDependentSystemUnavailableException(String system, String connectURL, Throwable t) {
+    super(getLogMessage(system, connectURL), t);
   }
 
   private static String getLogMessage(String system, String connectURL) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
@@ -151,7 +151,7 @@ public class SparkHoodieHBaseIndex<T extends HoodieRecordPayload> extends SparkH
       return ConnectionFactory.createConnection(hbaseConfig);
     } catch (IOException e) {
       throw new HoodieDependentSystemUnavailableException(HoodieDependentSystemUnavailableException.HBASE,
-          quorum + ":" + port);
+          quorum + ":" + port, e);
     }
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
I tried to upgrade hdfs to version 3.0 and found that hbase reported an error and could not connect, but hbase was normal, and debug found that it was a jar conflict problem. Exception failed to print detailed stack log, resulting in no precise location of the cause of the problem.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.