### PR TITLE
[HUDI-2055] Added metric for time of lastSync

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -289,6 +289,8 @@ public class DeltaSync implements Serializable {
           srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
     }
 
+    metrics.updateDeltaStreamerSyncMetrics(System.currentTimeMillis());
+
     // Clear persistent RDDs
     jssc.getPersistentRDDs().values().forEach(JavaRDD::unpersist);
     return result;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
@@ -95,6 +95,12 @@ public class HoodieDeltaStreamerMetrics implements Serializable {
     }
   }
 
+  public void updateDeltaStreamerSyncMetrics(long syncEpochTimeInMs) {
+    if (config.isMetricsOn()) {
+      Metrics.registerGauge(getMetricsName("deltastreamer", "lastSync"), syncEpochTimeInMs);
+    }
+  }
+
   public long getDurationInMs(long ctxDuration) {
     return ctxDuration / 1000000;
   }


### PR DESCRIPTION
## What is the purpose of the pull request

We monitor our running instances of DeltaStreamer. We currently have the problem that we can't see from our monitoring if the DeltaStreamer is not doing any commits because it has problems or because there are simply no events to consume.

## Brief change log
This PR adds a metric `lastSync` that is similar to `commitTime` but increments after every successful sync and not only a successful commit.

## Verify this pull request

Look for the metric `<topic>_deltastreamer_lastSync`.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.