### PR TITLE
[HUDI-2115] FileSlices in the filegroup is not descending by timestamp

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -21,13 +21,11 @@ package org.apache.hudi.common.model;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -62,9 +60,7 @@ public class HoodieFileGroup implements Serializable {
   public HoodieFileGroup(HoodieFileGroup fileGroup) {
     this.timeline = fileGroup.timeline;
     this.fileGroupId = fileGroup.fileGroupId;
-    this.fileSlices = new TreeMap<>(fileGroup.fileSlices.entrySet().stream()
-        .map(e -> Pair.of(e.getKey(), new FileSlice(e.getValue())))
-        .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
+    this.fileSlices = new TreeMap<>(fileGroup.fileSlices);
     this.lastInstant = fileGroup.lastInstant;
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.testutils.MockHoodieTimeline;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieFileGroup {
+
+  @Test
+  public void testCommittedFileSlices() {
+    // "000" is archived
+    Stream<String> completed = Arrays.asList("001").stream();
+    Stream<String> inflight = Arrays.asList("002").stream();
+    MockHoodieTimeline activeTimeline = new MockHoodieTimeline(completed, inflight);
+    HoodieFileGroup fileGroup = new HoodieFileGroup("", "data",
+        activeTimeline.getCommitsTimeline().filterCompletedInstants());
+    for (int i = 0; i < 3; i++) {
+      HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i);
+      fileGroup.addBaseFile(baseFile);
+    }
+    assertEquals(2, fileGroup.getAllFileSlices().count());
+    assertTrue(!fileGroup.getAllFileSlices().anyMatch(s -> s.getBaseInstantTime().equals("002")));
+    assertEquals(3, fileGroup.getAllFileSlicesIncludingInflight().count());
+    assertTrue(fileGroup.getLatestFileSlice().get().getBaseInstantTime().equals("001"));
+    assertTrue((new HoodieFileGroup(fileGroup)).getLatestFileSlice().get().getBaseInstantTime().equals("001"));
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Fix the bug that fileslices in the filegroup is not descending by timestamp when using one of the constructors

## Brief change log

- small bug fix

## Verify this pull request

This pull request is already covered by existing tests

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.