### PR TITLE
[HUDI-2636] - made release notes more discoverable

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -195,7 +195,7 @@ module.exports = {
           ],
         },
         {to: '/powered-by', label: "Who's Using", position: 'left'},
-        {to: '/releases/download', label: 'Download', position: 'left'},
+        {to: '/releases/download', label: 'Release Notes', position: 'left'},
         // right
         {
           type: 'docsVersionDropdown',
@@ -254,10 +254,6 @@ module.exports = {
             },
             {
               label: 'Releases',
-              to: '/releases/release-0.9.0',
-            },
-            {
-              label: 'Download',
               to: '/releases/download',
             },
             {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -195,7 +195,7 @@ module.exports = {
           ],
         },
         {to: '/powered-by', label: "Who's Using", position: 'left'},
-        {to: '/releases/download', label: 'Release Notes', position: 'left'},
+        {to: '/releases/all-releases', label: 'Releases', position: 'left'},
         // right
         {
           type: 'docsVersionDropdown',
@@ -254,7 +254,7 @@ module.exports = {
             },
             {
               label: 'Releases',
-              to: '/releases/download',
+              to: '/releases/all-releases',
             },
             {
               label: 'Who\'s Using',

--- a/website/releases/all-releases.md
+++ b/website/releases/all-releases.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes
+title: Releases
 sidebar_position: 1
 keywords: [hudi, download, release notes]
 toc: true

--- a/website/releases/download.md
+++ b/website/releases/download.md
@@ -1,45 +1,44 @@
 ---
-title: Download
+title: Release Notes
 sidebar_position: 1
-keywords: [ hudi, download]
+keywords: [hudi, download, release notes]
 toc: true
 last_modified_at: 2019-12-30T15:59:57-04:00
 ---
 
 ### Release 0.9.0
-* Source Release : [Apache Hudi 0.9.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.9.0/hudi-0.9.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.9.0](/releases/release-0.9.0))
+* Release Notes : ([Release Notes for Apache Hudi 0.9.0](/releases/release-0.9.0))
+* Download Source : [Apache Hudi 0.9.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.9.0/hudi-0.9.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.9.0/hudi-0.9.0.src.tgz.sha512))
 
 ### Release 0.8.0
-* Source Release : [Apache Hudi 0.8.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.8.0/hudi-0.8.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.8.0](/releases/release-0.8.0))
+* Release Notes : ([Release Notes for Apache Hudi 0.8.0](/releases/release-0.8.0))
+* Download Source : [Apache Hudi 0.8.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.8.0/hudi-0.8.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.8.0/hudi-0.8.0.src.tgz.sha512))
 
 ### Release 0.7.0
-* Source Release : [Apache Hudi 0.7.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.7.0/hudi-0.7.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.7.0](/releases/release-0.7.0))
+* Release Notes : ([Release Notes for Apache Hudi 0.7.0](/releases/release-0.7.0))
+* Download Source : [Apache Hudi 0.7.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.7.0/hudi-0.7.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.7.0/hudi-0.7.0.src.tgz.sha512))
 
 ### Release 0.6.0
-* Source Release : [Apache Hudi 0.6.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.6.0/hudi-0.6.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.6.0](/releases/release-0.6.0))
+* Release Notes: ([Release Notes for Apache Hudi 0.6.0](/releases/release-0.6.0))
+* Download Source : [Apache Hudi 0.6.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.6.0/hudi-0.6.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.6.0/hudi-0.6.0.src.tgz.sha512))
 
 ### Release 0.5.3
-* Source Release : [Apache Hudi 0.5.3 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.3/hudi-0.5.3.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.5.3](/releases/release-0.5.3))
+* Release Notes: ([Release Notes for Apache Hudi 0.5.3](/releases/release-0.5.3))
+* Download Source : [Apache Hudi 0.5.3 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.3/hudi-0.5.3.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.3/hudi-0.5.3.src.tgz.sha512))
 
 ### Release 0.5.2-incubating
-* Source Release : [Apache Hudi 0.5.2-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.5.2](/releases/older-releases#release-052-incubating-docs))
+* Release Notes: ([Release Notes for Apache Hudi 0.5.2](/releases/older-releases#release-052-incubating-docs))
+* Download Source : [Apache Hudi 0.5.2-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.2-incubating/hudi-0.5.2-incubating.src.tgz.sha512))
 
 ### Release 0.5.1-incubating
-* Source Release : [Apache Hudi 0.5.1-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.5.1](/releases/older-releases#release-051-incubating-docs))
+* Release Notes: ([Release Notes for Apache Hudi 0.5.1](/releases/older-releases#release-051-incubating-docs))
+* Download Source : [Apache Hudi 0.5.1-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.1-incubating/hudi-0.5.1-incubating.src.tgz.sha512))
 
 ### Release 0.5.0-incubating
-* Source Release : [Apache Hudi 0.5.0-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.sha512))
-* Release Note : ([Release Note for Apache Hudi 0.5.0](/releases/older-releases#release-050-incubating-docs))
+* Release Notes: ([Release Notes for Apache Hudi 0.5.0](/releases/older-releases#release-050-incubating-docs))
+* Download Source : [Apache Hudi 0.5.0-incubating Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz) ([asc](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.5.0-incubating/hudi-0.5.0-incubating.src.tgz.sha512))
 
-## Verify Release
-
+## Verify Release Download
 It is essential that you verify the integrity of the downloaded files using the PGP signatures. Please read [How to Verify Downloaded Files](https://www.apache.org/info/verification.html)
 for more information on how and why you should verify our releases.
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

The release notes were hard to find. It was tribal knowledge to know they are stored under "Downloads"

## Brief change log

  - Renamed the Download tab to Release Notes
  - Minor tweak to the language on the release notes page
  - Updated footer

## Verify this pull request

*(Please pick either of the following options)*

  - This pull request is a trivial doc cleanup

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [x] CI is green

 - [X] Necessary doc changes done or have another open PR
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
