### PR TITLE
[WIP][HUDI-1295] Metadata Index - Bloom filter and Column stats metadata to speed up index lookups

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -126,6 +126,10 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
     HoodieData<ImmutablePair<String, HoodieKey>> fileComparisonPairs =
         explodeRecordsWithFileComparisons(partitionToFileInfo, partitionRecordKeyPairs);
 
+    //TODO: Remove the below debug print
+    // fileComparisonPairs.collectAsList().forEach(entry -> LOG.error("XXX LookupIndex 2:  FileComparisonPairs: " +
+    // entry.left + ", " + entry.right.getRecordKey() + ", " + entry.right.getPartitionPath()));
+
     return bloomIndexHelper.findMatchingFilesForRecordKeys(config, context, hoodieTable,
         partitionRecordKeyPairs, fileComparisonPairs, partitionToFileInfo, recordsPerPartition);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -19,20 +19,27 @@
 
 package org.apache.hudi.index.bloom;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.ColumnID;
+import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndexUtils;
@@ -43,9 +50,12 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -80,9 +90,14 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
     HoodiePairData<String, String> partitionRecordKeyPairs = records.mapToPair(
         record -> new ImmutablePair<>(record.getPartitionPath(), record.getRecordKey()));
 
+    HoodieTimer timer = new HoodieTimer().startTimer();
     // Step 2: Lookup indexes for all the partition/recordkey pair
     HoodiePairData<HoodieKey, HoodieRecordLocation> keyFilenamePairs =
         lookupIndex(partitionRecordKeyPairs, context, hoodieTable);
