### PR TITLE
[HUDI-1913] Using streams instead of loops for input/output

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.cli.utils;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.logging.Logger;
@@ -41,13 +40,10 @@ public class InputStreamConsumer extends Thread {
     try {
       InputStreamReader isr = new InputStreamReader(is);
       BufferedReader br = new BufferedReader(isr);
-      String line;
-      while ((line = br.readLine()) != null) {
-        LOG.info(line);
-      }
-    } catch (IOException ioe) {
-      LOG.severe(ioe.toString());
-      ioe.printStackTrace();
+      br.lines().forEach(LOG::info);
+    } catch (Exception e) {
+      LOG.severe(e.toString());
+      e.printStackTrace();
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -100,10 +100,9 @@ public class DFSPropertiesConfiguration {
    */
   public void addProperties(BufferedReader reader) throws IOException {
     try {
-      String line;
-      while ((line = reader.readLine()) != null) {
+      reader.lines().forEach(line -> {
         if (line.startsWith("#") || line.equals("") || !line.contains("=")) {
-          continue;
+          return;
         }
         String[] split = splitProperty(line);
         if (line.startsWith("include=") || line.startsWith("include =")) {
@@ -111,7 +110,8 @@ public class DFSPropertiesConfiguration {
         } else {
           props.setProperty(split[0], split[1]);
         }
-      }
+      });
+
     } finally {
       reader.close();
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
@@ -112,10 +112,7 @@ public class HoodieWithTimelineServer implements Serializable {
 
       try (BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
         StringBuilder result = new StringBuilder();
-        String line;
-        while ((line = rd.readLine()) != null) {
-          result.append(line);
-        }
+        rd.lines().forEach(result::append);
         System.out.println("Got result (" + result + ")");
         return result.toString();
       } catch (IOException e) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
@@ -212,14 +212,11 @@ public class UtilitiesTestBase {
     // to get hold of resources bundled with jar
     private static ClassLoader classLoader = Helpers.class.getClassLoader();
 
-    public static String readFile(String testResourcePath) throws IOException {
+    public static String readFile(String testResourcePath) {
       BufferedReader reader =
           new BufferedReader(new InputStreamReader(classLoader.getResourceAsStream(testResourcePath)));
       StringBuffer sb = new StringBuffer();
-      String line;
-      while ((line = reader.readLine()) != null) {
-        sb.append(line + "\n");
-      }
+      reader.lines().forEach(line -> sb.append(line).append("\n"));
       return sb.toString();
     }
 
@@ -227,10 +224,7 @@ public class UtilitiesTestBase {
       BufferedReader reader =
           new BufferedReader(new InputStreamReader(new FileInputStream(absolutePathForResource)));
       StringBuffer sb = new StringBuffer();
-      String line;
-      while ((line = reader.readLine()) != null) {
-        sb.append(line + "\n");
-      }
+      reader.lines().forEach(line -> sb.append(line).append("\n"));
       return sb.toString();
     }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

This commit addresses one issue, we could use streams instead of loops for improving the readability and makes the code more compact.

#

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.