### PR TITLE
[HUDI-1817] when query incr view of hudi table by using spark-sql, the result is duplication

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -239,7 +239,7 @@ public class HoodieInputFormatUtils {
            * those partitions.
            */
           for (Path path : inputPaths) {
-            if (path.toString().contains(s)) {
+            if (path.toString().endsWith(s)) {
               return true;
             }
           }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -239,6 +240,38 @@ public class TestHoodieParquetInputFormat {
     FileStatus[] files = inputFormat.listStatus(jobConf);
     assertEquals(0, files.length,
         "We should exclude commit 100 when returning incremental pull with start commit time as 100");
+  }
+
+  @Test
+  public void testMultiPartitionTableIncremental() throws IOException {
+    // initial commit
+    java.nio.file.Path tablePath = Paths.get(basePath.toString(), "raw_trips");
+
+    // create hudi table and insert data to it
+    // create only one file
+    File partitionDir1 = InputFormatTestUtil
+        .prepareMultiPartitionTable(basePath, baseFileFormat, 1, "100", "1");
+    createCommitFile(basePath, "100", "2016/05/1");
+
+    // insert new data to partition "2016/05/11"
+    // create only one file
+    File partitionDir2 = InputFormatTestUtil
+        .prepareMultiPartitionTable(basePath, baseFileFormat, 1, "100", "11");
+    createCommitFile(basePath, "101", "2016/05/11");
+
+
+    // now partitionDir2.getPath().contain(partitionDir1.getPath()), and hudi-1817 will occur
+    assertEquals(true, partitionDir2.getPath().contains(partitionDir1.getPath()));
+
+    // set partitionDir2 to be the inputPaths of current inputFormat
+    FileInputFormat.setInputPaths(jobConf, partitionDir2.getPath());
+
+    // set incremental startCommit=0 and numberOfCommitsToPull=3  to pull all the data from hudi table
+    InputFormatTestUtil.setupIncremental(jobConf, "0", 3);
+
+    FileStatus[] files = inputFormat.listStatus(jobConf);
+    assertEquals(1, files.length,
+        "We should get one file from partition: " + partitionDir2.getPath());
   }
 
   @Test

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/testutils/InputFormatTestUtil.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/testutils/InputFormatTestUtil.java
@@ -72,6 +72,17 @@ public class InputFormatTestUtil {
         commitNumber);
   }
 
+  public static File prepareMultiPartitionTable(java.nio.file.Path basePath, HoodieFileFormat baseFileFormat, int numberOfFiles,
+                                  String commitNumber, String finalLevelPartitionName)
+      throws IOException {
+    HoodieTestUtils.init(HoodieTestUtils.getDefaultHadoopConf(), basePath.toString(), HoodieTableType.COPY_ON_WRITE,
+        baseFileFormat);
+    java.nio.file.Path partitionPath = basePath.resolve(Paths.get("2016", "05", finalLevelPartitionName));
+    Files.createDirectories(partitionPath);
+    return simulateInserts(partitionPath.toFile(), baseFileFormat.getFileExtension(), "fileId1" + finalLevelPartitionName, numberOfFiles,
+        commitNumber);
+  }
+
   public static File simulateInserts(File partitionPath, String baseFileExtension, String fileId, int numberOfFiles,
                                      String commitNumber)
       throws IOException {


### PR DESCRIPTION
…e result is wrong

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

fix the bug of HoodieInputFormatUtils.getAffectedPartitions
HoodieInputFormatUtils.getAffectedPartitions use String.contains method to filter the affected partition,  
this logical  can't distinguish  those partitions which have same prefix correctly：
for example：  partition1  fullPath is  “/tmp/tableName/p=1”
                         partition2 fullPath is "/tmp/tableName/p=11"
                         partition3 fullPath is "/tmp/tableName/p=111

assume that  we have a cow hudi table which has three partitions:  
partition1  fullPath is  “/tmp/tableName/p=1”   and this partition has only one file :  file1
partition2 fullPath is "/tmp/tableName/p=11"  and this partition has only one file :  file2
partition3 fullPath is "/tmp/tableName/p=111"  and this partition has only one file :  file3

now we want to query the incr view of this hudi table by sparksql （the incr view involve partition1，partition2，partition3）
sparksql will create  hadoopRdds for each partition and union those rdds,
since hudi table has three partitions,  spark will create three hadoopRdd( rdd1, rdd2, rdd3)
rdd1:  holds the inputpath of  “/tmp/tableName/p=1”
rdd2:  holds the inputpath of  “/tmp/tableName/p=11”
rdd2:  holds the inputpath of  “/tmp/tableName/p=111”

when spark get the incremental files from rdd1,   hoodie return file1.  The return result is ok
when spark try to get the incremental files from rdd2,   since the bug of HoodieInputFormatUtils.getAffectedPartitions hudi will return file1 and file2.     The return result  is wrong,  file1 should not be returned
when spark try to get the incremental files from rdd3,   since the bug of HoodieInputFormatUtils.getAffectedPartitions  file1 and file2 and file 3 will be returned. This result is wrong,  file1 and file2 should not be returned



test step:

val base_data = spark.read.parquet("/tmp/tb_base")
val upsert_data = spark.read.parquet("/tmp/tb_upsert")

base_data.write.format("hudi").option(TABLE_TYPE_OPT_KEY, MOR_TABLE_TYPE_OPT_VAL).option(PRECOMBINE_FIELD_OPT_KEY, "col2").option(RECORDKEY_FIELD_OPT_KEY, "primary_key").option(PARTITIONPATH_FIELD_OPT_KEY, "col0").option(KEYGENERATOR_CLASS_OPT_KEY, "org.apache.hudi.keygen.SimpleKeyGenerator").option(OPERATION_OPT_KEY, "bulk_insert").option(HIVE_SYNC_ENABLED_OPT_KEY, "true").option(HIVE_PARTITION_FIELDS_OPT_KEY, "col0").option(HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY, "org.apache.hudi.hive.MultiPartKeysValueExtractor").option(HIVE_DATABASE_OPT_KEY, "testdb").option(HIVE_TABLE_OPT_KEY, "tb_test_mor_par").option(HIVE_USE_JDBC_OPT_KEY, "false").option("hoodie.bulkinsert.shuffle.parallelism", 4).option("hoodie.insert.shuffle.parallelism", 4).option("hoodie.upsert.shuffle.parallelism", 4).option("hoodie.delete.shuffle.parallelism", 4).option("hoodie.datasource.write.hive_style_partitioning", "true").option(TABLE_NAME, "tb_test_mor_par").mode(Overwrite).save(s"/tmp/testdb/tb_test_mor_par")

upsert_data.write.format("hudi").option(TABLE_TYPE_OPT_KEY, MOR_TABLE_TYPE_OPT_VAL).option(PRECOMBINE_FIELD_OPT_KEY, "col2").option(RECORDKEY_FIELD_OPT_KEY, "primary_key").option(PARTITIONPATH_FIELD_OPT_KEY, "col0").option(KEYGENERATOR_CLASS_OPT_KEY, "org.apache.hudi.keygen.SimpleKeyGenerator").option(OPERATION_OPT_KEY, "upsert").option(HIVE_SYNC_ENABLED_OPT_KEY, "true").option(HIVE_PARTITION_FIELDS_OPT_KEY, "col0").option(HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY, "org.apache.hudi.hive.MultiPartKeysValueExtractor").option(HIVE_DATABASE_OPT_KEY, "testdb").option(HIVE_TABLE_OPT_KEY, "tb_test_mor_par").option(HIVE_USE_JDBC_OPT_KEY, "false").option("hoodie.bulkinsert.shuffle.parallelism", 4).option("hoodie.insert.shuffle.parallelism", 4).option("hoodie.upsert.shuffle.parallelism", 4).option("hoodie.delete.shuffle.parallelism", 4).option("hoodie.datasource.write.hive_style_partitioning", "true").option(TABLE_NAME, "tb_test_mor_par").mode(Append).save(s"/tmp/testdb/tb_test_mor_par")

query incr view by sparksql:

set hoodie.tb_test_mor_par.consume.mode=INCREMENTAL;
set hoodie.tb_test_mor_par.consume.start.timestamp=20210420145330;
set hoodie.tb_test_mor_par.consume.max.commits=3;
select _hoodie_commit_time,primary_key,col0,col1,col2,col3,col4,col5,col6,col7 from testdb.tb_test_mor_par_rt where _hoodie_commit_time > '20210420145330' order by primary_key;


_hoodie_commit_time	primary_key	col0	col1	col6	col7
------------------------------------------------+
20210420155738	20	77	sC	1587887604000000	739
20210420155738	21	66	ps	1609790497000000	61
20210420155738	22	47	1P	1584600429000000	835
20210420155738	23	36	5K	1607634808000000	538
20210420155738	24	1	BA	1606857113000000	775
20210420155738	24	101	BA	1606857113000000	775
20210420155738	24	100	BA	1606857113000000	775
20210420155738	24	102	BA	1606857113000000	775

tb_test_mor_par has 8 partitions:  "1", "101", "100", "102", "77", "66", "47", "36"
primary_key 24 is duplicate three times.  since  "1" is contained by  "101","100", "102"







## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

add new UT, to cover this change

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.