### PR TITLE
[HUDI-2151]  Flipping defaults

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -121,8 +121,8 @@ public class HoodieIndexConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> BLOOM_INDEX_FILTER_TYPE = ConfigProperty
       .key("hoodie.bloom.index.filter.type")
-      .defaultValue(BloomFilterTypeCode.SIMPLE.name())
-      .withDocumentation("Filter type used. Default is BloomFilterTypeCode.SIMPLE. "
+      .defaultValue(BloomFilterTypeCode.DYNAMIC_V0.name())
+      .withDocumentation("Filter type used. Default is BloomFilterTypeCode.DYNAMIC_V0. "
           + "Available values are [BloomFilterTypeCode.SIMPLE , BloomFilterTypeCode.DYNAMIC_V0]. "
           + "Dynamic bloom filters auto size themselves based on number of keys.");
 
@@ -183,7 +183,7 @@ public class HoodieIndexConfig extends HoodieConfig {
    */
   public static final ConfigProperty<String> BLOOM_INDEX_UPDATE_PARTITION_PATH = ConfigProperty
       .key("hoodie.bloom.index.update.partition.path")
-      .defaultValue("false")
+      .defaultValue("true")
       .withDocumentation("Only applies if index type is GLOBAL_BLOOM. "
           + "When set to true, an update including the partition path of a record that already exists will result in "
           + "inserting the incoming record into the new partition and deleting the original record in the old partition. "
@@ -191,7 +191,7 @@ public class HoodieIndexConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> SIMPLE_INDEX_UPDATE_PARTITION_PATH = ConfigProperty
       .key("hoodie.simple.index.update.partition.path")
-      .defaultValue("false")
+      .defaultValue("true")
       .withDocumentation("Similar to " + BLOOM_INDEX_UPDATE_PARTITION_PATH + ", but for simple index.");
 
   private EngineType engineType;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -114,7 +114,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> TIMELINE_LAYOUT_VERSION = ConfigProperty
       .key("hoodie.timeline.layout.version")
-      .noDefaultValue()
+      .defaultValue(Integer.toString(TimelineLayoutVersion.VERSION_1))
       .sinceVersion("0.5.1")
       .withDocumentation("Controls the layout of the timeline. Version 0 relied on renames, Version 1 (default) models "
           + "the timeline as an immutable log relying only on atomic writes for object storage.");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1973,6 +1973,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         getConfigBuilder().withRollbackUsingMarkers(rollbackUsingMarkers).withAutoCommit(false)
             .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder()
                 .withConsistencyCheckEnabled(true)
+                .withEnableOptimisticConsistencyGuard(enableOptimisticConsistencyGuard)
                 .withOptimisticConsistencyGuardSleepTimeMs(1).build())
             .withProperties(properties).build();
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
@@ -2204,6 +2205,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
             .withMaxConsistencyCheckIntervalMs(1).withInitialConsistencyCheckIntervalMs(1).withEnableOptimisticConsistencyGuard(enableOptimisticConsistencyGuard).build())
         .build()) : (getConfigBuilder().withAutoCommit(false)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true)
+            .withEnableOptimisticConsistencyGuard(enableOptimisticConsistencyGuard)
             .withOptimisticConsistencyGuardSleepTimeMs(1).build())
         .build());
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieGlobalBloomIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieGlobalBloomIndex.java
@@ -177,7 +177,8 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
 
   @Test
   public void testTagLocation() throws Exception {
-    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath).build();
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withBloomIndexUpdatePartitionPath(false).build()).build();
     SparkHoodieGlobalBloomIndex index = new SparkHoodieGlobalBloomIndex(config);
     HoodieTable hoodieTable = HoodieSparkTable.create(config, context, metaClient);
     HoodieSparkWriteableTestTable testTable = HoodieSparkWriteableTestTable.of(hoodieTable, SCHEMA);

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/ConsistencyGuardConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/ConsistencyGuardConfig.java
@@ -77,7 +77,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   // config to enable OptimisticConsistencyGuard in finalizeWrite instead of FailSafeConsistencyGuard
   public static final ConfigProperty<Boolean> ENABLE_OPTIMISTIC_CONSISTENCY_GUARD_PROP = ConfigProperty
       .key("_hoodie.optimistic.consistency.guard.enable")
-      .defaultValue(true)
+      .defaultValue(false)
       .sinceVersion("0.6.0")
       .withDocumentation("Enable consistency guard, which optimistically assumes consistency is achieved after a certain time period.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -81,7 +81,7 @@ public class HoodieTableConfig extends HoodieConfig implements Serializable {
 
   public static final ConfigProperty<HoodieTableVersion> HOODIE_TABLE_VERSION_PROP = ConfigProperty
       .key("hoodie.table.version")
-      .defaultValue(HoodieTableVersion.ONE)
+      .defaultValue(HoodieTableVersion.ZERO)
       .withDocumentation("Version of table, used for running upgrade/downgrade steps between releases with potentially "
           + "breaking/backwards compatible changes.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -81,7 +81,7 @@ public class HoodieTableConfig extends HoodieConfig implements Serializable {
 
   public static final ConfigProperty<HoodieTableVersion> HOODIE_TABLE_VERSION_PROP = ConfigProperty
       .key("hoodie.table.version")
-      .defaultValue(HoodieTableVersion.ZERO)
+      .defaultValue(HoodieTableVersion.ONE)
       .withDocumentation("Version of table, used for running upgrade/downgrade steps between releases with potentially "
           + "breaking/backwards compatible changes.");
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -252,7 +252,7 @@ object DataSourceWriteOptions {
    */
   val ENABLE_ROW_WRITER: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.row.writer.enable")
-    .defaultValue("false")
+    .defaultValue("true")
     .withDocumentation("When set to true, will perform write operations directly using the spark native " +
       "`Row` representation, avoiding any additional conversion costs.")
 


### PR DESCRIPTION

## What is the purpose of the pull request

Flipping default value for some of the critical configs. 
- Optimistic Consistency guard ("_hoodie.optimistic.consistency.guard.enable") : true -> false
- Enable row writer for bulk_insert("hoodie.datasource.write.row.writer.enable"): false -> true
- Hoodie table version("hoodie.table.version") : ZERO -> ONE
- Hoodie bloom filter index type("hoodie.bloom.index.filter.type"): SIMPLE -> DYNAMIC_V0
- Hoodie timeline layout version ("hoodie.timeline.layout.version"): no default -> 1
- Hoodie global index update partition path("hoodie.bloom.index.update.partition.path" and "hoodie.simple.index.update.partition.path"): false -> true

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
