### PR TITLE
[HUDI-735] Fixing error messages on record key field not found in schema

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/SparkKeyGeneratorInterface.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/SparkKeyGeneratorInterface.java
@@ -22,6 +22,11 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Spark key generator interface.
  */
@@ -32,4 +37,18 @@ public interface SparkKeyGeneratorInterface extends KeyGeneratorInterface {
   String getPartitionPath(Row row);
 
   String getPartitionPath(InternalRow internalRow, StructType structType);
+
+  /**
+   * validates record key
+   * @param schema schema of the internalRow
+   * @throws IllegalArgumentException
+   */
+  default void validateKeyGenProps(StructType schema) throws IllegalArgumentException {
+    Set<String> columnSet = new HashSet<>(Arrays.asList(schema.fieldNames()));
+    for (String recordKeyFieldName : getRecordKeyFieldNames()) {
+      if (!columnSet.contains(recordKeyFieldName)) {
+        throw new IllegalArgumentException("record key '" + recordKeyFieldName + "' does not exist in incoming dataframe schema: " + schema);
+      }
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -229,7 +229,11 @@ object HoodieSparkSqlWriter {
             }
             sparkContext.getConf.registerAvroSchemas(schema)
             log.info(s"Registered avro schema : ${schema.toString(true)}")
-
+            val columnSet = df.columns.toSet
+            if (keyGenerator.isInstanceOf[org.apache.hudi.keygen.SparkKeyGeneratorInterface]) {
+              keyGenerator.asInstanceOf[org.apache.hudi.keygen.SparkKeyGeneratorInterface]
+                  .validateKeyGenProps(df.schema);
+            }
             // Convert to RDD[HoodieRecord]
             val genericRecords: RDD[GenericRecord] = HoodieSparkUtils.createRdd(df, structName, nameSpace, reconcileSchema,
               org.apache.hudi.common.util.Option.of(schema))


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*If record key does not exists in table schema , then current error messaging was not clear for user to understand.
Added exception if record key does not exist*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
