### PR TITLE
[HUDI-2192] Clean up Multiple versions of scala libraries detected Wa…

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -48,6 +48,7 @@
             <args>
               <arg>-nobootcp</arg>
             </args>
+            <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
           </configuration>
         </plugin>
       </plugins>

--- a/hudi-spark-datasource/hudi-spark-common/pom.xml
+++ b/hudi-spark-datasource/hudi-spark-common/pom.xml
@@ -47,6 +47,7 @@
             <args>
               <arg>-nobootcp</arg>
             </args>
+            <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
           </configuration>
         </plugin>
         <plugin>

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -49,6 +49,7 @@
             <args>
               <arg>-nobootcp</arg>
             </args>
+            <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
           </configuration>
         </plugin>
         <plugin>

--- a/hudi-spark-datasource/hudi-spark2/pom.xml
+++ b/hudi-spark-datasource/hudi-spark2/pom.xml
@@ -47,6 +47,7 @@
             <args>
               <arg>-nobootcp</arg>
             </args>
+            <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
           </configuration>
         </plugin>
         <plugin>

--- a/hudi-spark-datasource/hudi-spark3/pom.xml
+++ b/hudi-spark-datasource/hudi-spark3/pom.xml
@@ -47,6 +47,7 @@
             <args>
               <arg>-nobootcp</arg>
             </args>
+            <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,9 @@
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>${scala-maven-plugin.version}</version>
+          <configuration>
+            <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1327,6 +1330,7 @@
                   <excludes>
                     <exclude>${project.basedir}/src/main/scala</exclude>
                   </excludes>
+                  <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
## What is the purpose of the pull request

To cleanup multiple versions of scala warning

```
[INFO] --- scala-maven-plugin:3.3.1:testCompile (scala-test-compile) @ hudi-cli ---
[WARNING]  Expected all dependencies to require Scala version: 2.11.12
[WARNING]  org.apache.hudi:hudi-cli:0.9.0-SNAPSHOT requires scala version: 2.11.12
[WARNING]  org.apache.hudi:hudi-spark-client:0.9.0-SNAPSHOT requires scala version: 2.11.12
[WARNING]  org.apache.hudi:hudi-spark_2.11:0.9.0-SNAPSHOT requires scala version: 2.11.12
[WARNING]  org.apache.hudi:hudi-spark-client:0.9.0-SNAPSHOT requires scala version: 2.11.12
[WARNING]  org.apache.hudi:hudi-spark-common_2.11:0.9.0-SNAPSHOT requires scala version: 2.11.12
[WARNING]  org.apache.hudi:hudi-spark_2.11:0.9.0-SNAPSHOT requires scala version: 2.11.12
[WARNING]  com.fasterxml.jackson.module:jackson-module-scala_2.11:2.6.7.1 requires scala version: 2.11.8
[WARNING] Multiple versions of scala libraries detected!
```

so to clean up this warnings there are multiple ways :
1. Update scala-maven-plugin version - but this leads to other errors
2. Set specific compatible version - this did not work
3. Ignore these warnings by setting checkMultipleScalaVersions flag - this is what I have done

Note : This change does not have any impact on build

## Brief change log

Updated pom.xml to set `checkMultipleScalaVersions` to `false`

## Verify this pull request

- This pull request is a trivial rework / code cleanup without any test coverage.

- Build locally to verify warnings are cleaned up


## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.