### PR TITLE
[HUDI-2557] Shade javax.servlet for flink bundle jar

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -153,6 +153,10 @@
               </artifactSet>
               <relocations>
                 <relocation>
+                  <pattern>javax.servlet.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}javax.servlet.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.apache.avro.</pattern>
                   <shadedPattern>${flink.bundle.shade.prefix}org.apache.avro.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
Shade javax.servlet for flink bundle ja

Tips
Thank you very much for contributing to Apache Hudi.
Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.
What is the purpose of the pull request
*solve javax.servlet jar dependence conflict

Brief change log
(for example:)

*Modify hudi-flink-bundle pom.xml
Verify this pull request
hudi-flink-bundle pom.xml


[HUDI-2557] Shade javax.servlet for flink bundle jar #3798