### PR TITLE
[HUDI-3030] InProcessLockPovider as default when any async servcies enabled with no lock provider override

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
@@ -464,7 +464,7 @@ public abstract class AbstractHoodieWriteClient<T extends HoodieRecordPayload, I
   }
 
   protected void runTableServicesInline(HoodieTable<T, I, K, O> table, HoodieCommitMetadata metadata, Option<Map<String, String>> extraMetadata) {
-    if (config.isAnyTableServicesInline()) {
+    if (config.areAnyTableServicesInline()) {
       if (config.isMetadataTableEnabled()) {
         table.getHoodieView().sync();
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/AbstractHoodieWriteClient.java
@@ -464,7 +464,7 @@ public abstract class AbstractHoodieWriteClient<T extends HoodieRecordPayload, I
   }
 
   protected void runTableServicesInline(HoodieTable<T, I, K, O> table, HoodieCommitMetadata metadata, Option<Map<String, String>> extraMetadata) {
-    if (config.inlineTableServices()) {
+    if (config.isAnyTableServicesInline()) {
       if (config.isMetadataTableEnabled()) {
         table.getHoodieView().sync();
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
@@ -2291,9 +2292,12 @@ public class HoodieWriteConfig extends HoodieConfig {
       // Async table services can update the metadata table and a lock provider is
       // needed to guard against any concurrent table write operations. If user has
       // not configured any lock provider, let's use the InProcess lock provider.
+      final TypedProperties writeConfigProperties = writeConfig.getProps();
+      final boolean isLockProviderPropertySet = writeConfigProperties.containsKey(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME)
+          || writeConfigProperties.containsKey(HoodieLockConfig.LOCK_PROVIDER_CLASS_PROP);
       if (!isLockConfigSet) {
         HoodieLockConfig.Builder lockConfigBuilder = HoodieLockConfig.newBuilder().fromProperties(writeConfig.getProps());
-        if (writeConfig.areAnyTableServicesAsync()) {
+        if (!isLockProviderPropertySet && writeConfig.areAnyTableServicesAsync()) {
           lockConfigBuilder.withLockProvider(InProcessLockProvider.class);
         }
         writeConfig.setDefault(lockConfigBuilder.build());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1840,7 +1840,7 @@ public class HoodieWriteConfig extends HoodieConfig {
    *
    * @return True if any table services are configured to run inline, false otherwise.
    */
-  public Boolean isAnyTableServicesInline() {
+  public Boolean areAnyTableServicesInline() {
     return inlineClusteringEnabled() || inlineCompactionEnabled() || isAutoClean();
   }
 
@@ -1849,7 +1849,7 @@ public class HoodieWriteConfig extends HoodieConfig {
    *
    * @return True if any table services are configured to run async, false otherwise.
    */
-  public Boolean isAnyTableServicesAsync() {
+  public Boolean areAnyTableServicesAsync() {
     return isAsyncClusteringEnabled() || !inlineCompactionEnabled() || isAsyncClean();
   }
 
@@ -2288,9 +2288,12 @@ public class HoodieWriteConfig extends HoodieConfig {
           HoodieLayoutConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultValue(TIMELINE_LAYOUT_VERSION_NUM, String.valueOf(TimelineLayoutVersion.CURR_VERSION));
 
+      // Async table services can update the metadata table and a lock provider is
+      // needed to guard against any concurrent table write operations. If user has
+      // not configured any lock provider, let's use the InProcess lock provider.
       if (!isLockConfigSet) {
         HoodieLockConfig.Builder lockConfigBuilder = HoodieLockConfig.newBuilder().fromProperties(writeConfig.getProps());
-        if (writeConfig.isAnyTableServicesAsync()) {
+        if (writeConfig.areAnyTableServicesAsync()) {
           lockConfigBuilder.withLockProvider(InProcessLockProvider.class);
         }
         writeConfig.setDefault(lockConfigBuilder.build());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -21,6 +21,7 @@ package org.apache.hudi.config;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.bootstrap.BootstrapMode;
 import org.apache.hudi.client.transaction.ConflictResolutionStrategy;
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
@@ -1834,8 +1835,22 @@ public class HoodieWriteConfig extends HoodieConfig {
     return WriteConcurrencyMode.fromValue(getString(WRITE_CONCURRENCY_MODE));
   }
 
-  public Boolean inlineTableServices() {
+  /**
+   * Are any table services configured to run inline?
+   *
+   * @return True if any table services are configured to run inline, false otherwise.
+   */
+  public Boolean isAnyTableServicesInline() {
     return inlineClusteringEnabled() || inlineCompactionEnabled() || isAutoClean();
+  }
+
+  /**
+   * Are any table services configured to run async?
+   *
+   * @return True if any table services are configured to run async, false otherwise.
+   */
+  public Boolean isAnyTableServicesAsync() {
+    return isAsyncClusteringEnabled() || !inlineCompactionEnabled() || isAsyncClean();
   }
 
   public String getPreCommitValidators() {
@@ -2267,13 +2282,19 @@ public class HoodieWriteConfig extends HoodieConfig {
           HoodiePayloadConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultOnCondition(!isMetadataConfigSet,
           HoodieMetadataConfig.newBuilder().withEngineType(engineType).fromProperties(writeConfig.getProps()).build());
-      writeConfig.setDefaultOnCondition(!isLockConfigSet,
-          HoodieLockConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultOnCondition(!isPreCommitValidationConfigSet,
           HoodiePreCommitValidatorConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultOnCondition(!isLayoutConfigSet,
           HoodieLayoutConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultValue(TIMELINE_LAYOUT_VERSION_NUM, String.valueOf(TimelineLayoutVersion.CURR_VERSION));
+
+      if (!isLockConfigSet) {
+        HoodieLockConfig.Builder lockConfigBuilder = HoodieLockConfig.newBuilder().fromProperties(writeConfig.getProps());
+        if (writeConfig.isAnyTableServicesAsync()) {
+          lockConfigBuilder.withLockProvider(InProcessLockProvider.class);
+        }
+        writeConfig.setDefault(lockConfigBuilder.build());
+      }
     }
 
     private void validate() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -128,7 +128,7 @@ public class TestHoodieWriteConfig {
         put(ASYNC_CLEAN.key(), "false");
       }
     });
-    assertTrue(writeConfig.isAnyTableServicesAsync());
+    assertTrue(writeConfig.areAnyTableServicesAsync());
     assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
 
     // 2. Async clean
@@ -140,7 +140,7 @@ public class TestHoodieWriteConfig {
         put(ASYNC_CLEAN.key(), "true");
       }
     });
-    assertTrue(writeConfig.isAnyTableServicesAsync());
+    assertTrue(writeConfig.areAnyTableServicesAsync());
     assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
 
     // 3. Async compaction
@@ -152,7 +152,7 @@ public class TestHoodieWriteConfig {
         put(ASYNC_CLEAN.key(), "false");
       }
     });
-    assertTrue(writeConfig.isAnyTableServicesAsync());
+    assertTrue(writeConfig.areAnyTableServicesAsync());
     assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
 
     // 4. All inline services
@@ -164,8 +164,8 @@ public class TestHoodieWriteConfig {
         put(ASYNC_CLEAN.key(), "false");
       }
     });
-    assertFalse(writeConfig.isAnyTableServicesAsync());
-    assertTrue(writeConfig.isAnyTableServicesInline());
+    assertFalse(writeConfig.areAnyTableServicesAsync());
+    assertTrue(writeConfig.areAnyTableServicesInline());
     assertEquals(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.defaultValue(), writeConfig.getLockProviderClass());
 
     // 5. User override for the lock provider should always take the precedence
@@ -179,7 +179,7 @@ public class TestHoodieWriteConfig {
 
     // Default config should have default lock provider
     writeConfig = createWriteConfig(Collections.emptyMap());
-    if (!writeConfig.isAnyTableServicesAsync()) {
+    if (!writeConfig.areAnyTableServicesAsync()) {
       assertEquals(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.defaultValue(), writeConfig.getLockProviderClass());
     } else {
       assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
@@ -188,9 +188,7 @@ public class TestHoodieWriteConfig {
 
   private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {
     final Properties properties = new Properties();
-    for (Map.Entry<String, String> entry : configs.entrySet()) {
-      properties.setProperty(entry.getKey(), entry.getValue());
-    }
+    configs.forEach(properties::setProperty);
     return HoodieWriteConfig.newBuilder()
         .withPath("/tmp")
         .withProperties(properties)

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -20,6 +20,8 @@ package org.apache.hudi.config;
 
 import org.apache.hudi.client.transaction.FileSystemBasedLockProviderTestClass;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
+import org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.config.HoodieWriteConfig.Builder;
@@ -176,6 +178,15 @@ public class TestHoodieWriteConfig {
             .build())
         .build();
     assertEquals(FileSystemBasedLockProviderTestClass.class.getName(), writeConfig.getLockProviderClass());
+
+    // 6. User can set the lock provider via properties
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(), ZookeeperBasedLockProvider.class.getName());
+    writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withProperties(properties)
+        .build();
+    assertEquals(ZookeeperBasedLockProvider.class.getName(), writeConfig.getLockProviderClass());
 
     // Default config should have default lock provider
     writeConfig = createWriteConfig(Collections.emptyMap());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.config;
 
+import org.apache.hudi.client.transaction.FileSystemBasedLockProviderTestClass;
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.config.HoodieWriteConfig.Builder;
@@ -30,13 +32,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
 
+import static org.apache.hudi.config.HoodieClusteringConfig.ASYNC_CLUSTERING_ENABLE;
+import static org.apache.hudi.config.HoodieCompactionConfig.ASYNC_CLEAN;
+import static org.apache.hudi.config.HoodieCompactionConfig.AUTO_CLEAN;
+import static org.apache.hudi.config.HoodieCompactionConfig.INLINE_COMPACT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieWriteConfig {
@@ -102,6 +110,91 @@ public class TestHoodieWriteConfig {
             EngineType.SPARK, MarkerType.TIMELINE_SERVER_BASED,
             EngineType.FLINK, MarkerType.DIRECT,
             EngineType.JAVA, MarkerType.DIRECT));
+  }
+
+  @Test
+  public void testDefaultLockProviderWhenAsyncServicesEnabled() {
+    final String inProcessLockProviderClassName = InProcessLockProvider.class.getCanonicalName();
+
+    // Any async clustering enabled should use InProcess lock provider
+    // as default when no other lock provider is set.
+
+    // 1. Async clustering
+    HoodieWriteConfig writeConfig = createWriteConfig(new HashMap<String, String>() {
+      {
+        put(ASYNC_CLUSTERING_ENABLE.key(), "true");
+        put(INLINE_COMPACT.key(), "true");
+        put(AUTO_CLEAN.key(), "true");
+        put(ASYNC_CLEAN.key(), "false");
+      }
+    });
+    assertTrue(writeConfig.isAnyTableServicesAsync());
+    assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
+
+    // 2. Async clean
+    writeConfig = createWriteConfig(new HashMap<String, String>() {
+      {
+        put(ASYNC_CLUSTERING_ENABLE.key(), "false");
+        put(INLINE_COMPACT.key(), "true");
+        put(AUTO_CLEAN.key(), "true");
+        put(ASYNC_CLEAN.key(), "true");
+      }
+    });
+    assertTrue(writeConfig.isAnyTableServicesAsync());
+    assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
+
+    // 3. Async compaction
+    writeConfig = createWriteConfig(new HashMap<String, String>() {
+      {
+        put(ASYNC_CLUSTERING_ENABLE.key(), "false");
+        put(INLINE_COMPACT.key(), "false");
+        put(AUTO_CLEAN.key(), "true");
+        put(ASYNC_CLEAN.key(), "false");
+      }
+    });
+    assertTrue(writeConfig.isAnyTableServicesAsync());
+    assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
+
+    // 4. All inline services
+    writeConfig = createWriteConfig(new HashMap<String, String>() {
+      {
+        put(ASYNC_CLUSTERING_ENABLE.key(), "false");
+        put(INLINE_COMPACT.key(), "true");
+        put(AUTO_CLEAN.key(), "true");
+        put(ASYNC_CLEAN.key(), "false");
+      }
+    });
+    assertFalse(writeConfig.isAnyTableServicesAsync());
+    assertTrue(writeConfig.isAnyTableServicesInline());
+    assertEquals(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.defaultValue(), writeConfig.getLockProviderClass());
+
+    // 5. User override for the lock provider should always take the precedence
+    writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withLockConfig(HoodieLockConfig.newBuilder()
+            .withLockProvider(FileSystemBasedLockProviderTestClass.class)
+            .build())
+        .build();
+    assertEquals(FileSystemBasedLockProviderTestClass.class.getName(), writeConfig.getLockProviderClass());
+
+    // Default config should have default lock provider
+    writeConfig = createWriteConfig(Collections.emptyMap());
+    if (!writeConfig.isAnyTableServicesAsync()) {
+      assertEquals(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.defaultValue(), writeConfig.getLockProviderClass());
+    } else {
+      assertEquals(inProcessLockProviderClassName, writeConfig.getLockProviderClass());
+    }
+  }
+
+  private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {
+    final Properties properties = new Properties();
+    for (Map.Entry<String, String> entry : configs.entrySet()) {
+      properties.setProperty(entry.getKey(), entry.getValue());
+    }
+    return HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withProperties(properties)
+        .build();
   }
 
   private ByteArrayOutputStream saveParamsIntoOutputStream(Map<String, String> params) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -199,8 +199,12 @@ public class HoodieConfig implements Serializable {
 
   public void setDefaultOnCondition(boolean condition, HoodieConfig config) {
     if (condition) {
-      props.putAll(config.getProps());
+      setDefault(config);
     }
+  }
+
+  public void setDefault(HoodieConfig config) {
+    props.putAll(config.getProps());
   }
 
   public <T> String getStringOrThrow(ConfigProperty<T> configProperty, String errorMessage) throws HoodieException {


### PR DESCRIPTION
## What is the purpose of the pull request

 - Making InProcessLockProvider as the default lock provider when
   any async services are enabled and when no lock provider is
   explicitly set.

 - This is the workaround for metadata table updates racing with
   async table serice operations


## Verify this pull request

 - Added unit test to verify the writer config default lock config

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
