### PR TITLE
[HUDI-1975] Exclude metrics-core 3.1.2 from Dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,12 @@
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_dropwizard</artifactId>
         <version>${prometheus.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.prometheus</groupId>


### PR DESCRIPTION
## What is the purpose of the pull request

- Multiple versions of metrics core are present in the build which could have caused https://github.com/apache/hudi/issues/2774

- This change is to exclude metrics core 3.1.2 dependency brought in by Prometheus and use the updated version

## Brief change log

 Exclude metrics-core 3.1.2 from `simpleclient_dropwizard`

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.