### PR TITLE
[HUDI-2357] MERGE INTO doesn't work for tables created using CTAS

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/InsertIntoHoodieTableCommand.scala
@@ -193,7 +193,8 @@ object InsertIntoHoodieTableCommand extends Logging {
         s"[${insertPartitions.keys.mkString(" " )}]" +
         s" not equal to the defined partition in table[${table.partitionColumnNames.mkString(",")}]")
     }
-    val parameters = withSparkConf(sparkSession, table.storage.properties)() ++ extraOptions
+    val options = table.storage.properties ++ extraOptions
+    val parameters = withSparkConf(sparkSession, options)()
 
     val tableType = parameters.getOrElse(TABLE_TYPE.key, TABLE_TYPE.defaultValue)
 
@@ -201,7 +202,7 @@ object InsertIntoHoodieTableCommand extends Logging {
     val path = getTableLocation(table, sparkSession)
 
     val tableSchema = table.schema
-    val options = table.storage.properties
+
     val primaryColumns = HoodieOptionConfig.getPrimaryColumns(options)
 
     val keyGenClass = if (primaryColumns.nonEmpty) {


### PR DESCRIPTION


## What is the purpose of the pull request

*Fix the missing extraOptions passed by CTAS. This missing options will lead the Merge Into not work for CTAS.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
