### PR TITLE
[HUDI-2706] refactor spark-sql to make consistent with DataFrame api

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
@@ -113,7 +113,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     Object persistedOrderingVal = getNestedFieldVal((GenericRecord) currentValue,
         properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY), true);
     Comparable incomingOrderingVal = (Comparable) getNestedFieldVal((GenericRecord) incomingRecord,
-        properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY), false);
+        properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY), true);
     return persistedOrderingVal == null || ((Comparable) persistedOrderingVal).compareTo(incomingOrderingVal) <= 0;
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -145,7 +145,7 @@ object HoodieSparkSqlWriter {
           .setPartitionFields(partitionColumns)
           .setPopulateMetaFields(populateMetaFields)
           .setRecordKeyFields(hoodieConfig.getString(RECORDKEY_FIELD))
-          .setKeyGeneratorClassProp(HoodieWriterUtils.getRealKeyGenerator(hoodieConfig))
+          .setKeyGeneratorClassProp(HoodieWriterUtils.getOriginKeyGenerator(parameters))
           .setHiveStylePartitioningEnable(hoodieConfig.getBoolean(HIVE_STYLE_PARTITIONING))
           .setUrlEncodePartitioning(hoodieConfig.getBoolean(URL_ENCODE_PARTITIONING))
           .initTable(sparkContext.hadoopConfiguration, path)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -116,7 +116,9 @@ object HoodieWriterUtils {
     }
   }
 
