### PR TITLE
[HUDI-2113] Fix integration testing failure caused by sql results out…

### DIFF
--- a/docker/demo/hive-batch1.commands
+++ b/docker/demo/hive-batch1.commands
@@ -21,16 +21,16 @@ select symbol, max(ts) from stock_ticks_cow group by symbol HAVING symbol = 'GOO
 select symbol, max(ts) from stock_ticks_mor_ro group by symbol HAVING symbol = 'GOOG';
 select symbol, max(ts) from stock_ticks_mor_rt group by symbol HAVING symbol = 'GOOG';
 
-select symbol, ts, volume, open, close  from stock_ticks_cow where  symbol = 'GOOG';
-select symbol, ts, volume, open, close  from stock_ticks_mor_ro where  symbol = 'GOOG';
-select symbol, ts, volume, open, close  from stock_ticks_mor_rt where  symbol = 'GOOG';
+select symbol, ts, volume, open, close  from stock_ticks_cow where  symbol = 'GOOG' order by ts;
+select symbol, ts, volume, open, close  from stock_ticks_mor_ro where  symbol = 'GOOG' order by ts;
+select symbol, ts, volume, open, close  from stock_ticks_mor_rt where  symbol = 'GOOG' order by ts;
 
 select symbol, max(ts) from stock_ticks_cow_bs group by symbol HAVING symbol = 'GOOG';
 select symbol, max(ts) from stock_ticks_mor_bs_ro group by symbol HAVING symbol = 'GOOG';
 select symbol, max(ts) from stock_ticks_mor_bs_rt group by symbol HAVING symbol = 'GOOG';
 
-select symbol, ts, volume, open, close  from stock_ticks_cow_bs where  symbol = 'GOOG';
-select symbol, ts, volume, open, close  from stock_ticks_mor_bs_ro where  symbol = 'GOOG';
-select symbol, ts, volume, open, close  from stock_ticks_mor_bs_rt where  symbol = 'GOOG';
+select symbol, ts, volume, open, close  from stock_ticks_cow_bs where  symbol = 'GOOG' order by ts;
+select symbol, ts, volume, open, close  from stock_ticks_mor_bs_ro where  symbol = 'GOOG' order by ts;
+select symbol, ts, volume, open, close  from stock_ticks_mor_bs_rt where  symbol = 'GOOG' order by ts;
 
 !quit

--- a/docker/demo/hive-batch2-after-compaction.commands
+++ b/docker/demo/hive-batch2-after-compaction.commands
@@ -20,13 +20,13 @@ add jar ${hudi.hadoop.bundle};
 select symbol, max(ts) from stock_ticks_mor_ro group by symbol HAVING symbol = 'GOOG';
 select symbol, max(ts) from stock_ticks_mor_rt group by symbol HAVING symbol = 'GOOG';
 
-select symbol, ts, volume, open, close  from stock_ticks_mor_ro where  symbol = 'GOOG';
-select symbol, ts, volume, open, close  from stock_ticks_mor_rt where  symbol = 'GOOG';
+select symbol, ts, volume, open, close  from stock_ticks_mor_ro where  symbol = 'GOOG' order by ts;
+select symbol, ts, volume, open, close  from stock_ticks_mor_rt where  symbol = 'GOOG' order by ts;
 
 select symbol, max(ts) from stock_ticks_mor_bs_ro group by symbol HAVING symbol = 'GOOG';
 select symbol, max(ts) from stock_ticks_mor_bs_rt group by symbol HAVING symbol = 'GOOG';
 
-select symbol, ts, volume, open, close  from stock_ticks_mor_bs_ro where  symbol = 'GOOG';
-select symbol, ts, volume, open, close  from stock_ticks_mor_bs_rt where  symbol = 'GOOG';
+select symbol, ts, volume, open, close  from stock_ticks_mor_bs_ro where  symbol = 'GOOG' order by ts;
+select symbol, ts, volume, open, close  from stock_ticks_mor_bs_rt where  symbol = 'GOOG' order by ts;
 
 !quit

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -88,6 +89,17 @@ public class ITTestHoodieDemo extends ITTestBase {
           + " --hoodie-conf hoodie.datasource.hive_sync.partition_fields=%s "
           + " --hoodie-conf hoodie.datasource.hive_sync.database=default "
           + " --hoodie-conf hoodie.datasource.hive_sync.table=%s";
+
+
+  @AfterEach
+  public void clean() throws Exception {
+    String hdfsCmd = "hdfs dfs -rm -R ";
+    List<String> tablePaths = CollectionUtils.createImmutableList(
+        COW_BASE_PATH, MOR_BASE_PATH, COW_BOOTSTRAPPED_BASE_PATH, MOR_BOOTSTRAPPED_BASE_PATH);
+    for (String tablePath : tablePaths) {
+      executeCommandStringInDocker(ADHOC_1_CONTAINER, hdfsCmd + tablePath, true);
+    }
+  }
 
   @Test
   public void testParquetDemo() throws Exception {


### PR DESCRIPTION
## What is the purpose of the pull request

Improve the stability of the integration testing, and make it friendly to debug for developers

## Brief change log

  - Fix the failure caused by hive sql returned results out of order
  - Clean the HDFS directory of the test table after each test, instead of recreating the docker to prevent the running exception caused by table already exists when debug.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is already covered by existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.