### PR TITLE
[WIP] [HUDI-2488] Adding an async indexing mechanism to add new partitions to metadata table

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
@@ -156,7 +156,7 @@ public class RepairsCommand implements CommandMarker {
     newProps.load(new FileInputStream(new File(overwriteFilePath)));
     Map<String, String> oldProps = client.getTableConfig().propsMap();
     Path metaPathDir = new Path(client.getBasePath(), METAFOLDER_NAME);
-    HoodieTableConfig.createHoodieProperties(client.getFs(), metaPathDir, newProps);
+    HoodieTableConfig.create(client.getFs(), metaPathDir, newProps);
 
     TreeSet<String> allPropKeys = new TreeSet<>();
     allPropKeys.addAll(newProps.keySet().stream().map(Object::toString).collect(Collectors.toSet()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -114,6 +114,7 @@ public class UpgradeDowngrade {
         return;
       }
 
+      //TODO: migrate all this to the new way of updating table config?
       if (fs.exists(updatedPropsFilePath)) {
         // this can be left over .updated file from a failed attempt before. Many cases exist here.
         // a) We failed while writing the .updated file and it's content is partial (e.g hdfs)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -377,7 +377,7 @@ public class HoodieTableMetaClient implements Serializable {
     }
 
     initializeBootstrapDirsIfNotExists(hadoopConf, basePath, fs);
-    HoodieTableConfig.createHoodieProperties(fs, metaPathDir, props);
+    HoodieTableConfig.create(fs, metaPathDir, props);
     // We should not use fs.getConf as this might be different from the original configuration
     // used to create the fs in unit tests
     HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(basePath).build();

--- a/hudi-common/src/test/java/org/apache/hudi/common/bootstrap/TestBootstrapIndex.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/bootstrap/TestBootstrapIndex.java
@@ -94,7 +94,7 @@ public class TestBootstrapIndex extends HoodieCommonTestHarness {
     props.put(HoodieTableConfig.BOOTSTRAP_INDEX_ENABLE.key(), "false");
     Properties properties = new Properties();
     properties.putAll(props);
-    HoodieTableConfig.createHoodieProperties(metaClient.getFs(), new Path(metaClient.getMetaPath()), properties);
+    HoodieTableConfig.create(metaClient.getFs(), new Path(metaClient.getMetaPath()), properties);
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).build();
     BootstrapIndex bootstrapIndex = BootstrapIndex.getBootstrapIndex(metaClient);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.exception.HoodieIOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieTableConfig extends HoodieCommonTestHarness {
+
+  private FileSystem fs;
+  private Path metaPath;
+  private Path cfgPath;
+  private Path backupCfgPath;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    initPath();
+    fs = new Path(basePath).getFileSystem(new Configuration());
+    metaPath = new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME);
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
+    HoodieTableConfig.create(fs, metaPath, props);
+    cfgPath = new Path(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE);
+    backupCfgPath = new Path(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE_BACKUP);
+  }
+
+  @Test
+  public void testCreate() throws IOException {
+    assertTrue(fs.exists(new Path(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE)));
+    HoodieTableConfig config = new HoodieTableConfig(fs, metaPath.toString(), null);
+    assertEquals(4, config.getProps().size());
+  }
+
+  @Test
+  public void testUpdate() throws IOException {
+    Properties updatedProps = new Properties();
+    updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table2");
+    updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELD.key(), "new_field");
+    HoodieTableConfig.update(fs, metaPath, updatedProps);
+
+    assertTrue(fs.exists(cfgPath));
+    assertFalse(fs.exists(backupCfgPath));
+    HoodieTableConfig config = new HoodieTableConfig(fs, metaPath.toString(), null);
+    assertEquals(5, config.getProps().size());
+    assertEquals("test-table2", config.getTableName());
+    assertEquals("new_field", config.getPreCombineField());
+  }
+
+  @Test
+  public void testReadsWhenPropsFileDoesNotExist() throws IOException {
+    fs.delete(cfgPath, false);
+    assertThrows(HoodieIOException.class, () -> {
+      new HoodieTableConfig(fs, metaPath.toString(), null);
+    });
+  }
+
+  @Test
+  public void testReadsWithUpdateFailures() throws IOException {
+    HoodieTableConfig config = new HoodieTableConfig(fs, metaPath.toString(), null);
+    fs.delete(cfgPath, false);
+    try (FSDataOutputStream out = fs.create(backupCfgPath)) {
+      config.getProps().store(out, "");
+    }
+
+    assertFalse(fs.exists(cfgPath));
+    assertTrue(fs.exists(backupCfgPath));
+    config = new HoodieTableConfig(fs, metaPath.toString(), null);
+    assertEquals(4, config.getProps().size());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testUpdateRecovery(boolean shouldPropsFileExist) throws IOException {
+    HoodieTableConfig config = new HoodieTableConfig(fs, metaPath.toString(), null);
+    if (!shouldPropsFileExist) {
+      fs.delete(cfgPath, false);
+    }
+    try (FSDataOutputStream out = fs.create(backupCfgPath)) {
+      config.getProps().store(out, "");
+    }
+
+    HoodieTableConfig.recoverIfNeeded(fs, cfgPath, backupCfgPath);
+    assertTrue(fs.exists(cfgPath));
+    assertFalse(fs.exists(backupCfgPath));
+    config = new HoodieTableConfig(fs, metaPath.toString(), null);
+    assertEquals(4, config.getProps().size());
+  }
+}


### PR DESCRIPTION
Ground work - add mechanism to safely update and recover table properties

  - Fail safe mechanism, that lets queries succeed off a backup file
  - Readers who are not upgraded to this version of code will just fail until recovery is done.
  - Added unit tests that exercises all these scenarios.
  - [Pending] Adding CLI for recovery, updation to table command.
  - [Pending] Add some hash based verfication to ensure any rare partial writes for HDFS

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
