### PR TITLE
[HUDI-1938] Don't flush to disk before notifyCompleteCheckpoint

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -305,6 +305,24 @@ public class FlinkOptions {
       .defaultValue(100) // default 100 MB
       .withDescription("Max memory in MB for merge, default 100MB");
 
+  public static final ConfigOption<Boolean> DETECT_INSTANT_ENABLE = ConfigOptions
+          .key("write.detect.instant.enable")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to detect new instant from hoodie table when checkpoint not complete and memory size larger than maxBufferSize, default false");
+
+  public static final ConfigOption<Long> DETECT_INSTANT_INTERVAL_MS = ConfigOptions
+       .key("write.detect.instant.interval.ms")
+       .longType()
+       .defaultValue(100L)
+       .withDescription("Flag to indicate how long (by millisecond) to retry detect a new instant");
+
+  public static final ConfigOption<Long> DETECT_INSTANT_TIMEOUT_SECONDS = ConfigOptions
+       .key("write.detect.instant.timeout.seconds")
+       .longType()
+       .defaultValue(300L) // default 5min
+       .withDescription("Timeout for detect new instant");
+
   // ------------------------------------------------------------------------
   //  Compaction Options
   // ------------------------------------------------------------------------

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -30,14 +30,17 @@ import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.ObjectSizeCalculator;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.sink.event.BatchWriteSuccessEvent;
+import org.apache.hudi.sink.event.ResponseEvent;
 import org.apache.hudi.table.action.commit.FlinkWriteHelper;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -55,6 +58,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -146,6 +155,16 @@ public class StreamWriteFunction<K, I, O>
   private transient TotalSizeTracer tracer;
 
   /**
+   * control flush to disk.
+   */
+  private transient boolean canFlush = true;
+
+  /**
+   * A single-thread executor.
+   */
+  private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  /**
    * Constructs a StreamingSinkFunction.
    *
    * @param config The config options
@@ -177,10 +196,13 @@ public class StreamWriteFunction<K, I, O>
     // it would check the validity.
     // wait for the buffer data flush out and request a new instant
     flushRemaining(false);
+
+    // disable flush, until received event from coordinator
+    this.canFlush = false;
   }
 
   @Override
-  public void processElement(I value, KeyedProcessFunction<K, I, O>.Context ctx, Collector<O> out) {
+  public void processElement(I value, KeyedProcessFunction<K, I, O>.Context ctx, Collector<O> out) throws Exception {
     bufferRecord((HoodieRecord<?>) value);
   }
 
@@ -255,6 +277,20 @@ public class StreamWriteFunction<K, I, O>
       default:
         throw new RuntimeException("Unsupported write operation : " + writeOperation);
     }
+  }
+
+  public void handleOperatorEvent(OperatorEvent operatorEvent) {
+    ValidationUtils.checkState(operatorEvent instanceof ResponseEvent,
+            "The writer can only handle ResponseEvent");
+
+    ResponseEvent event = (ResponseEvent) operatorEvent;
+    if (event.isCommitted()) {
+      LOG.info("Received commit success from coordinator.");
+    } else {
+      LOG.warn("Received commit failed from coordinator.");
+    }
+
+    this.canFlush = true;
   }
 
   /**
@@ -420,6 +456,41 @@ public class StreamWriteFunction<K, I, O>
     return StreamerUtil.generateBucketKey(record.getPartitionPath(), fileId);
   }
 
+  private void waitForNewInstant() throws InterruptedException, ExecutionException {
+    long detectInstantInterval = this.config.getLong(FlinkOptions.DETECT_INSTANT_INTERVAL_MS);
+    long detectInstantTimeout = this.config.getLong(FlinkOptions.DETECT_INSTANT_TIMEOUT_SECONDS);
+
+    Future<?> future = executor.submit(() -> {
+      while (!canFlush) {
+        final String instant = this.writeClient.getLastPendingInstant(this.actionType);
+        if (instant != null) {
+          if (this.currentInstant == null || instant.compareTo(this.currentInstant) > 0) {
+            this.currentInstant = instant;
+            this.canFlush = true;
+            break;
+          }
+        }
+
+        LOG.info("Retry to get new instant, lastInstant is {}, now instant is {}.", this.currentInstant, instant);
+
+        try {
+          // Reduce the frequency of access to the FileSystem
+          Thread.sleep(detectInstantInterval);
+        } catch (InterruptedException e) {
+          LOG.warn("Got InterruptedException waiting for new instant, ignore.", e);
+        }
+      }
+    });
+
+    try {
+      future.get(detectInstantTimeout, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      if (!canFlush) {
+        throw new RuntimeException("Timeout waiting for detect new instant.");
+      }
+    }
+  }
+
   /**
    * Buffers the given record.
    *
@@ -431,7 +502,7 @@ public class StreamWriteFunction<K, I, O>
    *
    * @param value HoodieRecord
    */
-  private void bufferRecord(HoodieRecord<?> value) {
+  private void bufferRecord(HoodieRecord<?> value) throws Exception {
     final String bucketID = getBucketID(value);
 
     DataBucket bucket = this.buckets.computeIfAbsent(bucketID,
@@ -440,30 +511,31 @@ public class StreamWriteFunction<K, I, O>
     boolean flushBucket = bucket.detector.detect(item);
     boolean flushBuffer = this.tracer.trace(bucket.detector.lastRecordSize);
     if (flushBucket) {
-      flushBucket(bucket);
-      this.tracer.countDown(bucket.detector.totalSize);
-      bucket.reset();
+      boolean flush = flushBucket(bucket);
+      if (flush) {
+        this.tracer.countDown(bucket.detector.totalSize);
+        bucket.reset();
+      }
     } else if (flushBuffer) {
-      // find the max size bucket and flush it out
-      List<DataBucket> sortedBuckets = this.buckets.values().stream()
-          .sorted((b1, b2) -> Long.compare(b2.detector.totalSize, b1.detector.totalSize))
-          .collect(Collectors.toList());
-      final DataBucket bucketToFlush = sortedBuckets.get(0);
-      flushBucket(bucketToFlush);
-      this.tracer.countDown(bucketToFlush.detector.totalSize);
-      bucketToFlush.reset();
+      flushBuffer();
     }
     bucket.records.add(item);
   }
 
   @SuppressWarnings("unchecked, rawtypes")
-  private void flushBucket(DataBucket bucket) {
+  private boolean flushBucket(DataBucket bucket) {
+    if (!canFlush) {
+      // in case there are flush before last instant commit
+      LOG.info("Last commit has not committed, skip.");
+      return false;
+    }
+
     final String instant = this.writeClient.getLastPendingInstant(this.actionType);
 
     if (instant == null) {
       // in case there are empty checkpoints that has no input data
-      LOG.info("No inflight instant when flushing data, cancel.");
-      return;
+      LOG.info("No inflight instant when flushing data, skip.");
+      return false;
     }
 
     List<HoodieRecord> records = bucket.writeBuffer();
@@ -481,15 +553,36 @@ public class StreamWriteFunction<K, I, O>
         .isEndInput(false)
         .build();
     this.eventGateway.sendEventToCoordinator(event);
+
+    return true;
+  }
+
+  @SuppressWarnings("unchecked, rawtypes")
+  private void flushBuffer() throws ExecutionException, InterruptedException {
+    // if current memorySize larger than maxBufferSize and no response message received from coordinator,
+    // should blocking until the lastPendingInstant update to avoid oom.
+    if (!canFlush && this.config.getBoolean(FlinkOptions.DETECT_INSTANT_ENABLE)) {
+      LOG.warn("Trigger the flushBuffer but no response message received from coordinator, blocking until the lastPendingInstant update.");
+      waitForNewInstant();
+    }
+
+    // find the max size bucket and flush it out
+    List<DataBucket> sortedBuckets = this.buckets.values().stream()
+            .sorted((b1, b2) -> Long.compare(b2.detector.totalSize, b1.detector.totalSize))
+            .collect(Collectors.toList());
+    final DataBucket bucketToFlush = sortedBuckets.get(0);
+    boolean flush = flushBucket(bucketToFlush);
+    if (flush) {
+      this.tracer.countDown(bucketToFlush.detector.totalSize);
+      bucketToFlush.reset();
+    }
   }
 
   @SuppressWarnings("unchecked, rawtypes")
   private void flushRemaining(boolean isEndInput) {
     this.currentInstant = this.writeClient.getLastPendingInstant(this.actionType);
     if (this.currentInstant == null) {
-      // in case there are empty checkpoints that has no input data
-      LOG.info("No inflight instant when flushing data, cancel.");
-      return;
+      throw new HoodieException("No inflight instant when flushRemaining!");
     }
     final List<WriteStatus> writeStatus;
     if (buckets.size() > 0) {

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
@@ -43,7 +43,7 @@ public class StreamWriteOperator<I>
 
   @Override
   public void handleOperatorEvent(OperatorEvent operatorEvent) {
-    // do nothing
+    sinkFunction.handleOperatorEvent(operatorEvent);
   }
 
   void setOperatorEventGateway(OperatorEventGateway operatorEventGateway) {

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/event/ResponseEvent.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/event/ResponseEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.event;
+
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+
+/**
+ * An operator event to response.
+ */
+public class ResponseEvent implements OperatorEvent {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean committed;
+
+    public ResponseEvent(boolean committed) {
+        this.committed = committed;
+    }
+
+    public boolean isCommitted() {
+        return committed;
+    }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*The detailed information is here : https://issues.apache.org/jira/browse/HUDI-1938*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.