### PR TITLE
[HUDI-2301] Support Flink async compaction scheduling

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -430,14 +430,14 @@ public class FlinkOptions extends HoodieConfig {
   public static final ConfigOption<Boolean> COMPACTION_SCHEDULE_ENABLED = ConfigOptions
       .key("compaction.schedule.enabled")
       .booleanType()
-      .defaultValue(true) // default true for MOR write
-      .withDescription("Schedule the compaction plan, enabled by default for MOR");
+      .defaultValue(false) // default false for MOR write
+      .withDescription("Schedule the compaction plan, disabled by default for MOR");
 
   public static final ConfigOption<Boolean> COMPACTION_ASYNC_ENABLED = ConfigOptions
       .key("compaction.async.enabled")
       .booleanType()
-      .defaultValue(true) // default true for MOR write
-      .withDescription("Async Compaction, enabled by default for MOR");
+      .defaultValue(false) // default false for MOR write
+      .withDescription("Async Compaction, disabled by default for MOR");
 
   public static final ConfigOption<Integer> COMPACTION_TASKS = ConfigOptions
       .key("compaction.tasks")
@@ -486,8 +486,8 @@ public class FlinkOptions extends HoodieConfig {
   public static final ConfigOption<Boolean> CLEAN_ASYNC_ENABLED = ConfigOptions
       .key("clean.async.enabled")
       .booleanType()
-      .defaultValue(true)
-      .withDescription("Whether to cleanup the old commits immediately on new commits, enabled by default");
+      .defaultValue(false)
+      .withDescription("Whether to cleanup the old commits immediately on new commits, disabled by default");
 
   public static final ConfigOption<Integer> CLEAN_RETAIN_COMMITS = ConfigOptions
       .key("clean.retain_commits")

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
@@ -61,8 +61,8 @@ public class FlinkCompactionConfig extends Configuration {
   @Parameter(names = {"--compaction-delta-seconds"}, description = "Max delta seconds time needed to trigger compaction, default 1 hour", required = false)
   public Integer compactionDeltaSeconds = 3600;
 
-  @Parameter(names = {"--clean-async-enabled"}, description = "Whether to cleanup the old commits immediately on new commits, enabled by default", required = false)
-  public Boolean cleanAsyncEnable = false;
+  @Parameter(names = {"--clean-async-enabled"}, description = "Whether to cleanup the old commits immediately on new commits, disabled by default", required = false)
+  public Boolean cleanAsyncEnable = true;
 
   @Parameter(names = {"--clean-retain-commits"},
       description = "Number of commits to retain. So data will be retained for num_of_commits * time_between_commits (scheduled).\n"
@@ -93,7 +93,7 @@ public class FlinkCompactionConfig extends Configuration {
       + "There is a risk of losing data when scheduling compaction outside the writer job.\n"
       + "Scheduling compaction in the writer job and only let this job do the compaction execution is recommended.\n"
       + "Default is false", required = false)
-  public Boolean schedule = false;
+  public Boolean schedule = true;
 
   public static final String SEQ_FIFO = "FIFO";
   public static final String SEQ_LIFO = "LIFO";
@@ -101,6 +101,12 @@ public class FlinkCompactionConfig extends Configuration {
       + "1). FIFO: execute the oldest plan first;\n"
       + "2). LIFO: execute the latest plan first, by default LIFO", required = false)
   public String compactionSeq = SEQ_LIFO;
+
+  @Parameter(names = {"--max-scheduling-wait-time"}, description = "Max wait time in ms when async scheduling is enabled. Default is 600 seconds.", required = false)
+  public Long maxWaitTime = 600000L;
+
+  @Parameter(names = {"--timeline-refresh-rate"}, description = "Reload timeline rate in ms. Default is 10 seconds.", required = false)
+  public Long refreshRate = 10000L;
 
   /**
    * Transforms a {@code HoodieFlinkCompaction.config} into {@code Configuration}.

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
@@ -52,7 +52,7 @@ import org.apache.flink.util.Collector;
 import java.util.Objects;
 
 /**
- * The function to build the write profile incrementally for records within a checkpoint,
+ * The function to build the write phudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.javarofile incrementally for records within a checkpoint,
  * it then assigns the bucket with ID using the {@link BucketAssigner}.
  *
  * <p>All the records are tagged with HoodieRecordLocation, instead of real instant time,

--- a/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -398,6 +398,16 @@ public class StreamerUtil {
     }
   }
 
+  public static String incrementInstantTime(String instant, int incrementInSecond) {
+    try {
+      long ts = HoodieActiveTimeline.COMMIT_FORMATTER.parse(instant).getTime();
+      return HoodieActiveTimeline.COMMIT_FORMATTER.format(new Date(ts + incrementInSecond * 1000L));
+    } catch (ParseException e) {
+      throw new HoodieException("Get incrementInstantTime error with instant " + instant
+          + " plus " + incrementInSecond + " second", e);
+    }
+  }
+
   public static boolean isValidFile(FileStatus fileStatus) {
     final String extension = FSUtils.getFileExtension(fileStatus.getPath().toString());
     if (PARQUET.getFileExtension().equals(extension)) {

--- a/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -35,6 +35,9 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   protected void setUp(Configuration conf) {
     // trigger the compaction for every finished checkpoint
     conf.setInteger(FlinkOptions.COMPACTION_DELTA_COMMITS, 1);
+    conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, true);
+    conf.setBoolean(FlinkOptions.COMPACTION_ASYNC_ENABLED, true);
+
   }
 
   @Override

--- a/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -24,6 +24,7 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.Configuration;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -87,6 +88,14 @@ public class TestStreamerUtil {
         () -> StreamerUtil.medianInstantTime(lower, higher),
         "The first argument should have newer instant time");
   }
+
+  @Test
+  void testIncrementInstantTime() {
+    String ts = "20210705125959";
+    String incremented = StreamerUtil.incrementInstantTime(ts, 1);
+    assertThat(incremented, is("20210705130000"));
+  }
+
 
   @Test
   void testInstantTimeDiff() {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*
https://issues.apache.org/jira/browse/HUDI-2302
## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
