### PR TITLE
[HUDI-2320] Add support ByteArrayDeserializer in AvroKafkaSource

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -254,7 +254,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>bijection-avro_${scala.binary.version}</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.7</version>
     </dependency>
 
     <!-- Kafka -->


### PR DESCRIPTION
## What is the purpose of the pull request
Add support ByteArrayDeserializer in AvroKafkaSource



## Verify this pull request

When the 'value.serializer' of Kafka Avro Producer is 'org.apache.kafka.common.serialization.ByteArraySerializer',Use the following configuration

--source-class org.apache.hudi.utilities.sources.AvroKafkaSource \
--schemaprovider-class org.apache.hudi.utilities.schema.JdbcbasedSchemaProvider \
--hoodie-conf "hoodie.deltastreamer.source.kafka.value.deserializer.class=org.apache.kafka.common.serialization.ByteArrayDeserializer"

For now,It will throw an exception:
java.lang.ClassCastException: [B cannot be cast to org.apache.avro.generic.GenericRecord

After support ByteArrayDeserializer,Use the configuration above，It works properly.And there is no need to provide 'schema.registry.url',For example, we can use the JdbcbasedSchemaProvider to get the sourceSchema
