### PR TITLE
[HUDI-2908] Fixed partitions produced by layout optimization in case order-by key is composed of a single column

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/spark/OrderingIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/spark/OrderingIndexHelper.java
@@ -100,7 +100,7 @@ public class OrderingIndexHelper {
     }
     // only one col to sort, no need to use z-order
     if (sortCols.size() == 1) {
-      return df.repartitionByRange(fieldNum, org.apache.spark.sql.functions.col(sortCols.get(0)));
+      return df.repartitionByRange(fileNum, org.apache.spark.sql.functions.col(sortCols.get(0)));
     }
     Map<Integer, StructField> fieldMap = sortCols
         .stream().collect(Collectors.toMap(e -> Arrays.asList(df.schema().fields()).indexOf(columnsMap.get(e)), e -> columnsMap.get(e)));


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fixed partitions produced by layout optimization in case order-by key is composed of a single column

## Brief change log

Fixed partitions produced by layout optimization in case order-by key is composed of a single column

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
