### PR TITLE
[HUDI-2716] InLineFS support for S3FS logs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFileSystem.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFileSystem.java
@@ -63,7 +63,7 @@ public class InLineFileSystem extends FileSystem {
 
   @Override
   public FSDataInputStream open(Path inlinePath, int bufferSize) throws IOException {
-    Path outerPath = InLineFSUtils.getOuterfilePathFromInlinePath(inlinePath);
+    Path outerPath = InLineFSUtils.getOuterFilePathFromInlinePath(inlinePath);
     FileSystem outerFs = outerPath.getFileSystem(conf);
     FSDataInputStream outerStream = outerFs.open(outerPath, bufferSize);
     return new InLineFsDataInputStream(InLineFSUtils.startOffset(inlinePath), outerStream, InLineFSUtils.length(inlinePath));
@@ -80,7 +80,7 @@ public class InLineFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path inlinePath) throws IOException {
-    Path outerPath = InLineFSUtils.getOuterfilePathFromInlinePath(inlinePath);
+    Path outerPath = InLineFSUtils.getOuterFilePathFromInlinePath(inlinePath);
     FileSystem outerFs = outerPath.getFileSystem(conf);
     FileStatus status = outerFs.getFileStatus(outerPath);
     FileStatus toReturn = new FileStatus(InLineFSUtils.length(inlinePath), status.isDirectory(), status.getReplication(), status.getBlockSize(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -374,21 +374,23 @@ public abstract class AbstractHoodieLogRecordReader {
       LOG.info("Number of remaining logblocks to merge " + logBlocks.size());
       // poll the element at the bottom of the stack since that's the order it was inserted
       HoodieLogBlock lastBlock = logBlocks.pollLast();
-      switch (lastBlock.getBlockType()) {
-        case AVRO_DATA_BLOCK:
-          processDataBlock((HoodieAvroDataBlock) lastBlock, keys);
-          break;
-        case HFILE_DATA_BLOCK:
-          processDataBlock((HoodieHFileDataBlock) lastBlock, keys);
-          break;
-        case DELETE_BLOCK:
-          Arrays.stream(((HoodieDeleteBlock) lastBlock).getKeysToDelete()).forEach(this::processNextDeletedKey);
-          break;
-        case CORRUPT_BLOCK:
-          LOG.warn("Found a corrupt block which was not rolled back");
-          break;
-        default:
-          break;
+      if (lastBlock != null) {
+        switch (lastBlock.getBlockType()) {
+          case AVRO_DATA_BLOCK:
+            processDataBlock((HoodieAvroDataBlock) lastBlock, keys);
+            break;
+          case HFILE_DATA_BLOCK:
+            processDataBlock((HoodieHFileDataBlock) lastBlock, keys);
+            break;
+          case DELETE_BLOCK:
+            Arrays.stream(((HoodieDeleteBlock) lastBlock).getKeysToDelete()).forEach(this::processNextDeletedKey);
+            break;
+          case CORRUPT_BLOCK:
+            LOG.warn("Found a corrupt block which was not rolled back");
+            break;
+          default:
+            break;
+        }
       }
     }
     // At this step the lastBlocks are consumed. We track approximate progress by number of log-files seen

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -374,23 +374,21 @@ public abstract class AbstractHoodieLogRecordReader {
       LOG.info("Number of remaining logblocks to merge " + logBlocks.size());
       // poll the element at the bottom of the stack since that's the order it was inserted
       HoodieLogBlock lastBlock = logBlocks.pollLast();
-      if (lastBlock != null) {
-        switch (lastBlock.getBlockType()) {
-          case AVRO_DATA_BLOCK:
-            processDataBlock((HoodieAvroDataBlock) lastBlock, keys);
-            break;
-          case HFILE_DATA_BLOCK:
-            processDataBlock((HoodieHFileDataBlock) lastBlock, keys);
-            break;
-          case DELETE_BLOCK:
-            Arrays.stream(((HoodieDeleteBlock) lastBlock).getKeysToDelete()).forEach(this::processNextDeletedKey);
-            break;
-          case CORRUPT_BLOCK:
-            LOG.warn("Found a corrupt block which was not rolled back");
-            break;
-          default:
-            break;
-        }
+      switch (lastBlock.getBlockType()) {
+        case AVRO_DATA_BLOCK:
+          processDataBlock((HoodieAvroDataBlock) lastBlock, keys);
+          break;
+        case HFILE_DATA_BLOCK:
+          processDataBlock((HoodieHFileDataBlock) lastBlock, keys);
+          break;
+        case DELETE_BLOCK:
+          Arrays.stream(((HoodieDeleteBlock) lastBlock).getKeysToDelete()).forEach(this::processNextDeletedKey);
+          break;
+        case CORRUPT_BLOCK:
+          LOG.warn("Found a corrupt block which was not rolled back");
+          break;
+        default:
+          break;
       }
     }
     // At this step the lastBlocks are consumed. We track approximate progress by number of log-files seen

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReader.java
@@ -44,6 +44,7 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
   private final Schema readerSchema;
   private final boolean readBlocksLazily;
   private final boolean reverseLogReader;
+  private final boolean enableInLineReading;
   private int bufferSize;
 
   private static final Logger LOG = LogManager.getLogger(HoodieLogFormatReader.class);
@@ -62,6 +63,7 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
     this.reverseLogReader = reverseLogReader;
     this.bufferSize = bufferSize;
     this.prevReadersInOpenState = new ArrayList<>();
+    this.enableInLineReading = enableInlineReading;
     if (logFiles.size() > 0) {
       HoodieLogFile nextLogFile = logFiles.remove(0);
       this.currentReader = new HoodieLogFileReader(fs, nextLogFile, readerSchema, bufferSize, readBlocksLazily, false, enableInlineReading);
@@ -104,7 +106,8 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
           this.prevReadersInOpenState.add(currentReader);
         }
         this.currentReader =
-            new HoodieLogFileReader(fs, nextLogFile, readerSchema, bufferSize, readBlocksLazily, false);
+            new HoodieLogFileReader(fs, nextLogFile, readerSchema, bufferSize, readBlocksLazily, false,
+                this.enableInLineReading);
       } catch (IOException io) {
         throw new HoodieIOException("unable to initialize read with log file ", io);
       }


### PR DESCRIPTION
## What is the purpose of the pull request

InLineFS doesn't work with S3 logs. First, the S3 path derived from the InLineFS converted input log path is missing proper scheme separator leading to S3 log file reading issues. Then there was a NPE during the insert/update/query paths. 

## Brief change log

* Fixed a bug a HoodieLogFormatReader which was preventing the inline read for subsequent data blocks after the first one
* Fixed the NPE when processing data blocks
* Making InLineFS URI format same as other non LocalFileSystem URIs
* Enhanced the unit tests for inline fs format checks


## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
