### PR TITLE
[HUDI-1790] Added SqlSource to fetch data from any partitions for backfill use case

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SqlSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SqlSource.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.DataSourceUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import java.util.Collections;
+
+/**
+ * SQL Source that reads from any table, used mainly for backfill jobs which will process specific partition dates.
+ */
+public class SqlSource extends RowSource {
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LogManager.getLogger(SqlSource.class);
+  private final String sourceSql;
+  private final SparkSession spark;
+
+  public SqlSource(
+      TypedProperties props,
+      JavaSparkContext sparkContext,
+      SparkSession sparkSession,
+      SchemaProvider schemaProvider) {
+    super(props, sparkContext, sparkSession, schemaProvider);
+    DataSourceUtils.checkRequiredProperties(
+        props, Collections.singletonList(SqlSource.Config.SOURCE_SQL));
+    sourceSql = props.getString(SqlSource.Config.SOURCE_SQL);
+    spark = sparkSession;
+  }
+
+  @Override
+  protected Pair<Option<Dataset<Row>>, String> fetchNextBatch(
+      Option<String> lastCkptStr, long sourceLimit) {
+    LOG.warn(sourceSql);
+    Dataset<Row> source = spark.sql(sourceSql);
+    LOG.warn(source.showString(10, 0, true));
+    // Remove Hoodie meta columns except partition path from input source.
+    Dataset<Row> src =
+        source.drop(
+            HoodieRecord.HOODIE_META_COLUMNS.stream()
+                .filter(x -> !x.equals(HoodieRecord.PARTITION_PATH_METADATA_FIELD))
+                .toArray(String[]::new));
+    return Pair.of(Option.of(src), null);
+  }
+
+  /**
+   * Configs supported.
+   */
+  private static class Config {
+
+    private static final String SOURCE_SQL = "hoodie.deltastreamer.source.sql";
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlSource.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.testutils.sources;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.deltastreamer.SourceFormatAdapter;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+import org.apache.hudi.utilities.sources.InputBatch;
+import org.apache.hudi.utilities.sources.SqlSource;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test against {@link SqlSource}.
+ */
+public class TestSqlSource extends UtilitiesTestBase {
+
+  private final boolean useFlattenedSchema = false;
+  protected FilebasedSchemaProvider schemaProvider;
+  protected HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+  private String dfsRoot;
+  private String fileSuffix;
+
+  @BeforeAll
+  public static void initClass() throws Exception {
+    UtilitiesTestBase.initClass();
+  }
+
+  @AfterAll
+  public static void cleanupClass() {
+    UtilitiesTestBase.cleanupClass();
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    dfsRoot = dfsBasePath + "/parquetFiles";
+    super.setup();
+    schemaProvider = new FilebasedSchemaProvider(Helpers.setupSchemaOnDFS(), jsc);
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    super.teardown();
+  }
+
+  /**
+   * Generates a batch of test data and writes the data to a file and register a test table.
+   *
+   * @param filename    The name of the file.
+   * @param instantTime The commit time.
+   * @param n           The number of records to generate.
+   */
+  private void generateTestTable(String filename, String instantTime, int n) throws IOException {
+    Path path = new Path(dfsRoot, filename + fileSuffix);
+    Helpers.saveParquetToDFS(Helpers.toGenericRecords(dataGenerator.generateInserts(instantTime, n, useFlattenedSchema)), path);
+    sparkSession.read().parquet(dfsRoot).createOrReplaceTempView("test_sql_table");
+  }
+
+  /**
+   * Runs the test scenario of reading data from the source.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testSqlSource() throws IOException {
+    UtilitiesTestBase.dfs.mkdirs(new Path(dfsRoot));
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.deltastreamer.source.sql", "select * from test_sql_table");
+    SqlSource sqlSource = new SqlSource(props, jsc, sparkSession, schemaProvider);
+    SourceFormatAdapter sourceFormatAdapter = new SourceFormatAdapter(sqlSource);
+
+    // Produce new data, extract new data
+    generateTestTable("1", "001", 10000);
+
+    // Test fetching Avro format
+    InputBatch<JavaRDD<GenericRecord>> fetch1 =
+        sourceFormatAdapter.fetchNewDataInAvroFormat(Option.empty(), Long.MAX_VALUE);
+
+    // Test Avro to Row format
+    Dataset<Row> fetch1Rows = AvroConversionUtils
+        .createDataFrame(JavaRDD.toRDD(fetch1.getBatch().get()),
+            schemaProvider.getSourceSchema().toString(), sparkSession);
+    assertEquals(10000, fetch1Rows.count());
+
+    // Test fetching Row format
+    InputBatch<Dataset<Row>> fetch1AsRows =
+        sourceFormatAdapter.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE);
+    assertEquals(10000, fetch1AsRows.getBatch().get().count());
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlSource.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TestSqlSource extends UtilitiesTestBase {
 
   private final boolean useFlattenedSchema = false;
+  private final String sqlSourceConfig = "hoodie.deltastreamer.source.sql.sql.query";
   protected FilebasedSchemaProvider schemaProvider;
   protected HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
   private String dfsRoot;
@@ -103,7 +104,7 @@ public class TestSqlSource extends UtilitiesTestBase {
    */
   @Test
   public void testSqlSourceAvroFormat() throws IOException {
-    props.setProperty("hoodie.deltastreamer.source.sql.sql.query", "select * from test_sql_table");
+    props.setProperty(sqlSourceConfig, "select * from test_sql_table");
     sqlSource = new SqlSource(props, jsc, sparkSession, schemaProvider);
     sourceFormatAdapter = new SourceFormatAdapter(sqlSource);
 
@@ -126,7 +127,7 @@ public class TestSqlSource extends UtilitiesTestBase {
    */
   @Test
   public void testSqlSourceRowFormat() throws IOException {
-    props.setProperty("hoodie.deltastreamer.source.sql.sql.query", "select * from test_sql_table");
+    props.setProperty(sqlSourceConfig, "select * from test_sql_table");
     sqlSource = new SqlSource(props, jsc, sparkSession, schemaProvider);
     sourceFormatAdapter = new SourceFormatAdapter(sqlSource);
 
@@ -144,7 +145,7 @@ public class TestSqlSource extends UtilitiesTestBase {
    */
   @Test
   public void testSqlSourceMoreRecordsThanSourceLimit() throws IOException {
-    props.setProperty("hoodie.deltastreamer.source.sql.sql.query", "select * from test_sql_table");
+    props.setProperty(sqlSourceConfig, "select * from test_sql_table");
     sqlSource = new SqlSource(props, jsc, sparkSession, schemaProvider);
     sourceFormatAdapter = new SourceFormatAdapter(sqlSource);
 
@@ -161,7 +162,7 @@ public class TestSqlSource extends UtilitiesTestBase {
    */
   @Test
   public void testSqlSourceZeroRecord() throws IOException {
-    props.setProperty("hoodie.deltastreamer.source.sql.sql.query", "select * from test_sql_table where 1=0");
+    props.setProperty(sqlSourceConfig, "select * from test_sql_table where 1=0");
     sqlSource = new SqlSource(props, jsc, sparkSession, schemaProvider);
     sourceFormatAdapter = new SourceFormatAdapter(sqlSource);
 
@@ -178,7 +179,7 @@ public class TestSqlSource extends UtilitiesTestBase {
    */
   @Test
   public void testSqlSourceInvalidTable() throws IOException {
-    props.setProperty("hoodie.deltastreamer.source.sql.sql.query", "select * from not_exist_sql_table");
+    props.setProperty(sqlSourceConfig, "select * from not_exist_sql_table");
     sqlSource = new SqlSource(props, jsc, sparkSession, schemaProvider);
     sourceFormatAdapter = new SourceFormatAdapter(sqlSource);
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*This pull request adds a new source to delta streamer, to perform snapshot queries mainly used for backfilling historical partitions.*

## Brief change log

  - *Added a new SqlSource to delta streamer to handle backfills for any specific date range snapshot queries.*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Added TestSqlSource to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.