### PR TITLE
[HUDI-3025] Add additional wait time for namenode availability during IT tests initiatialization 

### DIFF
--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
@@ -20,6 +20,8 @@ package org.apache.hudi.integ;
 
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.DockerCmdExecFactory;
@@ -153,19 +155,13 @@ public abstract class ITTestBase {
     try {
       TestExecStartResultCallback resultCallback =
           executeCommandStringInDocker(ADHOC_1_CONTAINER, "nc -z -v namenode 8020", true, true);
-      String stdoutString = resultCallback.getStdout().toString().trim();
       String stderrString = resultCallback.getStderr().toString().trim();
-      LOG.info("Result: nc -z -v namenode 8020");
-      LOG.info("Stdout");
-      LOG.info(stdoutString);
-      LOG.info("Stderr");
-      LOG.info(stderrString);
       if (!stderrString.contains("open")) {
         Thread.sleep(1000);
         return false;
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      throw new HoodieException("Exception thrown while wiating for namenode to be up ", e);
     }
     return true;
   }

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
@@ -234,7 +234,7 @@ public abstract class ITTestBase {
 
   protected TestExecStartResultCallback executeCommandStringInDocker(
       String containerName, String cmd, boolean expectedToSucceed) throws Exception {
-    return executeCommandStringInDocker(containerName, cmd, false, expectedToSucceed);
+    return executeCommandStringInDocker(containerName, cmd, true, expectedToSucceed);
   }
 
   protected TestExecStartResultCallback executeCommandStringInDocker(


### PR DESCRIPTION
## What is the purpose of the pull request

All CI runs are failing due to namenode going into safe mode. We rootcaused it as, no sufficient time given for namenode to come up during initialization. So, first test fails. but from subsequent tests, it succeeds. So, adding additional wait time to ensure namenode is up before completing the initialization. 

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
