### PR TITLE
[HUDI-2779] Cache BaseDir if HudiTableNotFound Exception thrown

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hadoop;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -43,6 +44,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -218,8 +220,9 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
         } catch (TableNotFoundException e) {
           // Non-hoodie path, accept it.
           if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("(1) Caching non-hoodie path under %s \n",  baseDir.toString()));
+            LOG.debug(String.format("(1) Caching non-hoodie path under %s and %s \n",  folder.toString(), baseDir.toString()));
           }
+          nonHoodiePathCache.add(folder.toString());
           nonHoodiePathCache.add(baseDir.toString());
           return true;
         }
@@ -237,6 +240,12 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
       throw new HoodieException(msg, e);
     }
   }
+
+  @VisibleForTesting
+  public Set<String> getNonHoodiePathCache() {
+    return nonHoodiePathCache;
+  }
+
 
   @Override
   public void setConf(Configuration conf) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -44,7 +44,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -218,7 +218,7 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
         } catch (TableNotFoundException e) {
           // Non-hoodie path, accept it.
           if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("(1) Caching non-hoodie path under %s with basePath %s \n",  folder.toString(), baseDir.toString()));
+            LOG.debug(String.format("(1) Caching non-hoodie path under %s with basePath %s \n", folder.toString(), baseDir.toString()));
           }
           nonHoodiePathCache.add(folder.toString());
           nonHoodiePathCache.add(baseDir.toString());

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -173,6 +173,13 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
       }
 
       if (baseDir != null) {
+        // Check whether baseDir in nonHoodiePathCache
+        if (nonHoodiePathCache.contains(baseDir.toString())) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Accepting non-hoodie path from cache: " + path);
+          }
+          return true;
+        }
         HoodieTableFileSystemView fsView = null;
         try {
           HoodieTableMetaClient metaClient = metaClientCache.get(baseDir.toString());
@@ -211,9 +218,9 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
         } catch (TableNotFoundException e) {
           // Non-hoodie path, accept it.
           if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("(1) Caching non-hoodie path under %s \n", folder.toString()));
+            LOG.debug(String.format("(1) Caching non-hoodie path under %s \n",  baseDir.toString()));
           }
-          nonHoodiePathCache.add(folder.toString());
+          nonHoodiePathCache.add(baseDir.toString());
           return true;
         }
       } else {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.hadoop;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -72,7 +71,7 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
   /**
    * Paths that are known to be non-hoodie tables.
    */
-  private Set<String> nonHoodiePathCache;
+  Set<String> nonHoodiePathCache;
 
   /**
    * Table Meta Client Cache.
@@ -219,7 +218,7 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
         } catch (TableNotFoundException e) {
           // Non-hoodie path, accept it.
           if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("(1) Caching non-hoodie path under %s and %s \n",  folder.toString(), baseDir.toString()));
+            LOG.debug(String.format("(1) Caching non-hoodie path under %s with basePath %s \n",  folder.toString(), baseDir.toString()));
           }
           nonHoodiePathCache.add(folder.toString());
           nonHoodiePathCache.add(baseDir.toString());
@@ -239,12 +238,6 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
       throw new HoodieException(msg, e);
     }
   }
-
-  @VisibleForTesting
-  public Set<String> getNonHoodiePathCache() {
-    return nonHoodiePathCache;
-  }
-
 
   @Override
   public void setConf(Configuration conf) {

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
@@ -68,10 +68,11 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     assertFalse(pathFilter.accept(testTable.getInflightCommitFilePath("003")));
     assertFalse(pathFilter.accept(testTable.getRequestedCompactionFilePath("004")));
     assertFalse(pathFilter.accept(new Path("file:///" + basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/")));
+    assertFalse(pathFilter.accept(new Path("file:///" + basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/hoodie.properties")));
     assertFalse(pathFilter.accept(new Path("file:///" + basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME)));
 
     assertEquals(1, pathFilter.metaClientCache.size());
-    assertEquals(0, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 0");
+    assertEquals(0, pathFilter.nonHoodiePathCache.size(), "NonHoodiePathCache size should be 0");
   }
 
   @Test
@@ -83,7 +84,7 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     java.nio.file.Path path2 = Paths.get(basePath, "nonhoodiefolder/somefile");
     Files.createFile(path2);
     assertTrue(pathFilter.accept(new Path(path2.toUri())));
-    assertEquals(2, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 2");
+    assertEquals(2, pathFilter.nonHoodiePathCache.size(), "NonHoodiePathCache size should be 2");
   }
 
   @Test
@@ -95,6 +96,6 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     Path partitionPath2 = testTable.getPartitionPath(p2).getParent();
     assertTrue(pathFilter.accept(partitionPath1), "Directories should be accepted");
     assertTrue(pathFilter.accept(partitionPath2), "Directories should be accepted");
-    assertEquals(2, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 2");
+    assertEquals(2, pathFilter.nonHoodiePathCache.size(), "NonHoodiePathCache size should be 2");
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
@@ -71,6 +71,7 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     assertFalse(pathFilter.accept(new Path("file:///" + basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME)));
 
     assertEquals(1, pathFilter.metaClientCache.size());
+    assertEquals(0, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 0");
   }
 
   @Test
@@ -82,6 +83,7 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     java.nio.file.Path path2 = Paths.get(basePath, "nonhoodiefolder/somefile");
     Files.createFile(path2);
     assertTrue(pathFilter.accept(new Path(path2.toUri())));
+    assertEquals(2, pathFilter.getNonHoodiePathCache().size());
   }
 
   @Test
@@ -93,5 +95,6 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     Path partitionPath2 = testTable.getPartitionPath(p2).getParent();
     assertTrue(pathFilter.accept(partitionPath1), "Directories should be accepted");
     assertTrue(pathFilter.accept(partitionPath2), "Directories should be accepted");
+    assertEquals(2, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 1");
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieROTablePathFilter.java
@@ -83,7 +83,7 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     java.nio.file.Path path2 = Paths.get(basePath, "nonhoodiefolder/somefile");
     Files.createFile(path2);
     assertTrue(pathFilter.accept(new Path(path2.toUri())));
-    assertEquals(2, pathFilter.getNonHoodiePathCache().size());
+    assertEquals(2, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 2");
   }
 
   @Test
@@ -95,6 +95,6 @@ public class TestHoodieROTablePathFilter extends HoodieCommonTestHarness {
     Path partitionPath2 = testTable.getPartitionPath(p2).getParent();
     assertTrue(pathFilter.accept(partitionPath1), "Directories should be accepted");
     assertTrue(pathFilter.accept(partitionPath2), "Directories should be accepted");
-    assertEquals(2, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 1");
+    assertEquals(2, pathFilter.getNonHoodiePathCache().size(), "NonHoodiePathCache size should be 2");
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
Cache BaseDir instead of folder to improve performance if `HudiTableNotFound `exception thrown.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
