### PR TITLE
[HUDI-1241][WIP] Generate configuration doc automatically

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.config;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 
 import java.io.Serializable;
@@ -87,6 +88,14 @@ public class ConfigProperty<T> implements Serializable {
   public ConfigProperty<T> withDocumentation(String doc) {
     Objects.requireNonNull(doc);
     return new ConfigProperty<>(key, defaultValue, doc, sinceVersion, deprecatedVersion, inferFunction, alternatives);
+  }
+
+  public String doc() {
+    return hasDoc() ? doc : StringUtils.EMPTY_STRING;
+  }
+
+  public boolean hasDoc() {
+    return !StringUtils.isNullOrEmpty(doc);
   }
 
   public ConfigProperty<T> withAlternatives(String... alternatives) {

--- a/hudi-utilities/generate_config_docs.sh
+++ b/hudi-utilities/generate_config_docs.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Usage: ./scripts/checkout_pr.sh
+#
+# Checkout a given branch. Assumes that the branch exists in remote.
+# Run HoodieConfigDocGenerator class that generates markdown file with configurations.
+#
+set -eou pipefail
+
+function printUsage {
+  echo "Usage: $(basename "${0}") [-r REMOTE] [-f] <branch-name>" 2>&1
+  echo '   -r  REMOTE remote to grab PR from (default: apache)'
+  echo '   -f         force overwrite of local branch (default: fail if exists)'
+  exit 1
+}
+
+if [[ ${#} -eq 0 ]]; then
+  printUsage
+fi
+
+REMOTE="origin"
+FORCE=""
+while getopts ":r:f" arg; do
+  case "${arg}" in
+    r)
+      REMOTE="${OPTARG}"
+      ;;
+    f)
+      FORCE="--force"
+      ;;
+    ?)
+      printUsage
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"
+
+# Debug output
+BRANCH_NAME=$1
+
+# Checkout the branch.
+#git fetch ${REMOTE} && git checkout ${BRANCH_NAME}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Provide dependencies in the classpath
+HUDI_UTIL_JAR=`ls -c $DIR/../packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_*SNAPSHOT.jar`
+HUDI_SPARK_JAR=`ls -c $DIR/../packaging/hudi-spark-bundle/target/hudi-spark*.jar | grep -v sources | head -1`
+# Run the class
+java -cp $DIR/target/classes/:${HUDI_UTIL_JAR}:$HUDI_SPARK_JAR org.apache.hudi.utilities.HoodieConfigDocGenerator "$@"

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -360,6 +360,20 @@
       <version>${hive.version}</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.reflections/reflections -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.12</version>
+    </dependency>
+
+    <dependency>
+      <groupId>net.steppschuh.markdowngenerator</groupId>
+      <artifactId>markdowngenerator</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+
+
     <!-- Hoodie - Test -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieConfigDocGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieConfigDocGenerator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
+
+import net.steppschuh.markdowngenerator.table.Table;
+import net.steppschuh.markdowngenerator.text.heading.Heading;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.reflections.Reflections;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import static org.reflections.ReflectionUtils.getAllFields;
+import static org.reflections.ReflectionUtils.withTypeAssignableTo;
+
+/**
+ * 1. Get all subclasses of {@link HoodieConfig}
+ * 2. For each subclass, get all fields of type {@link ConfigProperty}.
+ * 3. Add config key and description to table row.
+ */
+public class HoodieConfigDocGenerator {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieConfigDocGenerator.class);
+
+  public static void main(String[] args) {
+    Reflections reflections = new Reflections("org.apache.hudi");
+    Set<Class<? extends HoodieConfig>> subTypes = reflections.getSubTypesOf(HoodieConfig.class);
+    // Top heading
+    StringBuilder configDocBuilder = new StringBuilder()
+        .append(new Heading("Configurations", 1))
+        .append("\n\n");
+    for (Class<? extends HoodieConfig> subType : subTypes) {
+      // sub-heading
+      configDocBuilder.append(new Heading(subType.getSimpleName(), 2)).append("\n\n");
+      // new table
+      Table.Builder tableBuilder = new Table.Builder()
+          .withAlignments(Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT)
+          .addRow("Option Name", "Property", "Required", "Default", "Remarks");
+      Set<Field> fields = getAllFields(subType, withTypeAssignableTo(ConfigProperty.class));
+      for (Field field : fields) {
+        ConfigProperty obj = null;
+        try {
+          ConfigProperty f = (ConfigProperty) field.get(obj);
+          tableBuilder.addRow(field.getName(), f.key(), "NO", f.hasDefaultValue() ? f.defaultValue() : "", f.doc());
+        } catch (IllegalAccessException e) {
+          LOG.error("Error while getting field through reflection ", e);
+        }
+      }
+      configDocBuilder.append(tableBuilder.build()).append("\n\n");
+    }
+    try {
+      LOG.info("Generating markdown file");
+      Files.write(Paths.get("confid_doc.md"), configDocBuilder.toString().getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      LOG.error("Error while writing to markdown file ", e);
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Generates the configuration doc automatically by scanning all class that extend `HoodieConfig`.

## Brief change log

- Add Reflections to get subTypes of ConfigProperty.

- Generate tables for configs.

- Write markdown to file.

## Verify this pull request

Run the `generate_config_docs.sh` script in `hudi_utilities` by giving a branch name. It should produce an output file named `config_doc.md`. Alternatively, checkout a branch and just run `HoodieConfigDocGenerator` from IDE.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.