### PR TITLE
[HUDI-2974] Make the prefix for metrics name configurable

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1628,6 +1628,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieMetricsPrometheusConfig.PUSHGATEWAY_RANDOM_JOBNAME_SUFFIX);
   }
 
+  public String getMetricReporterMetricsNamePrefix() {
+    return getStringOrDefault(HoodieMetricsConfig.METRICS_REPORTER_PREFIX);
+  }
+  
   /**
    * memory configs.
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -67,7 +67,7 @@ public class HoodieMetricsConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> METRICS_REPORTER_PREFIX = ConfigProperty
       .key(METRIC_PREFIX + ".reporter.metricsname.prefix")
-      .noDefaultValue()
+      .defaultValue("")
       .sinceVersion("0.11.0")
       .withInferFunction(cfg -> {
         if (cfg.contains(HoodieTableConfig.NAME)) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -22,6 +22,8 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieMetricsCloudWatchConfig;
 import org.apache.hudi.metrics.MetricsReporterType;
 
@@ -62,6 +64,18 @@ public class HoodieMetricsConfig extends HoodieConfig {
       .defaultValue("")
       .sinceVersion("0.6.0")
       .withDocumentation("");
+
+  public static final ConfigProperty<String> METRICS_REPORTER_PREFIX = ConfigProperty
+      .key(METRIC_PREFIX + ".reporter.metricsname.prefix")
+      .noDefaultValue()
+      .sinceVersion("0.11.0")
+      .withInferFunction(cfg -> {
+        if (cfg.contains(HoodieTableConfig.NAME)) {
+          return Option.of(cfg.getString(HoodieTableConfig.NAME));
+        }
+        return Option.empty();
+      })
+      .withDocumentation("The prefix given to the metrics names.");
 
   // Enable metrics collection from executors
   public static final ConfigProperty<String> EXECUTOR_METRICS_ENABLE = ConfigProperty

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -215,7 +215,7 @@ public class HoodieMetrics {
   }
 
   String getMetricsName(String action, String metric) {
-    return config == null ? null : String.format("%s.%s.%s", tableName, action, metric);
+    return config == null ? null : String.format("%s.%s.%s", config.getMetricReporterMetricsNamePrefix(), action, metric);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -21,6 +21,7 @@ package org.apache.hudi.metrics;
 import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.exception.HoodieException;
 
 import com.codahale.metrics.MetricRegistry;
@@ -46,7 +47,7 @@ public class Metrics {
 
   private Metrics(HoodieWriteConfig metricConfig) {
     registry = new MetricRegistry();
-    commonMetricPrefix = metricConfig.getTableName();
+    commonMetricPrefix = metricConfig.getStringOrDefault(HoodieMetricsConfig.METRICS_REPORTER_PREFIX);
     reporter = MetricsReporterFactory.createReporter(metricConfig, registry);
     if (reporter == null) {
       throw new RuntimeException("Cannot initialize Reporter.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -47,7 +47,7 @@ public class Metrics {
 
   private Metrics(HoodieWriteConfig metricConfig) {
     registry = new MetricRegistry();
-    commonMetricPrefix = metricConfig.getStringOrDefault(HoodieMetricsConfig.METRICS_REPORTER_PREFIX);
+    commonMetricPrefix = metricConfig.getMetricReporterMetricsNamePrefix();
     reporter = MetricsReporterFactory.createReporter(metricConfig, registry);
     if (reporter == null) {
       throw new RuntimeException("Cannot initialize Reporter.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -21,7 +21,6 @@ package org.apache.hudi.metrics;
 import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.exception.HoodieException;
 
 import com.codahale.metrics.MetricRegistry;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
@@ -74,7 +74,7 @@ public class HoodieDeltaStreamerMetrics implements Serializable {
   }
 
   String getMetricsName(String action, String metric) {
-    return config == null ? null : String.format("%s.%s.%s", tableName, action, metric);
+    return config == null ? null : String.format("%s.%s.%s", config.getMetricReporterMetricsNamePrefix(), action, metric);
   }
 
   public void updateDeltaStreamerMetrics(long durationInNs) {


### PR DESCRIPTION
Currently metrics names always start with table name. This makes it less flexible to create grafana dashboards with prometheus query. since its easier to have consistent metrics names across all spark/deltastreamer jobs.

Adding a new config for the prefix name, but Keeping the default as the table name to ensure compatibility with current deployments.

