### PR TITLE
[MINOR] Added metric reporter Prometheus to HoodieBackedTableMetadataWriter

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -186,8 +186,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
               .toJmxHost(writeConfig.getJmxHost());
           break;
         case DATADOG:
-          // TODO:
-          break;
+        case PROMETHEUS:
+        case PROMETHEUS_PUSHGATEWAY:
         case CONSOLE:
         case INMEMORY:
           break;


### PR DESCRIPTION
## What is the purpose of the pull request

Add support for metric reporter type Prometheus inside HoodieBackedTableMetadataWriter

## Brief change log

  - Added case statement for Prometheus metric reporter
  - I removed the existing TODO marker since it had no description and i personally cant see a TODO here. But im also fine to leave it here

## Verify this pull request
- Sadly i cant run the Deltastream with metadata enabled because of the hbase dependency of Hudi and our Hadoop 3.3.0 containing a to new guava version (21 vs 27). I will open an Issue for this. But i think change is trivial

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.