### PR TITLE
[HUDI-2553] Metadata table compaction trigger max delta commits default config (re-enable)

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -71,7 +71,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   // Maximum delta commits before compaction occurs
   public static final ConfigProperty<Integer> COMPACT_NUM_DELTA_COMMITS = ConfigProperty
       .key(METADATA_PREFIX + ".compact.max.delta.commits")
-      .defaultValue(24)
+      .defaultValue(10)
       .sinceVersion("0.7.0")
       .withDocumentation("Controls how often the metadata table is compacted.");
 


### PR DESCRIPTION
## What is the purpose of the pull request

Setting the max delta commits default config to 10 (previously it was 24) to trigger the compaction in metadata table quicker than before.

The previous change for this https://github.com/apache/hudi/pull/3784 is suspected for breaking CI, so re-doing this change to let CI catch the flakiness if any.

## Brief change log

* Updated the default config value in HoodieMetadataConfig.java

## Verify this pull request

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
