### PR TITLE
[HUDI-2194] Skip the latest N partitions when choosing partitions to create ClusteringPlan

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -77,7 +77,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> CLUSTERING_SKIP_PARTITIONS_FROM_LATEST = ConfigProperty
           .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "daybased.skipfromlatest.partitions")
           .defaultValue("0")
-          .sinceVersion("0.7.0")
+          .sinceVersion("0.9.0")
           .withDocumentation("Number of partitions to skip from latest when choosing partitions to create ClusteringPlan");
 
   public static final ConfigProperty<String> CLUSTERING_PLAN_SMALL_FILE_LIMIT = ConfigProperty

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -159,6 +159,11 @@ public class HoodieClusteringConfig extends HoodieConfig {
       return this;
     }
 
+    public Builder withClusteringSkipPartitionsFromLatest(int clusteringSkipPartitionsFromLatest) {
+      clusteringConfig.setValue(CLUSTERING_SKIP_PARTITIONS_FROM_LATEST, String.valueOf(clusteringSkipPartitionsFromLatest));
+      return this;
+    }
+
     public Builder withClusteringPlanSmallFileLimit(long clusteringSmallFileLimit) {
       clusteringConfig.setValue(CLUSTERING_PLAN_SMALL_FILE_LIMIT, String.valueOf(clusteringSmallFileLimit));
       return this;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -64,6 +64,12 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Number of partitions to list to create ClusteringPlan");
 
+  public static final ConfigProperty<String> CLUSTERING_SKIP_PARTITIONS_FROM_LATEST = ConfigProperty
+          .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "daybased.skipfromlatest.partitions")
+          .defaultValue("0")
+          .sinceVersion("0.7.0")
+          .withDocumentation("Number of partitions to skip from latest when choosing partitions to create ClusteringPlan");
+
   public static final ConfigProperty<String> CLUSTERING_PLAN_SMALL_FILE_LIMIT = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "small.file.limit")
       .defaultValue(String.valueOf(600 * 1024 * 1024L))

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -733,6 +733,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.CLUSTERING_TARGET_PARTITIONS);
   }
 
+  public int getSkipPartitionsFromLatestForClustering() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_SKIP_PARTITIONS_FROM_LATEST);
+  }
+
   public String getClusteringSortColumns() {
     return getString(HoodieClusteringConfig.CLUSTERING_SORT_COLUMNS_PROPERTY);
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/plan/strategy/SparkRecentDaysClusteringPlanStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/plan/strategy/SparkRecentDaysClusteringPlanStrategy.java
@@ -112,8 +112,10 @@ public class SparkRecentDaysClusteringPlanStrategy<T extends HoodieRecordPayload
   @Override
   protected List<String> filterPartitionPaths(List<String> partitionPaths) {
     int targetPartitionsForClustering = getWriteConfig().getTargetPartitionsForClustering();
+    int skipPartitionsFromLatestForClustering = getWriteConfig().getSkipPartitionsFromLatestForClustering();
     return partitionPaths.stream()
         .sorted(Comparator.reverseOrder())
+        .skip(Math.max(skipPartitionsFromLatestForClustering, 0))
         .limit(targetPartitionsForClustering > 0 ? targetPartitionsForClustering : partitionPaths.size())
         .collect(Collectors.toList());
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkRecentDaysClusteringPlanStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkRecentDaysClusteringPlanStrategy.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.clustering.plan.strategy;
+
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.config.HoodieClusteringConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieSparkCopyOnWriteTable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class TestSparkRecentDaysClusteringPlanStrategy {
+  @Mock
+  HoodieSparkCopyOnWriteTable table;
+  @Mock
+  HoodieSparkEngineContext context;
+  HoodieWriteConfig hoodieWriteConfig;
+
+  @BeforeEach
+  public void setUp() {
+    this.hoodieWriteConfig = HoodieWriteConfig
+            .newBuilder()
+            .withPath("Fake_Table_Path")
+            .withClusteringConfig(HoodieClusteringConfig
+                    .newBuilder()
+                    .withClusteringSkipPartitionsFromLatest(1)
+                    .withClusteringTargetPartitions(1)
+                    .build())
+            .build();
+  }
+
+  @Test
+  public void testFilterPartitionPaths() {
+    SparkRecentDaysClusteringPlanStrategy sg = new SparkRecentDaysClusteringPlanStrategy(table, context, hoodieWriteConfig);
+    ArrayList<String> fakeTimeBasedPartitionsPath = new ArrayList<>();
+    fakeTimeBasedPartitionsPath.add("20210718");
+    fakeTimeBasedPartitionsPath.add("20210716");
+    fakeTimeBasedPartitionsPath.add("20210719");
+    List list = sg.filterPartitionPaths(fakeTimeBasedPartitionsPath);
+    assertEquals(1, list.size());
+    assertSame("20210718", list.get(0));
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/projects/HUDI/issues/HUDI-2194

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
As we known, SparkRecentDaysClusteringPlanStrategy is the default clustering strategy to create ClusteringPlan. And it is useful when Hudi table is partitioned by time.
 
For now, users can set `hoodie.clustering.plan.strategy.daybased.lookback.partitions` to  control the number of partitions to list from the latest partition to create ClusteringPlan.

For example, we have 6 partitions based on date, and users set `hoodie.clustering.plan.strategy.daybased.lookback.partitions` 2

![image](https://user-images.githubusercontent.com/69956021/126144048-d1b3c468-235b-4d65-baf5-9c5e6d15db22.png)

Hudi will do cluster with partition 20210722 and partition 20210723

Sometimes users also what to skip N partitions from latest when make clustering plan because latest partitions contains lots of update data or some reasons else.
 
This patch will add a new config named `
hoodie.clustering.plan.strategy.daybased.skipfromlatest.partitions
` to control the 
number of partitions to skip from latest when choosing partitions to create ClusteringPlan
 
For example users set `hoodie.clustering.plan.strategy.daybased.lookback.partitions` 2 and 
`
hoodie.clustering.plan.strategy.daybased.skipfromlatest.partitions
` 2

![image](https://user-images.githubusercontent.com/69956021/126144273-d8648ea7-98e3-43c5-9f70-be367025db4f.png)

Hudi will do cluster with partition 20210720 and partition 20210721 which skipped 2 latest partitions.

Also the default value is 0 which means skip nothing.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.