### PR TITLE
[HUDI-2591] Bootstrap metadata table only if upgrade / downgrade is not required.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -104,16 +104,18 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   /**
    * Hudi backed table metadata writer.
    *
-   * @param hadoopConf     - Hadoop configuration to use for the metadata writer
-   * @param writeConfig    - Writer config
-   * @param engineContext  - Engine context
-   * @param actionMetadata - Optional action metadata to help decide bootstrap operations
-   * @param <T>            - Action metadata types extending Avro generated SpecificRecordBase
+   * @param hadoopConf                 - Hadoop configuration to use for the metadata writer
+   * @param writeConfig                - Writer config
+   * @param engineContext              - Engine context
+   * @param actionMetadata             - Optional action metadata to help decide bootstrap operations
+   * @param <T>                        - Action metadata types extending Avro generated SpecificRecordBase
+   * @param instantInProgressTimestamp - Timestamp of any instant in progress
    */
   protected <T extends SpecificRecordBase> HoodieBackedTableMetadataWriter(Configuration hadoopConf,
                                                                            HoodieWriteConfig writeConfig,
                                                                            HoodieEngineContext engineContext,
-                                                                           Option<T> actionMetadata) {
+                                                                           Option<T> actionMetadata,
+                                                                           Option<String> instantInProgressTimestamp) {
     this.dataWriteConfig = writeConfig;
     this.engineContext = engineContext;
     this.hadoopConf = new SerializableConfiguration(hadoopConf);
@@ -137,12 +139,17 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       initRegistry();
       this.dataMetaClient =
           HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(dataWriteConfig.getBasePath()).build();
-      initialize(engineContext, actionMetadata);
+      initialize(engineContext, actionMetadata, instantInProgressTimestamp);
       initTableMetadata();
     } else {
       enabled = false;
       this.metrics = Option.empty();
     }
+  }
+
+  public HoodieBackedTableMetadataWriter(Configuration hadoopConf, HoodieWriteConfig writeConfig,
+      HoodieEngineContext engineContext) {
+    this(hadoopConf, writeConfig, engineContext, Option.empty(), Option.empty());
   }
 
   protected abstract void initRegistry();
