### PR TITLE
[HUDI-1841] Tweak the min max commits to keep when setting up cleanin…

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -352,6 +352,18 @@ public class FlinkOptions {
       .withDescription("Number of commits to retain. So data will be retained for num_of_commits * time_between_commits (scheduled).\n"
           + "This also directly translates into how much you can incrementally pull on this table, default 10");
 
+  public static final ConfigOption<Integer> ARCHIVE_MAX_COMMITS = ConfigOptions
+      .key("archive.max_commits")
+      .intType()
+      .defaultValue(30)// default max 30 commits
+      .withDescription("Max number of commits to keep before archiving older commits into a sequential log, default 30");
+
+  public static final ConfigOption<Integer> ARCHIVE_MIN_COMMITS = ConfigOptions
+      .key("archive.min_commits")
+      .intType()
+      .defaultValue(20)// default min 20 commits
+      .withDescription("Min number of commits to keep before archiving older commits into a sequential log, default 20");
+
   // ------------------------------------------------------------------------
   //  Hive Sync Options
   // ------------------------------------------------------------------------

--- a/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -203,6 +203,7 @@ public class StreamerUtil {
                     // override and hardcode to 20,
                     // actually Flink cleaning is always with parallelism 1 now
                     .withCleanerParallelism(20)
+                    .archiveCommitsWith(conf.getInteger(FlinkOptions.ARCHIVE_MIN_COMMITS), conf.getInteger(FlinkOptions.ARCHIVE_MAX_COMMITS))
                     .build())
             .withMemoryConfig(
                 HoodieMemoryConfig.newBuilder()


### PR DESCRIPTION
…g retain commits for Flink

If the retain commits is greater that min commits to keep, reset the
options:

1. min commits to keep: retain commits + 10
2. max commits to keep: retain commits + 20

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.