### PR TITLE
Fixed RAT config for "hudi-utilities-bundle" to ignore transient build-bound artifiacts

### DIFF
--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -36,6 +36,28 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludeSubProjects>false</excludeSubProjects>
+          <numUnapprovedLicenses>0</numUnapprovedLicenses>
+          <excludes>
+            <exclude>NOTICE</exclude>
+            <exclude>DISCLAIMER</exclude>
+            <exclude>**/.*</exclude>
+            <exclude>**/*.json</exclude>
+            <exclude>**/*.log</exclude>
+            <exclude>**/*.sqltemplate</exclude>
+            <exclude>**/compose_env</exclude>
+            <exclude>**/*NOTICE*</exclude>
+            <exclude>**/*LICENSE*</exclude>
+            <exclude>**/dependency-reduced-pom.xml</exclude>
+            <exclude>**/test/resources/*.data</exclude>
+            <exclude>**/test/resources/*.commit</exclude>
+            <exclude>**/target/**</exclude>
+            <exclude>**/generated-sources/**</exclude>
+            <exclude>.github/**</exclude>
+            <exclude>**/*.sql</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

This PR fixes RAT Maven plugin configuration to make sure that running `mvn clean package install` isn't having issues with RAT plugin complaining about transient files lacking Apache license attribution

Example failure when running `mvn clean package -DskipTests -Dspark3 -Dscala.usejavacp=true`
```
[ERROR] Failed to execute goal org.apache.rat:apache-rat-plugin:0.12:check (default) on project hudi-utilities-bundle_2.12: Too many files with unapproved license: 4 See RAT report in: /Users/alexey.kudinkin/code/github/apache/hudi/packaging/hudi-utilities-bundle/target/rat.txt -> [Help 1]
```

Files RAT is complaining about (lacking the license header)
```
Files with unapproved licenses:

  /Users/alexey.kudinkin/code/github/apache/hudi/packaging/hudi-utilities-bundle/target/rat.txt
  /Users/alexey.kudinkin/code/github/apache/hudi/packaging/hudi-utilities-bundle/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
  /Users/alexey.kudinkin/code/github/apache/hudi/packaging/hudi-utilities-bundle/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
  /Users/alexey.kudinkin/code/github/apache/hudi/packaging/hudi-utilities-bundle/target/maven-archiver/pom.properties
```

## Brief change log

- Fixing RAT plugin config, replicating one from root `pom.xml` (stripping license configuration part)

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

This change verified with running successfully `mvn clean package -DskipTests -Dspark3 -Dscala.usejavacp=true`

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
