### PR TITLE
[HUDI-2230] Make codahale timers transient to avoid serializable exceptions

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
@@ -33,9 +33,9 @@ public class HoodieDeltaStreamerMetrics implements Serializable {
   public String overallTimerName = null;
   public String hiveSyncTimerName = null;
   public String metaSyncTimerName = null;
-  private Timer overallTimer = null;
-  public Timer hiveSyncTimer = null;
-  public Timer metaSyncTimer = null;
+  private transient Timer overallTimer = null;
+  public transient Timer hiveSyncTimer = null;
+  public transient Timer metaSyncTimer = null;
 
   public HoodieDeltaStreamerMetrics(HoodieWriteConfig config) {
     this.config = config;


### PR DESCRIPTION
## What is the purpose of the pull request

Enabling graphite metrics currently throws a `Task not serializable` exception due to the non-transient, non-serializable `Timer` member variables in `HoodieDeltaStreamerMetrics`. 

## Brief change log

- Add `transient` keyword to `Timer` vars in `HoodieDeltaStreamerMetrics`

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.