### PR TITLE
[HUDI-2393] Add yamls for large scale testing

### DIFF
--- a/docker/demo/config/test-suite/large-scale/cow-large-scale-long-running.yaml
+++ b/docker/demo/config/test-suite/large-scale/cow-large-scale-long-running.yaml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Sanity yaml to test simple operations.
+dag_name: cow-large-scale-long-running.yaml
+dag_rounds: 50
+dag_intermittent_delay_mins: 1
+dag_content:
+  first_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 10
+      repeat_count: 1
+      num_records_insert: 1000000 # this will generate about 1.5 GB data
+    type: InsertNode
+    deps: none
+  second_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 10
+      repeat_count: 1
+      num_records_insert: 100000
+    deps: first_insert
+    type: InsertNode
+  third_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 5
+      repeat_count: 1
+      num_records_insert: 300000
+    deps: second_insert
+    type: InsertNode
+  first_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: third_insert
+  first_upsert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 2
+      num_records_insert: 3000
+      repeat_count: 1
+      num_records_upsert: 100000
+      num_partitions_upsert: 10
+    type: UpsertNode
+    deps: first_validate
+  first_delete:
+    config:
+      num_partitions_delete: 5
+      num_records_delete: 8000
+    type: DeleteNode
+    deps: first_upsert
+  second_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: first_delete

--- a/docker/demo/config/test-suite/large-scale/cow-large-scale-sanity.yaml
+++ b/docker/demo/config/test-suite/large-scale/cow-large-scale-sanity.yaml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Sanity yaml to test simple operations.
+dag_name: cow-large-scale-sanity.yaml
+dag_rounds: 1
+dag_intermittent_delay_mins: 1
+dag_content:
+  first_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 100
+      repeat_count: 1
+      num_records_insert: 3000000 # this will generate about 60GB data
+    type: InsertNode
+    deps: none
+  second_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 50
+      repeat_count: 1
+      num_records_insert: 1000000
+    deps: first_insert
+    type: InsertNode
+  third_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 5
+      repeat_count: 1
+      num_records_insert: 300000
+    deps: second_insert
+    type: InsertNode
+  first_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: third_insert
+  first_upsert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 2
+      num_records_insert: 3000
+      repeat_count: 1
+      num_records_upsert: 100000
+      num_partitions_upsert: 20
+    type: UpsertNode
+    deps: first_validate
+  first_delete:
+    config:
+      num_partitions_delete: 5
+      num_records_delete: 8000
+    type: DeleteNode
+    deps: first_upsert
+  second_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: first_delete

--- a/docker/demo/config/test-suite/large-scale/mor-large-scale-long-running.yaml
+++ b/docker/demo/config/test-suite/large-scale/mor-large-scale-long-running.yaml
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Sanity yaml to test simple operations.
+dag_name: mor-large-scale-long-running.yaml
+dag_rounds: 50
+dag_intermittent_delay_mins: 1
+dag_content:
+  first_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 10
+      repeat_count: 1
+      num_records_insert: 1000000 # this will generate about 1.5 GB data
+    type: InsertNode
+    deps: none
+  second_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 10
+      repeat_count: 1
+      num_records_insert: 100000
+    deps: first_insert
+    type: InsertNode
+  third_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 5
+      repeat_count: 1
+      num_records_insert: 300000
+    deps: second_insert
+    type: InsertNode
+  first_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: third_insert
+  first_upsert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 2
+      num_records_insert: 3000
+      repeat_count: 1
+      num_records_upsert: 100000
+      num_partitions_upsert: 10
+    type: UpsertNode
+    deps: first_validate
+  first_schedule_compact:
+    config:
+    type: ScheduleCompactNode
+    deps: first_upsert
+  first_delete:
+    config:
+      num_partitions_delete: 5
+      num_records_delete: 8000
+    type: DeleteNode
+    deps: first_schedule_compact
+  second_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: first_delete

--- a/docker/demo/config/test-suite/large-scale/mor-large-scale-sanity.yaml
+++ b/docker/demo/config/test-suite/large-scale/mor-large-scale-sanity.yaml
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Sanity yaml to test simple operations.
+dag_name: mor-large-scale-sanity.yaml
+dag_rounds: 1
+dag_intermittent_delay_mins: 1
+dag_content:
+  first_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 100
+      repeat_count: 1
+      num_records_insert: 3000000 # this will generate about 60GB data
+    type: InsertNode
+    deps: none
+  second_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 50
+      repeat_count: 1
+      num_records_insert: 1000000
+    deps: first_insert
+    type: InsertNode
+  third_insert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 5
+      repeat_count: 1
+      num_records_insert: 300000
+    deps: second_insert
+    type: InsertNode
+  first_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: third_insert
+  first_upsert:
+    config:
+      record_size: 1000
+      num_partitions_insert: 2
+      num_records_insert: 3000
+      repeat_count: 1
+      num_records_upsert: 100000
+      num_partitions_upsert: 20
+    type: UpsertNode
+    deps: first_validate
+  first_schedule_compact:
+    config:
+    type: ScheduleCompactNode
+    deps: first_upsert
+  first_delete:
+    config:
+      num_partitions_delete: 5
+      num_records_delete: 8000
+    type: DeleteNode
+    deps: first_schedule_compact
+  second_validate:
+    config:
+      validate_hive: false
+    type: ValidateDatasetNode
+    deps: first_delete


### PR DESCRIPTION
## Brief change log
  - Added two yamls that will run COW and MOR with compaction sanity with slightly bigger dataset (~60gb).
  - To generate more data, just increase `num_partitions_(insert/upsert)` and `num_records_(insert/upsert)`.

## Verify this pull request

Verified manually run the sanity test on EMR (m5.4xlarge, 1 master and upto 4 cores).

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
