### PR TITLE
[HUDI-2876] for hive/presto hudi should remove the temp file which cr…

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
@@ -189,8 +189,10 @@ class RealtimeCompactedRecordReader extends AbstractRealtimeRecordReader
 
   @Override
   public void close() throws IOException {
-    ((ExternalSpillableMap) deltaRecordMap).close();
     parquetReader.close();
+    // need clean the tmp file which created by logScanner
+    // Otherwise, for resident process such as presto, the /tmp directory will overflow
+    ((ExternalSpillableMap) deltaRecordMap).close();
   }
 
   @Override

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.hadoop.config.HoodieRealtimeConfig;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils;
@@ -188,6 +189,7 @@ class RealtimeCompactedRecordReader extends AbstractRealtimeRecordReader
 
   @Override
   public void close() throws IOException {
+    ((ExternalSpillableMap) deltaRecordMap).close();
     parquetReader.close();
   }
 


### PR DESCRIPTION
…eated by HoodieMergedLogRecordSanner  when the query finished.

## *Tips*
RealtimeCompactedRecordReader should close deltaRecordMap when the query finished to clear tmp file。
now HoodieMergedLogRecordScanner will create a tmp dir for read log.  this file will be deleted only when the jvm exit.

for presto/ hive local query（hive server deal those query）,  the query jvm will not exit。 with more and more query happen， the  tmp dir will become more and more larger。

before patch
step1: start beeline
step2:   repeated execute:  select * from lj_rt limit 1
step3: cd /tmp    we found many hudi-BITCAST-xxxxx dir
**hudi-BITCASK-39c1910d-44b4-4bd7-b558-e8a0c4c502b0
hudi-BITCASK-46056741-2408-4021-8288-f4bebc1e2614
hudi-BITCASK-5ce46a11-354a-42fb-aec1-2fe1227a3ed4
hudi-BITCASK-689d7333-dcfb-4fda-9f4e-3bc31acded33**

after patch
those hudi-BITCAST-xxx dir will be deleted.


## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
