### PR TITLE
[HUDI-2402]Hive Sync supports Kerberos authentication 

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -592,6 +592,18 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(false)
       .withDescription("INT64 with original type TIMESTAMP_MICROS is converted to hive timestamp type.\n"
           + "Disabled by default for backward compatibility.");
+    
+ public static final ConfigOption<Boolean> HIVE_SYNC_USE_KERBEROS = ConfigOptions
+          .key("hive_sync.use_kerberos")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to use Kerberos authentication.");
+
+  public static final ConfigOption<String> HIVE_SYNC_KERBEROS_PRINCIPAL = ConfigOptions
+          .key("hive_sync.kerberos_principal")
+          .stringType()
+          .defaultValue("")
+          .withDescription("Hive metastore principal.");
 
   // -------------------------------------------------------------------------
   //  Utilities

--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -593,7 +593,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("INT64 with original type TIMESTAMP_MICROS is converted to hive timestamp type.\n"
           + "Disabled by default for backward compatibility.");
     
- public static final ConfigOption<Boolean> HIVE_SYNC_USE_KERBEROS = ConfigOptions
+  public static final ConfigOption<Boolean> HIVE_SYNC_USE_KERBEROS = ConfigOptions
       .key("hive_sync.use_kerberos")
       .booleanType()
       .defaultValue(false)

