### PR TITLE
[HUDI-2210] Replace deprecated method isDir with isDirectory

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -137,7 +137,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     // take the desired number of splits into account
     minNumSplits = Math.max(minNumSplits, this.numSplits);
 
-    final List<FileInputSplit> inputSplits = new ArrayList<FileInputSplit>(minNumSplits);
+    final List<FileInputSplit> inputSplits = new ArrayList<>(minNumSplits);
 
     // get all the files that are involved in the splits
     List<FileStatus> files = new ArrayList<>();
@@ -148,7 +148,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       final FileSystem fs = FSUtils.getFs(hadoopPath.toString(), this.conf.conf());
       final FileStatus pathFile = fs.getFileStatus(hadoopPath);
 
-      if (pathFile.isDir()) {
+      if (pathFile.isDirectory()) {
         totalLength += addFilesInDir(hadoopPath, files, true);
       } else {
         testForUnsplittable(pathFile);
@@ -164,7 +164,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       for (final FileStatus file : files) {
         final FileSystem fs = FSUtils.getFs(file.getPath().toString(), this.conf.conf());
         final BlockLocation[] blocks = fs.getFileBlockLocations(file, 0, file.getLen());
-        Set<String> hosts = new HashSet<String>();
+        Set<String> hosts = new HashSet<>();
         for (BlockLocation block : blocks) {
           hosts.addAll(Arrays.asList(block.getHosts()));
         }
@@ -173,10 +173,10 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
           len = READ_WHOLE_SPLIT_FLAG;
         }
         FileInputSplit fis = new FileInputSplit(splitNum++, new Path(file.getPath().toUri()), 0, len,
-            hosts.toArray(new String[hosts.size()]));
+            hosts.toArray(new String[0]));
         inputSplits.add(fis);
       }
-      return inputSplits.toArray(new FileInputSplit[inputSplits.size()]);
+      return inputSplits.toArray(new FileInputSplit[0]);
     }
 
 
@@ -214,7 +214,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
           @Override
           public int compare(BlockLocation o1, BlockLocation o2) {
             long diff = o1.getLength() - o2.getOffset();
-            return diff < 0L ? -1 : (diff > 0L ? 1 : 0);
+            return Long.compare(diff, 0L);
           }
         });
 
@@ -257,7 +257,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       }
     }
 
-    return inputSplits.toArray(new FileInputSplit[inputSplits.size()]);
+    return inputSplits.toArray(new FileInputSplit[0]);
   }
 
   @Override
@@ -301,7 +301,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     long length = 0;
 
     for (FileStatus dir : fs.listStatus(hadoopPath)) {
-      if (dir.isDir()) {
+      if (dir.isDirectory()) {
         if (acceptFile(dir) && enumerateNestedFiles) {
           length += addFilesInDir(dir.getPath(), files, logExcludedFiles);
         } else {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.