### PR TITLE
[HUDI-1426] Updated classname in doc as per code

### DIFF
--- a/content/docs/writing_data.html
+++ b/content/docs/writing_data.html
@@ -683,7 +683,7 @@ The value for <code class="highlighter-rouge">hoodie.datasource.write.partitionp
   <li>Simple record key and custom timestamp based partition path (with optional hive style partitioning) - <code class="highlighter-rouge">TimestampBasedKeyGenerator.java</code></li>
   <li>Composite record keys (combination of multiple fields) and composite partition paths - <code class="highlighter-rouge">ComplexKeyGenerator.java</code></li>
   <li>Composite record keys and timestamp based partition paths (composite also supported) - You might need to move to 0.6.0 and use <code class="highlighter-rouge">CustomKeyGenerator.java</code> class</li>
-  <li>Non partitioned table - <code class="highlighter-rouge">NonPartitionedKeyGenerator.java</code>. Non-partitioned tables can currently only have a single key column, <a href="https://issues.apache.org/jira/browse/HUDI-1053">HUDI-1053</a></li>
+  <li>Non partitioned table - <code class="highlighter-rouge">NonpartitionedKeyGenerator.java</code>. Non-partitioned tables can currently only have a single key column, <a href="https://issues.apache.org/jira/browse/HUDI-1053">HUDI-1053</a></li>
 </ul>
 
 <h2 id="syncing-to-hive">Syncing to Hive</h2>

--- a/docs/_docs/2_2_writing_data.md
+++ b/docs/_docs/2_2_writing_data.md
@@ -322,7 +322,7 @@ For those on hudi versions < 0.6.0, you can use the following key generator clas
  - Simple record key and custom timestamp based partition path (with optional hive style partitioning) - `TimestampBasedKeyGenerator.java`
  - Composite record keys (combination of multiple fields) and composite partition paths - `ComplexKeyGenerator.java`
  - Composite record keys and timestamp based partition paths (composite also supported) - You might need to move to 0.6.0 and use `CustomKeyGenerator.java` class
- - Non partitioned table - `NonPartitionedKeyGenerator.java`. Non-partitioned tables can currently only have a single key column, [HUDI-1053](https://issues.apache.org/jira/browse/HUDI-1053)
+ - Non partitioned table - `NonpartitionedKeyGenerator.java`. Non-partitioned tables can currently only have a single key column, [HUDI-1053](https://issues.apache.org/jira/browse/HUDI-1053)
  
  
 ## Syncing to Hive


### PR DESCRIPTION
## What is the purpose of the pull request

The document references to class `NonPartitionedKeyGenerator `, however in the code it is `NonpartitionedKeyGenerator`, Updating the doc as there was objection on renaming the class itself to camel format as per the discussion here https://github.com/apache/hudi/pull/2998

## Brief change log

Updated document to point to correct class name `NonpartitionedKeyGenerator `

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.