### PR TITLE
[HUDI-2743] Assume path exists and defer fs.exists() in AbstractTableFileSystemView

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -315,13 +315,16 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
    * @throws IOException
    */
   protected FileStatus[] listPartition(Path partitionPath) throws IOException {
-    // Create the path if it does not exist already
-    if (!metaClient.getFs().exists(partitionPath)) {
-      metaClient.getFs().mkdirs(partitionPath);
-      return new FileStatus[0];
-    } else {
+    try {
       return metaClient.getFs().listStatus(partitionPath);
+    } catch (IOException e) {
+      // Create the path if it does not exist already
+      if (!metaClient.getFs().exists(partitionPath)) {
+        metaClient.getFs().mkdirs(partitionPath);
+        return new FileStatus[0];
+      }
     }
+    throw new HoodieIOException(String.format("Failed to list partition path: %s", partitionPath));
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the pull request

In most cases the partition already exists, so we need not do the `fs.exists()` call everytime, only do it whne not found. This will help improve the listing performance.

## Verify this pull request

This pull request is already covered by existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
