### PR TITLE
[HUDI-2033] ClassCastException Throw When PreCombineField Is String Type

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.hudi.command.payload
 
 import java.util.{Base64, Properties}
 import java.util.concurrent.Callable
-
 import scala.collection.JavaConverters._
 import com.google.common.cache.CacheBuilder
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord, IndexedRecord}
+import org.apache.avro.util.Utf8
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro
@@ -290,15 +290,15 @@ object ExpressionPayload {
 
   /**
    * As the "baseEvaluator" return "UTF8String" for the string type which cannot be process by
-   * the Avro, The StringConvertEvaluator will convert the "UTF8String" to "String".
+   * the Avro, The StringConvertEvaluator will convert the "UTF8String" to "Utf8".
    */
   case class StringConvertEvaluator(baseEvaluator: IExpressionEvaluator) extends IExpressionEvaluator {
     /**
-     * Convert the UTF8String to String
+     * Convert the UTF8String to Utf8
      */
     override def eval(record: IndexedRecord): Array[AnyRef] = {
-      baseEvaluator.eval(record).map{
-        case s: UTF8String => s.toString
+      baseEvaluator.eval(record).map {
+        case s: UTF8String => new Utf8(s.toString)
         case o => o
       }
     }


### PR DESCRIPTION

## What is the purpose of the pull request

Fix ClassCastException throw out when merge with string-type `preCombineField` .

## Brief change log

Change the return type of sql expression to avro `Utf8`  instead of `String`

## Verify this pull request

  - Add Test Different Type of PreCombineField in TestMergeIntoTable

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.