@@ -234,11 +241,17 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
   /**
    * Initialize the metadata table if it does not exist.
-   * <p>
+   *
    * If the metadata table does not exist, then file and partition listing is used to bootstrap the table.
+   *
+   * @param engineContext
+   * @param actionMetadata Action metadata types extending Avro generated SpecificRecordBase
+   * @param instantInProgressTimestamp Timestamp of an instant in progress on the dataset. This instant is ignored
+   *                                   while deciding to bootstrap the metadata table.
    */
   protected abstract <T extends SpecificRecordBase> void initialize(HoodieEngineContext engineContext,
-                                                                    Option<T> actionMetadata);
+                                                                    Option<T> actionMetadata,
+                                                                    Option<String> instantInProgressTimestamp);
 
   public void initTableMetadata() {
     try {
@@ -260,11 +273,13 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * @param dataMetaClient - Meta client for the data table
    * @param actionMetadata - Optional action metadata
    * @param <T>            - Action metadata types extending Avro generated SpecificRecordBase
+   * @param instantInProgressTimestamp - Timestamp of an instant in progress on the dataset. This instant is ignored
    * @throws IOException
    */
   protected <T extends SpecificRecordBase> void bootstrapIfNeeded(HoodieEngineContext engineContext,
                                                                   HoodieTableMetaClient dataMetaClient,
-                                                                  Option<T> actionMetadata) throws IOException {
+                                                                  Option<T> actionMetadata,
+                                                                  Option<String> instantInProgressTimestamp) throws IOException {
     HoodieTimer timer = new HoodieTimer().startTimer();
 
     boolean exists = dataMetaClient.getFs().exists(new Path(metadataWriteConfig.getBasePath(),
@@ -291,7 +306,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
     if (!exists) {
       // Initialize for the first time by listing partitions and files directly from the file system
-      if (bootstrapFromFilesystem(engineContext, dataMetaClient)) {
+      if (bootstrapFromFilesystem(engineContext, dataMetaClient, instantInProgressTimestamp)) {
         metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.INITIALIZE_STR, timer.endTimer()));
       }
     }
@@ -347,23 +362,29 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * Initialize the Metadata Table by listing files and partitions from the file system.
    *
    * @param dataMetaClient {@code HoodieTableMetaClient} for the dataset.
+   * @param instantInProgressTimestamp
    */
-  private boolean bootstrapFromFilesystem(HoodieEngineContext engineContext, HoodieTableMetaClient dataMetaClient) throws IOException {
+  private boolean bootstrapFromFilesystem(HoodieEngineContext engineContext, HoodieTableMetaClient dataMetaClient,
+      Option<String> instantInProgressTimestamp) throws IOException {
     ValidationUtils.checkState(enabled, "Metadata table cannot be initialized as it is not enabled");
 
     // We can only bootstrap if there are no pending operations on the dataset
-    Option<HoodieInstant> pendingDataInstant = Option.fromJavaOptional(dataMetaClient.getActiveTimeline()
-        .getReverseOrderedInstants().filter(i -> !i.isCompleted()).findFirst());
-    if (pendingDataInstant.isPresent()) {
+    List<HoodieInstant> pendingDataInstant = dataMetaClient.getActiveTimeline()
+        .getInstants().filter(i -> !i.isCompleted())
+        .filter(i -> !instantInProgressTimestamp.isPresent() || !i.getTimestamp().equals(instantInProgressTimestamp.get()))
+        .collect(Collectors.toList());
+
+    if (!pendingDataInstant.isEmpty()) {
       metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.BOOTSTRAP_ERR_STR, 1));
-      LOG.warn("Cannot bootstrap metadata table as operation is in progress in dataset: " + pendingDataInstant.get());
+      LOG.warn("Cannot bootstrap metadata table as operation(s) are in progress on the dataset: "
+          + Arrays.toString(pendingDataInstant.toArray()));
       return false;
     }
 
     // If there is no commit on the dataset yet, use the SOLO_COMMIT_TIMESTAMP as the instant time for initial commit
-    // Otherwise, we use the latest commit timestamp.
-    String createInstantTime = dataMetaClient.getActiveTimeline().getReverseOrderedInstants().findFirst()
-        .map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
+    // Otherwise, we use the timestamp of the latest completed action.
+    String createInstantTime = dataMetaClient.getActiveTimeline().filterCompletedInstants()
+        .getReverseOrderedInstants().findFirst().map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
     LOG.info("Creating a new metadata table in " + metadataWriteConfig.getBasePath() + " at instant " + createInstantTime);
 
     HoodieTableMetaClient.withPropertyBuilder()

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -62,7 +62,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
                                                                       HoodieWriteConfig writeConfig,
                                                                       HoodieEngineContext engineContext,
                                                                       Option<T> actionMetadata) {
-    super(hadoopConf, writeConfig, engineContext, actionMetadata);
+    super(hadoopConf, writeConfig, engineContext, actionMetadata, Option.empty());
   }
 
   @Override
@@ -78,10 +78,11 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
   @Override
   protected <T extends SpecificRecordBase> void initialize(HoodieEngineContext engineContext,
-                                                           Option<T> actionMetadata) {
+                                                           Option<T> actionMetadata,
+                                                           Option<String> instantInProgressTimestamp) {
     try {
       if (enabled) {
-        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata);
+        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata, instantInProgressTimestamp);
       }
     } catch (IOException e) {
       LOG.error("Failed to initialize metadata table. Disabling the writer.", e);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -79,10 +79,10 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   protected <T extends SpecificRecordBase> void initialize(HoodieEngineContext engineContext,
                                                            Option<T> actionMetadata,
-                                                           Option<String> instantInProgressTimestamp) {
+                                                           Option<String> inflightInstantTimestamp) {
     try {
       if (enabled) {
-        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata, instantInProgressTimestamp);
+        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata, inflightInstantTimestamp);
       }
     } catch (IOException e) {
       LOG.error("Failed to initialize metadata table. Disabling the writer.", e);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -84,13 +84,13 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
 
   @Deprecated
   public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig, boolean rollbackPending) {
-    super(context, writeConfig);
+    this(context, writeConfig, Option.empty());
   }
 
   @Deprecated
   public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig, boolean rollbackPending,
                              Option<EmbeddedTimelineService> timelineService) {
-    super(context, writeConfig, timelineService);
+    this(context, writeConfig, timelineService);
   }
 
   public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -48,23 +48,41 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
   private static final Logger LOG = LogManager.getLogger(SparkHoodieBackedTableMetadataWriter.class);
 
-  public static HoodieTableMetadataWriter create(Configuration conf, HoodieWriteConfig writeConfig,
-                                                 HoodieEngineContext context) {
-    return create(conf, writeConfig, context, Option.empty());
-  }
-
+  /**
+   * Return a Spark based implementation of {@code HoodieTableMetadataWriter} which can be used to
+   * write to the metadata table.
+   *
+   * If the metadata table does not exist, an attempt is made to bootstrap it but there is no guarantted that
+   * table will end up bootstrapping at this time.
+   *
+   * @param conf
+   * @param writeConfig
+   * @param context
+   * @param actionMetadata
+   * @param instantInProgressTimestamp Timestamp of an instant which is in-progress. This instant is ignored while
+   *                                   attempting to bootstrap the table.
+   * @return An instance of the {@code HoodieTableMetadataWriter}
+   */
   public static <T extends SpecificRecordBase> HoodieTableMetadataWriter create(Configuration conf,
                                                                                 HoodieWriteConfig writeConfig,
                                                                                 HoodieEngineContext context,
-                                                                                Option<T> actionMetadata) {
-    return new SparkHoodieBackedTableMetadataWriter(conf, writeConfig, context, actionMetadata);
+                                                                                Option<T> actionMetadata,
+                                                                                Option<String> instantInProgressTimestamp) {
+    return new SparkHoodieBackedTableMetadataWriter(conf, writeConfig, context, actionMetadata,
+                                                    instantInProgressTimestamp);
+  }
+
+  public static HoodieTableMetadataWriter create(Configuration conf, HoodieWriteConfig writeConfig,
+                                                 HoodieEngineContext context) {
+    return create(conf, writeConfig, context, Option.empty(), Option.empty());
   }
 
   <T extends SpecificRecordBase> SparkHoodieBackedTableMetadataWriter(Configuration hadoopConf,
                                                                       HoodieWriteConfig writeConfig,
                                                                       HoodieEngineContext engineContext,
-                                                                      Option<T> actionMetadata) {
-    super(hadoopConf, writeConfig, engineContext, actionMetadata);
+                                                                      Option<T> actionMetadata,
+                                                                      Option<String> instantInProgressTimestamp) {
+    super(hadoopConf, writeConfig, engineContext, actionMetadata, instantInProgressTimestamp);
   }
 
   @Override
@@ -84,7 +102,8 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
   @Override
   protected <T extends SpecificRecordBase> void initialize(HoodieEngineContext engineContext,
-                                                           Option<T> actionMetadata) {
+                                                           Option<T> actionMetadata,
+                                                           Option<String> instantInProgressTimestamp) {
     try {
       metrics.map(HoodieMetadataMetrics::registry).ifPresent(registry -> {
         if (registry instanceof DistributedRegistry) {
@@ -94,7 +113,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       });
 
       if (enabled) {
-        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata);
+        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata, instantInProgressTimestamp);
       }
     } catch (IOException e) {
       LOG.error("Failed to initialize metadata table. Disabling the writer.", e);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -59,17 +59,17 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
    * @param writeConfig
    * @param context
    * @param actionMetadata
-   * @param instantInProgressTimestamp Timestamp of an instant which is in-progress. This instant is ignored while
-   *                                   attempting to bootstrap the table.
+   * @param inflightInstantTimestamp Timestamp of an instant which is in-progress. This instant is ignored while
+   *                                 attempting to bootstrap the table.
    * @return An instance of the {@code HoodieTableMetadataWriter}
    */
   public static <T extends SpecificRecordBase> HoodieTableMetadataWriter create(Configuration conf,
                                                                                 HoodieWriteConfig writeConfig,
                                                                                 HoodieEngineContext context,
                                                                                 Option<T> actionMetadata,
-                                                                                Option<String> instantInProgressTimestamp) {
+                                                                                Option<String> inflightInstantTimestamp) {
     return new SparkHoodieBackedTableMetadataWriter(conf, writeConfig, context, actionMetadata,
-                                                    instantInProgressTimestamp);
+                                                    inflightInstantTimestamp);
   }
 
   public static HoodieTableMetadataWriter create(Configuration conf, HoodieWriteConfig writeConfig,
@@ -81,8 +81,8 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
                                                                       HoodieWriteConfig writeConfig,
                                                                       HoodieEngineContext engineContext,
                                                                       Option<T> actionMetadata,
-                                                                      Option<String> instantInProgressTimestamp) {
-    super(hadoopConf, writeConfig, engineContext, actionMetadata, instantInProgressTimestamp);
+                                                                      Option<String> inflightInstantTimestamp) {
+    super(hadoopConf, writeConfig, engineContext, actionMetadata, inflightInstantTimestamp);
   }
 
   @Override
@@ -103,7 +103,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   protected <T extends SpecificRecordBase> void initialize(HoodieEngineContext engineContext,
                                                            Option<T> actionMetadata,
-                                                           Option<String> instantInProgressTimestamp) {
+                                                           Option<String> inflightInstantTimestamp) {
     try {
       metrics.map(HoodieMetadataMetrics::registry).ifPresent(registry -> {
         if (registry instanceof DistributedRegistry) {
@@ -113,7 +113,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       });
 
       if (enabled) {
-        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata, instantInProgressTimestamp);
+        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata, inflightInstantTimestamp);
       }
     } catch (IOException e) {
       LOG.error("Failed to initialize metadata table. Disabling the writer.", e);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
@@ -128,7 +128,7 @@ public abstract class HoodieSparkTable<T extends HoodieRecordPayload>
     }
     if (isMetadataTableAvailable) {
       return Option.of(SparkHoodieBackedTableMetadataWriter.create(context.getHadoopConf().get(), config, context,
-          actionMetadata));
+          actionMetadata, Option.empty()));
     } else {
       return Option.empty();
     }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Metadata table is bootstrapped in the SparkRDDWriteClient constructor. Check for the upgrade/downgrade is performed during the operation when the HoodieTable object is created.

If the dataset is upgraded to new version, the metadata table will be deleted. The bootstrap of the metadata table in the constructor will be a waste.

Hence, we should bootstrap only if an upgrade / downgrade is not required on the dataset.

This PR fixes double bootstrap of metadata table.

## Brief change log

Check if upgrade/downgrade is required before bootstrapping metadata table.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
