### PR TITLE
[HUDI-2496] Insert duplicate keys when precombined is deactivated

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieConcatHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieConcatHandle.java
@@ -18,8 +18,13 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -34,7 +39,9 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -44,21 +51,21 @@ import java.util.Map;
  * Simplified Logic:
  * For every existing record
  *     Write the record as is
- * For all incoming records, write to file as is.
+ * For all incoming records, write to file as is, without de-duplicating based on the record key.
  *
  * Illustration with simple data.
  * Incoming data:
- *     rec1_2, rec4_2, rec5_1, rec6_1
+ *     rec1_2, rec1_3, rec4_2, rec5_1, rec6_1
  * Existing data:
  *     rec1_1, rec2_1, rec3_1, rec4_1
  *
  * For every existing record, write to storage as is.
  *    => rec1_1, rec2_1, rec3_1 and rec4_1 is written to storage
  * Write all records from incoming set to storage
- *    => rec1_2, rec4_2, rec5_1 and rec6_1
+ *    => rec1_2, rec1_3, rec4_2, rec5_1 and rec6_1
  *
  * Final snapshot in storage
- * rec1_1, rec2_1, rec3_1, rec4_1, rec1_2, rec4_2, rec5_1, rec6_1
+ * rec1_1, rec2_1, rec3_1, rec4_1, rec1_2, rec1_3, rec4_2, rec5_1, rec6_1
  *
  * Users should ensure there are no duplicates when "insert" operation is used and if the respective config is enabled. So, above scenario should not
  * happen and every batch should have new records to be inserted. Above example is for illustration purposes only.
