### PR TITLE
[HUDI-1904]  Introduce SchemaProviderInterface to make SchemaProvider unified

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/schema/SchemaProviderInterface.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/schema/SchemaProviderInterface.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.schema;
 
 import org.apache.avro.Schema;
+import org.apache.hudi.ApiMaturityLevel;
+import org.apache.hudi.PublicAPIMethod;
 
 import java.io.Serializable;
 
@@ -27,8 +29,10 @@ import java.io.Serializable;
  */
 public interface SchemaProviderInterface extends Serializable {
 
+  @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
   Schema getSourceSchema();
 
+  @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
   default Schema getTargetSchema() {
     // by default, use source schema as target for hoodie table as well
     return getSourceSchema();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/schema/SchemaProviderInterface.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/schema/SchemaProviderInterface.java
@@ -25,12 +25,13 @@ import java.io.Serializable;
 /**
  * Class to provide schema for reading data and also writing into a Hoodie table.
  */
-public abstract class SchemaProvider implements Serializable {
+public interface SchemaProviderInterface extends Serializable {
 
-  public abstract Schema getSourceSchema();
+  Schema getSourceSchema();
 
-  public Schema getTargetSchema() {
+  default Schema getTargetSchema() {
     // by default, use source schema as target for hoodie table as well
     return getSourceSchema();
   }
+
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/schema/FilebasedSchemaProvider.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/schema/FilebasedSchemaProvider.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.schema;
 
-import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieIOException;
@@ -30,38 +29,13 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
-import java.util.Collections;
 
 /**
  * A simple schema provider, that reads off files on DFS.
  */
-public class FilebasedSchemaProvider extends SchemaProvider {
-
-  /**
-   * Configs supported.
-   */
-  public static class Config {
-    private static final String SOURCE_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.source.schema.file";
-    private static final String TARGET_SCHEMA_FILE_PROP = "hoodie.deltastreamer.schemaprovider.target.schema.file";
-  }
+public class FilebasedSchemaProvider implements SchemaProviderInterface {
 
   private final Schema sourceSchema;
-
-  private Schema targetSchema;
-
-  public FilebasedSchemaProvider(TypedProperties props) {
-    StreamerUtil.checkRequiredProperties(props, Collections.singletonList(Config.SOURCE_SCHEMA_FILE_PROP));
-    FileSystem fs = FSUtils.getFs(props.getString(Config.SOURCE_SCHEMA_FILE_PROP), StreamerUtil.getHadoopConf());
-    try {
-      this.sourceSchema = new Schema.Parser().parse(fs.open(new Path(props.getString(Config.SOURCE_SCHEMA_FILE_PROP))));
-      if (props.containsKey(Config.TARGET_SCHEMA_FILE_PROP)) {
-        this.targetSchema =
-            new Schema.Parser().parse(fs.open(new Path(props.getString(Config.TARGET_SCHEMA_FILE_PROP))));
-      }
-    } catch (IOException ioe) {
-      throw new HoodieIOException("Error reading schema", ioe);
-    }
-  }
 
   public FilebasedSchemaProvider(Configuration conf) {
     final String readSchemaPath = conf.getString(FlinkOptions.READ_AVRO_SCHEMA_PATH);
@@ -76,14 +50,5 @@ public class FilebasedSchemaProvider extends SchemaProvider {
   @Override
   public Schema getSourceSchema() {
     return sourceSchema;
-  }
-
-  @Override
-  public Schema getTargetSchema() {
-    if (targetSchema != null) {
-      return targetSchema;
-    } else {
-      return super.getTargetSchema();
-    }
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -20,19 +20,16 @@ package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.ApiMaturityLevel;
 import org.apache.hudi.PublicAPIClass;
-import org.apache.hudi.PublicAPIMethod;
 import org.apache.hudi.common.config.TypedProperties;
 
-import org.apache.avro.Schema;
+import org.apache.hudi.schema.SchemaProviderInterface;
 import org.apache.spark.api.java.JavaSparkContext;
 
-import java.io.Serializable;
-
 /**
- * Class to provide schema for reading data and also writing into a Hoodie table.
+ * Base implementation of {@link SchemaProviderInterface} for spark engine.
  */
 @PublicAPIClass(maturity = ApiMaturityLevel.STABLE)
-public abstract class SchemaProvider implements Serializable {
+public abstract class SchemaProvider implements SchemaProviderInterface {
 
   protected TypedProperties config;
 
@@ -45,14 +42,5 @@ public abstract class SchemaProvider implements Serializable {
   protected SchemaProvider(TypedProperties props, JavaSparkContext jssc) {
     this.config = props;
     this.jssc = jssc;
-  }
-
-  @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
-  public abstract Schema getSourceSchema();
-
-  @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
-  public Schema getTargetSchema() {
-    // by default, use source schema as target for hoodie table as well
-    return getSourceSchema();
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Make `SchemaProvider spark-free and move it ` to ` hudi-client-common` to support multi engines without introducing it many times*

## Brief change log

Make `SchemaProvider spark-free and move it ` to ` hudi-client-common`, make it the base schema provider for all engines.

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.