### PR TITLE
[HUDI-2077] Set schema validation from main write config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -151,7 +151,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
         .withWriteConcurrencyMode(WriteConcurrencyMode.SINGLE_WRITER)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .withAutoCommit(true)
-        .withAvroSchemaValidate(true)
+        .withAvroSchemaValidate(writeConfig.getAvroSchemaValidate())
         .withEmbeddedTimelineServerEnabled(false)
         .withPath(HoodieTableMetadata.getMetadataTableBasePath(writeConfig.getBasePath()))
         .withSchema(HoodieMetadataRecord.getClassSchema().toString())


### PR DESCRIPTION
## What is the purpose of the pull request

Set schema validation config for the metadata table from main write config. This is disabled by default. Note that this might not be the root cause of flakiness in `TestHoodieDeltaStreamer.testAsyncClusteringServiceWithCompaction`. Please see [this comment](https://issues.apache.org/jira/browse/HUDI-2077?focusedCommentId=17431004&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17431004).

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
