### PR TITLE
[HUDI-2301] fix FileSliceMetrics utils bug

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestFileSliceMetricUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestFileSliceMetricUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.utils;
+
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestFileSliceMetricUtils {
+
+  @Test
+  public void testFileSliceMetricUtilsWithoutFile() {
+    Map<String, Double> metrics = new HashMap<>();
+    List<FileSlice> fileSlices = new ArrayList<>();
+    final long defaultBaseFileSize = 10 * 1024 * 1024;
+    final double epsilon = 1e-5;
+    FileSliceMetricUtils.addFileSliceCommonMetrics(fileSlices, metrics, defaultBaseFileSize);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_READ_MB), epsilon);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_WRITE_MB), epsilon);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_MB), epsilon);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_LOG_FILE_SIZE), epsilon);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_LOG_FILES), epsilon);
+  }
+
+  @Test
+  public void testFileSliceMetricUtilsWithoutLogFile() {
+    Map<String, Double> metrics = new HashMap<>();
+    List<FileSlice> fileSlices = new ArrayList<>();
+    final long defaultBaseFileSize = 10 * 1024 * 1024;
+    final double epsilon = 1e-5;
+    fileSlices.add(buildFileSlice(15 * 1024 * 1024, new ArrayList<>()));
+    fileSlices.add(buildFileSlice(20 * 1024 * 1024, new ArrayList<>()));
+    fileSlices.add(buildFileSlice(0, new ArrayList<>()));
+    FileSliceMetricUtils.addFileSliceCommonMetrics(fileSlices, metrics, defaultBaseFileSize);
+    assertEquals(35.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_READ_MB), epsilon);
+    assertEquals(45.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_WRITE_MB), epsilon);
+    assertEquals(80.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_MB), epsilon);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_LOG_FILE_SIZE), epsilon);
+    assertEquals(0.0, metrics.get(FileSliceMetricUtils.TOTAL_LOG_FILES), epsilon);
+  }
+
+  @Test
+  public void testFileSliceMetricUtilsWithLogFile() {
+    Map<String, Double> metrics = new HashMap<>();
+    List<FileSlice> fileSlices = new ArrayList<>();
+    final long defaultBaseFileSize = 10 * 1024 * 1024;
+    final double epsilon = 1e-5;
+    fileSlices.add(buildFileSlice(15 * 1024 * 1024,
+        new ArrayList<>(Arrays.asList(5 * 1024 * 1024L, 3 * 1024 * 1024L))));
+    fileSlices.add(buildFileSlice(20 * 1024 * 1024,
+        new ArrayList<>(Collections.singletonList(2 * 1024 * 1024L))));
+    FileSliceMetricUtils.addFileSliceCommonMetrics(fileSlices, metrics, defaultBaseFileSize);
+    assertEquals(45.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_READ_MB), epsilon);
+    assertEquals(35.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_WRITE_MB), epsilon);
+    assertEquals(80.0, metrics.get(FileSliceMetricUtils.TOTAL_IO_MB), epsilon);
+    assertEquals(10.0 * 1024 * 1024, metrics.get(FileSliceMetricUtils.TOTAL_LOG_FILE_SIZE), epsilon);
+    assertEquals(3.0, metrics.get(FileSliceMetricUtils.TOTAL_LOG_FILES), epsilon);
+  }
+
+  private FileSlice buildFileSlice(long baseFileLen, List<Long> logFileLens) {
+    final String baseFilePath = ".b5068208-e1a4-11e6-bf01-fe55135034f3_20170101134598.log.1";
+    FileSlice slice = new FileSlice("partition_0",
+        HoodieActiveTimeline.createNewInstantTime(),
+        UUID.randomUUID().toString());
+    HoodieBaseFile baseFile = new HoodieBaseFile(baseFilePath);
+    baseFile.setFileLen(baseFileLen);
+    slice.setBaseFile(baseFile);
+    int logVersion = 1;
+    for (long logFileLen : logFileLens) {
+      String logFilePath = "." + UUID.randomUUID().toString() + "_20170101134598.log." + logVersion;
+      HoodieLogFile logFile = new HoodieLogFile(logFilePath);
+      logFile.setFileLen(logFileLen);
+      slice.addLogFile(logFile);
+      logVersion++;
+    }
+    return slice;
+  }
+
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

To fix bug of metrics calculation error
In the original code, the calculation of totalReadIO and totalWriteIO will only obtain the size of one of the Fileslice

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
