### PR TITLE
[HUDI-2803]Remove the aws packages from hudi flink bundle jar

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -81,7 +81,6 @@
                   <include>org.apache.hudi:hudi-sync-common</include>
                   <include>org.apache.hudi:hudi-hadoop-mr</include>
                   <include>org.apache.hudi:hudi-timeline-service</include>
-                  <include>org.apache.hudi:hudi-aws</include>
 
                   <include>com.yammer.metrics:metrics-core</include>
                   <include>com.beust:jcommander</include>
@@ -150,10 +149,6 @@
                   <include>org.apache.hbase:hbase-protocol</include>
                   <include>org.apache.htrace:htrace-core</include>
                   <include>commons-codec:commons-codec</include>
-
-                  <include>com.amazonaws:dynamodb-lock-client</include>
-                  <include>com.amazonaws:aws-java-sdk-dynamodb</include>
-                  <include>com.amazonaws:aws-java-sdk-core</include>
                 </includes>
               </artifactSet>
               <relocations>


### PR DESCRIPTION

## What is the purpose of the pull request

Remove the aws packages from hudi flink bundle jar

## Brief change log

  - Remove the aws packages from hudi flink bundle jar

## Verify this pull request


This pull request is a trivial rework / code cleanup without any test coverage.

