### PR TITLE
[HUDI-2499] Make jdbc-url, user and pass as non-required for other sync-modes

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -40,13 +40,13 @@ public class HiveSyncConfig implements Serializable {
   @Parameter(names = {"--base-file-format"}, description = "Format of the base files (PARQUET (or) HFILE)")
   public String baseFileFormat = "PARQUET";
 
-  @Parameter(names = {"--user"}, description = "Hive username", required = true)
+  @Parameter(names = {"--user"}, description = "Hive username")
   public String hiveUser;
 
-  @Parameter(names = {"--pass"}, description = "Hive password", required = true)
+  @Parameter(names = {"--pass"}, description = "Hive password")
   public String hivePass;
 
-  @Parameter(names = {"--jdbc-url"}, description = "Hive jdbc connect url", required = true)
+  @Parameter(names = {"--jdbc-url"}, description = "Hive jdbc connect url")
   public String jdbcUrl;
 
   @Parameter(names = {"--base-path"}, description = "Basepath of hoodie table to sync", required = true)

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This class offers DDL executor backed by the jdbc This class preserves the old useJDBC = true way of doing things.
@@ -44,6 +45,9 @@ public class JDBCExecutor extends QueryBasedDDLExecutor {
 
   public JDBCExecutor(HiveSyncConfig config, FileSystem fs) {
     super(config, fs);
+    Objects.requireNonNull(config.jdbcUrl, "--jdbc-url option is required for jdbc sync mode");
+    Objects.requireNonNull(config.hiveUser, "--user option is required for jdbc sync mode");
+    Objects.requireNonNull(config.hivePass, "--pass option is required for jdbc sync mode");
     this.config = config;
     createHiveConnection(config.jdbcUrl, config.hiveUser, config.hivePass);
   }


### PR DESCRIPTION
## What is the purpose of the pull request

- Currently `jdbc-url, user and pass` are required configs to be passed to `run_sync_tool.sh`  for every sync mode.
- These configs are not required for HMS mode and hence marked as non-required.

## Brief change log

- Modified `HiveSyncConfig` to remove `required` option from `jdbc-url, user and pass` options
- Added nonNull checks in `JDBCExecutor`

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
