### PR TITLE
[HUDI-2297] Estimate available memory size  accurately for spillable map.

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkTaskContextSupplier.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkTaskContextSupplier.java
@@ -78,6 +78,14 @@ public class SparkTaskContextSupplier extends TaskContextSupplier implements Ser
             .get(SPARK_EXECUTOR_MEMORY_FRACTION_PROP, DEFAULT_SPARK_EXECUTOR_MEMORY_FRACTION));
       }
       return Option.empty();
+    } else if (prop == EngineProperty.TOTAL_CORES_PER_EXECUTOR) {
+      final String DEFAULT_SPARK_EXECUTOR_CORES = "1";
+      final String SPARK_EXECUTOR_EXECUTOR_CORES_PROP = "spark.executor.cores";
+      if (SparkEnv.get() != null) {
+        return Option.ofNullable(SparkEnv.get().conf()
+            .get(SPARK_EXECUTOR_EXECUTOR_CORES_PROP, DEFAULT_SPARK_EXECUTOR_CORES));
+      }
+      return Option.empty();
     }
     throw new HoodieException("Unknown engine property :" + prop);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/EngineProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/EngineProperty.java
@@ -26,8 +26,9 @@ public enum EngineProperty {
   EMBEDDED_SERVER_HOST,
   // Pool/queue to use to run compaction.
   COMPACTION_POOL_NAME,
+  TOTAL_CORES_PER_EXECUTOR,
   // Amount of total memory available to each engine executor
   TOTAL_MEMORY_AVAILABLE,
   // Fraction of that memory, that is already in use by the engine
-  MEMORY_FRACTION_IN_USE,
+  MEMORY_FRACTION_IN_USE
 }


### PR DESCRIPTION
## What is the purpose of the pull request

Estimate available memory size for spillable map accurately to avoid OOM. 
For spark engine, there is always more than one task running on the executor and each task maintains a spillable map. The old way doesn't consider this situation and results in OOM. 

## Brief change log

  - *Modify the way to estimate spillable map available memory in `IOUtils`*

## Verify this pull request

unit test cannot cover

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
