### PR TITLE
[HUDI-1944] Support Hudi to read from committed offset

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -227,7 +227,7 @@ public class KafkaOffsetGen {
             fromOffsets = getGroupOffsets(consumer, topicPartitions);
             break;
           default:
-            throw new HoodieNotSupportedException("Auto reset value must be one of 'earliest' or 'latest' or 'none' ");
+            throw new HoodieNotSupportedException("Auto reset value must be one of 'earliest' or 'latest' or 'group' ");
         }
       }
 
@@ -340,7 +340,7 @@ public class KafkaOffsetGen {
       if (committedOffsetAndMetadata != null) {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
-        LOG.warn("There are no commits associated with this consumer group, starting to consume form latest offset");
+        LOG.warn("There are no commits associated with this consumer group, starting to consume from latest offset");
         fromOffsets = consumer.endOffsets(topicPartitions);
         break;
       }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -136,7 +136,7 @@ public class TestKafkaOffsetGen {
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
     testUtils.createTopic(TEST_TOPIC_NAME, 2);
     testUtils.sendMessages(TEST_TOPIC_NAME, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
-    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("none"));
+    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("group"));
     String lastCheckpointString = TEST_TOPIC_NAME + ",0:250,1:249";
     kafkaOffsetGen.commitOffsetToKafka(lastCheckpointString);
     // don't pass lastCheckpointString as we want to read from group committed offset
@@ -147,7 +147,7 @@ public class TestKafkaOffsetGen {
     assertEquals(399, nextOffsetRanges[1].untilOffset());
 
     // committed offsets are not present for the consumer group
-    kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("none"));
+    kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("group"));
     nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
     assertEquals(500, nextOffsetRanges[0].fromOffset());
     assertEquals(500, nextOffsetRanges[0].untilOffset());


### PR DESCRIPTION
## What is the purpose of the pull request

This is a followup to - https://github.com/apache/hudi/pull/3092, this change adds support to read from committed offset

## Brief change log

- Update `KafkaOffsetGen` to read from consumer group committed offset
- Added `NONE` to `KafkaResetOffsetStrategies` 

## Verify this pull request

This change added tests and can be verified as follows:

  - Added unit test `testGetNextOffsetRangesFromGroup` in `TestKafkaOffsetGen`

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.