### PR TITLE
[HUDI-2718] ExternalSpillableMap payload size re-estimation throws ArithmeticException

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -94,8 +94,7 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
   }
 
   public ExternalSpillableMap(Long maxInMemorySizeInBytes, String baseFilePath, SizeEstimator<T> keySizeEstimator,
-                              SizeEstimator<R> valueSizeEstimator, DiskMapType diskMapType,
-                              boolean isCompressionEnabled) throws IOException {
+                              SizeEstimator<R> valueSizeEstimator, DiskMapType diskMapType, boolean isCompressionEnabled) throws IOException {
     this.inMemoryMap = new HashMap<>();
     this.baseFilePath = baseFilePath;
     this.maxInMemorySizeInBytes = (long) Math.floor(maxInMemorySizeInBytes * sizingFactorForInMemoryMap);
@@ -117,7 +116,7 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
                 break;
               case BITCASK:
               default:
-                diskBasedMap = new BitCaskDiskMap<>(baseFilePath, isCompressionEnabled);
+                diskBasedMap =  new BitCaskDiskMap<>(baseFilePath, isCompressionEnabled);
             }
           } catch (IOException e) {
             throw new HoodieIOException(e.getMessage(), e);
@@ -205,12 +204,11 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
   public R put(T key, R value) {
     if (this.currentInMemoryMapSize < maxInMemorySizeInBytes || inMemoryMap.containsKey(key)) {
       if (shouldEstimatePayloadSize && estimatedPayloadSize == 0) {
-        // At first, use the size estimate of a record being inserted into the Spillable map.
-        // Note, the converter may overestimate the size of a record in the JVM.
+        // At first, use the sizeEstimate of a record being inserted into the spillable map.
+        // Note, the converter may over estimate the size of a record in the JVM
         this.estimatedPayloadSize = keySizeEstimator.sizeEstimate(key) + valueSizeEstimator.sizeEstimate(value);
-        LOG.debug("Estimated Payload size => " + estimatedPayloadSize);
-      } else if (shouldEstimatePayloadSize
-          && !inMemoryMap.isEmpty()
+        LOG.info("Estimated Payload size => " + estimatedPayloadSize);
+      } else if (shouldEstimatePayloadSize && !inMemoryMap.isEmpty()
           && (inMemoryMap.size() % NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE == 0)) {
         // Re-estimate the size of a record by calculating the size of the entire map containing
         // N entries and then dividing by the number of entries present (N). This helps to get a
@@ -219,7 +217,7 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
         this.currentInMemoryMapSize = totalMapSize;
         this.estimatedPayloadSize = totalMapSize / inMemoryMap.size();
         shouldEstimatePayloadSize = false;
-        LOG.debug("New Estimated Payload size => " + this.estimatedPayloadSize);
+        LOG.info("New Estimated Payload size => " + this.estimatedPayloadSize);
       }
       if (!inMemoryMap.containsKey(key)) {
         // TODO : Add support for adjusting payloadSize for updates to the same key

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
@@ -361,21 +361,14 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
     // Remove the key immediately to make the map empty again.
     records.remove(seedRecord.getRecordKey());
 
-    // Payload size re-estimation should not happen as the map
-    // size has not reached the minimum size threshold for
-    // recalculation.
-    assertDoesNotThrow(() -> {
-      records.put(seedRecord.getRecordKey(), seedRecord);
-    }, "ExternalSpillableMap put() should not throw exception!");
-
-    // Put more records than the threshold to trigger payload size re-estimation
-    while (records.getDiskBasedMapNumEntries() < 1) {
-      List<HoodieRecord> hoodieRecords = SchemaTestUtil.generateHoodieTestRecordsWithoutHoodieMetadata(0, 250);
-      hoodieRecords.stream().forEach(r -> {
-        records.put(r.getRecordKey(), r);
-        recordKeys.add(r.getRecordKey());
-      });
-    }
+    // Verify payload size re-estimation does not throw exception
+    List<HoodieRecord> hoodieRecords = SchemaTestUtil.generateHoodieTestRecordsWithoutHoodieMetadata(0, 250);
+    hoodieRecords.stream().forEach(hoodieRecord -> {
+      assertDoesNotThrow(() -> {
+        records.put(hoodieRecord.getRecordKey(), hoodieRecord);
+      }, "ExternalSpillableMap put() should not throw exception!");
+      recordKeys.add(hoodieRecord.getRecordKey());
+    });
   }
 
   private static Stream<Arguments> testArguments() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -341,11 +342,6 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
     assertEquals(gRecord.get(fieldName).toString(), newValue);
   }
 
-  // TODO : come up with a performance eval test for spillableMap
-  @Test
-  public void testLargeInsertUpsert() {
-  }
-
   @Test
   public void testPayloadSizeEstimate() throws IOException, URISyntaxException {
     final ExternalSpillableMap.DiskMapType diskMapType = ExternalSpillableMap.DiskMapType.BITCASK;
@@ -368,7 +364,9 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
     // Payload size re-estimation should not happen as the map
     // size has not reached the minimum size threshold for
     // recalculation.
-    records.put(seedRecord.getRecordKey(), seedRecord);
+    assertDoesNotThrow(() -> {
+      records.put(seedRecord.getRecordKey(), seedRecord);
+    }, "ExternalSpillableMap put() should not throw exception!");
 
     // Put more records than the threshold to trigger payload size re-estimation
     while (records.getDiskBasedMapNumEntries() < 1) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
@@ -343,7 +343,7 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testPayloadSizeEstimate() throws IOException, URISyntaxException {
+  public void testEstimationWithEmptyMap() throws IOException, URISyntaxException {
     final ExternalSpillableMap.DiskMapType diskMapType = ExternalSpillableMap.DiskMapType.BITCASK;
     final boolean isCompressionEnabled = false;
     final Schema schema = SchemaTestUtil.getSimpleSchema();


### PR DESCRIPTION
## What is the purpose of the pull request

Avoid ArithmeticException from ExternalSpillableMap put operations.

## Brief change log

- ExternalSpillableMap does the payload/value size estimation on the first put to
  determine when to spill over to disk map. The payload size re-estimation also
  happens after a minimum threshold of puts. This size re-estimation goes my the
  current in-memory map size for calculating average payload size and does attempts
  divide by zero operation when the map is size is empty. Avoiding the
  ArithmeticException during the payload size re-estimate by checking the map size
  upfront.

- Added an unit test to repro the case and exercise the fix.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
