### PR TITLE
[HUDI-2800] Remove rdd.isEmpty() validation to prevent CreateHandle b…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/cluster/SparkExecuteClusteringCommitActionExecutor.java
@@ -84,7 +84,6 @@ public class SparkExecuteClusteringCommitActionExecutor<T extends HoodieRecordPa
     JavaRDD<WriteStatus> statuses = updateIndex(writeStatusRDD, writeMetadata);
     writeMetadata.setWriteStats(statuses.map(WriteStatus::getStat).collect());
     writeMetadata.setPartitionToReplaceFileIds(getPartitionToReplacedFileIds(writeMetadata));
-    validateWriteResult(writeMetadata);
     commitOnAutoCommit(writeMetadata);
     if (!writeMetadata.getCommitMetadata().isPresent()) {
       HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(writeMetadata.getWriteStats().get(), writeMetadata.getPartitionToReplaceFileIds(),


### PR DESCRIPTION
…eing called twice

## What is the purpose of the pull request

From HUDI-2800:
> SparkExecuteClusteringCommitActionExecutor L103. 
> We have a collect() and isEmpty(). collect() triggers the actual execution of all writes. But a following isEmpty() triggers just one spark task which again creates a file w/ same fileId but with different write token. Confirmed this from logs.

## Brief change log

Removed the empty write status validation. The `isEmpty` check is causing another evaluation which triggers `CreateHandle`. Apar from that, the check is redundant. We are already checking [whether write stat has errors](https://github.com/apache/hudi/blob/264e1ce63c24b09d891068aca1fc40b815a958f7/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java#L384-L387) and throw exception. So this check does not add much value.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
