### PR TITLE
[MINOR] Fixed the log which should only be printed when the Metadata Table is disabled.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -92,7 +92,9 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
   }
 
   private void initIfNeeded() {
-    if (enabled && this.metaClient == null) {
+    if (!enabled) {
+      LOG.info("Metadata table is disabled for " + datasetBasePath);
+    } else if (this.metaClient == null) {
       this.metadataBasePath = HoodieTableMetadata.getMetadataTableBasePath(datasetBasePath);
       try {
         this.metaClient = HoodieTableMetaClient.builder().setConf(hadoopConf.get()).setBasePath(metadataBasePath).build();
@@ -107,8 +109,6 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         this.enabled = false;
         this.metaClient = null;
       }
-    } else {
-      LOG.info("Metadata table is disabled.");
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

The function initIfNeeded() is called through multiple code paths and should only log "Metadata table is disabled" when the table is disabled. 

## Brief change log


## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.