### PR TITLE
[HUDI-2143] Tweak the default compaction target IO to 500GB when flin…

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -146,8 +146,8 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
     conf.setString(FlinkOptions.TABLE_NAME.key(), tableName);
     // hoodie key about options
     setupHoodieKeyOptions(conf, table);
-    // cleaning options
-    setupCleaningOptions(conf);
+    // compaction options
+    setupCompactionOptions(conf);
     // infer avro schema from physical DDL schema
     inferAvroSchema(conf, schema.toRowDataType().notNull().getLogicalType());
   }
@@ -186,9 +186,9 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   }
 
   /**
-   * Sets up the cleaning options from the table definition.
+   * Sets up the compaction options from the table definition.
    */
-  private static void setupCleaningOptions(Configuration conf) {
+  private static void setupCompactionOptions(Configuration conf) {
     int commitsToRetain = conf.getInteger(FlinkOptions.CLEAN_RETAIN_COMMITS);
     int minCommitsToKeep = conf.getInteger(FlinkOptions.ARCHIVE_MIN_COMMITS);
     if (commitsToRetain >= minCommitsToKeep) {
@@ -198,6 +198,12 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
           FlinkOptions.CLEAN_RETAIN_COMMITS.key(), commitsToRetain);
       conf.setInteger(FlinkOptions.ARCHIVE_MIN_COMMITS, commitsToRetain + 10);
       conf.setInteger(FlinkOptions.ARCHIVE_MAX_COMMITS, commitsToRetain + 20);
+    }
+    if (conf.getBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED)
+        && !conf.getBoolean(FlinkOptions.COMPACTION_ASYNC_ENABLED)
+        && FlinkOptions.isDefaultValueDefined(conf, FlinkOptions.COMPACTION_TARGET_IO)) {
+      // if compaction schedule is on, tweak the target io to 500GB
+      conf.setLong(FlinkOptions.COMPACTION_TARGET_IO, 500 * 1024L);
     }
   }
 


### PR DESCRIPTION
…k async compaction is off

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.