### PR TITLE
[HUDI-2844][CLI] Fixing archived Timeline crashing if timeline contains REPLACE_COMMIT

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -148,13 +148,13 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
     if (loadDetails) {
       Option.ofNullable(getMetadataKey(action))
           .map(key -> {
-              Object actionData = record.get(key);
-              if (action.equals(HoodieTimeline.COMPACTION_ACTION)) {
-                this.readCommits.put(instantTime, HoodieAvroUtils.indexedRecordToBytes((IndexedRecord)actionData));
-              } else {
-                this.readCommits.put(instantTime, actionData.toString().getBytes(StandardCharsets.UTF_8));
-              }
-              return null;
+            Object actionData = record.get(key);
+            if (action.equals(HoodieTimeline.COMPACTION_ACTION)) {
+              this.readCommits.put(instantTime, HoodieAvroUtils.indexedRecordToBytes((IndexedRecord)actionData));
+            } else {
+              this.readCommits.put(instantTime, actionData.toString().getBytes(StandardCharsets.UTF_8));
+            }
+            return null;
           });
     }
     return new HoodieInstant(HoodieInstant.State.valueOf(record.get(ACTION_STATE).toString()), action, instantTime);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -36,7 +36,6 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -148,13 +147,13 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
     final String action = record.get(ACTION_TYPE_KEY).toString();
     if (loadDetails) {
       getMetadataKey(action).map(key -> {
-          Object actionData = record.get(key);
-          if (action.equals(HoodieTimeline.COMPACTION_ACTION)) {
-            this.readCommits.put(instantTime, HoodieAvroUtils.indexedRecordToBytes((IndexedRecord)actionData));
-          } else {
-            this.readCommits.put(instantTime, actionData.toString().getBytes(StandardCharsets.UTF_8));
-          }
-          return null;
+        Object actionData = record.get(key);
+        if (action.equals(HoodieTimeline.COMPACTION_ACTION)) {
+          this.readCommits.put(instantTime, HoodieAvroUtils.indexedRecordToBytes((IndexedRecord)actionData));
+        } else {
+          this.readCommits.put(instantTime, actionData.toString().getBytes(StandardCharsets.UTF_8));
+        }
+        return null;
       });
     }
     return new HoodieInstant(HoodieInstant.State.valueOf(record.get(ACTION_STATE).toString()), action, instantTime);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

When doing `commits showarchived` in CLI it fails if REPLACE_COMMIT is present in the archived Timeline:

```
hudi:hoodie_benchmark->commits showarchived 5993625 [Spring Shell] ERROR org.springframework.shell.core.SimpleExecutionStrategy - Command failed org.apache.hudi.exception.HoodieIOException: Unknown action in metadata replacecommit 5993625 [Spring Shell] WARN org.springframework.shell.core.JLineShellComponent.exceptions - Unknown action in metadata replacecommit org.apache.hudi.exception.HoodieIOException: Unknown action in metadata replacecommit
```

## Brief change log

 - Fixed archived Metadata Timeline to support REPLACE_COMMIT action
 - Make sure no exception is thrown in case we couldn't extract Metadata for the given Commit type

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
