### PR TITLE
[HUDI-2013] Removed option to fallback to file listing when Metadata Table is enabled.

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
@@ -969,8 +969,7 @@ public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(useFileListingMetadata)
-            .enableMetrics(enableMetrics)
-            .enableFallback(false).build())
+            .enableMetrics(enableMetrics).build())
         .withMetricsConfig(HoodieMetricsConfig.newBuilder().on(enableMetrics)
             .withExecutorMetrics(true).usePrefix("unit-test").build());
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -67,10 +67,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
   public static final String CLEANER_COMMITS_RETAINED_PROP = METADATA_PREFIX + ".cleaner.commits.retained";
   public static final int DEFAULT_CLEANER_COMMITS_RETAINED = 3;
 
-  // Controls whether or not, upon failure to fetch from metadata table, should fallback to listing.
-  public static final String ENABLE_FALLBACK_PROP = METADATA_PREFIX + ".fallback.enable";
-  public static final String DEFAULT_ENABLE_FALLBACK = "true";
-
   // Regex to filter out matching directories during bootstrap
   public static final String DIRECTORY_FILTER_REGEX = METADATA_PREFIX + ".dir.filter.regex";
   public static final String DEFAULT_DIRECTORY_FILTER_REGEX = "";
@@ -99,10 +95,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
 
   public boolean useFileListingMetadata() {
     return Boolean.parseBoolean(props.getProperty(METADATA_ENABLE_PROP));
-  }
-
-  public boolean enableFallback() {
-    return Boolean.parseBoolean(props.getProperty(ENABLE_FALLBACK_PROP));
   }
 
   public boolean validateFileListingMetadata() {
@@ -140,11 +132,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
 
     public Builder enableMetrics(boolean enableMetrics) {
       props.setProperty(METADATA_METRICS_ENABLE_PROP, String.valueOf(enableMetrics));
-      return this;
-    }
-
-    public Builder enableFallback(boolean fallback) {
-      props.setProperty(ENABLE_FALLBACK_PROP, String.valueOf(fallback));
       return this;
     }
 
@@ -218,8 +205,6 @@ public final class HoodieMetadataConfig extends DefaultHoodieConfig {
           String.valueOf(DEFAULT_FILE_LISTING_PARALLELISM));
       setDefaultOnCondition(props, !props.containsKey(HOODIE_ASSUME_DATE_PARTITIONING_PROP),
           HOODIE_ASSUME_DATE_PARTITIONING_PROP, DEFAULT_ASSUME_DATE_PARTITIONING);
-      setDefaultOnCondition(props, !props.containsKey(ENABLE_FALLBACK_PROP), ENABLE_FALLBACK_PROP,
-          DEFAULT_ENABLE_FALLBACK);
       setDefaultOnCondition(props, !props.containsKey(DIRECTORY_FILTER_REGEX), DIRECTORY_FILTER_REGEX,
           DEFAULT_DIRECTORY_FILTER_REGEX);
       return config;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -101,11 +101,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
       try {
         return fetchAllPartitionPaths();
       } catch (Exception e) {
-        if (metadataConfig.enableFallback()) {
-          LOG.error("Failed to retrieve list of partition from metadata", e);
-        } else {
-          throw new HoodieMetadataException("Failed to retrieve list of partition from metadata", e);
-        }
+        throw new HoodieMetadataException("Failed to retrieve list of partition from metadata", e);
       }
     }
     return new FileSystemBackedTableMetadata(getEngineContext(), hadoopConf, datasetBasePath,
@@ -129,11 +125,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
       try {
         return fetchAllFilesInPartition(partitionPath);
       } catch (Exception e) {
-        if (metadataConfig.enableFallback()) {
-          LOG.error("Failed to retrieve files in partition " + partitionPath + " from metadata", e);
-        } else {
-          throw new HoodieMetadataException("Failed to retrieve files in partition " + partitionPath + " from metadata", e);
-        }
+        throw new HoodieMetadataException("Failed to retrieve files in partition " + partitionPath + " from metadata", e);
       }
     }
 
@@ -293,6 +285,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
   protected abstract List<HoodieInstant> findInstantsToSync();
 
+  @Override
   public boolean isInSync() {
     return enabled && findInstantsToSync().isEmpty();
   }


### PR DESCRIPTION
## What is the purpose of the pull request

Fixed potential issues when metadata table is deployed in production.

## Brief change log

Removed the option hoodie.metadata.feedback.enable

## Verify this pull request

This pull request is already covered by all metadata table tests in TestHoodieBackedMetadata.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.