### PR TITLE
[HUDI-1518] Remove the logic that delete replaced file when archive

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/ReplaceArchivalHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/ReplaceArchivalHelper.java
@@ -20,24 +20,14 @@ package org.apache.hudi.client;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.hadoop.fs.Path;
 
-import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieRollingStatMetadata;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.view.TableFileSystemView;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import java.io.IOException;
 import java.io.Serializable;
-import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * Operates on marker files for a given write action (commit, delta commit, compaction).
@@ -60,46 +50,5 @@ public class ReplaceArchivalHelper implements Serializable {
     // Do not archive Rolling Stats, cannot set to null since AVRO will throw null pointer
     avroMetaData.getExtraMetadata().put(HoodieRollingStatMetadata.ROLLING_STAT_METADATA_KEY, "");
     return avroMetaData;
-  }
-
-  /**
-   * Delete all files represented by FileSlices in parallel. Return true if all files are deleted successfully.
-   */
-  public static boolean deleteReplacedFileGroups(HoodieEngineContext context, HoodieTableMetaClient metaClient,
-                                                 TableFileSystemView fileSystemView,
-                                                 HoodieInstant instant, List<String> replacedPartitions) {
-    // There is no file id to be replaced in the very first replace commit file for insert overwrite operation
-    if (replacedPartitions.isEmpty()) {
-      LOG.warn("Found no partition files to replace");
-      return true;
-    }
-    context.setJobStatus(ReplaceArchivalHelper.class.getSimpleName(), "Delete replaced file groups");
-    List<Boolean> f = context.map(replacedPartitions, partition -> {
-      Stream<FileSlice> fileSlices =  fileSystemView.getReplacedFileGroupsBeforeOrOn(instant.getTimestamp(), partition)
-          .flatMap(HoodieFileGroup::getAllRawFileSlices);
-      return fileSlices.allMatch(slice -> deleteFileSlice(slice, metaClient, instant));
-    }, replacedPartitions.size());
-
-    return f.stream().reduce((x, y) -> x & y).orElse(true);
-  }
-
-  private static boolean deleteFileSlice(FileSlice fileSlice, HoodieTableMetaClient metaClient, HoodieInstant instant) {
-    boolean baseFileDeleteSuccess = fileSlice.getBaseFile().map(baseFile ->
-        deletePath(new Path(baseFile.getPath()), metaClient, instant)).orElse(true);
-
-    boolean logFileSuccess = fileSlice.getLogFiles().map(logFile ->
-        deletePath(logFile.getPath(), metaClient, instant)).allMatch(x -> x);
-    return baseFileDeleteSuccess & logFileSuccess;
-  }
-
-  private static boolean deletePath(Path path, HoodieTableMetaClient metaClient, HoodieInstant instant) {
-    try {
-      LOG.info("Deleting " + path + " before archiving " + instant);
-      metaClient.getFs().delete(path);
-      return true;
-    } catch (IOException e) {
-      LOG.error("unable to delete file groups that are replaced", e);
-      return false;
-    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTimelineArchiveLog.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTimelineArchiveLog.java
@@ -300,11 +300,6 @@ public class HoodieTimelineArchiveLog<T extends HoodieAvroPayload, I, K, O> {
       LOG.info("Wrapper schema " + wrapperSchema.toString());
       List<IndexedRecord> records = new ArrayList<>();
       for (HoodieInstant hoodieInstant : instants) {
-        // TODO HUDI-1518 Cleaner now takes care of removing replaced file groups. This call to deleteReplacedFileGroups can be removed.
-        boolean deleteSuccess = deleteReplacedFileGroups(context, hoodieInstant);
-        if (!deleteSuccess) {
-          LOG.warn("Unable to delete file(s) for " + hoodieInstant.getFileName() + ", replaced files possibly deleted by cleaner");
-        }
         try {
           deleteAnyLeftOverMarkerFiles(context, hoodieInstant);
           records.add(convertToAvroRecord(hoodieInstant));
@@ -329,17 +324,6 @@ public class HoodieTimelineArchiveLog<T extends HoodieAvroPayload, I, K, O> {
     if (markerFiles.deleteMarkerDir(context, config.getMarkersDeleteParallelism())) {
       LOG.info("Cleaned up left over marker directory for instant :" + instant);
     }
-  }
-
-  private boolean deleteReplacedFileGroups(HoodieEngineContext context, HoodieInstant instant) {
-    if (!instant.isCompleted() || !HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())) {
-      // only delete files for completed replace instants
-      return true;
-    }
-
-    TableFileSystemView fileSystemView = this.table.getFileSystemView();
-    List<String> replacedPartitions = getReplacedPartitions(instant);
-    return ReplaceArchivalHelper.deleteReplacedFileGroups(context, metaClient, fileSystemView, instant, replacedPartitions);
   }
 
   private List<String> getReplacedPartitions(HoodieInstant instant) {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*
https://issues.apache.org/jira/browse/HUDI-1518 
## What is the purpose of the pull request

Since https://github.com/apache/hudi/pull/2422 Cleaner now takes care of removing replaced file groups. This call to deleteReplacedFileGroups can be removed. 

Also it's a little confused that archive can delete data file even users set auto.clean false.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.