### PR TITLE
[MINOR] Fix travis from errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,26 @@ jdk:
   - openjdk8
 jobs:
   include:
-    - name: "Unit tests for hudi-spark-client"
-      env: MODE=unit MODULES=hudi-client/hudi-spark-client HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-client"
+      env: MODE=unit MODULES='hudi-client/hudi-client-common,hudi-client/hudi-java-client,hudi-client/hudi-spark-client,hudi-client/hudi-flink-client' HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-utilities"
       env: MODE=unit MODULES=hudi-utilities HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-common"
+      env: MODE=unit MODULES=hudi-common HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-cli"
+      env: MODE=unit MODULES=hudi-cli HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-hadoop-mr"
+      env: MODE=unit MODULES=hudi-hadoop-mr HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark-datasource"
+      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark,hudi-spark-datasource/hudi-spark2,hudi-spark-datasource/hudi-spark3,hudi-spark-datasource/hudi-spark-common' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-timeline-service"
+      env: MODE=unit MODULES=hudi-timeline-service HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-sync"
+      env: MODE=unit MODULES='hudi-sync/hudi-sync-common,hudi-sync/hudi-hive-sync,hudi-sync/hudi-dla-sync' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-flink"
+      env: MODE=unit MODULES=hudi-flink HUDI_QUIETER_LOGGING=1
     - name: "All other unit tests"
-      env: MODE=unit MODULES='!hudi-utilities,!hudi-client/hudi-spark-client' HUDI_QUIETER_LOGGING=1
+      env: MODE=unit MODULES='!hudi-utilities,!hudi-client,!hudi-common,!hudi-cli,!hudi-hadoop-mr,!hudi-spark-datasource,!hudi-timeline-service,!hudi-sync,!hudi-flink' HUDI_QUIETER_LOGGING=1
     - name: "Functional tests"
       env: MODE=functional HUDI_QUIETER_LOGGING=1
     - name: "Integration tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,12 @@ jdk:
   - openjdk8
 jobs:
   include:
-    - name: "Unit tests for hudi-client"
-      env: MODE=unit MODULES='hudi-client/hudi-client-common,hudi-client/hudi-java-client,hudi-client/hudi-spark-client,hudi-client/hudi-flink-client' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark-client"
+      env: MODE=unit MODULES=hudi-client/hudi-spark-client HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-utilities"
       env: MODE=unit MODULES=hudi-utilities HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-common"
-      env: MODE=unit MODULES=hudi-common HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-cli"
-      env: MODE=unit MODULES=hudi-cli HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-hadoop-mr"
-      env: MODE=unit MODULES=hudi-hadoop-mr HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-spark-datasource"
-      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark-common,hudi-spark-datasource/hudi-spark,hudi-spark-datasource/hudi-spark2,hudi-spark-datasource/hudi-spark3' HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-timeline-service"
-      env: MODE=unit MODULES=hudi-timeline-service HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-sync"
-      env: MODE=unit MODULES='hudi-sync/hudi-sync-common,hudi-sync/hudi-hive-sync,hudi-sync/hudi-dla-sync' HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-flink"
-      env: MODE=unit MODULES=hudi-flink HUDI_QUIETER_LOGGING=1
     - name: "All other unit tests"
-      env: MODE=unit MODULES='!hudi-client/hudi-client-common,!hudi-client/hudi-java-client,!hudi-client/hudi-spark-client,!hudi-client/hudi-flink-client,!hudi-utilities,!hudi-common,!hudi-cli,!hudi-hadoop-mr,!hudi-spark-datasource/hudi-spark,!hudi-spark-datasource/hudi-spark2,!hudi-spark-datasource/hudi-spark3,!hudi-spark-datasource/hudi-spark-common,!hudi-timeline-service,!hudi-sync/hudi-sync-common,!hudi-sync/hudi-hive-sync,!hudi-sync/hudi-dla-sync,!hudi-flink' HUDI_QUIETER_LOGGING=1
+      env: MODE=unit MODULES='!hudi-utilities,!hudi-client/hudi-spark-client' HUDI_QUIETER_LOGGING=1
     - name: "Functional tests"
       env: MODE=functional HUDI_QUIETER_LOGGING=1
     - name: "Integration tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     - name: "Unit tests for hudi-flink"
       env: MODE=unit MODULES=hudi-flink HUDI_QUIETER_LOGGING=1
     - name: "All other unit tests"
