### PR TITLE
[HUDI-2455] Adding spark_avro dependency to hudi-integ-test

### DIFF
--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -87,6 +87,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-avro_${scala.binary.version}</artifactId>
+    </dependency>
 
     <!-- Hoodie -->
     <dependency>


### PR DESCRIPTION
Recently, fail to build hudi in master branch using `mvn clean package -DskipTest`.

The rroor message is as follows:

```
[ERROR] /hudi/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/utils/SparkSqlUtils.scala:32: error: object avro is not a member of package org.apache.spark.sql 
[ERROR] import org.apache.spark.sql.avro.SchemaConverters 
[ERROR] ^ 
[ERROR] /hudi/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/utils/SparkSqlUtils.scala:142: error: not found: value SchemaConverters 
[ERROR] val structType = SchemaConverters.toSqlType(schema).dataType.asInstanceOf[StructType] 
[ERROR] ^ 
[ERROR] two errors found```