### PR TITLE
[HUDI-2368] Catch Throwable in BoundedInMemoryExecutor

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryExecutor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryExecutor.java
@@ -90,7 +90,7 @@ public class BoundedInMemoryExecutor<I, O, E> {
         try {
           preExecute();
           producer.produce(queue);
-        } catch (Exception e) {
+        } catch (Throwable e) {
           LOG.error("error producing records", e);
           queue.markAsFailed(e);
           throw e;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryQueue.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BoundedInMemoryQueue.java
@@ -78,10 +78,10 @@ public class BoundedInMemoryQueue<I, O> implements Iterable<O> {
   private final long memoryLimit;
 
   /**
-   * it holds the root cause of the exception in case either queueing records
+   * it holds the root cause of the Throwable in case either queueing records
    * (consuming from inputIterator) fails or thread reading records from queue fails.
    */
-  private final AtomicReference<Exception> hasFailed = new AtomicReference<>(null);
+  private final AtomicReference<Throwable> hasFailed = new AtomicReference<>(null);
 
   /** Used for indicating that all the records from queue are read successfully. **/
   private final AtomicBoolean isReadDone = new AtomicBoolean(false);
@@ -251,7 +251,7 @@ public class BoundedInMemoryQueue<I, O> implements Iterable<O> {
   /**
    * API to allow producers and consumer to communicate termination due to failure.
    */
-  public void markAsFailed(Exception e) {
+  public void markAsFailed(Throwable e) {
     this.hasFailed.set(e);
     // release the permits so that if the queueing thread is waiting for permits then it will
     // get it.


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*Now BoundedInMemoryExecutor only catch Exception in produce async thread and don't process the caillback result. But there may throw error in produce async thread, that we can't identify the problem and don't know why the data is missing!*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
