### PR TITLE
[HUDI-1781] Fix Flink streaming reader throws ClassCastException

### DIFF
--- a/hudi-flink/src/test/java/org/apache/hudi/table/HoodieDataSourceITCase.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/table/HoodieDataSourceITCase.java
@@ -408,8 +408,8 @@ public class HoodieDataSourceITCase extends AbstractTestBase {
     streamTableEnv.executeSql(createHoodieTable);
 
     // execute query and assert throws exception
-    assertThrows(HoodieException.class, () -> execSelectSql(streamTableEnv, "select * from t1", 10)
-                , "No successful commits under path " + tempFile.getAbsolutePath());
+    assertThrows(HoodieException.class, () -> execSelectSql(streamTableEnv, "select * from t1", 10),
+            "No successful commits under path " + tempFile.getAbsolutePath());
 
   }
 

--- a/hudi-flink/src/test/java/org/apache/hudi/table/HoodieDataSourceITCase.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/table/HoodieDataSourceITCase.java
@@ -408,7 +408,8 @@ public class HoodieDataSourceITCase extends AbstractTestBase {
     streamTableEnv.executeSql(createHoodieTable);
 
     // execute query and assert throws exception
-    assertThrows(HoodieException.class, () -> execSelectSql(streamTableEnv, "select * from t1", 10), "No successful commits under path " + tempFile.getAbsolutePath());
+    assertThrows(HoodieException.class, () -> execSelectSql(streamTableEnv, "select * from t1", 10)
+                , "No successful commits under path " + tempFile.getAbsolutePath());
 
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Fix Flink streaming reader throws ClassCastException when reading from empty table path*

## Brief change log

  - *Change force cast to if clause*

## Verify this pull request

This pull request is already covered by existing tests*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.