### PR TITLE
[HUDI-1847] Adding inline scheduling support for spark datasource path for compaction and clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -464,7 +464,7 @@ public abstract class BaseHoodieWriteClient<T extends HoodieRecordPayload, I, K,
   }
 
   protected void runTableServicesInline(HoodieTable<T, I, K, O> table, HoodieCommitMetadata metadata, Option<Map<String, String>> extraMetadata) {
-    if (config.areAnyTableServicesInline() || config.scheduleInlineTableServices()) {
+    if (config.areAnyTableServicesExecutedInline() || config.areAnyTableServicesScheduledInline()) {
       if (config.isMetadataTableEnabled()) {
         table.getHoodieView().sync();
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -464,44 +464,44 @@ public abstract class BaseHoodieWriteClient<T extends HoodieRecordPayload, I, K,
   }
 
   protected void runTableServicesInline(HoodieTable<T, I, K, O> table, HoodieCommitMetadata metadata, Option<Map<String, String>> extraMetadata) {
-      if (config.areAnyTableServicesInline() || config.scheduleAsyncTableServices()) {
-        if (config.isMetadataTableEnabled()) {
-          table.getHoodieView().sync();
-        }
-        // Do an inline compaction if enabled
-        if (config.inlineCompactionEnabled()) {
-          runAnyPendingCompactions(table);
-          metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
-          inlineCompact(extraMetadata, !config.scheduleAsyncCompaction());
-        } else {
-          metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "false");
-        }
-
-        // if just async schedule
-        if (config.scheduleAsyncCompaction() && table.getActiveTimeline().getWriteTimeline().filterPendingCompactionTimeline().getInstants().count() == 0) {
-          // proceed only if there are no pending compactions
-          // ?? what value to add for the metadata. true/false?
-          metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
-          inlineCompact(extraMetadata, !config.scheduleAsyncCompaction());
-        }
-
-        // Do an inline clustering if enabled
-        if (config.inlineClusteringEnabled() || config.scheduleAsyncClustering()) {
-          runAnyPendingClustering(table);
-          metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true");
-          inlineCluster(extraMetadata, !config.scheduleAsyncCompaction());
-        } else {
-          metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "false");
-        }
-
-        // if just async schedule
-        if (config.scheduleAsyncClustering() && table.getActiveTimeline().filterPendingReplaceTimeline().getInstants().count() == 0) {
-          // proceed only if there are no pending clustering
-          // ?? what value to add for the metadata. true/false?
-          metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true");
-          inlineCluster(extraMetadata, !config.scheduleAsyncCompaction());
-        }
+    if (config.areAnyTableServicesInline() || config.scheduleInlineTableServices()) {
+      if (config.isMetadataTableEnabled()) {
+        table.getHoodieView().sync();
       }
+      // Do an inline compaction if enabled
+      if (config.inlineCompactionEnabled()) {
+        runAnyPendingCompactions(table);
+        metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
+        inlineScheduleCompactAndOptionallyExecute(extraMetadata, !config.scheduleInlineCompaction());
+      } else {
+        metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "false");
+      }
+
+      // if just inline schedule
+      if (config.scheduleInlineCompaction() && !table.getActiveTimeline().getWriteTimeline().filterPendingCompactionTimeline().getInstants().findAny().isPresent()) {
+        // proceed only if there are no pending compactions
+        // ?? what value to add for the metadata. true/false?
+        metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
+        inlineScheduleCompactAndOptionallyExecute(extraMetadata, false);
+      }
+
+      // Do an inline clustering if enabled
+      if (config.inlineClusteringEnabled()) {
+        runAnyPendingClustering(table);
+        metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true");
+        inlineScheduleClusterAndOptionallyExecute(extraMetadata, !config.scheduleInlineCompaction());
+      } else {
+        metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "false");
+      }
+
+      // if just inline schedule
+      if (config.scheduleInlineClustering() && !table.getActiveTimeline().filterPendingReplaceTimeline().getInstants().findAny().isPresent()) {
+        // proceed only if there are no pending clustering
+        // ?? what value to add for the metadata. true/false?
+        metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true");
+        inlineScheduleClusterAndOptionallyExecute(extraMetadata, false);
+      }
+    }
   }
 
   protected void runAnyPendingCompactions(HoodieTable<T, I, K, O> table) {
@@ -1021,8 +1021,9 @@ public abstract class BaseHoodieWriteClient<T extends HoodieRecordPayload, I, K,
 
   /**
    * Performs a compaction operation on a table, serially before or after an insert/upsert action.
+   * Scheduling is done inline, and optionally execution as well.
    */
-  protected Option<String> inlineCompact(Option<Map<String, String>> extraMetadata, boolean executeInline) {
+  protected Option<String> inlineScheduleCompactAndOptionallyExecute(Option<Map<String, String>> extraMetadata, boolean executeInline) {
     Option<String> compactionInstantTimeOpt = scheduleCompaction(extraMetadata);
     if (executeInline) {
       compactionInstantTimeOpt.ifPresent(compactInstantTime -> {
@@ -1134,8 +1135,9 @@ public abstract class BaseHoodieWriteClient<T extends HoodieRecordPayload, I, K,
 
   /**
    * Executes a clustering plan on a table, serially before or after an insert/upsert action.
+   * Schedules clustering inline and may be optionally execute.
    */
-  protected Option<String> inlineCluster(Option<Map<String, String>> extraMetadata, boolean executeInline) {
+  protected Option<String> inlineScheduleClusterAndOptionallyExecute(Option<Map<String, String>> extraMetadata, boolean executeInline) {
     Option<String> clusteringInstantOpt = scheduleClustering(extraMetadata);
     if (executeInline) {
       clusteringInstantOpt.ifPresent(clusteringInstant -> {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -477,11 +477,11 @@ public abstract class BaseHoodieWriteClient<T extends HoodieRecordPayload, I, K,
         metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "false");
       }
 
-      // if just inline schedule
-      if (config.scheduleInlineCompaction() && !table.getActiveTimeline().getWriteTimeline().filterPendingCompactionTimeline().getInstants().findAny().isPresent()) {
+      // if just inline schedule is enabled
+      if (!config.inlineCompactionEnabled() && config.scheduleInlineCompaction()
+          && !table.getActiveTimeline().getWriteTimeline().filterPendingCompactionTimeline().getInstants().findAny().isPresent()) {
         // proceed only if there are no pending compactions
-        // ?? what value to add for the metadata. true/false?
-        metadata.addMetadata(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
+        metadata.addMetadata(HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT.key(), "true");
         inlineScheduleCompactAndOptionallyExecute(extraMetadata, false);
       }
 
@@ -494,11 +494,11 @@ public abstract class BaseHoodieWriteClient<T extends HoodieRecordPayload, I, K,
         metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "false");
       }
 
-      // if just inline schedule
-      if (config.scheduleInlineClustering() && !table.getActiveTimeline().filterPendingReplaceTimeline().getInstants().findAny().isPresent()) {
+      // if just inline schedule is enabled
+      if (!config.inlineClusteringEnabled() && config.scheduleInlineClustering()
+          && !table.getActiveTimeline().filterPendingReplaceTimeline().getInstants().findAny().isPresent()) {
         // proceed only if there are no pending clustering
-        // ?? what value to add for the metadata. true/false?
-        metadata.addMetadata(HoodieClusteringConfig.INLINE_CLUSTERING.key(), "true");
+        metadata.addMetadata(HoodieClusteringConfig.SCHEDULE_INLINE_CLUSTERING.key(), "true");
         inlineScheduleClusterAndOptionallyExecute(extraMetadata, false);
       }
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -177,10 +177,10 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .withDocumentation("Determines how to handle updates, deletes to file groups that are under clustering."
           + " Default strategy just rejects the update");
 
-  public static final ConfigProperty<String> ASYNC_CLUSTERING_SCHEDULE = ConfigProperty
-      .key("hoodie.clustering.schedule.async")
+  public static final ConfigProperty<String> SCHEDULE_INLINE_CLUSTERING = ConfigProperty
+      .key("hoodie.clustering.schedule.inline")
       .defaultValue("false")
-      .withDocumentation("When set to true, clustering service will be attempted for scheduling after each write. Users have to ensure "
+      .withDocumentation("When set to true, clustering service will be attempted for inline scheduling after each write. Users have to ensure "
           + "they have a separate job to run async clustering(execution) for the one scheduled by this writer");
 
   public static final ConfigProperty<String> ASYNC_CLUSTERING_ENABLE = ConfigProperty
@@ -508,6 +508,11 @@ public class HoodieClusteringConfig extends HoodieConfig {
 
     public Builder withInlineClustering(Boolean inlineClustering) {
       clusteringConfig.setValue(INLINE_CLUSTERING, String.valueOf(inlineClustering));
+      return this;
+    }
+
+    public Builder withScheduleInlineClustering(Boolean scheduleInlineClustering) {
+      clusteringConfig.setValue(SCHEDULE_INLINE_CLUSTERING, String.valueOf(scheduleInlineClustering));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -581,9 +581,9 @@ public class HoodieClusteringConfig extends HoodieConfig {
 
       boolean inlineCluster = clusteringConfig.getBoolean(HoodieClusteringConfig.INLINE_CLUSTERING);
       boolean inlineClusterSchedule = clusteringConfig.getBoolean(HoodieClusteringConfig.SCHEDULE_INLINE_CLUSTERING);
-      ValidationUtils.checkArgument(inlineCluster && inlineClusterSchedule, String.format("Either of inline clustering (%s) or "
-              + "schedule inline clustering (%s) can be enabled. Both can't be set to true at the same time", HoodieClusteringConfig.INLINE_CLUSTERING.key(),
-          HoodieClusteringConfig.SCHEDULE_INLINE_CLUSTERING.key()));
+      ValidationUtils.checkArgument(!(inlineCluster && inlineClusterSchedule), String.format("Either of inline clustering (%s) or "
+              + "schedule inline clustering (%s) can be enabled. Both can't be set to true at the same time. %s,%s", HoodieClusteringConfig.INLINE_CLUSTERING.key(),
+          HoodieClusteringConfig.SCHEDULE_INLINE_CLUSTERING.key(), inlineCluster, inlineClusterSchedule));
       return clusteringConfig;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -177,6 +177,12 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .withDocumentation("Determines how to handle updates, deletes to file groups that are under clustering."
           + " Default strategy just rejects the update");
 
+  public static final ConfigProperty<String> ASYNC_CLUSTERING_SCHEDULE = ConfigProperty
+      .key("hoodie.clustering.schedule.async")
+      .defaultValue("false")
+      .withDocumentation("When set to true, clustering service will be attempted for scheduling after each write. Users have to ensure "
+          + "they have a separate job to run async clustering(execution) for the one scheduled by this writer");
+
   public static final ConfigProperty<String> ASYNC_CLUSTERING_ENABLE = ConfigProperty
       .key("hoodie.clustering.async.enabled")
       .defaultValue("false")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -718,9 +718,9 @@ public class HoodieCompactionConfig extends HoodieConfig {
 
       boolean inlineCompact = compactionConfig.getBoolean(HoodieCompactionConfig.INLINE_COMPACT);
       boolean inlineCompactSchedule = compactionConfig.getBoolean(HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT);
-      ValidationUtils.checkArgument(inlineCompact && inlineCompactSchedule, String.format("Either of inline compaction (%s) or "
-              + "schedule inline compaction (%s) can be enabled. Both can't be set to true at the same time", HoodieCompactionConfig.INLINE_COMPACT.key(),
-          HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT.key()));
+      ValidationUtils.checkArgument(!(inlineCompact && inlineCompactSchedule), String.format("Either of inline compaction (%s) or "
+              + "schedule inline compaction (%s) can be enabled. Both can't be set to true at the same time. %s, %s", HoodieCompactionConfig.INLINE_COMPACT.key(),
+          HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT.key(), inlineCompact, inlineCompactSchedule));
       return compactionConfig;
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -90,10 +90,10 @@ public class HoodieCompactionConfig extends HoodieConfig {
       .withDocumentation("When set to true, compaction service is triggered after each write. While being "
           + " simpler operationally, this adds extra latency on the write path.");
 
-  public static final ConfigProperty<String> SCHEDULE_ASYNC_COMPACT = ConfigProperty
-      .key("hoodie.compact.schedule.async")
+  public static final ConfigProperty<String> SCHEDULE_INLINE_COMPACT = ConfigProperty
+      .key("hoodie.compact.schedule.inline")
       .defaultValue("false")
-      .withDocumentation("When set to true, compaction service will be attempted for scheduling after each write. Users have to ensure "
+      .withDocumentation("When set to true, compaction service will be attempted for inline scheduling after each write. Users have to ensure "
           + "they have a separate job to run async compaction(execution) for the one scheduled by this writer");
 
   public static final ConfigProperty<String> INLINE_COMPACT_NUM_DELTA_COMMITS = ConfigProperty
@@ -543,8 +543,8 @@ public class HoodieCompactionConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withScheduleAsyncCompaction(Boolean scheduleAsyncCompaction) {
-      compactionConfig.setValue(SCHEDULE_ASYNC_COMPACT, String.valueOf(scheduleAsyncCompaction));
+    public Builder withScheduleInlineCompaction(Boolean scheduleAsyncCompaction) {
+      compactionConfig.setValue(SCHEDULE_INLINE_COMPACT, String.valueOf(scheduleAsyncCompaction));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -90,6 +90,12 @@ public class HoodieCompactionConfig extends HoodieConfig {
       .withDocumentation("When set to true, compaction service is triggered after each write. While being "
           + " simpler operationally, this adds extra latency on the write path.");
 
+  public static final ConfigProperty<String> SCHEDULE_ASYNC_COMPACT = ConfigProperty
+      .key("hoodie.compact.schedule.async")
+      .defaultValue("false")
+      .withDocumentation("When set to true, compaction service will be attempted for scheduling after each write. Users have to ensure "
+          + "they have a separate job to run async compaction(execution) for the one scheduled by this writer");
+
   public static final ConfigProperty<String> INLINE_COMPACT_NUM_DELTA_COMMITS = ConfigProperty
       .key("hoodie.compact.inline.max.delta.commits")
       .defaultValue("5")
@@ -534,6 +540,11 @@ public class HoodieCompactionConfig extends HoodieConfig {
 
     public Builder withInlineCompaction(Boolean inlineCompaction) {
       compactionConfig.setValue(INLINE_COMPACT, String.valueOf(inlineCompaction));
+      return this;
+    }
+
+    public Builder withScheduleAsyncCompaction(Boolean scheduleAsyncCompaction) {
+      compactionConfig.setValue(SCHEDULE_ASYNC_COMPACT, String.valueOf(scheduleAsyncCompaction));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -94,7 +94,11 @@ public class HoodieCompactionConfig extends HoodieConfig {
       .key("hoodie.compact.schedule.inline")
       .defaultValue("false")
       .withDocumentation("When set to true, compaction service will be attempted for inline scheduling after each write. Users have to ensure "
-          + "they have a separate job to run async compaction(execution) for the one scheduled by this writer");
+          + "they have a separate job to run async compaction(execution) for the one scheduled by this writer. Users can choose to set both "
+          + "`hoodie.compact.inline` and `hoodie.compact.schedule.inline` to false and have both scheduling and execution triggered by any async process. "
+          + "But if `hoodie.compact.inline` is set to false, and `hoodie.compact.schedule.inline` is set to true, regular writers will schedule compaction inline, "
+          + "but users are expected to trigger async job for execution. If `hoodie.compact.inline` is set to true, regular writers will do both scheduling and "
+          + "execution inline for compaction");
 
   public static final ConfigProperty<String> INLINE_COMPACT_NUM_DELTA_COMMITS = ConfigProperty
       .key("hoodie.compact.inline.max.delta.commits")
@@ -711,6 +715,12 @@ public class HoodieCompactionConfig extends HoodieConfig {
                   + "missing data from few instants.",
               HoodieCompactionConfig.MIN_COMMITS_TO_KEEP.key(), minInstantsToKeep,
               HoodieCompactionConfig.CLEANER_COMMITS_RETAINED.key(), cleanerCommitsRetained));
+
+      boolean inlineCompact = compactionConfig.getBoolean(HoodieCompactionConfig.INLINE_COMPACT);
+      boolean inlineCompactSchedule = compactionConfig.getBoolean(HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT);
+      ValidationUtils.checkArgument(inlineCompact && inlineCompactSchedule, String.format("Either of inline compaction (%s) or "
+              + "schedule inline compaction (%s) can be enabled. Both can't be set to true at the same time", HoodieCompactionConfig.INLINE_COMPACT.key(),
+          HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT.key()));
       return compactionConfig;
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1859,11 +1859,11 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   /**
-   * Are any table services configured to run inline?
+   * Are any table services configured to run inline for both scheduling and execution?
    *
    * @return True if any table services are configured to run inline, false otherwise.
    */
-  public Boolean areAnyTableServicesInline() {
+  public Boolean areAnyTableServicesExecutedInline() {
     return inlineClusteringEnabled() || inlineCompactionEnabled() || isAutoClean();
   }
 
@@ -1876,7 +1876,7 @@ public class HoodieWriteConfig extends HoodieConfig {
     return isAsyncClusteringEnabled() || !inlineCompactionEnabled() || isAsyncClean();
   }
 
-  public Boolean scheduleInlineTableServices() {
+  public Boolean areAnyTableServicesScheduledInline() {
     return scheduleInlineCompaction() || scheduleInlineClustering();
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1140,8 +1140,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieCompactionConfig.INLINE_COMPACT);
   }
 
-  public boolean scheduleAsyncCompaction() {
-    return getBoolean(HoodieCompactionConfig.SCHEDULE_ASYNC_COMPACT);
+  public boolean scheduleInlineCompaction() {
+    return getBoolean(HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT);
   }
 
   public CompactionTriggerStrategy getInlineCompactTriggerStrategy() {
@@ -1184,8 +1184,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieClusteringConfig.INLINE_CLUSTERING);
   }
 
-  public boolean scheduleAsyncClustering() {
-    return getBoolean(HoodieClusteringConfig.ASYNC_CLUSTERING_SCHEDULE);
+  public boolean scheduleInlineClustering() {
+    return getBoolean(HoodieClusteringConfig.SCHEDULE_INLINE_CLUSTERING);
   }
 
   public boolean isAsyncClusteringEnabled() {
@@ -1876,8 +1876,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return isAsyncClusteringEnabled() || !inlineCompactionEnabled() || isAsyncClean();
   }
 
-  public Boolean scheduleAsyncTableServices() {
-    return scheduleAsyncCompaction() || scheduleAsyncClustering();
+  public Boolean scheduleInlineTableServices() {
+    return scheduleInlineCompaction() || scheduleInlineClustering();
   }
 
   public String getPreCommitValidators() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1140,6 +1140,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieCompactionConfig.INLINE_COMPACT);
   }
 
+  public boolean scheduleAsyncCompaction() {
+    return getBoolean(HoodieCompactionConfig.SCHEDULE_ASYNC_COMPACT);
+  }
+
   public CompactionTriggerStrategy getInlineCompactTriggerStrategy() {
     return CompactionTriggerStrategy.valueOf(getString(HoodieCompactionConfig.INLINE_COMPACT_TRIGGER_STRATEGY));
   }
@@ -1178,6 +1182,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean inlineClusteringEnabled() {
     return getBoolean(HoodieClusteringConfig.INLINE_CLUSTERING);
+  }
+
+  public boolean scheduleAsyncClustering() {
+    return getBoolean(HoodieClusteringConfig.ASYNC_CLUSTERING_SCHEDULE);
   }
 
   public boolean isAsyncClusteringEnabled() {
@@ -1866,6 +1874,10 @@ public class HoodieWriteConfig extends HoodieConfig {
    */
   public Boolean areAnyTableServicesAsync() {
     return isAsyncClusteringEnabled() || !inlineCompactionEnabled() || isAsyncClean();
+  }
+
+  public Boolean scheduleAsyncTableServices() {
+    return scheduleAsyncCompaction() || scheduleAsyncClustering();
   }
 
   public String getPreCommitValidators() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -167,7 +167,7 @@ public class TestHoodieWriteConfig {
       }
     });
     assertFalse(writeConfig.areAnyTableServicesAsync());
-    assertTrue(writeConfig.areAnyTableServicesInline());
+    assertTrue(writeConfig.areAnyTableServicesExecutedInline());
     assertEquals(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.defaultValue(), writeConfig.getLockProviderClass());
 
     // 5. User override for the lock provider should always take the precedence

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1376,6 +1376,40 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   }
 
   @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testInlineScheduleClustering(boolean scheduleInlineClustering) throws IOException {
+    testInsertTwoBatches(true);
+
+    // setup clustering config.
+    HoodieClusteringConfig clusteringConfig = HoodieClusteringConfig.newBuilder().withClusteringMaxNumGroups(10)
+        .withClusteringTargetPartitions(0).withInlineClusteringNumCommits(1).withInlineClustering(false).withScheduleInlineClustering(scheduleInlineClustering)
+        .withPreserveHoodieCommitMetadata(true).build();
+
+    HoodieWriteConfig config = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY).withAutoCommit(false)
+        .withClusteringConfig(clusteringConfig)
+        .withProps(getPropertiesForKeyGen()).build();
+    SparkRDDWriteClient client = getHoodieWriteClient(config);
+    dataGen = new HoodieTestDataGenerator(new String[] {"2015/03/16"});
+    String commitTime1 = HoodieActiveTimeline.createNewInstantTime();
+    List<HoodieRecord> records1 = dataGen.generateInserts(commitTime1, 200);
+    client.startCommitWithTime(commitTime1);
+    JavaRDD<HoodieRecord> insertRecordsRDD1 = jsc.parallelize(records1, 2);
+    JavaRDD<WriteStatus> statuses = client.upsert(insertRecordsRDD1, commitTime1);
+    List<WriteStatus> statusList = statuses.collect();
+    assertNoWriteErrors(statusList);
+    client.commit(commitTime1, statuses);
+
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(basePath).build();
+    List<Pair<HoodieInstant, HoodieClusteringPlan>> pendingClusteringPlans =
+        ClusteringUtils.getAllPendingClusteringPlans(metaClient).collect(Collectors.toList());
+    if (scheduleInlineClustering) {
+      assertEquals(1, pendingClusteringPlans.size());
+    } else {
+      assertEquals(0, pendingClusteringPlans.size());
+    }
+  }
+
+  @ParameterizedTest
   @MethodSource("populateMetaFieldsAndPreserveMetadataParams")
   public void testClusteringWithSortColumns(boolean populateMetaFields, boolean preserveCommitMetadata) throws Exception {
     // setup clustering config.
@@ -1528,7 +1562,6 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     Pair<Pair<List<HoodieRecord>, List<String>>, Set<HoodieFileGroupId>> allRecords = testInsertTwoBatches(populateMetaFields);
     testClustering(clusteringConfig, populateMetaFields, completeClustering, assertSameFileIds, validatorClasses, sqlQueryForEqualityValidation, sqlQueryForSingleResultValidation, allRecords);
     return allRecords.getLeft().getLeft();
-
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableClustering.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableClustering.java
@@ -132,7 +132,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
         newCommitTime = "003";
         client.startCommitWithTime(newCommitTime);
         records = dataGen.generateUpdates(newCommitTime, 100);
-        updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime);
+        updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, false);
       }
 
       HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
@@ -201,7 +201,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
         newCommitTime = "003";
         client.startCommitWithTime(newCommitTime);
         records = dataGen.generateUpdates(newCommitTime, 100);
-        updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime);
+        updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, false);
       }
 
       HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableIncrementalRead.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableIncrementalRead.java
@@ -118,7 +118,7 @@ public class TestHoodieSparkMergeOnReadTableIncrementalRead extends SparkClientF
       String updateTime = "004";
       client.startCommitWithTime(updateTime);
       List<HoodieRecord> records004 = dataGen.generateUpdates(updateTime, 100);
-      updateRecordsInMORTable(metaClient, records004, client, cfg, updateTime);
+      updateRecordsInMORTable(metaClient, records004, client, cfg, updateTime, false);
 
       // verify RO incremental reads - only one base file shows up because updates to into log files
       incrementalROFiles = getROIncrementalFiles(partitionPath, false);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.HoodieSparkTable;
@@ -129,6 +130,56 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
             "Must contain 200 records");
       } else {
         assertEquals(200, HoodieClientTestUtils.countRecordsOptionallySince(jsc(), basePath(), sqlContext(), timeline, Option.empty()));
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testInlineScheduleCompaction(boolean scheduleInlineCompaction) throws Exception {
+    HoodieFileFormat fileFormat = HoodieFileFormat.PARQUET;
+    Properties properties = new Properties();
+    properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), fileFormat.toString());
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, properties);
+
+    HoodieWriteConfig cfg = getConfigBuilder(false)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024 * 1024)
+            .withInlineCompaction(false).withMaxNumDeltaCommitsBeforeCompaction(2).withPreserveCommitMetadata(true).withScheduleInlineCompaction(scheduleInlineCompaction).build())
+        .build();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
+
+      HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+      /*
+       * Write 1 (only inserts)
+       */
+      String newCommitTime = "001";
+      client.startCommitWithTime(newCommitTime);
+
+      List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
+      Stream<HoodieBaseFile> dataFiles = insertRecordsToMORTable(metaClient, records, client, cfg, newCommitTime, true);
+      assertTrue(dataFiles.findAny().isPresent(), "should list the base files we wrote in the delta commit");
+
+      /*
+       * Write 2 (updates)
+       */
+      newCommitTime = "004";
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 100);
+      updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, true);
+
+      // validate compaction has been scheduled inline
+      /*HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
+      hoodieTable.getHoodieView().sync();
+      FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
+      HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+      Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
+      assertTrue(dataFilesToRead.findAny().isPresent());*/
+
+      // verify that there is a commit
+      if (scheduleInlineCompaction) {
+        assertEquals(metaClient.reloadActiveTimeline().getAllCommitsTimeline().filterPendingCompactionTimeline().countInstants(), 1);
+      } else {
+        assertEquals(metaClient.reloadActiveTimeline().getAllCommitsTimeline().filterPendingCompactionTimeline().countInstants(), 0);
       }
     }
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -167,14 +167,6 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
       records = dataGen.generateUpdates(newCommitTime, 100);
       updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, true);
 
-      // validate compaction has been scheduled inline
-      /*HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
-      hoodieTable.getHoodieView().sync();
-      FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
-      HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
-      Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
-      assertTrue(dataFilesToRead.findAny().isPresent());*/
-
       // verify that there is a commit
       if (scheduleInlineCompaction) {
         assertEquals(metaClient.reloadActiveTimeline().getAllCommitsTimeline().filterPendingCompactionTimeline().countInstants(), 1);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -105,7 +105,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
       newCommitTime = "004";
       client.startCommitWithTime(newCommitTime);
       records = dataGen.generateUpdates(newCommitTime, 100);
-      updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime);
+      updateRecordsInMORTable(metaClient, records, client, cfg, newCommitTime, false);
 
       String compactionCommitTime = client.scheduleCompaction(Option.empty()).get().toString();
       client.compact(compactionCommitTime);


### PR DESCRIPTION
## What is the purpose of the pull request

At the write client layer, inline and async has a very tighter meaning. enabling inline compaction means, both scheduling and execution is inline. Same applies to clustering as well. If async config is enabled, both scheduling and execution has to be done async and regular writer will not do anything. But any scheduling has to be done in a coordinated manner or in other words, there should not be any other operation inflight. For eg, if someone has a separate process to schedule and execute compaction, they have to ensure no other writers are in progress while scheduling. If not, it might lead to data loss. Which means, this puts an extra burden for users to configure lock providers. But Hudi has the intelligence where scheduling can be done inline, but execution can be done async. Just that the configs aren't lined up well. So, adding two new configs named `hoodie.compact.schedule.inline` and `hoodie.clustering.schedule.inline`. When enabled, scheduling will happen inline by regular writers. And the expectation is that, users will have a separate job to execute the already scheduled ones. By this, users don't have to configure lock providers. With metadata table, this constraint might change, but if not for metadata table, users should have a way to exploit async execution of table services. 

Note:
I have not fixed the deltastreamer flow yet.
- Wanted to hear opinions if the approach is good.
-Deltastreamer current state of things
when async table services are enabled, scheduling will happen using explicit writeclient.scheduleClustering() and execution will happen in a different thread. We could potentially enable the new configs added as part of this patch and remove explicit scheduling calls from deltastreamer. Will take it up as a follow up. 


## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
