### PR TITLE
[HUDI-2031] JVM occasionally crashes during compaction when spark speculative execution is enabled

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryExecutor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryExecutor.java
@@ -139,6 +139,10 @@ public class BoundedInMemoryExecutor<I, O, E> {
       Future<E> future = startConsumer();
       // Wait for consumer to be done
       return future.get();
+    } catch (InterruptedException ie) {
+      shutdownNow();
+      Thread.currentThread().interrupt();
+      throw new HoodieException(ie);
     } catch (Exception e) {
       throw new HoodieException(e);
     }


### PR DESCRIPTION
…culative execution is enabled

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Fix JVM crashes during compaction.

## Brief change log

Handle InterruptedException separately, interrupt all async threads (producers & consumer) and restore the interrupted status in `BoundedInMemoryExecutor`

## Verify this pull request


  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.