### PR TITLE
[HUDI-2259]Fix the exception of Merge Into when source table with columnAliases

### DIFF
--- a/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/hudi/parser/HoodieSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/hudi/parser/HoodieSqlAstBuilder.scala
@@ -185,12 +185,11 @@ class HoodieSqlAstBuilder(conf: SQLConf, delegate: ParserInterface) extends Hood
     */
   protected def mayApplyAliasPlan(tableAlias: TableAliasContext, plan: LogicalPlan): LogicalPlan = {
     if (tableAlias.strictIdentifier != null) {
-      val subquery = SubqueryAlias(tableAlias.strictIdentifier.getText, plan)
       if (tableAlias.identifierList != null) {
         val columnNames = visitIdentifierList(tableAlias.identifierList)
-        UnresolvedSubqueryColumnAliases(columnNames, subquery)
+        SubqueryAlias(tableAlias.strictIdentifier.getText,UnresolvedSubqueryColumnAliases(columnNames, plan))
       } else {
-        subquery
+        SubqueryAlias(tableAlias.strictIdentifier.getText, plan)
       }
     } else {
       plan


### PR DESCRIPTION
Fix the exception of Merge Into when source table with columnAliases.
But  still not support when the target table with columnAliases,I don't know is this because hudi whether itself is not supported this case for now.