-  // Detects conflicts between new parameters and existing table configurations
+  /**
+   * Detects conflicts between new parameters and existing table configurations
+   */
   def validateTableConfig(spark: SparkSession, params: Map[String, String],
       tableConfig: HoodieConfig): Unit = {
     val resolver = spark.sessionState.conf.resolver

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -17,15 +17,19 @@
 
 package org.apache.hudi
 
+import java.util.Properties
+
+import org.apache.hudi.DataSourceOptionsHelper.allAlternatives
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE
 import org.apache.hudi.common.config.{HoodieConfig, TypedProperties}
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.exception.HoodieException
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hudi.command.SqlKeyGenerator
 
-import java.util.Properties
 import scala.collection.JavaConversions.mapAsJavaMap
-import scala.collection.JavaConverters.{mapAsScalaMapConverter, _}
-import scala.collection.JavaConverters.mapAsScalaMapConverter
-import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory
+import scala.collection.JavaConverters._
 
 /**
  * WriterUtils to assist in write path in Datasource and tests.
@@ -101,5 +105,74 @@ object HoodieWriterUtils {
     val properties = new Properties()
     properties.putAll(mapAsJavaMap(parameters))
     new HoodieConfig(properties)
+  }
+
+  def getRealKeyGenerator(hoodieConfig: HoodieConfig): String = {
+    val kg = hoodieConfig.getString(KEYGENERATOR_CLASS_NAME.key())
+    if (classOf[SqlKeyGenerator].getCanonicalName == kg) {
+      hoodieConfig.getString(SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME)
+    } else {
+      kg
+    }
+  }
+
+  // Detects conflicts between new parameters and existing table configurations
+  def validateTableConfig(spark: SparkSession, params: Map[String, String],
+      tableConfig: HoodieConfig): Unit = {
+    val resolver = spark.sessionState.conf.resolver
+    val diffConfigs = StringBuilder.newBuilder
+    params.foreach { case (key, value) =>
+      val existingValue = getStringFromTableConfigWithAlternatives(tableConfig, key)
+      if (null != existingValue && !resolver(existingValue, value)) {
+        diffConfigs.append(s"$key:\t$value\t${tableConfig.getString(key)}\n")
+      }
+    }
+
+    if (null != tableConfig) {
+      val datasourceRecordKey = params.getOrElse(RECORDKEY_FIELD.key(), null)
+      val tableConfigRecordKey = tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS)
+      if (null != datasourceRecordKey && null != tableConfigRecordKey
+          && datasourceRecordKey != tableConfigRecordKey) {
+        diffConfigs.append(s"RecordKey:\t$datasourceRecordKey\t$tableConfigRecordKey\n")
+      }
+
+      val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)
+      val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELD)
+      if (null != datasourcePreCombineKey && null != tableConfigPreCombineKey
+          && datasourcePreCombineKey != tableConfigPreCombineKey) {
+        diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
+      }
+
+      val datasourceKeyGen = {
+        val kg = params.getOrElse(KEYGENERATOR_CLASS_NAME.key(), null)
+        if (classOf[SqlKeyGenerator].getCanonicalName == kg) {
+          params.getOrElse(SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME, null)
+        } else {
+          kg
+        }
+      }
+      val tableConfigKeyGen = tableConfig.getString(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME)
+      if (null != datasourceKeyGen && null != tableConfigKeyGen
+          && datasourceKeyGen != tableConfigKeyGen) {
+        diffConfigs.append(s"KeyGenerator:\t$datasourceKeyGen\t$tableConfigKeyGen\n")
+      }
+    }
+
+    if (diffConfigs.nonEmpty) {
+      diffConfigs.insert(0, "\nConfig conflict(key\tcurrent value\texisting value):\n")
+      throw new HoodieException(diffConfigs.toString.trim)
+    }
+  }
+
+  private def getStringFromTableConfigWithAlternatives(tableConfig: HoodieConfig, key: String): String = {
+    if (null == tableConfig) {
+      null
+    } else {
+      if (allAlternatives.contains(key)) {
+        tableConfig.getString(allAlternatives(key))
+      } else {
+        tableConfig.getString(key)
+      }
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -107,10 +107,10 @@ object HoodieWriterUtils {
     new HoodieConfig(properties)
   }
 
-  def getRealKeyGenerator(hoodieConfig: HoodieConfig): String = {
-    val kg = hoodieConfig.getString(KEYGENERATOR_CLASS_NAME.key())
+  def getOriginKeyGenerator(parameters: Map[String, String]): String = {
+    val kg = parameters.getOrElse(KEYGENERATOR_CLASS_NAME.key(), null)
     if (classOf[SqlKeyGenerator].getCanonicalName == kg) {
-      hoodieConfig.getString(SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME)
+      parameters.getOrElse(SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME, null)
     } else {
       kg
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -145,14 +145,7 @@ object HoodieWriterUtils {
         diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
       }
 
-      val datasourceKeyGen = {
-        val kg = params.getOrElse(KEYGENERATOR_CLASS_NAME.key(), null)
-        if (classOf[SqlKeyGenerator].getCanonicalName == kg) {
-          params.getOrElse(SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME, null)
-        } else {
-          kg
-        }
-      }
+      val datasourceKeyGen = getOriginKeyGenerator(params)
       val tableConfigKeyGen = tableConfig.getString(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME)
       if (null != datasourceKeyGen && null != tableConfigKeyGen
           && datasourceKeyGen != tableConfigKeyGen) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
@@ -107,7 +107,7 @@ object HoodieOptionConfig {
 
   private lazy val reverseValueMapping = valueMapping.map(f => f._2 -> f._1)
 
-  def withDefaultSqlOption(options: Map[String, String]): Map[String, String] = defaultSqlOption ++ options
+  def withDefaultSqlOptions(options: Map[String, String]): Map[String, String] = defaultSqlOptions ++ options
 
   /**
    * Mapping the sql's short name key/value in the options to the hoodie's config key/value.
@@ -142,7 +142,7 @@ object HoodieOptionConfig {
     options.map(kv => tableConfigKeyToSqlKey.getOrElse(kv._1, kv._1) -> reverseValueMapping.getOrElse(kv._2, kv._2))
   }
 
-  private lazy val defaultSqlOption: Map[String, String] = {
+  private lazy val defaultSqlOptions: Map[String, String] = {
     HoodieOptionConfig.getClass.getDeclaredFields
       .filter(f => f.getType == classOf[HoodieOption[_]])
       .map(f => {f.setAccessible(true); f.get(HoodieOptionConfig).asInstanceOf[HoodieOption[_]]})
@@ -152,7 +152,7 @@ object HoodieOptionConfig {
   }
 
   private lazy val defaultTableConfig: Map[String, String] = {
-    mappingSqlOptionToHoodieParam(defaultSqlOption)
+    mappingSqlOptionToHoodieParam(defaultSqlOptions)
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
@@ -199,8 +199,7 @@ object HoodieOptionConfig {
 
     // validate primary key
     val primaryKeys = options.get(SQL_KEY_TABLE_PRIMARY_KEY.sqlKeyName)
-      .map(_.split(",")
-      .filter(_.length > 0))
+      .map(_.split(",").filter(_.length > 0))
     ValidationUtils.checkArgument(primaryKeys.nonEmpty, "No `primaryKey` is specified.")
     primaryKeys.get.foreach { primaryKey =>
       ValidationUtils.checkArgument(schema.exists(f => resolver(f.name, primaryKey)),
@@ -216,7 +215,7 @@ object HoodieOptionConfig {
 
     // validate table type
     val tableType = options.get(SQL_KEY_TABLE_TYPE.sqlKeyName)
-    ValidationUtils.checkArgument(tableType.nonEmpty, "No `tableType` is specified.")
+    ValidationUtils.checkArgument(tableType.nonEmpty, "No `type` is specified.")
     ValidationUtils.checkArgument(
       tableType.get.equalsIgnoreCase(HoodieOptionConfig.SQL_VALUE_TABLE_TYPE_COW) ||
       tableType.get.equalsIgnoreCase(HoodieOptionConfig.SQL_VALUE_TABLE_TYPE_MOR),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlUtils.scala
@@ -90,7 +90,7 @@ object HoodieSqlUtils extends SparkAdapterSupport {
     val sparkEngine = new HoodieSparkEngineContext(new JavaSparkContext(spark.sparkContext))
     val metadataConfig = {
       val properties = new Properties()
-      properties.putAll((spark.sessionState.conf.getAllConfs ++ table.storage.properties).asJava)
+      properties.putAll((spark.sessionState.conf.getAllConfs ++ table.storage.properties ++ table.properties).asJava)
       HoodieMetadataConfig.newBuilder.fromProperties(properties).build()
     }
     FSUtils.getAllPartitionPaths(sparkEngine, metadataConfig, getTableLocation(table, spark)).asScala

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -202,8 +202,9 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
           val targetTableId = getMergeIntoTargetTableId(mergeInto)
           val targetTable =
             sparkSession.sessionState.catalog.getTableMetadata(targetTableId)
-          val targetTableType = HoodieOptionConfig.getTableType(targetTable.storage.properties)
-          val preCombineField = HoodieOptionConfig.getPreCombineField(targetTable.storage.properties)
+          val tblProperties = targetTable.storage.properties ++ targetTable.properties
+          val targetTableType = HoodieOptionConfig.getTableType(tblProperties)
+          val preCombineField = HoodieOptionConfig.getPreCombineField(tblProperties)
 
           // Get the map of target attribute to value of the update assignments.
           val target2Values = resolvedAssignments.map {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
@@ -105,8 +105,13 @@ object AlterHoodieTableAddColumnsCommand {
     val path = getTableLocation(table, sparkSession)
 
     val jsc = new JavaSparkContext(sparkSession.sparkContext)
-    val client = DataSourceUtils.createHoodieClient(jsc, schema.toString,
-      path, table.identifier.table, HoodieWriterUtils.parametersWithWriteDefaults(table.storage.properties).asJava)
+    val client = DataSourceUtils.createHoodieClient(
+      jsc,
+      schema.toString,
+      path,
+      table.identifier.table,
+      HoodieWriterUtils.parametersWithWriteDefaults(table.storage.properties ++ table.properties).asJava
+    )
 
     val hadoopConf = sparkSession.sessionState.newHadoopConf()
     val metaClient = HoodieTableMetaClient.builder().setBasePath(path).setConf(hadoopConf).build()

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableDropPartitionCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableDropPartitionCommand.scala
@@ -92,7 +92,7 @@ extends RunnableCommand {
       .build()
     val tableConfig = metaClient.getTableConfig
 
-    val optParams = withSparkConf(sparkSession, table.storage.properties) {
+    withSparkConf(sparkSession, table.storage.properties) {
       Map(
         "path" -> path,
         TBL_NAME.key -> tableIdentifier.table,
@@ -104,10 +104,6 @@ extends RunnableCommand {
         PARTITIONPATH_FIELD.key -> tableConfig.getPartitionFieldProp
       )
     }
-
-    val parameters = HoodieWriterUtils.parametersWithWriteDefaults(optParams)
-    val translatedOptions = DataSourceWriteOptions.translateSqlOptions(parameters)
-    translatedOptions
   }
 
   def normalizePartitionSpec[T](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -102,7 +102,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
     // if CTAS, we treat the table we just created as nonexistent
     val isTableExists = if (ctas) false else tableExistsInPath(path, conf)
     var existingTableConfig = Map.empty[String, String]
-    val sqlOptions = HoodieOptionConfig.withDefaultSqlOption(tblProperties)
+    val sqlOptions = HoodieOptionConfig.withDefaultSqlOptions(tblProperties)
     val catalogTableProps = HoodieOptionConfig.mappingSqlOptionToTableConfig(tblProperties)
 
     // get final schema and parameters

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -75,7 +75,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
     }
 
     // get schema with meta fields, table config if hudi table exists, options including
-    // table configs and properties of the catalog tabe
+    // table configs and properties of the catalog table
     val path = getTableLocation(table, sparkSession)
     val (finalSchema, existingTableConfig, tableSqlOptions) = parseSchemaAndConfigs(sparkSession, path)
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.command
 import org.apache.avro.Schema
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
 import org.apache.hudi.hive.MultiPartKeysValueExtractor
@@ -80,8 +81,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Runnab
   private lazy val targetTable =
     sparkSession.sessionState.catalog.getTableMetadata(targetTableIdentify)
 
-  private lazy val targetTableType =
-    HoodieOptionConfig.getTableType(targetTable.storage.properties)
+  private lazy val tblProperties = targetTable.storage.properties ++ targetTable.properties
+
+  private lazy val targetTableType = HoodieOptionConfig.getTableType(tblProperties)
 
   /**
    *
@@ -124,7 +126,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Runnab
     assert(updateActions.size <= 1, s"Only support one updateAction currently, current update action count is: ${updateActions.size}")
 
     val updateAction = updateActions.headOption
-    HoodieOptionConfig.getPreCombineField(targetTable.storage.properties).map(preCombineField => {
+    HoodieOptionConfig.getPreCombineField(tblProperties).map(preCombineField => {
       val sourcePreCombineField =
         updateAction.map(u => u.assignments.filter {
             case Assignment(key: AttributeReference, _) => key.name.equalsIgnoreCase(preCombineField)
@@ -242,8 +244,13 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Runnab
     // Append the table schema to the parameters. In the case of merge into, the schema of sourceDF
     // may be different from the target table, because the are transform logical in the update or
     // insert actions.
+    val opertion = if (StringUtils.isNullOrEmpty(parameters.getOrElse(PRECOMBINE_FIELD.key, ""))) {
+      INSERT_OPERATION_OPT_VAL
+    } else {
+      UPSERT_OPERATION_OPT_VAL
+    }
     var writeParams = parameters +
-      (OPERATION.key -> UPSERT_OPERATION_OPT_VAL) +
+      (OPERATION.key -> opertion) +
       (HoodieWriteConfig.WRITE_SCHEMA.key -> getTableSchema.toString) +
       (DataSourceWriteOptions.TABLE_TYPE.key -> targetTableType)
 
@@ -436,38 +443,38 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Runnab
       .setConf(conf)
       .build()
     val tableConfig = metaClient.getTableConfig
-    val options = targetTable.storage.properties
-    val definedPk = HoodieOptionConfig.getPrimaryColumns(options)
-    // TODO Currently the mergeEqualConditionKeys must be the same the primary key.
-    if (targetKey2SourceExpression.keySet != definedPk.toSet) {
-      throw new IllegalArgumentException(s"Merge Key[${targetKey2SourceExpression.keySet.mkString(",")}] is not" +
-        s" Equal to the defined primary key[${definedPk.mkString(",")}] in table $targetTableName")
-    }
+    val tableSchema = getTableSqlSchema(metaClient).get
+    val partitionColumns = tableConfig.getPartitionFieldProp.split(",").map(_.toLowerCase)
+    val partitionSchema = StructType(tableSchema.filter(f => partitionColumns.contains(f.name)))
+    val options = tblProperties
+    val preCombineColumn = Option(tableConfig.getPreCombineField).getOrElse("")
+
     // Enable the hive sync by default if spark have enable the hive metastore.
     val enableHive = isEnableHive(sparkSession)
     withSparkConf(sparkSession, options) {
       Map(
         "path" -> path,
-        RECORDKEY_FIELD.key -> targetKey2SourceExpression.keySet.mkString(","),
-        PRECOMBINE_FIELD.key -> targetKey2SourceExpression.keySet.head, // set a default preCombine field
+        RECORDKEY_FIELD.key -> tableConfig.getRecordKeyFieldProp,
+        PRECOMBINE_FIELD.key -> preCombineColumn,
         TBL_NAME.key -> targetTableName,
-        PARTITIONPATH_FIELD.key -> targetTable.partitionColumnNames.mkString(","),
+        PARTITIONPATH_FIELD.key -> tableConfig.getPartitionFieldProp,
         PAYLOAD_CLASS_NAME.key -> classOf[ExpressionPayload].getCanonicalName,
         HIVE_STYLE_PARTITIONING.key -> tableConfig.getHiveStylePartitioningEnable,
         URL_ENCODE_PARTITIONING.key -> tableConfig.getUrlEncodePartitoning,
-        KEYGENERATOR_CLASS_NAME.key -> tableConfig.getKeyGeneratorClassName,
+        KEYGENERATOR_CLASS_NAME.key -> classOf[SqlKeyGenerator].getCanonicalName,
+        SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME -> tableConfig.getKeyGeneratorClassName,
         META_SYNC_ENABLED.key -> enableHive.toString,
         HIVE_SYNC_MODE.key -> HiveSyncMode.HMS.name(),
         HIVE_USE_JDBC.key -> "false",
         HIVE_DATABASE.key -> targetTableDb,
         HIVE_TABLE.key -> targetTableName,
         HIVE_SUPPORT_TIMESTAMP_TYPE.key -> "true",
-        HIVE_PARTITION_FIELDS.key -> targetTable.partitionColumnNames.mkString(","),
+        HIVE_PARTITION_FIELDS.key -> tableConfig.getPartitionFieldProp,
         HIVE_PARTITION_EXTRACTOR_CLASS.key -> classOf[MultiPartKeysValueExtractor].getCanonicalName,
         HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key -> "200", // set the default parallelism to 200 for sql
         HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key -> "200",
         HoodieWriteConfig.DELETE_PARALLELISM_VALUE.key -> "200",
-        SqlKeyGenerator.PARTITION_SCHEMA -> targetTable.partitionSchema.toDDL
+        SqlKeyGenerator.PARTITION_SCHEMA -> partitionSchema.toDDL
       )
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -244,13 +244,13 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Runnab
     // Append the table schema to the parameters. In the case of merge into, the schema of sourceDF
     // may be different from the target table, because the are transform logical in the update or
     // insert actions.
-    val opertion = if (StringUtils.isNullOrEmpty(parameters.getOrElse(PRECOMBINE_FIELD.key, ""))) {
+    val operation = if (StringUtils.isNullOrEmpty(parameters.getOrElse(PRECOMBINE_FIELD.key, ""))) {
       INSERT_OPERATION_OPT_VAL
     } else {
       UPSERT_OPERATION_OPT_VAL
     }
     var writeParams = parameters +
-      (OPERATION.key -> opertion) +
+      (OPERATION.key -> operation) +
       (HoodieWriteConfig.WRITE_SCHEMA.key -> getTableSchema.toString) +
       (DataSourceWriteOptions.TABLE_TYPE.key -> targetTableType)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
@@ -206,7 +206,7 @@ public class HoodieJavaApp {
         .option(DataSourceWriteOptions.OPERATION().key(), "delete")
         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "_row_key")
+        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
         .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key(),
             nonPartitionedTable ? NonpartitionedKeyGenerator.class.getCanonicalName()
                 : SimpleKeyGenerator.class.getCanonicalName()) // Add Key Extractor

--- a/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
+++ b/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
@@ -18,7 +18,7 @@ set hoodie.delete.shuffle.parallelism = 1;
 
 # CTAS
 
-create table h0 using hudi options(type = '${tableType}')
+create table h0 using hudi options(type = '${tableType}', primaryKey = 'id')
 as select 1 as id, 'a1' as name, 10 as price;
 +----------+
 | ok       |
@@ -30,7 +30,7 @@ select id, name, price from h0;
 +-----------+
 
 create table h0_p using hudi partitioned by(dt)
-options(type = '${tableType}')
+options(type = '${tableType}', primaryKey = 'id')
 as select cast('2021-05-07 00:00:00' as timestamp) as dt,
  1 as id, 'a1' as name, 10 as price;
 +----------+

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/HoodieSparkSqlWriterSuite2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/HoodieSparkSqlWriterSuite2.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.keygen.{ComplexKeyGenerator, SimpleKeyGenerator}
+
+import org.apache.spark.sql.hudi.command.SqlKeyGenerator
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HoodieSparkSqlWriterSuite2 {
+
+  @Test
+  def testGetRealKeyGenerator(): Unit = {
+    // for dataframe write
+    val m1 = Map(
+      HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key -> classOf[ComplexKeyGenerator].getName
+    )
+    val kg1 = HoodieWriterUtils.getOriginKeyGenerator(m1)
+    assertTrue(kg1 == classOf[ComplexKeyGenerator].getName)
+
+    // for sql write
+    val m2 = Map(
+      HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key -> classOf[SqlKeyGenerator].getName,
+      SqlKeyGenerator.ORIGIN_KEYGEN_CLASS_NAME -> classOf[SimpleKeyGenerator].getName
+    )
+    val kg2 = HoodieWriterUtils.getOriginKeyGenerator(m2)
+    assertTrue(kg2 == classOf[SimpleKeyGenerator].getName)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/HoodieSparkSqlWriterSuite2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/HoodieSparkSqlWriterSuite2.scala
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test
 class HoodieSparkSqlWriterSuite2 {
 
   @Test
-  def testGetRealKeyGenerator(): Unit = {
+  def testGetOriginKeyGenerator(): Unit = {
     // for dataframe write
     val m1 = Map(
       HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key -> classOf[ComplexKeyGenerator].getName

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -102,7 +102,10 @@ class TestDataSourceForBootstrap {
       .save(srcPath)
 
     // Perform bootstrap
-    val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+    val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
+      DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL,
+      extraOpts = Map(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator")
+    )
 
     // Read bootstrapped table and verify count
     var hoodieROViewDF1 = spark.read.format("hudi").load(basePath + "/*")
@@ -475,8 +478,8 @@ class TestDataSourceForBootstrap {
   }
 
   def runMetadataBootstrapAndVerifyCommit(tableType: String,
-                                          partitionColumns: Option[String] = None,
-                                          extraOpts: Map[String, String] = Map.empty): String = {
+      partitionColumns: Option[String] = None,
+      extraOpts: Map[String, String] = Map.empty): String = {
     val bootstrapDF = spark.emptyDataFrame
     bootstrapDF.write
       .format("hudi")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -478,8 +478,8 @@ class TestDataSourceForBootstrap {
   }
 
   def runMetadataBootstrapAndVerifyCommit(tableType: String,
-      partitionColumns: Option[String] = None,
-      extraOpts: Map[String, String] = Map.empty): String = {
+                                          partitionColumns: Option[String] = None,
+                                          extraOpts: Map[String, String] = Map.empty): String = {
     val bootstrapDF = spark.emptyDataFrame
     bootstrapDF.write
       .format("hudi")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTable.scala
@@ -38,7 +38,7 @@ class TestAlterTable extends TestHoodieSqlBase {
              |  ts long
              |) using hudi
              | location '$tablePath'
-             | options (
+             | tblproperties (
              |  type = '$tableType',
              |  primaryKey = 'id',
              |  preCombineField = 'ts'
@@ -127,7 +127,7 @@ class TestAlterTable extends TestHoodieSqlBase {
              |  dt string
              |) using hudi
              | location '${tmp.getCanonicalPath}/$partitionedTable'
-             | options (
+             | tblproperties (
              |  type = '$tableType',
              |  primaryKey = 'id',
              |  preCombineField = 'ts'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -38,7 +38,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
          |  dt string
          | )
          | using hudi
-         | options (
+         | tblproperties (
          |  primaryKey = 'id',
          |  preCombineField = 'ts'
          | )
@@ -77,7 +77,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         spark.sql(
           s"""
              |create table $tableName using hudi
-             | options (
+             |tblproperties (
              | primaryKey = 'id',
              | preCombineField = 'ts'
              |)
@@ -105,7 +105,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
          |  dt string
          | )
          | using hudi
-         | options (
+         | tblproperties (
          |  primaryKey = 'id',
          |  preCombineField = 'ts'
          | )
@@ -151,7 +151,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         spark.sql(
           s"""
              |create table $tableName using hudi
-             | options (
+             |tblproperties (
              | primaryKey = 'id',
              | preCombineField = 'ts'
              |)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCompactionTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCompactionTable.scala
@@ -31,7 +31,7 @@ class TestCompactionTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  type = 'mor',
            |  preCombineField = 'ts'
@@ -82,7 +82,7 @@ class TestCompactionTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  type = 'mor',
            |  preCombineField = 'ts'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDeleteTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDeleteTable.scala
@@ -33,7 +33,7 @@ class TestDeleteTable extends TestHoodieSqlBase {
              |  ts long
              |) using hudi
              | location '${tmp.getCanonicalPath}/$tableName'
-             | options (
+             | tblproperties (
              |  type = '$tableType',
              |  primaryKey = 'id',
              |  preCombineField = 'ts'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieOptionConfig.scala
@@ -24,7 +24,8 @@ import org.apache.hudi.testutils.HoodieClientTestBase
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 
-import org.junit.jupiter.api.{Assertions, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import org.scalatest.Matchers.intercept
 
@@ -44,10 +45,10 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
   def testWithDefaultSqlOptions(): Unit = {
     val ops1 = Map("primaryKey" -> "id")
     val with1 = HoodieOptionConfig.withDefaultSqlOptions(ops1)
-    Assertions.assertTrue(with1.size == 3)
-    Assertions.assertTrue(with1("primaryKey") == "id")
-    Assertions.assertTrue(with1("type") == "cow")
-    Assertions.assertTrue(with1("payloadClass") == classOf[DefaultHoodieRecordPayload].getName)
+    assertTrue(with1.size == 3)
+    assertTrue(with1("primaryKey") == "id")
+    assertTrue(with1("type") == "cow")
+    assertTrue(with1("payloadClass") == classOf[DefaultHoodieRecordPayload].getName)
 
     val ops2 = Map("primaryKey" -> "id",
       "preCombineField" -> "timestamp",
@@ -55,7 +56,7 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
       "payloadClass" -> classOf[OverwriteWithLatestAvroPayload].getName
     )
     val with2 = HoodieOptionConfig.withDefaultSqlOptions(ops2)
-    Assertions.assertTrue(ops2 == with2)
+    assertTrue(ops2 == with2)
   }
 
   @Test
@@ -68,12 +69,12 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
     )
     val tableConfigs = HoodieOptionConfig.mappingSqlOptionToTableConfig(sqlOptions)
 
-    Assertions.assertTrue(tableConfigs.size == 5)
-    Assertions.assertTrue(tableConfigs(HoodieTableConfig.RECORDKEY_FIELDS.key) == "id,addr")
-    Assertions.assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELD.key) == "timestamp")
-    Assertions.assertTrue(tableConfigs(HoodieTableConfig.TYPE.key) == "MERGE_ON_READ")
-    Assertions.assertTrue(tableConfigs("hoodie.index.type") == "INMEMORY")
-    Assertions.assertTrue(tableConfigs("hoodie.compact.inline") == "true")
+    assertTrue(tableConfigs.size == 5)
+    assertTrue(tableConfigs(HoodieTableConfig.RECORDKEY_FIELDS.key) == "id,addr")
+    assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELD.key) == "timestamp")
+    assertTrue(tableConfigs(HoodieTableConfig.TYPE.key) == "MERGE_ON_READ")
+    assertTrue(tableConfigs("hoodie.index.type") == "INMEMORY")
+    assertTrue(tableConfigs("hoodie.compact.inline") == "true")
   }
 
   @Test
@@ -86,8 +87,8 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
       "key123" -> "value456"
     )
     val tableConfigs = HoodieOptionConfig.deleteHooideOptions(sqlOptions)
-    Assertions.assertTrue(tableConfigs.size == 1)
-    Assertions.assertTrue(tableConfigs("key123") == "value456")
+    assertTrue(tableConfigs.size == 1)
+    assertTrue(tableConfigs("key123") == "value456")
   }
 
   @Test
@@ -100,8 +101,8 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
       "key123" -> "value456"
     )
     val tableConfigs = HoodieOptionConfig.extractSqlOptions(sqlOptions)
-    Assertions.assertTrue(tableConfigs.size == 3)
-    Assertions.assertTrue(tableConfigs.keySet == Set("primaryKey", "preCombineField", "type"))
+    assertTrue(tableConfigs.size == 3)
+    assertTrue(tableConfigs.keySet == Set("primaryKey", "preCombineField", "type"))
   }
 
   @Test
@@ -127,7 +128,7 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
     val e1 = intercept[IllegalArgumentException] {
       HoodieOptionConfig.validateTable(spark, schema, sqlOptions1)
     }
-    Assertions.assertTrue(e1.getMessage.contains("No `primaryKey` is specified."))
+    assertTrue(e1.getMessage.contains("No `primaryKey` is specified."))
 
     // primary field not found
     val sqlOptions2 = baseSqlOptions ++ Map(
@@ -137,7 +138,7 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
     val e2 = intercept[IllegalArgumentException] {
       HoodieOptionConfig.validateTable(spark, schema, sqlOptions2)
     }
-    Assertions.assertTrue(e2.getMessage.contains("Can't find primary key"))
+    assertTrue(e2.getMessage.contains("Can't find primary key"))
 
     // preCombine field not found
     val sqlOptions3 = baseSqlOptions ++ Map(
@@ -148,7 +149,7 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
     val e3 = intercept[IllegalArgumentException] {
       HoodieOptionConfig.validateTable(spark, schema, sqlOptions3)
     }
-    Assertions.assertTrue(e3.getMessage.contains("Can't find precombine key"))
+    assertTrue(e3.getMessage.contains("Can't find precombine key"))
 
     // miss type parameter
     val sqlOptions4 = baseSqlOptions ++ Map(
@@ -158,7 +159,7 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
     val e4 = intercept[IllegalArgumentException] {
       HoodieOptionConfig.validateTable(spark, schema, sqlOptions4)
     }
-    Assertions.assertTrue(e4.getMessage.contains("No `type` is specified."))
+    assertTrue(e4.getMessage.contains("No `type` is specified."))
 
     // type is invalid
     val sqlOptions5 = baseSqlOptions ++ Map(
@@ -169,7 +170,7 @@ class TestHoodieOptionConfig extends HoodieClientTestBase {
     val e5 = intercept[IllegalArgumentException] {
       HoodieOptionConfig.validateTable(spark, schema, sqlOptions5)
     }
-    Assertions.assertTrue(e5.getMessage.contains("'type' must be 'cow' or 'mor'"))
+    assertTrue(e5.getMessage.contains("'type' must be 'cow' or 'mor'"))
 
     // right options and schema
     val sqlOptions6 = baseSqlOptions ++ Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieOptionConfig.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, OverwriteWithLatestAvroPayload}
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.testutils.HoodieClientTestBase
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+
+import org.junit.jupiter.api.{Assertions, BeforeEach, Test}
+
+import org.scalatest.Matchers.intercept
+
+class TestHoodieOptionConfig extends HoodieClientTestBase {
+
+  var spark: SparkSession = _
+
+  /**
+   * Setup method running before each test.
+   */
+  @BeforeEach override def setUp() {
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+  }
+
+  @Test
+  def testWithDefaultSqlOptions(): Unit = {
+    val ops1 = Map("primaryKey" -> "id")
+    val with1 = HoodieOptionConfig.withDefaultSqlOptions(ops1)
+    Assertions.assertTrue(with1.size == 3)
+    Assertions.assertTrue(with1("primaryKey") == "id")
+    Assertions.assertTrue(with1("type") == "cow")
+    Assertions.assertTrue(with1("payloadClass") == classOf[DefaultHoodieRecordPayload].getName)
+
+    val ops2 = Map("primaryKey" -> "id",
+      "preCombineField" -> "timestamp",
+      "type" -> "mor",
+      "payloadClass" -> classOf[OverwriteWithLatestAvroPayload].getName
+    )
+    val with2 = HoodieOptionConfig.withDefaultSqlOptions(ops2)
+    Assertions.assertTrue(ops2 == with2)
+  }
+
+  @Test
+  def testMappingSqlOptionToTableConfig(): Unit = {
+    val sqlOptions = Map("primaryKey" -> "id,addr",
+      "preCombineField" -> "timestamp",
+      "type" -> "mor",
+      "hoodie.index.type" -> "INMEMORY",
+      "hoodie.compact.inline" -> "true"
+    )
+    val tableConfigs = HoodieOptionConfig.mappingSqlOptionToTableConfig(sqlOptions)
+
+    Assertions.assertTrue(tableConfigs.size == 5)
+    Assertions.assertTrue(tableConfigs(HoodieTableConfig.RECORDKEY_FIELDS.key) == "id,addr")
+    Assertions.assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELD.key) == "timestamp")
+    Assertions.assertTrue(tableConfigs(HoodieTableConfig.TYPE.key) == "MERGE_ON_READ")
+    Assertions.assertTrue(tableConfigs("hoodie.index.type") == "INMEMORY")
+    Assertions.assertTrue(tableConfigs("hoodie.compact.inline") == "true")
+  }
+
+  @Test
+  def testDeleteHooideOptions(): Unit = {
+    val sqlOptions = Map("primaryKey" -> "id,addr",
+      "preCombineField" -> "timestamp",
+      "type" -> "mor",
+      "hoodie.index.type" -> "INMEMORY",
+      "hoodie.compact.inline" -> "true",
+      "key123" -> "value456"
+    )
+    val tableConfigs = HoodieOptionConfig.deleteHooideOptions(sqlOptions)
+    Assertions.assertTrue(tableConfigs.size == 1)
+    Assertions.assertTrue(tableConfigs("key123") == "value456")
+  }
+
+  @Test
+  def testExtractSqlOptions(): Unit = {
+    val sqlOptions = Map("primaryKey" -> "id,addr",
+      "preCombineField" -> "timestamp",
+      "type" -> "mor",
+      "hoodie.index.type" -> "INMEMORY",
+      "hoodie.compact.inline" -> "true",
+      "key123" -> "value456"
+    )
+    val tableConfigs = HoodieOptionConfig.extractSqlOptions(sqlOptions)
+    Assertions.assertTrue(tableConfigs.size == 3)
+    Assertions.assertTrue(tableConfigs.keySet == Set("primaryKey", "preCombineField", "type"))
+  }
+
+  @Test
+  def testValidateTable(): Unit = {
+    val baseSqlOptions = Map(
+      "hoodie.datasource.write.hive_style_partitioning" -> "true",
+      "hoodie.datasource.write.partitionpath.urlencode" -> "false",
+      "hoodie.table.keygenerator.class" -> "org.apache.hudi.keygen.ComplexKeyGenerator"
+    )
+
+    val schema = StructType(
+      Seq(StructField("id", IntegerType, true),
+        StructField("name", StringType, true),
+        StructField("timestamp", TimestampType, true),
+        StructField("dt", StringType, true))
+    )
+
+    // miss primaryKey parameter
+    val sqlOptions1 = baseSqlOptions ++ Map(
+      "type" -> "mor"
+    )
+
+    val e1 = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema, sqlOptions1)
+    }
+    Assertions.assertTrue(e1.getMessage.contains("No `primaryKey` is specified."))
+
+    // primary field not found
+    val sqlOptions2 = baseSqlOptions ++ Map(
+      "primaryKey" -> "xxx",
+      "type" -> "mor"
+    )
+    val e2 = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema, sqlOptions2)
+    }
+    Assertions.assertTrue(e2.getMessage.contains("Can't find primary key"))
+
+    // preCombine field not found
+    val sqlOptions3 = baseSqlOptions ++ Map(
+      "primaryKey" -> "id",
+      "preCombineField" -> "ts",
+      "type" -> "mor"
+    )
+    val e3 = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema, sqlOptions3)
+    }
+    Assertions.assertTrue(e3.getMessage.contains("Can't find precombine key"))
+
+    // miss type parameter
+    val sqlOptions4 = baseSqlOptions ++ Map(
+      "primaryKey" -> "id",
+      "preCombineField" -> "timestamp"
+    )
+    val e4 = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema, sqlOptions4)
+    }
+    Assertions.assertTrue(e4.getMessage.contains("No `type` is specified."))
+
+    // type is invalid
+    val sqlOptions5 = baseSqlOptions ++ Map(
+      "primaryKey" -> "id",
+      "preCombineField" -> "timestamp",
+      "type" -> "abc"
+    )
+    val e5 = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema, sqlOptions5)
+    }
+    Assertions.assertTrue(e5.getMessage.contains("'type' must be 'cow' or 'mor'"))
+
+    // right options and schema
+    val sqlOptions6 = baseSqlOptions ++ Map(
+      "primaryKey" -> "id",
+      "preCombineField" -> "timestamp",
+      "type" -> "cow"
+    )
+    HoodieOptionConfig.validateTable(spark, schema, sqlOptions6)
+  }
+
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -36,6 +36,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  ts long,
            |  dt string
            |) using hudi
