### PR TITLE
[HUDI-2561] BitCaskDiskMap - avoiding hostname resolution when logging messages

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.io.Serializable;
-import java.net.InetAddress;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashSet;
@@ -133,9 +132,7 @@ public final class BitCaskDiskMap<T extends Serializable, R extends Serializable
       writeOnlyFile.getParentFile().mkdir();
     }
     writeOnlyFile.createNewFile();
-    LOG.info("Spilling to file location " + writeOnlyFile.getAbsolutePath() + " in host ("
-        + InetAddress.getLocalHost().getHostAddress() + ") with hostname (" + InetAddress.getLocalHost().getHostName()
-        + ")");
+    LOG.debug("Spilling to file location " + writeOnlyFile.getAbsolutePath());
     // Make sure file is deleted when JVM exits
     writeOnlyFile.deleteOnExit();
   }


### PR DESCRIPTION
## What is the purpose of the pull request

InetAddress.getLocalHost() can take up as much as 30+seconds if the network
configurations are not done right. This might be due to local hostname
missing IPv6 address mapping in /etc/hosts or network configs slowing down
any IPv6 name resolutions. If this API is used for logging verbose messages
and that too in the hot code path, it can lead to order of magnitude
slowness in the overall task completion.

## Brief change log

* BitCaskDiskMap - modified the logging message to exclude localhost name resolution

## Verify this pull request

* TestCleaner verified with and without fixes


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