-      env: MODE=unit MODULES='!hudi-utilities,!hudi-client,!hudi-common,!hudi-cli,!hudi-hadoop-mr,!hudi-spark-datasource,!hudi-timeline-service,!hudi-sync,!hudi-flink' HUDI_QUIETER_LOGGING=1
+      env: MODE=unit MODULES='!hudi-client/hudi-client-common,!hudi-client/hudi-java-client,!hudi-client/hudi-spark-client,!hudi-client/hudi-flink-client,!hudi-utilities,!hudi-common,!hudi-cli,!hudi-hadoop-mr,!hudi-spark-datasource/hudi-spark,!hudi-spark-datasource/hudi-spark2,!hudi-spark-datasource/hudi-spark3,!hudi-spark-datasource/hudi-spark-common,!hudi-timeline-service,!hudi-sync/hudi-sync-common,!hudi-sync/hudi-hive-sync,!hudi-sync/hudi-dla-sync,!hudi-flink' HUDI_QUIETER_LOGGING=1
     - name: "Functional tests"
       env: MODE=functional HUDI_QUIETER_LOGGING=1
     - name: "Integration tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,8 @@ jobs:
       env: MODE=unit MODULES=hudi-cli HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-hadoop-mr"
       env: MODE=unit MODULES=hudi-hadoop-mr HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-spark"
-      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark' HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-spark2"
-      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark2' HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-spark3"
-      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark3' HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-spark-common"
-      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark-common' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark-datasource"
+      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark-common,hudi-spark-datasource/hudi-spark,hudi-spark-datasource/hudi-spark2,hudi-spark-datasource/hudi-spark3' HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-timeline-service"
       env: MODE=unit MODULES=hudi-timeline-service HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-sync"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,14 @@ jobs:
       env: MODE=unit MODULES=hudi-cli HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-hadoop-mr"
       env: MODE=unit MODULES=hudi-hadoop-mr HUDI_QUIETER_LOGGING=1
