### PR TITLE
[HUDI-2391] Download page fixes in accordance with asf requirements

### DIFF
--- a/website/releases/download.md
+++ b/website/releases/download.md
@@ -6,35 +6,62 @@ toc: true
 last_modified_at: 2019-12-30T15:59:57-04:00
 ---
 
-## Release 0.9.0
+### Release 0.9.0
 * Source Release : [Apache Hudi 0.9.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.9.0/hudi-0.9.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.9.0](/releases/release-0.9.0))
 
-## Release 0.8.0
+### Release 0.8.0
 * Source Release : [Apache Hudi 0.8.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.8.0/hudi-0.8.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.8.0](/releases/release-0.8.0))
 
-## Release 0.7.0
+### Release 0.7.0
 * Source Release : [Apache Hudi 0.7.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.7.0/hudi-0.7.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.7.0](/releases/release-0.7.0))
 
-## Release 0.6.0
+### Release 0.6.0
 * Source Release : [Apache Hudi 0.6.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.6.0/hudi-0.6.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.6.0](/releases/release-0.6.0))
 
-## Release 0.5.3
+### Release 0.5.3
 * Source Release : [Apache Hudi 0.5.3 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.3/hudi-0.5.3.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.5.3](/releases/release-0.5.3))
 
-## Release 0.5.2-incubating
+### Release 0.5.2-incubating
 * Source Release : [Apache Hudi 0.5.2-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.5.2](/releases/older-releases#release-052-incubating-docs))
 
-## Release 0.5.1-incubating
+### Release 0.5.1-incubating
 * Source Release : [Apache Hudi 0.5.1-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.5.1](/releases/older-releases#release-051-incubating-docs))
 
-## Release 0.5.0-incubating
+### Release 0.5.0-incubating
 * Source Release : [Apache Hudi 0.5.0-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.5.0](/releases/older-releases#release-050-incubating-docs))
 
+## Verify Release
+
+It is essential that you verify the integrity of the downloaded files using the PGP signatures. Please read [How to Verify Downloaded Files](https://www.apache.org/info/verification.html)
+for more information on how and why you should verify our releases.
+
+The PGP signatures can be verified using PGP or GPG. First download the [KEYS](https://downloads.apache.org/hudi/KEYS) file as well as the
+.asc signature files for the relevant release packages. Make sure you get these files from the main distribution directory, rather than from
+a mirror. Then verify the signatures using:
+
+```
+% pgpk -a KEYS
+% pgpv hudi-X.Y.Z.src.tgz.asc
+```
+
+or
+
+```
+% pgp -ka KEYS
+% pgp hudi-X.Y.Z.src.tgz.asc
+```
+
+or
+
+```
+% gpg --import KEYS
+% gpg --verify hudi-X.Y.Z.src.tgz.asc hudi-X.Y.Z.src.tgz
+```

--- a/website/releases/older-releases.md
+++ b/website/releases/older-releases.md
@@ -11,10 +11,6 @@ more recent releases listed [here](http://hudi.apache.org/releases)
 
 ## [Release 0.5.2-incubating](https://github.com/apache/hudi/releases/tag/release-0.5.2-incubating) ([docs](/docs/quick-start-guide))
 
-### Download Information
-* Source Release : [Apache Hudi 0.5.2-incubating Source Release](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.sha512))
-* Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
-
 ### Migration Guide for this release
 * Write Client restructuring has moved classes around ([HUDI-554](https://issues.apache.org/jira/browse/HUDI-554)). Package `client` now has all the various client classes, that do the transaction management. `func` renamed to `execution` and some helpers moved to `client/utils`. All compaction code under `io` now under `table/compact`. Rollback code under `table/rollback` and in general all code for individual operations under `table`. This change only affects the apps/projects depending on hudi-client. Users of deltastreamer/datasource will not need to change anything.
 
@@ -36,10 +32,6 @@ temp_query --sql "select Instant, NumInserts, NumWrites from satishkotha_debug w
 The raw release notes are available [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12322822&version=12346606)
 
 ## [Release 0.5.1-incubating](https://github.com/apache/hudi/releases/tag/release-0.5.1-incubating) ([docs](/docs/quick-start-guide))
-
-### Download Information
-* Source Release : [Apache Hudi 0.5.1-incubating Source Release](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.sha512))
-* Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
 
 ### Migration Guide for this release
 * Upgrade hudi readers (query engines) first with 0.5.1-incubating release before upgrading writer.
@@ -81,10 +73,6 @@ The raw release notes are available [here](https://issues.apache.org/jira/secure
 The raw release notes are available [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12322822&version=12346183)
 
 ## [Release 0.5.0-incubating](https://github.com/apache/hudi/releases/tag/release-0.5.0-incubating) ([docs](/docs/quick-start-guide))
-
-### Download Information
-* Source Release : [Apache Hudi 0.5.0-incubating Source Release](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.sha512))
-* Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
 
 ### Release Highlights
 * Package and format renaming from com.uber.hoodie to org.apache.hudi (See migration guide section below)

--- a/website/releases/release-0.5.3.md
+++ b/website/releases/release-0.5.3.md
@@ -7,10 +7,6 @@ last_modified_at: 2020-05-28T08:40:00-07:00
 ---
 # [Release 0.5.3](https://github.com/apache/hudi/releases/tag/release-0.5.3) ([docs](/docs/quick-start-guide))
 
-## Download Information
- * Source Release : [Apache Hudi 0.5.3 Source Release](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.sha512))
- * Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
-
 ## Migration Guide for this release
  * This is a bug fix only release and no special migration steps needed when upgrading from 0.5.2. If you are upgrading from earlier releases “X”, please make sure you read the migration guide for each subsequent release between “X” and 0.5.3
  * 0.5.3 is the first hudi release after graduation. As a result, all hudi jars will no longer have "-incubating" in the version name. In all the places where hudi version is referred, please make sure "-incubating" is no longer present.

--- a/website/releases/release-0.6.0.md
+++ b/website/releases/release-0.6.0.md
@@ -7,10 +7,6 @@ last_modified_at: 2020-05-28T08:40:00-07:00
 ---
 # [Release 0.6.0](https://github.com/apache/hudi/releases/tag/release-0.6.0) ([docs](/docs/quick-start-guide))
 
-## Download Information
- * Source Release : [Apache Hudi 0.6.0 Source Release](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.sha512))
- * Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
-
 ## Migration Guide for this release
  - If migrating from release older than 0.5.3, please also check the upgrade instructions for each subsequent release below.
  - With 0.6.0 Hudi is moving from list based rollback to marker based rollbacks. To smoothly aid this transition a 

--- a/website/releases/release-0.7.0.md
+++ b/website/releases/release-0.7.0.md
@@ -7,10 +7,6 @@ last_modified_at: 2020-05-28T08:40:00-07:00
 ---
 # [Release 0.7.0](https://github.com/apache/hudi/releases/tag/release-0.7.0) ([docs](/docs/quick-start-guide))
 
-## Download Information
-* Source Release : [Apache Hudi 0.7.0 Source Release](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.sha512))
-* Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
-
 ## Migration Guide for this release
 - If migrating from release older than 0.5.3, please also check the upgrade instructions for each subsequent release below.
 - Specifically check upgrade instructions for 0.6.0. This release does not introduce any new table versions.

--- a/website/releases/release-0.8.0.md
+++ b/website/releases/release-0.8.0.md
@@ -7,10 +7,6 @@ last_modified_at: 2020-05-28T08:40:00-07:00
 ---
 # [Release 0.8.0](https://github.com/apache/hudi/releases/tag/release-0.8.0) ([docs](/docs/quick-start-guide))
 
-## Download Information
-* Source Release : [Apache Hudi 0.8.0 Source Release](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.sha512))
-* Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
-
 ## Migration Guide for this release
 - If migrating from release older than 0.5.3, please also check the upgrade instructions for each subsequent release below.
 - Specifically check upgrade instructions for 0.6.0. This release does not introduce any new table versions.

--- a/website/releases/release-0.9.0.md
+++ b/website/releases/release-0.9.0.md
@@ -7,10 +7,6 @@ last_modified_at: 2021-08-26T08:40:00-07:00
 ---
 # [Release 0.9.0](https://github.com/apache/hudi/releases/tag/release-0.9.0) ([docs](/docs/quick-start-guide))
 
-## Download Information
-* Source Release : [Apache Hudi 0.9.0 Source Release](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.sha512))
-* Apache Hudi jars corresponding to this release is available [here](https://repository.apache.org/#nexus-search;quick~hudi)
-
 ## Migration Guide for this release
 - If migrating from an older release, please also check the upgrade instructions for each subsequent release below.
 - With 0.9.0, Hudi is adding more table properties to aid in using an existing hudi table with spark-sql. 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

This PR fixes Hudi website Download page in accordance with ASF requirements. The jira has the email from moderator of **announce@apache.org** which suggests the changes.

- Added `Verify Release` section on the downloads page. For this I referred to other recent announcements for https://tika.apache.org/download.html and https://apisix.apache.org/downloads/
- The `Verify Release` section has link to the `KEYS`
- Removed the download links from individual release pages, as then they might raise concerns that `Verify Release` information is not present in each and every release page along with the download information.
- Since I removed the download links from individual release pages, it also resolves the concern raised that the source release is not linked to the mirror but instead to https://downloads.apache.org/
- The source release on the Downloads page already links to the mirror, so it should be fine.

## Brief change log

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
