### PR TITLE
[WIP] [HUDI-2884] Allow loading external configs while querying Hudi tables

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -165,10 +165,17 @@ public class DFSPropertiesConfiguration {
     }
   }
 
-  public static TypedProperties getGlobalProps() {
+  /**
+   * Returns a deep copy of global props
+   */
+  public static TypedProperties getCopiedGlobalProps() {
     final TypedProperties globalProps = new TypedProperties();
     globalProps.putAll(GLOBAL_PROPS);
     return globalProps;
+  }
+
+  public static TypedProperties getGlobalProps() {
+    return GLOBAL_PROPS;
   }
 
   public TypedProperties getProps() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -180,7 +180,7 @@ public class HoodieConfig implements Serializable {
 
   public TypedProperties getProps(boolean includeGlobalProps) {
     if (includeGlobalProps) {
-      TypedProperties mergedProps = DFSPropertiesConfiguration.getGlobalProps();
+      TypedProperties mergedProps = DFSPropertiesConfiguration.getCopiedGlobalProps();
       mergedProps.putAll(props);
       return mergedProps;
     } else {

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
@@ -65,7 +65,7 @@ public class HoodieFlinkStreamer {
       env.setStateBackend(new FsStateBackend(cfg.flinkCheckPointPath));
     }
 
-    TypedProperties kafkaProps = DFSPropertiesConfiguration.getGlobalProps();
+    TypedProperties kafkaProps = DFSPropertiesConfiguration.getCopiedGlobalProps();
     kafkaProps.putAll(StreamerUtil.appendKafkaProps(cfg));
 
     // Read from kafka source

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -18,7 +18,7 @@
 package org.apache.hudi
 
 import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE, QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, QUERY_TYPE_SNAPSHOT_OPT_VAL}
-import org.apache.hudi.common.config.{ConfigProperty, HoodieConfig}
+import org.apache.hudi.common.config.{ConfigProperty, DFSPropertiesConfiguration, HoodieConfig}
 import org.apache.hudi.common.fs.ConsistencyGuardConfig
 import org.apache.hudi.common.model.{HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.HoodieTableConfig
@@ -840,13 +840,14 @@ object DataSourceOptionsHelper {
   def parametersWithReadDefaults(parameters: Map[String, String]): Map[String, String] = {
     // First check if the ConfigUtils.IS_QUERY_AS_RO_TABLE has set by HiveSyncTool,
     // or else use query type from QUERY_TYPE.
-    val queryType = parameters.get(ConfigUtils.IS_QUERY_AS_RO_TABLE)
+    val paramsWithGlobalProps = DFSPropertiesConfiguration.getCopiedGlobalProps.asScala.toMap ++ parameters
+    val queryType = paramsWithGlobalProps.get(ConfigUtils.IS_QUERY_AS_RO_TABLE)
       .map(is => if (is.toBoolean) QUERY_TYPE_READ_OPTIMIZED_OPT_VAL else QUERY_TYPE_SNAPSHOT_OPT_VAL)
-      .getOrElse(parameters.getOrElse(QUERY_TYPE.key, QUERY_TYPE.defaultValue()))
+      .getOrElse(paramsWithGlobalProps.getOrElse(QUERY_TYPE.key, QUERY_TYPE.defaultValue()))
 
     Map(
       QUERY_TYPE.key -> queryType
-    ) ++ translateConfigurations(parameters)
+    ) ++ translateConfigurations(paramsWithGlobalProps)
   }
 
   implicit def scalaFunctionToJavaFunction[From, To](function: (From) => To): JavaFunction[From, To] = {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -47,7 +47,7 @@ object HoodieWriterUtils {
     * @return
     */
   def parametersWithWriteDefaults(parameters: Map[String, String]): Map[String, String] = {
-    val globalProps = DFSPropertiesConfiguration.getGlobalProps.asScala
+    val globalProps = DFSPropertiesConfiguration.getCopiedGlobalProps.asScala
     val props = new Properties()
     props.putAll(parameters)
     val hoodieConfig: HoodieConfig = new HoodieConfig(props)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -171,7 +171,7 @@ class HoodieCatalogTable(val spark: SparkSession, val table: CatalogTable) exten
    * @return schema, table parameters in which all parameters aren't sql-styled.
    */
   private def parseSchemaAndConfigs(): (StructType, Map[String, String]) = {
-    val globalProps = DFSPropertiesConfiguration.getGlobalProps.asScala.toMap
+    val globalProps = DFSPropertiesConfiguration.getCopiedGlobalProps.asScala.toMap
     val globalTableConfigs = mappingSparkDatasourceConfigsToTableConfigs(globalProps)
     val globalSqlOptions = HoodieOptionConfig.mappingTableConfigToSqlOption(globalTableConfigs)
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlUtils.scala
@@ -277,7 +277,7 @@ object HoodieSqlUtils extends SparkAdapterSupport {
    */
   def withSparkConf(spark: SparkSession, options: Map[String, String])
                    (baseConfig: Map[String, String] = Map.empty): Map[String, String] = {
-    baseConfig ++ DFSPropertiesConfiguration.getGlobalProps.asScala ++ // Table options has the highest priority
+    baseConfig ++ DFSPropertiesConfiguration.getCopiedGlobalProps.asScala ++ // Table options has the highest priority
       (spark.sessionState.conf.getAllConfs ++ HoodieOptionConfig.mappingSqlOptionToHoodieParam(options))
         .filterKeys(_.startsWith("hoodie."))
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSqlConf.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSqlConf.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.hudi.DataSourceReadOptions._
 import org.apache.hudi.common.config.DFSPropertiesConfiguration
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
@@ -60,20 +61,21 @@ class TestSqlConf extends TestHoodieSqlBase with BeforeAndAfter {
            | )
        """.stripMargin)
 
-      // First merge with a extra input field 'flag' (insert a new record)
-      spark.sql(
-        s"""
-           | merge into $tableName
-           | using (
-           |  select 1 as id, 'a1' as name, 10 as price, 1000 as ts, '1' as flag, $partitionVal as year
-           | ) s0
-           | on s0.id = $tableName.id
-           | when matched and flag = '1' then update set
-           | id = s0.id, name = s0.name, price = s0.price, ts = s0.ts, year = s0.year
-           | when not matched and flag = '1' then insert *
-       """.stripMargin)
+      // First insert a new record
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, $partitionVal)")
+
+      val metaClient = HoodieTableMetaClient.builder()
+        .setBasePath(tablePath)
+        .setConf(spark.sessionState.newHadoopConf())
+        .build()
+      val firstCommit = metaClient.getActiveTimeline.filterCompletedInstants().lastInstant().get().getTimestamp
+
+      // Then insert another new record
+      spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, $partitionVal)")
+
       checkAnswer(s"select id, name, price, ts, year from $tableName")(
-        Seq(1, "a1", 10.0, 1000, partitionVal)
+        Seq(1, "a1", 10.0, 1000, partitionVal),
+        Seq(2, "a2", 10.0, 1000, partitionVal)
       )
 
       // By default, Spark DML would set table type to COW and use Hive style partitioning, here we
@@ -84,6 +86,15 @@ class TestSqlConf extends TestHoodieSqlBase with BeforeAndAfter {
         new Path(tablePath).getFileSystem(new Configuration),
         s"$tablePath/" + HoodieTableMetaClient.METAFOLDER_NAME,
         HoodieTableConfig.PAYLOAD_CLASS_NAME.defaultValue).getTableType)
+
+      // Manually pass incremental configs to global configs to make sure Hudi query is able to load the
+      // global configs
+      DFSPropertiesConfiguration.getGlobalProps.setProperty(QUERY_TYPE.key, QUERY_TYPE_INCREMENTAL_OPT_VAL)
+      DFSPropertiesConfiguration.getGlobalProps.setProperty(BEGIN_INSTANTTIME.key, firstCommit)
+      spark.catalog.refreshTable(tableName)
+      checkAnswer(s"select id, name, price, ts, year from $tableName")(
+        Seq(2, "a2", 10.0, 1000, partitionVal)
+      )
 
       // delete the record
       spark.sql(s"delete from $tableName where year = $partitionVal")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -187,7 +187,7 @@ public class UtilHelpers {
   }
 
   public static TypedProperties buildProperties(List<String> props) {
-    TypedProperties properties = DFSPropertiesConfiguration.getGlobalProps();
+    TypedProperties properties = DFSPropertiesConfiguration.getCopiedGlobalProps();
     props.forEach(x -> {
       String[] kv = x.split("=");
       ValidationUtils.checkArgument(kv.length == 2);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Currently when doing Hudi queries w/ Spark, it won't load the external configurations. Say if customers enabled metadata listing in their global config file, then this would let them actually query w/o metadata feature enabled. This CR fixes this issue and allows loading global configs during the Hudi reading phase.
## Brief change log

## Verify this pull request
  - Modified TestSqlConf to verify the change.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