@@ -66,16 +73,22 @@ import java.util.Map;
 public class HoodieConcatHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieMergeHandle<T, I, K, O> {
 
   private static final Logger LOG = LogManager.getLogger(HoodieConcatHandle.class);
+  // a representation of incoming records that tolerates duplicate keys.
+  private final Iterator<HoodieRecord<T>> recordItr;
 
-  public HoodieConcatHandle(HoodieWriteConfig config, String instantTime, HoodieTable hoodieTable, Iterator recordItr,
-                            String partitionPath, String fileId, TaskContextSupplier taskContextSupplier, Option<BaseKeyGenerator> keyGeneratorOpt) {
-    super(config, instantTime, hoodieTable, recordItr, partitionPath, fileId, taskContextSupplier, keyGeneratorOpt);
+  public HoodieConcatHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                            Iterator<HoodieRecord<T>> recordItr, String partitionPath, String fileId,
+                            TaskContextSupplier taskContextSupplier, Option<BaseKeyGenerator> keyGeneratorOpt) {
+    super(config, instantTime, hoodieTable, Collections.emptyIterator(), partitionPath, fileId, taskContextSupplier, keyGeneratorOpt);
+    this.recordItr = recordItr;
   }
 
   public HoodieConcatHandle(HoodieWriteConfig config, String instantTime, HoodieTable hoodieTable, Map keyToNewRecords, String partitionPath, String fileId,
       HoodieBaseFile dataFileToBeMerged, TaskContextSupplier taskContextSupplier) {
+    // if incoming data is a Map, fallback to Map representation of incoming records
     super(config, instantTime, hoodieTable, keyToNewRecords, partitionPath, fileId, dataFileToBeMerged, taskContextSupplier,
         Option.empty());
+    this.recordItr = Collections.emptyIterator();
   }
 
   /**
@@ -93,5 +106,35 @@ public class HoodieConcatHandle<T extends HoodieRecordPayload, I, K, O> extends 
       throw new HoodieUpsertException(errMsg, e);
     }
     recordsWritten++;
+  }
+
+  boolean needsUpdateLocation() {
+    return true;
+  }
+
+  @Override
+  public List<WriteStatus> close() {
+    try {
+      while (recordItr.hasNext()) {
+        HoodieRecord<T> record = recordItr.next();
+
+        if (needsUpdateLocation()) {
+          record.unseal();
+          record.setNewLocation(new HoodieRecordLocation(instantTime, fileId));
+          record.seal();
+        }
+        Schema schema = useWriterSchema ? tableSchemaWithMetaFields : tableSchema;
+        Option<IndexedRecord> insertRecord = record.getData().getInsertValue(schema, config.getProps());
+        // just skip the ignored record
+        if (insertRecord.isPresent() && insertRecord.get().equals(IGNORE_RECORD)) {
+          continue;
+        }
+        writeRecord(record, insertRecord);
+        insertRecordsWritten++;
+      }
+    } catch (IOException e) {
+      throw new HoodieUpsertException("Failed to close UpdateHandle", e);
+    }
+    return super.close();
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceConsistentInserts.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceConsistentInserts.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.hive.NonPartitionedExtractor
+import org.apache.hudi.keygen.NonpartitionedKeyGenerator
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.spark.sql.SaveMode.Append
+import org.apache.spark.sql.functions.col
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{Tag, Test}
+
+
+@Tag("functional")
+class TestCOWDataSourceConsistentInserts extends SparkClientFunctionalTestHarness {
+
+  val opts = Map(
+    DataSourceWriteOptions.TABLE_NAME.key() -> "language",
+    DataSourceWriteOptions.TABLE_TYPE.key() -> DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL,
+    DataSourceWriteOptions.OPERATION.key() -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+    DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "lang",
+    DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "score",
+    DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key() -> classOf[NonpartitionedKeyGenerator].getCanonicalName,
+    DataSourceWriteOptions.HIVE_PARTITION_EXTRACTOR_CLASS.key() -> classOf[NonPartitionedExtractor].getCanonicalName,
+    DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key() -> "true",
+    DataSourceWriteOptions.INSERT_DROP_DUPS.key() -> "false",
+    HoodieWriteConfig.TBL_NAME.key() -> "language",
+    HoodieWriteConfig.COMBINE_BEFORE_INSERT.key() -> "false",
+    HoodieWriteConfig.MERGE_ALLOW_DUPLICATE_ON_INSERTS_ENABLE.key() -> "true",
+    HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key() -> "1",
+    HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key() -> "1",
+    HoodieWriteConfig.BULKINSERT_PARALLELISM_VALUE.key() -> "1",
+    HoodieWriteConfig.FINALIZE_WRITE_PARALLELISM_VALUE.key() -> "1",
+    HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key() -> (120 * 1024 * 1024).toString,
+    "spark.default.parallelism" -> "1",
+    "spark.sql.shuffle.partitions" -> "1"
+  )
+
+  @Test
+  def insertsWithDuplicatesShouldBeConsistent(): Unit = {
+    val inserts1 = spark.createDataFrame(("python", 1) :: ("scala", 5) :: ("scala", 4) :: ("haskell", 5) :: Nil).toDF("lang", "score")
+    inserts1.write.format("hudi").options(opts).mode(Append).save(basePath)
+    val tableData1 = spark.read.format("hudi").load(basePath)
+    tableData1.show()
+    assertEquals(2, tableData1.where(col("_hoodie_record_key") === "scala").count())
+
+    val inserts2 = spark.createDataFrame(("scala", 5) ::  ("java", 3) :: ("java", 4) :: Nil).toDF("lang", "score")
+    inserts2.write.format("hudi").options(opts).mode(Append).save(basePath)
+    val tableData2 = spark.read.format("hudi").load(basePath)
+    tableData2.show()
+    assertEquals(3, tableData2.where(col("_hoodie_record_key") === "scala").count())
+    assertEquals(2, tableData2.where(col("_hoodie_record_key") === "java").count())
+  }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*The purpose of this PR is to provide a fix in the issue described in [ISSUE-3709](https://github.com/apache/hudi/issues/3709). Specifically, when using INSERT mode the library should not pre-combine input dataset if precombine is deactivated.*

## Brief change log
  - *Modify HoodieConcatHandle so it does not use an underlying Map to store incoming records. The Map is not really needed in this case; the key lookup is avoided, since merge is simply a concatenation of the old with new records.*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Added org.apache.hudi.functional.TestCOWDataSourceConsistentInserts to verify the change.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
