### PR TITLE
[HUDI-3087] Fix DedupeSparkJob typo

### DIFF
--- a/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
+++ b/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
@@ -233,7 +233,7 @@ class DedupeSparkJob(basePath: String,
     }
 
     println("No duplicates found & counts are in check!!!! ")
-    // 4. Prepare to copy the fixed files back.
+    // 5. Prepare to copy the fixed files back.
     fileNameToPathMap.foreach { case (_, filePath) =>
       val srcPath = new Path(s"$repairOutputPath/${filePath.getName}")
       val dstPath = new Path(s"$basePath/$duplicatedPartitionPath/${filePath.getName}")


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
