### PR TITLE
[HUDI-2099] Hive lock which state is WATING should be released, otherw…

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveMetastoreBasedLockProvider.java
@@ -192,6 +192,11 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
           throw e;
         }
       }
+    } finally {
+      // it is better to release WAITING lock, otherwise hive lock will hang forever
+      if (this.lock != null && this.lock.getState() != LockState.ACQUIRED) {
+        hiveClient.unlock(this.lock.getLockid());
+      }
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/functional/TestHiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/functional/TestHiveMetastoreBasedLockProvider.java
@@ -128,6 +128,35 @@ public class TestHiveMetastoreBasedLockProvider extends HiveSyncFunctionalTestHa
   }
 
   @Test
+  public void testWaitingLock() throws Exception {
+    // create different HiveMetastoreBasedLockProvider to simulate different applications
+    HiveMetastoreBasedLockProvider lockProvider1 = new HiveMetastoreBasedLockProvider(lockConfiguration, hiveConf());
+    HiveMetastoreBasedLockProvider lockProvider2 = new HiveMetastoreBasedLockProvider(lockConfiguration, hiveConf());
+    lockComponent.setOperationType(DataOperationType.NO_TXN);
+    Assertions.assertTrue(lockProvider1.acquireLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP), TimeUnit.MILLISECONDS, lockComponent));
+    try {
+      boolean acquireStatus = lockProvider2.acquireLock(lockConfiguration.getConfig()
+          .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP), TimeUnit.MILLISECONDS, lockComponent);
+      Assertions.assertFalse(acquireStatus);
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    lockProvider1.unlock();
+    // create the third HiveMetastoreBasedLockProvider to acquire lock
+    HiveMetastoreBasedLockProvider lockProvider3 = new HiveMetastoreBasedLockProvider(lockConfiguration, hiveConf());
+    boolean acquireStatus = lockProvider3.acquireLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP), TimeUnit.MILLISECONDS, lockComponent);
+    // we should acquired lock, since lockProvider1 has already released lock
+    Assertions.assertTrue(acquireStatus);
+    lockProvider3.unlock();
+    // close all HiveMetastoreBasedLockProvider
+    lockProvider1.close();
+    lockProvider2.close();
+    lockProvider3.close();
+  }
+
+  @Test
   public void testUnlockWithoutLock() {
     HiveMetastoreBasedLockProvider lockProvider = new HiveMetastoreBasedLockProvider(lockConfiguration, hiveConf());
     lockComponent.setOperationType(DataOperationType.NO_TXN);


### PR DESCRIPTION
…ise this hive lock will be locked forever

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request


when we acquire hive lock failed and the lock state is WATING， we should release this WATING lock； otherwise this hive lock will be locked forever。

test step：

use hive lock to control concurrent write for hudi， let‘s call this lock hive_lock

start three writers to write hudi table by using hive_lock concurrently， one of the writer will failed to acquire hive lock due to competition issues。

**Exception in thread "main" org.apache.hudi.exception.HoodieLockException: Unable to acquire lock, lock object LockResponse(lockid:76, state:WAITING)**

 

start another writer to write hudi table by using same hive_lock， then we find hive_lock is locked forever, we have no way to acquire it

**Exception in thread "main" org.apache.hudi.exception.HoodieLockException: Unable to acquire lock, lock object LockResponse(lockid:87, state:WAITING)**

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

new UT added。

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.