### PR TITLE
[HUDI-1914] Add fetching latest schema to table command in hudi-cli

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -23,14 +23,21 @@ import org.apache.hudi.cli.HoodiePrintHelper;
 import org.apache.hudi.cli.TableHeader;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.exception.TableNotFoundException;
 
+import org.apache.avro.Schema;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +47,8 @@ import java.util.List;
  */
 @Component
 public class TableCommand implements CommandMarker {
+
+  private static final Logger LOG = LogManager.getLogger(TableCommand.class);
 
   static {
     System.out.println("Table command getting loaded");
@@ -141,5 +150,42 @@ public class TableCommand implements CommandMarker {
   public String refreshMetadata() {
     HoodieCLI.refreshTableMetadata();
     return "Metadata for table " + HoodieCLI.getTableMetaClient().getTableConfig().getTableName() + " refreshed.";
+  }
+
+  /**
+   * Fetches table schema in avro format.
+   */
+  @CliCommand(value = "fetch table schema", help = "Fetches latest table schema")
+  public String fetchTableSchema(
+      @CliOption(key = {"outputFilePath"}, mandatory = false, help = "File path to write schema") final String outputFilePath) throws Exception {
+    HoodieTableMetaClient client = HoodieCLI.getTableMetaClient();
+    TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(client);
+    Schema schema = tableSchemaResolver.getTableAvroSchema();
+    if (outputFilePath != null) {
+      LOG.info("Latest table schema : " + schema.toString(true));
+      writeToFile(outputFilePath, schema.toString(true));
+      return String.format("Latest table schema written to %s", outputFilePath);
+    } else {
+      return String.format("Latest table schema %s", schema.toString(true));
+    }
+  }
+
+  /**
+   * Use Streams when you are dealing with raw data.
+   * @param filePath output file path.
+   * @param data to be written to file.
+   */
+  private static void writeToFile(String filePath, String data) throws IOException {
+    File outFile = new File(filePath);
+    if (outFile.exists()) {
+      outFile.delete();
+    }
+    OutputStream os = null;
+    try {
+      os = new FileOutputStream(outFile);
+      os.write(data.getBytes(), 0, data.length());
+    } finally {
+      os.close();
+    }
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

- Adding support to fetch table schema in hudi-cli

## Brief change log

  - Added "fetch table schema" command to hudi-cli. 
  - Optionally --outputFilePath can be supplied if one wish to get the schema written to file. 

## Verify this pull request

This change added tests and can be verified as follows:

  - Added tests to TestTableCommand
  - Also tested w/ local set up. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.