### PR TITLE
[HUDI-2187] Add a shim layer to support multiple hive version

### DIFF
--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -278,6 +278,16 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.spark-project.hive</groupId>
+          <artifactId>hive-exec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.spark-project.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveMetastoreClientFactory.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveMetastoreClientFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hudi.common.util.StringUtils;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
+/**
+ * Factory to create Hive metastore client.
+ */
+public class HiveMetastoreClientFactory {
+
+  private HiveMetastoreClientFactory() {}
+
+  public static HiveMetastoreClientWrapper create(HiveConf hiveConf, String hiveVersion) {
+    checkArgument(!StringUtils.isNullOrEmpty(hiveVersion), "hiveVersion cannot be null or empty");
+    return new HiveMetastoreClientWrapper(hiveConf, hiveVersion);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveMetastoreClientWrapper.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveMetastoreClientWrapper.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.hive.client.HiveShim;
+
+import org.apache.thrift.TException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
+/**
+ * Wrapper class for Hive Metastore Client, which embeds a HiveShim layer to handle different Hive versions.
+ * Methods provided mostly conforms to IMetaStoreClient interfaces except those that require shims.
+ *
+ * This code is mainly copy from Apache/Flink.
+ */
+public class HiveMetastoreClientWrapper implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveMetastoreClientWrapper.class);
+
+  private final IMetaStoreClient client;
+
+  private final HiveConf hiveConf;
+
+  private final HiveShim hiveShim;
+
+  public HiveMetastoreClientWrapper(HiveConf hiveConf, String hiveVersion) {
+    checkArgument(hiveVersion != null, "hive version cannot be null");
+    this.hiveConf = hiveConf;
+    hiveShim = HiveShimLoader.loadHiveShim(StringUtils.isNullOrEmpty(hiveVersion) ? HiveShimLoader.getHiveVersion() : hiveVersion);
+    client = createMetastoreClient();
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  public List<String> getAllTables(String databaseName) throws TException {
+    return client.getAllTables(databaseName);
+  }
+
+  public List<Partition> listPartitions(String dbName, String tblName, short max) throws TException {
+    return client.listPartitions(dbName, tblName, max);
+  }
+
+  public boolean tableExists(String databaseName, String tableName) throws TException {
+    return client.tableExists(databaseName, tableName);
+  }
+
+  public Database getDatabase(String name) throws TException {
+    return client.getDatabase(name);
+  }
+
+  public void createDatabase(Database database) throws TException {
+    client.createDatabase(database);
+  }
+
+  public Table getTable(String databaseName, String tableName) throws TException {
+    return client.getTable(databaseName, tableName);
+  }
+
+  public void createTable(Table table) throws TException {
+    client.createTable(table);
+  }
+
+  //-------- Start of shimmed methods ----------
+
+  private IMetaStoreClient createMetastoreClient() {
+    return hiveShim.getHiveMetastoreClient(hiveConf);
+  }
+
+  public void alter_table(String defaultDatabaseName, String tblName, Table table) throws TException {
+    hiveShim.alterTable(client, defaultDatabaseName, tblName, table);
+  }
+
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveShimLoader.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveShimLoader.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hive.common.util.HiveVersionInfo;
+import org.apache.hudi.hive.client.HiveShim;
+import org.apache.hudi.hive.client.HiveShimV220;
+import org.apache.hudi.hive.client.HiveShimV210;
+import org.apache.hudi.hive.client.HiveShimV201;
+import org.apache.hudi.hive.client.HiveShimV122;
+import org.apache.hudi.hive.client.HiveShimV121;
+import org.apache.hudi.hive.client.HiveShimV111;
+import org.apache.hudi.hive.client.HiveShimV234;
+import org.apache.hudi.hive.client.HiveShimV230;
+import org.apache.hudi.hive.client.HiveShimV233;
+import org.apache.hudi.hive.client.HiveShimV100;
+import org.apache.hudi.hive.client.HiveShimV101;
+import org.apache.hudi.hive.client.HiveShimV110;
+import org.apache.hudi.hive.client.HiveShimV120;
+import org.apache.hudi.hive.client.HiveShimV200;
+import org.apache.hudi.hive.client.HiveShimV211;
+import org.apache.hudi.hive.client.HiveShimV231;
+import org.apache.hudi.hive.client.HiveShimV232;
+import org.apache.hudi.hive.client.HiveShimV235;
+import org.apache.hudi.hive.client.HiveShimV236;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A loader to load HiveShim.
+ *
+ * This code is mainly copy from Apache/Flink.
+ */
+public class HiveShimLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveShimLoader.class);
+
+  public static final String HIVE_VERSION_V1_0_0 = "1.0.0";
+  public static final String HIVE_VERSION_V1_0_1 = "1.0.1";
+  public static final String HIVE_VERSION_V1_1_0 = "1.1.0";
+  public static final String HIVE_VERSION_V1_1_1 = "1.1.1";
+  public static final String HIVE_VERSION_V1_2_0 = "1.2.0";
+  public static final String HIVE_VERSION_V1_2_1 = "1.2.1";
+  public static final String HIVE_VERSION_V1_2_2 = "1.2.2";
+  public static final String HIVE_VERSION_V2_0_0 = "2.0.0";
+  public static final String HIVE_VERSION_V2_0_1 = "2.0.1";
+  public static final String HIVE_VERSION_V2_1_0 = "2.1.0";
+  public static final String HIVE_VERSION_V2_1_1 = "2.1.1";
+  public static final String HIVE_VERSION_V2_2_0 = "2.2.0";
+  public static final String HIVE_VERSION_V2_3_0 = "2.3.0";
+  public static final String HIVE_VERSION_V2_3_1 = "2.3.1";
+  public static final String HIVE_VERSION_V2_3_2 = "2.3.2";
+  public static final String HIVE_VERSION_V2_3_3 = "2.3.3";
+  public static final String HIVE_VERSION_V2_3_4 = "2.3.4";
+  public static final String HIVE_VERSION_V2_3_5 = "2.3.5";
+  public static final String HIVE_VERSION_V2_3_6 = "2.3.6";
+
+  private static final Map<String, HiveShim> HIVE_SHIMS = new ConcurrentHashMap<>(2);
+
+  private HiveShimLoader() {
+  }
+
+  public static HiveShim loadHiveShim(String version) {
+    return HIVE_SHIMS.computeIfAbsent(version, (v) -> {
+      if (v.startsWith(HIVE_VERSION_V1_0_0)) {
+        return new HiveShimV100();
+      }
+      if (v.startsWith(HIVE_VERSION_V1_0_1)) {
+        return new HiveShimV101();
+      }
+      if (v.startsWith(HIVE_VERSION_V1_1_0)) {
+        return new HiveShimV110();
+      }
+      if (v.startsWith(HIVE_VERSION_V1_1_1)) {
+        return new HiveShimV111();
+      }
+      if (v.startsWith(HIVE_VERSION_V1_2_0)) {
+        return new HiveShimV120();
+      }
+      if (v.startsWith(HIVE_VERSION_V1_2_1)) {
+        return new HiveShimV121();
+      }
+      if (v.startsWith(HIVE_VERSION_V1_2_2)) {
+        return new HiveShimV122();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_0_0)) {
+        return new HiveShimV200();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_0_1)) {
+        return new HiveShimV201();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_1_0)) {
+        return new HiveShimV210();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_1_1)) {
+        return new HiveShimV211();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_2_0)) {
+        return new HiveShimV220();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_0)) {
+        return new HiveShimV230();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_1)) {
+        return new HiveShimV231();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_2)) {
+        return new HiveShimV232();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_3)) {
+        return new HiveShimV233();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_4)) {
+        return new HiveShimV234();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_5)) {
+        return new HiveShimV235();
+      }
+      if (v.startsWith(HIVE_VERSION_V2_3_6)) {
+        return new HiveShimV236();
+      }
+      throw new HoodieHiveSyncException("Unsupported Hive version " + v);
+    });
+  }
+
+  public static String getHiveVersion() {
+    return HiveVersionInfo.getVersion();
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -120,6 +120,9 @@ public class HiveSyncConfig implements Serializable {
   @Parameter(names = {"--spark-schema-length-threshold"}, description = "The maximum length allowed in a single cell when storing additional schema information in Hive's metastore.")
   public int sparkSchemaLengthThreshold = 4000;
 
+  @Parameter(names = {"--hive-version"}, description = "hive version that hudi use, not suggests user to specific", required = false)
+  public String hiveVersion;
+
   // enhance the similar function in child class
   public static HiveSyncConfig copy(HiveSyncConfig cfg) {
     HiveSyncConfig newConfig = new HiveSyncConfig();
@@ -143,6 +146,7 @@ public class HiveSyncConfig implements Serializable {
     newConfig.batchSyncNum = cfg.batchSyncNum;
     newConfig.syncAsSparkDataSourceTable = cfg.syncAsSparkDataSourceTable;
     newConfig.sparkSchemaLengthThreshold = cfg.sparkSchemaLengthThreshold;
+    newConfig.hiveVersion = cfg.hiveVersion;
     return newConfig;
   }
 
@@ -174,6 +178,7 @@ public class HiveSyncConfig implements Serializable {
       + ", createManagedTable=" + createManagedTable
       + ", syncAsSparkDataSourceTable=" + syncAsSparkDataSourceTable
       + ", sparkSchemaLengthThreshold=" + sparkSchemaLengthThreshold
+      + ", hiveVersion=" + hiveVersion
       + '}';
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShim.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShim.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import org.apache.thrift.TException;
+
+/**
+ * A shim layer to support different versions of Hive.
+ *
+ * This code and it's concrete implement is mainly copy from Apache/Flink.
+ */
+public interface HiveShim {
+
+  /**
+   * Create a Hive Metastore client based on the given HiveConf object.
+   *
+   * @param hiveConf HiveConf instance
+   * @return an IMetaStoreClient instance
+   */
+  IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf);
+
+  /**
+   * Alters a Hive table.
+   *
+   * @param client       the Hive metastore client
+   * @param databaseName the name of the database to which the table belongs
+   * @param tableName    the name of the table to be altered
+   * @param table        the new Hive table
+   */
+  void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table)
+          throws InvalidOperationException, MetaException, TException;
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV100.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV100.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import org.apache.hudi.hive.HoodieHiveSyncException;
+
+import org.apache.thrift.TException;
+
+/**
+ * Shim for Hive version 1.0.0.
+ */
+public class HiveShimV100 implements HiveShim {
+
+  @Override
+  public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
+    try {
+      return new HiveMetaStoreClient(hiveConf);
+    } catch (MetaException ex) {
+      throw new HoodieHiveSyncException("Failed to create Hive Metastore client", ex);
+    }
+  }
+
+  @Override
+  public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
+    client.alter_table(databaseName, tableName, table);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV101.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV101.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 1.0.1.
+ */
+public class HiveShimV101 extends HiveShimV100 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV110.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV110.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 1.1.0.
+ */
+public class HiveShimV110 extends HiveShimV101 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV111.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV111.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 1.1.1.
+ */
+public class HiveShimV111 extends HiveShimV110 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV120.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV120.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import org.apache.hudi.hive.HoodieHiveSyncException;
+
+import org.apache.thrift.TException;
+
+import java.lang.reflect.Method;
+
+/**
+ * Shim for Hive version 1.2.0.
+ */
+public class HiveShimV120 extends HiveShimV111 {
+
+  @Override
+  public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
+    try {
+      Method method = RetryingMetaStoreClient.class.getMethod("getProxy", HiveConf.class);
+      // getProxy is a static method
+      return (IMetaStoreClient) method.invoke(null, (hiveConf));
+    } catch (Exception ex) {
+      throw new HoodieHiveSyncException("Failed to create Hive Metastore client", ex);
+    }
+  }
+
+  @Override
+  public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
+    // For Hive-1.2.x, we need to tell HMS not to update stats. Otherwise, the stats we put in the table
+    // parameters can be overridden. The extra config we add here will be removed by HMS after it's used.
+    // Don't use StatsSetupConst.DO_NOT_UPDATE_STATS because it wasn't defined in Hive 1.1.x.
+    table.getParameters().put("DO_NOT_UPDATE_STATS", "true");
+    client.alter_table(databaseName, tableName, table);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV121.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV121.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 1.2.1.
+ */
+public class HiveShimV121 extends HiveShimV120 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV122.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV122.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 1.2.2.
+ */
+public class HiveShimV122 extends HiveShimV121 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV200.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV200.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+
+import org.apache.hudi.hive.HoodieHiveSyncException;
+
+import java.lang.reflect.Method;
+
+/**
+ * Shim for Hive version 2.0.0.
+ */
+public class HiveShimV200 extends HiveShimV122 {
+
+  @Override
+  public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
+    try {
+      Class<?>[] constructorArgTypes = {HiveConf.class};
+      Object[] constructorArgs = {hiveConf};
+      Method method = RetryingMetaStoreClient.class.getMethod("getProxy", HiveConf.class,
+              constructorArgTypes.getClass(), constructorArgs.getClass(), String.class);
+      // getProxy is a static method
+      return (IMetaStoreClient) method.invoke(null, hiveConf, constructorArgTypes, constructorArgs,
+              HiveMetaStoreClient.class.getName());
+    } catch (Exception ex) {
+      throw new HoodieHiveSyncException("Failed to create Hive Metastore client", ex);
+    }
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV201.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV201.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.0.1.
+ */
+public class HiveShimV201 extends HiveShimV200 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV210.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV210.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.1.0.
+ */
+public class HiveShimV210 extends HiveShimV201 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV211.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV211.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.1.1.
+ */
+public class HiveShimV211 extends HiveShimV210 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV220.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV220.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.2.0.
+ */
+public class HiveShimV220 extends HiveShimV211 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV230.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV230.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import org.apache.hudi.hive.HoodieHiveSyncException;
+
+import org.apache.thrift.TException;
+
+import java.lang.reflect.Method;
+
+/**
+ * Shim for Hive version 2.3.0.
+ */
+public class HiveShimV230 extends HiveShimV220 {
+
+  @Override
+  public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
+    try {
+      Method method = RetryingMetaStoreClient.class.getMethod("getProxy", HiveConf.class, Boolean.TYPE);
+      // getProxy is a static method
+      return (IMetaStoreClient) method.invoke(null, hiveConf, true);
+    } catch (Exception ex) {
+      throw new HoodieHiveSyncException("Failed to create Hive Metastore client", ex);
+    }
+  }
+
+  @Override
+  public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
+    client.alter_table(databaseName, tableName, table);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV231.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV231.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.3.1.
+ */
+public class HiveShimV231 extends HiveShimV230 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV232.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV232.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.3.2.
+ */
+public class HiveShimV232 extends HiveShimV231 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV233.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV233.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.3.3.
+ */
+public class HiveShimV233 extends HiveShimV232 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV234.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV234.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.3.4.
+ */
+public class HiveShimV234 extends HiveShimV233 {
+
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV235.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV235.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.3.5.
+ */
+public class HiveShimV235 extends HiveShimV234 {
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV236.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/client/HiveShimV236.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.client;
+
+/**
+ * Shim for Hive version 2.3.6.
+ */
+public class HiveShimV236 extends HiveShimV235 {
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -567,6 +567,7 @@ public class TestHiveSyncTool {
 
     hiveSyncConfig.syncMode = syncMode;
     HiveTestUtil.hiveSyncConfig.batchSyncNum = 2;
+    HiveTestUtil.hiveSyncConfig.hiveVersion = "2.3.1";
     String commitTime1 = "100";
     HiveTestUtil.createCOWTable(commitTime1, 5, true);
     HoodieHiveClient hiveClient =
@@ -938,8 +939,8 @@ public class TestHiveSyncTool {
 
   @Test
   public void testConnectExceptionIgnoreConfigSet() throws IOException, URISyntaxException, HiveException, MetaException {
-    hiveSyncConfig.useJdbc = true;
-    HiveTestUtil.hiveSyncConfig.useJdbc = true;
+    hiveSyncConfig.useJdbc = false;
+    HiveTestUtil.hiveSyncConfig.useJdbc = false;
     HiveTestUtil.hiveSyncConfig.batchSyncNum = 2;
     String instantTime = "100";
     HiveTestUtil.createCOWTable(instantTime, 5, false);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -119,6 +119,7 @@ public class HiveTestUtil {
     hiveSyncConfig.assumeDatePartitioning = true;
     hiveSyncConfig.usePreApacheInputFormat = false;
     hiveSyncConfig.partitionFields = Collections.singletonList("datestr");
+    hiveSyncConfig.hiveVersion = "2.3.1";
 
     dtfOut = DateTimeFormat.forPattern("yyyy/MM/dd");
     ddlExecutor = new HiveQueryDDLExecutor(hiveSyncConfig, fileSystem, getHiveConf());


### PR DESCRIPTION

*Support multiple versions of hive, the main idea is to use reflection to get hive under the user's classpath in which get the corresponding client* 

See the RFC for more details: https://cwiki.apache.org/confluence/display/HUDI/RFC+-+31%3A+Hive+integration+Improvment

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.