### PR TITLE
[HUDI-2848]When I run hudi-cli.sh using hadoop 3.2.1 , this is a error about guava class conflict

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -234,6 +234,12 @@
       <groupId>org.springframework.shell</groupId>
       <artifactId>spring-shell</artifactId>
       <version>${spring.shell.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What is the purpose of the pull request
When hadoop.version is 3.2.1, spark.version is 3.1.1,I run hudi-cli.sh, this is a error:
![image](https://user-images.githubusercontent.com/9431947/143192585-df8103a7-73b6-4624-8465-d596728e567e.png)

I find th version about guava depended by hadoop is 27.0-jre. But i build the code, the version in the package is 17.0. So I think it's a bug.

When I  build code, I find the dependency tree is :
```
[INFO] +- org.springframework.shell:spring-shell:jar:1.2.0.RELEASE:compile
[INFO] |  +- com.google.guava:guava:jar:17.0:compile
[INFO] |  +- jline:jline:jar:2.12:compile
[INFO] |  +- org.springframework:spring-context-support:jar:4.2.4.RELEASE:compile
[INFO] |  |  +- org.springframework:spring-beans:jar:4.2.4.RELEASE:compile
[INFO] |  |  \- org.springframework:spring-context:jar:4.2.4.RELEASE:compile
[INFO] |  |     +- org.springframework:spring-aop:jar:4.2.4.RELEASE:compile
[INFO] |  |     \- org.springframework:spring-expression:jar:4.2.4.RELEASE:compile
```

So I pull  a request. Thanks.


jira: https://issues.apache.org/jira/browse/HUDI-2848
