### PR TITLE
[HUDI-2168] Fix for AccessControlException for anonymous user

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
@@ -144,6 +144,7 @@ public class HdfsTestService {
     String user = System.getProperty("user.name");
     config.set("hadoop.proxyuser." + user + ".groups", "*");
     config.set("hadoop.proxyuser." + user + ".hosts", "*");
+    config.setBoolean("dfs.permissions",false);
     return config;
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

To fix access control exception while running the test cases which involves starting the Hive service

## Brief change log

Set config 
```
config.setBoolean("dfs.permissions",false);
```

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

- Verified the tests are running locally after this change


## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.