### PR TITLE
[HUDI-2435]tuning clustering handle errors

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieSparkClusteringClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieSparkClusteringClient.java
@@ -19,16 +19,21 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 
+import org.apache.hudi.common.util.Option;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Async clustering client for Spark datasource.
@@ -47,8 +52,11 @@ public class HoodieSparkClusteringClient<T extends HoodieRecordPayload> extends
   public void cluster(HoodieInstant instant) throws IOException {
     LOG.info("Executing clustering instance " + instant);
     SparkRDDWriteClient<T> writeClient = (SparkRDDWriteClient<T>) clusteringClient;
-    JavaRDD<WriteStatus> res = writeClient.cluster(instant.getTimestamp(), true).getWriteStatuses();
-    if (res != null && res.collect().stream().anyMatch(WriteStatus::hasErrors)) {
+    Option<HoodieCommitMetadata> commitMetadata = writeClient.cluster(instant.getTimestamp(), true).getCommitMetadata();
+    List<HoodieWriteStat> writeStats = commitMetadata.get().getPartitionToWriteStats().entrySet().stream().flatMap(e ->
+            e.getValue().stream()).collect(Collectors.toList());
+    long errorsCount = writeStats.stream().mapToLong(HoodieWriteStat::getTotalWriteErrors).sum();
+    if (errorsCount > 0) {
       // TODO: Should we treat this fatal and throw exception?
       LOG.error("Clustering for instant (" + instant + ") failed with write errors");
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -24,7 +24,6 @@ import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.client.SparkRDDWriteClient;
-import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -34,12 +33,10 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.exception.HoodieClusteringException;
 import org.apache.hudi.exception.HoodieException;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.jetbrains.annotations.TestOnly;
 


### PR DESCRIPTION
https://issues.apache.org/jira/projects/HUDI/issues/HUDI-2435

## What is the purpose of the pull request

Before clustering job/ async clustering finished, hudi will perform errors check using `JavaRDD<WriteStatus> writeResponse`

https://github.com/apache/hudi/blob/dde57b293cd22ef1bd89f44054f109a52fc20e56/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java#L194

https://github.com/apache/hudi/blob/1196736185272afaeda37328f1c52ccd5c6dc017/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java#L299

`collect` is a spark action, when executor is crashed by accident and the cache of `JavaRDD<WriteStatus>` is lost, so that this collect action will trigger a complete compute and create unexpected marker files or data files.

We should use `Option<HoodieCommitMetadata> commitMetadata` to do handle errors work instead.
<img width="1665" alt="屏幕快照 2021-09-14 下午9 38 45" src="https://user-images.githubusercontent.com/69956021/133395021-61a17d4e-51c0-40b1-9867-45907ee312ff.png">


## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
