### PR TITLE
[HUDI-2069] Fix KafkaAvroSchemaDeserializer to not rely on reflection

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -382,8 +382,6 @@ object DataSourceWriteOptions {
 
   // Avro Kafka Source configs
   val KAFKA_AVRO_VALUE_DESERIALIZER = "hoodie.deltastreamer.source.kafka.value.deserializer.class"
-
-  // Schema provider class to be set to be used in custom kakfa deserializer
-  val SCHEMA_PROVIDER_CLASS_PROP = "hoodie.deltastreamer.schemaprovider.class"
-
+  // Schema to be used in custom kakfa deserializer
+  val KAFKA_AVRO_VALUE_DESERIALIZER_SCHEMA = "hoodie.deltastreamer.source.kafka.value.deserializer.schema"
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java
@@ -24,14 +24,11 @@ import org.apache.avro.Schema;
 
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 
 /**
  * Extending {@link KafkaAvroSchemaDeserializer} as we need to be able to inject reader schema during deserialization.
@@ -51,9 +48,7 @@ public class KafkaAvroSchemaDeserializer extends KafkaAvroDeserializer {
     super.configure(configs, isKey);
     try {
       TypedProperties props = getConvertToTypedProperties(configs);
-      String className = props.getString(DataSourceWriteOptions.SCHEMA_PROVIDER_CLASS_PROP());
-      SchemaProvider schemaProvider = (SchemaProvider) ReflectionUtils.loadClass(className, props);
-      sourceSchema = Objects.requireNonNull(schemaProvider).getSourceSchema();
+      sourceSchema = new Schema.Parser().parse(props.getString(DataSourceWriteOptions.KAFKA_AVRO_VALUE_DESERIALIZER_SCHEMA()));
     } catch (Throwable e) {
       throw new HoodieException(e);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -63,11 +63,11 @@ public class AvroKafkaSource extends AvroSource {
       props.put(NATIVE_KAFKA_VALUE_DESERIALIZER_PROP, KafkaAvroDeserializer.class);
     } else {
       try {
+        props.put(NATIVE_KAFKA_VALUE_DESERIALIZER_PROP, Class.forName(deserializerClassName));
         if (schemaProvider == null) {
           throw new HoodieIOException("SchemaProvider has to be set to use custom Deserializer");
         }
-        props.put(DataSourceWriteOptions.SCHEMA_PROVIDER_CLASS_PROP(), schemaProvider.getClass().getName());
-        props.put(NATIVE_KAFKA_VALUE_DESERIALIZER_PROP, Class.forName(deserializerClassName));
+        props.put(DataSourceWriteOptions.KAFKA_AVRO_VALUE_DESERIALIZER_SCHEMA(), schemaProvider.getSourceSchema().toString());
       } catch (ClassNotFoundException e) {
         String error = "Could not load custom avro kafka deserializer: " + deserializerClassName;
         LOG.error(error);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -176,7 +176,9 @@ public class KafkaOffsetGen {
     props.keySet().stream().filter(prop -> {
       // In order to prevent printing unnecessary warn logs, here filter out the hoodie
       // configuration items before passing to kafkaParams
-      return !prop.toString().startsWith("hoodie.");
+      return !prop.toString().startsWith("hoodie.")
+              // We need to pass some properties to kafka client so that KafkaAvroSchemaDeserializer can use it
+              || prop.toString().startsWith("hoodie.deltastreamer.source.kafka.value.deserializer.");
     }).forEach(prop -> {
       kafkaParams.put(prop.toString(), props.get(prop.toString()));
     });


### PR DESCRIPTION
Hi Hudi Team!

## What is the purpose of the pull request
We are using Deltastreamer to ingest events from kafka into an S3 store.
We had some incident this week after some of our producers switched to a new schema version, but some remained on older schem versions.

We stumbled over this PR https://github.com/apache/hudi/pull/2619. With the following settings we can enable the Custom avro kafka deserializer
```
hoodie.deltastreamer.source.kafka.value.deserializer.class=org.apache.hudi.utilities.deser.KafkaAvroSchemaDeserializer
hoodie.deltastreamer.schemaprovider.class=org.apache.hudi.utilities.schema.FilebasedSchemaProvider
```

Doing so we noticed that KafkaAvroSchemaDeserializer tries instanciating the configured SchemaProvider via reflection. It calls the constructor in https://github.com/apache/hudi/blob/cdb9b48170ef98634babd8954392efb1c1b90fcf/hudi-utilities/src/main/java/org/apache/hudi/utilities/deser/KafkaAvroSchemaDeserializer.java#L55 resulting in
```
Caused by: java.lang.NoSuchMethodException: org.apache.hudi.utilities.schema.SchemaProviderWithPostProcessor.<init>(org.apache.hudi.common.config.TypedProperties)
```
There are multiple problems here
* The Class has not the needed constructor
* As we are using FilebasedSchemaProvider it calls the wrong class wrapping the FilebasedSchemaProvider
* The FilebasedSchemaProvider needs the JavaSparkContext to work correctly. I think we dont have access to the JavaSparkContext in KafkaAvroSchemaDeserializer
* In the master branch we don't pass any "hoodie.*" Setting to the Kafka client (change since 0.8.0 in https://github.com/apache/hudi/pull/2754) so either we rename the settings to not start with hoodie or we pass them to Kafka client. In the master branch the feature is currently broken.

## Brief change log

This PR modifies the KafkaAvroSchemaDeserializer, so that it does not rely on Reflection to call the SchemaProvider.
Instead it uses the normal progam flow to ask the SchemaProvider for the sourceSchema.
It then passes the sourceSchema as Property to the KafkaAvroSchemaDeserializer so that it can be used for deserialization.
Also we pass all "hoodie.deltastreamer.source.kafka.value.deserializer.*" properties to the Kafka client

Anyway: I wonder if it is a good idea to make the usage of KafkaAvroSchemaDeserializer the default. IMHO it woud make sense.

## Verify this pull request
You have to enable the feature with
```
hoodie.deltastreamer.source.kafka.value.deserializer.class=org.apache.hudi.utilities.deser.KafkaAvroSchemaDeserializer
```

This pull request is already covered by existing tests, such as TestKafkaAvroSchemaDeserializer

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.