### PR TITLE
[HUDI-2203] When the orderingVal is the same, take the latest one

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -49,7 +49,7 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   @Override
   public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload another) {
     // pick the payload with greatest ordering value
-    if (another.orderingVal.compareTo(orderingVal) > 0) {
+    if (another.orderingVal.compareTo(orderingVal) >= 0) {
       return another;
     } else {
       return this;

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestOverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestOverwriteWithLatestAvroPayload.java
@@ -75,6 +75,25 @@ public class TestOverwriteWithLatestAvroPayload {
   }
 
   @Test
+  public void testPreCombineOrderingValEqualsRecords() throws IOException {
+    GenericRecord record1 = new GenericData.Record(schema);
+    record1.put("id", "1");
+    record1.put("partition", "partition0");
+    record1.put("ts", 0L);
+    record1.put("_hoodie_is_deleted", false);
+
+    GenericRecord record2 = new GenericData.Record(schema);
+    record2.put("id", "1");
+    record2.put("partition", "partition1");
+    record2.put("ts", 0L);
+    record2.put("_hoodie_is_deleted", false);
+
+    OverwriteWithLatestAvroPayload payload1 = new OverwriteWithLatestAvroPayload(record1, 0);
+    OverwriteWithLatestAvroPayload payload2 = new OverwriteWithLatestAvroPayload(record2, 0);
+    assertEquals(payload1.preCombine(payload2), payload2);
+  }
+
+  @Test
   public void testDeletedRecord() throws IOException {
     GenericRecord record1 = new GenericData.Record(schema);
     record1.put("id", "1");


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

OverwriteWithLatestAvroPayload.

When the orderingVal is the same, select the later data

## Brief change log

org.apache.hudi.common.model.OverwriteWithLatestAvroPayload.class
org.apache.hudi.common.model.TestOverwriteWithLatestAvroPayload.class

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.