### PR TITLE
[HUDI-1426] Rename classname in camel case format

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/NonPartitionedAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/NonPartitionedAvroKeyGenerator.java
@@ -29,12 +29,12 @@ import java.util.stream.Collectors;
 /**
  * Avro simple Key generator for unpartitioned Hive Tables.
  */
-public class NonpartitionedAvroKeyGenerator extends BaseKeyGenerator {
+public class NonPartitionedAvroKeyGenerator extends BaseKeyGenerator {
 
   private static final String EMPTY_PARTITION = "";
   private static final List<String> EMPTY_PARTITION_FIELD_LIST = new ArrayList<>();
 
-  public NonpartitionedAvroKeyGenerator(TypedProperties props) {
+  public NonPartitionedAvroKeyGenerator(TypedProperties props) {
     super(props);
     this.recordKeyFields = Arrays.stream(props.getString(KeyGeneratorOptions.RECORDKEY_FIELD_OPT_KEY)
         .split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/NonPartitionedKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/NonPartitionedKeyGenerator.java
@@ -29,38 +29,38 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Simple Key generator for unpartitioned Hive Tables.
+ * Simple Key generator for unPartitioned Hive Tables.
  */
-public class NonpartitionedKeyGenerator extends BuiltinKeyGenerator {
+public class NonPartitionedKeyGenerator extends BuiltinKeyGenerator {
 
-  private final NonpartitionedAvroKeyGenerator nonpartitionedAvroKeyGenerator;
+  private final NonPartitionedAvroKeyGenerator nonPartitionedAvroKeyGenerator;
 
-  public NonpartitionedKeyGenerator(TypedProperties props) {
+  public NonPartitionedKeyGenerator(TypedProperties props) {
     super(props);
     this.recordKeyFields = Arrays.stream(props.getString(KeyGeneratorOptions.RECORDKEY_FIELD_OPT_KEY)
         .split(",")).map(String::trim).collect(Collectors.toList());
     this.partitionPathFields = Collections.emptyList();
-    nonpartitionedAvroKeyGenerator = new NonpartitionedAvroKeyGenerator(props);
+    nonPartitionedAvroKeyGenerator = new NonPartitionedAvroKeyGenerator(props);
   }
 
   @Override
   public String getRecordKey(GenericRecord record) {
-    return nonpartitionedAvroKeyGenerator.getRecordKey(record);
+    return nonPartitionedAvroKeyGenerator.getRecordKey(record);
   }
 
   @Override
   public String getPartitionPath(GenericRecord record) {
-    return nonpartitionedAvroKeyGenerator.getPartitionPath(record);
+    return nonPartitionedAvroKeyGenerator.getPartitionPath(record);
   }
 
   @Override
   public List<String> getPartitionPathFields() {
-    return nonpartitionedAvroKeyGenerator.getPartitionPathFields();
+    return nonPartitionedAvroKeyGenerator.getPartitionPathFields();
   }
 
   @Override
   public String getPartitionPath(Row row) {
-    return nonpartitionedAvroKeyGenerator.getEmptyPartition();
+    return nonPartitionedAvroKeyGenerator.getEmptyPartition();
   }
 
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestNonPartitionedKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestNonPartitionedKeyGenerator.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static junit.framework.TestCase.assertEquals;
 
-public class TestNonpartitionedKeyGenerator extends KeyGeneratorTestUtilities {
+public class TestNonPartitionedKeyGenerator extends KeyGeneratorTestUtilities {
 
   private TypedProperties getCommonProps(boolean getComplexRecordKey) {
     TypedProperties properties = new TypedProperties();
@@ -69,13 +69,13 @@ public class TestNonpartitionedKeyGenerator extends KeyGeneratorTestUtilities {
 
   @Test
   public void testNullRecordKeyFields() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> new NonpartitionedKeyGenerator(getPropertiesWithoutRecordKeyProp()));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new NonPartitionedKeyGenerator(getPropertiesWithoutRecordKeyProp()));
   }
 
   @Test
   public void testNonNullPartitionPathFields() {
     TypedProperties properties = getPropertiesWithPartitionPathProp();
-    NonpartitionedKeyGenerator keyGenerator = new NonpartitionedKeyGenerator(properties);
+    NonPartitionedKeyGenerator keyGenerator = new NonPartitionedKeyGenerator(properties);
     GenericRecord record = getRecord();
     Row row = KeyGeneratorTestUtilities.getRow(record);
     Assertions.assertEquals(properties.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_OPT_KEY), "timestamp,ts_ms");
@@ -85,7 +85,7 @@ public class TestNonpartitionedKeyGenerator extends KeyGeneratorTestUtilities {
   @Test
   public void testNullPartitionPathFields() {
     TypedProperties properties = getPropertiesWithoutPartitionPathProp();
-    NonpartitionedKeyGenerator keyGenerator = new NonpartitionedKeyGenerator(properties);
+    NonPartitionedKeyGenerator keyGenerator = new NonPartitionedKeyGenerator(properties);
     GenericRecord record = getRecord();
     Row row = KeyGeneratorTestUtilities.getRow(record);
     Assertions.assertEquals(keyGenerator.getPartitionPath(row), "");
@@ -93,7 +93,7 @@ public class TestNonpartitionedKeyGenerator extends KeyGeneratorTestUtilities {
 
   @Test
   public void testWrongRecordKeyField() {
-    NonpartitionedKeyGenerator keyGenerator = new NonpartitionedKeyGenerator(getWrongRecordKeyFieldProps());
+    NonPartitionedKeyGenerator keyGenerator = new NonPartitionedKeyGenerator(getWrongRecordKeyFieldProps());
     Assertions.assertThrows(HoodieKeyException.class, () -> keyGenerator.getRecordKey(getRecord()));
     Assertions.assertThrows(HoodieKeyException.class, () -> keyGenerator.buildFieldPositionMapIfNeeded(KeyGeneratorTestUtilities.structType));
   }
@@ -103,7 +103,7 @@ public class TestNonpartitionedKeyGenerator extends KeyGeneratorTestUtilities {
     TypedProperties properties = new TypedProperties();
     properties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_OPT_KEY, "timestamp");
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_OPT_KEY, "");
-    NonpartitionedKeyGenerator keyGenerator = new NonpartitionedKeyGenerator(properties);
+    NonPartitionedKeyGenerator keyGenerator = new NonPartitionedKeyGenerator(properties);
     assertEquals(keyGenerator.getRecordKeyFields().size(), 1);
     assertEquals(keyGenerator.getPartitionPathFields().size(), 0);
 
@@ -120,7 +120,7 @@ public class TestNonpartitionedKeyGenerator extends KeyGeneratorTestUtilities {
     TypedProperties properties = new TypedProperties();
     properties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_OPT_KEY, "timestamp,driver");
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_OPT_KEY, "");
-    NonpartitionedKeyGenerator keyGenerator = new NonpartitionedKeyGenerator(properties);
+    NonPartitionedKeyGenerator keyGenerator = new NonPartitionedKeyGenerator(properties);
     assertEquals(keyGenerator.getRecordKeyFields().size(), 2);
     assertEquals(keyGenerator.getPartitionPathFields().size(), 0);
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();

--- a/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -20,7 +20,7 @@ package org.apache.hudi.table;
 
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
-import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
+import org.apache.hudi.keygen.NonPartitionedAvroKeyGenerator;
 import org.apache.hudi.util.AvroSchemaConverter;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -171,9 +171,9 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
     // tweak the key gen class if possible
     final String[] partitions = conf.getString(FlinkOptions.PARTITION_PATH_FIELD).split(",");
     if (partitions.length == 1 && partitions[0].equals("")) {
-      conf.setString(FlinkOptions.KEYGEN_CLASS, NonpartitionedAvroKeyGenerator.class.getName());
+      conf.setString(FlinkOptions.KEYGEN_CLASS, NonPartitionedAvroKeyGenerator.class.getName());
       LOG.info("Table option [{}] is reset to {} because this is a non-partitioned table",
-          FlinkOptions.KEYGEN_CLASS.key(), NonpartitionedAvroKeyGenerator.class.getName());
+          FlinkOptions.KEYGEN_CLASS.key(), NonPartitionedAvroKeyGenerator.class.getName());
       return;
     }
     final String[] pks = conf.getString(FlinkOptions.RECORD_KEY_FIELD).split(",");

--- a/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -20,7 +20,7 @@ package org.apache.hudi.table;
 
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
-import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
+import org.apache.hudi.keygen.NonPartitionedAvroKeyGenerator;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
 
@@ -169,7 +169,7 @@ public class TestHoodieTableFactory {
     final HoodieTableSource tableSource3 = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext3);
     final Configuration conf3 = tableSource3.getConf();
     assertThat(conf3.get(FlinkOptions.RECORD_KEY_FIELD), is("f0,f1"));
-    assertThat(conf3.get(FlinkOptions.KEYGEN_CLASS), is(NonpartitionedAvroKeyGenerator.class.getName()));
+    assertThat(conf3.get(FlinkOptions.KEYGEN_CLASS), is(NonPartitionedAvroKeyGenerator.class.getName()));
   }
 
   @Test
@@ -256,7 +256,7 @@ public class TestHoodieTableFactory {
     final HoodieTableSink tableSink3 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sinkContext3);
     final Configuration conf3 = tableSink3.getConf();
     assertThat(conf3.get(FlinkOptions.RECORD_KEY_FIELD), is("f0,f1"));
-    assertThat(conf3.get(FlinkOptions.KEYGEN_CLASS), is(NonpartitionedAvroKeyGenerator.class.getName()));
+    assertThat(conf3.get(FlinkOptions.KEYGEN_CLASS), is(NonPartitionedAvroKeyGenerator.class.getName()));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
@@ -27,7 +27,7 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hive.MultiPartKeysValueExtractor;
 import org.apache.hudi.hive.NonPartitionedExtractor;
-import org.apache.hudi.keygen.NonpartitionedKeyGenerator;
+import org.apache.hudi.keygen.NonPartitionedKeyGenerator;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 
 import com.beust.jcommander.JCommander;
@@ -153,7 +153,7 @@ public class HoodieJavaApp {
         .option(HoodieWriteConfig.TABLE_NAME, tableName)
         // Add Key Extractor
         .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY(),
-            nonPartitionedTable ? NonpartitionedKeyGenerator.class.getCanonicalName()
+            nonPartitionedTable ? NonPartitionedKeyGenerator.class.getCanonicalName()
                 : SimpleKeyGenerator.class.getCanonicalName())
         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE_OPT_KEY(), "false")
         // This will remove any existing data at path below, and create a
@@ -179,7 +179,7 @@ public class HoodieJavaApp {
         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
         .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
         .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY(),
-            nonPartitionedTable ? NonpartitionedKeyGenerator.class.getCanonicalName()
+            nonPartitionedTable ? NonPartitionedKeyGenerator.class.getCanonicalName()
                 : SimpleKeyGenerator.class.getCanonicalName()) // Add Key Extractor
         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS_PROP, "1")
         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE_OPT_KEY(), "false")
@@ -206,7 +206,7 @@ public class HoodieJavaApp {
         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
         .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "_row_key")
         .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY(),
-            nonPartitionedTable ? NonpartitionedKeyGenerator.class.getCanonicalName()
+            nonPartitionedTable ? NonPartitionedKeyGenerator.class.getCanonicalName()
                 : SimpleKeyGenerator.class.getCanonicalName()) // Add Key Extractor
         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS_PROP, "1")
         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE_OPT_KEY(), "false")

--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
@@ -25,7 +25,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hive.MultiPartKeysValueExtractor;
 import org.apache.hudi.hive.NonPartitionedExtractor;
-import org.apache.hudi.keygen.NonpartitionedKeyGenerator;
+import org.apache.hudi.keygen.NonPartitionedKeyGenerator;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 
 import com.beust.jcommander.JCommander;
@@ -178,7 +178,7 @@ public class HoodieJavaGenerateApp {
         .option(HoodieWriteConfig.TABLE_NAME, tableName)
         // Add Key Extractor
         .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY(),
-            nonPartitionedTable ? NonpartitionedKeyGenerator.class.getCanonicalName()
+            nonPartitionedTable ? NonPartitionedKeyGenerator.class.getCanonicalName()
                 : SimpleKeyGenerator.class.getCanonicalName())
         .mode(commitType);
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestBootstrap.java
@@ -56,7 +56,7 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.index.HoodieIndex.IndexType;
-import org.apache.hudi.keygen.NonpartitionedKeyGenerator;
+import org.apache.hudi.keygen.NonPartitionedKeyGenerator;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 import org.apache.hudi.table.action.bootstrap.BootstrapUtils;
 import org.apache.hudi.testutils.HoodieClientTestBase;
@@ -199,7 +199,7 @@ public class TestBootstrap extends HoodieClientTestBase {
 
     int totalRecords = 100;
     String keyGeneratorClass = partitioned ? SimpleKeyGenerator.class.getCanonicalName()
-        : NonpartitionedKeyGenerator.class.getCanonicalName();
+        : NonPartitionedKeyGenerator.class.getCanonicalName();
     final String bootstrapModeSelectorClass;
     final String bootstrapCommitInstantTs;
     final boolean checkNumRawFiles;

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieSparkSqlWriterSuite.scala
@@ -28,7 +28,7 @@ import org.apache.hudi.common.model.{HoodieRecord, HoodieRecordPayload}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieException
-import org.apache.hudi.keygen.{NonpartitionedKeyGenerator, SimpleKeyGenerator}
+import org.apache.hudi.keygen.{NonPartitionedKeyGenerator, SimpleKeyGenerator}
 import org.apache.hudi.hive.HiveSyncConfig
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.{AvroConversionUtils, DataSourceUtils, DataSourceWriteOptions, HoodieSparkSqlWriter, HoodieWriterUtils}
@@ -381,7 +381,7 @@ class HoodieSparkSqlWriterSuite extends FunSuite with Matchers {
             DataSourceWriteOptions.OPERATION_OPT_KEY -> DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL,
             DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY -> "_row_key",
             DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY -> "partition",
-            HoodieBootstrapConfig.BOOTSTRAP_KEYGEN_CLASS -> classOf[NonpartitionedKeyGenerator].getCanonicalName)
+            HoodieBootstrapConfig.BOOTSTRAP_KEYGEN_CLASS -> classOf[NonPartitionedKeyGenerator].getCanonicalName)
           val fooTableParams = HoodieWriterUtils.parametersWithWriteDefaults(fooTableModifier)
 
           val client = spy(DataSourceUtils.createHoodieClient(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -639,7 +639,7 @@ class TestCOWDataSource extends HoodieClientTestBase {
 
   @Test def testSparkPartitonByWithNonpartitionedKeyGenerator() {
     // Empty string column
-    var writer = getDataFrameWriter(classOf[NonpartitionedKeyGenerator].getName)
+    var writer = getDataFrameWriter(classOf[NonPartitionedKeyGenerator].getName)
     writer.partitionBy("")
       .save(basePath)
 
@@ -648,7 +648,7 @@ class TestCOWDataSource extends HoodieClientTestBase {
     assertTrue(recordsReadDF.filter(col("_hoodie_partition_path") =!= lit("")).count() == 0)
 
     // Non-existent column
-    writer = getDataFrameWriter(classOf[NonpartitionedKeyGenerator].getName)
+    writer = getDataFrameWriter(classOf[NonPartitionedKeyGenerator].getName)
     writer.partitionBy("abc")
       .save(basePath)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
-import org.apache.hudi.keygen.NonpartitionedKeyGenerator
+import org.apache.hudi.keygen.NonPartitionedKeyGenerator
 import org.apache.hudi.testutils.HoodieClientTestBase
 import org.apache.log4j.LogManager
 import org.apache.spark.sql._
@@ -533,7 +533,7 @@ class TestMORDataSource extends HoodieClientTestBase {
       .option(RECORDKEY_FIELD_OPT_KEY, "id")
       .option(PRECOMBINE_FIELD_OPT_KEY, "version")
       .option(PARTITIONPATH_FIELD_OPT_KEY, "")
-      .option(KEYGENERATOR_CLASS_OPT_KEY, classOf[NonpartitionedKeyGenerator].getName)
+      .option(KEYGENERATOR_CLASS_OPT_KEY, classOf[NonPartitionedKeyGenerator].getName)
       .mode(SaveMode.Append)
       .save(basePath)
   }


### PR DESCRIPTION
## What is the purpose of the pull request

This PR renames two classes according to came case format. Hudi documentation points to camel case format https://hudi.apache.org/docs/writing_data.html however in code it is not followed

```
Non partitioned table - NonPartitionedKeyGenerator.java. Non-partitioned tables can currently only have a single key column, HUDI-1053
```

## Brief change log

- Rename `NonpartitionedAvroKeyGenerator` to `NonPartitionedAvroKeyGenerator`
- Rename `NonpartitionedKeyGenerator` to `NonPartitionedKeyGenerator`

## Verify this pull request

This pull request is a trivial code cleanup and is already covered by existing tests, such as 
- hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestNonPartitionedKeyGenerator.java
- hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
- hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestBootstrap.java
- hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
- hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.