### PR TITLE
[HUDI-2195]  Sync Hive Failed When Execute  CTAS In Spark2 And Spark3

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlUtils.scala
@@ -181,8 +181,7 @@ object HoodieSqlUtils extends SparkAdapterSupport {
   }
 
   /**
-   * Append the SparkSession config and table options to the baseConfig.
-   * We add the "spark" prefix to hoodie's config key.
+   * Append the spark config and table options to the baseConfig.
    */
   def withSparkConf(spark: SparkSession, options: Map[String, String])
                    (baseConfig: Map[String, String]): Map[String, String] = {

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -115,6 +115,8 @@
                   <include>org.apache.curator:curator-client</include>
                   <include>org.apache.curator:curator-recipes</include>
                   <include>commons-codec:commons-codec</include>
+                  <include>org.json:json</include>
+                  <include>org.apache.calcite:calcite-core</include>
                 </includes>
               </artifactSet>
               <relocations>
@@ -367,7 +369,18 @@
       <artifactId>curator-recipes</artifactId>
       <version>${zk-curator.version}</version>
     </dependency>
-
+<!--    import json to fix the crash when sync meta in spark-->
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>${json.version}</version>
+    </dependency>
+<!--    import calcite to support hive3 & spark 3-->
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <version>${calcite.version}</version>
+    </dependency>
     <!-- TODO: Reinvestigate PR 633 -->
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,8 @@
     <presto.bundle.bootstrap.shade.prefix>org.apache.hudi.</presto.bundle.bootstrap.shade.prefix>
     <shadeSources>true</shadeSources>
     <zk-curator.version>2.7.1</zk-curator.version>
+    <json.version>20200518</json.version>
+    <calcite.version>1.16.0</calcite.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
## What is the purpose of the pull request

Fix the bug that sync hive meta failed when execute CTAS in spark2 & spark3.

The exception for spark2 is:

> java.lang.NoClassDefFoundError: org/json/JSONException
	at org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.analyzeCreateTable(SemanticAnalyzer.java:10847)

The exception for spark3 is:

> java.lang.NoClassDefFoundError: org/apache/calcite/rel/type/RelDataTypeSystemjava.lang.NoClassDefFoundError: org/apache/calcite/rel/type/RelDataTypeSystem at org.apache.hadoop.hive.ql.parse.SemanticAnalyzerFactory.get(SemanticAnalyzerFactory.java:318) at org.apache.hadoop.hive.ql.Driver.compile(Driver.java:484) at org.apache.hadoop.hive.ql.Driver.compileInternal(Driver.java:1317) at 

## Brief change log

  - Add the json dependency to hudi-spark-bundle.
  - Add the calcite dependency to hudi-spark-bundle.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.