### PR TITLE
[HUDI-2090] When hudi metadata is enabled, use different users to quer…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
@@ -80,6 +80,13 @@ public final class BitCaskDiskMap<T extends Serializable, R extends Serializable
 
   public BitCaskDiskMap(String baseFilePath) throws IOException {
     this.valueMetadataMap = new ConcurrentHashMap<>();
+    // create uudi prefix for baseFilePath
+    if (baseFilePath.equals("/tmp/view_map")) {
+      this.writeOnlyFile = new File(baseFilePath + UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    } else {
+      // this baseFilePath is manually specified by user, we should not change it
+      this.writeOnlyFile = new File(baseFilePath, UUID.randomUUID().toString());
+    }
     this.writeOnlyFile = new File(baseFilePath, UUID.randomUUID().toString());
     this.filePath = writeOnlyFile.getPath();
     initFile(writeOnlyFile);


### PR DESCRIPTION
…y table, the query will failed

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

when hudi metadata is enabled, use different user to query table, the query will failed.

The user permissions of the temporary directory(default value is /tmp/view_map) generated by DiskBasedMap are incorrect. This directory only has permissions for the user who execute query  firstly, and other users have no permissions to access it , which leads to this problem

test step：

step1: create hudi table with metadata enabled.
step2： create two users（omm，user2） to query the table which created by step1
step3： 
1）using omm user to  query hudi table
DiskBasedMap will generate view_map with permissions drwx------.
2）using user2 user to query hudi table
now user2 has no right to access view_map which created by omm,   the exception will throws:
     **org.apache.hudi.exception.HoodieIOException: IOException when creating ExternalSplillableMap at /tmp/view_map**

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request


Manually verified the change

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.