### PR TITLE
[HUDI-2073] Fix the bug of hoodieClusteringJob never quit

### DIFF
--- a/hudi-cli/conf/hudi-env.sh
+++ b/hudi-cli/conf/hudi-env.sh
@@ -20,4 +20,3 @@
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"/etc/hadoop/conf"}
 export SPARK_CONF_DIR=${SPARK_CONF_DIR:-"/etc/spark/conf"}
 export CLIENT_JAR=${CLIENT_JAR}
-export SPARK_MASTER=local[*]

--- a/hudi-cli/conf/hudi-env.sh
+++ b/hudi-cli/conf/hudi-env.sh
@@ -20,3 +20,4 @@
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"/etc/hadoop/conf"}
 export SPARK_CONF_DIR=${SPARK_CONF_DIR:-"/etc/spark/conf"}
 export CLIENT_JAR=${CLIENT_JAR}
+export SPARK_MASTER=local[*]

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -149,11 +149,11 @@ public class HoodieClusteringJob {
 
   private int doCluster(JavaSparkContext jsc) throws Exception {
     String schemaStr = getSchemaFromLatestInstant();
-    SparkRDDWriteClient<HoodieRecordPayload> client =
-        UtilHelpers.createHoodieClient(jsc, cfg.basePath, schemaStr, cfg.parallelism, Option.empty(), props);
-    JavaRDD<WriteStatus> writeResponse =
-        client.cluster(cfg.clusteringInstantTime, true).getWriteStatuses();
-    return UtilHelpers.handleErrors(jsc, cfg.clusteringInstantTime, writeResponse);
+    try (SparkRDDWriteClient<HoodieRecordPayload> client = UtilHelpers.createHoodieClient(jsc, cfg.basePath, schemaStr, cfg.parallelism, Option.empty(), props)) {
+      JavaRDD<WriteStatus> writeResponse =
+              client.cluster(cfg.clusteringInstantTime, true).getWriteStatuses();
+      return UtilHelpers.handleErrors(jsc, cfg.clusteringInstantTime, writeResponse);
+    }
   }
 
   @TestOnly
@@ -163,12 +163,12 @@ public class HoodieClusteringJob {
 
   private Option<String> doSchedule(JavaSparkContext jsc) throws Exception {
     String schemaStr = getSchemaFromLatestInstant();
-    SparkRDDWriteClient<HoodieRecordPayload> client =
-        UtilHelpers.createHoodieClient(jsc, cfg.basePath, schemaStr, cfg.parallelism, Option.empty(), props);
-    if (cfg.clusteringInstantTime != null) {
-      client.scheduleClusteringAtInstant(cfg.clusteringInstantTime, Option.empty());
-      return Option.of(cfg.clusteringInstantTime);
+    try (SparkRDDWriteClient<HoodieRecordPayload> client = UtilHelpers.createHoodieClient(jsc, cfg.basePath, schemaStr, cfg.parallelism, Option.empty(), props)) {
+      if (cfg.clusteringInstantTime != null) {
+        client.scheduleClusteringAtInstant(cfg.clusteringInstantTime, Option.empty());
+        return Option.of(cfg.clusteringInstantTime);
+      }
+      return client.scheduleClustering(Option.empty());
     }
-    return client.scheduleClustering(Option.empty());
   }
 }


### PR DESCRIPTION
Fix https://issues.apache.org/jira/browse/HUDI-2073
## What is the purpose of the pull request

Users can launch HoodieClusteringJob through sparkSubmit to 

1. Scheduling clustering
2. Execute clustering

But these spark jobs will never finished and SparkSubmit never quit even jobs are finished or failed.

This is because clustering job will init a SparkRDDWriteClient to doSchedule or do cluster But did not close this client after that. It will cause that `jsc.stop();` can't kill this sparkJob and hang forever.

This PR is trying to fix this bug.
## Brief change log
add a try(client) {xxxx} to make sure that this client will be closed no matter this job is successful or failed after used.
Also this pr is tested on my local env and works fine.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.