### PR TITLE
[HUDI-1690] use jsc union instead of rdd union

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SparkExecuteClusteringCommitActionExecutor<T extends HoodieRecordPayload<T>>
     extends BaseSparkCommitActionExecutor<T> {
@@ -90,10 +91,12 @@ public class SparkExecuteClusteringCommitActionExecutor<T extends HoodieRecordPa
 
     JavaSparkContext engineContext = HoodieSparkEngineContext.getSparkContext(context);
     // execute clustering for each group async and collect WriteStatus
-    JavaRDD<WriteStatus> writeStatusRDD = clusteringPlan.getInputGroups().stream()
+    Stream<JavaRDD<WriteStatus>> writeStatusRDDStream = clusteringPlan.getInputGroups().stream()
         .map(inputGroup -> runClusteringForGroupAsync(inputGroup, clusteringPlan.getStrategy().getStrategyParams()))
-        .map(CompletableFuture::join)
-        .reduce((rdd1, rdd2) -> rdd1.union(rdd2)).orElse(engineContext.emptyRDD());
+        .map(CompletableFuture::join);
+
+    JavaRDD<WriteStatus>[] writeStatuses = convertStreamToArray(writeStatusRDDStream);
+    JavaRDD<WriteStatus> writeStatusRDD = engineContext.union(writeStatuses);
     
     HoodieWriteMetadata<JavaRDD<WriteStatus>> writeMetadata = buildWriteMetadata(writeStatusRDD);
     JavaRDD<WriteStatus> statuses = updateIndex(writeStatusRDD, writeMetadata);
@@ -107,6 +110,19 @@ public class SparkExecuteClusteringCommitActionExecutor<T extends HoodieRecordPa
       writeMetadata.setCommitMetadata(Option.of(commitMetadata));
     }
     return writeMetadata;
+  }
+
+  /**
+   * Stream to array conversion with generic type is not straightforward.
+   * Implement a utility method to abstract high level logic. This needs to be improved in future
+   */
+  private JavaRDD<WriteStatus>[] convertStreamToArray(Stream<JavaRDD<WriteStatus>> writeStatusRDDStream) {
+    Object[] writeStatusObjects = writeStatusRDDStream.toArray(Object[]::new);
+    JavaRDD<WriteStatus>[] writeStatusRDDArray = new JavaRDD[writeStatusObjects.length];
+    for (int i = 0; i < writeStatusObjects.length; i++) {
+      writeStatusRDDArray[i] = (JavaRDD<WriteStatus>) writeStatusObjects[i];
+    }
+    return writeStatusRDDArray;
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the pull request
RDD Union has limitation on number of tasks that can be in list. Use jsc union instead

## Brief change log
RDD Union has limitation on number of tasks that can be in list. Use jsc union instead to avoid stack overflow at scale

## Verify this pull request
This pull request is already covered by existing clustering tests. Improvement is expected at large scale

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.