### PR TITLE
[HUDI-1290] Add Debezium Source for deltastreamer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * Base class that provides support for seamlessly applying changes captured via Debezium.
+ * <p>
+ * Debezium change event types are determined for the op field in the payload
+ * <p>
+ * - For inserts, op=i
+ * - For deletes, op=d
+ * - For updates, op=u
+ * - For snapshort inserts, op=r
+ * <p>
+ * This payload implementation will issue matching insert, delete, updates against the hudi table
+ */
+public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
+
+  private static final Logger LOG = LogManager.getLogger(AbstractDebeziumAvroPayload.class);
+
+  public AbstractDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public AbstractDebeziumAvroPayload(Option<GenericRecord> record) {
+    super(record);
+  }
+
+  @Override
+  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+    IndexedRecord insertRecord = getInsertRecord(schema);
+    return handleDeleteOperation(insertRecord);
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+    // Step 1: If the time occurrence of the current record in storage is higher than the time occurrence of the
+    // insert record (including a delete record), pick the current record.
+    if (shouldPickCurrentRecord(currentValue, getInsertRecord(schema), schema)) {
+      return Option.of(currentValue);
+    }
+    // Step 2: Pick the insert record (as a delete record if its a deleted event)
+    return getInsertValue(schema);
+  }
+
+  protected abstract boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException;
+
+  private Option<IndexedRecord> handleDeleteOperation(IndexedRecord insertRecord) {
+    boolean delete = false;
+    if (insertRecord instanceof GenericRecord) {
+      GenericRecord record = (GenericRecord) insertRecord;
+      Object value = record.get(DebeziumConstants.FLATTENED_OP_COL_NAME);
+      delete = value != null && value.toString().equalsIgnoreCase(DebeziumConstants.DELETE_OP);
+    }
+
+    return delete ? Option.empty() : Option.of(insertRecord);
+  }
+
+  private IndexedRecord getInsertRecord(Schema schema) throws IOException {
+    return super.getInsertValue(schema).get();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
@@ -40,41 +40,42 @@ public class DebeziumConstants {
 
   // INPUT COLUMNS SPECIFIC TO MYSQL
   public static final String INCOMING_SOURCE_FILE_FIELD = "source.file";
-  public static final String INP_QUALIFIED_SOURCE_POS_FIELD = "source.pos";
-  public static final String INP_QUALIFIED_SOURCE_ROW_FIELD = "source.row";
+  public static final String INCOMING_SOURCE_POS_FIELD = "source.pos";
+  public static final String INCOMING_SOURCE_ROW_FIELD = "source.row";
 
   // INPUT COLUMNS SPECIFIC TO POSTGRES
   public static final String INCOMING_SOURCE_LSN_FIELD = "source.lsn";
   public static final String INCOMING_SOURCE_XMIN_FIELD = "source.xmin";
 
   // OUTPUT COLUMNS
-  public static final String MODIFIED_OP_COL_NAME = "_change_operation_type";
+  public static final String FLATTENED_OP_COL_NAME = "_change_operation_type";
   public static final String UPSTREAM_PROCESSING_TS_COL_NAME = "_upstream_event_processed_ts_ms";
-  public static final String MODIFIED_SHARD_NAME = "db_shard_source_partition";
-  public static final String MODIFIED_TS_COL_NAME = "_event_origin_ts_ms";
-  public static final String MODIFIED_TX_ID_COL_NAME = "_event_tx_id";
+  public static final String FLATTENED_SHARD_NAME = "db_shard_source_partition";
+  public static final String FLATTENED_TS_COL_NAME = "_event_origin_ts_ms";
+  public static final String FLATTENED_TX_ID_COL_NAME = "_event_tx_id";
 
   // OUTPUT COLUMNS SPECIFIC TO MYSQL
-  public static final String SOURCE_FILE_COL_NAME = "_event_bin_file";
-  public static final String SOURCE_POS_COL_NAME = "_event_pos";
-  public static final String SOURCE_ROW_COL_NAME = "_event_row";
+  public static final String FLATTENED_FILE_COL_NAME = "_event_bin_file";
+  public static final String FLATTENED_POS_COL_NAME = "_event_pos";
+  public static final String FLATTENED_ROW_COL_NAME = "_event_row";
+  public static final String ADDED_SEQ_COL_NAME = "_event_seq";
 
   // OUTPUT COLUMNS SPECIFIC TO POSTGRES
-  public static final String MODIFIED_LSN_COL_NAME = "_event_lsn";
-  public static final String MODIFIED_XMIN_COL_NAME = "_event_xmin";
+  public static final String FLATTENED_LSN_COL_NAME = "_event_lsn";
+  public static final String FLATTENED_XMIN_COL_NAME = "_event_xmin";
 
   // Other Constants
   public static final String DELETE_OP = "d";
 
   // List of meta data columns
   public static List<String> META_COLUMNS = Collections.unmodifiableList(Arrays.asList(
-      MODIFIED_OP_COL_NAME,
+      FLATTENED_OP_COL_NAME,
       UPSTREAM_PROCESSING_TS_COL_NAME,
-      MODIFIED_TS_COL_NAME,
-      MODIFIED_TX_ID_COL_NAME,
-      MODIFIED_LSN_COL_NAME,
-      MODIFIED_XMIN_COL_NAME,
-      MODIFIED_SHARD_NAME
+      FLATTENED_TS_COL_NAME,
+      FLATTENED_TX_ID_COL_NAME,
+      FLATTENED_LSN_COL_NAME,
+      FLATTENED_XMIN_COL_NAME,
+      FLATTENED_SHARD_NAME
   ));
 }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Constants used by {@link DebeziumSource} and {@link DebeziumAvroPayload}.
+ */
+public class DebeziumConstants {
+
+  // INPUT COLUMNS
+  public static final String INCOMING_BEFORE_FIELD = "before";
+  public static final String INCOMING_AFTER_FIELD = "after";
+  public static final String INCOMING_SOURCE_FIELD = "source";
+  public static final String INCOMING_OP_FIELD = "op";
+  public static final String INCOMING_TS_MS_FIELD = "ts_ms";
+
+  public static final String INCOMING_SOURCE_NAME_FIELD = "source.name";
+  public static final String INCOMING_SOURCE_TS_MS_FIELD = "source.ts_ms";
+  public static final String INCOMING_SOURCE_TXID_FIELD = "source.txId";
+
+  // INPUT COLUMNS SPECIFIC TO MYSQL
+  public static final String INCOMING_SOURCE_FILE_FIELD = "source.file";
+  public static final String INP_QUALIFIED_SOURCE_POS_FIELD = "source.pos";
+  public static final String INP_QUALIFIED_SOURCE_ROW_FIELD = "source.row";
+
+  // INPUT COLUMNS SPECIFIC TO POSTGRES
+  public static final String INCOMING_SOURCE_LSN_FIELD = "source.lsn";
+  public static final String INCOMING_SOURCE_XMIN_FIELD = "source.xmin";
+
+  // OUTPUT COLUMNS
+  public static final String MODIFIED_OP_COL_NAME = "_change_operation_type";
+  public static final String UPSTREAM_PROCESSING_TS_COL_NAME = "_upstream_event_processed_ts_ms";
+  public static final String MODIFIED_SHARD_NAME = "db_shard_source_partition";
+  public static final String MODIFIED_TS_COL_NAME = "_event_origin_ts_ms";
+  public static final String MODIFIED_TX_ID_COL_NAME = "_event_tx_id";
+
+  // OUTPUT COLUMNS SPECIFIC TO MYSQL
+  public static final String SOURCE_FILE_COL_NAME = "_event_bin_file";
+  public static final String SOURCE_POS_COL_NAME = "_event_pos";
+  public static final String SOURCE_ROW_COL_NAME = "_event_row";
+
+  // OUTPUT COLUMNS SPECIFIC TO POSTGRES
+  public static final String MODIFIED_LSN_COL_NAME = "_event_lsn";
+  public static final String MODIFIED_XMIN_COL_NAME = "_event_xmin";
+
+  // Other Constants
+  public static final String DELETE_OP = "d";
+
+  // List of meta data columns
+  public static List<String> META_COLUMNS = Collections.unmodifiableList(Arrays.asList(
+      MODIFIED_OP_COL_NAME,
+      UPSTREAM_PROCESSING_TS_COL_NAME,
+      MODIFIED_TS_COL_NAME,
+      MODIFIED_TX_ID_COL_NAME,
+      MODIFIED_LSN_COL_NAME,
+      MODIFIED_XMIN_COL_NAME,
+      MODIFIED_SHARD_NAME
+  ));
+}
+

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -53,8 +53,7 @@ public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   private String extractSeq(IndexedRecord record) {
-    GenericRecord genericRecord = (GenericRecord) record;
-    return genericRecord.get(DebeziumConstants.ADDED_SEQ_COL_NAME).toString();
+    return ((CharSequence) ((GenericRecord) record).get(DebeziumConstants.ADDED_SEQ_COL_NAME)).toString();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * Provides support for seamlessly applying changes captured via Debezium for MysqlDB.
+ * <p>
+ * Debezium change event types are determined for the op field in the payload
+ * <p>
+ * - For inserts, op=i
+ * - For deletes, op=d
+ * - For updates, op=u
+ * - For snapshort inserts, op=r
+ * <p>
+ * This payload implementation will issue matching insert, delete, updates against the hudi table
+ */
+public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
+
+  private static final Logger LOG = LogManager.getLogger(MySqlDebeziumAvroPayload.class);
+
+  public MySqlDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public MySqlDebeziumAvroPayload(Option<GenericRecord> record) {
+    super(record);
+  }
+
+  private String extractSeq(IndexedRecord record) {
+    GenericRecord genericRecord = (GenericRecord) record;
+    return genericRecord.get(DebeziumConstants.ADDED_SEQ_COL_NAME).toString();
+  }
+
+  @Override
+  protected boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException {
+    String currentSourceSeq = extractSeq(currentRecord);
+    String insertSourceSeq = extractSeq(insertRecord);
+    // Pick the current value in storage only if its Seq (file+pos) is latest
+    // compared to the Seq (file+pos) of the insert value
+    return insertSourceSeq.compareTo(currentSourceSeq) < 0;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.model.debezium;
 
-import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;
@@ -45,7 +44,7 @@ import java.util.List;
  * <p>
  * This payload implementation will issue matching insert, delete, updates against the hudi table
  */
-public class PostgresDebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
+public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
 
   private static final Logger LOG = LogManager.getLogger(PostgresDebeziumAvroPayload.class);
   public static final String DEBEZIUM_TOASTED_VALUE = "__debezium_unavailable_value";
@@ -58,53 +57,30 @@ public class PostgresDebeziumAvroPayload extends OverwriteWithLatestAvroPayload 
     super(record);
   }
 
-  private Option<IndexedRecord> handleDeleteOperation(IndexedRecord insertRecord) {
-    boolean delete = false;
-    if (insertRecord instanceof GenericRecord) {
-      GenericRecord record = (GenericRecord) insertRecord;
-      Object value = record.get(DebeziumConstants.MODIFIED_OP_COL_NAME);
-      delete = value != null && value.toString().equalsIgnoreCase(DebeziumConstants.DELETE_OP);
-    }
-
-    return delete ? Option.empty() : Option.of(insertRecord);
-  }
-
   private Long extractLSN(IndexedRecord record) {
     GenericRecord genericRecord = (GenericRecord) record;
-    return (Long) genericRecord.get(DebeziumConstants.MODIFIED_LSN_COL_NAME);
+    return (Long) genericRecord.get(DebeziumConstants.FLATTENED_LSN_COL_NAME);
   }
 
-  private boolean shouldPickCurrentRecord(IndexedRecord currentRecord, Schema schema) throws IOException {
-    IndexedRecord insertRecord = super.getInsertValue(schema).get();
+  @Override
+  protected boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException {
     Long currentSourceLSN = extractLSN(currentRecord);
     Long insertSourceLSN = extractLSN(insertRecord);
+
     // Pick the current value in storage only if its LSN is latest compared to the LSN of the insert value
     return insertSourceLSN < currentSourceLSN;
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
-    IndexedRecord insertRecord = super.getInsertValue(schema).get();
-    return handleDeleteOperation(insertRecord);
-  }
-
-  @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
-    // Step 1: If the LSN of the current record in storage is higher than the LSN of the
-    // insert record (including a delete record), pick the current record.
-    if (shouldPickCurrentRecord(currentValue, schema)) {
-      return Option.of(currentValue);
-    }
-
-    // Step 2: Pick the insert record (as a delete record),
-    // but get toasted column values from current record
-    Option<IndexedRecord> insertOrDeleteRecord = getInsertValue(schema);
+    // Specific to Postgres: If the updated record has TOASTED columns,
+    // we will need to keep the previous value for those columns
+    // see https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-toasted-values
+    Option<IndexedRecord> insertOrDeleteRecord = super.combineAndGetUpdateValue(currentValue, schema);
 
     if (insertOrDeleteRecord.isPresent()) {
       List<Schema.Field> fields = insertOrDeleteRecord.get().getSchema().getFields();
 
-      // If the updated record has TOASTED columns, we will need to keep the previous value for those columns
-      // see https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-toasted-values
       fields.forEach(field -> {
         // There are only four avro data types that have unconstrained sizes, which are
         // NON-NULLABLE STRING, NULLABLE STRING, NON-NULLABLE BYTES, NULLABLE BYTES

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Provides support for seamlessly applying changes captured via Debezium for PostgresDB.
+ * <p>
+ * Debezium change event types are determined for the op field in the payload
+ * <p>
+ * - For inserts, op=i
+ * - For deletes, op=d
+ * - For updates, op=u
+ * - For snapshort inserts, op=r
+ * <p>
+ * This payload implementation will issue matching insert, delete, updates against the hudi table
+ */
+public class PostgresDebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
+
+  public static final String DEBEZIUM_TOASTED_VALUE = "__debezium_unavailable_value";
+
+  public PostgresDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public PostgresDebeziumAvroPayload(Option<GenericRecord> record) {
+    super(record);
+  }
+
+  private Option<IndexedRecord> handleDeleteOperation(IndexedRecord insertRecord) {
+    boolean delete = false;
+    if (insertRecord instanceof GenericRecord) {
+      GenericRecord record = (GenericRecord) insertRecord;
+      Object value = record.get(DebeziumConstants.MODIFIED_OP_COL_NAME);
+      delete = value != null && value.toString().equalsIgnoreCase(DebeziumConstants.DELETE_OP);
+    }
+
+    return delete ? Option.empty() : Option.of(insertRecord);
+  }
+
+  private Long extractLSN(IndexedRecord record) {
+    GenericRecord genericRecord = (GenericRecord) record;
+    return (Long) genericRecord.get(DebeziumConstants.MODIFIED_LSN_COL_NAME);
+  }
+
+  private boolean shouldPickCurrentRecord(IndexedRecord currentRecord, Schema schema) throws IOException {
+    IndexedRecord insertRecord = super.getInsertValue(schema).get();
+    Long currentSourceLSN = extractLSN(currentRecord);
+    Long insertSourceLSN = extractLSN(insertRecord);
+    // Pick the current value in storage only if its LSN is latest compared to the LSN of the insert value
+    return insertSourceLSN < currentSourceLSN;
+  }
+
+  @Override
+  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+    IndexedRecord insertRecord = super.getInsertValue(schema).get();
+    return handleDeleteOperation(insertRecord);
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+    // Step 1: If the LSN of the current record in storage is higher than the LSN of the
+    // insert record (including a delete record), pick the current record.
+    if (shouldPickCurrentRecord(currentValue, schema)) {
+      return Option.of(currentValue);
+    }
+
+    // Step 2: Pick the insert record (as a delete record),
+    // but get toasted column values from current record
+    Option<IndexedRecord> insertOrDeleteRecord = getInsertValue(schema);
+
+    if (insertOrDeleteRecord.isPresent()) {
+      List<Schema.Field> fields = insertOrDeleteRecord.get().getSchema().getFields();
+
+      // If the updated record has TOASTED columns, we will need to keep the previous value for those columns
+      // see https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-toasted-values
+      fields.forEach(field -> {
+        // There are only four avro data types that have unconstrained sizes, which are
+        // NON-NULLABLE STRING, NULLABLE STRING, NON-NULLABLE BYTES, NULLABLE BYTES
+        boolean isToastedValue =
+            (
+                (
+                    field.schema().getType() == Schema.Type.STRING
+                        || (field.schema().getType() == Schema.Type.UNION && field.schema().getTypes().stream().anyMatch(s -> s.getType() == Schema.Type.STRING))
+                )
+                    && ((GenericData.Record) insertOrDeleteRecord.get()).get(field.name()) != null
+                    // Check length first as an optimization
+                    && ((CharSequence) ((GenericData.Record) insertOrDeleteRecord.get()).get(field.name())).length() == DEBEZIUM_TOASTED_VALUE.length()
+                    && DEBEZIUM_TOASTED_VALUE.equals(((CharSequence) ((GenericData.Record) insertOrDeleteRecord.get()).get(field.name())).toString())
+            )
+                ||
+                (
+                    (
+                        field.schema().getType() == Schema.Type.BYTES
+                            || (field.schema().getType() == Schema.Type.UNION && field.schema().getTypes().stream().anyMatch(s -> s.getType() == Schema.Type.BYTES))
+                    )
+                        && ((GenericData.Record) insertOrDeleteRecord.get()).get(field.name()) != null
+                        && ((ByteBuffer) ((GenericData.Record) insertOrDeleteRecord.get()).get(field.name())).array().length == DEBEZIUM_TOASTED_VALUE.length()
+                        && DEBEZIUM_TOASTED_VALUE.equals(new String(((ByteBuffer) ((GenericData.Record) insertOrDeleteRecord.get()).get(field.name())).array(), StandardCharsets.UTF_8))
+                );
+
+        if (isToastedValue) {
+          ((GenericData.Record) insertOrDeleteRecord.get()).put(field.name(), ((GenericData.Record) currentValue).get(field.name()));
+        }
+      });
+    }
+    return insertOrDeleteRecord;
+  }
+}
+

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -25,6 +25,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -45,6 +47,7 @@ import java.util.List;
  */
 public class PostgresDebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
 
+  private static final Logger LOG = LogManager.getLogger(PostgresDebeziumAvroPayload.class);
   public static final String DEBEZIUM_TOASTED_VALUE = "__debezium_unavailable_value";
 
   public PostgresDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -98,6 +98,8 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   /**
+   * Returns true if a column is either of type string or a union of one or more strings that contain a debezium toasted value.
+   *
    * @param incomingRecord The incoming avro record
    * @param field          the column of interest
    * @return
@@ -111,6 +113,8 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   /**
+   * Returns true if a column is either of type bytes or a union of one or more bytes that contain a debezium toasted value.
+   *
    * @param incomingRecord The incoming avro record
    * @param field          the column of interest
    * @return

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or mo contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestMySqlDebeziumAvroPayload {
+
+  private static final String KEY_FIELD_NAME = "Key";
+
+  private Schema avroSchema;
+
+  @BeforeEach
+  void setUp() {
+
+    this.avroSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
+        new Schema.Field("_change_operation_type", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("_event_seq", Schema.create(Schema.Type.STRING), "", null)
+    ));
+  }
+
+  @Test
+  public void testInsert() throws IOException {
+    GenericRecord insertRecord = createRecord(0, Operation.INSERT, "00001.111");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(insertRecord, "00001.111");
+    validateRecord(payload.getInsertValue(avroSchema), 0, Operation.INSERT, "00001.111");
+  }
+
+  @Test
+  public void testPreCombine() {
+    GenericRecord insertRecord = createRecord(0, Operation.INSERT, "00002.111");
+    MySqlDebeziumAvroPayload insertPayload = new MySqlDebeziumAvroPayload(insertRecord, "00002.111");
+
+    GenericRecord updateRecord = createRecord(0, Operation.UPDATE, "00001.111");
+    MySqlDebeziumAvroPayload updatePayload = new MySqlDebeziumAvroPayload(updateRecord, "00001.111");
+
+    GenericRecord deleteRecord = createRecord(0, Operation.DELETE, "00002.11");
+    MySqlDebeziumAvroPayload deletePayload = new MySqlDebeziumAvroPayload(deleteRecord, "00002.11");
+
+    assertEquals(insertPayload, insertPayload.preCombine(updatePayload));
+    assertEquals(deletePayload, deletePayload.preCombine(updatePayload));
+    assertEquals(insertPayload, deletePayload.preCombine(insertPayload));
+  }
+
+  @Test
+  public void testMergeWithUpdate() throws IOException {
+    GenericRecord updateRecord = createRecord(1, Operation.UPDATE, "00002.11");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(updateRecord, "00002.11");
+
+    GenericRecord existingRecord = createRecord(1, Operation.INSERT, "00001.111");
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
+    validateRecord(mergedRecord, 1, Operation.UPDATE, "00002.11");
+
+    GenericRecord lateRecord = createRecord(1, Operation.UPDATE, "00000.222");
+    payload = new MySqlDebeziumAvroPayload(lateRecord, "00000.222");
+    mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
+    validateRecord(mergedRecord, 1, Operation.INSERT, "00001.111");
+  }
+
+  @Test
+  public void testMergeWithDelete() throws IOException {
+    GenericRecord deleteRecord = createRecord(2, Operation.DELETE, "00002.11");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(deleteRecord, "00002.11");
+
+    GenericRecord existingRecord = createRecord(2, Operation.UPDATE, "00001.111");
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
+    // expect nothing to be committed to table
+    assertFalse(mergedRecord.isPresent());
+
+    GenericRecord lateRecord = createRecord(2, Operation.DELETE, "00000.222");
+    payload = new MySqlDebeziumAvroPayload(lateRecord, "00000.222");
+    mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
+    validateRecord(mergedRecord, 2, Operation.UPDATE, "00001.111");
+  }
+
+  private GenericRecord createRecord(int primaryKeyValue, Operation op, String seqValue) {
+    GenericRecord record = new GenericData.Record(avroSchema);
+    record.put(KEY_FIELD_NAME, primaryKeyValue);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, op.op);
+    record.put(DebeziumConstants.ADDED_SEQ_COL_NAME, seqValue);
+    return record;
+  }
+
+  private void validateRecord(Option<IndexedRecord> iRecord, int primaryKeyValue, Operation op, String seqValue) {
+    IndexedRecord record = iRecord.get();
+    assertEquals(primaryKeyValue, (int) record.get(0));
+    assertEquals(op.op, record.get(1).toString());
+    assertEquals(seqValue, record.get(2).toString());
+  }
+
+  private enum Operation {
+    INSERT("c"),
+    UPDATE("u"),
+    DELETE("d");
+
+    public final String op;
+
+    Operation(String op) {
+      this.op = op;
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -29,11 +29,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMySqlDebeziumAvroPayload {
 
@@ -43,11 +41,10 @@ public class TestMySqlDebeziumAvroPayload {
 
   @BeforeEach
   void setUp() {
-
     this.avroSchema = Schema.createRecord(Arrays.asList(
         new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
-        new Schema.Field("_change_operation_type", Schema.create(Schema.Type.STRING), "", null),
-        new Schema.Field("_event_seq", Schema.create(Schema.Type.STRING), "", null)
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME, Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field(DebeziumConstants.ADDED_SEQ_COL_NAME, Schema.create(Schema.Type.STRING), "", null)
     ));
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -114,7 +114,7 @@ public class TestPostgresDebeziumAvroPayload {
         .record("test_schema")
         .namespace("test_namespace")
         .fields()
-        .name(DebeziumConstants.MODIFIED_LSN_COL_NAME).type().longType().noDefault()
+        .name(DebeziumConstants.FLATTENED_LSN_COL_NAME).type().longType().noDefault()
         .name("string_col").type().stringType().noDefault()
         .name("byte_col").type().bytesType().noDefault()
         .name("string_null_col_1").type().nullable().stringType().noDefault()
@@ -124,7 +124,7 @@ public class TestPostgresDebeziumAvroPayload {
         .endRecord();
 
     GenericRecord oldVal = new GenericData.Record(avroSchema);
-    oldVal.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 100L);
+    oldVal.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, 100L);
     oldVal.put("string_col", "valid string value");
     oldVal.put("byte_col", ByteBuffer.wrap("valid byte value".getBytes()));
     oldVal.put("string_null_col_1", "valid string value");
@@ -133,7 +133,7 @@ public class TestPostgresDebeziumAvroPayload {
     oldVal.put("byte_null_col_2", null);
 
     GenericRecord newVal = new GenericData.Record(avroSchema);
-    newVal.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 105L);
+    newVal.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, 105L);
     newVal.put("string_col", PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE);
     newVal.put("byte_col", ByteBuffer.wrap(PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE.getBytes()));
     newVal.put("string_null_col_1", null);
@@ -157,16 +157,16 @@ public class TestPostgresDebeziumAvroPayload {
   private GenericRecord createRecord(int primaryKeyValue, Operation op, long lsnValue) {
     GenericRecord record = new GenericData.Record(avroSchema);
     record.put(KEY_FIELD_NAME, primaryKeyValue);
-    record.put(DebeziumConstants.MODIFIED_OP_COL_NAME, op.op);
-    record.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, lsnValue);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, op.op);
+    record.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, lsnValue);
     return record;
   }
 
   private void validateRecord(Option<IndexedRecord> iRecord, int primaryKeyValue, Operation op, long lsnValue) {
     IndexedRecord record = iRecord.get();
-    assertTrue((int) record.get(0) == primaryKeyValue);
-    assertTrue(record.get(1).toString().equals(op.op));
-    assertTrue((long) record.get(2) == lsnValue);
+    assertEquals(primaryKeyValue, (int) record.get(0));
+    assertEquals(op.op, record.get(1).toString());
+    assertEquals(lsnValue, (long) record.get(2));
   }
 
   private enum Operation {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -62,7 +62,23 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   @Test
-  public void testUpdate() throws Exception {
+  public void testPreCombine() {
+    GenericRecord insertRecord = createRecord(0, Operation.INSERT, 120L);
+    PostgresDebeziumAvroPayload insertPayload = new PostgresDebeziumAvroPayload(insertRecord, 120L);
+
+    GenericRecord updateRecord = createRecord(0, Operation.UPDATE, 99L);
+    PostgresDebeziumAvroPayload updatePayload = new PostgresDebeziumAvroPayload(updateRecord, 99L);
+
+    GenericRecord deleteRecord = createRecord(0, Operation.DELETE, 111L);
+    PostgresDebeziumAvroPayload deletePayload = new PostgresDebeziumAvroPayload(deleteRecord, 111L);
+
+    assertEquals(insertPayload, insertPayload.preCombine(updatePayload));
+    assertEquals(deletePayload, deletePayload.preCombine(updatePayload));
+    assertEquals(insertPayload, deletePayload.preCombine(insertPayload));
+  }
+
+  @Test
+  public void testMergeWithUpdate() throws IOException {
     GenericRecord updateRecord = createRecord(1, Operation.UPDATE, 100L);
     PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(updateRecord, 100L);
 
@@ -77,7 +93,7 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   @Test
-  public void testDelete() throws Exception {
+  public void testMergeWithDelete() throws IOException {
     GenericRecord deleteRecord = createRecord(2, Operation.DELETE, 100L);
     PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(deleteRecord, 100L);
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -32,26 +32,24 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestPostgresDebeziumAvroPayload {
 
   private static final String KEY_FIELD_NAME = "Key";
-  private static final String AVRO_SCHEMA_STRING = "{\"type\": \"record\","
-      + "\"name\": \"events\"," + "\"fields\": [ "
-      + "{\"name\": \"" + KEY_FIELD_NAME + "\", \"type\" : \"int\"},"
-      + "{\"name\": \"_change_operation_type\", \"type\": \"string\"},"
-      + "{\"name\": \"_event_lsn\", \"type\" : \"long\"}"
-      + "]}";
-
   private Schema avroSchema;
 
   @BeforeEach
   void setUp() {
-    this.avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_STRING);
+    this.avroSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME, Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field(DebeziumConstants.FLATTENED_LSN_COL_NAME, Schema.create(Schema.Type.LONG), "", null)
+    ));
   }
 
   @Test
@@ -148,8 +146,8 @@ public class TestPostgresDebeziumAvroPayload {
 
     assertEquals("valid string value", outputRecord.get("string_col"));
     assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_col")).array(), StandardCharsets.UTF_8));
-    assertEquals(null, outputRecord.get("string_null_col_1"));
-    assertEquals(null, outputRecord.get("byte_null_col_1"));
+    assertNull(outputRecord.get("string_null_col_1"));
+    assertNull(outputRecord.get("byte_null_col_1"));
     assertEquals("valid string value", ((Utf8) outputRecord.get("string_null_col_2")).toString());
     assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_null_col_2")).array(), StandardCharsets.UTF_8));
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPostgresDebeziumAvroPayload {
+
+  private static final String AVRO_SCHEMA_STRING = "{\"type\": \"record\","
+      + "\"name\": \"events\"," + "\"fields\": [ "
+      + "{\"name\": \"Key\", \"type\" : \"int\"},"
+      + "{\"name\": \"_change_operation_type\", \"type\": \"string\"},"
+      + "{\"name\": \"_event_lsn\", \"type\" : \"long\"}"
+      + "]}";
+
+  @Test
+  public void testInsert() throws IOException {
+    Schema avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_STRING);
+    GenericRecord record = new GenericData.Record(avroSchema);
+    record.put("Key", 0);
+    record.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "c");
+    record.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 100L);
+
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(record, 100L);
+
+    Option<IndexedRecord> outputPayload = payload.getInsertValue(avroSchema);
+    assertTrue((int) outputPayload.get().get(0) == 0);
+    assertTrue(outputPayload.get().get(1).toString().equals("c"));
+    assertTrue((long) outputPayload.get().get(2) == 100L);
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    Schema avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_STRING);
+    GenericRecord newRecord = new GenericData.Record(avroSchema);
+    newRecord.put("Key", 1);
+    newRecord.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "u");
+    newRecord.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 100L);
+
+    GenericRecord oldRecord = new GenericData.Record(avroSchema);
+    oldRecord.put("Key", 0);
+    oldRecord.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "c");
+    oldRecord.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 99L);
+
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(newRecord, 100L);
+
+    Option<IndexedRecord> outputPayload = payload.combineAndGetUpdateValue(oldRecord, avroSchema);
+    assertTrue((int) outputPayload.get().get(0) == 1);
+    assertTrue(outputPayload.get().get(1).toString().equals("u"));
+    assertTrue((long) outputPayload.get().get(2) == 100L);
+
+    GenericRecord lateRecord = new GenericData.Record(avroSchema);
+    lateRecord.put("Key", 1);
+    lateRecord.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "u");
+    lateRecord.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 98L);
+    payload = new PostgresDebeziumAvroPayload(lateRecord, 98L);
+    outputPayload = payload.combineAndGetUpdateValue(oldRecord, avroSchema);
+    assertTrue((int) outputPayload.get().get(0) == 0);
+    assertTrue(outputPayload.get().get(1).toString().equals("c"));
+    assertTrue((long) outputPayload.get().get(2) == 99L);
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Schema avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_STRING);
+    GenericRecord deleteRecord = new GenericData.Record(avroSchema);
+    deleteRecord.put("Key", 2);
+    deleteRecord.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "d");
+    deleteRecord.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 100L);
+
+    GenericRecord oldRecord = new GenericData.Record(avroSchema);
+    oldRecord.put("Key", 3);
+    oldRecord.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "u");
+    oldRecord.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 99L);
+
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(deleteRecord, 100L);
+
+    Option<IndexedRecord> outputPayload = payload.combineAndGetUpdateValue(oldRecord, avroSchema);
+    // expect nothing to be committed to table
+    assertFalse(outputPayload.isPresent());
+
+    GenericRecord lateRecord = new GenericData.Record(avroSchema);
+    lateRecord.put("Key", 1);
+    lateRecord.put(DebeziumConstants.MODIFIED_OP_COL_NAME, "d");
+    lateRecord.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 98L);
+    payload = new PostgresDebeziumAvroPayload(lateRecord, 98L);
+    outputPayload = payload.combineAndGetUpdateValue(oldRecord, avroSchema);
+    assertTrue((int) outputPayload.get().get(0) == 3);
+    assertTrue(outputPayload.get().get(1).toString().equals("u"));
+    assertTrue((long) outputPayload.get().get(2) == 99L);
+  }
+
+  @Test
+  public void testMergeWithToastedValues() throws IOException {
+    Schema avroSchema = SchemaBuilder.builder()
+        .record("test_schema")
+        .namespace("test_namespace")
+        .fields()
+        .name(DebeziumConstants.MODIFIED_LSN_COL_NAME).type().longType().noDefault()
+        .name("string_col").type().stringType().noDefault()
+        .name("byte_col").type().bytesType().noDefault()
+        .name("string_null_col_1").type().nullable().stringType().noDefault()
+        .name("byte_null_col_1").type().nullable().bytesType().noDefault()
+        .name("string_null_col_2").type().nullable().stringType().noDefault()
+        .name("byte_null_col_2").type().nullable().bytesType().noDefault()
+        .endRecord();
+
+    GenericRecord oldVal = new GenericData.Record(avroSchema);
+    oldVal.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 100L);
+    oldVal.put("string_col", "valid string value");
+    oldVal.put("byte_col", ByteBuffer.wrap("valid byte value".getBytes()));
+    oldVal.put("string_null_col_1", "valid string value");
+    oldVal.put("byte_null_col_1", ByteBuffer.wrap("valid byte value".getBytes()));
+    oldVal.put("string_null_col_2", null);
+    oldVal.put("byte_null_col_2", null);
+
+    GenericRecord newVal = new GenericData.Record(avroSchema);
+    newVal.put(DebeziumConstants.MODIFIED_LSN_COL_NAME, 105L);
+    newVal.put("string_col", PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE);
+    newVal.put("byte_col", ByteBuffer.wrap(PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE.getBytes()));
+    newVal.put("string_null_col_1", null);
+    newVal.put("byte_null_col_1", null);
+    newVal.put("string_null_col_2", "valid string value");
+    newVal.put("byte_null_col_2", ByteBuffer.wrap("valid byte value".getBytes()));
+
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(Option.of(newVal));
+
+    GenericRecord outputRecord = (GenericRecord) payload
+        .combineAndGetUpdateValue(oldVal, avroSchema).get();
+
+    assertEquals("valid string value", outputRecord.get("string_col"));
+    assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_col")).array(), StandardCharsets.UTF_8));
+    assertEquals(null, outputRecord.get("string_null_col_1"));
+    assertEquals(null, outputRecord.get("byte_null_col_1"));
+    assertEquals("valid string value", ((Utf8) outputRecord.get("string_null_col_2")).toString());
+    assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_null_col_2")).array(), StandardCharsets.UTF_8));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -49,7 +49,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
    */
   public static class Config {
 
-    private static final String SRC_SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.url";
+    public static final String SRC_SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.url";
     private static final String TARGET_SCHEMA_REGISTRY_URL_PROP =
         "hoodie.deltastreamer.schemaprovider.registry.targetUrl";
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -67,7 +67,6 @@ public abstract class DebeziumSource extends RowSource {
   // these are native kafka's config. do not change the config names.
   private static final String NATIVE_KAFKA_KEY_DESERIALIZER_PROP = "key.deserializer";
   private static final String NATIVE_KAFKA_VALUE_DESERIALIZER_PROP = "value.deserializer";
-  private static final String SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.url";
   private static final String OVERRIDE_CHECKPOINT_STRING = "hoodie.debezium.override.initial.checkpoint.key";
   private static final String CONNECT_NAME_KEY = "connect.name";
   private static final String DATE_CONNECT_NAME = "custom.debezium.DateString";
@@ -120,7 +119,7 @@ public abstract class DebeziumSource extends RowSource {
       return Pair.of(Option.of(sparkSession.emptyDataFrame()), overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr);
     } else {
       try {
-        String schemaStr = schemaRegistryProvider.fetchSchemaFromRegistry(SCHEMA_REGISTRY_URL_PROP);
+        String schemaStr = schemaRegistryProvider.fetchSchemaFromRegistry(props.getString(SchemaRegistryProvider.Config.SRC_SCHEMA_REGISTRY_URL_PROP));
         Dataset<Row> dataset = toDataset(offsetRanges, offsetGen, schemaStr);
         LOG.info(String.format("Spark schema of Kafka Payload for topic %s:\n%s", offsetGen.getTopicName(), dataset.schema().treeString()));
         LOG.info(String.format("New checkpoint string: %s", CheckpointUtils.offsetsToStr(offsetRanges)));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -89,7 +89,6 @@ public abstract class DebeziumSource extends RowSource {
 
     try {
       props.put(NATIVE_KAFKA_VALUE_DESERIALIZER_PROP, Class.forName(deserializerClassName));
-      LOG.error("WNI native kafka " + deserializerClassName);
     } catch (ClassNotFoundException e) {
       String error = "Could not load custom avro kafka deserializer: " + deserializerClassName;
       LOG.error(error);
@@ -151,13 +150,11 @@ public abstract class DebeziumSource extends RowSource {
     AvroConvertor convertor = new AvroConvertor(schemaStr);
     Dataset<Row> kafkaData;
     if (deserializerClassName.equals(StringDeserializer.class.getName())) {
-      LOG.error("WNI native kafka11 " + deserializerClassName);
       kafkaData = AvroConversionUtils.createDataFrame(
           KafkaUtils.<String, String>createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges, LocationStrategies.PreferConsistent())
               .map(obj -> convertor.fromJson(obj.value()))
               .rdd(), schemaStr, sparkSession);
     } else {
-      LOG.error("WNI native kafka22 " + deserializerClassName);
       kafkaData = AvroConversionUtils.createDataFrame(
           KafkaUtils.createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges, LocationStrategies.PreferConsistent())
               .map(obj -> (GenericRecord) obj.value())

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -1,0 +1,245 @@
+package org.apache.hudi.utilities.sources.debezium;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericRecord;
+
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.RowSource;
+import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen;
+import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.streaming.kafka010.KafkaUtils;
+import org.apache.spark.streaming.kafka010.LocationStrategies;
+import org.apache.spark.streaming.kafka010.OffsetRange;
+
+/**
+ * Base class for Debezium streaming source which expects change events as Kafka Avro records.
+ * Obtains the schema from the confluent schema-registry.
+ */
+public abstract class DebeziumSource extends RowSource {
+
+  private static final Logger LOG = LogManager.getLogger(DebeziumSource.class);
+  private static final String SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.url";
+  private static final String OVERRIDE_CHECKPOINT_STRING = "hoodie.debezium.override.initial.checkpoint.key";
+  private static final String CONNECT_NAME_KEY = "connect.name";
+  private static final String DATE_CONNECT_NAME = "custom.debezium.DateString";
+
+  private final KafkaOffsetGen offsetGen;
+  private final HoodieDeltaStreamerMetrics metrics;
+
+  public DebeziumSource(TypedProperties props, JavaSparkContext sparkContext,
+                        SparkSession sparkSession,
+                        SchemaProvider schemaProvider,
+                        HoodieDeltaStreamerMetrics metrics) {
+    super(props, sparkContext, sparkSession, schemaProvider);
+    props.put("key.deserializer", StringDeserializer.class);
+    props.put("value.deserializer", KafkaAvroDeserializer.class);
+
+    offsetGen = new KafkaOffsetGen(props);
+    this.metrics = metrics;
+  }
+
+  @Override
+  protected Pair<Option<Dataset<Row>>, String> fetchNextBatch(Option<String> lastCkptStr, long sourceLimit) {
+    String overrideCheckpointStr = props.getString(OVERRIDE_CHECKPOINT_STRING, "");
+
+    OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCkptStr, sourceLimit, metrics);
+    long totalNewMsgs = CheckpointUtils.totalNewMessages(offsetRanges);
+    LOG.info("About to read " + totalNewMsgs + " from Kafka for topic :" + offsetGen.getTopicName());
+
+    if (totalNewMsgs == 0) {
+      // If there are no new messages, use empty dataframe with no schema. This is because the schema from schema registry can only be considered
+      // up to date if a change event has occured.
+      return Pair.of(Option.of(sparkSession.emptyDataFrame()), overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr);
+    } else {
+      try {
+        String schemaStr = fetchSchemaFromRegistry(props.getString(SCHEMA_REGISTRY_URL_PROP));
+        Dataset<Row> dataset = toDataset(offsetRanges, offsetGen, schemaStr);
+        LOG.info(String.format("Spark schema of Kafka Payload for topic %s:\n%s", offsetGen.getTopicName(), dataset.schema().treeString()));
+        LOG.info(String.format("New checkpoint string: %s", CheckpointUtils.offsetsToStr(offsetRanges)));
+        return Pair.of(Option.of(dataset), overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr);
+      } catch (IOException exc) {
+        LOG.error("Fatal error reading and parsing incoming debezium event", exc);
+        throw new HoodieException("Fatal error reading and parsing incoming debezium event", exc);
+      }
+    }
+  }
+
+  /**
+   * Debezium Kafka Payload has a nested structure, flatten it specific to the Database type.
+   * @param rawKafkaData Dataset of the Debezium CDC event from the kafka
+   * @return A flattened dataset.
+   */
+  protected abstract Dataset<Row> processDataset(Dataset<Row> rawKafkaData);
+
+
+  /**
+   * Converts a Kafka Topic offset into a Spark dataset.
+   *
+   * @param offsetRanges Offset ranges
+   * @param offsetGen    KafkaOffsetGen
+   * @return Spark dataset
+   */
+  private Dataset<Row> toDataset(OffsetRange[] offsetRanges, KafkaOffsetGen offsetGen, String schemaStr) {
+    Dataset<Row> kafkaData = AvroConversionUtils.createDataFrame(
+        KafkaUtils.createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges, LocationStrategies.PreferConsistent())
+            .map(obj -> (GenericRecord) obj.value())
+            .rdd(), schemaStr, sparkSession);
+
+    // Flatten debezium payload, specific to each DB type (postgres/ mysql/ etc..)
+    Dataset<Row> debeziumDataset = processDataset(kafkaData);
+
+    // Some required transformations to ensure debezium data types are converted to spark supported types.
+    return convertArrayColumnsToString(convertColumnToNullable(sparkSession,
+        convertDateColumns(debeziumDataset, new Schema.Parser().parse(schemaStr))));
+  }
+
+  /**
+   * The method takes the provided url {@code registryUrl} and gets the schema from the schema registry using that url.
+   * If the caller provides userInfo credentials in the url (e.g "https://foo:bar@schemaregistry.org") then the credentials
+   * are extracted the url using the Matcher and the extracted credentials are set on the request as an Authorization
+   * header.
+   * @param registryUrl
+   * @return the Schema in String form.
+   * @throws IOException
+   */
+  private String fetchSchemaFromRegistry(String registryUrl) throws IOException {
+    URL registry;
+    HttpURLConnection connection;
+    Matcher matcher = Pattern.compile("://(.*?)@").matcher(registryUrl);
+    if (matcher.find()) {
+      String creds = matcher.group(1);
+      String urlWithoutCreds = registryUrl.replace(creds + "@", "");
+      registry = new URL(urlWithoutCreds);
+      connection = (HttpURLConnection) registry.openConnection();
+      setAuthorizationHeader(matcher.group(1), connection);
+    } else {
+      registry = new URL(registryUrl);
+      connection = (HttpURLConnection) registry.openConnection();
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode node = mapper.readTree(getStream(connection));
+    String schema = node.get("schema").asText();
+    LOG.info(String.format("Reading schema from %s: %s", registryUrl, schema));
+    return schema;
+  }
+
+  private void setAuthorizationHeader(String creds, HttpURLConnection connection) {
+    String encodedAuth = Base64.getEncoder().encodeToString(creds.getBytes(StandardCharsets.UTF_8));
+    connection.setRequestProperty("Authorization", "Basic " + encodedAuth);
+  }
+
+  private InputStream getStream(HttpURLConnection connection) throws IOException {
+    return connection.getInputStream();
+  }
+
+  /**
+   * Converts string formatted date columns into Spark date columns.
+   *
+   * @param dataset Spark dataset
+   * @param schema  Avro schema from Debezium
+   * @return Converted dataset
+   */
+  public static Dataset<Row> convertDateColumns(Dataset<Row> dataset, Schema schema) {
+    if (schema.getField("before") != null) {
+      List<String> dateFields = schema.getField("before")
+          .schema()
+          .getTypes()
+          .get(1)
+          .getFields()
+          .stream()
+          .filter(field -> {
+            if (field.schema().getType() == Type.UNION) {
+              return field.schema().getTypes().stream().anyMatch(
+                  schemaInUnion -> DATE_CONNECT_NAME.equals(schemaInUnion.getProp(CONNECT_NAME_KEY))
+              );
+            } else {
+              return DATE_CONNECT_NAME.equals(field.schema().getProp(CONNECT_NAME_KEY));
+            }
+          }).map(Field::name).collect(Collectors.toList());
+
+      LOG.info("Date fields: " + dateFields.toString());
+
+      for (String dateCol : dateFields) {
+        dataset = dataset.withColumn(dateCol, functions.col(dateCol).cast(DataTypes.DateType));
+      }
+    }
+
+    return dataset;
+  }
+
+  /**
+   * Utility function for converting columns to nullable. This is useful when required to make a column nullable to match a nullable column from Debezium change
+   * events.
+   *
+   * @param sparkSession SparkSession object
+   * @param dataset      Dataframe to modify
+   * @return Modified dataframe
+   */
+  private static Dataset<Row> convertColumnToNullable(SparkSession sparkSession, Dataset<Row> dataset) {
+    List<String> columns = Arrays.asList(dataset.columns());
+    StructField[] modifiedStructFields = Arrays.stream(dataset.schema().fields()).map(field -> columns
+        .contains(field.name()) ? new StructField(field.name(), field.dataType(), true, field.metadata()) : field)
+        .toArray(StructField[]::new);
+
+    return sparkSession.createDataFrame(dataset.rdd(), new StructType(modifiedStructFields));
+  }
+
+  /**
+   * Converts Array types to String types because not all Debezium array columns are supported to be converted
+   * to Spark array columns.
+   *
+   * @param dataset Dataframe to modify
+   * @return Modified dataframe
+   */
+  private static Dataset<Row> convertArrayColumnsToString(Dataset<Row> dataset) {
+    List<String> arrayColumns = Arrays.stream(dataset.schema().fields())
+        .filter(field -> field.dataType().typeName().toLowerCase().startsWith("array"))
+        .map(StructField::name)
+        .collect(Collectors.toList());
+
+    for (String colName : arrayColumns) {
+      dataset = dataset.withColumn(colName, functions.col(colName).cast(DataTypes.StringType));
+    }
+
+    return dataset;
+  }
+}
+

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/PostgresDebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/PostgresDebeziumSource.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Source for incrementally ingesting debezium generated change logs for PostgresDB.
+ */
+public class PostgresDebeziumSource extends DebeziumSource {
+
+  public PostgresDebeziumSource(TypedProperties props, JavaSparkContext sparkContext,
+                                SparkSession sparkSession,
+                                SchemaProvider schemaProvider,
+                                HoodieDeltaStreamerMetrics metrics) {
+    super(props, sparkContext, sparkSession, schemaProvider, metrics);
+  }
+
+  /**
+   * Debezium Kafka Payload has a nested structure (see https://debezium.io/documentation/reference/1.4/connectors/postgresql.html#postgresql-create-events).
+   * This function flattens this nested structure for the Postgres data, and also extracts a subset of Debezium metadata fields.
+   *
+   * @param rowDataset Dataset containing Debezium Payloads
+   * @return New dataset with flattened columns
+   */
+  @Override
+  protected Dataset<Row> processDataset(Dataset<Row> rowDataset) {
+    if (rowDataset.columns().length > 0) {
+      // Pick selective debezium and postgres meta fields: pick the row values from before field for delete record
+      // and row values from after field for insert or update records.
+      Dataset<Row> insertedOrUpdatedData = rowDataset
+          .selectExpr(
+              String.format("%s as %s", DebeziumConstants.INCOMING_OP_FIELD, DebeziumConstants.MODIFIED_OP_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_TS_MS_FIELD, DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_NAME_FIELD, DebeziumConstants.MODIFIED_SHARD_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD, DebeziumConstants.MODIFIED_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TXID_FIELD, DebeziumConstants.MODIFIED_TX_ID_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_LSN_FIELD, DebeziumConstants.MODIFIED_LSN_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_XMIN_FIELD, DebeziumConstants.MODIFIED_XMIN_COL_NAME),
+              String.format("%s.*", DebeziumConstants.INCOMING_AFTER_FIELD)
+          )
+          .filter(rowDataset.col(DebeziumConstants.INCOMING_OP_FIELD).notEqual(DebeziumConstants.DELETE_OP));
+
+      Dataset<Row> deletedData = rowDataset
+          .selectExpr(
+              String.format("%s as %s", DebeziumConstants.INCOMING_OP_FIELD, DebeziumConstants.MODIFIED_OP_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_TS_MS_FIELD, DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_NAME_FIELD, DebeziumConstants.MODIFIED_SHARD_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD, DebeziumConstants.MODIFIED_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TXID_FIELD, DebeziumConstants.MODIFIED_TX_ID_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_LSN_FIELD, DebeziumConstants.MODIFIED_LSN_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_XMIN_FIELD, DebeziumConstants.MODIFIED_XMIN_COL_NAME),
+              String.format("%s.*", DebeziumConstants.INCOMING_BEFORE_FIELD)
+          )
+          .filter(rowDataset.col(DebeziumConstants.INCOMING_OP_FIELD).equalTo(DebeziumConstants.DELETE_OP));
+
+      return insertedOrUpdatedData.union(deletedData);
+    } else {
+      return rowDataset;
+    }
+  }
+}
+

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestAbstractDebeziumSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestAbstractDebeziumSource.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
+import org.apache.hudi.utilities.deltastreamer.SourceFormatAdapter;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
+import org.apache.hudi.utilities.sources.InputBatch;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.streaming.kafka010.KafkaTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+
+public abstract class TestAbstractDebeziumSource extends UtilitiesTestBase {
+
+  private static final String TEST_TOPIC_NAME = "hoodie_test";
+
+  private final HoodieDeltaStreamerMetrics metrics = mock(HoodieDeltaStreamerMetrics.class);
+  private KafkaTestUtils testUtils;
+
+  @BeforeAll
+  public static void initClass() throws Exception {
+    UtilitiesTestBase.initClass(false);
+  }
+
+  @AfterAll
+  public static void cleanupClass() {
+    UtilitiesTestBase.cleanupClass();
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    super.setup();
+    testUtils = new KafkaTestUtils();
+    testUtils.setup();
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    super.teardown();
+    testUtils.teardown();
+  }
+
+  private TypedProperties createPropsForJsonSource() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.deltastreamer.source.kafka.topic", TEST_TOPIC_NAME);
+    props.setProperty("bootstrap.servers", testUtils.brokerAddress());
+    props.setProperty("auto.offset.reset", "earliest");
+    props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    props.setProperty("hoodie.deltastreamer.schemaprovider.registry.url", "localhost");
+    props.setProperty("hoodie.deltastreamer.source.kafka.value.deserializer.class", StringDeserializer.class.getName());
+    props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+    return props;
+  }
+
+  protected abstract String getIndexName();
+
+  protected abstract String getSourceClass();
+
+  protected abstract String getSchema();
+
+  protected abstract GenericRecord generateMetaFields(GenericRecord record);
+
+  protected abstract void validateMetaFields(Dataset<Row> records);
+
+  @ParameterizedTest
+  @MethodSource("testArguments")
+  public void testDebeziumEvents(Operation operation) throws Exception {
+
+    String sourceClass = getSourceClass();
+
+    // topic setup.
+    testUtils.createTopic(TEST_TOPIC_NAME, 2);
+    TypedProperties props = createPropsForJsonSource();
+
+    SchemaProvider schemaProvider = new MockSchemaRegistryProvider(props, jsc, this);
+    SourceFormatAdapter debeziumSource = new SourceFormatAdapter(UtilHelpers.createSource(sourceClass, props, jsc, sparkSession, schemaProvider, metrics));
+
+    testUtils.sendMessages(TEST_TOPIC_NAME, new String[] {generateDebeziumEvent(operation).toString()});
+
+    InputBatch<Dataset<Row>> fetch = debeziumSource.fetchNewDataInRowFormat(Option.empty(), 10);
+    assertEquals(1, fetch.getBatch().get().count());
+
+    // Ensure the before fields are picked for DELETE CDC Events,
+    // and after fields are picked for INSERT and UPDATE CDC Events.
+    final String fieldPrefix = (operation.equals(Operation.DELETE)) ? "before_" : "after_";
+    assertTrue(fetch.getBatch().get().select("type").collectAsList().stream()
+        .allMatch(r -> r.getString(0).startsWith(fieldPrefix)));
+    assertTrue(fetch.getBatch().get().select("type").collectAsList().stream()
+        .allMatch(r -> r.getString(0).startsWith(fieldPrefix)));
+
+    // Validate DB specific meta fields
+    validateMetaFields(fetch.getBatch().get());
+  }
+
+  private GenericRecord generateDebeziumEvent(Operation op) {
+    Schema schema = new Schema.Parser().parse(getSchema());
+    String indexName = getIndexName().concat(".ghschema.gharchive.Value");
+    GenericRecord rec = new GenericData.Record(schema);
+    rec.put(DebeziumConstants.INCOMING_OP_FIELD, op.op);
+    rec.put(DebeziumConstants.INCOMING_TS_MS_FIELD, 100L);
+
+    // Before
+    Schema.Field beforeField = schema.getField(DebeziumConstants.INCOMING_BEFORE_FIELD);
+    Schema beforeSchema = beforeField.schema().getTypes().get(beforeField.schema().getIndexNamed(indexName));
+    GenericRecord beforeRecord = new GenericData.Record(beforeSchema);
+
+    beforeRecord.put("id", 1);
+    beforeRecord.put("date", "1/1/2020");
+    beforeRecord.put("type", "before_type");
+    beforeRecord.put("payload", "before_payload");
+    beforeRecord.put("timestamp", 1000L);
+    rec.put(DebeziumConstants.INCOMING_BEFORE_FIELD, beforeRecord);
+
+    // After
+    Schema.Field afterField = schema.getField(DebeziumConstants.INCOMING_AFTER_FIELD);
+    Schema afterSchema = afterField.schema().getTypes().get(afterField.schema().getIndexNamed(indexName));
+    GenericRecord afterRecord = new GenericData.Record(afterSchema);
+
+    afterRecord.put("id", 1);
+    afterRecord.put("date", "1/1/2021");
+    afterRecord.put("type", "after_type");
+    afterRecord.put("payload", "after_payload");
+    afterRecord.put("timestamp", 3000L);
+    rec.put(DebeziumConstants.INCOMING_AFTER_FIELD, afterRecord);
+
+    return generateMetaFields(rec);
+  }
+
+  private static class MockSchemaRegistryProvider extends SchemaRegistryProvider {
+
+    private final String schema;
+
+    public MockSchemaRegistryProvider(TypedProperties props, JavaSparkContext jssc, TestAbstractDebeziumSource source) {
+      super(props, jssc);
+      schema = source.getSchema();
+    }
+
+    @Override
+    public String fetchSchemaFromRegistry(String registryUrl) throws IOException {
+      return schema;
+    }
+  }
+
+  private static Stream<Arguments> testArguments() {
+    return Stream.of(
+        arguments(Operation.INSERT),
+        arguments(Operation.UPDATE),
+        arguments(Operation.DELETE)
+    );
+  }
+
+  private enum Operation {
+    INSERT("c"),
+    UPDATE("u"),
+    DELETE("d");
+
+    public final String op;
+
+    Operation(String op) {
+      this.op = op;
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
@@ -21,26 +21,19 @@ package org.apache.hudi.utilities.sources.debezium;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
+import org.apache.hudi.payload.AWSDmsAvroPayload;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
 import org.apache.hudi.utilities.deltastreamer.SourceFormatAdapter;
 import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
 import org.apache.hudi.utilities.sources.InputBatch;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.MockProducer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -52,11 +45,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 
 public class TestPostgresDebeziumSource extends UtilitiesTestBase {
@@ -292,15 +292,15 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
     props.setProperty("auto.offset.reset", "earliest");
     props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     props.setProperty("hoodie.deltastreamer.schemaprovider.registry.url", "localhost");
-    props.setProperty("schema.registry.url", "localhost");
     props.setProperty("hoodie.deltastreamer.source.kafka.value.deserializer.class", StringDeserializer.class.getName());
     props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
 
     return props;
   }
 
-  @Test
-  public void testJsonKafkaSource() {
+  @ParameterizedTest
+  @MethodSource("testArguments")
+  public void testInsertDebeziumEvent(Operation operation) {
     // topic setup.
     testUtils.createTopic(TEST_TOPIC_NAME, 2);
     TypedProperties props = createPropsForJsonSource();
@@ -308,10 +308,26 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
     PostgresDebeziumSource postgresDebeziumSource = new PostgresDebeziumSource(props, jsc, sparkSession, schemaProvider, metrics);
     SourceFormatAdapter debeziumSource = new SourceFormatAdapter(postgresDebeziumSource);
 
-    testUtils.sendMessages(TEST_TOPIC_NAME, new String[] { generateDebeziumEvent(Operation.INSERT).toString() });
+    testUtils.sendMessages(TEST_TOPIC_NAME, new String[] { generateDebeziumEvent(operation).toString() });
 
-    InputBatch<Dataset<Row>> fetch1 = debeziumSource.fetchNewDataInRowFormat(Option.empty(), 900);
-    assertEquals(1, fetch1.getBatch().get().count());
+    InputBatch<Dataset<Row>> fetch = debeziumSource.fetchNewDataInRowFormat(Option.empty(), 10);
+    assertEquals(1, fetch.getBatch().get().count());
+
+    // Ensure the before fields are picked for DELETE CDC Events,
+    // and after fields are picked for INSERT and UPDATE CDC Events.
+    final String fieldPrefix = (operation.equals(Operation.DELETE)) ? "before_" : "after_";
+    
+    assertTrue(fetch.getBatch().get().select("type").collectAsList().stream()
+        .allMatch(r -> r.getString(0).startsWith(fieldPrefix)));
+    assertTrue(fetch.getBatch().get().select("type").collectAsList().stream()
+        .allMatch(r -> r.getString(0).startsWith(fieldPrefix)));
+
+    assertTrue(fetch.getBatch().get().select(DebeziumConstants.MODIFIED_TX_ID_COL_NAME).collectAsList().stream()
+      .allMatch(r -> r.getLong(0) > 0));
+    assertTrue(fetch.getBatch().get().select(DebeziumConstants.MODIFIED_LSN_COL_NAME).collectAsList().stream()
+        .allMatch(r -> r.getLong(0) > 0));
+    assertTrue(fetch.getBatch().get().select(DebeziumConstants.MODIFIED_TS_COL_NAME).collectAsList().stream()
+        .allMatch(r -> r.getLong(0) > 0));
   }
 
   private static GenericRecord generateDebeziumEvent(Operation op) {
@@ -326,6 +342,8 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
 
     beforeRecord.put("id", 1);
     beforeRecord.put("date", "1/1/2020");
+    beforeRecord.put("type", "before_type");
+    beforeRecord.put("payload", "before_payload");
     beforeRecord.put("timestamp", 1000L);
     rec.put(DebeziumConstants.INCOMING_BEFORE_FIELD, beforeRecord);
 
@@ -336,6 +354,8 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
 
     afterRecord.put("id", 1);
     afterRecord.put("date", "1/1/2021");
+    afterRecord.put("type", "after_type");
+    afterRecord.put("payload", "after_payload");
     afterRecord.put("timestamp", 3000L);
     rec.put(DebeziumConstants.INCOMING_AFTER_FIELD, afterRecord);
 
@@ -377,5 +397,13 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
     public String fetchSchemaFromRegistry(String registryUrl) throws IOException {
       return POSTGRES_GITHUB_SCHEMA;
     }
+  }
+
+  private static Stream<Arguments> testArguments() {
+    return Stream.of(
+        arguments(Operation.INSERT),
+        arguments(Operation.UPDATE),
+        arguments(Operation.DELETE)
+    );
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
@@ -32,8 +32,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -58,21 +56,21 @@ import static org.mockito.Mockito.mock;
 public class TestPostgresDebeziumSource extends UtilitiesTestBase {
 
   private static String TEST_TOPIC_NAME = "hoodie_test";
-  private static final String POSTGRES_GITHUB_SCHEMA = "{\"connect.name\": \"postgres.ghschema.gharchive.Envelope\",\n" +
-      "  \"fields\": [{\"default\": null,\"name\": \"before\",\"type\": [\"null\",{\"connect.name\": \"postgres.ghschema.gharchive.Value\",\n" +
-      "  \"fields\": [{\"name\": \"id\",\"type\": \"string\"},{\"name\": \"date\",\"type\": \"string\"},{\"default\": null,\"name\": \"timestamp\",\n" +
-      "  \"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"type\",\"type\": [\"null\",\"string\"]},{\"default\": null,\"name\": \"payload\",\n" +
-      "  \"type\": [\"null\",\"string\"]},{\"default\": null,\"name\": \"org\",\"type\": [\"null\",\"string\"]},{\"default\": null,\"name\": \"created_at\",\n" +
-      "  \"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"public\",\"type\": [\"null\",\"boolean\"]}],\"name\": \"Value\",\"type\": \"record\"\n" +
-      "  }]},{\"default\": null,\"name\": \"after\",\"type\": [\"null\",\"Value\"]},{\"name\": \"source\",\"type\": {\"connect.name\": \"io.debezium.connector.postgresql.Source\",\n" +
-      "  \"fields\": [{\"name\": \"connector\",\"type\": \"string\"},{\"name\": \"name\",\"type\": \"string\"},{\"name\": \"ts_ms\",\"type\": \"long\"},\n" +
-      "  {\"name\": \"db\",\"type\": \"string\"},{\"name\": \"schema\",\"type\": \"string\"},{\"name\": \"table\",\"type\": \"string\"},{\"default\": null,\n" +
-      "  \"name\": \"txId\",\"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"lsn\",\"type\": [\"null\",\"long\"]},{\"default\": null,\n" +
-      "  \"name\": \"xmin\",\"type\": [\"null\",\"long\"]}],\"name\": \"Source\",\"namespace\": \"io.debezium.connector.postgresql\",\"type\": \"record\"\n" +
-      "  }},{\"name\": \"op\",\"type\": \"string\"},{\"default\": null,\"name\": \"ts_ms\",\"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"transaction\",\n" +
-      "  \"type\": [\"null\",{\"fields\": [{\"name\": \"id\",\"type\": \"string\"},{\"name\": \"total_order\",\"type\": \"long\"},{\"name\": \"data_collection_order\",\n" +
-      "  \"type\": \"long\"}],\"name\": \"ConnectDefault\",\"namespace\": \"io.confluent.connect.avro\",\"type\": \"record\"}]}],\"name\": \"Envelope\",\n" +
-      "  \"namespace\": \"postgres.ghschema.gharchive\",\"type\": \"record\"}";
+  private static final String POSTGRES_GITHUB_SCHEMA = "{\"connect.name\": \"postgres.ghschema.gharchive.Envelope\",\n"
+      + "  \"fields\": [{\"default\": null,\"name\": \"before\",\"type\": [\"null\",{\"connect.name\": \"postgres.ghschema.gharchive.Value\",\n"
+      + "  \"fields\": [{\"name\": \"id\",\"type\": \"string\"},{\"name\": \"date\",\"type\": \"string\"},{\"default\": null,\"name\": \"timestamp\",\n"
+      + "  \"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"type\",\"type\": [\"null\",\"string\"]},{\"default\": null,\"name\": \"payload\",\n"
+      + "  \"type\": [\"null\",\"string\"]},{\"default\": null,\"name\": \"org\",\"type\": [\"null\",\"string\"]},{\"default\": null,\"name\": \"created_at\",\n"
+      + "  \"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"public\",\"type\": [\"null\",\"boolean\"]}],\"name\": \"Value\",\"type\": \"record\"\n"
+      + "  }]},{\"default\": null,\"name\": \"after\",\"type\": [\"null\",\"Value\"]},{\"name\": \"source\",\"type\": {\"connect.name\": \"io.debezium.connector.postgresql.Source\",\n"
+      + "  \"fields\": [{\"name\": \"connector\",\"type\": \"string\"},{\"name\": \"name\",\"type\": \"string\"},{\"name\": \"ts_ms\",\"type\": \"long\"},\n"
+      + "  {\"name\": \"db\",\"type\": \"string\"},{\"name\": \"schema\",\"type\": \"string\"},{\"name\": \"table\",\"type\": \"string\"},{\"default\": null,\n"
+      + "  \"name\": \"txId\",\"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"lsn\",\"type\": [\"null\",\"long\"]},{\"default\": null,\n"
+      + "  \"name\": \"xmin\",\"type\": [\"null\",\"long\"]}],\"name\": \"Source\",\"namespace\": \"io.debezium.connector.postgresql\",\"type\": \"record\"\n"
+      + "  }},{\"name\": \"op\",\"type\": \"string\"},{\"default\": null,\"name\": \"ts_ms\",\"type\": [\"null\",\"long\"]},{\"default\": null,\"name\": \"transaction\",\n"
+      + "  \"type\": [\"null\",{\"fields\": [{\"name\": \"id\",\"type\": \"string\"},{\"name\": \"total_order\",\"type\": \"long\"},{\"name\": \"data_collection_order\",\n"
+      + "  \"type\": \"long\"}],\"name\": \"ConnectDefault\",\"namespace\": \"io.confluent.connect.avro\",\"type\": \"record\"}]}],\"name\": \"Envelope\",\n"
+      + "  \"namespace\": \"postgres.ghschema.gharchive\",\"type\": \"record\"}";
   private static final Schema POSTGRES_GITHUB_AVRO_SCHEMA = new Schema.Parser().parse(POSTGRES_GITHUB_SCHEMA);
 
   private MockSchemaRegistryProvider schemaProvider;
@@ -88,7 +86,6 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
   public static void cleanupClass() {
     UtilitiesTestBase.cleanupClass();
   }
-
 
   @BeforeEach
   public void setup() throws Exception {
@@ -127,7 +124,7 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
     PostgresDebeziumSource postgresDebeziumSource = new PostgresDebeziumSource(props, jsc, sparkSession, schemaProvider, metrics);
     SourceFormatAdapter debeziumSource = new SourceFormatAdapter(postgresDebeziumSource);
 
-    testUtils.sendMessages(TEST_TOPIC_NAME, new String[] { generateDebeziumEvent(operation).toString() });
+    testUtils.sendMessages(TEST_TOPIC_NAME, new String[] {generateDebeziumEvent(operation).toString()});
 
     InputBatch<Dataset<Row>> fetch = debeziumSource.fetchNewDataInRowFormat(Option.empty(), 10);
     assertEquals(1, fetch.getBatch().get().count());
@@ -142,7 +139,7 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
         .allMatch(r -> r.getString(0).startsWith(fieldPrefix)));
 
     assertTrue(fetch.getBatch().get().select(DebeziumConstants.MODIFIED_TX_ID_COL_NAME).collectAsList().stream()
-      .allMatch(r -> r.getLong(0) > 0));
+        .allMatch(r -> r.getLong(0) > 0));
     assertTrue(fetch.getBatch().get().select(DebeziumConstants.MODIFIED_LSN_COL_NAME).collectAsList().stream()
         .allMatch(r -> r.getLong(0) > 0));
     assertTrue(fetch.getBatch().get().select(DebeziumConstants.MODIFIED_TS_COL_NAME).collectAsList().stream()

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
@@ -293,6 +293,7 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
     props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     props.setProperty("hoodie.deltastreamer.schemaprovider.registry.url", "localhost");
     props.setProperty("schema.registry.url", "localhost");
+    props.setProperty("hoodie.deltastreamer.source.kafka.value.deserializer.class", StringDeserializer.class.getName());
     props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
 
     return props;
@@ -306,21 +307,7 @@ public class TestPostgresDebeziumSource extends UtilitiesTestBase {
 
     PostgresDebeziumSource postgresDebeziumSource = new PostgresDebeziumSource(props, jsc, sparkSession, schemaProvider, metrics);
     SourceFormatAdapter debeziumSource = new SourceFormatAdapter(postgresDebeziumSource);
-    TypedProperties prop1 = new TypedProperties();
-    prop1.put("key.serializer", StringSerializer.class);
-    prop1.put("value.serializer", StringSerializer.class);
-    prop1.put("bootstrap.servers", testUtils.brokerAddress());
-    //prop1.setProperty("schema.registry.url", "localhost");
 
-    //Producer<String, String> mockProducer = new KafkaProducer<>(prop1);
-    //ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(TEST_TOPIC_NAME, "key", "vale");// generateDebeziumEvent(Operation.INSERT));
-    //mockProducer.send(kafkaRecord);
-    LOG.error("WNI " + testUtils.brokerAddress());
-    // 1. Extract without any checkpoint => get all the data, respecting sourceLimit
-    //assertEquals(Option.empty(), debeziumSource.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE).getBatch());
-
-    //Map<String, GenericRecord> testMap = new HashMap<>();
-    //testMap.put("key", generateDebeziumEvent(Operation.INSERT));
     testUtils.sendMessages(TEST_TOPIC_NAME, new String[] { generateDebeziumEvent(Operation.INSERT).toString() });
 
     InputBatch<Dataset<Row>> fetch1 = debeziumSource.fetchNewDataInRowFormat(Option.empty(), 900);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/debezium/TestPostgresDebeziumSource.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
+import org.apache.hudi.utilities.deltastreamer.SourceFormatAdapter;
+import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
+import org.apache.hudi.utilities.sources.InputBatch;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.streaming.kafka010.KafkaTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class TestPostgresDebeziumSource extends UtilitiesTestBase {
+
+  private static final Logger LOG = LogManager.getLogger(TestPostgresDebeziumSource.class);
+  private static String TEST_TOPIC_NAME = "hoodie_test";
+  private static final String POSTGRES_GITHUB_SCHEMA = "{\n" +
+      "  \"connect.name\": \"postgres.ghschema.gharchive.Envelope\",\n" +
+      "  \"fields\": [\n" +
+      "    {\n" +
+      "      \"default\": null,\n" +
+      "      \"name\": \"before\",\n" +
+      "      \"type\": [\n" +
+      "        \"null\",\n" +
+      "        {\n" +
+      "          \"connect.name\": \"postgres.ghschema.gharchive.Value\",\n" +
+      "          \"fields\": [\n" +
+      "            {\n" +
+      "              \"name\": \"id\",\n" +
+      "              \"type\": \"string\"\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"name\": \"date\",\n" +
+      "              \"type\": \"string\"\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"default\": null,\n" +
+      "              \"name\": \"timestamp\",\n" +
+      "              \"type\": [\n" +
+      "                \"null\",\n" +
+      "                \"long\"\n" +
+      "              ]\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"default\": null,\n" +
+      "              \"name\": \"type\",\n" +
+      "              \"type\": [\n" +
+      "                \"null\",\n" +
+      "                \"string\"\n" +
+      "              ]\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"default\": null,\n" +
+      "              \"name\": \"payload\",\n" +
+      "              \"type\": [\n" +
+      "                \"null\",\n" +
+      "                \"string\"\n" +
+      "              ]\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"default\": null,\n" +
+      "              \"name\": \"org\",\n" +
+      "              \"type\": [\n" +
+      "                \"null\",\n" +
+      "                \"string\"\n" +
+      "              ]\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"default\": null,\n" +
+      "              \"name\": \"created_at\",\n" +
+      "              \"type\": [\n" +
+      "                \"null\",\n" +
+      "                \"long\"\n" +
+      "              ]\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"default\": null,\n" +
+      "              \"name\": \"public\",\n" +
+      "              \"type\": [\n" +
+      "                \"null\",\n" +
+      "                \"boolean\"\n" +
+      "              ]\n" +
+      "            }\n" +
+      "          ],\n" +
+      "          \"name\": \"Value\",\n" +
+      "          \"type\": \"record\"\n" +
+      "        }\n" +
+      "      ]\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"default\": null,\n" +
+      "      \"name\": \"after\",\n" +
+      "      \"type\": [\n" +
+      "        \"null\",\n" +
+      "        \"Value\"\n" +
+      "      ]\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"name\": \"source\",\n" +
+      "      \"type\": {\n" +
+      "        \"connect.name\": \"io.debezium.connector.postgresql.Source\",\n" +
+      "        \"fields\": [\n" +
+      "          {\n" +
+      "            \"name\": \"connector\",\n" +
+      "            \"type\": \"string\"\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"name\": \"name\",\n" +
+      "            \"type\": \"string\"\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"name\": \"ts_ms\",\n" +
+      "            \"type\": \"long\"\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"name\": \"db\",\n" +
+      "            \"type\": \"string\"\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"default\": null,\n" +
+      "            \"name\": \"sequence\",\n" +
+      "            \"type\": [\n" +
+      "              \"null\",\n" +
+      "              \"string\"\n" +
+      "            ]\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"name\": \"schema\",\n" +
+      "            \"type\": \"string\"\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"name\": \"table\",\n" +
+      "            \"type\": \"string\"\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"default\": null,\n" +
+      "            \"name\": \"txId\",\n" +
+      "            \"type\": [\n" +
+      "              \"null\",\n" +
+      "              \"long\"\n" +
+      "            ]\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"default\": null,\n" +
+      "            \"name\": \"lsn\",\n" +
+      "            \"type\": [\n" +
+      "              \"null\",\n" +
+      "              \"long\"\n" +
+      "            ]\n" +
+      "          },\n" +
+      "          {\n" +
+      "            \"default\": null,\n" +
+      "            \"name\": \"xmin\",\n" +
+      "            \"type\": [\n" +
+      "              \"null\",\n" +
+      "              \"long\"\n" +
+      "            ]\n" +
+      "          }\n" +
+      "        ],\n" +
+      "        \"name\": \"Source\",\n" +
+      "        \"namespace\": \"io.debezium.connector.postgresql\",\n" +
+      "        \"type\": \"record\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"name\": \"op\",\n" +
+      "      \"type\": \"string\"\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"default\": null,\n" +
+      "      \"name\": \"ts_ms\",\n" +
+      "      \"type\": [\n" +
+      "        \"null\",\n" +
+      "        \"long\"\n" +
+      "      ]\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"default\": null,\n" +
+      "      \"name\": \"transaction\",\n" +
+      "      \"type\": [\n" +
+      "        \"null\",\n" +
+      "        {\n" +
+      "          \"fields\": [\n" +
+      "            {\n" +
+      "              \"name\": \"id\",\n" +
+      "              \"type\": \"string\"\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"name\": \"total_order\",\n" +
+      "              \"type\": \"long\"\n" +
+      "            },\n" +
+      "            {\n" +
+      "              \"name\": \"data_collection_order\",\n" +
+      "              \"type\": \"long\"\n" +
+      "            }\n" +
+      "          ],\n" +
+      "          \"name\": \"ConnectDefault\",\n" +
+      "          \"namespace\": \"io.confluent.connect.avro\",\n" +
+      "          \"type\": \"record\"\n" +
+      "        }\n" +
+      "      ]\n" +
+      "    }\n" +
+      "  ],\n" +
+      "  \"name\": \"Envelope\",\n" +
+      "  \"namespace\": \"postgres.ghschema.gharchive\",\n" +
+      "  \"type\": \"record\"\n" +
+      "}";
+  private static final Schema POSTGRES_GITHUB_AVRO_SCHEMA = new Schema.Parser().parse(POSTGRES_GITHUB_SCHEMA);
+
+  private MockSchemaRegistryProvider schemaProvider;
+  private KafkaTestUtils testUtils;
+  private HoodieDeltaStreamerMetrics metrics = mock(HoodieDeltaStreamerMetrics.class);
+
+  @BeforeAll
+  public static void initClass() throws Exception {
+    UtilitiesTestBase.initClass(false);
+  }
+
+  @AfterAll
+  public static void cleanupClass() {
+    UtilitiesTestBase.cleanupClass();
+  }
+
+
+  @BeforeEach
+  public void setup() throws Exception {
+    super.setup();
+    testUtils = new KafkaTestUtils();
+    testUtils.setup();
+    schemaProvider = new MockSchemaRegistryProvider(createPropsForJsonSource(), jsc);
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    super.teardown();
+    testUtils.teardown();
+  }
+
+  private TypedProperties createPropsForJsonSource() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.deltastreamer.source.kafka.topic", TEST_TOPIC_NAME);
+    props.setProperty("bootstrap.servers", testUtils.brokerAddress());
+    props.setProperty("auto.offset.reset", "earliest");
+    props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    props.setProperty("hoodie.deltastreamer.schemaprovider.registry.url", "localhost");
+    props.setProperty("schema.registry.url", "localhost");
+    props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+    return props;
+  }
+
+  @Test
+  public void testJsonKafkaSource() {
+    // topic setup.
+    testUtils.createTopic(TEST_TOPIC_NAME, 2);
+    TypedProperties props = createPropsForJsonSource();
+
+    PostgresDebeziumSource postgresDebeziumSource = new PostgresDebeziumSource(props, jsc, sparkSession, schemaProvider, metrics);
+    SourceFormatAdapter debeziumSource = new SourceFormatAdapter(postgresDebeziumSource);
+    TypedProperties prop1 = new TypedProperties();
+    prop1.put("key.serializer", StringSerializer.class);
+    prop1.put("value.serializer", StringSerializer.class);
+    prop1.put("bootstrap.servers", testUtils.brokerAddress());
+    //prop1.setProperty("schema.registry.url", "localhost");
+
+    //Producer<String, String> mockProducer = new KafkaProducer<>(prop1);
+    //ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(TEST_TOPIC_NAME, "key", "vale");// generateDebeziumEvent(Operation.INSERT));
+    //mockProducer.send(kafkaRecord);
+    LOG.error("WNI " + testUtils.brokerAddress());
+    // 1. Extract without any checkpoint => get all the data, respecting sourceLimit
+    //assertEquals(Option.empty(), debeziumSource.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE).getBatch());
+
+    //Map<String, GenericRecord> testMap = new HashMap<>();
+    //testMap.put("key", generateDebeziumEvent(Operation.INSERT));
+    testUtils.sendMessages(TEST_TOPIC_NAME, new String[] { generateDebeziumEvent(Operation.INSERT).toString() });
+
+    InputBatch<Dataset<Row>> fetch1 = debeziumSource.fetchNewDataInRowFormat(Option.empty(), 900);
+    assertEquals(1, fetch1.getBatch().get().count());
+  }
+
+  private static GenericRecord generateDebeziumEvent(Operation op) {
+    GenericRecord rec = new GenericData.Record(POSTGRES_GITHUB_AVRO_SCHEMA);
+    rec.put(DebeziumConstants.INCOMING_OP_FIELD, op.op);
+    rec.put(DebeziumConstants.INCOMING_TS_MS_FIELD, 100L);
+
+    // Before
+    Schema.Field beforeField = POSTGRES_GITHUB_AVRO_SCHEMA.getField(DebeziumConstants.INCOMING_BEFORE_FIELD);
+    Schema beforeSchema = beforeField.schema().getTypes().get(beforeField.schema().getIndexNamed("postgres.ghschema.gharchive.Value"));
+    GenericRecord beforeRecord = new GenericData.Record(beforeSchema);
+
+    beforeRecord.put("id", 1);
+    beforeRecord.put("date", "1/1/2020");
+    beforeRecord.put("timestamp", 1000L);
+    rec.put(DebeziumConstants.INCOMING_BEFORE_FIELD, beforeRecord);
+
+    // After
+    Schema.Field afterField = POSTGRES_GITHUB_AVRO_SCHEMA.getField(DebeziumConstants.INCOMING_AFTER_FIELD);
+    Schema afterSchema = afterField.schema().getTypes().get(afterField.schema().getIndexNamed("postgres.ghschema.gharchive.Value"));
+    GenericRecord afterRecord = new GenericData.Record(afterSchema);
+
+    afterRecord.put("id", 1);
+    afterRecord.put("date", "1/1/2021");
+    afterRecord.put("timestamp", 3000L);
+    rec.put(DebeziumConstants.INCOMING_AFTER_FIELD, afterRecord);
+
+    // Source
+    GenericRecord sourceRecord = new GenericData.Record(POSTGRES_GITHUB_AVRO_SCHEMA.getField(DebeziumConstants.INCOMING_SOURCE_FIELD).schema());
+    sourceRecord.put("name", "postgres");
+    sourceRecord.put("connector", "test");
+    sourceRecord.put("db", "postgres");
+    sourceRecord.put("schema", "ghschema");
+    sourceRecord.put("table", "gharchive");
+    sourceRecord.put("ts_ms", 3000L);
+    sourceRecord.put("txId", 100L);
+    sourceRecord.put("lsn", 1L);
+    sourceRecord.put("xmin", 111L);
+    rec.put(DebeziumConstants.INCOMING_SOURCE_FIELD, sourceRecord);
+
+    return rec;
+  }
+
+  private enum Operation {
+    INSERT("c"),
+    UPDATE("u"),
+    DELETE("d");
+
+    public final String op;
+
+    Operation(String op) {
+      this.op = op;
+    }
+  }
+
+  private static class MockSchemaRegistryProvider extends SchemaRegistryProvider {
+
+    public MockSchemaRegistryProvider(TypedProperties props, JavaSparkContext jssc) {
+      super(props, jssc);
+    }
+
+    @Override
+    public String fetchSchemaFromRegistry(String registryUrl) throws IOException {
+      return POSTGRES_GITHUB_SCHEMA;
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
@@ -85,6 +85,7 @@ import java.util.List;
 
 /**
  * Abstract test that provides a dfs & spark contexts.
+ *
  */
 public class UtilitiesTestBase {
 
@@ -161,10 +162,6 @@ public class UtilitiesTestBase {
       jsc.stop();
       jsc = null;
     }
-    if (null != sqlContext) {
-      sqlContext.clearCache();
-      sqlContext = null;
-    }
     if (sparkSession != null) {
       sparkSession.close();
       sparkSession = null;
@@ -176,7 +173,7 @@ public class UtilitiesTestBase {
 
   /**
    * Helper to get hive sync config.
-   *
+   * 
    * @param basePath
    * @param tableName
    * @return
@@ -197,7 +194,7 @@ public class UtilitiesTestBase {
 
   /**
    * Initialize Hive DB.
-   *
+   * 
    * @throws IOException
    */
   private static void clearHiveDb() throws IOException {
@@ -206,9 +203,9 @@ public class UtilitiesTestBase {
     HiveSyncConfig hiveSyncConfig = getHiveSyncConfig("/dummy", "dummy");
     hiveConf.addResource(hiveServer.getHiveConf());
     HoodieTableMetaClient.withPropertyBuilder()
-        .setTableType(HoodieTableType.COPY_ON_WRITE)
-        .setTableName(hiveSyncConfig.tableName)
-        .initTable(dfs.getConf(), hiveSyncConfig.basePath);
+      .setTableType(HoodieTableType.COPY_ON_WRITE)
+      .setTableName(hiveSyncConfig.tableName)
+      .initTable(dfs.getConf(), hiveSyncConfig.basePath);
 
     QueryBasedDDLExecutor ddlExecutor = new JDBCExecutor(hiveSyncConfig, dfs);
     ddlExecutor.runSQL("drop database if exists " + hiveSyncConfig.databaseName);
@@ -276,10 +273,10 @@ public class UtilitiesTestBase {
      * Converts the json records into CSV format and writes to a file.
      *
      * @param hasHeader  whether the CSV file should have a header line.
-     * @param sep        the column separator to use.
-     * @param lines      the records in JSON format.
-     * @param fs         {@link FileSystem} instance.
-     * @param targetPath File path.
+     * @param sep  the column separator to use.
+     * @param lines  the records in JSON format.
+     * @param fs  {@link FileSystem} instance.
+     * @param targetPath  File path.
      * @throws IOException
      */
     public static void saveCsvToDFS(
@@ -396,9 +393,9 @@ public class UtilitiesTestBase {
     }
 
     private static void addAvroRecord(
-        VectorizedRowBatch batch,
-        GenericRecord record,
-        TypeDescription orcSchema
+            VectorizedRowBatch batch,
+            GenericRecord record,
+            TypeDescription orcSchema
     ) {
       for (int c = 0; c < batch.numCols; c++) {
         ColumnVector colVector = batch.cols[c];

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
@@ -85,7 +85,6 @@ import java.util.List;
 
 /**
  * Abstract test that provides a dfs & spark contexts.
- *
  */
 public class UtilitiesTestBase {
 
@@ -162,6 +161,10 @@ public class UtilitiesTestBase {
       jsc.stop();
       jsc = null;
     }
+    if (null != sqlContext) {
+      sqlContext.clearCache();
+      sqlContext = null;
+    }
     if (sparkSession != null) {
       sparkSession.close();
       sparkSession = null;
@@ -173,7 +176,7 @@ public class UtilitiesTestBase {
 
   /**
    * Helper to get hive sync config.
-   * 
+   *
    * @param basePath
    * @param tableName
    * @return
@@ -194,7 +197,7 @@ public class UtilitiesTestBase {
 
   /**
    * Initialize Hive DB.
-   * 
+   *
    * @throws IOException
    */
   private static void clearHiveDb() throws IOException {
@@ -203,9 +206,9 @@ public class UtilitiesTestBase {
     HiveSyncConfig hiveSyncConfig = getHiveSyncConfig("/dummy", "dummy");
     hiveConf.addResource(hiveServer.getHiveConf());
     HoodieTableMetaClient.withPropertyBuilder()
-      .setTableType(HoodieTableType.COPY_ON_WRITE)
-      .setTableName(hiveSyncConfig.tableName)
-      .initTable(dfs.getConf(), hiveSyncConfig.basePath);
+        .setTableType(HoodieTableType.COPY_ON_WRITE)
+        .setTableName(hiveSyncConfig.tableName)
+        .initTable(dfs.getConf(), hiveSyncConfig.basePath);
 
     QueryBasedDDLExecutor ddlExecutor = new JDBCExecutor(hiveSyncConfig, dfs);
     ddlExecutor.runSQL("drop database if exists " + hiveSyncConfig.databaseName);
@@ -273,10 +276,10 @@ public class UtilitiesTestBase {
      * Converts the json records into CSV format and writes to a file.
      *
      * @param hasHeader  whether the CSV file should have a header line.
-     * @param sep  the column separator to use.
-     * @param lines  the records in JSON format.
-     * @param fs  {@link FileSystem} instance.
-     * @param targetPath  File path.
+     * @param sep        the column separator to use.
+     * @param lines      the records in JSON format.
+     * @param fs         {@link FileSystem} instance.
+     * @param targetPath File path.
      * @throws IOException
      */
     public static void saveCsvToDFS(
@@ -393,9 +396,9 @@ public class UtilitiesTestBase {
     }
 
     private static void addAvroRecord(
-            VectorizedRowBatch batch,
-            GenericRecord record,
-            TypeDescription orcSchema
+        VectorizedRowBatch batch,
+        GenericRecord record,
+        TypeDescription orcSchema
     ) {
       for (int c = 0; c < batch.numCols; c++) {
         ColumnVector colVector = batch.cols[c];


### PR DESCRIPTION
## What is the purpose of the pull request

Add Debezium Source for deltastreamer, allowing deltastreamer users to ingest the debezium change log records from kafka for Postgres DB. This implements RFC-39

## Brief change log

- Implemented a debezium source that can ingest JSON and AVRO change records from debezium kafka connector.  The schema is read from the confluent schema registry
- Implemented a debezium payload that implement preCombine and merge of records based on the LSN field in postgres, that represents the actual sequence of the change logs
- 
## Verify this pull request

Tested with RDS instance of postgres, debezium kafka connect and kafka. Tested with insert, update and delete operations.