### PR TITLE
[HUDI-2206] Fix checkpoint blocked because getLastPendingInstant() ac…

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -207,6 +207,7 @@ public class StreamWriteFunction<K, I, O>
             TypeInformation.of(WriteMetadataEvent.class)
         ));
 
+    this.currentInstant = this.writeClient.getLastPendingInstant(this.actionType);
     if (context.isRestored()) {
       restoreWriteMetadata();
     } else {
@@ -214,7 +215,6 @@ public class StreamWriteFunction<K, I, O>
     }
     // blocks flushing until the coordinator starts a new instant
     this.confirming = true;
-    this.currentInstant = this.writeClient.getLastPendingInstant(this.actionType);
   }
 
   @Override


### PR DESCRIPTION
…tion after than restoreWriteMetadata() action

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Fix checkpoint blocked because getLastPendingInstant() action after than restoreWriteMetadata() action which will cause a deadlock during checkpoint.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.