### PR TITLE
[HUDI-2181] Fix the incorrect doc descriptions for FlinkCreateHandle

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkCreateHandle.java
@@ -41,9 +41,9 @@ import java.util.List;
  * A {@link HoodieCreateHandle} that supports CREATE write incrementally(mini-batches).
  *
  * <p>For the first mini-batch, it initializes and sets up the next file path to write,
- * then closes the file writer. The subsequent mini-batches are appended to a file with new name,
- * the new file would then rename to this file name,
- * behaves like each mini-batch data are appended to the same file.
+ * then closes the file writer. The subsequent mini-batches are written to a file.
+ *
+ * behaves like each mini-batch data is generated to a new file.
  *
  * @see FlinkMergeAndReplaceHandle
  */


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.