### PR TITLE
[HUDI-2671] Fix kafka offset handling in Kafka Connect protocol

### DIFF
--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/ConnectTransactionParticipant.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/ConnectTransactionParticipant.java
@@ -149,7 +149,7 @@ public class ConnectTransactionParticipant implements TransactionParticipant {
     LOG.info("Started a new transaction after receiving START_COMMIT for commit " + currentCommitTime);
     try {
       ongoingTransactionInfo = new TransactionInfo<>(currentCommitTime, writerProvider.getWriter(currentCommitTime));
-      ongoingTransactionInfo.setLastWrittenKafkaOffset(committedKafkaOffset);
+      ongoingTransactionInfo.setExpectedKafkaOffset(committedKafkaOffset);
     } catch (Exception exception) {
       LOG.warn("Error received while starting a new transaction", exception);
     }
@@ -188,7 +188,7 @@ public class ConnectTransactionParticipant implements TransactionParticipant {
           .setParticipantInfo(
               ControlMessage.ParticipantInfo.newBuilder()
                   .setWriteStatus(KafkaConnectUtils.buildWriteStatuses(writeStatuses))
-                  .setKafkaOffset(ongoingTransactionInfo.getLastWrittenKafkaOffset())
+                  .setKafkaOffset(ongoingTransactionInfo.getExpectedKafkaOffset())
                   .build()
           ).build();
 
@@ -201,9 +201,9 @@ public class ConnectTransactionParticipant implements TransactionParticipant {
   }
 
   private void handleAckCommit(ControlMessage message) {
-    // Update lastKafkCommitedOffset locally.
-    if (ongoingTransactionInfo != null && committedKafkaOffset < ongoingTransactionInfo.getLastWrittenKafkaOffset()) {
-      committedKafkaOffset = ongoingTransactionInfo.getLastWrittenKafkaOffset();
+    // // Update committedKafkaOffset that tracks the last committed kafka offset locally.
+    if (ongoingTransactionInfo != null && committedKafkaOffset < ongoingTransactionInfo.getExpectedKafkaOffset()) {
+      committedKafkaOffset = ongoingTransactionInfo.getExpectedKafkaOffset();
     }
     syncKafkaOffsetWithLeader(message);
     cleanupOngoingTransaction();
@@ -215,13 +215,17 @@ public class ConnectTransactionParticipant implements TransactionParticipant {
         try {
           SinkRecord record = buffer.peek();
           if (record != null
-              && record.kafkaOffset() >= ongoingTransactionInfo.getLastWrittenKafkaOffset()) {
+              && record.kafkaOffset() == ongoingTransactionInfo.getExpectedKafkaOffset()) {
             ongoingTransactionInfo.getWriter().writeRecord(record);
-            ongoingTransactionInfo.setLastWrittenKafkaOffset(record.kafkaOffset() + 1);
-          } else if (record != null && record.kafkaOffset() < committedKafkaOffset) {
-            LOG.warn(String.format("Received a kafka record with offset %s prior to last committed offset %s for partition %s",
-                record.kafkaOffset(), ongoingTransactionInfo.getLastWrittenKafkaOffset(),
-                partition));
+            ongoingTransactionInfo.setExpectedKafkaOffset(record.kafkaOffset() + 1);
+          } else if (record != null && record.kafkaOffset() > ongoingTransactionInfo.getExpectedKafkaOffset()) {
+            LOG.warn(String.format("Received a kafka record with offset %s above the next expected kafka offset %s for partition %s, "
+                    + "hence resetting the kafka offset to %s",
+                record.kafkaOffset(),
+                ongoingTransactionInfo.getExpectedKafkaOffset(),
+                partition,
+                ongoingTransactionInfo.getExpectedKafkaOffset()));
+            context.offset(partition, ongoingTransactionInfo.getExpectedKafkaOffset());
           }
           buffer.poll();
         } catch (Exception exception) {
@@ -250,13 +254,11 @@ public class ConnectTransactionParticipant implements TransactionParticipant {
       // Recover kafka committed offsets, treating the commit offset from the coordinator
       // as the source of truth
       if (coordinatorCommittedKafkaOffset != null && coordinatorCommittedKafkaOffset >= 0) {
-        if (coordinatorCommittedKafkaOffset != committedKafkaOffset) {
-          LOG.warn(String.format("Recovering the kafka offset for partition %s to offset %s instead of local offset %s",
-              partition.partition(), coordinatorCommittedKafkaOffset, committedKafkaOffset));
-          context.offset(partition, coordinatorCommittedKafkaOffset);
-        }
         committedKafkaOffset = coordinatorCommittedKafkaOffset;
+        return;
       }
     }
+    // If the coordinator does not have a committed offset for this partition, reset to zero offset.
+    committedKafkaOffset = 0;
   }
 }

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/TransactionInfo.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/transaction/TransactionInfo.java
@@ -29,13 +29,13 @@ public class TransactionInfo<T> {
 
   private final String commitTime;
   private final ConnectWriter<T> writer;
-  private long lastWrittenKafkaOffset;
+  private long expectedKafkaOffset;
   private boolean commitInitiated;
 
   public TransactionInfo(String commitTime, ConnectWriter<T> writer) {
     this.commitTime = commitTime;
     this.writer = writer;
-    this.lastWrittenKafkaOffset = 0;
+    this.expectedKafkaOffset = 0;
     this.commitInitiated = false;
   }
 
@@ -47,16 +47,16 @@ public class TransactionInfo<T> {
     return writer;
   }
 
-  public long getLastWrittenKafkaOffset() {
-    return lastWrittenKafkaOffset;
+  public long getExpectedKafkaOffset() {
+    return expectedKafkaOffset;
   }
 
   public boolean isCommitInitiated() {
     return commitInitiated;
   }
 
-  public void setLastWrittenKafkaOffset(long lastWrittenKafkaOffset) {
-    this.lastWrittenKafkaOffset = lastWrittenKafkaOffset;
+  public void setExpectedKafkaOffset(long expectedKafkaOffset) {
+    this.expectedKafkaOffset = expectedKafkaOffset;
   }
 
   public void commitInitiated() {


### PR DESCRIPTION
## What is the purpose of the pull request

[HUDI-2671] When there are two sink workers running, there can be a case where one participant joins after the coordinator starts a first commit, which needs to be rolled back later since the other participant does not receive the START_COMMIT message for the transaction.  In this case, later on in a new commit, `writeRecords()` can miss records because `ongoingTransactionInfo.getLastWrittenKafkaOffset()` is behind the record offsets in the buffer.  This causes missing records in the target Hudi table.

This PR fixes the issue by not accepting kafka offsets that are above the current expected value, and resets the kafka offset when such situation happens. The corresponding tests are also added.


## Brief change log
- Fixed an issue with missing records due to participant accepting kafka offsets higher than last written offset.
 
## Verify this pull request
- added and improved the unit tests for participant's handling of kafka offset.