+    final long indexLookupTime = timer.endTimer();
+    if (config.getMetadataConfig().isIndexLookupTimerEnabled()) {
+      LOG.error("Index lookup for " + records.count() + " records took: " + (indexLookupTime / 1000.0) + " sec");
+    }
 
     // Cache the result, for subsequent stages.
     if (config.getBloomIndexUseCaching()) {
@@ -111,27 +126,25 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
   private HoodiePairData<HoodieKey, HoodieRecordLocation> lookupIndex(
       HoodiePairData<String, String> partitionRecordKeyPairs, final HoodieEngineContext context,
       final HoodieTable hoodieTable) {
-    // Obtain records per partition, in the incoming records
+    // Step 1: Obtain records per partition, in the incoming records
     Map<String, Long> recordsPerPartition = partitionRecordKeyPairs.countByKey();
     List<String> affectedPartitionPathList = new ArrayList<>(recordsPerPartition.keySet());
 
     // Step 2: Load all involved files as <Partition, filename> pairs
-    List<Pair<String, BloomIndexFileInfo>> fileInfoList =
-        loadInvolvedFiles(affectedPartitionPathList, context, hoodieTable);
-    final Map<String, List<BloomIndexFileInfo>> partitionToFileInfo =
+    List<Pair<String, BloomIndexFileInfo>> fileInfoList = (config.getMetadataConfig().isColumnStatsEnabled()
+        ? loadColumnStats(affectedPartitionPathList, context, hoodieTable) :
+        loadInvolvedFiles(affectedPartitionPathList, context, hoodieTable));
+
+    final Map<String, List<BloomIndexFileInfo>> partitionToFilesMap =
         fileInfoList.stream().collect(groupingBy(Pair::getLeft, mapping(Pair::getRight, toList())));
 
     // Step 3: Obtain a HoodieData, for each incoming record, that already exists, with the file id,
     // that contains it.
     HoodieData<ImmutablePair<String, HoodieKey>> fileComparisonPairs =
-        explodeRecordsWithFileComparisons(partitionToFileInfo, partitionRecordKeyPairs);
-
-    //TODO: Remove the below debug print
-    // fileComparisonPairs.collectAsList().forEach(entry -> LOG.error("XXX LookupIndex 2:  FileComparisonPairs: " +
-    // entry.left + ", " + entry.right.getRecordKey() + ", " + entry.right.getPartitionPath()));
+        explodeRecordsWithFileComparisons(partitionToFilesMap, partitionRecordKeyPairs);
 
     return bloomIndexHelper.findMatchingFilesForRecordKeys(config, context, hoodieTable,
-        partitionRecordKeyPairs, fileComparisonPairs, partitionToFileInfo, recordsPerPartition);
+        partitionRecordKeyPairs, fileComparisonPairs, partitionToFilesMap, recordsPerPartition);
   }
 
   /**
@@ -140,7 +153,8 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
   List<Pair<String, BloomIndexFileInfo>> loadInvolvedFiles(
       List<String> partitions, final HoodieEngineContext context, final HoodieTable hoodieTable) {
     // Obtain the latest data files from all the partitions.
-    List<Pair<String, String>> partitionPathFileIDList = getLatestBaseFilesForAllPartitions(partitions, context, hoodieTable).stream()
+    List<Pair<String, String>> partitionPathFileIDList = getLatestBaseFilesForAllPartitions(partitions, context,
+        hoodieTable).stream()
         .map(pair -> Pair.of(pair.getKey(), pair.getValue().getFileId()))
         .collect(toList());
 
@@ -157,6 +171,71 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
           return Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue()));
         }
       }, Math.max(partitionPathFileIDList.size(), 1));
+    } else {
+      return partitionPathFileIDList.stream()
+          .map(pf -> Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue()))).collect(toList());
+    }
+  }
+
+  /**
+   * Load all involved files as <Partition, filename> pair List.
+   */
+  List<Pair<String, BloomIndexFileInfo>> loadColumnStats(
+      List<String> partitions, final HoodieEngineContext context, final HoodieTable hoodieTable) {
+    // Obtain the latest data files from all the partitions.
+    List<Pair<String, String>> partitionPathFileIDList = getLatestBaseFilesForAllPartitions(partitions, context,
+        hoodieTable).stream()
+        .map(pair -> Pair.of(pair.getKey(), pair.getValue().getFileId()))
+        .collect(toList());
+
+    if (config.getBloomIndexPruneByRanges()) {
+      // also obtain file ranges, if range pruning is enabled
+      context.setJobStatus(this.getClass().getName(), "Obtain key ranges for file slices (range pruning=on)");
+
+      return context.flatMap(partitions, new SerializableFunction<String, Stream<Pair<String, BloomIndexFileInfo>>>() {
+        @Override
+        public Stream<Pair<String, BloomIndexFileInfo>> apply(String partitionName) throws Exception {
+
+          final String colIDHash = new ColumnID(HoodieRecord.RECORD_KEY_METADATA_FIELD).asBase64EncodedString();
+          final String partitionNameHash = new PartitionID(partitionName).asBase64EncodedString();
+
+          List<Pair<String, String>> partitionFileIdNameList =
+              HoodieIndexUtils.getLatestBaseFilesForPartition(partitionName,
+                  hoodieTable).stream().map(baseFile -> Pair.of(baseFile.getFileId(), baseFile.getFileName())).collect(toList());
+
+          try {
+
+            Map<String, String> colStatKeyToFileIdMap = new HashMap<>();
+            List<String> columnStatKeys = new ArrayList<>();
+            for (Pair<String, String> fileIdFileName : partitionFileIdNameList) {
+              final String colStatKeyHash = colIDHash
+                  .concat(partitionNameHash)
+                  .concat(new FileID(fileIdFileName.getRight()).asBase64EncodedString());
+              columnStatKeys.add(colStatKeyHash);
+              colStatKeyToFileIdMap.put(colStatKeyHash, fileIdFileName.getLeft());
+            }
+            Collections.sort(columnStatKeys);
+
+            Map<String, HoodieColumnStats> columnKeyHashToStatMap = hoodieTable
+                .getMetadataTable().getColumnStats(columnStatKeys);
+
+            List<Pair<String, BloomIndexFileInfo>> result = new ArrayList<>();
+            for (Map.Entry<String, HoodieColumnStats> entry : columnKeyHashToStatMap.entrySet()) {
+              result.add(Pair.of(partitionName,
+                  new BloomIndexFileInfo(
+                      colStatKeyToFileIdMap.get(entry.getKey()),
+                      entry.getValue().getRangeLow(),
+                      entry.getValue().getRangeHigh()
+                  )));
+            }
+            return result.stream();
+
+          } catch (MetadataNotFoundException me) {
+            throw new HoodieMetadataException("Unable to find range metadata in file :" + partitionName);
+          }
+        }
+      }, Math.max(partitions.size(), 1));
+
     } else {
       return partitionPathFileIDList.stream()
           .map(pf -> Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue()))).collect(toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Takes a bunch of keys and returns ones that are present in the file group.
+ */
+public class HoodieKeyMetaBloomIndexGroupedLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
+    I, K, O> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaBloomIndexGroupedLookupHandle.class);
+
+  private final HoodieTableType tableType;
+
+  private final BloomFilter bloomFilter;
+
+  private final List<String> candidateRecordKeys;
+
+  private long totalKeysChecked;
+
+  public HoodieKeyMetaBloomIndexGroupedLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
+                                                    Pair<String, String> partitionPathFileIdPair, String fileName) {
+    super(config, null, hoodieTable, partitionPathFileIdPair);
+    this.tableType = hoodieTable.getMetaClient().getTableType();
+
+    this.candidateRecordKeys = new ArrayList<>();
+    this.totalKeysChecked = 0;
+    HoodieTimer timer = new HoodieTimer().startTimer();
+
+    Option<ByteBuffer> bloomFilterByteBuffer =
+        hoodieTable.getMetadataTable().getBloomFilter(new FileID(fileName));
+    if (!bloomFilterByteBuffer.isPresent()) {
+      throw new HoodieIndexException("BloomFilter missing for " + fileName);
+    }
+
+    // TODO: Go via the factory and the filter type
+    this.bloomFilter =
+        new HoodieDynamicBoundedBloomFilter(StandardCharsets.UTF_8.decode(bloomFilterByteBuffer.get()).toString(),
+            BloomFilterTypeCode.DYNAMIC_V0);
+
+    LOG.debug(String.format("Read bloom filter from %s,%s, size: %s in %d ms", partitionPathFileIdPair, fileName,
+        bloomFilterByteBuffer.get().array().length, timer.endTimer()));
+  }
+
+  /**
+   * Given a list of row keys and one file, return only row keys existing in that file.
+   */
+  public List<String> checkCandidatesAgainstFile(Configuration configuration, List<String> candidateRecordKeys,
+                                                 Path filePath) throws HoodieIndexException {
+    List<String> foundRecordKeys = new ArrayList<>();
+    try {
+      // Load all rowKeys from the file, to double-confirm
+      if (!candidateRecordKeys.isEmpty()) {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+        Set<String> fileRowKeys = createNewFileReader().filterRowKeys(new HashSet<>(candidateRecordKeys));
+        foundRecordKeys.addAll(fileRowKeys);
+        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)", filePath,
+            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+        LOG.debug("Keys matching for file " + filePath + " => " + foundRecordKeys);
+      }
+    } catch (Exception e) {
+      throw new HoodieIndexException("Error checking candidate keys against file.", e);
+    }
+    return foundRecordKeys;
+  }
+
+  /**
+   * Adds the key for look up.
+   */
+  public void addKey(String recordKey) {
+    // check record key against bloom filter of current file & add to possible keys if needed
+    if (bloomFilter.mightContain(recordKey)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Record key " + recordKey + " matches bloom filter in  " + partitionPathFilePair);
+      }
+      candidateRecordKeys.add(recordKey);
+    }
+    totalKeysChecked++;
+  }
+
+  /**
+   * Of all the keys, that were added, return a list of keys that were actually found in the file group.
+   */
+  public MetaBloomIndexGroupedKeyLookupResult getLookupResult() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("#The candidate row keys for " + partitionPathFilePair + " => " + candidateRecordKeys);
+    }
+
+    HoodieBaseFile dataFile = getLatestDataFile();
+    List<String> matchingKeys =
+        checkCandidatesAgainstFile(hoodieTable.getHadoopConf(), candidateRecordKeys, new Path(dataFile.getPath()));
+    LOG.debug(
+        String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)", totalKeysChecked,
+            candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+    return new MetaBloomIndexGroupedKeyLookupResult(partitionPathFilePair.getRight(), partitionPathFilePair.getLeft(),
+        dataFile.getCommitTime(), matchingKeys);
+  }
+
+  /**
+   * Encapsulates the result from a key lookup.
+   */
+  public static class MetaBloomIndexGroupedKeyLookupResult {
+
+    private final String fileId;
+    private final String baseInstantTime;
+    private final List<String> matchingRecordKeys;
+    private final String partitionPath;
+
+    public MetaBloomIndexGroupedKeyLookupResult(String fileId, String partitionPath, String baseInstantTime,
+                                                List<String> matchingRecordKeys) {
+      this.fileId = fileId;
+      this.partitionPath = partitionPath;
+      this.baseInstantTime = baseInstantTime;
+      this.matchingRecordKeys = matchingRecordKeys;
+    }
+
+    public String getFileId() {
+      return fileId;
+    }
+
+    public String getBaseInstantTime() {
+      return baseInstantTime;
+    }
+
+    public String getPartitionPath() {
+      return partitionPath;
+    }
+
+    public List<String> getMatchingRecordKeys() {
+      return matchingRecordKeys;
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.table.HoodieTable;
@@ -69,7 +70,8 @@ public class HoodieKeyMetaBloomIndexGroupedLookupHandle<T extends HoodieRecordPa
     HoodieTimer timer = new HoodieTimer().startTimer();
 
     Option<ByteBuffer> bloomFilterByteBuffer =
-        hoodieTable.getMetadataTable().getBloomFilter(new FileID(fileName));
+        hoodieTable.getMetadataTable().getBloomFilter(new PartitionID(partitionPathFileIdPair.getLeft()),
+            new FileID(fileName));
     if (!bloomFilterByteBuffer.isPresent()) {
       throw new HoodieIndexException("BloomFilter missing for " + fileName);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.SimpleBloomFilter;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Takes a bunch of keys and returns ones that are present in the file group.
+ */
+public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
+    I, K, O> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaBloomIndexLookupHandle.class);
+
+  private final HoodieTableType tableType;
+
+  private final BloomFilter bloomFilter;
+
+  private final List<String> candidateRecordKeys;
+
+  private long totalKeysChecked;
+
+  public HoodieKeyMetaBloomIndexLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
+                                             Pair<String, String> partitionPathFileIdPair, String fileName) {
+    super(config, null, hoodieTable, partitionPathFileIdPair);
+    this.tableType = hoodieTable.getMetaClient().getTableType();
+    this.candidateRecordKeys = new ArrayList<>();
+    this.totalKeysChecked = 0;
+    HoodieTimer timer = new HoodieTimer().startTimer();
+
+    Option<ByteBuffer> bloomFilterByteBuffer =
+        hoodieTable.getMetadataTable().getBloomFilter(new FileID(fileName));
+    if (!bloomFilterByteBuffer.isPresent()) {
+      throw new HoodieIndexException("BloomFilter missing for " + fileName);
+    }
+    this.bloomFilter = new SimpleBloomFilter(StandardCharsets.UTF_8.decode(bloomFilterByteBuffer.get()).toString());
+    LOG.error(String.format("Read bloom filter from %s in %d ms", partitionPathFileIdPair, timer.endTimer()));
+  }
+
+  /**
+   * Given a list of row keys and one file, return only row keys existing in that file.
+   */
+  public List<String> checkCandidatesAgainstFile(Configuration configuration, List<String> candidateRecordKeys,
+                                                 Path filePath) throws HoodieIndexException {
+    List<String> foundRecordKeys = new ArrayList<>();
+    try {
+      // Load all rowKeys from the file, to double-confirm
+      if (!candidateRecordKeys.isEmpty()) {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+        Set<String> fileRowKeys = createNewFileReader().filterRowKeys(new HashSet<>(candidateRecordKeys));
+        foundRecordKeys.addAll(fileRowKeys);
+        LOG.error(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)", filePath,
+            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+        LOG.error("Keys matching for file " + filePath + " => " + foundRecordKeys);
+      }
+    } catch (Exception e) {
+      throw new HoodieIndexException("Error checking candidate keys against file.", e);
+    }
+    return foundRecordKeys;
+  }
+
+  /**
+   * Adds the key for look up.
+   */
+  public void addKey(String recordKey) {
+    // check record key against bloom filter of current file & add to possible keys if needed
+    if (bloomFilter.mightContain(recordKey)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Record key " + recordKey + " matches bloom filter in  " + partitionPathFilePair);
+      }
+      candidateRecordKeys.add(recordKey);
+    }
+    totalKeysChecked++;
+  }
+
+  /**
+   * Of all the keys, that were added, return a list of keys that were actually found in the file group.
+   */
+  public MetaBloomIndexKeyLookupResult getLookupResult() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("#The candidate row keys for " + partitionPathFilePair + " => " + candidateRecordKeys);
+    }
+
+    HoodieBaseFile dataFile = getLatestDataFile();
+    List<String> matchingKeys =
+        checkCandidatesAgainstFile(hoodieTable.getHadoopConf(), candidateRecordKeys, new Path(dataFile.getPath()));
+    LOG.error(
+        String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)", totalKeysChecked,
+            candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+    return new MetaBloomIndexKeyLookupResult(partitionPathFilePair.getRight(), partitionPathFilePair.getLeft(),
+        dataFile.getCommitTime(), matchingKeys);
+  }
+
+  /**
+   * Encapsulates the result from a key lookup.
+   */
+  public static class MetaBloomIndexKeyLookupResult {
+
+    private final String fileId;
+    private final String baseInstantTime;
+    private final List<String> matchingRecordKeys;
+    private final String partitionPath;
+
+    public MetaBloomIndexKeyLookupResult(String fileId, String partitionPath, String baseInstantTime,
+                                         List<String> matchingRecordKeys) {
+      this.fileId = fileId;
+      this.partitionPath = partitionPath;
+      this.baseInstantTime = baseInstantTime;
+      this.matchingRecordKeys = matchingRecordKeys;
+    }
+
+    public String getFileId() {
+      return fileId;
+    }
+
+    public String getBaseInstantTime() {
+      return baseInstantTime;
+    }
+
+    public String getPartitionPath() {
+      return partitionPath;
+    }
+
+    public List<String> getMatchingRecordKeys() {
+      return matchingRecordKeys;
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.io;
 
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.collection.Pair;
@@ -27,9 +29,6 @@ import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.table.HoodieTable;
 
 import java.io.IOException;
-
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 
 /**
  * Base class for read operations done logically on the file group.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -377,9 +377,11 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
         .initTable(hadoopConf.get(), metadataWriteConfig.getBasePath());
 
     initTableMetadata();
-    initializeFileGroups(dataMetaClient, MetadataPartitionType.FILES, createInstantTime, 1);
+    initializeFileGroups(dataMetaClient, MetadataPartitionType.FILES, createInstantTime,
+        MetadataPartitionType.FILES.getFileGroupCount());
     if (isBloomFilterEnabled) {
-      initializeFileGroups(dataMetaClient, MetadataPartitionType.BLOOM_FILTERS, createInstantTime, 1);
+      initializeFileGroups(dataMetaClient, MetadataPartitionType.BLOOM_FILTERS, createInstantTime,
+          MetadataPartitionType.BLOOM_FILTERS.getFileGroupCount());
     }
 
     // List all partitions in the basePath of the containing dataset
@@ -544,7 +546,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    */
   @Override
   public void update(HoodieCommitMetadata commitMetadata, String instantTime) {
-    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(commitMetadata, instantTime));
+    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(commitMetadata,
+        dataMetaClient, instantTime));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -749,4 +749,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
     return Option.empty();
   }
 
