### PR TITLE
[HUDI-2875] Make HoodieParquetWriter Thread safe and memory executor …

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieConcatHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieConcatHandle.java
@@ -34,6 +34,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
@@ -65,6 +67,7 @@ import java.util.Map;
  * Users should ensure there are no duplicates when "insert" operation is used and if the respective config is enabled. So, above scenario should not
  * happen and every batch should have new records to be inserted. Above example is for illustration purposes only.
  */
+@NotThreadSafe
 public class HoodieConcatHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieMergeHandle<T, I, K, O> {
 
   private static final Logger LOG = LogManager.getLogger(HoodieConcatHandle.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
@@ -42,12 +42,15 @@ import org.apache.hudi.table.HoodieTable;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+@NotThreadSafe
 public class HoodieCreateHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieWriteHandle<T, I, K, O> {
 
   private static final Logger LOG = LogManager.getLogger(HoodieCreateHandle.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -53,6 +53,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,6 +92,7 @@ import java.util.Set;
  *
  * </p>
  */
+@NotThreadSafe
 public class HoodieMergeHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieWriteHandle<T, I, K, O> {
 
   private static final Logger LOG = LogManager.getLogger(HoodieMergeHandle.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
@@ -32,6 +32,8 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.apache.avro.generic.GenericRecord;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -45,6 +47,7 @@ import java.util.Queue;
  * The implementation performs a merge-sort by comparing the key of the record being written to the list of
  * keys in newRecordKeys (sorted in-memory).
  */
+@NotThreadSafe
 public class HoodieSortedMergeHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieMergeHandle<T, I, K, O> {
 
   private Queue<String> newRecordKeysSorted = new PriorityQueue<>();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieUnboundedCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieUnboundedCreateHandle.java
@@ -28,11 +28,14 @@ import org.apache.hudi.table.HoodieTable;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 /**
  * A HoodieCreateHandle which writes all data into a single file.
  * <p>
  * Please use this with caution. This can end up creating very large files if not used correctly.
  */
+@NotThreadSafe
 public class HoodieUnboundedCreateHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieCreateHandle<T, I, K, O> {
 
   private static final Logger LOG = LogManager.getLogger(HoodieUnboundedCreateHandle.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetWriter.java
@@ -31,13 +31,18 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * HoodieParquetWriter extends the ParquetWriter to help limit the size of underlying file. Provides a way to check if
  * the current file can take more records with the <code>canWrite()</code>
+ *
+ * ATTENTION: HoodieParquetWriter is not thread safe and developer should take care of the order of write and close
  */
+@NotThreadSafe
 public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends IndexedRecord>
     extends ParquetWriter<IndexedRecord> implements HoodieFileWriter<R> {
 
@@ -106,5 +111,10 @@ public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends Indexe
     if (populateMetaFields) {
       writeSupport.add(key);
     }
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
@@ -99,13 +99,16 @@ public class HoodieMergeHelper<T extends HoodieRecordPayload> extends
     } catch (Exception e) {
       throw new HoodieException(e);
     } finally {
+      // HUDI-2875: mergeHandle is not thread safe, we should totally terminate record inputting
+      // and executor firstly and then close mergeHandle.
       if (reader != null) {
         reader.close();
       }
-      mergeHandle.close();
       if (null != wrapper) {
         wrapper.shutdownNow();
+        wrapper.awaitTermination();
       }
+      mergeHandle.close();
     }
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/execution/FlinkLazyInsertIterable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/execution/FlinkLazyInsertIterable.java
@@ -66,6 +66,7 @@ public class FlinkLazyInsertIterable<T extends HoodieRecordPayload> extends Hood
     } finally {
       if (null != bufferedIteratorExecutor) {
         bufferedIteratorExecutor.shutdownNow();
+        bufferedIteratorExecutor.awaitTermination();
       }
     }
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkMergeHelper.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkMergeHelper.java
@@ -102,13 +102,16 @@ public class FlinkMergeHelper<T extends HoodieRecordPayload> extends BaseMergeHe
     } catch (Exception e) {
       throw new HoodieException(e);
     } finally {
+      // HUDI-2875: mergeHandle is not thread safe, we should totally terminate record inputting
+      // and executor firstly and then close mergeHandle.
       if (reader != null) {
         reader.close();
       }
-      mergeHandle.close();
       if (null != wrapper) {
         wrapper.shutdownNow();
+        wrapper.awaitTermination();
       }
+      mergeHandle.close();
     }
   }
 }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/JavaLazyInsertIterable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/JavaLazyInsertIterable.java
@@ -74,6 +74,7 @@ public class JavaLazyInsertIterable<T extends HoodieRecordPayload> extends Hoodi
     } finally {
       if (null != bufferedIteratorExecutor) {
         bufferedIteratorExecutor.shutdownNow();
+        bufferedIteratorExecutor.awaitTermination();
       }
     }
   }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaMergeHelper.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaMergeHelper.java
@@ -102,13 +102,16 @@ public class JavaMergeHelper<T extends HoodieRecordPayload> extends BaseMergeHel
     } catch (Exception e) {
       throw new HoodieException(e);
     } finally {
+      // HUDI-2875: mergeHandle is not thread safe, we should totally terminate record inputting
+      // and executor firstly and then close mergeHandle.
       if (reader != null) {
         reader.close();
       }
-      mergeHandle.close();
       if (null != wrapper) {
         wrapper.shutdownNow();
+        wrapper.awaitTermination();
       }
+      mergeHandle.close();
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/SparkLazyInsertIterable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/SparkLazyInsertIterable.java
@@ -95,6 +95,7 @@ public class SparkLazyInsertIterable<T extends HoodieRecordPayload> extends Hood
     } finally {
       if (null != bufferedIteratorExecutor) {
         bufferedIteratorExecutor.shutdownNow();
+        bufferedIteratorExecutor.awaitTermination();
       }
     }
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/OrcBootstrapMetadataHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/OrcBootstrapMetadataHandler.java
@@ -80,10 +80,11 @@ class OrcBootstrapMetadataHandler extends BaseBootstrapMetadataHandler {
     } catch (Exception e) {
       throw new HoodieException(e);
     } finally {
-      bootstrapHandle.close();
       if (null != wrapper) {
         wrapper.shutdownNow();
+        wrapper.awaitTermination();
       }
+      bootstrapHandle.close();
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryExecutorInSpark.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryExecutorInSpark.java
@@ -38,15 +38,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 
 import scala.Tuple2;
 
@@ -55,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -171,139 +161,43 @@ public class TestBoundedInMemoryExecutorInSpark extends HoodieClientTestHarness 
   }
 
   @Test
-  public void testExecutorTermination() throws ExecutionException, InterruptedException {
-    // HUDI-2875: sleep time in this UT is designed deliberately. It represents the case that
-    // consumer is slower than producer and the queue connecting them is non-empty.
-    // firstly test a nonSafe usage
-    ExecutorService executionThread = Executors.newSingleThreadExecutor();
-    Future<Boolean> testResult = executionThread.submit(new ExecutorConcurrentUsageTask(false));
-    // let executor run some time
-    sleepUninterruptibly(2 * 1000);
-    executionThread.shutdownNow();
-    boolean concurrentSafe = !testResult.get();
-    assertFalse(concurrentSafe, "Should find concurrent issue");
-    // test a thread safe usage
-    executionThread = Executors.newSingleThreadExecutor();
-    testResult = executionThread.submit(new ExecutorConcurrentUsageTask(true));
-    sleepUninterruptibly(2 * 1000);
-    executionThread.shutdownNow();
-    concurrentSafe = !testResult.get();
-    assertTrue(concurrentSafe, "Should not find concurrent issue");
-  }
-
-  private static void sleepUninterruptibly(int milliseconds) {
-    long remainingNanos = TimeUnit.MILLISECONDS.toNanos(milliseconds);
-    long end = System.nanoTime() + remainingNanos;
-    while (true) {
-      try {
-        TimeUnit.NANOSECONDS.sleep(remainingNanos);
-        return;
-      } catch (InterruptedException interruptedException) {
-        remainingNanos = end - System.nanoTime();
+  public void testExecutorTermination() {
+    HoodieWriteConfig hoodieWriteConfig = mock(HoodieWriteConfig.class);
+    when(hoodieWriteConfig.getWriteBufferLimitBytes()).thenReturn(1024);
+    Iterator<GenericRecord> unboundedRecordIter = new Iterator<GenericRecord>() {
+      @Override
+      public boolean hasNext() {
+        return true;
       }
-    }
-  }
 
-  private class ExecutorConcurrentUsageTask implements Callable<Boolean> {
-    private final boolean correct;
+      @Override
+      public GenericRecord next() {
+        return dataGen.generateGenericRecord();
+      }
+    };
 
-    private ExecutorConcurrentUsageTask(boolean correct) {
-      this.correct = correct;
-    }
-
-    @Override
-    public Boolean call() throws Exception {
-      HoodieWriteConfig hoodieWriteConfig = mock(HoodieWriteConfig.class);
-      when(hoodieWriteConfig.getWriteBufferLimitBytes()).thenReturn(1024 * 1024);
-
-      Iterator<GenericRecord> unboundedRecordIter = new Iterator<GenericRecord>() {
-        private final Random random = new Random();
-        private final HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
-
-        @Override
-        public boolean hasNext() {
-          return true;
-        }
-
-        @Override
-        public GenericRecord next() {
-          String randomStr = UUID.randomUUID().toString();
-          return dataGenerator.generateRecordForTripSchema(randomStr, randomStr, randomStr, random.nextLong());
-        }
-      };
-
-      NonThreadSafeConsumer nonThreadSafeConsumer = new NonThreadSafeConsumer();
-      BoundedInMemoryExecutor<GenericRecord, Tuple2<GenericRecord, GenericRecord>, Integer> executor = null;
-      try {
-        executor = new BoundedInMemoryExecutor(hoodieWriteConfig.getWriteBufferLimitBytes(), unboundedRecordIter, nonThreadSafeConsumer,
-            rec -> rec, getPreExecuteRunnable());
-        executor.execute();
-      } catch (Exception e) {
-        if (!(e instanceof HoodieException) || !(e.getCause() instanceof InterruptedException)) {
-          fail("Unexpected exception thrown here: ", e);
-        }
-      } finally {
-        // here we simulate correct order to close executor and consumer
-        if (correct) {
-          if (executor != null) {
-            executor.shutdownNow();
-            executor.awaitTermination();
+    BoundedInMemoryQueueConsumer<HoodieLazyInsertIterable.HoodieInsertValueGenResult<HoodieRecord>, Integer> consumer =
+        new BoundedInMemoryQueueConsumer<HoodieLazyInsertIterable.HoodieInsertValueGenResult<HoodieRecord>, Integer>() {
+          @Override
+          protected void consumeOneRecord(HoodieLazyInsertIterable.HoodieInsertValueGenResult<HoodieRecord> record) {
           }
-          nonThreadSafeConsumer.close(2);
-        } else {
-          // here we simulate incorrect order to close executor and consumer
-          nonThreadSafeConsumer.close(2);
-          if (executor != null) {
-            executor.shutdownNow();
-            executor.awaitTermination();
+
+          @Override
+          protected void finish() {
           }
-        }
-      }
-      return nonThreadSafeConsumer.foundConcurrentUsage;
-    }
-  }
 
-  private static class NonThreadSafeConsumer extends BoundedInMemoryQueueConsumer<GenericRecord, Integer> {
-    private final ReentrantLock lock = new ReentrantLock();
-    private boolean foundConcurrentUsage = false;
+          @Override
+          protected Integer getResult() {
+            return 0;
+          }
+        };
 
-    @Override
-    protected void consumeOneRecord(GenericRecord record) {
-      boolean getLock = lock.tryLock();
-      if (!getLock) {
-        foundConcurrentUsage = true;
-      }
-      if (getLock) {
-        try {
-          // simulate write avro into parquet. It is slower than the speed producer produce.
-          sleepUninterruptibly(10);
-        } finally {
-          lock.unlock();
-        }
-      }
-    }
-
-    @Override
-    protected void finish() {
-    }
-
-    @Override
-    protected Integer getResult() {
-      return 0;
-    }
-
-    public void close(int seconds) {
-      boolean getLock = lock.tryLock();
-      if (!getLock) {
-        foundConcurrentUsage = true;
-      }
-      if (getLock) {
-        try {
-          sleepUninterruptibly(seconds * 1000);
-        } finally {
-          lock.unlock();
-        }
-      }
-    }
+    BoundedInMemoryExecutor<HoodieRecord, Tuple2<HoodieRecord, Option<IndexedRecord>>, Integer> executor =
+        new BoundedInMemoryExecutor(hoodieWriteConfig.getWriteBufferLimitBytes(), unboundedRecordIter,
+            consumer, getTransformFunction(HoodieTestDataGenerator.AVRO_SCHEMA),
+            getPreExecuteRunnable());
+    executor.shutdownNow();
+    boolean terminatedGracefully = executor.awaitTermination();
+    assertTrue(terminatedGracefully);
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryExecutorInSpark.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryExecutorInSpark.java
@@ -28,6 +28,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.testutils.HoodieClientTestHarness;
 
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
@@ -35,7 +36,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import scala.Tuple2;
 
@@ -44,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -105,6 +117,7 @@ public class TestBoundedInMemoryExecutorInSpark extends HoodieClientTestHarness 
     } finally {
       if (executor != null) {
         executor.shutdownNow();
+        executor.awaitTermination();
       }
     }
   }
@@ -152,6 +165,144 @@ public class TestBoundedInMemoryExecutorInSpark extends HoodieClientTestHarness 
     } finally {
       if (executor != null) {
         executor.shutdownNow();
+        executor.awaitTermination();
+      }
+    }
+  }
+
+  @Test
+  public void testExecutorTermination() throws ExecutionException, InterruptedException {
+    // HUDI-2875: sleep time in this UT is designed deliberately. It represents the case that
+    // consumer is slower than producer and the queue connecting them is non-empty.
+    // firstly test a nonSafe usage
+    ExecutorService executionThread = Executors.newSingleThreadExecutor();
+    Future<Boolean> testResult = executionThread.submit(new ExecutorConcurrentUsageTask(false));
+    // let executor run some time
+    sleepUninterruptibly(2 * 1000);
+    executionThread.shutdownNow();
+    boolean concurrentSafe = !testResult.get();
+    assertFalse(concurrentSafe, "Should find concurrent issue");
+    // test a thread safe usage
+    executionThread = Executors.newSingleThreadExecutor();
+    testResult = executionThread.submit(new ExecutorConcurrentUsageTask(true));
+    sleepUninterruptibly(2 * 1000);
+    executionThread.shutdownNow();
+    concurrentSafe = !testResult.get();
+    assertTrue(concurrentSafe, "Should not find concurrent issue");
+  }
+
+  private static void sleepUninterruptibly(int milliseconds) {
+    long remainingNanos = TimeUnit.MILLISECONDS.toNanos(milliseconds);
+    long end = System.nanoTime() + remainingNanos;
+    while (true) {
+      try {
+        TimeUnit.NANOSECONDS.sleep(remainingNanos);
+        return;
+      } catch (InterruptedException interruptedException) {
+        remainingNanos = end - System.nanoTime();
+      }
+    }
+  }
+
+  private class ExecutorConcurrentUsageTask implements Callable<Boolean> {
+    private final boolean correct;
+
+    private ExecutorConcurrentUsageTask(boolean correct) {
+      this.correct = correct;
+    }
+
+    @Override
+    public Boolean call() throws Exception {
+      HoodieWriteConfig hoodieWriteConfig = mock(HoodieWriteConfig.class);
+      when(hoodieWriteConfig.getWriteBufferLimitBytes()).thenReturn(1024 * 1024);
+
+      Iterator<GenericRecord> unboundedRecordIter = new Iterator<GenericRecord>() {
+        private final Random random = new Random();
+        private final HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+
+        @Override
+        public boolean hasNext() {
+          return true;
+        }
+
+        @Override
+        public GenericRecord next() {
+          String randomStr = UUID.randomUUID().toString();
+          return dataGenerator.generateRecordForTripSchema(randomStr, randomStr, randomStr, random.nextLong());
+        }
+      };
+
+      NonThreadSafeConsumer nonThreadSafeConsumer = new NonThreadSafeConsumer();
+      BoundedInMemoryExecutor<GenericRecord, Tuple2<GenericRecord, GenericRecord>, Integer> executor = null;
+      try {
+        executor = new BoundedInMemoryExecutor(hoodieWriteConfig.getWriteBufferLimitBytes(), unboundedRecordIter, nonThreadSafeConsumer,
+            rec -> rec, getPreExecuteRunnable());
+        executor.execute();
+      } catch (Exception e) {
+        if (!(e instanceof HoodieException) || !(e.getCause() instanceof InterruptedException)) {
+          fail("Unexpected exception thrown here: ", e);
+        }
+      } finally {
+        // here we simulate correct order to close executor and consumer
+        if (correct) {
+          if (executor != null) {
+            executor.shutdownNow();
+            executor.awaitTermination();
+          }
+          nonThreadSafeConsumer.close(2);
+        } else {
+          // here we simulate incorrect order to close executor and consumer
+          nonThreadSafeConsumer.close(2);
+          if (executor != null) {
+            executor.shutdownNow();
+            executor.awaitTermination();
+          }
+        }
+      }
+      return nonThreadSafeConsumer.foundConcurrentUsage;
+    }
+  }
+
+  private static class NonThreadSafeConsumer extends BoundedInMemoryQueueConsumer<GenericRecord, Integer> {
+    private final ReentrantLock lock = new ReentrantLock();
+    private boolean foundConcurrentUsage = false;
+
+    @Override
+    protected void consumeOneRecord(GenericRecord record) {
+      boolean getLock = lock.tryLock();
+      if (!getLock) {
+        foundConcurrentUsage = true;
+      }
+      if (getLock) {
+        try {
+          // simulate write avro into parquet. It is slower than the speed producer produce.
+          sleepUninterruptibly(10);
+        } finally {
+          lock.unlock();
+        }
+      }
+    }
+
+    @Override
+    protected void finish() {
+    }
+
+    @Override
+    protected Integer getResult() {
+      return 0;
+    }
+
+    public void close(int seconds) {
+      boolean getLock = lock.tryLock();
+      if (!getLock) {
+        foundConcurrentUsage = true;
+      }
+      if (getLock) {
+        try {
+          sleepUninterruptibly(seconds * 1000);
+        } finally {
+          lock.unlock();
+        }
       }
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -860,12 +860,14 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     return false;
   }
 
+  public GenericRecord generateGenericRecord() {
+    return generateGenericRecord(genPseudoRandomUUID(rand).toString(), "0",
+        genPseudoRandomUUID(rand).toString(), genPseudoRandomUUID(rand).toString(), rand.nextLong());
+  }
+
   public List<GenericRecord> generateGenericRecords(int numRecords) {
     List<GenericRecord> list = new ArrayList<>();
-    IntStream.range(0, numRecords).forEach(i -> {
-      list.add(generateGenericRecord(genPseudoRandomUUID(rand).toString(), "0",
-          genPseudoRandomUUID(rand).toString(), genPseudoRandomUUID(rand).toString(), rand.nextLong()));
-    });
+    IntStream.range(0, numRecords).forEach(i -> list.add(generateGenericRecord()));
     return list;
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fix problem mentioned in https://issues.apache.org/jira/browse/HUDI-2875.


## Brief change log
1. Add a graceful exit for BoundedInMemoryExecutor.
2. let's first totally stop BoundedInMemoryExecutor and then close HoodieMergeHandle in SparkMergeHelper.
3. Add a UT to test above case

## Verify this pull request


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
