### PR TITLE
[HUDI-2946] Upgrade maven plugins to be compatible with higher Java versions

### DIFF
--- a/docker/hoodie/hadoop/pom.xml
+++ b/docker/hoodie/hadoop/pom.xml
@@ -54,7 +54,7 @@
     <docker.hive.version>2.3.3</docker.hive.version>
     <docker.hadoop.version>2.8.4</docker.hadoop.version>
     <docker.presto.version>0.217</docker.presto.version>
-    <dockerfile.maven.version>1.4.3</dockerfile.maven.version>
+    <dockerfile.maven.version>1.4.13</dockerfile.maven.version>
     <checkstyle.skip>true</checkstyle.skip>
     <main.basedir>${project.parent.basedir}</main.basedir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,10 @@
   </organization>
 
   <properties>
-    <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
-    <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.4</maven-deploy-plugin.version>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Saw several issues while building Hudi w/ Java 11:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:2.6:test-jar (default) on project hudi-common: Execution default of goal org.apache.maven.plugins:maven-jar-plugin:2.6:test-jar failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-jar-plugin:2.6:test-jar: java.lang.ExceptionInInitializerError: null[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.1:shade (default) on project hudi-hadoop-mr-bundle: Error creating shaded jar: Problem shading JAR /workspace/workspace/rchertar.bigtop.hudi-rpm-mainline-6.x-0.9.0/build/hudi/rpm/BUILD/hudi-0.9.0-1-SNAPSHOT/packaging/hudi-hadoop-mr-bundle/target/hudi-hadoop-mr-bundle-0.9.0-1-SNAPSHOT.jar entry org/apache/hudi/hadoop/bundle/Main.class: java.lang.IllegalArgumentException -> [Help 1]


We need to upgrade maven plugin versions to make it be compatible with Java 11.

Also upgrade dockerfile-maven-plugin to latest versions to support Java 11 https://github.com/spotify/dockerfile-maven/pull/230

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
