### PR TITLE
[MINOR] Use fixed JDK version for CI, with applicable OpenJDK distro

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
           architecture: x64
       - name: Build Project
         env:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        java: [8, 8.0.192]
         include:
           - scala: "scala-2.11"
             spark: "spark2"
@@ -25,7 +26,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java }}
           distribution: 'adopt'
           architecture: x64
       - name: Build Project

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'zulu'
           architecture: x64
       - name: Build Project
         env:


### PR DESCRIPTION
## What is the purpose of the pull request

This pull request enables Apache Hudi to do GitHub Actions actions/setup-java against the latest JDK 8 version (as was the case before this pull request) as well as a fixed JDK 8 version. This is useful because if you do a build and the fixed JDK 8 version is green (it succeeded), while the latest JDK 8 version is red (it failed), that gives you information about the reason for the build failure: it was because of something to do with the latest JDK 8 and not something connected directly to your code.

You were using 'adopt', which is no more, 'temurin' and 'zulu' are the two officially supported options, 'temurin' is new and doesn't yet have all/as many versions as 'zulu' does, which is older and therefore has a longer history applicable to this. Hence changed from 'adopt' to 'zulu'.

## Brief change log

This change added tests and can be verified as follows:

  - *Make a change anywhere and commit or provide a pull request.*
  - *The actions/setup-java will do two builds, i.e., against two different JDK 8 versions.*
  - *Both will/should go green..*