+           | tblproperties (primaryKey = 'id')
            | partitioned by (dt)
            | location '${tmp.getCanonicalPath}'
        """.stripMargin)
@@ -75,7 +76,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName'
-           | options (
+           | tblproperties (
            |  type = 'cow',
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
@@ -115,7 +116,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName2'
-           | options (
+           | tblproperties (
            |  type = 'mor',
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
@@ -146,6 +147,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  ts long,
            |  dt string
            |) using hudi
+           | tblproperties (primaryKey = 'id')
            | partitioned by (dt)
            | location '${tmp.getCanonicalPath}/$tableName'
        """.stripMargin)
@@ -191,6 +193,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  price double,
            |  ts long
            | ) using hudi
+           | tblproperties (primaryKey = 'id')
            | location '${tmp.getCanonicalPath}/$tblNonPartition'
          """.stripMargin)
       spark.sql(s"insert into $tblNonPartition select 1, 'a1', 10, 1000")
@@ -245,6 +248,7 @@ class TestInsertTable extends TestHoodieSqlBase {
              |  price double,
              |  dt $partitionType
              |) using hudi
+             | tblproperties (primaryKey = 'id')
              | partitioned by (dt)
              | location '${tmp.getCanonicalPath}/$tableName'
        """.stripMargin)
