### PR TITLE
[HUDI-1836] Logging consuming instant to StreamReadOperator#processSplits

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
@@ -152,6 +152,8 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
       return;
     }
 
+    LOG.info("Processing input split : {}", split);
+
     format.open(split);
     try {
       RowData nextElement = null;

--- a/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
@@ -152,6 +152,7 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
       return;
     }
 
+    // This log is important to indicate the consuming process, there is only one log message for one data bucket.
     LOG.info("Processing input split : {}", split);
 
     format.open(split);

--- a/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
@@ -95,16 +95,16 @@ public class MergeOnReadInputSplit implements InputSplit {
 
   @Override
   public String toString() {
-    return "MergeOnReadInputSplit{" +
-            "splitNum=" + splitNum +
-            ", basePath=" + basePath +
-            ", logPaths=" + logPaths +
-            ", latestCommit='" + latestCommit + '\'' +
-            ", tablePath='" + tablePath + '\'' +
-            ", maxCompactionMemoryInBytes=" + maxCompactionMemoryInBytes +
-            ", mergeType='" + mergeType + '\'' +
-            ", instantRange=" + instantRange +
-            '}';
+    return "MergeOnReadInputSplit{"
+            + "splitNum=" + splitNum
+            + ", basePath=" + basePath
+            + ", logPaths=" + logPaths
+            + ", latestCommit='" + latestCommit + '\''
+            + ", tablePath='" + tablePath + '\''
+            + ", maxCompactionMemoryInBytes=" + maxCompactionMemoryInBytes
+            + ", mergeType='" + mergeType + '\''
+            + ", instantRange=" + instantRange
+            + '}';
   }
   
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
@@ -92,4 +92,19 @@ public class MergeOnReadInputSplit implements InputSplit {
   public int getSplitNumber() {
     return this.splitNum;
   }
+
+  @Override
+  public String toString() {
+    return "MergeOnReadInputSplit{" +
+            "splitNum=" + splitNum +
+            ", basePath=" + basePath +
+            ", logPaths=" + logPaths +
+            ", latestCommit='" + latestCommit + '\'' +
+            ", tablePath='" + tablePath + '\'' +
+            ", maxCompactionMemoryInBytes=" + maxCompactionMemoryInBytes +
+            ", mergeType='" + mergeType + '\'' +
+            ", instantRange=" + instantRange +
+            '}';
+  }
+  
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Add the instant time log so that we can track the consuming latency and progress.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.