### PR TITLE
[MINOR] Fix EXTERNAL_RECORD_AND_SCHEMA_TRANSFORMATION config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -339,8 +339,9 @@ public class HoodieWriteConfig extends HoodieConfig {
       .withDocumentation("");
 
   public static final ConfigProperty<String> EXTERNAL_RECORD_AND_SCHEMA_TRANSFORMATION = ConfigProperty
-      .key(AVRO_SCHEMA + ".externalTransformation")
+      .key(AVRO_SCHEMA.key() + ".external.transformation")
       .defaultValue("false")
+      .withAlternatives(AVRO_SCHEMA.key() + ".externalTransformation")
       .withDocumentation("");
 
   private ConsistencyGuardConfig consistencyGuardConfig;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -23,6 +23,8 @@ import org.apache.hudi.config.HoodieWriteConfig.Builder;
 
 import org.apache.hudi.index.HoodieIndex;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,16 +35,23 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieWriteConfig {
 
-  @Test
-  public void testPropertyLoading() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testPropertyLoading(boolean withAlternative) throws IOException {
     Builder builder = HoodieWriteConfig.newBuilder().withPath("/tmp");
     Map<String, String> params = new HashMap<>(3);
     params.put(HoodieCompactionConfig.CLEANER_COMMITS_RETAINED_PROP.key(), "1");
     params.put(HoodieCompactionConfig.MAX_COMMITS_TO_KEEP_PROP.key(), "5");
     params.put(HoodieCompactionConfig.MIN_COMMITS_TO_KEEP_PROP.key(), "2");
+    if (withAlternative) {
+      params.put("hoodie.avro.schema.externalTransformation", "true");
+    } else {
+      params.put("hoodie.avro.schema.external.transformation", "true");
+    }
     ByteArrayOutputStream outStream = saveParamsIntoOutputStream(params);
     ByteArrayInputStream inputStream = new ByteArrayInputStream(outStream.toByteArray());
     try {
@@ -54,6 +63,7 @@ public class TestHoodieWriteConfig {
     HoodieWriteConfig config = builder.build();
     assertEquals(5, config.getMaxCommitsToKeep());
     assertEquals(2, config.getMinCommitsToKeep());
+    assertTrue(config.shouldUseExternalSchemaTransformation());
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the pull request

`EXTERNAL_RECORD_AND_SCHEMA_TRANSFORMATION` config key depends on `AVRO_SCHEMA`, which is no longer a static string. This PR sets the key correctly for the aforementioned config.

## Verify this pull request

This pull request is already covered by existing tests, such as `TestHoodieWriteConfig`. Added assert for this particular config to verify the fix.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.