### PR TITLE
[HUDI-2841] Fixing lazy rollback for MOR with list based strategy

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackUtils.java
@@ -228,8 +228,9 @@ public class RollbackUtils {
     // used to write the new log files. In this case, the commit time for the log file is the compaction requested time.
     // But the index (global) might store the baseCommit of the base and not the requested, hence get the
     // baseCommit always by listing the file slice
-    Map<String, String> fileIdToBaseCommitTimeForLogMap = table.getSliceView().getLatestFileSlices(partitionPath)
-        .collect(Collectors.toMap(FileSlice::getFileId, FileSlice::getBaseInstantTime));
+    Map<String, String> fileIdToBaseCommitTimeForLogMap = table.getSliceView().getLatestFileSlicesBeforeOrOn(partitionPath, rollbackInstant.getTimestamp(),
+        true).collect(Collectors.toMap(FileSlice::getFileId, FileSlice::getBaseInstantTime));
+
     return commitMetadata.getPartitionToWriteStats().get(partitionPath).stream().filter(wStat -> {
 
       // Filter out stats without prevCommit since they are all inserts

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackUtils.java
@@ -228,6 +228,7 @@ public class RollbackUtils {
     // used to write the new log files. In this case, the commit time for the log file is the compaction requested time.
     // But the index (global) might store the baseCommit of the base and not the requested, hence get the
     // baseCommit always by listing the file slice
+    // With multi writers, rollbacks could be lazy. and so we need to use getLatestFileSlicesBeforeOrOn() instead of getLatestFileSlices()
     Map<String, String> fileIdToBaseCommitTimeForLogMap = table.getSliceView().getLatestFileSlicesBeforeOrOn(partitionPath, rollbackInstant.getTimestamp(),
         true).collect(Collectors.toMap(FileSlice::getFileId, FileSlice::getBaseInstantTime));
 


### PR DESCRIPTION
## What is the purpose of the pull request

Listing based rollback of delta commits in MOR table, uses latest file slice to fetch list of log files to be rolledback. With lazy cleaning in multi-writer flow, rollback could happen very late. i.e compaction could have triggered by then. And so we can't use latestFileSlice for rollback. Fixed to use getLatestFileSliceOnOrBefore the commit being rolledback. If not for the fix, we get a validation error thrown from rollback utils since latest file's have base commit time > commit being rolledback. 

## Brief change log

- Fixed rollback utils to use getLatestFileSliceOnOrBefore the commit being rolledback instead of getLatestfileSlice while collecting files to be rolledback for delta commits in MOR. 

## Verify this pull request

- Added test to TestHoodieSparkMergeOnReadTableRollback#testLazyRollbackOfFailedCommit

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
