### PR TITLE
[HUDI-2569] NoSuchMethodError: org.apache.hadoop.hive.ql.metadata.Hive.get

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -201,6 +201,10 @@
                   <shadedPattern>${flink.bundle.shade.prefix}org.apache.hadoop.hive.service.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.hadoop.hive.ql.metadata.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.hadoop.hive.ql.metadata.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.codahale.metrics.</pattern>
                   <shadedPattern>${flink.bundle.shade.prefix}com.codahale.metrics.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
Shade hive for flink bundle jar

Tips
Thank you very much for contributing to Apache Hudi.
Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.
What is the purpose of the pull request
*solve hive-exec jar dependence conflict

Brief change log
(for example:)

*Modify hudi-flink-bundle pom.xml
Verify this pull request
hudi-flink-bundle pom.xml