### PR TITLE
[HUDI-2662] Downloads from Nexus Pentaho repo taking too long

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -834,7 +834,6 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().archiveCommitsWith(2, 4)
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.NEVER)
             .retainCommits(1).retainFileVersions(1).withAutoClean(true).withAsyncClean(false).build())
-        .withEmbeddedTimelineServerEnabled(false)
         .build();
 
     List<HoodieRecord> records;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -834,6 +834,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().archiveCommitsWith(2, 4)
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.NEVER)
             .retainCommits(1).retainFileVersions(1).withAutoClean(true).withAsyncClean(false).build())
+        .withEmbeddedTimelineServerEnabled(false)
         .build();
 
     List<HoodieRecord> records;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -165,6 +165,10 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
           logRecords.put(entry.getKey(), entry.getValue());
         }
       }
+    } else {
+      for (String key : keys) {
+        logRecords.put(key, Option.empty());
+      }
     }
     timings.add(timer.endTimer());
     return logRecords;
@@ -199,12 +203,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
           }
         } else {
           // only log record
-          if (logRecords.containsKey(key) && logRecords.get(key).isPresent()) {
-            HoodieRecordPayload mergedPayload = logRecords.get(key).get().getData().preCombine(hoodieRecord.getData());
-            result.add(Pair.of(key, Option.of(new HoodieRecord(hoodieRecord.getKey(), mergedPayload))));
-          } else { // not found in both base file and log files
-            result.add(Pair.of(key, Option.empty()));
-          }
+          result.add(Pair.of(key, logRecords.get(key)));
         }
       }
       timings.add(timer.endTimer());

--- a/pom.xml
+++ b/pom.xml
@@ -1064,10 +1064,10 @@
       <id>confluent</id>
       <url>https://packages.confluent.io/maven/</url>
     </repository>
-    <repository>
+    <!--<repository>
       <id>pentaho.org</id>
       <url>https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release/</url>
-    </repository>
+    </repository>-->
   </repositories>
 
   <profiles>


### PR DESCRIPTION
## What is the purpose of the pull request

https://public.nexus.pentaho.org/repository/proxy-public-3rd-party-release is unavailable to serve any requests. We are removing the url from pom as we confirmed that all jars are available in other nexus repository urls. 

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
