### PR TITLE
[HUDI-1826] Add ORC support in HoodieSnapshotExporter

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
@@ -85,7 +85,7 @@ public class HoodieSnapshotExporter {
   public static class OutputFormatValidator implements IValueValidator<String> {
 
     public static final String HUDI = "hudi";
-    public static final List<String> FORMATS = CollectionUtils.createImmutableList("json", "parquet", HUDI);
+    public static final List<String> FORMATS = CollectionUtils.createImmutableList("json", "parquet", "orc", HUDI);
 
     @Override
     public void validate(String name, String value) {
@@ -104,7 +104,7 @@ public class HoodieSnapshotExporter {
     @Parameter(names = {"--target-output-path"}, description = "Base path for the target output files (snapshots)", required = true)
     public String targetOutputPath;
 
-    @Parameter(names = {"--output-format"}, description = "Output format for the exported dataset; accept these values: json|parquet|hudi", required = true,
+    @Parameter(names = {"--output-format"}, description = "Output format for the exported dataset; accept these values: json|parquet|orc|hudi", required = true,
         validateValueWith = OutputFormatValidator.class)
     public String outputFormat;
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieSnapshotExporter.java
@@ -19,8 +19,9 @@
 
 package org.apache.hudi.utilities;
 
-import com.beust.jcommander.ParameterException;
 import org.apache.hudi.utilities.HoodieSnapshotExporter.OutputFormatValidator;
+
+import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -53,5 +54,4 @@ public class TestHoodieSnapshotExporter {
       new OutputFormatValidator().validate(null, format);
     });
   }
-
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieSnapshotExporter.java
@@ -20,95 +20,15 @@
 package org.apache.hudi.utilities;
 
 import com.beust.jcommander.ParameterException;
-import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.utilities.HoodieSnapshotExporter.OutputFormatValidator;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_PROP;
-import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.RECORDKEY_FIELD_OPT_KEY;
-import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.PARTITIONPATH_FIELD_OPT_KEY;
-import static org.apache.spark.sql.SaveMode.Append;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestHoodieSnapshotExporter {
-
-  private SparkSession spark;
-  private static final String TABLE_NAME = "users";
-  private static final StructType SCHEMA = DataTypes.createStructType(Arrays.asList(
-          DataTypes.createStructField("id", DataTypes.LongType, false),
-          DataTypes.createStructField("name", DataTypes.StringType, false),
-          DataTypes.createStructField("age", DataTypes.LongType, false)
-  ));
-
-  @TempDir
-  public static Path workDir;
-
-  @BeforeAll
-  static void createHudiDataset() {
-    SparkSession spark = SparkSession
-            .builder()
-            .appName("Hoodie-data-writer")
-            .master("local[*]")
-            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-            .getOrCreate();
-    JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
-
-    List<List<Object>> createData = Arrays.asList(Arrays.asList(1L, "User1", 10L), Arrays.asList(2L, "User2", 20L));
-    List<List<Object>> updateData = Arrays.asList(Arrays.asList(2L, "User2", 30L));
-
-    JavaRDD<Row> createRdd = jsc.parallelize(createData).map((Function<List<Object>, Row>) record -> RowFactory.create(record.get(0), record.get(1), record.get(2)));
-    Dataset<Row> createDf = spark.createDataFrame(createRdd, SCHEMA);
-
-    JavaRDD<Row> updateRdd = jsc.parallelize(updateData).map((Function<List<Object>, Row>) record -> RowFactory.create(record.get(0), record.get(1), record.get(2)));
-    Dataset<Row> updateDf = spark.createDataFrame(updateRdd, SCHEMA);
-    
-    String basePath = workDir.toAbsolutePath() + File.separator + TABLE_NAME;
-
-    Arrays.asList(createDf, updateDf).forEach(df ->
-            df.write()
-            .format("hudi")
-            .option(RECORDKEY_FIELD_OPT_KEY, "id")
-            .option(PARTITIONPATH_FIELD_OPT_KEY, "id")
-            .option(PRECOMBINE_FIELD_PROP, "id")
-            .option(HoodieWriteConfig.INSERT_PARALLELISM, 2)
-            .option(HoodieWriteConfig.UPSERT_PARALLELISM, 2)
-            .option(HoodieWriteConfig.TABLE_NAME, TABLE_NAME)
-            .mode(Append)
-            .save(basePath)
-    );
-  }
-
-  @BeforeEach
-  public void createSparkSession() {
-    spark = SparkSession
-            .builder()
-            .appName("Hoodie-snapshot-exporter")
-            .master("local[*]")
-            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-            .getOrCreate();
-  }
 
   @ParameterizedTest
   @ValueSource(strings = {"json", "parquet", "orc", "hudi"})
@@ -134,39 +54,4 @@ public class TestHoodieSnapshotExporter {
     });
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"json", "parquet", "orc", "hudi"})
-  public void testSnapshotExport(String format) throws IOException {
-    HoodieSnapshotExporter.Config cfg = new HoodieSnapshotExporter.Config();
-    cfg.sourceBasePath = workDir.toAbsolutePath() + File.separator + TABLE_NAME;
-    cfg.targetOutputPath = workDir.toAbsolutePath() + File.separator + format;
-    cfg.outputFormat = format;
-
-    HoodieSnapshotExporter exporter = new HoodieSnapshotExporter();
-    exporter.export(JavaSparkContext.fromSparkContext(spark.sparkContext()), cfg);
-
-    Dataset<Row> readData = spark.read().schema(SCHEMA).format(format).load(cfg.targetOutputPath);
-    assertEquals(2, readData.count());
-
-    List<Row> rows = readData.collectAsList();
-    for (Row row: rows) {
-      Long id = row.getAs("id");
-      String name = row.getAs("name");
-      Long age = row.getAs("age");
-
-      Long expectedAge;
-      String expectedName;
-
-      if (id.equals(1L)) {
-        expectedName = "User1";
-        expectedAge = 10L;
-      } else {
-        expectedName = "User2";
-        expectedAge = 30L;
-      }
-
-      assertEquals(name, expectedName);
-      assertEquals(age, expectedAge);
-    }
-  }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieSnapshotExporter.java
@@ -19,20 +19,99 @@
 
 package org.apache.hudi.utilities;
 
-import org.apache.hudi.utilities.HoodieSnapshotExporter.OutputFormatValidator;
-
 import com.beust.jcommander.ParameterException;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.utilities.HoodieSnapshotExporter.OutputFormatValidator;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_PROP;
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.RECORDKEY_FIELD_OPT_KEY;
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.PARTITIONPATH_FIELD_OPT_KEY;
+import static org.apache.spark.sql.SaveMode.Append;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestHoodieSnapshotExporter {
 
+  private SparkSession spark;
+  private static final String TABLE_NAME = "users";
+  private static final StructType SCHEMA = DataTypes.createStructType(Arrays.asList(
+          DataTypes.createStructField("id", DataTypes.LongType, false),
+          DataTypes.createStructField("name", DataTypes.StringType, false),
+          DataTypes.createStructField("age", DataTypes.LongType, false)
+  ));
+
+  @TempDir
+  public static Path workDir;
+
+  @BeforeAll
+  static void createHudiDataset() {
+    SparkSession spark = SparkSession
+            .builder()
+            .appName("Hoodie-data-writer")
+            .master("local[*]")
+            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+            .getOrCreate();
+    JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
+
+    List<List<Object>> createData = Arrays.asList(Arrays.asList(1L, "User1", 10L), Arrays.asList(2L, "User2", 20L));
+    List<List<Object>> updateData = Arrays.asList(Arrays.asList(2L, "User2", 30L));
+
+    JavaRDD<Row> createRdd = jsc.parallelize(createData).map((Function<List<Object>, Row>) record -> RowFactory.create(record.get(0), record.get(1), record.get(2)));
+    Dataset<Row> createDf = spark.createDataFrame(createRdd, SCHEMA);
+
+    JavaRDD<Row> updateRdd = jsc.parallelize(updateData).map((Function<List<Object>, Row>) record -> RowFactory.create(record.get(0), record.get(1), record.get(2)));
+    Dataset<Row> updateDf = spark.createDataFrame(updateRdd, SCHEMA);
+    
+    String basePath = workDir.toAbsolutePath() + File.separator + TABLE_NAME;
+
+    Arrays.asList(createDf, updateDf).forEach(df ->
+            df.write()
+            .format("hudi")
+            .option(RECORDKEY_FIELD_OPT_KEY, "id")
+            .option(PARTITIONPATH_FIELD_OPT_KEY, "id")
+            .option(PRECOMBINE_FIELD_PROP, "id")
+            .option(HoodieWriteConfig.INSERT_PARALLELISM, 2)
+            .option(HoodieWriteConfig.UPSERT_PARALLELISM, 2)
+            .option(HoodieWriteConfig.TABLE_NAME, TABLE_NAME)
+            .mode(Append)
+            .save(basePath)
+    );
+  }
+
+  @BeforeEach
+  public void createSparkSession() {
+    spark = SparkSession
+            .builder()
+            .appName("Hoodie-snapshot-exporter")
+            .master("local[*]")
+            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+            .getOrCreate();
+  }
+
   @ParameterizedTest
-  @ValueSource(strings = {"json", "parquet", "hudi"})
+  @ValueSource(strings = {"json", "parquet", "orc", "hudi"})
   public void testValidateOutputFormatWithValidFormat(String format) {
     assertDoesNotThrow(() -> {
       new OutputFormatValidator().validate(null, format);
@@ -53,5 +132,41 @@ public class TestHoodieSnapshotExporter {
     assertThrows(ParameterException.class, () -> {
       new OutputFormatValidator().validate(null, format);
     });
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"json", "parquet", "orc", "hudi"})
+  public void testSnapshotExport(String format) throws IOException {
+    HoodieSnapshotExporter.Config cfg = new HoodieSnapshotExporter.Config();
+    cfg.sourceBasePath = workDir.toAbsolutePath() + File.separator + TABLE_NAME;
+    cfg.targetOutputPath = workDir.toAbsolutePath() + File.separator + format;
+    cfg.outputFormat = format;
+
+    HoodieSnapshotExporter exporter = new HoodieSnapshotExporter();
+    exporter.export(JavaSparkContext.fromSparkContext(spark.sparkContext()), cfg);
+
+    Dataset<Row> readData = spark.read().schema(SCHEMA).format(format).load(cfg.targetOutputPath);
+    assertEquals(2, readData.count());
+
+    List<Row> rows = readData.collectAsList();
+    for (Row row: rows) {
+      Long id = row.getAs("id");
+      String name = row.getAs("name");
+      Long age = row.getAs("age");
+
+      Long expectedAge;
+      String expectedName;
+
+      if (id.equals(1L)) {
+        expectedName = "User1";
+        expectedAge = 10L;
+      } else {
+        expectedName = "User2";
+        expectedAge = 30L;
+      }
+
+      assertEquals(name, expectedName);
+      assertEquals(age, expectedAge);
+    }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
@@ -213,7 +213,7 @@ public class TestHoodieSnapshotExporter extends FunctionalTestHarness {
   public class TestHoodieSnapshotExporterForNonHudi {
 
     @ParameterizedTest
-    @ValueSource(strings = {"json", "parquet"})
+    @ValueSource(strings = {"json", "parquet", "orc"})
     public void testExportAsNonHudi(String format) throws IOException {
       HoodieSnapshotExporter.Config cfg = new Config();
       cfg.sourceBasePath = sourcePath;


### PR DESCRIPTION
## What is the purpose of the pull request

Add support to export Hudi table as ORC

## Brief change log

Since ORC format is supported by Spark natively, essentially no change is needed in the code besides adding ORC as one of the supported formats in the list of formats within HoodieSnapshotExporter.

## Verify this pull request


This pull request is already covered by existing tests.
- Added ORC as one of the formats in TestHoodieSnapshotExporter


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.