### PR TITLE
Revert "[HUDI-2856] Bit cask disk map delete modified"

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
@@ -281,12 +281,12 @@ public final class BitCaskDiskMap<T extends Serializable, R extends Serializable
           }
         }
       }
+      writeOnlyFile.delete();
+      this.iterators.forEach(ClosableIterator::close);
     } catch (Exception e) {
       // delete the file for any sort of exception
-      LOG.error("BitCaskDisMap close error ", e);
-    } finally {
-      this.iterators.forEach(ClosableIterator::close);
       writeOnlyFile.delete();
+    } finally {
       super.close();
     }
   }


### PR DESCRIPTION
Reverts apache/hudi#4116

Reason: We encounter repetitive errors from BitCaskDiskMap during writes due to apache/hudi#4116.
```
14:23:40.363 [task-thread-hudi-sink-0] ERROR org.apache.hudi.common.util.collection.BitCaskDiskMap - BitCaskDisMap close error 
java.nio.channels.ClosedChannelException: null
	at sun.nio.ch.FileChannelImpl.ensureOpen(FileChannelImpl.java:110) ~[?:1.8.0_265]
	at sun.nio.ch.FileChannelImpl.force(FileChannelImpl.java:379) ~[?:1.8.0_265]
	at org.apache.hudi.common.util.collection.BitCaskDiskMap.close(BitCaskDiskMap.java:270) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.common.util.collection.ExternalSpillableMap.close(ExternalSpillableMap.java:261) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.connect.writers.BufferedConnectWriter.flushRecords(BufferedConnectWriter.java:121) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.connect.writers.AbstractConnectWriter.close(AbstractConnectWriter.java:95) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.connect.transaction.ConnectTransactionParticipant.cleanupOngoingTransaction(ConnectTransactionParticipant.java:249) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.connect.transaction.ConnectTransactionParticipant.handleAckCommit(ConnectTransactionParticipant.java:209) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.connect.transaction.ConnectTransactionParticipant.processRecords(ConnectTransactionParticipant.java:127) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.hudi.connect.HoodieSinkTask.put(HoodieSinkTask.java:114) [hudi-kafka-connect-bundle-0.10.0-rc2.jar:0.10.0-rc2]
	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:581) [connect-runtime-3.0.0.jar:?]
	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:329) [connect-runtime-3.0.0.jar:?]
	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:232) [connect-runtime-3.0.0.jar:?]
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:201) [connect-runtime-3.0.0.jar:?]
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:186) [connect-runtime-3.0.0.jar:?]
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:241) [connect-runtime-3.0.0.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_265]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_265]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_265]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_265]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_265]
```