-    - name: "Unit tests for hudi-spark-datasource"
-      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark,hudi-spark-datasource/hudi-spark2,hudi-spark-datasource/hudi-spark3,hudi-spark-datasource/hudi-spark-common' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark"
+      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark2"
+      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark2' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark3"
+      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark3' HUDI_QUIETER_LOGGING=1
+    - name: "Unit tests for hudi-spark-common"
+      env: MODE=unit MODULES='hudi-spark-datasource/hudi-spark-common' HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-timeline-service"
       env: MODE=unit MODULES=hudi-timeline-service HUDI_QUIETER_LOGGING=1
     - name: "Unit tests for hudi-sync"

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -38,6 +38,7 @@ class TestStreamingSource extends StreamTest {
   private val columns = Seq("id", "name", "price", "ts")
 
   override protected def sparkConf = {
+    super.spark.sparkContext.setLogLevel("WARN")
     super.sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -22,6 +22,7 @@ import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD
 import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM, INSERT_PARALLELISM, TABLE_NAME, UPSERT_PARALLELISM}
+import org.apache.log4j.Level
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.{Row, SaveMode}
 
@@ -37,8 +38,9 @@ class TestStreamingSource extends StreamTest {
   )
   private val columns = Seq("id", "name", "price", "ts")
 
+  org.apache.log4j.Logger.getRootLogger.setLevel(Level.WARN)
+
   override protected def sparkConf = {
-    super.spark.sparkContext.setLogLevel("WARN")
     super.sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
@@ -42,7 +42,7 @@ class TestHoodieSqlBase extends FunSuite with BeforeAndAfterAll {
     .config("hoodie.delete.shuffle.parallelism", "4")
     .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
     .getOrCreate()
-  spark.sparkContext.setLogLevel("ERROR");
+  spark.sparkContext.setLogLevel("WARN")
 
   private var tableId = 0
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
@@ -44,7 +44,6 @@ class TestHoodieSqlBase extends FunSuite with BeforeAndAfterAll {
     .config("hoodie.delete.shuffle.parallelism", "4")
     .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
     .getOrCreate()
-  spark.sparkContext.setLogLevel("WARN")
 
   private var tableId = 0
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
@@ -42,6 +42,7 @@ class TestHoodieSqlBase extends FunSuite with BeforeAndAfterAll {
     .config("hoodie.delete.shuffle.parallelism", "4")
     .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
     .getOrCreate()
+  spark.sparkContext.setLogLevel("ERROR");
 
   private var tableId = 0
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi
 
 import java.io.File
 
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.util.Utils
 import org.scalactic.source
@@ -32,15 +33,20 @@ class TestHoodieSqlBase extends FunSuite with BeforeAndAfterAll {
     dir
   }
 
+  private val sparkConf = new SparkConf()
+    .setMaster("local[1]")
+    .setAppName("hoodie sql test")
+    .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    .set("hoodie.insert.shuffle.parallelism", "4")
+    .set("hoodie.upsert.shuffle.parallelism", "4")
+    .set("hoodie.delete.shuffle.parallelism", "4")
+    .set("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
+
+  SparkContext.getOrCreate(sparkConf).setLogLevel("WARN")
+
   protected lazy val spark: SparkSession = SparkSession.builder()
-    .master("local[1]")
-    .appName("hoodie sql test")
+    .config(sparkConf)
     .withExtensions(new HoodieSparkSessionExtension)
-    .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    .config("hoodie.insert.shuffle.parallelism", "4")
-    .config("hoodie.upsert.shuffle.parallelism", "4")
-    .config("hoodie.delete.shuffle.parallelism", "4")
-    .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
     .getOrCreate()
   spark.sparkContext.setLogLevel("WARN")
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieSqlBase.scala
@@ -19,13 +19,14 @@ package org.apache.spark.sql.hudi
 
 import java.io.File
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.log4j.Level
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.util.Utils
 import org.scalactic.source
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 
 class TestHoodieSqlBase extends FunSuite with BeforeAndAfterAll {
+  org.apache.log4j.Logger.getRootLogger.setLevel(Level.WARN)
 
   private lazy val sparkWareHouse = {
     val dir = Utils.createTempDir()
@@ -33,20 +34,15 @@ class TestHoodieSqlBase extends FunSuite with BeforeAndAfterAll {
     dir
   }
 
-  private val sparkConf = new SparkConf()
-    .setMaster("local[1]")
-    .setAppName("hoodie sql test")
-    .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    .set("hoodie.insert.shuffle.parallelism", "4")
-    .set("hoodie.upsert.shuffle.parallelism", "4")
-    .set("hoodie.delete.shuffle.parallelism", "4")
-    .set("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
-
-  SparkContext.getOrCreate(sparkConf).setLogLevel("WARN")
-
   protected lazy val spark: SparkSession = SparkSession.builder()
-    .config(sparkConf)
+    .master("local[1]")
+    .appName("hoodie sql test")
     .withExtensions(new HoodieSparkSessionExtension)
+    .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    .config("hoodie.insert.shuffle.parallelism", "4")
+    .config("hoodie.upsert.shuffle.parallelism", "4")
+    .config("hoodie.delete.shuffle.parallelism", "4")
+    .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
     .getOrCreate()
   spark.sparkContext.setLogLevel("WARN")
 

--- a/hudi-spark-datasource/hudi-spark2/src/test/resources/log4j-surefire-quiet.properties
+++ b/hudi-spark-datasource/hudi-spark2/src/test/resources/log4j-surefire-quiet.properties
@@ -1,0 +1,30 @@
+###
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+log4j.rootLogger=WARN, CONSOLE
+log4j.logger.org.apache.hudi=DEBUG
+log4j.logger.org.apache.hadoop.hbase=ERROR
+
+# CONSOLE is set to be a ConsoleAppender.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+# CONSOLE uses PatternLayout.
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=[%-5p] %d %c %x - %m%n
+log4j.appender.CONSOLE.filter.a=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CONSOLE.filter.a.AcceptOnMatch=true
+log4j.appender.CONSOLE.filter.a.LevelMin=WARN
+log4j.appender.CONSOLE.filter.a.LevelMax=FATAL

--- a/hudi-spark-datasource/hudi-spark2/src/test/resources/log4j-surefire.properties
+++ b/hudi-spark-datasource/hudi-spark2/src/test/resources/log4j-surefire.properties
@@ -1,0 +1,31 @@
+###
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+log4j.rootLogger=WARN, CONSOLE
+log4j.logger.org.apache=INFO
+log4j.logger.org.apache.hudi=DEBUG
+log4j.logger.org.apache.hadoop.hbase=ERROR
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+# A1 uses PatternLayout.
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.CONSOLE.filter.a=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CONSOLE.filter.a.AcceptOnMatch=true
+log4j.appender.CONSOLE.filter.a.LevelMin=WARN
+log4j.appender.CONSOLE.filter.a.LevelMax=FATAL

--- a/hudi-spark-datasource/hudi-spark3/src/test/resources/log4j-surefire-quiet.properties
+++ b/hudi-spark-datasource/hudi-spark3/src/test/resources/log4j-surefire-quiet.properties
@@ -1,0 +1,30 @@
+###
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+log4j.rootLogger=WARN, CONSOLE
+log4j.logger.org.apache.hudi=DEBUG
+log4j.logger.org.apache.hadoop.hbase=ERROR
+
+# CONSOLE is set to be a ConsoleAppender.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+# CONSOLE uses PatternLayout.
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=[%-5p] %d %c %x - %m%n
+log4j.appender.CONSOLE.filter.a=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CONSOLE.filter.a.AcceptOnMatch=true
+log4j.appender.CONSOLE.filter.a.LevelMin=WARN
+log4j.appender.CONSOLE.filter.a.LevelMax=FATAL

--- a/hudi-spark-datasource/hudi-spark3/src/test/resources/log4j-surefire.properties
+++ b/hudi-spark-datasource/hudi-spark3/src/test/resources/log4j-surefire.properties
@@ -1,0 +1,31 @@
+###
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+log4j.rootLogger=WARN, CONSOLE
+log4j.logger.org.apache=INFO
+log4j.logger.org.apache.hudi=DEBUG
+log4j.logger.org.apache.hadoop.hbase=ERROR
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+# A1 uses PatternLayout.
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.CONSOLE.filter.a=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CONSOLE.filter.a.AcceptOnMatch=true
+log4j.appender.CONSOLE.filter.a.LevelMin=WARN
+log4j.appender.CONSOLE.filter.a.LevelMax=FATAL


### PR DESCRIPTION
Fix : Travis job 3 named `All other unit tests` is failed because of the error `The job exceeded the maximum log length, and has been terminated`

Also fixed the errors of spark2 and spark3 related UTs `log4j:ERROR Could not read configuration file from URL [file:/home/travis/build/apache/hudi/hudi-spark-datasource/hudi-spark2/src/test/resources/log4j-surefire-quiet.properties].`

## What is the purpose of the pull request
Reduce the the log message numbers of a single travis job by :

1. Split a big Travis job into multiple sub-jobs.
2. Changed the log level from info to warn.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.