### PR TITLE
[HUDI-2541] Eliminate the unnecessary usage of write client for flink

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieClient.java
@@ -87,7 +87,7 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
     this.context.setJobStatus("", "");
   }
 
-  private synchronized void stopEmbeddedServerView(boolean resetViewStorageConfig) {
+  protected synchronized void stopEmbeddedServerView(boolean resetViewStorageConfig) {
     if (timelineServer.isPresent() && shouldStopTimelineServer) {
       // Stop only if owner
       LOG.info("Stopping Timeline service !!");
@@ -101,7 +101,7 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
     }
   }
 
-  private synchronized void startEmbeddedServerView() {
+  protected synchronized void startEmbeddedServerView() {
     if (config.isEmbeddedTimelineServerEnabled()) {
       if (!timelineServer.isPresent()) {
         // Run Embedded Timeline Server

--- a/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -808,11 +808,11 @@ public class TestWriteCopyOnWrite {
     HoodieFlinkWriteClient writeClient = StreamerUtil.createWriteClient(conf, null);
     FileSystemViewStorageConfig viewStorageConfig = writeClient.getConfig().getViewStorageConfig();
 
-    assertSame(viewStorageConfig.getStorageType(), FileSystemViewStorageType.REMOTE_FIRST);
+    assertSame(viewStorageConfig.getStorageType(), FileSystemViewStorageType.MEMORY);
 
     // get another write client
     writeClient = StreamerUtil.createWriteClient(conf, null);
-    assertSame(writeClient.getConfig().getViewStorageConfig().getStorageType(), FileSystemViewStorageType.REMOTE_FIRST);
+    assertSame(writeClient.getConfig().getViewStorageConfig().getStorageType(), FileSystemViewStorageType.MEMORY);
     assertEquals(viewStorageConfig.getRemoteViewServerPort(), writeClient.getConfig().getViewStorageConfig().getRemoteViewServerPort());
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

*`HoodieFlinkWriteClient` defaults to start a embedded timeline server. If there is any dataset to write, the embedded server is definitely unnecessary to start.*

## Brief change log

  - *`HoodieFlinkWriteClient` overrides the `startEmbeddedServerView` and `stopEmbeddedServerView` to starts a embedded timeline server lazily.*

## Verify this pull request

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
