### PR TITLE
[HUDI-2046]Loaded too many classes like sun/reflect/GeneratedSerializationConstructorAccessor in JVM metaspace

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
@@ -73,6 +73,12 @@ public class WriteStatus implements Serializable {
     this.random = new Random(RANDOM_SEED);
   }
 
+  public WriteStatus() {
+    this.failureFraction = 0.0d;
+    this.trackSuccessRecords = false;
+    this.random = null;
+  }
+
   /**
    * Mark write as success, optionally using given parameters for the purpose of calculating some aggregate metrics.
    * This method is not meant to cache passed arguments, since WriteStatus objects are collected in Spark Driver.

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -88,6 +88,9 @@ public class HoodieRecord<T extends HoodieRecordPayload> implements Serializable
     this.sealed = record.sealed;
   }
 
+  public HoodieRecord() {
+  }
+
   public HoodieKey getKey() {
     return key;
   }


### PR DESCRIPTION
**What is the purpose of the pull request**
---
This pull requests will to fix loaded too many classes like sun.reflect.GeneratedSerializationConstructorAccessor in JVM metaspace when use kryo of spark with upsert data to hudi.

**Brief change log**
---
- add zero argument constructor in WriteStatus
- add zero argument constructor in HoodieRecord

JIRA Issue:https://issues.apache.org/jira/browse/HUDI-2046