### PR TITLE
[HUDI-2444] Fixing cleaning and rollback if retried after failed attempt

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -195,7 +195,7 @@ public class HoodieTableMetadataUtil {
 
     cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
       // Files deleted from a partition
-      List<String> deletedFiles = partitionMetadata.getSuccessDeleteFiles();
+      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
       HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, Option.empty(),
           Option.of(new ArrayList<>(deletedFiles)));
 
@@ -285,7 +285,7 @@ public class HoodieTableMetadataUtil {
       }
 
       final String partition = pm.getPartitionPath();
-      if (!pm.getSuccessDeleteFiles().isEmpty() && !shouldSkip) {
+      if ((!pm.getSuccessDeleteFiles().isEmpty() || !pm.getFailedDeleteFiles().isEmpty()) && !shouldSkip) {
         if (!partitionToDeletedFiles.containsKey(partition)) {
           partitionToDeletedFiles.put(partition, new ArrayList<>());
         }
@@ -293,6 +293,10 @@ public class HoodieTableMetadataUtil {
         // Extract deleted file name from the absolute paths saved in getSuccessDeleteFiles()
         List<String> deletedFiles = pm.getSuccessDeleteFiles().stream().map(p -> new Path(p).getName())
             .collect(Collectors.toList());
+        if (!pm.getFailedDeleteFiles().isEmpty()) {
+          deletedFiles.addAll(pm.getFailedDeleteFiles().stream().map(p -> new Path(p).getName())
+              .collect(Collectors.toList()));
+        }
         partitionToDeletedFiles.get(partition).addAll(deletedFiles);
       }
 


### PR DESCRIPTION
## What is the purpose of the pull request

- If cleaning or rollback failed on first attempt and then we re-attempt, commit metadata could miss files that were deleted during 1st attempt. We need to fix that since all changes need to be applied to metadata table. 

## Brief change log

- Fixed cleaning meta when applying changes to metadata table.
- Fixed rollback meta when applying changes to metadata table. 

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
