### PR TITLE
[HUDI-2503] HoodieFlinkWriteClient supports to allow parallel writing to tables using Locking service

### DIFF
--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.client.transaction.FileSystemBasedLockProviderTestClass;
+import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieWriteConflictException;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PATH_PROP_KEY;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
+
+  @Test
+  public void testHoodieClientBasicMultiWriter() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(FILESYSTEM_LOCK_PATH_PROP_KEY, basePath + "/.hoodie/.locks");
+    HoodieWriteConfig cfg =
+        getConfigBuilder()
+            .withCompactionConfig(
+                HoodieCompactionConfig.newBuilder()
+                    .withFailedWritesCleaningPolicy(
+                        HoodieFailedWritesCleaningPolicy.LAZY)
+                    .withAutoClean(false)
+                    .build())
+            .withWriteConcurrencyMode(
+                WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
+            .withLockConfig(
+                HoodieLockConfig.newBuilder()
+                    .withLockProvider(
+                        FileSystemBasedLockProviderTestClass.class)
+                    .build())
+            .withAutoCommit(false)
+            .withProperties(properties)
+            .build();
+    // Create the first commit
+    createCommitWithInserts(getHoodieWriteClient(cfg), "001", 1);
+    try {
+      ExecutorService executors = Executors.newFixedThreadPool(2);
+      HoodieFlinkWriteClient<?> client1 = getHoodieWriteClient(cfg);
+      HoodieFlinkWriteClient<?> client2 = getHoodieWriteClient(cfg);
+      Future<?> future1 =
+          executors.submit(
+              () -> {
+                String newCommitTime = "002";
+                int numRecords = 1;
+                try {
+                  createCommitWithUpserts(client1, newCommitTime, numRecords);
+                } catch (Exception e1) {
+                  assertTrue(e1 instanceof HoodieWriteConflictException);
+                  throw new RuntimeException(e1);
+                }
+              });
+      Future<?> future2 =
+          executors.submit(
+              () -> {
+                String newCommitTime = "003";
+                int numRecords = 1;
+                try {
+                  createCommitWithUpserts(client2, newCommitTime, numRecords);
+                } catch (Exception e2) {
+                  assertTrue(e2 instanceof HoodieWriteConflictException);
+                  throw new RuntimeException(e2);
+                }
+              });
+      future1.get();
+      future2.get();
+      Assertions.fail(
+          "Should not reach here, this means concurrent writes were handled incorrectly");
+    } catch (Exception e) {
+      // Expected to fail due to overlapping commits
+    }
+  }
+
+  private void createCommitWithInserts(
+      HoodieFlinkWriteClient<?> client, String newCommitTime, int numRecords)
+      throws Exception {
+    List<WriteStatus> result =
+        insertFirstBatch(client, newCommitTime, numRecords, HoodieFlinkWriteClient::insert);
+    assertTrue(client.commit(newCommitTime, result), "Commit should succeed");
+  }
+
+  private void createCommitWithUpserts(
+      HoodieFlinkWriteClient<?> client, String newCommitTime, int numRecords)
+      throws Exception {
+    List<WriteStatus> result =
+        updateBatch(client, newCommitTime, numRecords, HoodieFlinkWriteClient::upsert);
+    client.commit(newCommitTime, result);
+  }
+}

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.testutils;
+
+import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.fs.ConsistencyGuardConfig;
+import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieStorageConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex.IndexType;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.UUID.randomUUID;
+import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Base Class providing setup/cleanup and utility methods for testing Hoodie Client facing tests.
+ */
+public class HoodieClientTestBase extends HoodieClientTestHarness {
+
+  protected static final Logger LOG = LogManager.getLogger(HoodieClientTestBase.class);
+
+  private static final String FILE_ID = randomUUID().toString();
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    initResources();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    cleanupResources();
+  }
+
+  /**
+   * Get Default HoodieWriteConfig for tests.
+   *
+   * @return Default Hoodie Write Config for tests
+   */
+  public HoodieWriteConfig getConfig() {
+    return getConfigBuilder().build();
+  }
+
+  /**
+   * Get Config builder with default configs set.
+   *
+   * @return Config Builder
+   */
+  public HoodieWriteConfig.Builder getConfigBuilder() {
+    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+  }
+
+  public HoodieWriteConfig.Builder getConfigBuilder(String schemaStr) {
+    return getConfigBuilder(schemaStr, IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER);
+  }
+
+  /**
+   * Get Config builder with default configs set.
+   *
+   * @return Config Builder
+   */
+  public HoodieWriteConfig.Builder getConfigBuilder(
+      String schemaStr,
+      IndexType indexType,
+      HoodieFailedWritesCleaningPolicy cleaningPolicy) {
+    return HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(schemaStr)
+        .withParallelism(2, 2)
+        .withBulkInsertParallelism(2)
+        .withFinalizeWriteParallelism(2)
+        .withDeleteParallelism(2)
+        .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
+        .withWriteStatusClass(MetadataMergeWriteStatus.class)
+        .withConsistencyGuardConfig(
+            ConsistencyGuardConfig.newBuilder()
+                .withConsistencyCheckEnabled(true)
+                .build())
+        .withCompactionConfig(
+            HoodieCompactionConfig.newBuilder()
+                .withFailedWritesCleaningPolicy(cleaningPolicy)
+                .compactionSmallFileSize(1024 * 1024)
+                .build())
+        .withStorageConfig(
+            HoodieStorageConfig.newBuilder()
+                .hfileMaxFileSize(1024 * 1024)
+                .parquetMaxFileSize(1024 * 1024)
+                .orcMaxFileSize(1024 * 1024)
+                .build())
+        .forTable("test-trip-table")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(indexType).build())
+        .withEmbeddedTimelineServerEnabled(true)
+        .withFileSystemViewConfig(
+            FileSystemViewStorageConfig.newBuilder()
+                .withEnableBackupForRemoteFileSystemView(
+                    false) // Fail test if problem connecting to timeline-server
+                .withStorageType(FileSystemViewStorageType.EMBEDDED_KV_STORE)
+                .build());
+  }
+
+  public void assertPartitionMetadataForRecords(List<HoodieRecord> inputRecords, FileSystem fs)
+      throws IOException {
+    assertPartitionMetadata(
+        inputRecords.stream()
+            .map(HoodieRecord::getPartitionPath)
+            .distinct()
+            .toArray(String[]::new),
+        fs);
+  }
+
+  /**
+   * Ensure presence of partition meta-data at known depth.
+   *
+   * @param partitionPaths Partition paths to check
+   * @param fs             File System
+   * @throws IOException in case of error
+   */
+  public void assertPartitionMetadata(String[] partitionPaths, FileSystem fs) throws IOException {
+    for (String partitionPath : partitionPaths) {
+      assertTrue(
+          HoodiePartitionMetadata.hasPartitionMetadata(
+              fs, new Path(basePath, partitionPath)));
+      HoodiePartitionMetadata pmeta =
+          new HoodiePartitionMetadata(fs, new Path(basePath, partitionPath));
+      pmeta.readFromFS();
+      assertEquals(
+          HoodieTestDataGenerator.DEFAULT_PARTITION_DEPTH, pmeta.getPartitionDepth());
+    }
+  }
+
+  /**
+   * Helper to generate insert records generation function for testing Prepped version of API.
+   * Prepped APIs expect the records to be already de-duped and have location set. This wrapper
+   * takes care of record-location setting. Uniqueness is guaranteed by record-generation function
+   * itself.
+   *
+   * @param recordGenFunction Records Generation function
+   * @return Wrapped function
+   */
+  private Function2<List<HoodieRecord>, String, Integer> generateWrapInsertRecordsFn(
+      final Function2<List<HoodieRecord>, String, Integer> recordGenFunction) {
+    return (commit, numRecords) -> {
+      final List<HoodieRecord> records = recordGenFunction.apply(commit, numRecords);
+      records.forEach(r -> r.setCurrentLocation(new HoodieRecordLocation("I", FILE_ID)));
+      return records;
+    };
+  }
+
+  /**
+   * Helper to generate upsert records generation function for testing Prepped version of API.
+   * Prepped APIs expect the records to be already de-duped and have location set. This wrapper
+   * takes care of record-location setting. Uniqueness is guaranteed by record-generation function
+   * itself.
+   *
+   * @param recordGenFunction Records Generation function
+   * @return Wrapped function
+   */
+  private Function2<List<HoodieRecord>, String, Integer> generateWrapUpsertRecordsFn(
+      final Function2<List<HoodieRecord>, String, Integer> recordGenFunction) {
+    return (commit, numRecords) -> {
+      final List<HoodieRecord> records = recordGenFunction.apply(commit, numRecords);
+      records.forEach(r -> r.setCurrentLocation(new HoodieRecordLocation(commit, FILE_ID)));
+      return records;
+    };
+  }
+
+  /**
+   * Helper to insert first batch of records and do regular assertions on the state after
+   * successful completion.
+   *
+   * @param client                 Hoodie Write Client
+   * @param newCommitTime          New Commit Timestamp to be used
+   * @param numRecordsInThisCommit Number of records to be added in the new commit
+   * @param writeFn                Write Function to be used for insertion
+   * @return RDD of write-status
+   * @throws Exception in case of error
+   */
+  public List<WriteStatus> insertFirstBatch(
+      HoodieFlinkWriteClient client,
+      String newCommitTime,
+      int numRecordsInThisCommit,
+      Function3<List<WriteStatus>, HoodieFlinkWriteClient, List<HoodieRecord>, String>
+          writeFn)
+      throws Exception {
+    final Function2<List<HoodieRecord>, String, Integer> recordGenFunction =
+        generateWrapInsertRecordsFn(dataGen::generateInserts);
+    return writeBatch(
+        client, newCommitTime, numRecordsInThisCommit, recordGenFunction, writeFn);
+  }
+
+  /**
+   * Helper to upsert batch of records and do regular assertions on the state after successful
+   * completion.
+   *
+   * @param client                 Hoodie Write Client
+   * @param newCommitTime          New Commit Timestamp to be used
+   * @param numRecordsInThisCommit Number of records to be added in the new commit
+   * @param writeFn                Write Function to be used for upsert
+   * @return RDD of write-status
+   * @throws Exception in case of error
+   */
+  public List<WriteStatus> updateBatch(
+      HoodieFlinkWriteClient client,
+      String newCommitTime,
+      int numRecordsInThisCommit,
+      Function3<List<WriteStatus>, HoodieFlinkWriteClient, List<HoodieRecord>, String>
+          writeFn)
+      throws Exception {
+    final Function2<List<HoodieRecord>, String, Integer> recordGenFunction =
+        generateWrapUpsertRecordsFn(dataGen::generateUniqueUpdates);
+    return writeBatch(
+        client, newCommitTime, numRecordsInThisCommit, recordGenFunction, writeFn);
+  }
+
+  /**
+   * Helper to insert/upsert batch of records and do regular assertions on the state after
+   * successful completion.
+   *
+   * @param client                 Hoodie Write Client
+   * @param newCommitTime          New Commit Timestamp to be used
+   * @param numRecordsInThisCommit Number of records to be added in the new commit
+   * @param recordGenFunction      Records Generation Function
+   * @param writeFn                Write Function to be used for upsert
+   * @throws Exception in case of error
+   */
+  public List<WriteStatus> writeBatch(
+      HoodieFlinkWriteClient client,
+      String newCommitTime,
+      int numRecordsInThisCommit,
+      Function2<List<HoodieRecord>, String, Integer> recordGenFunction,
+      Function3<List<WriteStatus>, HoodieFlinkWriteClient, List<HoodieRecord>, String>
+          writeFn)
+      throws Exception {
+    // Write 1 (only inserts)
+    client.startCommitWithTime(newCommitTime);
+
+    List<HoodieRecord> writeRecords =
+        recordGenFunction.apply(newCommitTime, numRecordsInThisCommit);
+    List<WriteStatus> statuses = writeFn.apply(client, writeRecords, newCommitTime);
+    assertNoWriteErrors(statuses);
+    // Check the partition metadata is written out
+    assertPartitionMetadataForRecords(writeRecords, fs);
+    // Transition REQUESTED to INFLIGHT state
+    client.transitionRequestedToInflight(HoodieActiveTimeline.COMMIT_ACTION, newCommitTime);
+    return statuses;
+  }
+
+  // Functional Interfaces for passing lambda and Hoodie Write API contexts
+
+  @FunctionalInterface
+  public interface Function2<R, T1, T2> {
+
+    R apply(T1 v1, T2 v2) throws IOException;
+  }
+
+  @FunctionalInterface
+  public interface Function3<R, T1, T2, T3> {
+
+    R apply(T1 v1, T2 v2, T3 v3) throws IOException;
+  }
+}

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.testutils;
+
+import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.minicluster.HdfsTestService;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.util.FlinkClientUtil;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * The test harness for resource initialization and cleanup.
+ */
+@SuppressWarnings("checkstyle:Indentation")
+public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness
+    implements Serializable {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieClientTestHarness.class);
+
+  protected transient HoodieFlinkEngineContext context = HoodieFlinkEngineContext.DEFAULT;
+  protected transient Configuration hadoopConf = FlinkClientUtil.getHadoopConf();
+  protected transient FileSystem fs;
+  protected transient ExecutorService executorService;
+  protected transient HoodieTableMetaClient metaClient;
+  protected transient HoodieFlinkWriteClient<?> writeClient;
+  protected transient HoodieTableFileSystemView tableView;
+  protected transient HdfsTestService hdfsTestService;
+  protected transient MiniDFSCluster dfsCluster;
+  protected transient DistributedFileSystem dfs;
+
+  @AfterAll
+  public static void tearDownAll() throws IOException {
+    FileSystem.closeAll();
+  }
+
+  /**
+   * Initializes resource group for the subclasses of {@link HoodieClientTestBase}.
+   */
+  public void initResources() throws IOException {
+    initPath();
+    initTestDataGenerator();
+    initFileSystem();
+    initMetaClient();
+  }
+
+  /**
+   * Cleanups resource group for the subclasses of {@link HoodieClientTestBase}.
+   */
+  public void cleanupResources() throws IOException {
+    cleanupClients();
+    cleanupTestDataGenerator();
+    cleanupFileSystem();
+    cleanupDFS();
+    cleanupExecutorService();
+    System.gc();
+  }
+
+  /**
+   * Initializes a file system with the hadoop configuration of Spark context.
+   */
+  protected void initFileSystem() {
+    initFileSystemWithConfiguration(hadoopConf);
+  }
+
+  /**
+   * Cleanups file system.
+   *
+   * @throws IOException IOException
+   */
+  protected void cleanupFileSystem() throws IOException {
+    if (fs != null) {
+      LOG.warn("Closing file-system instance used in previous test-run");
+      fs.close();
+      fs = null;
+    }
+  }
+
+  /**
+   * Initializes an instance of {@link HoodieTableMetaClient} with a special table type specified
+   * by {@code getTableType()}.
+   *
+   * @throws IOException IOException
+   */
+  protected void initMetaClient() throws IOException {
+    initMetaClient(getTableType());
+  }
+
+  protected void initMetaClient(HoodieTableType tableType) throws IOException {
+    if (basePath == null) {
+      throw new IllegalStateException("The base path has not been initialized.");
+    }
+
+    metaClient = HoodieTestUtils.init(hadoopConf, basePath, tableType);
+  }
+
+  /**
+   * Cleanups hoodie clients.
+   */
+  protected void cleanupClients() {
+    if (metaClient != null) {
+      metaClient = null;
+    }
+    if (writeClient != null) {
+      writeClient.close();
+      writeClient = null;
+    }
+    if (tableView != null) {
+      tableView.close();
+      tableView = null;
+    }
+  }
+
+  /**
+   * Cleanups the distributed file system.
+   *
+   * @throws IOException IOException
+   */
+  protected void cleanupDFS() throws IOException {
+    if (hdfsTestService != null) {
+      hdfsTestService.stop();
+      dfsCluster.shutdown();
+      hdfsTestService = null;
+      dfsCluster = null;
+      dfs = null;
+    }
+    // Need to closeAll to clear FileSystem.Cache, required because DFS and LocalFS used in the
+    // same JVM
+    FileSystem.closeAll();
+  }
+
+  /**
+   * Cleanups the executor service.
+   */
+  protected void cleanupExecutorService() {
+    if (this.executorService != null) {
+      this.executorService.shutdownNow();
+      this.executorService = null;
+    }
+  }
+
+  private void initFileSystemWithConfiguration(Configuration configuration) {
+    if (basePath == null) {
+      throw new IllegalStateException("The base path has not been initialized.");
+    }
+
+    fs = FSUtils.getFs(basePath, configuration);
+    if (fs instanceof LocalFileSystem) {
+      LocalFileSystem lfs = (LocalFileSystem) fs;
+      // With LocalFileSystem, with checksum disabled, fs.open() returns an inputStream which
+      // is FSInputStream
+      // This causes ClassCastExceptions in LogRecordScanner (and potentially other places)
+      // calling fs.open
+      // So, for the tests, we enforce checksum verification to circumvent the problem
+      lfs.setVerifyChecksum(true);
+    }
+  }
+
+  public HoodieFlinkWriteClient<?> getHoodieWriteClient(HoodieWriteConfig cfg) {
+    if (null != writeClient) {
+      writeClient.close();
+      writeClient = null;
+    }
+    writeClient = new HoodieFlinkWriteClient<>(context, cfg);
+    return writeClient;
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

*The strategy interface for conflict resolution with multiple writers is introduced and the `SparkRDDWriteClient` has integrated with the `ConflictResolutionStrategy`. `HoodieFlinkWriteClient` should also support to allow parallel writing to tables using Locking service based on `ConflictResolutionStrategy`.*

## Brief change log

  - *`HoodieFlinkWriteClient` adds the integration with `ConflictResolutionStrategy` in the `preCommit()` method.*

## Verify this pull request

  - *Added the `TestHoodieClientMultiWriter` to verify whether `HoodieFlinkWriteClient` supports to allow parallel writing to tables using Locking service.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.