### PR TITLE
[HUDI-2068] Skip the assign state for SmallFileAssign when the state …

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssigner.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssigner.java
@@ -228,7 +228,7 @@ public class BucketAssigner implements AutoCloseable {
         return false;
       }
       SmallFileAssignState state = states[assignIdx];
-      if (!state.canAssign()) {
+      while (!state.canAssign()) {
         assignIdx += 1;
         if (assignIdx >= states.length) {
           noSpace = true;
@@ -236,7 +236,6 @@ public class BucketAssigner implements AutoCloseable {
         }
         // move to next slot if possible
         state = states[assignIdx];
-        assert state.canAssign();
       }
       state.assign();
       return true;


### PR DESCRIPTION
…can not assign initially

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.