### PR TITLE
[MINOR] Fixed checkstyle config to be based off Maven root-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Prerequisites for building Apache Hudi:
 * Unix-like system (like Linux, Mac OS X)
 * Java 8 (Java 9 or 10 may work)
 * Git
-* Maven
+* Maven (>=3.3.1)
 
 ```
 # Checkout code and build

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,8 @@
           <sourceDirectories>
             <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
           </sourceDirectories>
+          <!-- NOTE: This property is only available in Maven >= 3.3.1 -->
+          <propertyExpansion>basedir=${maven.multiModuleProjectDirectory}</propertyExpansion>
           <excludes>**\/generated-sources\/</excludes>
         </configuration>
         <executions>

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -305,7 +305,7 @@
         <module name="SimplifyBooleanExpression"/>
 
         <module name="ImportControl">
-            <property name="file" value="style/import-control.xml"/>
+            <property name="file" value="${basedir}/style/import-control.xml"/>
             <property name="path" value="^.*[\\/]hudi-client[\\/]hudi-client-common[\\/]src[\\/].*$"/>
         </module>
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fixed checkstyle config to be based off Maven root-dir (requires Maven >=3.3.1 to work properly);

This would allow to run tests seamlessly from IDE, which is currently failing, since you have to run Maven commands from the root of the project.

## Brief change log

- Fixed checkstyle config to be based off Maven root-dir (requires Maven >=3.3.1 to work properly);
- Updated README

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
