### PR TITLE
Added a quickstart redirect page to fix broken external links in GCP docs

### DIFF
--- a/website/src/pages/quickstart.md
+++ b/website/src/pages/quickstart.md
@@ -1,0 +1,14 @@
+---
+id: quickstart.html
+title: quickstart
+---
+
+import {Route} from '@docusaurus/router';
+
+<Route
+path={'/*'}
+component={() => {
+global.window && (global.window.location.href = '/docs/quick-start-guide');
+return null;
+}}
+/>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*This PR adds a redirect page for quickstart so that the GCP docs links are handled correctly.*

## Brief change log

*(for example:)*
  - *Added a new page for quickstart which directs to the latest docs quick-start page.*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
