### PR TITLE
[HUDI-1892] Fix NPE when avro field value is null

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -94,6 +94,6 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
    * Return true if value equals defaultValue otherwise false.
    */
   public Boolean overwriteField(Object value, Object defaultValue) {
-    return defaultValue == null ? value == null : defaultValue.toString().equals(value.toString());
+    return defaultValue == null ? value == null : defaultValue.toString().equals(String.valueOf(value));
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

This change is to handle a edge case where the field value can be null. This is specifically the case when the field schema could be of UNION type like `null,string`

## Brief change log

- Updated OverwriteWithLatestAvroPayload#overwriteField to use String.valueOf() to handle this case

## Verify this pull request

This pull request is already covered by existing tests

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.