### PR TITLE
[HUDI-1902] Global index for flink writer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -37,7 +37,7 @@ public abstract class BaseAvroPayload implements Serializable {
   /**
    * For purposes of preCombining.
    */
-  protected final Comparable orderingVal;
+  public final Comparable orderingVal;
 
   /**
    * Instantiate {@link BaseAvroPayload}.

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import java.util.Objects;
+
+/**
+ * Similar with {@link org.apache.hudi.common.model.HoodieRecordLocation} but with partition path.
+ */
+public class HoodieRecordGlobalLocation extends HoodieRecordLocation {
+  private static final long serialVersionUID = 1L;
+
+  private String partitionPath;
+
+  public HoodieRecordGlobalLocation() {
+  }
+
+  public HoodieRecordGlobalLocation(String partitionPath, String instantTime, String fileId) {
+    super(instantTime, fileId);
+    this.partitionPath = partitionPath;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("HoodieGlobalRecordLocation {");
+    sb.append("partitionPath=").append(partitionPath).append(", ");
+    sb.append("instantTime=").append(instantTime).append(", ");
+    sb.append("fileId=").append(fileId);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodieRecordGlobalLocation otherLoc = (HoodieRecordGlobalLocation) o;
+    return Objects.equals(partitionPath, otherLoc.partitionPath)
+        && Objects.equals(instantTime, otherLoc.instantTime)
+        && Objects.equals(fileId, otherLoc.fileId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionPath, instantTime, fileId);
+  }
+
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public void setPartitionPath(String partitionPath) {
+    this.partitionPath = partitionPath;
+  }
+
+  /**
+   * Returns the global record location from local.
+   */
+  public static HoodieRecordGlobalLocation fromLocal(String partitionPath, HoodieRecordLocation localLoc) {
+    return new HoodieRecordGlobalLocation(partitionPath, localLoc.getInstantTime(), localLoc.getFileId());
+  }
+
+  /**
+   * Returns the record location as local.
+   */
+  public HoodieRecordLocation toLocal(String instantTime) {
+    return new HoodieRecordLocation(instantTime, fileId);
+  }
+
+  /**
+   * Copy the location with given partition path.
+   */
+  public HoodieRecordGlobalLocation copy(String partitionPath) {
+    return new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId);
+  }
+}
+

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
@@ -26,8 +26,8 @@ import java.util.Objects;
  */
 public class HoodieRecordLocation implements Serializable {
 
-  private String instantTime;
-  private String fileId;
+  protected String instantTime;
+  protected String fileId;
 
   public HoodieRecordLocation() {
   }

--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -86,6 +86,13 @@ public class FlinkOptions {
       .defaultValue(1.5D)
       .withDescription("Index state ttl in days, default 1.5 day");
 
+  public static final ConfigOption<Boolean> INDEX_GLOBAL_ENABLED = ConfigOptions
+      .key("index.global.enabled")
+      .booleanType()
+      .defaultValue(true)
+      .withDescription("Whether to update index for the old partition path\n"
+          + "if same key record with different partition path came in, default true");
+
   // ------------------------------------------------------------------------
   //  Read Options
   // ------------------------------------------------------------------------

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/utils/PayloadCreation.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/utils/PayloadCreation.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.model.BaseAvroPayload;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.configuration.Configuration;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+
+/**
+ * Util to create hoodie pay load instance.
+ */
+public class PayloadCreation implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final boolean shouldCombine;
+  private final Constructor<?> constructor;
+  private final String preCombineField;
+
+  private PayloadCreation(
+      boolean shouldCombine,
+      Constructor<?> constructor,
+      @Nullable String preCombineField) {
+    this.shouldCombine = shouldCombine;
+    this.constructor = constructor;
+    this.preCombineField = preCombineField;
+  }
+
+  public static PayloadCreation instance(Configuration conf) throws Exception {
+    boolean shouldCombine = conf.getBoolean(FlinkOptions.INSERT_DROP_DUPS)
+        || WriteOperationType.fromValue(conf.getString(FlinkOptions.OPERATION)) == WriteOperationType.UPSERT;
+    String preCombineField = null;
+    final Class<?>[] argTypes;
+    final Constructor<?> constructor;
+    if (shouldCombine) {
+      preCombineField = conf.getString(FlinkOptions.PRECOMBINE_FIELD);
+      argTypes = new Class<?>[] {GenericRecord.class, Comparable.class};
+    } else {
+      argTypes = new Class<?>[] {Option.class};
+    }
+    final String clazz = conf.getString(FlinkOptions.PAYLOAD_CLASS);
+    constructor = ReflectionUtils.getClass(clazz).getConstructor(argTypes);
+    return new PayloadCreation(shouldCombine, constructor, preCombineField);
+  }
+
+  public HoodieRecordPayload<?> createPayload(GenericRecord record, boolean isDelete) throws Exception {
+    if (shouldCombine) {
+      ValidationUtils.checkState(preCombineField != null);
+      Comparable<?> orderingVal = (Comparable<?>) HoodieAvroUtils.getNestedFieldVal(record,
+          preCombineField, false);
+      return (HoodieRecordPayload<?>) constructor.newInstance(
+          isDelete ? null : record, orderingVal);
+    } else {
+      return (HoodieRecordPayload<?>) this.constructor.newInstance(Option.of(record));
+    }
+  }
+
+  public HoodieRecordPayload<?> createDeletePayload(BaseAvroPayload payload) throws Exception {
+    if (shouldCombine) {
+      return (HoodieRecordPayload<?>) constructor.newInstance(null, payload.orderingVal);
+    } else {
+      return (HoodieRecordPayload<?>) this.constructor.newInstance(Option.empty());
+    }
+  }
+}

--- a/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -256,8 +256,20 @@ public class TestData {
    * @param expected Expected string of the sorted rows
    */
   public static void assertRowsEquals(List<Row> rows, String expected) {
+    assertRowsEquals(rows, expected, 0);
+  }
+
+  /**
+   * Sort the {@code rows} using field at index {@code orderingPos} and asserts
+   * it equals with the expected string {@code expected}.
+   *
+   * @param rows     Actual result rows
+   * @param expected Expected string of the sorted rows
+   * @param orderingPos Field position for ordering
+   */
+  public static void assertRowsEquals(List<Row> rows, String expected, int orderingPos) {
     String rowsString = rows.stream()
-        .sorted(Comparator.comparing(o -> toStringSafely(o.getField(0))))
+        .sorted(Comparator.comparing(o -> toStringSafely(o.getField(orderingPos))))
         .collect(Collectors.toList()).toString();
     assertThat(rowsString, is(expected));
   }

--- a/hudi-flink/src/test/resources/test_source_4.data
+++ b/hudi-flink/src/test/resources/test_source_4.data
@@ -1,0 +1,8 @@
+{"uuid": "id1", "name": "Danny", "age": 24, "ts": "1970-01-01T00:00:01", "partition": "par1"}
+{"uuid": "id1", "name": "Stephen", "age": 34, "ts": "1970-01-01T00:00:02", "partition": "par1"}
+{"uuid": "id1", "name": "Julian", "age": 54, "ts": "1970-01-01T00:00:03", "partition": "par2"}
+{"uuid": "id1", "name": "Fabian", "age": 32, "ts": "1970-01-01T00:00:04", "partition": "par2"}
+{"uuid": "id1", "name": "Sophia", "age": 18, "ts": "1970-01-01T00:00:05", "partition": "par3"}
+{"uuid": "id1", "name": "Jane", "age": 19, "ts": "1970-01-01T00:00:06", "partition": "par3"}
+{"uuid": "id1", "name": "Ella", "age": 38, "ts": "1970-01-01T00:00:07", "partition": "par4"}
+{"uuid": "id1", "name": "Phoebe", "age": 52, "ts": "1970-01-01T00:00:08", "partition": "par4"}


### PR DESCRIPTION
Supports deduplication for record keys with different partition path.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.