### PR TITLE
[HUDI-2144]Bug-Fix:Offline clustering(HoodieClusteringJob) will cause insert action losing data

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
@@ -146,7 +146,7 @@ public class UpsertPartitioner<T extends HoodieRecordPayload<T>> extends Partiti
    * @return smallFiles not in clustering
    */
   private List<SmallFile> filterSmallFilesInClustering(final Set<String> pendingClusteringFileGroupsId, final List<SmallFile> smallFiles) {
-    if (this.config.isClusteringEnabled() || !pendingClusteringFileGroupsId.isEmpty()) {
+    if (!pendingClusteringFileGroupsId.isEmpty()) {
       return smallFiles.stream()
           .filter(smallFile -> !pendingClusteringFileGroupsId.contains(smallFile.location.getFileId())).collect(Collectors.toList());
     } else {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
@@ -146,7 +146,7 @@ public class UpsertPartitioner<T extends HoodieRecordPayload<T>> extends Partiti
    * @return smallFiles not in clustering
    */
   private List<SmallFile> filterSmallFilesInClustering(final Set<String> pendingClusteringFileGroupsId, final List<SmallFile> smallFiles) {
-    if (this.config.isClusteringEnabled()) {
+    if (this.config.isClusteringEnabled() || !pendingClusteringFileGroupsId.isEmpty()) {
       return smallFiles.stream()
           .filter(smallFile -> !pendingClusteringFileGroupsId.contains(smallFile.location.getFileId())).collect(Collectors.toList());
     } else {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -18,18 +18,23 @@
 
 package org.apache.hudi.table.action.commit;
 
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.ClusteringTestUtils;
 import org.apache.hudi.common.testutils.CompactionTestUtils;
 import org.apache.hudi.common.testutils.FileCreateUtils;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieHBaseIndexConfig;
@@ -348,6 +353,44 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
             "Bucket 0 is UPDATE");
     assertEquals("2", partitioner.getBucketInfo(0).fileIdPrefix,
             "Should be assigned to only file id not pending compaction which is 2");
+  }
+
+  @Test
+  public void testUpsertPartitionerWithSmallFileHandlingAndClusteringPlan() throws Exception {
+    final String testPartitionPath = DEFAULT_PARTITION_PATHS[0];
+
+    // create HoodieWriteConfig and set inline and async clustering disable here.
+    HoodieWriteConfig config = makeHoodieClientConfigBuilder()
+            .withCompactionConfig(HoodieCompactionConfig.newBuilder().build())
+            .withClusteringConfig(HoodieClusteringConfig.newBuilder().withInlineClustering(false).withAsyncClustering(false).build())
+            .withStorageConfig(HoodieStorageConfig.newBuilder().hfileMaxFileSize(1000 * 1024).parquetMaxFileSize(1000 * 1024).build())
+            .build();
+
+    // create file slice with instantTime 001 and build clustering plan including this created 001 file slice.
+    HoodieClusteringPlan clusteringPlan = ClusteringTestUtils.createClusteringPlan(metaClient, "001", "1");
+    // create requested replace commit
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
+            .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
+    FileCreateUtils.createRequestedReplaceCommit(basePath,"002", Option.of(requestedReplaceMetadata));
+
+    // create file slice 003
+    FileCreateUtils.createBaseFile(basePath, testPartitionPath, "002", "2", 1);
+    FileCreateUtils.createCommit(basePath, "002");
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+
+    // generate new data to be ingested
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {testPartitionPath});
+    List<HoodieRecord> insertRecords = dataGenerator.generateInserts("003", 100);
+    WorkloadProfile profile = new WorkloadProfile(buildProfile(jsc.parallelize(insertRecords)));
+
+    HoodieSparkTable table = HoodieSparkTable.create(config, context, metaClient);
+    // create UpsertPartitioner
+    UpsertPartitioner partitioner = new UpsertPartitioner(profile, context, table, config);
+
+    // for now we have file slice1 and file slice2 and file slice1 is contained in pending clustering plan
+    // So that only file slice2 can be used for ingestion.
+    assertEquals(1, partitioner.smallFiles.size(), "Should have 1 small file to be ingested.");
   }
 
   @Test

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -36,8 +36,8 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
-import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieHBaseIndexConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
@@ -373,7 +373,7 @@ public class TestUpsertPartitioner extends HoodieClientTestBase {
             .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
     FileCreateUtils.createRequestedReplaceCommit(basePath,"002", Option.of(requestedReplaceMetadata));
 
-    // create file slice 003
+    // create file slice 002
     FileCreateUtils.createBaseFile(basePath, testPartitionPath, "002", "2", 1);
     FileCreateUtils.createCommit(basePath, "002");
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/ClusteringTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/ClusteringTestUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hudi.common.testutils;
+
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ClusteringUtils;
+import org.apache.hudi.exception.HoodieException;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.hudi.common.testutils.FileCreateUtils.baseFileName;
+import static org.apache.hudi.common.testutils.FileCreateUtils.createBaseFile;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.DEFAULT_PARTITION_PATHS;
+
+public class ClusteringTestUtils {
+
+    public static HoodieClusteringPlan createClusteringPlan(HoodieTableMetaClient metaClient, String instantTime, String fileId) {
+        try {
+            final String basePath = metaClient.getBasePath();
+            final String partition = DEFAULT_PARTITION_PATHS[0];
+            createBaseFile(basePath, partition, instantTime, fileId);
+            FileSlice slice = new FileSlice(partition, instantTime, fileId);
+            slice.setBaseFile(new CompactionTestUtils.DummyHoodieBaseFile(Paths.get(basePath, partition,
+                    baseFileName(instantTime, fileId)).toString()));
+            List<FileSlice>[] fileSliceGroups = new List[] {Collections.singletonList(slice)};
+            HoodieClusteringPlan clusteringPlan = ClusteringUtils.createClusteringPlan("strategy", new HashMap<>(),
+                    fileSliceGroups, Collections.emptyMap());
+            return clusteringPlan;
+        } catch (Exception e) {
+            throw new HoodieException(e.getMessage(), e);
+        }
+    }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/ClusteringTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/ClusteringTestUtils.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
@@ -34,20 +35,20 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.DEFAULT_PARTITION
 
 public class ClusteringTestUtils {
 
-    public static HoodieClusteringPlan createClusteringPlan(HoodieTableMetaClient metaClient, String instantTime, String fileId) {
-        try {
-            final String basePath = metaClient.getBasePath();
-            final String partition = DEFAULT_PARTITION_PATHS[0];
-            createBaseFile(basePath, partition, instantTime, fileId);
-            FileSlice slice = new FileSlice(partition, instantTime, fileId);
-            slice.setBaseFile(new CompactionTestUtils.DummyHoodieBaseFile(Paths.get(basePath, partition,
-                    baseFileName(instantTime, fileId)).toString()));
-            List<FileSlice>[] fileSliceGroups = new List[] {Collections.singletonList(slice)};
-            HoodieClusteringPlan clusteringPlan = ClusteringUtils.createClusteringPlan("strategy", new HashMap<>(),
-                    fileSliceGroups, Collections.emptyMap());
-            return clusteringPlan;
-        } catch (Exception e) {
-            throw new HoodieException(e.getMessage(), e);
-        }
+  public static HoodieClusteringPlan createClusteringPlan(HoodieTableMetaClient metaClient, String instantTime, String fileId) {
+    try {
+      String basePath = metaClient.getBasePath();
+      String partition = DEFAULT_PARTITION_PATHS[0];
+      createBaseFile(basePath, partition, instantTime, fileId, 1);
+      FileSlice slice = new FileSlice(partition, instantTime, fileId);
+      slice.setBaseFile(new CompactionTestUtils.DummyHoodieBaseFile(Paths.get(basePath, partition,
+              baseFileName(instantTime, fileId)).toString()));
+      List<FileSlice>[] fileSliceGroups = new List[] {Collections.singletonList(slice)};
+      HoodieClusteringPlan clusteringPlan = ClusteringUtils.createClusteringPlan("strategy", new HashMap<>(),
+              fileSliceGroups, Collections.emptyMap());
+      return clusteringPlan;
+    } catch (Exception e) {
+      throw new HoodieException(e.getMessage(), e);
     }
+  }
 }


### PR DESCRIPTION
## What is the purpose of the pull request
Please read https://issues.apache.org/jira/projects/HUDI/issues/HUDI-2144 for details

## Brief change log
Modify UpsertPartitioner.java
![image](https://user-images.githubusercontent.com/69956021/124869844-60900e80-dff4-11eb-8543-f3d172080b72.png)


## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.