### PR TITLE
[HUDI-2579] Make deltastreamer checkpoint state merging more explicit

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -118,7 +118,7 @@ public class TransactionUtils {
     }
   }
 
-  private static void mergeCheckpointStateFromPreviousCommit(HoodieTableMetaClient metaClient, Option<HoodieCommitMetadata> thisMetadata) {
+  protected static void mergeCheckpointStateFromPreviousCommit(HoodieTableMetaClient metaClient, Option<HoodieCommitMetadata> thisMetadata) {
     overrideWithLatestCommitMetadata(metaClient, thisMetadata, Collections.singletonList(HoodieWriteConfig.DELTASTREAMER_CHECKPOINT_KEY));
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -119,7 +119,7 @@ public class TransactionUtils {
     }
     Option<Pair<HoodieInstant, Map<String, String>>> lastInstant = getLastCompletedTxnInstantAndMetadata(metaClient);
     if (lastInstant.isPresent() && thisMetadata.isPresent()) {
-      Stream<String> keys = thisMetadata.get().getExtraMetadata().keySet().stream();
+      Stream<String> keys = lastInstant.get().getRight().keySet().stream();
       keyPrefixes.stream().forEach(keyPrefix -> keys
           .filter(key -> key.startsWith(keyPrefix))
           .forEach(key -> thisMetadata.get().getExtraMetadata().put(key, lastInstant.get().getRight().get(key))));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.client.utils;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.hudi.client.transaction.ConflictResolutionStrategy;
@@ -53,8 +53,12 @@ public class TransactionUtils {
    * @return
    * @throws HoodieWriteConflictException
    */
-  public static Option<HoodieCommitMetadata> resolveWriteConflictIfAny(final HoodieTable table, final Option<HoodieInstant> currentTxnOwnerInstant,
-      final Option<HoodieCommitMetadata> thisCommitMetadata, final HoodieWriteConfig config, Option<HoodieInstant> lastCompletedTxnOwnerInstant) throws HoodieWriteConflictException {
+  public static Option<HoodieCommitMetadata> resolveWriteConflictIfAny(
+          final HoodieTable table,
+          final Option<HoodieInstant> currentTxnOwnerInstant,
+          final Option<HoodieCommitMetadata> thisCommitMetadata,
+          final HoodieWriteConfig config,
+          Option<HoodieInstant> lastCompletedTxnOwnerInstant) throws HoodieWriteConflictException {
     if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
       ConflictResolutionStrategy resolutionStrategy = config.getWriteConflictResolutionStrategy();
       Stream<HoodieInstant> instantStream = resolutionStrategy.getCandidateInstants(table.getActiveTimeline(), currentTxnOwnerInstant.get(), lastCompletedTxnOwnerInstant);
@@ -72,8 +76,11 @@ public class TransactionUtils {
         }
       });
       LOG.info("Successfully resolved conflicts, if any");
-      // carry over necessary metadata from latest commit metadata
-      overrideWithLatestCommitMetadata(table.getMetaClient(), thisOperation.getCommitMetadataOption(), currentTxnOwnerInstant, Arrays.asList(config.getWriteMetaKeyPrefixes().split(",")));
+
+      if (config.mergeDeltastreamerStateFromPreviousCommit()) {
+        mergeCheckpointStateFromPreviousCommit(table.getMetaClient(), thisOperation.getCommitMetadataOption());
+      }
+
       return thisOperation.getCommitMetadataOption();
     }
     return thisCommitMetadata;
@@ -111,16 +118,27 @@ public class TransactionUtils {
     }
   }
 
-  // override the current metadata with the metadata from the latest instant for the specified key prefixes
-  private static void overrideWithLatestCommitMetadata(HoodieTableMetaClient metaClient, Option<HoodieCommitMetadata> thisMetadata,
-      Option<HoodieInstant> thisInstant, List<String> keyPrefixes) {
+  private static void mergeCheckpointStateFromPreviousCommit(HoodieTableMetaClient metaClient, Option<HoodieCommitMetadata> thisMetadata) {
+    overrideWithLatestCommitMetadata(metaClient, thisMetadata, Collections.singletonList(HoodieWriteConfig.DELTASTREAMER_CHECKPOINT_KEY));
+  }
+
+  /**
+   * Generic method allowing us to override the current metadata with the metadata from
+   * the latest instant for the specified key prefixes
+   * @param metaClient
+   * @param thisMetadata
+   * @param keyPrefixes The key prefixes to merge from the previous commit
+   */
+  private static void overrideWithLatestCommitMetadata(HoodieTableMetaClient metaClient,
+                                                       Option<HoodieCommitMetadata> thisMetadata,
+                                                       List<String> keyPrefixes) {
     if (keyPrefixes.size() == 1 && keyPrefixes.get(0).length() < 1) {
       return;
     }
     Option<Pair<HoodieInstant, Map<String, String>>> lastInstant = getLastCompletedTxnInstantAndMetadata(metaClient);
     if (lastInstant.isPresent() && thisMetadata.isPresent()) {
-      Stream<String> keys = lastInstant.get().getRight().keySet().stream();
-      keyPrefixes.stream().forEach(keyPrefix -> keys
+      Stream<String> lastCommitMetadataKeys = lastInstant.get().getRight().keySet().stream();
+      keyPrefixes.stream().forEach(keyPrefix -> lastCommitMetadataKeys
           .filter(key -> key.startsWith(keyPrefix))
           .forEach(key -> thisMetadata.get().getExtraMetadata().put(key, lastInstant.get().getRight().get(key))));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -124,7 +124,7 @@ public class TransactionUtils {
 
   /**
    * Generic method allowing us to override the current metadata with the metadata from
-   * the latest instant for the specified key prefixes
+   * the latest instant for the specified key prefixes.
    * @param metaClient
    * @param thisMetadata
    * @param keyPrefixes The key prefixes to merge from the previous commit

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -373,12 +373,12 @@ public class HoodieWriteConfig extends HoodieConfig {
           + "if a conflict (writes affect the same file group) is detected.");
 
   public static final ConfigProperty<Boolean> WRITE_CONCURRENCY_MERGE_DELTASTREAMER_STATE = ConfigProperty
-          .key("hoodie.write.concurrency.merge.deltastreamer.state")
-          .defaultValue(false)
-          .withDocumentation("If enabled, this writer will merge Deltastreamer state "
-                  + "from the previous checkpoint in order to allow both realtime "
-                  + "and batch writers to ingest into a single table. "
-                  + "This should not be enabled on Deltastreamer writers.");
+      .key("hoodie.write.concurrency.merge.deltastreamer.state")
+      .defaultValue(false)
+      .withAlternatives("hoodie.write.meta.key.prefixes")
+      .withDocumentation("If enabled, this writer will merge Deltastreamer state from the previous checkpoint in order to allow both realtime "
+          + "and batch writers to ingest into a single table. This should not be enabled on Deltastreamer writers. Enabling this config means,"
+          + "for a spark writer, deltastreamer checkpoint will be copied over from previous commit to the current one.");
 
   /**
    * Currently the  use this to specify the write schema.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -85,6 +85,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   private static final long serialVersionUID = 0L;
 
+  // This is a constant as is should never be changed via config (will invalidate previous commits)
+  // It is here so that both the client and deltastreamer use the same reference
+  public static final String DELTASTREAMER_CHECKPOINT_KEY = "deltastreamer.checkpoint.key";
+
   public static final ConfigProperty<String> TBL_NAME = ConfigProperty
       .key("hoodie.table.name")
       .noDefaultValue()
@@ -367,6 +371,14 @@ public class HoodieWriteConfig extends HoodieConfig {
           + "SINGLE_WRITER: Only one active writer to the table. Maximizes throughput"
           + "OPTIMISTIC_CONCURRENCY_CONTROL: Multiple writers can operate on the table and exactly one of them succeed "
           + "if a conflict (writes affect the same file group) is detected.");
+
+  public static final ConfigProperty<Boolean> WRITE_CONCURRENCY_MERGE_DELTASTREAMER_STATE = ConfigProperty
+          .key("hoodie.write.concurrency.merge.deltastreamer.state")
+          .defaultValue(false)
+          .withDocumentation("If enabled, this writer will merge Deltastreamer state "
+                  + "from the previous checkpoint in order to allow both realtime "
+                  + "and batch writers to ingest into a single table. "
+                  + "This should not be enabled on Deltastreamer writers.");
 
   public static final ConfigProperty<String> WRITE_META_KEY_PREFIXES = ConfigProperty
       .key("hoodie.write.meta.key.prefixes")
@@ -1762,6 +1774,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public WriteConcurrencyMode getWriteConcurrencyMode() {
     return WriteConcurrencyMode.fromValue(getString(WRITE_CONCURRENCY_MODE));
+  }
+
+  public Boolean mergeDeltastreamerStateFromPreviousCommit() {
+    return getBoolean(HoodieWriteConfig.WRITE_CONCURRENCY_MERGE_DELTASTREAMER_STATE);
   }
 
   public Boolean inlineTableServices() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -380,12 +380,6 @@ public class HoodieWriteConfig extends HoodieConfig {
                   + "and batch writers to ingest into a single table. "
                   + "This should not be enabled on Deltastreamer writers.");
 
-  public static final ConfigProperty<String> WRITE_META_KEY_PREFIXES = ConfigProperty
-      .key("hoodie.write.meta.key.prefixes")
-      .defaultValue("")
-      .withDocumentation("Comma separated metadata key prefixes to override from latest commit "
-          + "during overlapping commits via multi writing");
-
   /**
    * Currently the  use this to specify the write schema.
    */
@@ -795,16 +789,6 @@ public class HoodieWriteConfig extends HoodieConfig {
    */
   @Deprecated
   public static final String DEFAULT_WRITE_CONCURRENCY_MODE = WRITE_CONCURRENCY_MODE.defaultValue();
-  /**
-   * @deprecated Use {@link #WRITE_META_KEY_PREFIXES} and its methods instead
-   */
-  @Deprecated
-  public static final String WRITE_META_KEY_PREFIXES_PROP = WRITE_META_KEY_PREFIXES.key();
-  /**
-   * @deprecated Use {@link #WRITE_META_KEY_PREFIXES} and its methods instead
-   */
-  @Deprecated
-  public static final String DEFAULT_WRITE_META_KEY_PREFIXES = WRITE_META_KEY_PREFIXES.defaultValue();
   /**
    * @deprecated Use {@link #ALLOW_MULTI_WRITE_ON_SAME_INSTANT_ENABLE} and its methods instead
    */
@@ -1784,10 +1768,6 @@ public class HoodieWriteConfig extends HoodieConfig {
     return inlineClusteringEnabled() || inlineCompactionEnabled() || isAutoClean();
   }
 
-  public String getWriteMetaKeyPrefixes() {
-    return getString(WRITE_META_KEY_PREFIXES);
-  }
-
   public String getPreCommitValidators() {
     return getString(HoodiePreCommitValidatorConfig.VALIDATOR_CLASS_NAMES);
   }
@@ -2144,11 +2124,6 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withWriteConcurrencyMode(WriteConcurrencyMode concurrencyMode) {
       writeConfig.setValue(WRITE_CONCURRENCY_MODE, concurrencyMode.value());
-      return this;
-    }
-
-    public Builder withWriteMetaKeyPrefixes(String writeMetaKeyPrefixes) {
-      writeConfig.setValue(WRITE_META_KEY_PREFIXES, writeMetaKeyPrefixes);
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestTransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestTransactionUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utils;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.client.utils.TransactionUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class TestTransactionUtils extends HoodieCommonTestHarness {
+
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        init();
+    }
+
+    public void init() throws Exception {
+        initPath();
+        initMetaClient();
+        metaClient.getFs().mkdirs(new Path(basePath));
+    }
+
+    @Test
+    public void testCheckpointStateMerge() throws IOException {
+        HoodieActiveTimeline timeline = new HoodieActiveTimeline(metaClient);
+
+        // Create completed commit with deltastreamer checkpoint state
+        HoodieInstant commitInstantWithCheckpointState = new HoodieInstant(
+                true,
+                HoodieTimeline.COMMIT_ACTION,
+                HoodieActiveTimeline.createNewInstantTime()
+        );
+        timeline.createNewInstant(commitInstantWithCheckpointState);
+
+        HoodieCommitMetadata metadataWithCheckpoint = new HoodieCommitMetadata();
+        String checkpointVal = "00001";
+        metadataWithCheckpoint.addMetadata(HoodieWriteConfig.DELTASTREAMER_CHECKPOINT_KEY, checkpointVal);
+        timeline.saveAsComplete(
+                commitInstantWithCheckpointState,
+                Option.of(metadataWithCheckpoint.toJsonString().getBytes(StandardCharsets.UTF_8))
+        );
+
+        // Inflight commit without checkpoint metadata
+        HoodieInstant commitInstantWithoutCheckpointState = new HoodieInstant(
+                true,
+                HoodieTimeline.COMMIT_ACTION,
+                HoodieActiveTimeline.createNewInstantTime()
+        );
+        timeline.createNewInstant(commitInstantWithoutCheckpointState);
+        HoodieCommitMetadata metadataWithoutCheckpoint = new HoodieCommitMetadata();
+
+        // Ensure that checkpoint state is merged in from previous completed commit
+        MockTransactionUtils.assertCheckpointStateWasMerged(metaClient, metadataWithoutCheckpoint, checkpointVal);
+    }
+
+    private static class MockTransactionUtils extends TransactionUtils {
+
+        public static void assertCheckpointStateWasMerged(
+                HoodieTableMetaClient metaClient,
+                HoodieCommitMetadata currentMetadata,
+                String expectedCheckpointState) {
+            TransactionUtils.mergeCheckpointStateFromPreviousCommit(metaClient, Option.of(currentMetadata));
+            assertEquals(
+                    expectedCheckpointState,
+                    currentMetadata.getExtraMetadata().get(HoodieWriteConfig.DELTASTREAMER_CHECKPOINT_KEY)
+            );
+        }
+    }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -106,6 +106,7 @@ import static org.apache.hudi.config.HoodieCompactionConfig.INLINE_COMPACT;
 import static org.apache.hudi.config.HoodieWriteConfig.AUTO_COMMIT_ENABLE;
 import static org.apache.hudi.config.HoodieWriteConfig.COMBINE_BEFORE_INSERT;
 import static org.apache.hudi.config.HoodieWriteConfig.COMBINE_BEFORE_UPSERT;
+import static org.apache.hudi.config.HoodieWriteConfig.WRITE_CONCURRENCY_MERGE_DELTASTREAMER_STATE;
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.CHECKPOINT_KEY;
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.CHECKPOINT_RESET_KEY;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_NAMESPACE;
@@ -715,6 +716,11 @@ public class DeltaSync implements Serializable {
         String.format("%s should be set to %s", COMBINE_BEFORE_INSERT.key(), cfg.filterDupes));
     ValidationUtils.checkArgument(config.shouldCombineBeforeUpsert(),
         String.format("%s should be set to %s", COMBINE_BEFORE_UPSERT.key(), combineBeforeUpsert));
+    ValidationUtils.checkArgument(!config.mergeDeltastreamerStateFromPreviousCommit(),
+        String.format(
+            "Deltastreamer processes should not merge state from previous deltastreamer commits. Please unset '%s'",
+            WRITE_CONCURRENCY_MERGE_DELTASTREAMER_STATE.key())
+    );
 
     return config;
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieClusteringConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hive.HiveSyncTool;
@@ -90,7 +91,7 @@ public class HoodieDeltaStreamer implements Serializable {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LogManager.getLogger(HoodieDeltaStreamer.class);
 
-  public static final String CHECKPOINT_KEY = "deltastreamer.checkpoint.key";
+  public static final String CHECKPOINT_KEY = HoodieWriteConfig.DELTASTREAMER_CHECKPOINT_KEY;
   public static final String CHECKPOINT_RESET_KEY = "deltastreamer.checkpoint.reset_key";
 
   protected final transient Config cfg;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -159,7 +159,6 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends SparkClientFunctiona
     // NOTE : Overriding the LockProvider to FileSystemBasedLockProviderTestClass since Zookeeper locks work in unit test but fail on Jenkins with connection timeouts
     setUpTestTable(tableType);
     prepareInitialConfigs(fs(), basePath, "foo");
-    // enable carrying forward latest checkpoint
     TypedProperties props = prepareMultiWriterProps(fs(), basePath, propsFilePath);
     props.setProperty("hoodie.write.lock.provider", "org.apache.hudi.client.transaction.FileSystemBasedLockProviderTestClass");
     props.setProperty("hoodie.write.lock.filesystem.path", tableBasePath);
@@ -181,7 +180,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends SparkClientFunctiona
     HoodieCommitMetadata commitMetadataForFirstInstant = HoodieCommitMetadata
         .fromBytes(timeline.getInstantDetails(timeline.firstInstant().get()).get(), HoodieCommitMetadata.class);
 
-    // run the backfill job, enable overriding checkpoint from the latest commit
+    // run the backfill job
     props = prepareMultiWriterProps(fs(), basePath, propsFilePath);
     props.setProperty("hoodie.write.lock.provider", "org.apache.hudi.client.transaction.FileSystemBasedLockProviderTestClass");
     props.setProperty("hoodie.write.lock.filesystem.path", tableBasePath);
@@ -199,6 +198,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends SparkClientFunctiona
 
     // Save the checkpoint information from the deltastreamer run and perform next write
     String checkpointAfterDeltaSync = getLatestMetadata(meta).getMetadata(CHECKPOINT_KEY);
+    // this writer will enable HoodieWriteConfig.WRITE_CONCURRENCY_MERGE_DELTASTREAMER_STATE.key() so that deltastreamer checkpoint will be carried over.
     performWriteWithDeltastreamerStateMerge();
 
     // Verify that the checkpoint is carried over

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -207,7 +207,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends SparkClientFunctiona
   }
 
   /**
-   * Performs a hudi datasource write with deltastreamer state merge enabled
+   * Performs a hudi datasource write with deltastreamer state merge enabled.
    */
   private void performWriteWithDeltastreamerStateMerge() {
     spark().read()


### PR DESCRIPTION
## What is the purpose of the pull request
In order to support multi-writer concurrency where one writer is the Deltastreamer, other writers must copy any checkpoint state from previous commits into their current one in order to prevent interleaved commits from crashing the deltastreamer. 

The code that does this did the following (before this change):
* Get all the keys for the *current* inflight commit metadata
* Filter out any keys that are not specified in the metadata config (a list of keys to replace)
* For keys that exist in the current metadata, pull the data for that key from the *previous* commit and replace the current commit's metadata property value with that value

This does not work because a non-deltastreamer writer (such as a spark datasource writer) will never have the checkpoint key specified in its commit metadata (`deltastreamer.checkpoint.key`) which results in a commit in the timeline that does not have checkpoint state. If the deltastreamer tries to start from that commit it will fail.

This fixes that by changing the keyset that is filtered from the current commit to the previous commit. This fixes two issues:
1. Checkpoint state is copied over from a previous commit which was made by the deltastreamer
2. If the deltastreamer process fails or is stopped for a prolonged period of time, the non-deltastreamer writers will continue to carry over the checkpoint state which will allow the deltastreamer to correctly start from its last known position


## Brief change log
- Added new config `hoodie.write.concurrency.merge.deltastreamer.state` which users can set to true with spark writer to enable multi writer across deltastreamer and spark writer. 
  - *Modify `TransactionUtils::overrideWithLatestCommitMetadata` to pull the keys from the last commit instead of the current commit*
  - Removed the now unused, ambiguous metadata key config (`hoodie.write.meta.key.prefixes`)

## Verify this pull request

Manually verified the change by running multiple writers against the same table
* Writer One: Deltastreamer, kafka source
* Writer Two:  Spark datasource, event data from existing hudi table
* Verified zero errors from deltastreamer over hundreds of interleaved commits
* Shut down deltastreamer for a prolonged period, then verified that I could start it back up without losing its position in kafka (checkpoint state in tact on recent commits)

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ x] Necessary doc changes done or have another open PR
       
