### PR TITLE
[MINOR] Fix README for hudi-kafka-connect

### DIFF
--- a/hudi-kafka-connect/README.md
+++ b/hudi-kafka-connect/README.md
@@ -94,7 +94,7 @@ cd $KAFKA_HOME
 Open a terminal to execute the following command:
 
 ```bash
-cd $HUDI_DIR/demo/
+cd $HUDI_DIR/hudi-kafka-connect/demo/
 bash setupKafka.sh -n <total_kafka_messages>
 ```
 
@@ -120,7 +120,7 @@ that can be changed based on the desired properties.
 
 ```bash
 curl -X DELETE http://localhost:8083/connectors/hudi-sink
-curl -X POST -H "Content-Type:application/json" -d @${HUDI_DIR}/hudi-kafka-connect/demo/config-sink.json http://localhost:8083/connectors
+curl -X POST -H "Content-Type:application/json" -d @$HUDI_DIR/hudi-kafka-connect/demo/config-sink.json http://localhost:8083/connectors
 ```
 
 Now, you should see that the connector is created and tasks are running.


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the tutorial in README.md for hudi-kafka-connect.

## Brief change log

- Edits to the commands so that they are runnable.

## Verify this pull request

Successfully run the commands in the tutorial to make sure Kafka Connect Sink for Hudi can be set up locally.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
