### PR TITLE
[HUDI-2404] Add metrics-jmx to spark and flink bundles

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -110,6 +110,7 @@
                   <include>com.twitter:bijection-core_${scala.binary.version}</include>
                   <include>io.dropwizard.metrics:metrics-core</include>
                   <include>io.dropwizard.metrics:metrics-graphite</include>
+                  <include>io.dropwizard.metrics:metrics-jmx</include>
                   <include>io.prometheus:simpleclient</include>
                   <include>io.prometheus:simpleclient_httpserver</include>
                   <include>io.prometheus:simpleclient_dropwizard</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -91,6 +91,7 @@
                   <include>com.twitter:bijection-core_${scala.binary.version}</include>
                   <include>io.dropwizard.metrics:metrics-core</include>
                   <include>io.dropwizard.metrics:metrics-graphite</include>
+                  <include>io.dropwizard.metrics:metrics-jmx</include>
                   <include>io.prometheus:simpleclient</include>
                   <include>io.prometheus:simpleclient_httpserver</include>
                   <include>io.prometheus:simpleclient_dropwizard</include>


### PR DESCRIPTION
## What is the purpose of the pull request

Add metrics-jmx to spark and flink bundles. Currently, when JMX is enabled using spark, the following error is thrown:
`java.lang.NoClassDefFoundError: org/apache/hudi/com/codahale/metrics/jmx/JmxReporter.` 

## Brief change log

  - Add metrics-jmx to spark bundle
  - Add metrics-jmx to flink bundle

## Verify this pull request

I verified the changes worked by rebuilding the spark package and running it with JMX. Let me know if other tests are required/encouraged!

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
