### PR TITLE
[HUDI-1620] Fix Metrics UTs and remove maven profile for azure tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: -Pazp-unit-tests -pl hudi-client/hudi-spark-client
+              options: -Punit-tests -pl hudi-client/hudi-spark-client
               publishJUnitResults: false
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               testRunTitle: 'unit tests spark client'
@@ -89,7 +89,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: -Pazp-unit-tests -pl hudi-utilities
+              options: -Punit-tests -pl hudi-utilities
               publishJUnitResults: false
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               testRunTitle: 'unit tests utilities'
@@ -121,7 +121,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: -Pazp-unit-tests -pl !hudi-utilities,!hudi-client/hudi-spark-client
+              options: -Punit-tests -pl !hudi-utilities,!hudi-client/hudi-spark-client
               publishJUnitResults: false
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               testRunTitle: 'unit tests other modules'

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieConsoleMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieConsoleMetrics.java
@@ -22,15 +22,19 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.apache.hudi.metrics.Metrics.registerGauge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class TestHoodieConsoleMetrics {
 
-  HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+  @Mock
+  HoodieWriteConfig config;
 
   @BeforeEach
   public void start() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieJmxMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieJmxMetrics.java
@@ -21,23 +21,34 @@ package org.apache.hudi.metrics;
 import org.apache.hudi.common.testutils.NetworkTestUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.apache.hudi.metrics.Metrics.registerGauge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * Test for the Jmx metrics report.
  */
+@ExtendWith(MockitoExtension.class)
 public class TestHoodieJmxMetrics {
 
-  HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+  @Mock
+  HoodieWriteConfig config;
+
+  @AfterEach
+  void shutdownMetrics() {
+    Metrics.shutdown();
+  }
 
   @Test
   public void testRegisterGauge() {
     when(config.isMetricsOn()).thenReturn(true);
+    when(config.getTableName()).thenReturn("foo");
     when(config.getMetricsReporterType()).thenReturn(MetricsReporterType.JMX);
     when(config.getJmxHost()).thenReturn("localhost");
     when(config.getJmxPort()).thenReturn(String.valueOf(NetworkTestUtils.nextFreePort()));
@@ -50,6 +61,7 @@ public class TestHoodieJmxMetrics {
   @Test
   public void testRegisterGaugeByRangerPort() {
     when(config.isMetricsOn()).thenReturn(true);
+    when(config.getTableName()).thenReturn("foo");
     when(config.getMetricsReporterType()).thenReturn(MetricsReporterType.JMX);
     when(config.getJmxHost()).thenReturn("localhost");
     when(config.getJmxPort()).thenReturn(String.valueOf(NetworkTestUtils.nextFreePort()));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
@@ -24,8 +24,12 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 import com.codahale.metrics.Timer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Random;
 import java.util.stream.Stream;
@@ -36,16 +40,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class TestHoodieMetrics {
 
-  private HoodieMetrics metrics;
+  @Mock
+  HoodieWriteConfig config;
+  HoodieMetrics metrics;
 
   @BeforeEach
-  public void start() {
-    HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+  void setUp() {
     when(config.isMetricsOn()).thenReturn(true);
     when(config.getMetricsReporterType()).thenReturn(MetricsReporterType.INMEMORY);
     metrics = new HoodieMetrics(config, "raw_table");
+  }
+
+  @AfterEach
+  void shutdownMetrics() {
+    Metrics.shutdown();
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/datadog/TestDatadogMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/datadog/TestDatadogMetricsReporter.java
@@ -19,9 +19,11 @@
 package org.apache.hudi.metrics.datadog;
 
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.metrics.datadog.DatadogHttpClient.ApiSite;
 
 import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -42,6 +44,11 @@ public class TestDatadogMetricsReporter {
 
   @Mock
   MetricRegistry registry;
+
+  @AfterEach
+  void shutdownMetrics() {
+    Metrics.shutdown();
+  }
 
   @Test
   public void instantiationShouldFailWhenNoApiKey() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/prometheus/TestPrometheusReporter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/prometheus/TestPrometheusReporter.java
@@ -20,16 +20,28 @@ package org.apache.hudi.metrics.prometheus;
 
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metrics.HoodieMetrics;
+import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.metrics.MetricsReporterType;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class TestPrometheusReporter {
 
-  HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+  @Mock
+  HoodieWriteConfig config;
+
+  @AfterEach
+  void shutdownMetrics() {
+    Metrics.shutdown();
+  }
 
   @Test
   public void testRegisterGauge() {

--- a/pom.xml
+++ b/pom.xml
@@ -1274,40 +1274,6 @@
       </build>
     </profile>
     <profile>
-      <id>azp-unit-tests</id>
-      <properties>
-        <skipUTs>false</skipUTs>
-        <skipFTs>true</skipFTs>
-        <skipITs>true</skipITs>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <dependencies>
-              <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit.jupiter.version}</version>
-              </dependency>
-            </dependencies>
-            <configuration combine.self="append">
-              <skip>${skipUTs}</skip>
-              <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
-              <excludedGroups>functional</excludedGroups>
-              <excludes>
-                <exclude>**/*FunctionalTestSuite.java</exclude>
-                <exclude>**/IT*.java</exclude>
-                <exclude>**/testsuite/**/Test*.java</exclude>
-                <exclude>**/TestPushGateWayReporter.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>javadocs</id>
       <build>
         <plugins>


### PR DESCRIPTION
- Make sure shutdown Metrics between unit test cases to ensure isolation
- Add more required mocks for TestPushGateWayReporter 
- Remove azp-unit-tests maven profile to include TestPushGateWayReporter in azure tests



## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.