### PR TITLE
[MINOR] Fixing spark_avro version in quick start for scala 2.11

### DIFF
--- a/docs/_docs/1_1_spark_quick_start_guide.cn.md
+++ b/docs/_docs/1_1_spark_quick_start_guide.cn.md
@@ -24,7 +24,7 @@ spark-shell \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
 // spark-shell for spark 2 with scala 2.11
 spark-shell \
-  --packages org.apache.hudi:hudi-spark-bundle_2.11:0.8.0,org.apache.spark:spark-avro_2.11:3.0.1 \
+  --packages org.apache.hudi:hudi-spark-bundle_2.11:0.8.0,org.apache.spark:spark-avro_2.11:2.4.4 \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
 ```
 

--- a/docs/_docs/1_1_spark_quick_start_guide.md
+++ b/docs/_docs/1_1_spark_quick_start_guide.md
@@ -27,7 +27,7 @@ spark-shell \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
 // spark-shell for spark 2 with scala 2.11
 spark-shell \
-  --packages org.apache.hudi:hudi-spark-bundle_2.11:0.8.0,org.apache.spark:spark-avro_2.11:3.0.1 \
+  --packages org.apache.hudi:hudi-spark-bundle_2.11:0.8.0,org.apache.spark:spark-avro_2.11:2.4.4 \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
 ```
 


### PR DESCRIPTION
## What is the purpose of the pull request

*Fixing spark_avro version in quick start for scala 11

## Brief change log

  - Fixing spark_avro version in quick start for scala 11

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.