@@ -273,6 +277,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  name string,
            |  price double
            |) using hudi
+           | tblproperties (primaryKey = 'id')
            | location '${tmp.getCanonicalPath}'
        """.stripMargin)
 
@@ -293,6 +298,7 @@ class TestInsertTable extends TestHoodieSqlBase {
          |  price double,
          |  dt string
          |) using hudi
+         | tblproperties (primaryKey = 'id')
          | partitioned by (dt)
        """.stripMargin)
     checkException(s"insert into $tableName partition(dt = '2021-06-20')" +
@@ -305,7 +311,7 @@ class TestInsertTable extends TestHoodieSqlBase {
         " count: 3，columns: (1,a1,10)"
     )
     spark.sql("set hoodie.sql.bulk.insert.enable = true")
-    spark.sql("set hoodie.sql.insert.mode= strict")
+    spark.sql("set hoodie.sql.insert.mode = strict")
 
     val tableName2 = generateTableName
     spark.sql(
@@ -316,7 +322,7 @@ class TestInsertTable extends TestHoodieSqlBase {
          |  price double,
          |  ts long
          |) using hudi
-         | options (
+         | tblproperties (
          |   primaryKey = 'id',
          |   preCombineField = 'ts'
          | )
@@ -325,6 +331,7 @@ class TestInsertTable extends TestHoodieSqlBase {
       "Table with primaryKey can not use bulk insert in strict mode."
     )
 
+    spark.sql("set hoodie.sql.insert.mode = non-strict")
     val tableName3 = generateTableName
     spark.sql(
       s"""
@@ -334,16 +341,18 @@ class TestInsertTable extends TestHoodieSqlBase {
          |  price double,
          |  dt string
          |) using hudi
+         | tblproperties (primaryKey = 'id')
          | partitioned by (dt)
        """.stripMargin)
     checkException(s"insert overwrite table $tableName3 values(1, 'a1', 10, '2021-07-18')")(
       "Insert Overwrite Partition can not use bulk insert."
     )
     spark.sql("set hoodie.sql.bulk.insert.enable = false")
-    spark.sql("set hoodie.sql.insert.mode= upsert")
+    spark.sql("set hoodie.sql.insert.mode = upsert")
   }
 
   test("Test bulk insert") {
+    spark.sql("set hoodie.sql.insert.mode = non-strict")
     withTempDir { tmp =>
       Seq("cow", "mor").foreach {tableType =>
         // Test bulk insert for single partition
@@ -356,8 +365,9 @@ class TestInsertTable extends TestHoodieSqlBase {
              |  price double,
              |  dt string
              |) using hudi
-             | options (
-             |  type = '$tableType'
+             | tblproperties (
+             |  type = '$tableType',
+             |  primaryKey = 'id'
              | )
              | partitioned by (dt)
              | location '${tmp.getCanonicalPath}/$tableName'
@@ -391,8 +401,9 @@ class TestInsertTable extends TestHoodieSqlBase {
              |  dt string,
              |  hh string
              |) using hudi
-             | options (
-             |  type = '$tableType'
+             | tblproperties (
+             |  type = '$tableType',
+             |  primaryKey = 'id'
              | )
              | partitioned by (dt, hh)
              | location '${tmp.getCanonicalPath}/$tableMultiPartition'
@@ -423,8 +434,9 @@ class TestInsertTable extends TestHoodieSqlBase {
              |  name string,
              |  price double
              |) using hudi
-             | options (
-             |  type = '$tableType'
+             | tblproperties (
+             |  type = '$tableType',
+             |  primaryKey = 'id'
              | )
              | location '${tmp.getCanonicalPath}/$nonPartitionedTable'
        """.stripMargin)
@@ -445,7 +457,7 @@ class TestInsertTable extends TestHoodieSqlBase {
           s"""
              |create table $tableName2
              |using hudi
-             |options(
+             |tblproperties(
              | type = '$tableType',
              | primaryKey = 'id'
              |)
@@ -459,9 +471,11 @@ class TestInsertTable extends TestHoodieSqlBase {
         )
       }
     }
+    spark.sql("set hoodie.sql.insert.mode = upsert")
   }
 
   test("Test combine before insert") {
+    spark.sql("set hoodie.sql.bulk.insert.enable = false")
     withTempDir{tmp =>
       val tableName = generateTableName
       spark.sql(
@@ -473,7 +487,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName'
-           | options (
+           | tblproperties (
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
            | )
@@ -495,6 +509,7 @@ class TestInsertTable extends TestHoodieSqlBase {
   }
 
   test("Test insert pk-table") {
+    spark.sql("set hoodie.sql.bulk.insert.enable = false")
     withTempDir{tmp =>
       val tableName = generateTableName
       spark.sql(
@@ -506,7 +521,7 @@ class TestInsertTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName'
-           | options (
+           | tblproperties (
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
            | )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoLogOnlyTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoLogOnlyTable.scala
@@ -34,7 +34,7 @@ class TestMergeIntoLogOnlyTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  type = 'mor',
            |  preCombineField = 'ts',

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable.scala
@@ -35,7 +35,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  preCombineField = 'ts'
            | )
@@ -137,7 +137,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$targetTable'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  preCombineField = 'ts'
            | )
@@ -203,7 +203,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
            |  ts long,
            |  dt string
            | ) using hudi
-           | options (
+           | tblproperties (
            |  type = 'mor',
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
@@ -313,7 +313,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
            |  price double,
            |  dt string
            | ) using hudi
-           | options (
+           | tblproperties (
            |  type = 'mor',
            |  primaryKey = 'id'
            | )
@@ -369,7 +369,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
              |  v long,
              |  dt string
              | ) using hudi
-             | options (
+             | tblproperties (
              |  type = '$tableType',
              |  primaryKey = 'id',
              |  preCombineField = 'v'
@@ -439,7 +439,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
              | price double,
              | _ts long
              |) using hudi
-             |options(
+             |tblproperties(
              | type ='$tableType',
              | primaryKey = 'id',
              | preCombineField = '_ts'
@@ -457,7 +457,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
              | price double,
              | _ts long
              |) using hudi
-             |options(
+             |tblproperties(
              | type ='$tableType',
              | primaryKey = 'id',
              | preCombineField = '_ts'
@@ -553,7 +553,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
              |  c $dataType
              |) using hudi
              | location '${tmp.getCanonicalPath}/$tableName'
-             | options (
+             | tblproperties (
              |  primaryKey ='id',
              |  preCombineField = 'c'
              | )
@@ -604,7 +604,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  type = 'mor',
            |  preCombineField = 'ts',
@@ -665,7 +665,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
              |  ts long
              |) using hudi
              | location '${tmp.getCanonicalPath}/$tableName'
-             | options (
+             | tblproperties (
              |  primaryKey ='id',
              |  preCombineField = 'ts'
              | )
@@ -711,7 +711,7 @@ class TestMergeIntoTable extends TestHoodieSqlBase {
              |  ts long
              |) using hudi
              | location '${tmp.getCanonicalPath}/$tableName'
-             | options (
+             | tblproperties (
              |  primaryKey ='id',
              |  preCombineField = 'ts'
              | )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
@@ -35,7 +35,7 @@ class TestMergeIntoTable2 extends TestHoodieSqlBase {
            |  ts long,
            |  dt string
            | ) using hudi
-           | options (
+           | tblproperties (
            |  type = 'mor',
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
@@ -145,7 +145,7 @@ class TestMergeIntoTable2 extends TestHoodieSqlBase {
       spark.sql(
         s"""
            |create table $tableName using hudi
-           |options(primaryKey = 'id')
+           |tblproperties(primaryKey = 'id')
            |location '${tmp.getCanonicalPath}'
            |as
            |select 1 as id, 'a1' as name
@@ -187,7 +187,7 @@ class TestMergeIntoTable2 extends TestHoodieSqlBase {
            |  m_value map<string, string>,
            |  ts long
            | ) using hudi
-           | options (
+           | tblproperties (
            |  type = 'mor',
            |  primaryKey = 'id',
            |  preCombineField = 'ts'
@@ -251,7 +251,7 @@ class TestMergeIntoTable2 extends TestHoodieSqlBase {
            |  dt string
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  preCombineField = 'ts'
            | )
@@ -333,7 +333,7 @@ class TestMergeIntoTable2 extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  preCombineField = 'ts'
            | )
@@ -376,7 +376,7 @@ class TestMergeIntoTable2 extends TestHoodieSqlBase {
            |  ts long
            |) using hudi
            | location '${tmp.getCanonicalPath}/$tableName'
-           | options (
+           | tblproperties (
            |  primaryKey ='id',
            |  preCombineField = 'ts'
            | )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestPartialUpdateForMergeInto.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestPartialUpdateForMergeInto.scala
@@ -32,7 +32,7 @@ class TestPartialUpdateForMergeInto extends TestHoodieSqlBase {
              | price double,
              | _ts long
              |) using hudi
-             |options(
+             |tblproperties(
              | type ='$tableType',
              | primaryKey = 'id',
              | preCombineField = '_ts'
@@ -60,7 +60,7 @@ class TestPartialUpdateForMergeInto extends TestHoodieSqlBase {
              | name string,
              | price double
              |) using hudi
-             |options(
+             |tblproperties(
              | type ='$tableType',
              | primaryKey = 'id'
              |)
@@ -92,7 +92,7 @@ class TestPartialUpdateForMergeInto extends TestHoodieSqlBase {
          | price double,
          | _ts long
          |) using hudi
-         |options(
+         |tblproperties(
          | type = 'cow',
          | primaryKey = 'id',
          | preCombineField = '_ts'
@@ -117,7 +117,7 @@ class TestPartialUpdateForMergeInto extends TestHoodieSqlBase {
          | price double,
          | _ts long
          |) using hudi
-         |options(
+         |tblproperties(
          | type = 'mor',
          | primaryKey = 'id',
          | preCombineField = '_ts'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestShowPartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestShowPartitions.scala
@@ -32,7 +32,7 @@ class TestShowPartitions extends TestHoodieSqlBase {
          |  price double,
          |  ts long
          |) using hudi
-         |options (
+         |tblproperties (
          |  primaryKey = 'id',
          |  preCombineField = 'ts'
          )
@@ -59,7 +59,7 @@ class TestShowPartitions extends TestHoodieSqlBase {
          |  dt string
          ) using hudi
          | partitioned by (dt)
-         | options (
+         | tblproperties (
          |   primaryKey = 'id',
          |   preCombineField = 'ts'
          | )
@@ -109,7 +109,7 @@ class TestShowPartitions extends TestHoodieSqlBase {
          |   day string
          | ) using hudi
          | partitioned by (year, month, day)
-         | options (
+         | tblproperties (
          |   primaryKey = 'id',
          |   preCombineField = 'ts'
          | )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
@@ -33,7 +33,7 @@ class TestUpdateTable extends TestHoodieSqlBase {
              |  ts long
              |) using hudi
              | location '${tmp.getCanonicalPath}/$tableName'
-             | options (
+             | tblproperties (
              |  type = '$tableType',
              |  primaryKey = 'id',
              |  preCombineField = 'ts'


### PR DESCRIPTION
## What is the purpose of the pull request

1. refactor `CreateHoodieTableCommand`;
2. use `TBLPROPERTIES` syntax to pass config instead of `OPTIONS`, and sync hudi's config to properties of the table rather other properties of the storage of the table in hive metastore, also keep compatible with `OPTIONS` syntax;
3. force to provide `PrimaryKey`, so that make Update/Delete available;
4. hudi spark-sql decouple from metastore as far as possible, get config from local hoodie.properties first;
5. modify operation and related configs when insert/merge, to make consistent with dataframe api.
6. add parameter validation for recordKey, preCombineKey, keyGenerator, even if those parameters are defined by different keys.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
