### PR TITLE
[HUDI-2487] Fix JsonKafkaSource cannot filter empty messages from kafka

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/JsonKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/JsonKafkaSource.java
@@ -69,7 +69,14 @@ public class JsonKafkaSource extends JsonSource {
 
   private JavaRDD<String> toRDD(OffsetRange[] offsetRanges) {
     return KafkaUtils.createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges,
-            LocationStrategies.PreferConsistent()).map(x -> (String) x.value());
+            LocationStrategies.PreferConsistent()).filter(x -> {
+              String msgValue = (String) x.value();
+              //Filter null messages from Kafka to prevent Exceptions
+              if (msgValue == null) {
+                return false;
+              }
+              return true;
+            }).map(x -> (String) x.value());
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/JsonKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/JsonKafkaSource.java
@@ -72,10 +72,7 @@ public class JsonKafkaSource extends JsonSource {
             LocationStrategies.PreferConsistent()).filter(x -> {
               String msgValue = (String) x.value();
               //Filter null messages from Kafka to prevent Exceptions
-              if (msgValue == null) {
-                return false;
-              }
-              return true;
+              return msgValue != null;
             }).map(x -> (String) x.value());
   }
 


### PR DESCRIPTION
## what is the purpose of the pull request
**This pull request solved the following problem:**

**(1)** When using DeltaStreamer in upsert mode, consume JSON data from Kafka to hudi and update hive tables, if some messages in Kafka are null, the task will throw an exception


## Brief change log
  - *Filter empty messages from Kafka in org.apache.hudi.utilities.sources.JsonKafkaSource#fetchNewData*

## Verify this pull request


This pull request is already covered by existing tests, such as *org.apache.hudi.utilities.functional.TestHoodieDeltaStreamer#testDistributedTestDataSource*.

[https://issues.apache.org/jira/browse/HUDI-2487](url)