### PR TITLE
[MINOR] Config CI bot user name and email to avoid error

### DIFF
--- a/.github/workflows/asf-site.ci.yml
+++ b/.github/workflows/asf-site.ci.yml
@@ -19,6 +19,8 @@ jobs:
           fetch-depth: 0
       - name: Prepare branch
         run: |
+          git config --global user.name "CI BOT"
+          git config --global user.email "cibot@hudi.apache.org"
           git checkout -b pr
           git remote add hudi https://${{ secrets.GITHUB_TOKEN }}@github.com/apache/hudi.git
           git pull --rebase hudi asf-site
@@ -38,5 +40,5 @@ jobs:
           rm -rf content
           cp -R ${{ env.DOCS_ROOT }}/build content
           git add -A
-          git -c "user.name=CI BOT" -c "user.email=cibot@hudi.apache.org" commit -am "GitHub Actions build asf-site"
+          git commit -am "GitHub Actions build asf-site"
           git push hudi pr:asf-site


### PR DESCRIPTION
## What is the purpose of the pull request

Config CI bot user name and email to avoid error.

CI errors out in the "Prepare branch" step:
```
0s
Run git checkout -b pr
  git checkout -b pr
  git remote add hudi https://***@github.com/apache/hudi.git
  git pull --rebase hudi asf-site
  shell: /usr/bin/bash -e {0}
  env:
    DOCS_ROOT: ./website
Switched to a new branch 'pr'
From https://github.com/apache/hudi
 * branch                asf-site   -> FETCH_HEAD
 * [new branch]          asf-site   -> hudi/asf-site
Rebasing (1/1)
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az154-601.kzav01uq0i3u1f1hch3ggm0mbb.bx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.
```

## Brief change log

- Adds git commands to configure user name and email

## Verify this pull request

Run CI to make sure it works.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
