### PR TITLE
Update quick-start-guide.md - incremental query

### DIFF
--- a/website/versioned_docs/version-0.9.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.9.0/quick-start-guide.md
@@ -704,6 +704,11 @@ Hudi also provides capability to obtain a stream of records that changed since g
 This can be achieved using Hudi's incremental querying and providing a begin time from which changes need to be streamed. 
 We do not need to specify endTime, if we want all changes after the given commit (as is the common case). 
 
+:::note
+Note that the amount of data you can incrementally pull from a table depends on the amount of retained commits. 
+Hudi automatically cleans old commits, the amount of retained commits can be specified using `CLEAN_RETAIN_COMMITS` parameter. 
+:::
+
 <Tabs
 defaultValue="scala"
 values={[


### PR DESCRIPTION
Hi,
I added a note on the incremental query, now it explicitly says that the amount of data available for incremental query depends on how many commits are retained.
This confused me a bit as a newcomer, should take some confusion from others looking at Hudi for the first time.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

This pull requests improves spark quick start guide.

## Brief change log

Added a note on the incremental query in quick-start-guide.md

## Verify this pull request

This pull request is a trivial rework.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