+  public HoodieTableMetadata getMetadataTable() {
+    return this.metadata;
+  }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -135,21 +135,24 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  protected void commit(String instantTime, Map<String, List<HoodieRecord>> partitionRecordsMap) {
+  protected void commit(String instantTime, Map<MetadataPartitionType, List<HoodieRecord>> partitionRecordsMap) {
     throw new HoodieMetadataException("Unsupported operation!");
   }
 
   /**
    * Tag each record with the location in the given partition.
-   *
+   * <p>
    * The record is tagged with respective file slice's location based on its record key.
    */
   private List<HoodieRecord> prepRecords(List<HoodieRecord> records, String partitionName, int numFileGroups) {
-    List<FileSlice> fileSlices = HoodieTableMetadataUtil.loadPartitionFileGroupsWithLatestFileSlices(metadataMetaClient, partitionName);
-    ValidationUtils.checkArgument(fileSlices.size() == numFileGroups, String.format("Invalid number of file groups: found=%d, required=%d", fileSlices.size(), numFileGroups));
+    List<FileSlice> fileSlices =
+        HoodieTableMetadataUtil.loadPartitionFileGroupsWithLatestFileSlices(metadataMetaClient, partitionName);
+    ValidationUtils.checkArgument(fileSlices.size() == numFileGroups,
+        String.format("Invalid number of file groups: found=%d, required=%d", fileSlices.size(), numFileGroups));
 
     return records.stream().map(r -> {
-      FileSlice slice = fileSlices.get(HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(r.getRecordKey(), numFileGroups));
+      FileSlice slice = fileSlices.get(HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(r.getRecordKey(),
+          numFileGroups));
       final String instantTime = slice.isEmpty() ? "I" : "U";
       r.setCurrentLocation(new HoodieRecordLocation(instantTime, slice.getFileId()));
       return r;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -40,6 +40,7 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetadataWriter {
@@ -131,6 +132,11 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     // Update total size of the metadata and count of base/log files
     metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata));
+  }
+
+  @Override
+  protected void commit(String instantTime, Map<String, List<HoodieRecord>> partitionRecordsMap) {
+    throw new HoodieMetadataException("Unsupported operation!");
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexCheckFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexCheckFunction.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.client.utils.LazyIterableIterator;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.io.HoodieKeyMetaBloomIndexLookupHandle;
+import org.apache.hudi.io.HoodieKeyMetaBloomIndexLookupHandle.MetaBloomIndexKeyLookupResult;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.TaskContext;
+import org.apache.spark.api.java.function.Function2;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexCheckFunction
+    implements Function2<Integer, Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>,
+    Iterator<List<MetaBloomIndexKeyLookupResult>>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexCheckFunction.class);
+  private final HoodieTable hoodieTable;
+
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexCheckFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<List<MetaBloomIndexKeyLookupResult>> call(Integer integer,
+                                                            Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tupleIterator) throws Exception {
+    return new LazyKeyCheckIterator(tupleIterator);
+  }
+
+  class LazyKeyCheckIterator extends LazyIterableIterator<Tuple2<Tuple2<String, String>, HoodieKey>,
+      List<MetaBloomIndexKeyLookupResult>> {
+
+    private HoodieKeyMetaBloomIndexLookupHandle keyLookupHandle;
+
+    LazyKeyCheckIterator(Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> filePartitionRecordKeyTripletItr) {
+      super(filePartitionRecordKeyTripletItr);
+    }
+
+    @Override
+    protected void start() {
+    }
+
+    @Override
+    protected List<MetaBloomIndexKeyLookupResult> computeNext() {
+
+      TaskContext tc = TaskContext.get();
+
+      List<MetaBloomIndexKeyLookupResult> ret = new ArrayList<>();
+      try {
+        // process one file in each go.
+        while (inputItr.hasNext()) {
+          Tuple2<Tuple2<String, String>, HoodieKey> currentTuple = inputItr.next();
+          final String fileName = currentTuple._1._1;
+          final String fileId = FSUtils.getFileId(fileName);
+          ValidationUtils.checkState(!fileId.isEmpty());
+          String partitionPath = currentTuple._2.getPartitionPath();
+          String recordKey = currentTuple._2.getRecordKey();
+          Pair<String, String> partitionPathFileIdPair = Pair.of(partitionPath, fileId);
+
+          // lazily init state
+          if (keyLookupHandle == null) {
+            keyLookupHandle = new HoodieKeyMetaBloomIndexLookupHandle(config, hoodieTable, partitionPathFileIdPair,
+                fileName);
+          }
+
+          // if continue on current file
+          if (keyLookupHandle.getPartitionPathFilePair().equals(partitionPathFileIdPair)) {
+            keyLookupHandle.addKey(recordKey);
+          } else {
+            // do the actual checking of file & break out
+            ret.add(keyLookupHandle.getLookupResult());
+            keyLookupHandle = new HoodieKeyMetaBloomIndexLookupHandle(config, hoodieTable, partitionPathFileIdPair,
+                fileName);
+            keyLookupHandle.addKey(recordKey);
+            break;
+          }
+        }
+
+        // handle case, where we ran out of input, close pending work, update return val
+        if (!inputItr.hasNext()) {
+          ret.add(keyLookupHandle.getLookupResult());
+        }
+      } catch (Throwable e) {
+        if (e instanceof HoodieException) {
+          throw e;
+        }
+        throw new HoodieIndexException("Error checking bloom filter index. ", e);
+      }
+
+      return ret;
+    }
+
+    @Override
+    protected void end() {
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexCheckFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexCheckFunction.java
@@ -31,7 +31,6 @@ import org.apache.hudi.io.HoodieKeyMetaBloomIndexLookupHandle.MetaBloomIndexKeyL
 import org.apache.hudi.table.HoodieTable;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.function.Function2;
 import scala.Tuple2;
 
@@ -77,8 +76,6 @@ public class HoodieBloomMetaIndexCheckFunction
 
     @Override
     protected List<MetaBloomIndexKeyLookupResult> computeNext() {
-
-      TaskContext tc = TaskContext.get();
 
       List<MetaBloomIndexKeyLookupResult> ret = new ArrayList<>();
       try {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexColStatFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexColStatFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.avro.model.HoodieColumnStats;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexColStatFunction
+    implements FlatMapFunction<Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>, Tuple2<Tuple2<String, String>,
+    HoodieKey>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexColStatFunction.class);
+  private final HoodieTable hoodieTable;
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexColStatFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> call(
+      Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tuple2Iterator) throws Exception {
+    Map<String, String> columnKeyHashToFileNameMap = new HashMap<>();
+    Map<String, List<HoodieKey>> columnKeyHashToHoodieKeysMap = new HashMap<>();
+    List<Tuple2<Tuple2<String, String>, HoodieKey>> result = new ArrayList<>();
+
+    while (tuple2Iterator.hasNext()) {
+      final Tuple2<Tuple2<String, String>, HoodieKey> entry = tuple2Iterator.next();
+      final String colStatKeyHash = entry._1._1;
+      final String fileName = entry._1._2;
+      final HoodieKey hoodieKey = entry._2;
+
+      columnKeyHashToHoodieKeysMap.computeIfAbsent(colStatKeyHash, e -> new ArrayList<>()).add(hoodieKey);
+      columnKeyHashToFileNameMap.putIfAbsent(colStatKeyHash, fileName);
+    }
+
+    Map<String, HoodieColumnStats> columnKeyHashToStatMap =
+        hoodieTable.getMetadataTable().getColumnStats(
+            columnKeyHashToHoodieKeysMap.keySet().stream().collect(Collectors.toList()));
+
+    for (Map.Entry<String, String> entry : columnKeyHashToFileNameMap.entrySet()) {
+      ValidationUtils.checkState(columnKeyHashToHoodieKeysMap.containsKey(entry.getKey()));
+      ValidationUtils.checkState(columnKeyHashToStatMap.containsKey(entry.getKey()));
+
+      final String fileName = entry.getValue();
+      final List<HoodieKey> keyList = columnKeyHashToHoodieKeysMap.get(entry.getKey());
+      final HoodieColumnStats keyColumnStat = columnKeyHashToStatMap.get(entry.getKey());
+
+      keyList.forEach(hoodieKey -> {
+        if ((Objects.requireNonNull(keyColumnStat.getRangeLow()).compareTo(hoodieKey.getRecordKey()) <= 0)
+            && (Objects.requireNonNull(keyColumnStat.getRangeHigh()).compareTo(hoodieKey.getRecordKey()) >= 0)) {
+          result.add(new Tuple2<>(new Tuple2<>(FSUtils.getFileId(fileName), fileName), hoodieKey));
+        }
+      });
+    }
+    return result.iterator();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexGroupedFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexGroupedFunction.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.io.HoodieKeyMetaBloomIndexGroupedLookupHandle.MetaBloomIndexGroupedKeyLookupResult;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieFileReaderFactory;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.TaskContext;
+import org.apache.spark.api.java.function.Function2;
+import scala.Tuple2;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexGroupedFunction
+    implements Function2<Integer, Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>,
+    Iterator<List<MetaBloomIndexGroupedKeyLookupResult>>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexGroupedFunction.class);
+  private final HoodieTable hoodieTable;
+
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexGroupedFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<List<MetaBloomIndexGroupedKeyLookupResult>> call(Integer integer,
+                                                                   Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tupleIterator) throws Exception {
+
+    List<List<MetaBloomIndexGroupedKeyLookupResult>> resultList = new ArrayList<>();
+
+    // <PartitionPath, FileName> => List<HoodieKey>
+    Map<Pair<String, String>, List<HoodieKey>> fileToKeysMap = new HashMap<>();
+
+    while (tupleIterator.hasNext()) {
+      Tuple2<Tuple2<String, String>, HoodieKey> entry = tupleIterator.next();
+      fileToKeysMap.computeIfAbsent(Pair.of(entry._2.getPartitionPath(), entry._1._1), k -> new ArrayList<>()).add(entry._2);
+    }
+
+    TaskContext tc = TaskContext.get();
+    fileToKeysMap.forEach((partitionPathFileNamePair, hoodieKeyList) -> {
+      final String partitionPath = partitionPathFileNamePair.getLeft();
+      final String fileName = partitionPathFileNamePair.getRight();
+
+      final String fileId = FSUtils.getFileId(fileName);
+      ValidationUtils.checkState(!fileId.isEmpty());
+
+      Option<ByteBuffer> fileBloomFilterByteBuffer =
+          hoodieTable.getMetadataTable().getBloomFilter(new FileID(fileName));
+      if (!fileBloomFilterByteBuffer.isPresent()) {
+        LOG.error("Failed to find the bloom filter for " + partitionPathFileNamePair.getLeft());
+      }
+
+      // TODO: use factory
+      HoodieDynamicBoundedBloomFilter fileBloomFilter =
+          new HoodieDynamicBoundedBloomFilter(StandardCharsets.UTF_8.decode(fileBloomFilterByteBuffer.get()).toString(),
+              BloomFilterTypeCode.DYNAMIC_V0);
+
+      List<String> candidateRecordKeys = new ArrayList<>();
+      hoodieKeyList.forEach(hoodieKey -> {
+        if (fileBloomFilter.mightContain(hoodieKey.getRecordKey())) {
+          candidateRecordKeys.add(hoodieKey.getRecordKey());
+        }
+      });
+
+      Option<HoodieBaseFile> dataFile = hoodieTable.getBaseFileOnlyView()
+          .getLatestBaseFile(partitionPath, fileId);
+      if (!dataFile.isPresent()) {
+        throw new HoodieIndexException("Failed to find the base file for partition: " + partitionPath
+            + ", fileId: " + fileId);
+      }
+
+      List<String> matchingKeys =
+          checkCandidatesAgainstFile(candidateRecordKeys, new Path(dataFile.get().getPath()));
+
+      LOG.debug(
+          String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
+              hoodieKeyList.size(), candidateRecordKeys.size(),
+              candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+
+      ArrayList<MetaBloomIndexGroupedKeyLookupResult> subList = new ArrayList<>();
+      subList.add(new MetaBloomIndexGroupedKeyLookupResult(fileId, partitionPath, dataFile.get().getCommitTime(),
+          matchingKeys));
+      resultList.add(subList);
+    });
+
+    return resultList.iterator();
+  }
+
+  public List<String> checkCandidatesAgainstFile(List<String> candidateRecordKeys,
+                                                 Path latestDataFilePath) throws HoodieIndexException {
+    List<String> foundRecordKeys = new ArrayList<>();
+    try {
+      // Load all rowKeys from the file, to double-confirm
+      if (!candidateRecordKeys.isEmpty()) {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+
+        final HoodieFileReader fileReader = HoodieFileReaderFactory.getFileReader(hoodieTable.getHadoopConf(),
+            latestDataFilePath);
+        Set<String> fileRowKeys = fileReader.filterRowKeys(new HashSet<>(candidateRecordKeys));
+        foundRecordKeys.addAll(fileRowKeys);
+        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)",
+            latestDataFilePath,
+            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+        LOG.debug("Keys matching for file " + latestDataFilePath + " => " + foundRecordKeys);
+      }
+    } catch (Exception e) {
+      throw new HoodieIndexException("Error checking candidate keys against file.", e);
+    }
+    return foundRecordKeys;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -162,8 +162,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
    * <p>
    * The record is tagged with respective file slice's location based on its record key.
    */
-  private JavaRDD<HoodieRecord> prepRecords(Map<MetadataPartitionType,
-      List<HoodieRecord>> partitionRecordsMap) {
+  private JavaRDD<HoodieRecord> prepRecords(Map<MetadataPartitionType, List<HoodieRecord>> partitionRecordsMap) {
 
     // The result set
     JavaRDD<HoodieRecord> rddAllPartitionRecords = null;
@@ -189,7 +188,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       if (rddAllPartitionRecords == null) {
         rddAllPartitionRecords = rddSinglePartitionRecords;
       } else {
-        rddAllPartitionRecords.union(rddSinglePartitionRecords);
+        rddAllPartitionRecords = rddAllPartitionRecords.union(rddSinglePartitionRecords);
       }
     }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -194,7 +194,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     testTable.doWriteOperation("0000003", UPSERT, emptyList(), asList("p1", "p2"), 1, true);
     syncTableMetadata(writeConfig);
 
-    List<String> partitions = metadataWriter(writeConfig).metadata().getAllPartitionPaths();
+    List<String> partitions = metadataWriter(writeConfig).getTableMetadata().getAllPartitionPaths();
     assertFalse(partitions.contains(nonPartitionDirectory),
         "Must not contain the non-partition " + nonPartitionDirectory);
     assertTrue(partitions.contains("p1"), "Must contain partition p1");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.client.functional;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -95,11 +97,17 @@ public class TestHoodieMetadataBase extends HoodieClientTestHarness {
   protected void initWriteConfigAndMetatableWriter(HoodieWriteConfig writeConfig, boolean enableMetadataTable) {
     this.writeConfig = writeConfig;
     if (enableMetadataTable) {
-      metadataWriter = SparkHoodieBackedTableMetadataWriter.create(hadoopConf, writeConfig, context);
+      metadataWriter = getMetadataWriter(hadoopConf, writeConfig, context);
       testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter);
     } else {
       testTable = HoodieTestTable.of(metaClient);
     }
+  }
+
+  protected HoodieTableMetadataWriter getMetadataWriter(final Configuration hadoopConf,
+                                                        HoodieWriteConfig writeConfig,
+                                                        HoodieSparkEngineContext context) {
+    return SparkHoodieBackedTableMetadataWriter.create(hadoopConf, writeConfig, context);
   }
 
   @AfterEach

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -80,7 +80,7 @@ public class TestHoodieBackedTableMetadataWriter extends TestHoodieMetadataBase 
     }
 
     @Override
-    protected void commit(String instantTime, Map<String, List<HoodieRecord>> partitionRecordsMap) {
+    protected void commit(String instantTime, Map<MetadataPartitionType, List<HoodieRecord>> partitionRecordsMap) {
       //
     }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.client.functional.TestHoodieMetadataBase;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieBackedTableMetadataWriter extends TestHoodieMetadataBase {
+  private static final Logger LOG = LogManager.getLogger(TestHoodieBackedTableMetadataWriter.class);
+
+  private class TestMetadataWriter extends HoodieBackedTableMetadataWriter {
+
+    /**
+     * Hudi backed table metadata writer.
+     *
+     * @param hadoopConf     - Hadoop configuration to use for the metadata writer
+     * @param writeConfig    - Writer config
+     * @param engineContext  - Engine context
+     * @param actionMetadata - Optional action metadata to help decide bootstrap operations
+     */
+    protected <T extends SpecificRecordBase> TestMetadataWriter(Configuration hadoopConf,
+                                                                HoodieWriteConfig writeConfig,
+                                                                HoodieEngineContext engineContext,
+                                                                Option<T> actionMetadata) {
+      super(hadoopConf, writeConfig, engineContext, actionMetadata);
+    }
+
+    @Override
+    protected void initRegistry() {
+      //
+    }
+
+    @Override
+    protected <T extends SpecificRecordBase> void initialize(HoodieEngineContext engineContext,
+                                                             Option<T> actionMetadata) {
+      try {
+        bootstrapIfNeeded(engineContext, dataMetaClient, actionMetadata);
+      } catch (IOException e) {
+        throw new HoodieMetadataException("Failed to initialize metadata table!");
+      }
+    }
+
+    @Override
+    protected void commit(List<HoodieRecord> records, String partitionName, String instantTime) {
+      //
+    }
+
+    @Override
+    protected void commit(String instantTime, Map<String, List<HoodieRecord>> partitionRecordsMap) {
+      //
+    }
+
+  }
+
+  protected HoodieTableMetadataWriter getMetadataWriter(final Configuration hadoopConf,
+                                                        HoodieWriteConfig writeConfig,
+                                                        HoodieSparkEngineContext context) {
+    return new TestMetadataWriter(hadoopConf, writeConfig, context, Option.empty());
+  }
+
+  @Test
+  public void testMetadataPartitionBloomFilter() throws Exception {
+    HoodieTableType tableType = HoodieTableType.COPY_ON_WRITE;
+    init(tableType);
+
+    final boolean isTestMetadataWriter = (metadataWriter instanceof TestMetadataWriter);
+    assertTrue(isTestMetadataWriter);
+
+    final TestMetadataWriter testMetadataWriter = (TestMetadataWriter) metadataWriter;
+    final HoodieBackedTableMetadata testTableMetadata = testMetadataWriter.getTableMetadata();
+
+    assertTrue(testTableMetadata.isBloomFilterMetadataEnabled);
+  }
+}

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -30,27 +30,65 @@
             "doc": "Type of the metadata record",
             "type": "int"
         },
-        {   "name": "filesystemMetadata",
+        {
+            "name": "filesystemMetadata",
             "doc": "Contains information about partitions and files within the dataset",
-            "type": ["null", {
-               "type": "map",
-               "values": {
+            "type": [
+                "null",
+                {
+                    "type": "map",
+                    "values": {
+                        "type": "record",
+                        "name": "HoodieMetadataFileInfo",
+                        "fields": [
+                            {
+                                "name": "size",
+                                "type": "long",
+                                "doc": "Size of the file"
+                            },
+                            {
+                                "name": "isDeleted",
+                                "type": "boolean",
+                                "doc": "True if this file has been deleted"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "doc": "Metadata about base file bloom filters",
+            "name": "BloomFilterMetadata",
+            "type": [
+                "null",
+                {
+                    "doc": "Base FileID and its BloomFilter details",
+                    "name": "HoodieMetadataBloomFilter",
                     "type": "record",
-                    "name": "HoodieMetadataFileInfo",
                     "fields": [
                         {
-                            "name": "size",
-                            "type": "long",
-                            "doc": "Size of the file"
+                            "doc": "Version of the bloom filter metadata",
+                            "name": "version",
+                            "type": "int"
                         },
                         {
-                            "name": "isDeleted",
-                            "type": "boolean",
-                            "doc": "True if this file has been deleted"
+                            "doc": "Instant timestamp when this metadata was created/updated",
+                            "name": "timestamp",
+                            "type": "string"
+                        },
+                        {
+                            "doc": "Bloom filter binary byte array",
+                            "name": "bloomfilter",
+                            "type": "bytes"
+                        },
+                        {
+                            "doc": "True if this entry is valid",
+                            "name": "valid",
+                            "type": "boolean"
                         }
                     ]
                 }
-            }]
+            ]
         }
     ]
 }

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -89,6 +89,40 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "ColumnStatsMetadata",
+            "doc": "Contains information about column ranges for all data files in the table",
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "name": "HoodieColumnStats",
+                    "fields": [
+                        {
+                            "name": "rangeLow",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "doc": "Low end of the range. For now, this is a String. Based on main data table schema, we can convert it to appropriate type"
+                        },
+                        {
+                            "name": "rangeHigh",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "doc": "High end of the range. For now, this is a String. Based on main data table schema, we can convert it to appropriate type"
+                        },
+                        {
+                            "name": "isDeleted",
+                            "type": "boolean",
+                            "doc": "True if this file has been deleted"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/HoodieDynamicBoundedBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/HoodieDynamicBoundedBloomFilter.java
@@ -63,7 +63,7 @@ public class HoodieDynamicBoundedBloomFilter implements BloomFilter {
    * @param serString the serialized string which represents the {@link HoodieDynamicBoundedBloomFilter}
    * @param typeCode  type code of the bloom filter
    */
-  HoodieDynamicBoundedBloomFilter(String serString, BloomFilterTypeCode typeCode) {
+  public HoodieDynamicBoundedBloomFilter(String serString, BloomFilterTypeCode typeCode) {
     // ignoring the type code for now, since we have just one version
     byte[] bytes = Base64CodecUtil.decode(serString);
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -53,6 +53,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.10.0")
       .withDocumentation("Enable indexing base files bloom filters for quicker key lookups");
 
+  // When the internal Metadata Table is enabled, can it
+  // index base file bloom filters for quicker key lookups?
+  public static final ConfigProperty<Boolean> COLUMN_STATS_METADATA_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".column_stats.enable")
+      .defaultValue(true)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable indexing base files column stats for quicker key lookups");
+
   public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = false;
 
   // Enable metrics for internal Metadata Table
@@ -159,6 +167,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean isBloomFiltersEnabled() {
     return getBoolean(BLOOM_FILTER_METADATA_ENABLE);
+  }
+
+  public boolean isColumnStatsEnabled() {
+    return getBoolean(COLUMN_STATS_METADATA_ENABLE);
   }
 
   public boolean enableMetrics() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -45,6 +45,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Enable the internal metadata table which serves table metadata like level file listings");
 
+  // When the internal Metadata Table is enabled, can it
+  // index base file bloom filters for quicker key lookups?
+  public static final ConfigProperty<Boolean> BLOOM_FILTER_METADATA_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".bloom_filter.enable")
+      .defaultValue(true)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable indexing base files bloom filters for quicker key lookups");
+
   public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = false;
 
   // Enable metrics for internal Metadata Table
@@ -147,6 +155,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean enabled() {
     return getBoolean(ENABLE);
+  }
+
+  public boolean isBloomFiltersEnabled() {
+    return getBoolean(BLOOM_FILTER_METADATA_ENABLE);
   }
 
   public boolean enableMetrics() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -61,6 +61,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.10.0")
       .withDocumentation("Enable indexing base files column stats for quicker key lookups");
 
+  public static final ConfigProperty<Boolean> INDEX_LOOKUP_LOGGING = ConfigProperty
+      .key(METADATA_PREFIX + ".index.lookup.logging")
+      .defaultValue(false)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable indexing lookup verbose logging");
+
+  public static final ConfigProperty<Boolean> INDEX_LOOKUP_TIMER = ConfigProperty
+      .key(METADATA_PREFIX + ".index.lookup.timer")
+      .defaultValue(true)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable indexing lookups timer logging");
+
   public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = false;
 
   // Enable metrics for internal Metadata Table
@@ -135,15 +147,26 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".enable.inline.reading")
       .defaultValue(true)
       .sinceVersion("0.10.0")
-      .withDocumentation("Enable inline reading of Log files. By default log block contents are read as byte[] using regular input stream and records "
-          + "are deserialized from it. Enabling this will read each log block as an inline file and read records from the same. For instance, "
+      .withDocumentation("Enable inline reading of Log files. By default log block contents are read as byte[] using "
+          + "regular input stream and records "
+          + "are deserialized from it. Enabling this will read each log block as an inline file and read records from"
+          + " the same. For instance, "
           + "for HFileDataBlock, a inline file will be read using HFileReader.");
 
+  // TODO: for the test
   public static final ConfigProperty<Boolean> ENABLE_FULL_SCAN_LOG_FILES = ConfigProperty
       .key(METADATA_PREFIX + ".enable.full.scan.log.files")
       .defaultValue(true)
       .sinceVersion("0.10.0")
-      .withDocumentation("Enable full scanning of log files while reading log records. If disabled, hudi does look up of only interested entries.");
+      .withDocumentation("Enable full scanning of log files while reading log records. If disabled, hudi does look up"
+          + " of only interested entries.");
+
+  public static final ConfigProperty<Boolean> BLOOM_FILTER_METADATA_BATCH_LOAD_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".bloom_filter.batch_load.enable")
+      .defaultValue(false)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable batch/bulk loading of bloom filter metadata for the entire partition when looking"
+          + " up index.");
 
   private HoodieMetadataConfig() {
     super();
@@ -167,6 +190,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean isBloomFiltersEnabled() {
     return getBoolean(BLOOM_FILTER_METADATA_ENABLE);
+  }
+
+  public boolean isBloomFiltersBatchLoadEnabled() {
+    return getBoolean(BLOOM_FILTER_METADATA_BATCH_LOAD_ENABLE);
+  }
+
+  public boolean isIndexLookupLoggingEnabled() {
+    return getBoolean(INDEX_LOOKUP_LOGGING);
+  }
+
+  public boolean isIndexLookupTimerEnabled() {
+    return getBoolean(INDEX_LOOKUP_TIMER);
   }
 
   public boolean isColumnStatsEnabled() {
@@ -203,6 +238,31 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder enable(boolean enable) {
       metadataConfig.setValue(ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder bloomFilterIndex(boolean enable) {
+      metadataConfig.setValue(BLOOM_FILTER_METADATA_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder bloomFilterIndexBatchLoad(boolean enable) {
+      metadataConfig.setValue(BLOOM_FILTER_METADATA_BATCH_LOAD_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder columnStatsIndex(boolean enable) {
+      metadataConfig.setValue(COLUMN_STATS_METADATA_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder indexLookupLogging(boolean enable) {
+      metadataConfig.setValue(INDEX_LOOKUP_LOGGING, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder indexLookupTimer(boolean enable) {
+      metadataConfig.setValue(INDEX_LOOKUP_TIMER, String.valueOf(enable));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -153,7 +153,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + " the same. For instance, "
           + "for HFileDataBlock, a inline file will be read using HFileReader.");
 
-  // TODO: for the test
   public static final ConfigProperty<Boolean> ENABLE_FULL_SCAN_LOG_FILES = ConfigProperty
       .key(METADATA_PREFIX + ".enable.full.scan.log.files")
       .defaultValue(true)

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFSUtils.java
@@ -47,7 +47,7 @@ public class InLineFSUtils {
   public static Path getInlineFilePath(Path outerPath, String origScheme, long inLineStartOffset, long inLineLength) {
     String subPath = outerPath.toString().substring(outerPath.toString().indexOf(":") + 1);
     return new Path(
-        InLineFileSystem.SCHEME + "://" + subPath + "/" + origScheme
+        InLineFileSystem.SCHEME + ":///" + subPath + "/" + origScheme
             + "/" + "?" + START_OFFSET_STR + EQUALS_STR + inLineStartOffset
             + "&" + LENGTH_STR + EQUALS_STR + inLineLength
     );
@@ -68,7 +68,10 @@ public class InLineFSUtils {
   public static Path getOuterfilePathFromInlinePath(Path inlinePath) {
     String scheme = inlinePath.getParent().getName();
     Path basePath = inlinePath.getParent().getParent();
-    return new Path(basePath.toString().replaceFirst(InLineFileSystem.SCHEME, scheme));
+    String pathExceptScheme = basePath.toString().substring(basePath.toString().indexOf(":") + 1);
+    String slashes = scheme.equals("s3a") ? ":/" : ":";
+    String fullPath = scheme + slashes + pathExceptScheme;
+    return new Path(fullPath);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnStatsMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnStatsMetadata.java
@@ -1,0 +1,102 @@
+package org.apache.hudi.common.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Objects;
+
+/**
+ * Hoodie Column Stats metadata.
+ */
+public class HoodieColumnStatsMetadata<T> {
+
+  private final String partitionPath;
+  private final String filePath;
+  private final String columnName;
+  private final T minValue;
+  private final T maxValue;
+  private final boolean isDeleted;
+
+  public HoodieColumnStatsMetadata(final String partitionPath, final String filePath, final String columnName, final T minValue, final T maxValue,
+                                   boolean isDeleted) {
+    this.partitionPath = partitionPath;
+    this.filePath = filePath;
+    this.columnName = columnName;
+    this.minValue = minValue;
+    this.maxValue = maxValue;
+    this.isDeleted = isDeleted;
+  }
+
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public String getFilePath() {
+    return this.filePath;
+  }
+
+  public String getColumnName() {
+    return this.columnName;
+  }
+
+  public T getMinValue() {
+    return this.minValue;
+  }
+
+  public T getMaxValue() {
+    return this.maxValue;
+  }
+
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HoodieColumnStatsMetadata<?> that = (HoodieColumnStatsMetadata<?>) o;
+    return Objects.equals(getPartitionPath(), that.getPartitionPath())
+        && Objects.equals(getFilePath(), that.getFilePath())
+        && Objects.equals(getColumnName(), that.getColumnName())
+        && Objects.equals(getMinValue(), that.getMinValue())
+        && Objects.equals(getMaxValue(), that.getMaxValue())
+        && Objects.equals(isDeleted(), that.isDeleted());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getColumnName(), getMinValue(), getMaxValue());
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieColumnRangeMetadata{"
+        + "partitionPath ='" + partitionPath + '\''
+        + "filePath ='" + filePath + '\''
+        + "columnName='" + columnName + '\''
+        + ", minValue=" + minValue
+        + ", maxValue=" + maxValue
+        + ", isDeleted=" + isDeleted + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -94,7 +94,8 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
   }
 
   public ExternalSpillableMap(Long maxInMemorySizeInBytes, String baseFilePath, SizeEstimator<T> keySizeEstimator,
-                              SizeEstimator<R> valueSizeEstimator, DiskMapType diskMapType, boolean isCompressionEnabled) throws IOException {
+                              SizeEstimator<R> valueSizeEstimator, DiskMapType diskMapType,
+                              boolean isCompressionEnabled) throws IOException {
     this.inMemoryMap = new HashMap<>();
     this.baseFilePath = baseFilePath;
     this.maxInMemorySizeInBytes = (long) Math.floor(maxInMemorySizeInBytes * sizingFactorForInMemoryMap);
@@ -116,7 +117,7 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
                 break;
               case BITCASK:
               default:
-                diskBasedMap =  new BitCaskDiskMap<>(baseFilePath, isCompressionEnabled);
+                diskBasedMap = new BitCaskDiskMap<>(baseFilePath, isCompressionEnabled);
             }
           } catch (IOException e) {
             throw new HoodieIOException(e.getMessage(), e);
@@ -208,7 +209,8 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
         // Note, the converter may over estimate the size of a record in the JVM
         this.estimatedPayloadSize = keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value);
         LOG.info("Estimated Payload size => " + estimatedPayloadSize);
-      } else if (shouldEstimatePayloadSize && inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
+      } else if (shouldEstimatePayloadSize && !inMemoryMap.isEmpty()
+          && inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0) {
         // Re-estimate the size of a record by calculating the size of the entire map containing
         // N entries and then dividing by the number of entries present (N). This helps to get a
         // correct estimation of the size of each record in the JVM.

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/ColumnID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/ColumnID.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.util.Base64CodecUtil;
 public class ColumnID extends HoodieID {
 
   private static final Type TYPE = Type.COLUMN;
-  private static final HashID.Size ID_COLUMN_HASH_SIZE = HashID.Size.BITS_64;
+  public static final HashID.Size ID_COLUMN_HASH_SIZE = HashID.Size.BITS_64;
   private final byte[] hash;
 
   public ColumnID(final String message) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -169,7 +169,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
     final Option<HoodieMetadataBloomFilter> optionalBloomFilterMetadata =
         hoodieRecord.get().getData().getBloomFilterMetadata();
-    if (optionalBloomFilterMetadata.isPresent()) {
+    if (!optionalBloomFilterMetadata.isPresent()) {
       LOG.error("Bloom filter metadata for " + fileID + " is not available!");
       return Option.empty();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -29,8 +29,11 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -138,5 +141,15 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
   @Override
   public void close() throws Exception {
     // no-op
+  }
+
+  @Override
+  public Option<ByteBuffer> getBloomFilter(FileID fileID) throws HoodieMetadataException {
+    return Option.empty();
+  }
+
+  @Override
+  public Map<String, ByteBuffer> getBloomFilters(List<FileID> fileIDList) throws HoodieMetadataException {
+    return Collections.emptyMap();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -30,6 +31,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
@@ -144,12 +146,17 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
   }
 
   @Override
-  public Option<ByteBuffer> getBloomFilter(FileID fileID) throws HoodieMetadataException {
-    return Option.empty();
+  public Option<ByteBuffer> getBloomFilter(final PartitionID partitionID, final FileID fileID) throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation - getBloomFilter for " + fileID);
   }
 
   @Override
-  public Map<String, ByteBuffer> getBloomFilters(List<FileID> fileIDList) throws HoodieMetadataException {
-    return Collections.emptyMap();
+  public Map<String, ByteBuffer> getBloomFilters(final List<Pair<PartitionID, FileID>> partitionIDFileIDList) throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation - getBloomFilters!");
+  }
+
+  @Override
+  public Map<String, HoodieColumnStats> getColumnStats(List<String> keySet) throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation - getColumnsStats!");
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataBloomFilterUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataBloomFilterUtil.java
@@ -59,7 +59,7 @@ public class HoodieMetadataBloomFilterUtil {
     HoodieMetadataBloomFilter metadataBloomFilter = new HoodieMetadataBloomFilter();
     HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(),
         HoodieMetadataPayload.METADATA_TYPE_BLOOM_FILTER, fileInfo,
-        null);
+        null, null);
     return new HoodieRecord<>(key, payload);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataBloomFilterUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataBloomFilterUtil.java
@@ -19,6 +19,16 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieMetadataBloomFilter;
+import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Util class for the metadata table bloom filter partition to
  * convert records while writing and reading to HFiles.
@@ -28,5 +38,29 @@ public class HoodieMetadataBloomFilterUtil {
   // Version for the whole bloom filter metadata. Will be needed in the
   // future to detect old and new versions, across upgrades/migration.
   public static final int VERSION_METADATA_BLOOM_FILTER = 1;
+
+  /**
+   * TODO: Comment.
+   *
+   * @param partition
+   * @param filesAdded
+   * @param filesDeleted
+   * @return
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createBloomFilterMetadataRecords(
+      String instantTime, String partition, Option<Map<String, Long>> filesAdded, Option<List<String>> filesDeleted) {
+    Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
+    filesAdded.ifPresent(
+        m -> m.forEach((filename, size) -> fileInfo.put(filename, new HoodieMetadataFileInfo(size, false))));
+    filesDeleted.ifPresent(
+        m -> m.forEach(filename -> fileInfo.put(filename, new HoodieMetadataFileInfo(0L, true))));
+
+    HoodieKey key = new HoodieKey(partition, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath());
+    HoodieMetadataBloomFilter metadataBloomFilter = new HoodieMetadataBloomFilter();
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(),
+        HoodieMetadataPayload.METADATA_TYPE_BLOOM_FILTER, fileInfo,
+        null);
+    return new HoodieRecord<>(key, payload);
+  }
 
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataBloomFilterUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataBloomFilterUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+/**
+ * Util class for the metadata table bloom filter partition to
+ * convert records while writing and reading to HFiles.
+ */
+public class HoodieMetadataBloomFilterUtil {
+
+  // Version for the whole bloom filter metadata. Will be needed in the
+  // future to detect old and new versions, across upgrades/migration.
+  public static final int VERSION_METADATA_BLOOM_FILTER = 1;
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -42,6 +42,7 @@ public class HoodieMetadataMetrics implements Serializable {
   public static final String LOOKUP_PARTITIONS_STR = "lookup_partitions";
   public static final String LOOKUP_FILES_STR = "lookup_files";
   public static final String LOOKUP_BLOOM_FILTERS_METADATA_STR = "lookup_bloom_filters_metadata";
+  public static final String LOOKUP_COLUMN_STATS_METADATA_STR = "lookup_column_stats_metadata";
   public static final String SCAN_STR = "scan";
   public static final String BASEFILE_READ_STR = "basefile_read";
   public static final String INITIALIZE_STR = "initialize";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -41,6 +41,7 @@ public class HoodieMetadataMetrics implements Serializable {
   // Metric names
   public static final String LOOKUP_PARTITIONS_STR = "lookup_partitions";
   public static final String LOOKUP_FILES_STR = "lookup_files";
+  public static final String LOOKUP_BLOOM_FILTERS_METADATA_STR = "lookup_bloom_filters_metadata";
   public static final String SCAN_STR = "scan";
   public static final String BASEFILE_READ_STR = "basefile_read";
   public static final String INITIALIZE_STR = "initialize";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieMetadataBloomFilter;
 import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -25,6 +26,8 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.hash.FileID;
+
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -35,6 +38,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -45,30 +49,46 @@ import java.util.stream.Stream;
 import static org.apache.hudi.metadata.HoodieTableMetadata.RECORDKEY_PARTITION_LIST;
 
 /**
- * This is a payload which saves information about a single entry in the Metadata Table.
- *
- * The type of the entry is determined by the "type" saved within the record. The following types of entries are saved:
- *
- *   1. List of partitions: There is a single such record
- *         key="__all_partitions__"
- *
- *   2. List of files in a Partition: There is one such record for each partition
- *         key=Partition name
- *
- *  During compaction on the table, the deletions are merged with additions and hence pruned.
- *
- * Metadata Table records are saved with the schema defined in HoodieMetadata.avsc. This class encapsulates the
- * HoodieMetadataRecord for ease of operations.
+ * MetadataTable records are persisted with the schema defined in HoodieMetadata.avsc.
+ * This class represents the payload for the MetadataTable.
+ * <p>
+ * This single metadata payload is shared by all the partitions under the metadata table.
+ * The partition specific records are determined by the field "type" saved within the record.
+ * The following types are supported:
+ * <p>
+ * METADATA_TYPE_PARTITION_LIST (1):
+ * -- List of all partitions. There is a single such record
+ * -- key = @{@link HoodieTableMetadata.RECORDKEY_PARTITION_LIST}
+ * <p>
+ * METADATA_TYPE_FILE_LIST (2):
+ * -- List of all files in a partition. There is one such record for each partition
+ * -- key = partition name
+ * <p>
+ * METADATA_TYPE_COLUMN_STATS (3):
+ * -- This is an index for column stats in the table
+ * <p>
+ * METADATA_TYPE_BLOOM_FILTER (4):
+ * -- This is an index for base file bloom filters. This is a map of FileID to its BloomFilter byte[].
+ * <p>
+ * During compaction on the table, the deletions are merged with additions and hence records are pruned.
  */
 public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadataPayload> {
-  // Type of the record
-  // This can be an enum in the schema but Avro 1.8 has a bug - https://issues.apache.org/jira/browse/AVRO-1810
-  private static final int PARTITION_LIST = 1;
-  private static final int FILE_LIST = 2;
+  // Type of the record. This can be an enum in the schema but Avro1.8
+  // has a bug - https://issues.apache.org/jira/browse/AVRO-1810
+  private static final int METADATA_TYPE_PARTITION_LIST = 1;
+  private static final int METADATA_TYPE_FILE_LIST = 2;
+  //private static final int METADATA_TYPE_COLUMN_STATS = 3;
+  private static final int METADATA_TYPE_BLOOM_FILTER = 4;
+
+  // Various metadata type record names in the payload
+  private static final String METADATA_RECORD_FILESYSTEM = "filesystemMetadata";
+  //private static final String METADATA_RECORD_COLUMN_STATS = "ColumnStatsMetadata";
+  private static final String METADATA_RECORD_BLOOM_FILTER = "BloomFilterMetadata";
 
   private String key = null;
   private int type = 0;
   private Map<String, HoodieMetadataFileInfo> filesystemMetadata = null;
+  private HoodieMetadataBloomFilter bloomFilterMetadata = null;
 
   public HoodieMetadataPayload(GenericRecord record, Comparable<?> orderingVal) {
     this(Option.of(record));
@@ -80,20 +100,51 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
       // https://issues.apache.org/jira/browse/AVRO-1811
       key = record.get().get("key").toString();
       type = (int) record.get().get("type");
-      if (record.get().get("filesystemMetadata") != null) {
-        filesystemMetadata = (Map<String, HoodieMetadataFileInfo>) record.get().get("filesystemMetadata");
+
+      if (record.get().get(METADATA_RECORD_FILESYSTEM) != null) {
+        filesystemMetadata = (Map<String, HoodieMetadataFileInfo>) record.get().get(METADATA_RECORD_FILESYSTEM);
         filesystemMetadata.keySet().forEach(k -> {
           GenericRecord v = filesystemMetadata.get(k);
-          filesystemMetadata.put(k.toString(), new HoodieMetadataFileInfo((Long)v.get("size"), (Boolean)v.get("isDeleted")));
+          filesystemMetadata.put(k.toString(), new HoodieMetadataFileInfo((Long) v.get("size"), (Boolean) v.get(
+              "isDeleted")));
         });
+      }
+
+      if (type == METADATA_TYPE_BLOOM_FILTER) {
+        final String FIELD_VERSION = "version";
+        final String FIELD_TIMESTAMP = "timestamp";
+        final String FIELD_BLOOM_FILTER = "bloomfilter";
+        final String FIELD_VALID = "valid";
+
+        final GenericRecord metadataRecord = (GenericRecord) record.get().get(METADATA_RECORD_BLOOM_FILTER);
+        if (metadataRecord == null) {
+          throw new HoodieMetadataException("Valid " + METADATA_RECORD_BLOOM_FILTER + " record expected for type: " + METADATA_TYPE_BLOOM_FILTER);
+        }
+        bloomFilterMetadata = new HoodieMetadataBloomFilter(
+            (Integer) metadataRecord.get(FIELD_VERSION),
+            (String) metadataRecord.get(FIELD_TIMESTAMP),
+            (ByteBuffer) metadataRecord.get(FIELD_BLOOM_FILTER),
+            (Boolean) metadataRecord.get(FIELD_VALID)
+        );
       }
     }
   }
 
   private HoodieMetadataPayload(String key, int type, Map<String, HoodieMetadataFileInfo> filesystemMetadata) {
+    this(key, type, filesystemMetadata, null);
+  }
+
+  private HoodieMetadataPayload(String key, int type, HoodieMetadataBloomFilter metadataBloomFilter) {
+    this(key, type, null, metadataBloomFilter);
+  }
+
+  private HoodieMetadataPayload(String key, int type,
+                                Map<String, HoodieMetadataFileInfo> filesystemMetadata,
+                                HoodieMetadataBloomFilter metadataBloomFilter) {
     this.key = key;
     this.type = type;
     this.filesystemMetadata = filesystemMetadata;
+    this.bloomFilterMetadata = metadataBloomFilter;
   }
 
   /**
@@ -103,55 +154,84 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    */
   public static HoodieRecord<HoodieMetadataPayload> createPartitionListRecord(List<String> partitions) {
     Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
-    partitions.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L,  false)));
+    partitions.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L, false)));
 
     HoodieKey key = new HoodieKey(RECORDKEY_PARTITION_LIST, MetadataPartitionType.FILES.partitionPath());
-    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), PARTITION_LIST, fileInfo);
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), METADATA_TYPE_PARTITION_LIST,
+        fileInfo, null);
     return new HoodieRecord<>(key, payload);
   }
 
   /**
    * Create and return a {@code HoodieMetadataPayload} to save list of files within a partition.
    *
-   * @param partition The name of the partition
-   * @param filesAdded Mapping of files to their sizes for files which have been added to this partition
+   * @param partition    The name of the partition
+   * @param filesAdded   Mapping of files to their sizes for files which have been added to this partition
    * @param filesDeleted List of files which have been deleted from this partition
    */
   public static HoodieRecord<HoodieMetadataPayload> createPartitionFilesRecord(String partition,
-                                                                               Option<Map<String, Long>> filesAdded, Option<List<String>> filesDeleted) {
+                                                                               Option<Map<String, Long>> filesAdded,
+                                                                               Option<List<String>> filesDeleted) {
     Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
     filesAdded.ifPresent(
         m -> m.forEach((filename, size) -> fileInfo.put(filename, new HoodieMetadataFileInfo(size, false))));
     filesDeleted.ifPresent(
-        m -> m.forEach(filename -> fileInfo.put(filename, new HoodieMetadataFileInfo(0L,  true))));
+        m -> m.forEach(filename -> fileInfo.put(filename, new HoodieMetadataFileInfo(0L, true))));
 
     HoodieKey key = new HoodieKey(partition, MetadataPartitionType.FILES.partitionPath());
-    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), FILE_LIST, fileInfo);
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), METADATA_TYPE_FILE_LIST, fileInfo,
+        null);
     return new HoodieRecord<>(key, payload);
+  }
+
+  /**
+   * Create bloom filter metadata record.
+   *
+   * @param fileID      - FileID for which the bloom filter needs to persisted
+   * @param timestamp   - Instant timestamp responsible for this record
+   * @param bloomFilter - Bloom filter for the File
+   * @param isValid     - Is the valid and the bloom filter valid
+   * @return Metadata payload containing the fileID and its bloom filter record
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createBloomFilterMetadataRecord(final FileID fileID,
+                                                                                    final String timestamp,
+                                                                                    final ByteBuffer bloomFilter,
+                                                                                    final boolean isValid) {
+    HoodieKey key = new HoodieKey(fileID.asBase64EncodedString(), MetadataPartitionType.BLOOM_FILTERS.partitionPath());
+
+    HoodieMetadataBloomFilter metadataBloomFilter =
+        new HoodieMetadataBloomFilter(HoodieMetadataBloomFilterUtil.VERSION_METADATA_BLOOM_FILTER,
+            timestamp, bloomFilter, isValid);
+    HoodieMetadataPayload metadataPayload = new HoodieMetadataPayload(key.getRecordKey(),
+        HoodieMetadataPayload.METADATA_TYPE_BLOOM_FILTER, metadataBloomFilter);
+    return new HoodieRecord<>(key, metadataPayload);
   }
 
   @Override
   public HoodieMetadataPayload preCombine(HoodieMetadataPayload previousRecord) {
     ValidationUtils.checkArgument(previousRecord.type == type,
-        "Cannot combine " + previousRecord.type  + " with " + type);
-
-    Map<String, HoodieMetadataFileInfo> combinedFileInfo = null;
+        "Cannot combine " + previousRecord.type + " with " + type);
 
     switch (type) {
-      case PARTITION_LIST:
-      case FILE_LIST:
-        combinedFileInfo = combineFilesystemMetadata(previousRecord);
-        break;
+      case METADATA_TYPE_PARTITION_LIST:
+      case METADATA_TYPE_FILE_LIST:
+        Map<String, HoodieMetadataFileInfo> combinedFileInfo = combineFilesystemMetadata(previousRecord);
+        return new HoodieMetadataPayload(key, type, combinedFileInfo);
+      case METADATA_TYPE_BLOOM_FILTER:
+        HoodieMetadataBloomFilter combineBloomFilterMetadata = combineBloomFilterMetadata(previousRecord);
+        return new HoodieMetadataPayload(key, type, combineBloomFilterMetadata);
       default:
         throw new HoodieMetadataException("Unknown type of HoodieMetadataPayload: " + type);
     }
+  }
 
-    return new HoodieMetadataPayload(key, type, combinedFileInfo);
+  private HoodieMetadataBloomFilter combineBloomFilterMetadata(HoodieMetadataPayload previousRecord) {
+    return this.bloomFilterMetadata;
   }
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord oldRecord, Schema schema) throws IOException {
-    HoodieMetadataPayload anotherPayload = new HoodieMetadataPayload(Option.of((GenericRecord)oldRecord));
+    HoodieMetadataPayload anotherPayload = new HoodieMetadataPayload(Option.of((GenericRecord) oldRecord));
     HoodieRecordPayload combinedPayload = preCombine(anotherPayload);
     return combinedPayload.getInsertValue(schema);
   }
@@ -162,7 +242,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
       return Option.empty();
     }
 
-    HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata);
+    HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata, bloomFilterMetadata);
     return Option.of(record);
   }
 
@@ -178,6 +258,17 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    */
   public List<String> getDeletions() {
     return filterFileInfoEntries(true).map(Map.Entry::getKey).sorted().collect(Collectors.toList());
+  }
+
+  /**
+   * Get the bloom filter metadata from this payload.
+   */
+  public Option<HoodieMetadataBloomFilter> getBloomFilterMetadata() {
+    if (bloomFilterMetadata == null) {
+      return Option.empty();
+    }
+
+    return Option.of(bloomFilterMetadata);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -75,10 +75,10 @@ import static org.apache.hudi.metadata.HoodieTableMetadata.RECORDKEY_PARTITION_L
 public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadataPayload> {
   // Type of the record. This can be an enum in the schema but Avro1.8
   // has a bug - https://issues.apache.org/jira/browse/AVRO-1810
-  private static final int METADATA_TYPE_PARTITION_LIST = 1;
-  private static final int METADATA_TYPE_FILE_LIST = 2;
-  //private static final int METADATA_TYPE_COLUMN_STATS = 3;
-  private static final int METADATA_TYPE_BLOOM_FILTER = 4;
+  protected static final int METADATA_TYPE_PARTITION_LIST = 1;
+  protected static final int METADATA_TYPE_FILE_LIST = 2;
+  //protected static final int METADATA_TYPE_COLUMN_STATS = 3;
+  protected static final int METADATA_TYPE_BLOOM_FILTER = 4;
 
   // Various metadata type record names in the payload
   private static final String METADATA_RECORD_FILESYSTEM = "filesystemMetadata";
@@ -138,9 +138,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     this(key, type, null, metadataBloomFilter);
   }
 
-  private HoodieMetadataPayload(String key, int type,
-                                Map<String, HoodieMetadataFileInfo> filesystemMetadata,
-                                HoodieMetadataBloomFilter metadataBloomFilter) {
+  protected HoodieMetadataPayload(String key, int type,
+                                  Map<String, HoodieMetadataFileInfo> filesystemMetadata,
+                                  HoodieMetadataBloomFilter metadataBloomFilter) {
     this.key = key;
     this.type = type;
     this.filesystemMetadata = filesystemMetadata;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -25,9 +25,12 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -102,6 +105,24 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * Fetch all files for given partition paths.
    */
   Map<String, FileStatus[]> getAllFilesInPartitions(List<String> partitionPaths) throws IOException;
+
+  /**
+   * Get the bloom filter for the FileID from the metadata table.
+   *
+   * @param fileID - FileID for which bloom filter needs to be retrieved
+   * @return BloomFilter byte buffer if available, otherwise empty
+   * @throws HoodieMetadataException
+   */
+  Option<ByteBuffer> getBloomFilter(final FileID fileID) throws HoodieMetadataException;
+
+  /**
+   * Get bloom filters for the list of FileIDs from the metadata table.
+   *
+   * @param fileIDList - List of FileIDs for which bloom filters need to be retrieved
+   * @return Map of FileID to its bloom filter byte buffer
+   * @throws HoodieMetadataException
+   */
+  Map<String, ByteBuffer> getBloomFilters(final List<FileID> fileIDList) throws HoodieMetadataException;
 
   /**
    * Get the instant time to which the metadata is synced w.r.t data timeline.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -25,7 +26,9 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
@@ -113,16 +116,26 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * @return BloomFilter byte buffer if available, otherwise empty
    * @throws HoodieMetadataException
    */
-  Option<ByteBuffer> getBloomFilter(final FileID fileID) throws HoodieMetadataException;
+  Option<ByteBuffer> getBloomFilter(final PartitionID partitionID, final FileID fileID) throws HoodieMetadataException;
 
   /**
    * Get bloom filters for the list of FileIDs from the metadata table.
    *
-   * @param fileIDList - List of FileIDs for which bloom filters need to be retrieved
+   * @param partitionIDFileIDList - List of FileIDs for which bloom filters need to be retrieved
    * @return Map of FileID to its bloom filter byte buffer
    * @throws HoodieMetadataException
    */
-  Map<String, ByteBuffer> getBloomFilters(final List<FileID> fileIDList) throws HoodieMetadataException;
+  Map<String, ByteBuffer> getBloomFilters(final List<Pair<PartitionID, FileID>> partitionIDFileIDList) throws HoodieMetadataException;
+
+  /**
+   * TODO: Comment.
+   *
+   * @param keyList
+   * @param keySet
+   * @return
+   * @throws HoodieMetadataException
+   */
+  Map<String, HoodieColumnStats> getColumnStats(final List<String> keySet) throws HoodieMetadataException;
 
   /**
    * Get the instant time to which the metadata is synced w.r.t data timeline.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -22,6 +22,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodieList;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -45,6 +46,7 @@ import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieMetadataException;
 
@@ -221,7 +223,7 @@ public class HoodieTableMetadataUtil {
         String pathWithPartition = hoodieWriteStat.getPath();
         if (pathWithPartition == null) {
           // Empty partition
-          LOG.warn("Unable to find path in write stat to update metadata table " + hoodieWriteStat);
+          LOG.error("Failed to find path in write stat to update metadata table " + hoodieWriteStat);
           return;
         }
 
@@ -233,14 +235,18 @@ public class HoodieTableMetadataUtil {
 
         Path writeFilePath = new Path(dataMetaClient.getBasePath(), pathWithPartition);
         try {
-          // TODO:
           HoodieFileReader<IndexedRecord> fileReader =
               HoodieFileReaderFactory.getFileReader(dataMetaClient.getHadoopConf(), writeFilePath);
-          ByteBuffer bloomByteBuffer = ByteBuffer.wrap(fileReader.readBloomFilter().serializeToString().getBytes());
+          final BloomFilter fileBloomFilter = fileReader.readBloomFilter();
+          if (fileBloomFilter == null) {
+            LOG.error("Failed to read bloom filter for " + writeFilePath);
+            return;
+          }
+          ByteBuffer bloomByteBuffer = ByteBuffer.wrap(fileBloomFilter.serializeToString().getBytes());
 
           // TODO: Improve the schema to include the filter type also
           HoodieRecord record = HoodieMetadataPayload.createBloomFilterMetadataRecord(
-              new FileID(filename), instantTime, bloomByteBuffer, true);
+              new PartitionID(partition), new FileID(filename), instantTime, bloomByteBuffer, true);
 
           records.add(record);
           fileReader.close();
@@ -604,9 +610,11 @@ public class HoodieTableMetadataUtil {
       return Collections.emptyList();
     }
 
+    // Considering only HoodieRecord.RECORD_KEY_METADATA_FIELD for index lookup
+    // TODO: Use all latest columns for full col index build and lookup
     return engineContext.flatMap(allWriteStats,
         writeStat -> translateWriteStatToColumnStats(writeStat, datasetMetaClient,
-            Option.of(getLatestColumns(datasetMetaClient))), allWriteStats.size());
+            Option.of(Collections.singletonList(HoodieRecord.RECORD_KEY_METADATA_FIELD))), allWriteStats.size());
   }
 
   private static List<String> getLatestColumns(HoodieTableMetaClient datasetMetaClient) throws Exception {
@@ -627,7 +635,7 @@ public class HoodieTableMetadataUtil {
     return getColumnStats(writeStat.getPartitionPath(), writeStat.getPath(), datasetMetaClient, latestColumns, false);
   }
 
-  public static Stream<HoodieRecord> getColumnStats(final String partitionpath, final String path,
+  public static Stream<HoodieRecord> getColumnStats(final String partitionPath, final String path,
                                                     HoodieTableMetaClient datasetMetaClient,
                                                     Option<List<String>> latestColumns,
                                                     boolean isDeleted) throws Exception {
@@ -637,10 +645,11 @@ public class HoodieTableMetadataUtil {
       Collection<HoodieColumnStatsMetadata<Comparable>> columnStatsMetadata = new ArrayList<>();
       if (!isDeleted) {
         columnStatsMetadata = new ParquetUtils().readColumnStatsFromParquetMetadata(
-            datasetMetaClient.getHadoopConf(), partitionpath, new Path(datasetMetaClient.getBasePath(), path));
+            datasetMetaClient.getHadoopConf(), partitionPath, new Path(datasetMetaClient.getBasePath(), path),
+            latestColumns);
       } else {
         columnStatsMetadata =
-            latestColumns.get().stream().map(entry -> new HoodieColumnStatsMetadata<Comparable>(partitionpath, path,
+            latestColumns.get().stream().map(entry -> new HoodieColumnStatsMetadata<Comparable>(partitionPath, path,
                 entry, null, null, true)).collect(Collectors.toList());
       }
       return HoodieMetadataPayload.createColumnStatsRecords(columnStatsMetadata);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -215,6 +215,7 @@ public class HoodieTableMetadataUtil {
 
         Path writeFilePath = new Path(dataMetaClient.getBasePath(), pathWithPartition);
         try {
+          // TODO:
           HoodieFileReader<IndexedRecord> fileReader =
               HoodieFileReaderFactory.getFileReader(dataMetaClient.getHadoopConf(), writeFilePath);
           ByteBuffer bloomByteBuffer = ByteBuffer.wrap(fileReader.readBloomFilter().serializeToString().getBytes());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 public enum MetadataPartitionType {
   FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 1),
-  COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 10),
-  BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-", 100);
+  // COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 1),
+  BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-", 10);
 
   // Partition path in metadata table.
   private final String partitionPath;
@@ -36,7 +36,7 @@ public enum MetadataPartitionType {
   MetadataPartitionType(final String partitionPath, final String fileIdPrefix, final int fileGroupCount) {
     this.partitionPath = partitionPath;
     this.fileIdPrefix = fileIdPrefix;
-    this.fileGroupCount = getFileGroupCount();
+    this.fileGroupCount = fileGroupCount;
   }
 
   public String partitionPath() {
@@ -58,7 +58,7 @@ public enum MetadataPartitionType {
   public static List<String> all() {
     return Arrays.asList(
         FILES.partitionPath(),
-        COLUMN_STATS.partitionPath(),
+        //COLUMN_STATS.partitionPath(),
         BLOOM_FILTERS.partitionPath
     );
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public enum MetadataPartitionType {
   FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 1),
-  // COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 1),
+  COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 10),
   BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-", 10);
 
   // Partition path in metadata table.
@@ -58,7 +58,7 @@ public enum MetadataPartitionType {
   public static List<String> all() {
     return Arrays.asList(
         FILES.partitionPath(),
-        //COLUMN_STATS.partitionPath(),
+        COLUMN_STATS.partitionPath(),
         BLOOM_FILTERS.partitionPath
     );
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -22,29 +22,44 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum MetadataPartitionType {
-  FILES("files", "files-"),
-  COLUMN_STATS("column_stats", "col-stats-"),
-  BLOOM_FILTERS("bloom_filters", "bloom-filters-");
+  FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 1),
+  COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 10),
+  BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-", 100);
 
-  // refers to partition path in metadata table.
+  // Partition path in metadata table.
   private final String partitionPath;
-  // refers to fileId prefix used for all file groups in this partition.
+  // FileId prefix used for all file groups in this partition.
   private final String fileIdPrefix;
+  // Total file groups
+  private final int fileGroupCount;
 
-  MetadataPartitionType(String partitionPath, String fileIdPrefix) {
+  MetadataPartitionType(final String partitionPath, final String fileIdPrefix, final int fileGroupCount) {
     this.partitionPath = partitionPath;
     this.fileIdPrefix = fileIdPrefix;
+    this.fileGroupCount = getFileGroupCount();
   }
 
   public String partitionPath() {
     return partitionPath;
   }
 
+  public String getPartitionPath() {
+    return partitionPath();
+  }
+
   public String getFileIdPrefix() {
     return fileIdPrefix;
   }
 
+  public int getFileGroupCount() {
+    return this.fileGroupCount;
+  }
+
   public static List<String> all() {
-    return Arrays.asList(MetadataPartitionType.FILES.partitionPath());
+    return Arrays.asList(
+        FILES.partitionPath(),
+        COLUMN_STATS.partitionPath(),
+        BLOOM_FILTERS.partitionPath
+    );
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -22,7 +22,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum MetadataPartitionType {
-  FILES("files", "files-");
+  FILES("files", "files-"),
+  COLUMN_STATS("column_stats", "col-stats-"),
+  BLOOM_FILTERS("bloom_filters", "bloom-filters-");
 
   // refers to partition path in metadata table.
   private final String partitionPath;


### PR DESCRIPTION
## What is the purpose of the pull request

- Today, base files have bloom filter at their footers and index lookups
  have to load the base file to perform any bloom lookups. Though we have
  interval tree based file purging, we still end up in significant amount
  of base file read for the bloom filter for the end index lookups for the
  keys. This index lookup operation can be made more performant by having
  all the bloom filters in a new metadata partition and doing pointed
  lookups based on keys.

- This PR adds the basic infrastructure for initializing the new bloom filter
  metadata partition, stubs for write and read code paths


## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
