### PR TITLE
[HUDI-2592] Fix write empty array when write.precombine.field is decimal type

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -547,7 +547,7 @@ public class HoodieAvroUtils {
             LogicalTypes.decimal(dc.getPrecision(), dc.getScale()));
       } else if (fieldSchema.getType() == Schema.Type.BYTES) {
         ByteBuffer byteBuffer = (ByteBuffer) fieldValue;
-        BigDecimal convertedValue = decimalConversion.fromBytes((ByteBuffer) fieldValue, fieldSchema,
+        BigDecimal convertedValue = decimalConversion.fromBytes(byteBuffer, fieldSchema,
                 LogicalTypes.decimal(dc.getPrecision(), dc.getScale()));
         byteBuffer.rewind();
         return convertedValue;

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -255,7 +255,6 @@ public class TestHoodieAvroUtils {
     ByteBuffer byteBuffer = ByteBuffer.wrap(bigDecimal.unscaledValue().toByteArray());
     rec.put("decimal_col", byteBuffer);
 
-
     Object decimalCol = HoodieAvroUtils.getNestedFieldVal(rec, "decimal_col", true);
     assertEquals(bigDecimal, decimalCol);
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

## Brief change log

fix write wrong value when write.precombine.field is decimal type

## Verify this pull request

 - TestHoodieAvroUtils add testGetNestedFieldValWithDecimalFiled

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
