### PR TITLE
[HUDI-2665] Fix overflow of huge log file in HoodieLogFormatWriter

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -148,10 +148,11 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     HoodieLogFormat.LogFormatVersion currentLogFormatVersion =
         new HoodieLogFormatVersion(HoodieLogFormat.CURRENT_VERSION);
 
-    FSDataOutputStream outputStream = getOutputStream();
-    long startPos = outputStream.getPos();
+    FSDataOutputStream originalOutputStream = getOutputStream();
+    long startPos = originalOutputStream.getPos();
     long sizeWritten = 0;
-
+    // HUDI-2655. here we wrap originalOutputStream to ensure huge blocks can be correctly written
+    FSDataOutputStream outputStream = new FSDataOutputStream(originalOutputStream, new FileSystem.Statistics(fs.getScheme()), startPos);
     for (HoodieLogBlock block: blocks) {
       long startSize = outputStream.size();
 
@@ -189,6 +190,11 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       outputStream.writeLong(outputStream.size() - startSize);
 
       // Fetch the size again, so it accounts also (9).
+
+      // HUDI-2655. Check the size written to avoid log blocks whose size overflow.
+      if (outputStream.size() == Integer.MAX_VALUE) {
+        throw new HoodieIOException("Blocks appended may overflow. Please decrease log block size or log block amount");
+      }
       sizeWritten +=  outputStream.size() - startSize;
     }
     // Flush all blocks to disk


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

https://issues.apache.org/jira/browse/HUDI-2665

## Brief change log

Allow HoodieLogFormatWriter to append at most 2GB data once call to appendBlock. And add a check to prevent huge block written

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
