### PR TITLE
[HUDI-2850] Clustering CLI - schedule and run command fixes to avoid NumberFormatException

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ClusteringCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ClusteringCommand.java
@@ -40,6 +40,13 @@ public class ClusteringCommand implements CommandMarker {
 
   private static final Logger LOG = LogManager.getLogger(ClusteringCommand.class);
 
+  /**
+   * Schedule clustering table service.
+   * <p>
+   * Example:
+   * > connect --path {path to hudi table}
+   * > clustering schedule --sparkMaster local --sparkMemory 2g
+   */
   @CliCommand(value = "clustering schedule", help = "Schedule Clustering")
   public String scheduleClustering(
       @CliOption(key = "sparkMaster", unspecifiedDefaultValue = SparkUtil.DEFAULT_SPARK_MASTER, help = "Spark master") final String master,
@@ -71,6 +78,14 @@ public class ClusteringCommand implements CommandMarker {
     return "Succeeded to schedule clustering for " + clusteringInstantTime;
   }
 
+  /**
+   * Run clustering table service.
+   * <p>
+   * Example:
+   * > connect --path {path to hudi table}
+   * > clustering schedule --sparkMaster local --sparkMemory 2g
+   * > clustering run --sparkMaster local --sparkMemory 2g --clusteringInstant  20211124005208
+   */
   @CliCommand(value = "clustering run", help = "Run Clustering")
   public String runClustering(
       @CliOption(key = "sparkMaster", unspecifiedDefaultValue = SparkUtil.DEFAULT_SPARK_MASTER, help = "Spark master") final String master,

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieBootstrapConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -79,12 +80,14 @@ public class SparkMain {
   }
 
   public static void main(String[] args) throws Exception {
-    String command = args[0];
-    LOG.info("Invoking SparkMain:" + command);
+    final String commandString = args[0];
+    LOG.info("Invoking SparkMain: " + commandString);
+    final SparkCommand cmd = SparkCommand.valueOf(commandString);
 
-    SparkCommand cmd = SparkCommand.valueOf(command);
+    ValidationUtils.checkArgument(args.length >= 4);
+    JavaSparkContext jsc = SparkUtil.initJavaSparkConf("hoodie-cli-" + commandString,
+        Option.of(args[1]), Option.of(args[2]));
 
-    JavaSparkContext jsc = SparkUtil.initJavaSparkConf("hoodie-cli-" + command, Option.of(args[1]), Option.of(args[2]));
     int returnCode = 0;
     try {
       switch (cmd) {
@@ -111,8 +114,8 @@ public class SparkMain {
           if (args.length > 13) {
             configs.addAll(Arrays.asList(args).subList(13, args.length));
           }
-          returnCode = dataLoad(jsc, command, args[3], args[4], args[5], args[6], args[7], args[8],
-                  Integer.parseInt(args[9]), args[10], Integer.parseInt(args[11]), propsFilePath, configs);
+          returnCode = dataLoad(jsc, commandString, args[3], args[4], args[5], args[6], args[7], args[8],
+              Integer.parseInt(args[9]), args[10], Integer.parseInt(args[11]), propsFilePath, configs);
           break;
         case COMPACT_RUN:
           assert (args.length >= 10);
@@ -159,33 +162,34 @@ public class SparkMain {
         case COMPACT_UNSCHEDULE_PLAN:
           assert (args.length == 9);
           doCompactUnschedule(jsc, args[3], args[4], args[5], Integer.parseInt(args[6]),
-                  Boolean.parseBoolean(args[7]), Boolean.parseBoolean(args[8]));
+              Boolean.parseBoolean(args[7]), Boolean.parseBoolean(args[8]));
           returnCode = 0;
           break;
         case CLUSTERING_RUN:
-          assert (args.length >= 8);
+          assert (args.length >= 9);
           propsFilePath = null;
-          if (!StringUtils.isNullOrEmpty(args[7])) {
-            propsFilePath = args[7];
+          if (!StringUtils.isNullOrEmpty(args[8])) {
+            propsFilePath = args[8];
           }
           configs = new ArrayList<>();
-          if (args.length > 8) {
-            configs.addAll(Arrays.asList(args).subList(8, args.length));
+          if (args.length > 9) {
+            configs.addAll(Arrays.asList(args).subList(9, args.length));
           }
-          returnCode = cluster(jsc, args[1], args[2], args[3], Integer.parseInt(args[4]), args[5],
-              Integer.parseInt(args[6]), false, propsFilePath, configs);
+          returnCode = cluster(jsc, args[3], args[4], args[5], Integer.parseInt(args[6]), args[2],
+              Integer.parseInt(args[7]), false, propsFilePath, configs);
           break;
         case CLUSTERING_SCHEDULE:
-          assert (args.length >= 6);
+          assert (args.length >= 7);
           propsFilePath = null;
-          if (!StringUtils.isNullOrEmpty(args[5])) {
-            propsFilePath = args[5];
+          if (!StringUtils.isNullOrEmpty(args[6])) {
+            propsFilePath = args[6];
           }
           configs = new ArrayList<>();
-          if (args.length > 6) {
-            configs.addAll(Arrays.asList(args).subList(6, args.length));
+          if (args.length > 7) {
+            configs.addAll(Arrays.asList(args).subList(7, args.length));
           }
-          returnCode = cluster(jsc, args[1], args[2], args[3], 1, args[4], 0, true, propsFilePath, configs);
+          returnCode = cluster(jsc, args[3], args[4], args[5], 1, args[2],
+              0, true, propsFilePath, configs);
           break;
         case CLEAN:
           assert (args.length >= 5);
@@ -229,7 +233,7 @@ public class SparkMain {
           break;
       }
     } catch (Throwable throwable) {
-      LOG.error("Fail to execute command", throwable);
+      LOG.error("Fail to execute commandString", throwable);
       returnCode = -1;
     } finally {
       jsc.stop();

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -80,11 +80,11 @@ public class SparkMain {
   }
 
   public static void main(String[] args) throws Exception {
+    ValidationUtils.checkArgument(args.length >= 4);
     final String commandString = args[0];
     LOG.info("Invoking SparkMain: " + commandString);
     final SparkCommand cmd = SparkCommand.valueOf(commandString);
 
-    ValidationUtils.checkArgument(args.length >= 4);
     JavaSparkContext jsc = SparkUtil.initJavaSparkConf("hoodie-cli-" + commandString,
         Option.of(args[1]), Option.of(args[2]));
 

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  */
 public class SparkUtil {
 
-  private static final String DEFAULT_SPARK_MASTER = "yarn";
+  public static final String DEFAULT_SPARK_MASTER = "yarn";
 
   /**
    * TODO: Need to fix a bunch of hardcoded stuff here eg: history server, spark distro.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -59,7 +59,7 @@ public class HoodieClusteringJob {
   public HoodieClusteringJob(JavaSparkContext jsc, Config cfg) {
     this.cfg = cfg;
     this.jsc = jsc;
-    this.props = cfg.propsFilePath == null
+    this.props = (cfg.propsFilePath == null || cfg.propsFilePath.isEmpty())
         ? UtilHelpers.buildProperties(cfg.configs)
         : readConfigFromFileSystem(jsc, cfg);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -59,7 +59,7 @@ public class HoodieClusteringJob {
   public HoodieClusteringJob(JavaSparkContext jsc, Config cfg) {
     this.cfg = cfg;
     this.jsc = jsc;
-    this.props = (cfg.propsFilePath == null || cfg.propsFilePath.isEmpty())
+    this.props = StringUtils.isNullOrEmpty(cfg.propsFilePath)
         ? UtilHelpers.buildProperties(cfg.configs)
         : readConfigFromFileSystem(jsc, cfg);
   }


### PR DESCRIPTION
## What is the purpose of the pull request

- Clustering CLI commands schedule and run are passing in arguments in the
   wrong order leading to parsing exception. Fixed the same.

 - Added sparMaster option to set the host when running the command

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
