### PR TITLE
[HUDI-2901] Fixed the bug clustering jobs cannot running in parallel

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.RewriteAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.util.FutureUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -63,7 +64,6 @@ import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -89,14 +89,17 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
 
   @Override
   public HoodieWriteMetadata<JavaRDD<WriteStatus>> performClustering(final HoodieClusteringPlan clusteringPlan, final Schema schema, final String instantTime) {
-    // execute clustering for each group async and collect WriteStatus
     JavaSparkContext engineContext = HoodieSparkEngineContext.getSparkContext(getEngineContext());
     // execute clustering for each group async and collect WriteStatus
-    Stream<JavaRDD<WriteStatus>> writeStatusRDDStream = allOf(clusteringPlan.getInputGroups().stream()
+    Stream<JavaRDD<WriteStatus>> writeStatusRDDStream = FutureUtils.allOf(
+        clusteringPlan.getInputGroups().stream()
         .map(inputGroup -> runClusteringForGroupAsync(inputGroup,
             clusteringPlan.getStrategy().getStrategyParams(),
             Option.ofNullable(clusteringPlan.getPreserveHoodieMetadata()).orElse(false),
-            instantTime)).collect(Collectors.toList())).join().stream();
+            instantTime))
+            .collect(Collectors.toList()))
+        .join()
+        .stream();
     JavaRDD<WriteStatus>[] writeStatuses = convertStreamToArray(writeStatusRDDStream);
     JavaRDD<WriteStatus> writeStatusRDD = engineContext.union(writeStatuses);
 
@@ -243,16 +246,6 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
 
       return new ConcatenatingIterator<>(iteratorsForPartition);
     }).map(this::transform);
-  }
-
-  private static <T> CompletableFuture<List<T>> allOf(@Nonnull List<CompletableFuture<T>> futures) {
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-        .thenApply(aVoid ->
-            futures.stream()
-                // NOTE: This join wouldn't block, since all the
-                //       futures are completed at this point.
-                .map(CompletableFuture::join)
-                .collect(Collectors.toList()));
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -95,8 +95,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
         .map(inputGroup -> runClusteringForGroupAsync(inputGroup,
             clusteringPlan.getStrategy().getStrategyParams(),
             Option.ofNullable(clusteringPlan.getPreserveHoodieMetadata()).orElse(false),
-            instantTime))
-        .map(CompletableFuture::join);
+            instantTime)).collect(Collectors.toList()).stream().map(CompletableFuture::join);
 
     JavaRDD<WriteStatus>[] writeStatuses = convertStreamToArray(writeStatusRDDStream);
     JavaRDD<WriteStatus> writeStatusRDD = engineContext.union(writeStatuses);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class for future operation.
+ */
+public class FutureUtils {
+
+  /**
+   * Parallel CompletableFutures
+   *
+   * @param futures CompletableFuture list
+   * @return a new CompletableFuture which will completed when all of the given CompletableFutures complete.
+   */
+  public static <T> CompletableFuture<List<T>> allOf(@Nonnull List<CompletableFuture<T>> futures) {
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        .thenApply(aVoid ->
+            futures.stream()
+                // NOTE: This join wouldn't block, since all the
+                //       futures are completed at this point.
+                .map(CompletableFuture::join)
+                .collect(Collectors.toList()));
+  }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

Fixed the bug clustering jobs cannot running in parallel。


after  patch：

![image](https://user-images.githubusercontent.com/13514703/144237550-0d60497e-c6ab-451e-9edf-e107f02b7546.png)


before patch：

![image](https://user-images.githubusercontent.com/13514703/144237615-d08f92ee-4ed3-4d08-a1aa-433a8c271856.png)

test code：
import java.sql.{Date, Timestamp}

import org.apache.hadoop.fs.Path
import org.apache.hudi.config.{HoodieClusteringConfig, HoodieWriteConfig}
import org.apache.spark.sql.functions.{col, lit}
import org.apache.spark.sql.{DataFrame, RowFactory, SaveMode, SparkSession}
import org.apache.spark.sql.types._

import scala.util.Random

object HbaseTest {

  val commonOpts = Map(
    "hoodie.insert.shuffle.parallelism" -> "50",
    "hoodie.upsert.shuffle.parallelism" -> "50",
    "hoodie.bulkinsert.shuffle.parallelism" -> "50",
    DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "c1",
    DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "p",
    DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "c2",
    HoodieWriteConfig.TBL_NAME.key -> "cl"
  )


  def main(args: Array[String]): Unit = {
    val spark = SparkSession
      .builder()
      .appName("Spark SQL data sources example")
      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
      .master("local[16]")
      .getOrCreate()

    val df = createComplexDataFrame(spark).withColumn("p", lit(1))
      .withColumn("keyid", col("c1")).withColumn("col3", col("c1"))

    val path = new Path("/tmp/default/clustering/cl")
    performClustering(df, path.toString)

    val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)

    fs.delete(path)

    spark.stop()

  }

  def createComplexDataFrame(spark: SparkSession): DataFrame = {
    val schema = new StructType()
      .add("c1", IntegerType)
      .add("c11", IntegerType)
      .add("c12", IntegerType)
      .add("c2", StringType)
      .add("c3", DecimalType(38,18))
      .add("c4", TimestampType)
      .add("c5", ShortType)
      .add("c6", DateType)
      .add("c7", BinaryType)
      .add("c8", ByteType)

    val rdd = spark.sparkContext.parallelize(0 to 1000000, 8).map { item =>
      val c1 = Integer.valueOf(item)
      val c11 = Integer.valueOf(Random.nextInt(1000000))
      val c12 = Integer.valueOf(Random.nextInt(1000000))
      val c2 = s" ${item}sdc"
      //val c3 = new java.math.BigDecimal(s"${Random.nextInt(1000)}.${item}")
      val c3 = new java.math.BigDecimal(s"${Random.nextInt(1000)}")
      val c4 = new Timestamp(System.currentTimeMillis())
      val c5 = java.lang.Short.valueOf(s"${16}")
      val c6 = Date.valueOf(s"${2020}-${item % 11  +  1}-${item % 28  + 1}")
      val c7 = Array(item).map(_.toByte)
      val c8 = java.lang.Byte.valueOf("9")

      RowFactory.create(c1, c11, c12, c2, c3, c4, c5, c6, c7, c8)
    }
    spark.createDataFrame(rdd, schema)
  }

  def performClustering(writeDf: DataFrame, basePath: String = "/tmp/default/clustering"): Unit = {
    writeDf.write.format("org.apache.hudi")
      .options(commonOpts)
      .option("hoodie.compact.inline", "false")
      .option(DataSourceWriteOptions.OPERATION.key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
      .option(DataSourceWriteOptions.TABLE_TYPE.key(), "COPY_ON_WRITE")
      // option for clustering
      .option("hoodie.parquet.small.file.limit", "0")
      .option("hoodie.clustering.inline", "true")
      .option("hoodie.clustering.inline.max.commits", "1")
      .option("hoodie.clustering.plan.strategy.small.file.limit", String.valueOf(2*1024*1024L))
      .option("hoodie.clustering.plan.strategy.max.bytes.per.group", String.valueOf(10*1024*1024L))
      .option("hoodie.clustering.plan.strategy.target.file.max.bytes", String.valueOf(4 * 1024* 1024L))
      .option(HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS.key, "c11, c12")
      .mode(SaveMode.Overwrite)
      .save(basePath)
    writeDf.show()
    Thread.sleep(200000)
  }
}
## Verify this pull request



This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
