### PR TITLE
[HUDI-1804] Continue to write when Flink write task restart because o…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/MarkerFiles.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/MarkerFiles.java
@@ -189,6 +189,46 @@ public class MarkerFiles implements Serializable {
    * The marker path will be <base-path>/.hoodie/.temp/<instant_ts>/2019/04/25/filename.marker.writeIOType.
    */
   public Path create(String partitionPath, String dataFileName, IOType type) {
+    Path markerPath = getMarkerPath(partitionPath, dataFileName, type);
+    try {
+      LOG.info("Creating Marker Path=" + markerPath);
+      fs.create(markerPath, false).close();
+    } catch (IOException e) {
+      throw new HoodieException("Failed to create marker file " + markerPath, e);
+    }
+    return markerPath;
+  }
+
+  /**
+   * The marker path will be <base-path>/.hoodie/.temp/<instant_ts>/2019/04/25/filename.marker.writeIOType.
+   *
+   * @return true if the marker file creates successfully,
+   * false if it already exists
+   */
+  public boolean createIfNotExists(String partitionPath, String dataFileName, IOType type) {
+    Path markerPath = getMarkerPath(partitionPath, dataFileName, type);
+    try {
+      if (fs.exists(markerPath)) {
+        LOG.warn("Marker Path=" + markerPath + " already exists, cancel creation");
+        return false;
+      }
+      LOG.info("Creating Marker Path=" + markerPath);
+      fs.create(markerPath, false).close();
+    } catch (IOException e) {
+      throw new HoodieException("Failed to create marker file " + markerPath, e);
+    }
+    return true;
+  }
+
+  /**
+   * Returns the marker path. Would create the partition path first if not exists.
+   *
+   * @param partitionPath The partition path
+   * @param dataFileName  The data file name
+   * @param type          The IO type
+   * @return path of the marker file
+   */
+  private Path getMarkerPath(String partitionPath, String dataFileName, IOType type) {
     Path path = FSUtils.getPartitionPath(markerDirPath, partitionPath);
     try {
       if (!fs.exists(path)) {
@@ -198,14 +238,7 @@ public class MarkerFiles implements Serializable {
       throw new HoodieIOException("Failed to make dir " + path, e);
     }
     String markerFileName = String.format("%s%s.%s", dataFileName, HoodieTableMetaClient.MARKER_EXTN, type.name());
-    Path markerPath = new Path(path, markerFileName);
-    try {
-      LOG.info("Creating Marker Path=" + markerPath);
-      fs.create(markerPath, false).close();
-    } catch (IOException e) {
-      throw new HoodieException("Failed to create marker file " + markerPath, e);
-    }
-    return markerPath;
+    return new Path(path, markerFileName);
   }
 
 }


### PR DESCRIPTION
…f container killing

The `FlinkMergeHande` creates a marker file under the metadata path
each time it initializes, when a write task restarts from killing, it
tries to create the existing file and reports error.

To solve this problem, skip the creation and use the original data file
as base file to merge.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.