### PR TITLE
[HUDI-2062] Catch FileNotFoundException in WriteProfiles #getCommitMetadataSafely

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
@@ -150,14 +150,17 @@ public class WriteProfiles {
       Path basePath,
       HoodieInstant instant,
       HoodieTimeline timeline) {
-    byte[] data = timeline.getInstantDetails(instant).get();
     try {
+      byte[] data = timeline.getInstantDetails(instant).get();
       return Option.of(HoodieCommitMetadata.fromBytes(data, HoodieCommitMetadata.class));
-    } catch (IOException e) {
+    } catch (FileNotFoundException fe) {
       // make this fail safe.
+      LOG.warn("Instant {} was deleted by the cleaner, ignore", instant.getTimestamp());
+      return Option.empty();
+    } catch (IOException e) {
       LOG.error("Get write metadata for table {} with instant {} and path: {} error",
           tableName, instant.getTimestamp(), basePath);
-      return Option.empty();
+      throw new HoodieException(e);
     }
   }
 


### PR DESCRIPTION
Catch FileNotFoundException in WriteProfiles #getCommitMetadataSafely

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.