### PR TITLE
[HUDI-2281] Add metadata client APIs to fetch list of data files and …

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieIncrementalMetadataClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieIncrementalMetadataClient.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * <code>HoodieIncrementalMetadataClient</code> allows to fetch details about incremental updates
+ * to the table using just the metadata.
+ *
+ */
+public class HoodieIncrementalMetadataClient implements Serializable {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieTableMetaClient.class);
+  private HoodieTableMetaClient metaClient;
+
+  /**
+   * Creates an HoodieIncrementalMetadataClient object.
+   *
+   * @param conf Hoodie Configuration
+   * @param basePath Base path of the Table
+   */
+  public HoodieIncrementalMetadataClient(Configuration conf, String basePath) throws IOException {
+    this(HoodieTableMetaClient.builder().setBasePath(basePath).setConf(conf).build());
+  }
+
+  /**
+   * Create HoodieIncrementalMetadataClient from HoodieTableMetaClient.
+   */
+  public HoodieIncrementalMetadataClient(HoodieTableMetaClient metaClient) {
+    this.metaClient = metaClient;
+  }
+
+  /**
+   * Get the underlying meta client object.
+   *
+   * @return Meta client
+   */
+  public HoodieTableMetaClient getMetaClient() {
+    return metaClient;
+  }
+
+  /**
+   * Relods the underlying meta client.
+   */
+  public void reload() {
+    this.metaClient.reloadActiveTimeline();
+  }
+
+  /**
+   * Gets the partitions modified from a hoodie instant.
+   *
+   * @param timeline Hoodie Timeline
+   * @param hoodieInstant Hoodie instant
+   * @return Pairs of Partition and the Filenames
+   * @throws HoodieIOException
+   */
+  private Stream<String> getPartitionNameFromInstant(
+      HoodieTimeline timeline,
+      HoodieInstant hoodieInstant) throws HoodieIOException {
+    switch (hoodieInstant.getAction()) {
+      case HoodieTimeline.COMMIT_ACTION:
+      case HoodieTimeline.DELTA_COMMIT_ACTION:
+        HoodieCommitMetadata commitMetadata;
+        try {
+          commitMetadata = HoodieCommitMetadata
+              .fromBytes(timeline.getInstantDetails(hoodieInstant).get(),
+                  HoodieCommitMetadata.class);
+        } catch (IOException e) {
+          throw new HoodieIOException("Unable to deserialize instant from avro", e);
+        }
+        return commitMetadata.getPartitionToWriteStats().keySet().stream();
+      case HoodieTimeline.REPLACE_COMMIT_ACTION:
+        HoodieReplaceCommitMetadata replaceCommitMetadata;
+        try {
+          replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(timeline.getInstantDetails(hoodieInstant).get(),
+              HoodieReplaceCommitMetadata.class);
+        } catch (IOException e) {
+          throw new HoodieIOException("Unable to deserialize instant from avro", e);
+        }
+        Set<String> allPartitions = new HashSet<>(replaceCommitMetadata.getPartitionToWriteStats().keySet());
+        allPartitions.addAll(replaceCommitMetadata.getPartitionToReplaceFileIds().keySet());
+        return allPartitions.stream();
+      case HoodieTimeline.CLEAN_ACTION:
+        try {
+          HoodieCleanMetadata cleanMetadata = TimelineMetadataUtils.deserializeHoodieCleanMetadata(timeline.getInstantDetails(hoodieInstant).get());
+          return cleanMetadata.getPartitionMetadata().keySet().stream();
+        } catch (IOException e) {
+          throw new HoodieIOException("unable to deserialize clean plan from avro", e);
+        }
+      default:
+        return Stream.empty();
+    }
+  }
+
+  /**
+   * Filters the instances from the timeline and returns the resulting partitions.
+   *
+   * @param timeline Hoodie timeline
+   * @param beginTs  Start commit timestamp
+   * @param endTs    End commit timestamp
+   * @return
+   */
+  private Stream<String> getPartitionNames(HoodieTimeline timeline, String beginTs, String endTs) {
+    return timeline.getInstants()
+        .filter(instant -> (HoodieTimeline.compareTimestamps(instant.getTimestamp(), HoodieTimeline.GREATER_THAN, beginTs) 
+            && (endTs == null || HoodieTimeline.compareTimestamps(instant.getTimestamp(), HoodieTimeline.LESSER_THAN_OR_EQUALS, endTs
+        ))))
+        .flatMap(i -> getPartitionNameFromInstant(timeline, i)).filter(s -> !s.isEmpty()).distinct();
+  }
+
+  /**
+   * Gets the list of partitions written since a commit timestamp.
+   * The filter will exclude begin timestamp.
+   *
+   * @param beginInstantTs Start commit timestamp
+   * @return List of partition paths
+   */
+  public List<String> getPartitionsMutatedSince(String beginInstantTs) {
+    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedInstants();
+    return getPartitionNames(timeline, beginInstantTs, null).collect(Collectors.toList());
+  }
+
+  /**
+   * Gets the list of partitions written to between two timestamps.
+   * The filter will exclude start timestamp and include end timestamp in the result.
+   *
+   * @param beginInstantTs Start commit timestamp
+   * @param endInstantTs   End commit timestamp
+   * @return List of partition paths
+   */
+  public List<String> getPartitionsMutatedBetween(String beginInstantTs, String endInstantTs) {
+    HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedInstants();
+    return getPartitionNames(timeline, beginInstantTs, endInstantTs).collect(Collectors.toList());
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieSnapshotMetadataClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieSnapshotMetadataClient.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+/**
+ * Provides an API for reading metadata
+ * 1) for latest commit.
+ * 2) as of given commit.
+ * 
+ * This only includes base files (parquet) today. But can be extended to return other metadata information.
+ */
+public class HoodieSnapshotMetadataClient {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieSnapshotMetadataClient.class);
+
+  private HoodieTableMetaClient metaClient;
+
+  /**
+   * Constructor to create metadata client.
+   * 
+   * @param conf hadoop configuration bag.
+   * @param basePath Table location absolute path.
+   */
+  public HoodieSnapshotMetadataClient(Configuration conf, String basePath) throws IOException {
+    this(HoodieTableMetaClient.builder().setBasePath(basePath).setConf(conf).build());
+  }
+
+  /**
+   * Create HoodieIncrementalMetadataClient from HoodieTableMetaClient.
+   */
+  public HoodieSnapshotMetadataClient(HoodieTableMetaClient metaClient) {
+    this.metaClient = metaClient;
+  }
+
+  /**
+   * Returns the latest set of data files that represent rows in table. Note that this only returns 'base' files and 
+   * not log files.
+   */
+  public Stream<Path> getLatestSnapshotFiles(String partitionPath) {
+    HoodieTableFileSystemView fileSystemView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
+    return fileSystemView.getLatestBaseFiles(partitionPath).map(bf -> new Path(bf.getPath()));
+  }
+
+  /**
+   * Returns set of data files that represent rows in table as of specified instant. 
+   * Note that this only returns 'base' files and not log files. 
+   * Also, note that this only works if corresponding base files are not removed by Cleaner.
+   */
+  public Stream<Path> getSnapshotFilesAt(String instant, String partitionPath) {
+    HoodieTableFileSystemView fileSystemView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
+    return fileSystemView.getLatestBaseFilesBeforeOrOn(partitionPath, instant).map(bf -> new Path(bf.getPath()));
+  }
+
+  /**
+   * Returns the latest commit instant time on hoodie table.
+   */
+  public Option<String> getLatestInstant() {
+    return this.metaClient.getActiveTimeline().getCommitTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::getTimestamp);
+  }
+
+  /**
+   * reload active timeline to read new commits (if any).
+   */
+  public void reload() {
+    this.metaClient.reloadActiveTimeline();
+  }
+
+  /**
+   * Getter for metaClient.
+   */
+  public HoodieTableMetaClient getMetaClient() {
+    return metaClient;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieIncrementalMetadataClient.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieIncrementalMetadataClient.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestHoodieIncrementalMetadataClient {
+  private static String TEST_WRITE_TOKEN = "1-0-1";
+  
+  @TempDir
+  public java.nio.file.Path folder;
+  
+  private String basePath;
+  private HoodieIncrementalMetadataClient incrementalMetadataClient;
+  private HoodieTableMetaClient metaClient;
+
+  private String fileId1 = UUID.randomUUID().toString();
+  private String fileId2 = UUID.randomUUID().toString();
+  private String fileId3 = UUID.randomUUID().toString();
+  private String fileId4 = UUID.randomUUID().toString();
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    basePath = folder.resolve("dataset").toString();
+    HoodieTestUtils.init(basePath, HoodieTableType.COPY_ON_WRITE);
+    setupDataFiles();
+    incrementalMetadataClient = new HoodieIncrementalMetadataClient(HoodieTestUtils.getDefaultHadoopConf(), basePath);
+    metaClient = incrementalMetadataClient.getMetaClient();
+    
+  }
+  
+  private void setupDataFiles() throws IOException {
+    // Put some files in the partition
+    new File(basePath).mkdirs();
+    String cleanTime1 = "0";
+    String commitTime1 = "1";
+    String commitTime2 = "2";
+    String commitTime3 = "3";
+    String commitTime4 = "4";
+    String replaceCommit5 = "5";
+    String partition1 = "p1";
+    String partition2 = "p2";
+    
+    String fullPartition1 = new Path(basePath, partition1).toString();
+    String fullPartition2 = new Path(basePath, partition2).toString();
+
+    new File(fullPartition1 + FSUtils.makeDataFileName(commitTime1, TEST_WRITE_TOKEN, fileId1)).createNewFile();
+    new File(fullPartition1 + FSUtils.makeDataFileName(commitTime4, TEST_WRITE_TOKEN, fileId1)).createNewFile();
+    
+    new File(fullPartition2 + FSUtils.makeDataFileName(commitTime1, TEST_WRITE_TOKEN, fileId2)).createNewFile();
+    new File(fullPartition2 + FSUtils.makeDataFileName(commitTime2, TEST_WRITE_TOKEN, fileId2)).createNewFile();
+    
+    new File(fullPartition1 + FSUtils.makeDataFileName(commitTime3, TEST_WRITE_TOKEN, fileId2)).createNewFile();
+    new File(fullPartition1 + FSUtils.makeDataFileName(commitTime3, TEST_WRITE_TOKEN, fileId3)).createNewFile();
+    new File(fullPartition1 + FSUtils.makeDataFileName(commitTime4, TEST_WRITE_TOKEN, fileId3)).createNewFile();
+    new File(fullPartition1
+        + FSUtils.makeLogFileName(fileId4, HoodieLogFile.DELTA_EXTENSION, commitTime4, 0, TEST_WRITE_TOKEN))
+        .createNewFile();
+
+    // Create commit/clean files
+    FileCreateUtils.createCommit(basePath, commitTime1, buildCommitMetadata(partition1, partition2));
+    FileCreateUtils.createCommit(basePath, commitTime2, buildCommitMetadata(partition2));
+    FileCreateUtils.createCommit(basePath, commitTime3, buildCommitMetadata(partition1));
+    FileCreateUtils.createCommit(basePath, commitTime4, buildCommitMetadata(partition1));
+
+    FileCreateUtils.createReplaceCommit(basePath, replaceCommit5, 
+        buildReplaceCommitMetadata(new String[] {partition1}, new String[] {partition2, "p3"}));
+  }
+
+  private HoodieReplaceCommitMetadata buildReplaceCommitMetadata(String[] partitionsReplaced, String[] partitionsAdded) {
+    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
+    for (String p : partitionsAdded) {
+      HoodieWriteStat writeStat = new HoodieWriteStat();
+      writeStat.setPartitionPath(p);
+      writeStat.setFileId("f1"); // fileId is not used in incremental metadata client
+      writeStat.setPrevCommit("");
+      writeStat.setNumInserts(10L);
+      writeStat.setNumDeletes(0L);
+      writeStat.setPath(p);
+      metadata.addWriteStat(p, writeStat);
+    }
+    
+    for (String p : partitionsReplaced) {
+      metadata.getPartitionToReplaceFileIds().putIfAbsent(p, new ArrayList<>());
+      metadata.getPartitionToReplaceFileIds().get(p).add("fReplacedId");
+    }
+    metadata.setCompacted(false);
+    metadata.setOperationType(WriteOperationType.INSERT);
+    return metadata;
+  }
+
+  private HoodieCommitMetadata buildCommitMetadata(String... partitions) {
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    for (String p : partitions) {
+      HoodieWriteStat writeStat = new HoodieWriteStat();
+      writeStat.setPartitionPath(p);
+      writeStat.setFileId("f1"); // fileId is not used in incremental metadata client
+      writeStat.setPrevCommit("");
+      writeStat.setNumInserts(10L);
+      writeStat.setNumDeletes(0L);
+      writeStat.setPath(p);
+      metadata.addWriteStat(p, writeStat);
+    }
+    metadata.setCompacted(false);
+    metadata.setOperationType(WriteOperationType.INSERT);
+    return metadata;
+  }
+
+  @Test
+  public void testIncremental() throws IOException {
+
+    List<String> partitions = incrementalMetadataClient.getPartitionsMutatedBetween("0", "4");
+    assertEquals(2, partitions.size());
+    assertEquals(Stream.of("p1", "p2").collect(Collectors.toList()), partitions);
+
+
+    partitions = incrementalMetadataClient.getPartitionsMutatedBetween("1", "2");
+    assertEquals(1, partitions.size());
+    assertEquals(Stream.of("p2").collect(Collectors.toList()), partitions); //only p2 is modified in commitTime2
+
+    partitions = incrementalMetadataClient.getPartitionsMutatedBetween("2", "4");
+    assertEquals(1, partitions.size());
+    assertEquals(Stream.of("p1").collect(Collectors.toList()), partitions); //only p1 is modified between commitTime2, commitTime4
+
+    partitions = incrementalMetadataClient.getPartitionsMutatedSince("2");
+    assertEquals(3, partitions.size());
+    assertEquals(Stream.of("p1", "p2", "p3").collect(Collectors.toList()), partitions);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieSnapshotMetadataClient.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieSnapshotMetadataClient.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestHoodieSnapshotMetadataClient {
+  private static String TEST_WRITE_TOKEN = "1-0-1";
+  
+  @TempDir
+  public java.nio.file.Path folder;
+  
+  private String basePath;
+  private String partitionPath;
+  private String fullPartitionPath;
+  private HoodieSnapshotMetadataClient snapshotMetadataClient;
+  private HoodieTableMetaClient metaClient;
+
+  private String fileId1 = UUID.randomUUID().toString();
+  private String fileId2 = UUID.randomUUID().toString();
+  private String fileId3 = UUID.randomUUID().toString();
+  private String fileId4 = UUID.randomUUID().toString();
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    basePath = folder.resolve("dataset").toString();
+    partitionPath = "2016/05/01/";
+    fullPartitionPath = basePath + "/" + partitionPath;
+    HoodieTestUtils.init(basePath, HoodieTableType.COPY_ON_WRITE);
+    setupDataFiles();
+    snapshotMetadataClient = new HoodieSnapshotMetadataClient(HoodieTestUtils.getDefaultHadoopConf(), basePath);
+    metaClient = snapshotMetadataClient.getMetaClient();
+    
+  }
+  
+  private void setupDataFiles() throws IOException {
+    // Put some files in the partition
+    new File(fullPartitionPath).mkdirs();
+    String cleanTime1 = "0";
+    String commitTime1 = "1";
+    String commitTime2 = "2";
+    String commitTime3 = "3";
+    String commitTime4 = "4";
+
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime1, TEST_WRITE_TOKEN, fileId1)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime4, TEST_WRITE_TOKEN, fileId1)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime1, TEST_WRITE_TOKEN, fileId2)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime2, TEST_WRITE_TOKEN, fileId2)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime3, TEST_WRITE_TOKEN, fileId2)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime3, TEST_WRITE_TOKEN, fileId3)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime4, TEST_WRITE_TOKEN, fileId3)).createNewFile();
+    new File(fullPartitionPath
+        + FSUtils.makeLogFileName(fileId4, HoodieLogFile.DELTA_EXTENSION, commitTime4, 0, TEST_WRITE_TOKEN))
+        .createNewFile();
+
+    // Create commit/clean files
+    new File(basePath + "/.hoodie/" + cleanTime1 + ".clean").createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime1 + ".commit").createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime2 + ".commit").createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime3 + ".commit").createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime4 + ".commit").createNewFile();
+  }
+
+  @Test
+  public void testSnapshotMetadata() throws IOException {
+    assertEquals("4", snapshotMetadataClient.getLatestInstant().get());
+    
+    Set<String> fileIds = snapshotMetadataClient.getLatestSnapshotFiles(partitionPath).map(FSUtils::getFileIdFromFilePath)
+        .collect(Collectors.toSet());
+    
+    //fileId4 has only log file. so ensure it doesnt show up in results.
+    assertEquals(Stream.of(fileId1, fileId2, fileId3).collect(Collectors.toSet()), fileIds);
+    
+    Set<String> fileIdsAt2 = snapshotMetadataClient.getSnapshotFilesAt("2", partitionPath).map(FSUtils::getFileIdFromFilePath)
+        .collect(Collectors.toSet());
+
+    // only fileId1/fileId2 exist at instant 2.
+    assertEquals(2, fileIdsAt2.size());
+    assertEquals(Stream.of(fileId1, fileId2).collect(Collectors.toSet()), fileIdsAt2);
+  }
+}


### PR DESCRIPTION

## What is the purpose of the pull request
Provide generic APIs to 
* get all modified partitions since a specified commit time
* get all data files written as part of latest commit
 
We have different consumers using these APIs to achieve cross-dc consistency and improving efficiency for single region compute

## Brief change log
* Add HoodieSnapshotMetadataClient to fetch data file paths written as part of a commit
* Add HoodieIncrementalMetadataClient to fetch partitions modified since last commit

## Verify this pull request
This change added tests

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.