### PR TITLE
[HUDI-1723] Fix path selector listing files with the same mod date

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -45,6 +45,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -224,6 +226,11 @@ public class FileCreateUtils {
 
   public static void createBaseFile(String basePath, String partitionPath, String instantTime, String fileId, long length)
       throws Exception {
+    createBaseFile(basePath, partitionPath, instantTime, fileId, length, Instant.now().toEpochMilli());
+  }
+
+  public static void createBaseFile(String basePath, String partitionPath, String instantTime, String fileId, long length, long lastModificationTimeMilli)
+      throws Exception {
     Path parentPath = Paths.get(basePath, partitionPath);
     Files.createDirectories(parentPath);
     Path baseFilePath = parentPath.resolve(baseFileName(instantTime, fileId));
@@ -231,6 +238,7 @@ public class FileCreateUtils {
       Files.createFile(baseFilePath);
     }
     new RandomAccessFile(baseFilePath.toFile(), "rw").setLength(length);
+    Files.setLastModifiedTime(baseFilePath, FileTime.fromMillis(lastModificationTimeMilli));
   }
 
   public static void createLogFile(String basePath, String partitionPath, String instantTime, String fileId, int version)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DFSPathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DFSPathSelector.java
@@ -121,28 +121,30 @@ public class DFSPathSelector implements Serializable {
       eligibleFiles.sort(Comparator.comparingLong(FileStatus::getModificationTime));
       // Filter based on checkpoint & input size, if needed
       long currentBytes = 0;
-      long maxModificationTime = Long.MIN_VALUE;
+      long newCheckpointTime = lastCheckpointTime;
       List<FileStatus> filteredFiles = new ArrayList<>();
       for (FileStatus f : eligibleFiles) {
-        if (currentBytes + f.getLen() >= sourceLimit) {
+        if (currentBytes + f.getLen() >= sourceLimit && f.getModificationTime() > newCheckpointTime) {
           // we have enough data, we are done
+          // Also, we've read up to a file with a newer modification time
+          // so that some files with the same modification time won't be skipped in next read
           break;
         }
 
-        maxModificationTime = f.getModificationTime();
+        newCheckpointTime = f.getModificationTime();
         currentBytes += f.getLen();
         filteredFiles.add(f);
       }
 
       // no data to read
       if (filteredFiles.isEmpty()) {
-        return new ImmutablePair<>(Option.empty(), lastCheckpointStr.orElseGet(() -> String.valueOf(Long.MIN_VALUE)));
+        return new ImmutablePair<>(Option.empty(), String.valueOf(newCheckpointTime));
       }
 
       // read the files out.
       String pathStr = filteredFiles.stream().map(f -> f.getPath().toString()).collect(Collectors.joining(","));
 
-      return new ImmutablePair<>(Option.ofNullable(pathStr), String.valueOf(maxModificationTime));
+      return new ImmutablePair<>(Option.ofNullable(pathStr), String.valueOf(newCheckpointTime));
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to read from source from checkpoint: " + lastCheckpointStr, ioe);
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelector.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.testutils.FileCreateUtils.createBaseFile;
+import static org.apache.hudi.utilities.sources.helpers.DFSPathSelector.Config.ROOT_INPUT_PATH_PROP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestDFSPathSelector {
+
+  DFSPathSelector selector;
+  FileSystem fs;
+  String basePath;
+  Path inputPath;
+
+  @BeforeEach
+  void setUp(@TempDir java.nio.file.Path tempDir) throws IOException {
+    basePath = tempDir.toString();
+    Configuration conf = HoodieTestUtils.getDefaultHadoopConf();
+    TypedProperties props = new TypedProperties();
+    props.setProperty(ROOT_INPUT_PATH_PROP, basePath);
+    selector = new DFSPathSelector(props, conf);
+    fs = FileSystem.get(conf);
+    inputPath = new Path(basePath);
+  }
+
+  @Test
+  public void listEligibleFilesShouldIgnoreCertainPrefixes() throws Exception {
+    createBaseFile(basePath, "p1", "000", "foo1", 1);
+    createBaseFile(basePath, "p1", "000", ".foo2", 1);
+    createBaseFile(basePath, "p1", "000", "_foo3", 1);
+
+    List<FileStatus> eligibleFiles = selector.listEligibleFiles(fs, inputPath, 0);
+    assertEquals(1, eligibleFiles.size());
+    assertTrue(eligibleFiles.get(0).getPath().getName().startsWith("foo1"));
+  }
+
+  @Test
+  public void listEligibleFilesShouldIgnore0LengthFiles() throws Exception {
+    createBaseFile(basePath, "p1", "000", "foo1", 1);
+    createBaseFile(basePath, "p1", "000", "foo2", 0);
+    createBaseFile(basePath, "p1", "000", "foo3", 0);
+
+    List<FileStatus> eligibleFiles = selector.listEligibleFiles(fs, inputPath, 0);
+    assertEquals(1, eligibleFiles.size());
+    assertTrue(eligibleFiles.get(0).getPath().getName().startsWith("foo1"));
+  }
+
+  @Test
+  public void listEligibleFilesShouldIgnoreFilesEarlierThanCheckpointTime() throws Exception {
+    createBaseFile(basePath, "p1", "000", "foo1", 1);
+    createBaseFile(basePath, "p1", "000", "foo2", 1);
+    createBaseFile(basePath, "p1", "000", "foo3", 1);
+
+    List<FileStatus> eligibleFiles = selector.listEligibleFiles(fs, inputPath, Long.MAX_VALUE);
+    assertEquals(0, eligibleFiles.size());
+  }
+
+  @Test
+  public void getNextFilePathsAndMaxModificationTimeShouldRespectSourceLimit() throws Exception {
+    createBaseFile(basePath, "p1", "000", "foo1", 10, 1000);
+    createBaseFile(basePath, "p1", "000", "foo2", 10, 2000);
+    createBaseFile(basePath, "p1", "000", "foo3", 10, 3000);
+    createBaseFile(basePath, "p1", "000", "foo4", 10, 4000);
+    createBaseFile(basePath, "p1", "000", "foo5", 10, 5000);
+    Pair<Option<String>, String> nextFilePathsAndCheckpoint = selector
+        .getNextFilePathsAndMaxModificationTime(null, Option.empty(), 30);
+    List<String> fileNames = Arrays
+        .stream(nextFilePathsAndCheckpoint.getLeft().get().split(","))
+        .map(p -> Paths.get(p).toFile().getName())
+        .sorted().collect(Collectors.toList());
+    assertEquals(2, fileNames.size());
+    assertTrue(fileNames.get(0).startsWith("foo1"));
+    assertTrue(fileNames.get(1).startsWith("foo2"));
+    String checkpointStr1stRead = nextFilePathsAndCheckpoint.getRight();
+    assertEquals(2000L, Long.parseLong(checkpointStr1stRead), "should read up to foo2 (inclusive)");
+  }
+
+  @Test
+  public void getNextFilePathsAndMaxModificationTimeShouldIgnoreSourceLimitIfSameModTimeFilesPresent() throws Exception {
+    createBaseFile(basePath, "p1", "000", "foo1", 10, 1000);
+    createBaseFile(basePath, "p1", "000", "foo2", 10, 1000);
+    createBaseFile(basePath, "p1", "000", "foo3", 10, 1000);
+    createBaseFile(basePath, "p1", "000", "foo4", 10, 2000);
+    createBaseFile(basePath, "p1", "000", "foo5", 10, 2000);
+    Pair<Option<String>, String> nextFilePathsAndCheckpoint = selector
+        .getNextFilePathsAndMaxModificationTime(null, Option.empty(), 20);
+    List<String> fileNames1stRead = Arrays
+        .stream(nextFilePathsAndCheckpoint.getLeft().get().split(","))
+        .map(p -> Paths.get(p).toFile().getName())
+        .sorted().collect(Collectors.toList());
+    assertEquals(3, fileNames1stRead.size());
+    assertTrue(fileNames1stRead.get(0).startsWith("foo1"));
+    assertTrue(fileNames1stRead.get(1).startsWith("foo2"));
+    assertTrue(fileNames1stRead.get(2).startsWith("foo3"));
+    String checkpointStr1stRead = nextFilePathsAndCheckpoint.getRight();
+    assertEquals(1000L, Long.parseLong(checkpointStr1stRead), "should read up to foo3 (inclusive)");
+
+    nextFilePathsAndCheckpoint = selector
+        .getNextFilePathsAndMaxModificationTime(null, Option.of(checkpointStr1stRead), 20);
+    List<String> fileNames2ndRead = Arrays
+        .stream(nextFilePathsAndCheckpoint.getLeft().get().split(","))
+        .map(p -> Paths.get(p).toFile().getName())
+        .sorted().collect(Collectors.toList());
+    assertEquals(2, fileNames2ndRead.size());
+    assertTrue(fileNames2ndRead.get(0).startsWith("foo4"));
+    assertTrue(fileNames2ndRead.get(1).startsWith("foo5"));
+    String checkpointStr2ndRead = nextFilePathsAndCheckpoint.getRight();
+    assertEquals(2000L, Long.parseLong(checkpointStr2ndRead), "should read up to foo5 (inclusive)");
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
@@ -20,25 +20,17 @@
 package org.apache.hudi.utilities.sources.helpers;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.testutils.HoodieClientTestHarness;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.SparkSession;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -46,45 +38,30 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.FileCreateUtils.createBaseFile;
 import static org.apache.hudi.utilities.sources.helpers.DFSPathSelector.Config.ROOT_INPUT_PATH_PROP;
+import static org.apache.hudi.utilities.sources.helpers.DatePartitionPathSelector.Config.PARTITIONS_LIST_PARALLELISM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestDFSPathSelectorCommonMethods {
+public class TestDFSPathSelectorCommonMethods extends HoodieClientTestHarness {
 
-  static SparkSession spark;
-  Configuration conf;
   TypedProperties props;
-  FileSystem fs;
-  String basePath;
   Path inputPath;
 
-  @BeforeAll
-  static void setUpAll() {
-    spark = SparkSession.builder()
-        .master("local[2]")
-        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-        .getOrCreate();
-  }
-
-  @AfterAll
-  static void tearDownAll() {
-    spark.close();
-  }
-
   @BeforeEach
-  void setUp(@TempDir java.nio.file.Path tempDir) throws IOException {
-    basePath = tempDir.toString();
-    conf = HoodieTestUtils.getDefaultHadoopConf();
+  void setUp() {
+    initSparkContexts();
+    initPath();
+    initFileSystem();
     props = new TypedProperties();
     props.setProperty(ROOT_INPUT_PATH_PROP, basePath);
-    fs = FileSystem.get(conf);
+    props.setProperty(PARTITIONS_LIST_PARALLELISM, "1");
     inputPath = new Path(basePath);
   }
 
   @ParameterizedTest
   @ValueSource(classes = {DFSPathSelector.class, DatePartitionPathSelector.class})
   public void listEligibleFilesShouldIgnoreCertainPrefixes(Class<?> clazz) throws Exception {
-    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, conf);
+    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, hadoopConf);
     createBaseFile(basePath, "p1", "000", "foo1", 1);
     createBaseFile(basePath, "p1", "000", ".foo2", 1);
     createBaseFile(basePath, "p1", "000", "_foo3", 1);
@@ -97,7 +74,7 @@ public class TestDFSPathSelectorCommonMethods {
   @ParameterizedTest
   @ValueSource(classes = {DFSPathSelector.class, DatePartitionPathSelector.class})
   public void listEligibleFilesShouldIgnore0LengthFiles(Class<?> clazz) throws Exception {
-    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, conf);
+    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, hadoopConf);
     createBaseFile(basePath, "p1", "000", "foo1", 1);
     createBaseFile(basePath, "p1", "000", "foo2", 0);
     createBaseFile(basePath, "p1", "000", "foo3", 0);
@@ -110,7 +87,7 @@ public class TestDFSPathSelectorCommonMethods {
   @ParameterizedTest
   @ValueSource(classes = {DFSPathSelector.class, DatePartitionPathSelector.class})
   public void listEligibleFilesShouldIgnoreFilesEarlierThanCheckpointTime(Class<?> clazz) throws Exception {
-    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, conf);
+    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, hadoopConf);
     createBaseFile(basePath, "p1", "000", "foo1", 1);
     createBaseFile(basePath, "p1", "000", "foo2", 1);
     createBaseFile(basePath, "p1", "000", "foo3", 1);
@@ -122,8 +99,7 @@ public class TestDFSPathSelectorCommonMethods {
   @ParameterizedTest
   @ValueSource(classes = {DFSPathSelector.class, DatePartitionPathSelector.class})
   public void getNextFilePathsAndMaxModificationTimeShouldRespectSourceLimit(Class<?> clazz) throws Exception {
-    JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
-    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, conf);
+    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, hadoopConf);
     createBaseFile(basePath, "p1", "000", "foo1", 10, 1000);
     createBaseFile(basePath, "p1", "000", "foo2", 10, 2000);
     createBaseFile(basePath, "p1", "000", "foo3", 10, 3000);
@@ -145,8 +121,7 @@ public class TestDFSPathSelectorCommonMethods {
   @ParameterizedTest
   @ValueSource(classes = {DFSPathSelector.class, DatePartitionPathSelector.class})
   public void getNextFilePathsAndMaxModificationTimeShouldIgnoreSourceLimitIfSameModTimeFilesPresent(Class<?> clazz) throws Exception {
-    JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
-    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, conf);
+    DFSPathSelector selector = (DFSPathSelector) ReflectionUtils.loadClass(clazz.getName(), props, hadoopConf);
     createBaseFile(basePath, "p1", "000", "foo1", 10, 1000);
     createBaseFile(basePath, "p1", "000", "foo2", 10, 1000);
     createBaseFile(basePath, "p1", "000", "foo3", 10, 1000);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestDFSPathSelectorCommonMethods.java
@@ -27,6 +27,7 @@ import org.apache.hudi.testutils.HoodieClientTestHarness;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -56,6 +57,11 @@ public class TestDFSPathSelectorCommonMethods extends HoodieClientTestHarness {
     props.setProperty(ROOT_INPUT_PATH_PROP, basePath);
     props.setProperty(PARTITIONS_LIST_PARALLELISM, "1");
     inputPath = new Path(basePath);
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    cleanupResources();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
DFSPathSelector skips reading source files when they have the same last modification time and when reading up to source limit at the same time. This quick fix is to lift source limit so that all source files can be read.

Detailed description of the bug can be found in JIRA https://issues.apache.org/jira/browse/HUDI-1723.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.