### PR TITLE
[HUDI-2218] Fix missing HoodieWriteStat in HoodieCreateHandle

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
@@ -73,6 +73,7 @@ public class HoodieCreateHandle<T extends HoodieRecordPayload, I, K, O> extends 
         taskContextSupplier);
     writeStatus.setFileId(fileId);
     writeStatus.setPartitionPath(partitionPath);
+    writeStatus.setStat(new HoodieWriteStat());
 
     this.path = makeNewPath(partitionPath);
 
@@ -200,7 +201,7 @@ public class HoodieCreateHandle<T extends HoodieRecordPayload, I, K, O> extends 
    * @throws IOException if error occurs
    */
   protected void setupWriteStatus() throws IOException {
-    HoodieWriteStat stat = new HoodieWriteStat();
+    HoodieWriteStat stat = writeStatus.getStat();
     stat.setPartitionPath(writeStatus.getPartitionPath());
     stat.setNumWrites(recordsWritten);
     stat.setNumDeletes(recordsDeleted);
@@ -214,7 +215,6 @@ public class HoodieCreateHandle<T extends HoodieRecordPayload, I, K, O> extends 
     RuntimeStats runtimeStats = new RuntimeStats();
     runtimeStats.setTotalCreateTime(timer.endTimer());
     stat.setRuntimeStats(runtimeStats);
-    writeStatus.setStat(stat);
   }
 
   protected long computeTotalWriteBytes() throws IOException {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
@@ -86,6 +86,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
         writeConfig.getWriteStatusFailureFraction());
     writeStatus.setPartitionPath(partitionPath);
     writeStatus.setFileId(fileId);
+    writeStatus.setStat(new HoodieWriteStat());
     try {
       HoodiePartitionMetadata partitionMetadata =
           new HoodiePartitionMetadata(
@@ -145,7 +146,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
    */
   public HoodieInternalWriteStatus close() throws IOException {
     fileWriter.close();
-    HoodieWriteStat stat = new HoodieWriteStat();
+    HoodieWriteStat stat = writeStatus.getStat();
     stat.setPartitionPath(partitionPath);
     stat.setNumWrites(writeStatus.getTotalRecords());
     stat.setNumDeletes(0);
@@ -160,7 +161,6 @@ public class HoodieRowDataCreateHandle implements Serializable {
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalCreateTime(currTimer.endTimer());
     stat.setRuntimeStats(runtimeStats);
-    writeStatus.setStat(stat);
     return writeStatus;
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -86,6 +86,7 @@ public class HoodieRowCreateHandle implements Serializable {
         writeConfig.getWriteStatusFailureFraction());
     writeStatus.setPartitionPath(partitionPath);
     writeStatus.setFileId(fileId);
+    writeStatus.setStat(new HoodieWriteStat());
     try {
       HoodiePartitionMetadata partitionMetadata =
           new HoodiePartitionMetadata(
@@ -144,7 +145,7 @@ public class HoodieRowCreateHandle implements Serializable {
    */
   public HoodieInternalWriteStatus close() throws IOException {
     fileWriter.close();
-    HoodieWriteStat stat = new HoodieWriteStat();
+    HoodieWriteStat stat = writeStatus.getStat();
     stat.setPartitionPath(partitionPath);
     stat.setNumWrites(writeStatus.getTotalRecords());
     stat.setNumDeletes(0);
@@ -159,7 +160,6 @@ public class HoodieRowCreateHandle implements Serializable {
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalCreateTime(currTimer.endTimer());
     stat.setRuntimeStats(runtimeStats);
-    writeStatus.setStat(stat);
     return writeStatus;
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

Some HoodieWriteStat being compute during the runtime was lost(e.g. compute min event time, which was stored at the HoodieWriteStat, in a customized payload), we need to initialize the HoodieWriteStat when initializing the handle.

## Brief change log

  - *Initialize the HoodieWriteStat when initializing the HoodieCreateHandle*

## Verify this pull request


This pull request is already covered by existing tests.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.