### PR TITLE
[HUDI-2359] Add basic "hoodie_is_deleted" unit tests to TestDataSourc…

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -36,6 +36,7 @@ import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieClientTestBase}
 import org.apache.log4j.LogManager
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.BooleanType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -784,5 +785,41 @@ class TestMORDataSource extends HoodieClientTestBase {
     val tempPath = new Path(basePath, HoodieTableMetaClient.TEMPFOLDER_NAME)
     val fs = tempPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
     assertEquals(true, fs.listStatus(tempPath).isEmpty)
+  }
+
+  @Test
+  def testHoodieIsDeletedMOR(): Unit =  {
+    val numRecords = 100
+    val numRecordsToDelete = 2
+    val schema = HoodieTestDataGenerator.SHORT_TRIP_SCHEMA
+    val records0 = recordsToStrings(dataGen.generateInsertsAsPerSchema("000", numRecords, schema)).toList
+    val inputDF0 = spark.read.json(spark.sparkContext.parallelize(records0, 2))
+    inputDF0.write.format("org.apache.hudi")
+      .options(commonOpts)
+      .option("hoodie.compact.inline", "false")
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val snapshotDF0 = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
+      .load(basePath + "/*/*/*/*")
+    assertEquals(numRecords, snapshotDF0.count())
+
+    val df1 = snapshotDF0.limit(numRecordsToDelete)
+    val dropDf = df1.drop(df1.columns.filter(_.startsWith("_hoodie_")): _*)
+
+    val df2 = dropDf.withColumn("_hoodie_is_deleted", lit(true).cast(BooleanType))
+    df2.write.format("org.apache.hudi")
+      .options(commonOpts)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val snapshotDF2 = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
+      .load(basePath + "/*/*/*/*")
+    assertEquals(numRecords - numRecordsToDelete, snapshotDF2.count())
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

JIRA : https://issues.apache.org/jira/browse/HUDI-2359

In issue thread https://github.com/apache/hudi/issues/3321, there was a discussion around the functionality of `hoodie_is_deleted` field.

1. We wanted to ensure that when this field was being set to `true`, that the specified record would be deleted.
2. We also wanted to make sure that this field only needed to be set to `true` for an incoming record, and not for existing records.

The goal of this PR is to add unit tests that follow similar reproductions as discussed in the above github issue thread.

@nsivabalan example https://gist.github.com/nsivabalan/e5ac69677ed05e9f2749fae67d3abc19 
@nmukerje example https://github.com/nmukerje/misc/blob/master/Hudi/Hudi_Pyspark_Delete_Upsert_Test.ipynb

## Verify this pull request


This change added test methods to existing test classes and can be verified as follows:
```
mvn -Dtest=TestMORDataSource#testHoodieIsDeletedMOR test -DfailIfNoTests=false -pl hudi-spark-datasource/hudi-spark/

mvn -Dtest=TestCOWDataSource#testHoodieIsDeletedCOW test -DfailIfNoTests=false -pl hudi-spark-datasource/hudi-spark/
```

## Committer checklist

 - [] Has a corresponding JIRA in PR title & commit
 
 - [] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.