--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -603,7 +603,7 @@ public class FlinkOptions extends HoodieConfig {
       .key("hive_sync.kerberos_principal")
       .stringType()
       .defaultValue("")
-       .withDescription("Hive metastore principal.");
+      .withDescription("Hive metastore principal.");
 
   // -------------------------------------------------------------------------
   //  Utilities

--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -594,16 +594,16 @@ public class FlinkOptions extends HoodieConfig {
           + "Disabled by default for backward compatibility.");
     
  public static final ConfigOption<Boolean> HIVE_SYNC_USE_KERBEROS = ConfigOptions
-          .key("hive_sync.use_kerberos")
-          .booleanType()
-          .defaultValue(false)
-          .withDescription("Whether to use Kerberos authentication.");
+      .key("hive_sync.use_kerberos")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Whether to use Kerberos authentication.");
 
   public static final ConfigOption<String> HIVE_SYNC_KERBEROS_PRINCIPAL = ConfigOptions
-          .key("hive_sync.kerberos_principal")
-          .stringType()
-          .defaultValue("")
-          .withDescription("Hive metastore principal.");
+      .key("hive_sync.kerberos_principal")
+      .stringType()
+      .defaultValue("")
+       .withDescription("Hive metastore principal.");
 
   // -------------------------------------------------------------------------
   //  Utilities

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -87,6 +87,8 @@ public class HiveSyncContext {
     hiveSyncConfig.skipROSuffix = conf.getBoolean(FlinkOptions.HIVE_SYNC_SKIP_RO_SUFFIX);
     hiveSyncConfig.assumeDatePartitioning = conf.getBoolean(FlinkOptions.HIVE_SYNC_ASSUME_DATE_PARTITION);
     hiveSyncConfig.withOperationField = conf.getBoolean(FlinkOptions.CHANGELOG_ENABLED);
+    hiveSyncConfig.useKerberos = conf.getBoolean(FlinkOptions.HIVE_SYNC_USE_KERBEROS);
+    hiveSyncConfig.kerberosPrincipal = conf.getString(FlinkOptions.HIVE_SYNC_KERBEROS_PRINCIPAL);
     return hiveSyncConfig;
   }
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
@@ -291,7 +291,12 @@ public class FlinkStreamerConfig extends Configuration {
   @Parameter(names = {"--hive-sync-support-timestamp"}, description = "INT64 with original type TIMESTAMP_MICROS is converted to hive timestamp type.\n"
           + "Disabled by default for backward compatibility.")
   public Boolean hiveSyncSupportTimestamp = false;
+  
+  @Parameter(names = {"--hive-use-kerberos"}, description = "Whether to use Kerberos for Hive. default false")
+  public Boolean useKerberos = false;
 
+  @Parameter(names = {"--hive-kerberos-principal"}, description = "hive metastore principal")
+  public String kerberosPrincipal;
 
   /**
    * Transforms a {@code HoodieFlinkStreamer.Config} into {@code Configuration}.
@@ -369,6 +374,8 @@ public class FlinkStreamerConfig extends Configuration {
     conf.setBoolean(FlinkOptions.HIVE_SYNC_IGNORE_EXCEPTIONS, config.hiveSyncIgnoreExceptions);
     conf.setBoolean(FlinkOptions.HIVE_SYNC_SKIP_RO_SUFFIX, config.hiveSyncSkipRoSuffix);
     conf.setBoolean(FlinkOptions.HIVE_SYNC_SUPPORT_TIMESTAMP, config.hiveSyncSupportTimestamp);
+    conf.setBoolean(FlinkOptions.HIVE_SYNC_USE_KERBEROS, config.useKerberos);
+    conf.setString(FlinkOptions.HIVE_SYNC_KERBEROS_PRINCIPAL, config.kerberosPrincipal);
     return conf;
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -200,7 +200,7 @@ object DataSourceWriteOptions {
     .key("hive_sync.kerberos_principal")
     .noDefaultValue()
     .withDocumentation("Hive metastore principal.")
- 
+
   /**
     * Translate spark parameters to hudi parameters
     *

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -191,6 +191,16 @@ object DataSourceWriteOptions {
     .withAlternatives("hoodie.datasource.write.storage.type")
     .withDocumentation("The table type for the underlying data, for this write. This can’t change between writes.")
 
+   val HIVE_SYNC_USE_KERBEROS: ConfigProperty[Boolean] = ConfigProperty
+    .key("hoodie.datasource.hive_sync.use_kerberos")
+    .defaultValue(false)
+    .withDocumentation("Whether to use Kerberos authentication.")
+
+  val HIVE_SYNC_KERBEROS_PRINCIPAL: ConfigProperty[String] = ConfigProperty
+    .key("hive_sync.kerberos_principal")
+    .noDefaultValue()
+    .withDocumentation("Hive metastore principal.")
+ 
   /**
     * Translate spark parameters to hudi parameters
     *

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -552,6 +552,8 @@ object HoodieSparkSqlWriter {
     hiveSyncConfig.syncMode = hoodieConfig.getString(HIVE_SYNC_MODE)
     hiveSyncConfig.serdeProperties = hoodieConfig.getString(HIVE_TABLE_SERDE_PROPERTIES)
     hiveSyncConfig.tableProperties = hoodieConfig.getString(HIVE_TABLE_PROPERTIES)
+    hiveSyncConfig.useKerberos = hoodieConfig.getBoolean(HIVE_SYNC_USE_KERBEROS)
+    hiveSyncConfig.kerberosPrincipal = hoodieConfig.getString(HIVE_SYNC_KERBEROS_PRINCIPAL)
     hiveSyncConfig
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -122,6 +122,12 @@ public class HiveSyncConfig implements Serializable {
 
   @Parameter(names = {"--with-operation-field"}, description = "Whether to include the '_hoodie_operation' field in the metadata fields")
   public Boolean withOperationField = false;
+  
+  @Parameter(names = {"--hive-use-kerberos"}, description = "Whether to use Kerberos for Hive. default false")
+  public Boolean useKerberos = false;
+
+  @Parameter(names = {"--hive-kerberos-principal"}, description = "hive metastore principal")
+  public String kerberosPrincipal;
 
   // enhance the similar function in child class
   public static HiveSyncConfig copy(HiveSyncConfig cfg) {
@@ -147,6 +153,8 @@ public class HiveSyncConfig implements Serializable {
     newConfig.syncAsSparkDataSourceTable = cfg.syncAsSparkDataSourceTable;
     newConfig.sparkSchemaLengthThreshold = cfg.sparkSchemaLengthThreshold;
     newConfig.withOperationField = cfg.withOperationField;
+    newConfig.useKerberos = cfg.useKerberos;
+    newConfig.kerberosPrincipal = cfg.kerberosPrincipal;
     return newConfig;
   }
 
@@ -179,6 +187,8 @@ public class HiveSyncConfig implements Serializable {
       + ", syncAsSparkDataSourceTable=" + syncAsSparkDataSourceTable
       + ", sparkSchemaLengthThreshold=" + sparkSchemaLengthThreshold
       + ", withOperationField=" + withOperationField
+      + ", useKerberos=" + useKerberos
+      + ", kerberosPrincipal=" + kerberosPrincipal
       + '}';
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -77,6 +77,10 @@ public class HiveSyncTool extends AbstractSyncTool {
     super(configuration.getAllProperties(), fs);
 
     try {
+      if (cfg.useKerberos) {
+        configuration.set("hive.metastore.sasl.enabled", "true");
+        configuration.set("hive.metastore.kerberos.principal", cfg.kerberosPrincipal);
+      }
       this.hoodieHiveClient = new HoodieHiveClient(cfg, configuration, fs);
     } catch (RuntimeException e) {
       if (cfg.ignoreExceptions) {


### PR DESCRIPTION
For Hive with Kerberos enabled, THE HMS of HUDI cannot access the Hive metadata
Hive.get(configuration).getMSC()
Methods before
Perform Kerberos authentication on the Flink client
Set the parameters for enabling Kerberos authentication and the configuration parameters for transmitting hive Principal to Hive
I added two parameters
1.hive_sync.use_kerberos
2.hive_sync.kerberos_principal
Use the following method to enable Hive Kerberos access control
CREATE TABLE t2(
Uuid VARCHAR (20),
The name VARCHAR (10),
The age INT,
Ts TIMESTAMP (3),
partition VARCHAR (20)
)
PARTITIONED BY (partition)
with(
'connector' = 'hudi',
'hive_sync.enable'='true',
'hive_sync.db'='test',
'hive_sync.table'='t2',
'hive_sync.mode'='hms',
'path' = 'hdfs://ip:8020/warehouse/hudi/t2',
'hive_sync.metastore.uris'='thrift://ip:9083',
'hive_sync.use_kerberos' = 'true',
'hive_sync.kerberos_principal' = 'hive/_HOST@BIGDATA'
)