### PR TITLE
[HUDI-2140] Fixed the unit test TestHoodieBackedMetadata.testOnlyValidPartitionsAdded.

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedMetadata.java
@@ -204,8 +204,7 @@ public class TestHoodieBackedMetadata extends HoodieClientTestHarness {
     HoodieTestTable testTable = HoodieTestTable.of(metaClient);
     testTable.withPartitionMetaFiles("p1", "p2", filteredDirectoryOne, filteredDirectoryTwo, filteredDirectoryThree)
         .addCommit("001").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10, 10)
-        .addCommit("002").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10, 10, 10)
-        .addInflightCommit("003").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10);
+        .addCommit("002").withBaseFilesInPartition("p1", 10).withBaseFilesInPartition("p2", 10, 10, 10);
 
     final HoodieWriteConfig writeConfig =
             getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.NEVER, true, true, false)


### PR DESCRIPTION

HUDI-2016 introduced a change which does not bootstrap Metadata Table if any non-complete commit is present. Hence, this unit tests needs to be fixed to remove the inflight commit.

## What is the purpose of the pull request

Fix a broken unit test

## Brief change log

Fixed the unit test by removing the inflight commit.

## Verify this pull request

This change added tests and can be verified as follows:

Unit Test passes

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.