### PR TITLE
[HUDI-2987] Fix payload event time extraction

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY;
+import static org.apache.hudi.common.model.OverwriteWithLatestAvroPayload.METADATA_EVENT_TIME_KEY;
 
 /**
  * Status of a write operation.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
@@ -48,7 +48,7 @@ public class HoodiePayloadConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> EVENT_TIME_FIELD = ConfigProperty
       .key(PAYLOAD_EVENT_TIME_FIELD_PROP_KEY)
-      .defaultValue("ts")
+      .noDefaultValue()
       .withDocumentation("Table column/field name to derive timestamp associated with the records. This can"
           + "be useful for e.g, determining the freshness of the table.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.SerializableSchema;
 import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.DateTimeUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -68,6 +69,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
+
+import static org.apache.hudi.common.model.BaseAvroPayload.DEFAULT_IGNORING_EVENT_TIME;
 
 /**
  * Helper class to do common stuff across Avro.
@@ -615,5 +618,12 @@ public class HoodieAvroUtils {
                                              String[] columns,
                                              SerializableSchema schema) {
     return getRecordColumnValues(record, columns, schema.get());
+  }
+
+  public static long getEventTime(GenericRecord record, Option<String> eventTimeField) {
+    Option<String> eventTimeOpt = Option.ofNullable(eventTimeField.isPresent()
+        ? getNestedFieldValAsString(record, eventTimeField.get(), true) : null);
+    return eventTimeOpt.isPresent()
+        ? DateTimeUtils.parseDateTime(eventTimeOpt.get()).toEpochMilli() : DEFAULT_IGNORING_EVENT_TIME;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
@@ -33,6 +33,9 @@ import static org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro;
 /**
  * The only difference with {@link DefaultHoodieRecordPayload} is that is does not
  * track the event time metadata for efficiency.
+ *
+ * @deprecated This is deprecated as event time won't be extracted by default
+ * in super class {@link DefaultHoodieRecordPayload}.
  */
 public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -27,6 +27,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -40,8 +42,14 @@ import java.util.Objects;
 public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
     implements HoodieRecordPayload<OverwriteWithLatestAvroPayload> {
 
+  public static final String METADATA_EVENT_TIME_KEY = "metadata.event_time.key";
+
+  public OverwriteWithLatestAvroPayload(GenericRecord record, Comparable orderingVal, long eventTime) {
+    super(record, orderingVal, eventTime);
+  }
+
   public OverwriteWithLatestAvroPayload(GenericRecord record, Comparable orderingVal) {
-    super(record, orderingVal);
+    this(record, orderingVal, DEFAULT_IGNORING_EVENT_TIME);
   }
 
   public OverwriteWithLatestAvroPayload(Option<GenericRecord> record) {
@@ -78,6 +86,16 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
     } else {
       return Option.of(indexedRecord);
     }
+  }
+
+  @Override
+  public Option<Map<String, String>> getMetadata() {
+    if (!usesEventTime()) {
+      return Option.empty();
+    }
+    Map<String, String> metadata = new HashMap<>(1);
+    metadata.put(METADATA_EVENT_TIME_KEY, String.valueOf(eventTime));
+    return Option.of(metadata);
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -26,8 +26,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -35,7 +33,6 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests {@link DefaultHoodieRecordPayload}.
@@ -119,43 +116,5 @@ public class TestDefaultHoodieRecordPayload {
     record.put("_hoodie_is_deleted", false);
     DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(Option.of(record));
     assertFalse(payload.getMetadata().isPresent());
-  }
-
-  @ParameterizedTest
-  @ValueSource(longs = {1L, 1612542030000L})
-  public void testGetEventTimeInMetadata(long eventTime) throws IOException {
-    GenericRecord record1 = new GenericData.Record(schema);
-    record1.put("id", "1");
-    record1.put("partition", "partition0");
-    record1.put("ts", 0L);
-    record1.put("_hoodie_is_deleted", false);
-
-    GenericRecord record2 = new GenericData.Record(schema);
-    record2.put("id", "1");
-    record2.put("partition", "partition0");
-    record2.put("ts", eventTime);
-    record2.put("_hoodie_is_deleted", false);
-
-    DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(record2, eventTime);
-    payload2.combineAndGetUpdateValue(record1, schema, props);
-    assertTrue(payload2.getMetadata().isPresent());
-    assertEquals(eventTime,
-        Long.parseLong(payload2.getMetadata().get().get(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY)));
-  }
-
-  @ParameterizedTest
-  @ValueSource(longs = {1L, 1612542030000L})
-  public void testGetEventTimeInMetadataForInserts(long eventTime) throws IOException {
-    GenericRecord record = new GenericData.Record(schema);
-
-    record.put("id", "1");
-    record.put("partition", "partition0");
-    record.put("ts", eventTime);
-    record.put("_hoodie_is_deleted", false);
-    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, eventTime);
-    payload.getInsertValue(schema, props);
-    assertTrue(payload.getMetadata().isPresent());
-    assertEquals(eventTime,
-        Long.parseLong(payload.getMetadata().get().get(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY)));
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -32,7 +32,7 @@ import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieRecordPayload, HoodieTableType, HoodieTimelineTimeZone, WriteOperationType}
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
-import org.apache.hudi.common.util.{CommitUtils, Option, ReflectionUtils, StringUtils}
+import org.apache.hudi.common.util.{CommitUtils, ReflectionUtils, StringUtils}
 import org.apache.hudi.config.HoodieBootstrapConfig.{BASE_PATH, INDEX_CLASS_NAME}
 import org.apache.hudi.config.{HoodieInternalConfig, HoodiePayloadConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieException
@@ -234,7 +234,8 @@ object HoodieSparkSqlWriter {
               operation.equals(WriteOperationType.UPSERT) ||
               parameters.getOrElse(HoodieWriteConfig.COMBINE_BEFORE_INSERT.key(),
                 HoodieWriteConfig.COMBINE_BEFORE_INSERT.defaultValue()).toBoolean
-            val eventTimeField = Option.ofNullable(hoodieConfig.getProps.getString(HoodiePayloadConfig.EVENT_TIME_FIELD.key, null))
+            val eventTimeField = org.apache.hudi.common.util.Option
+              .ofNullable(hoodieConfig.getProps.getString(HoodiePayloadConfig.EVENT_TIME_FIELD.key, null))
             val hoodieAllIncomingRecords = genericRecords.map(gr => {
               val processedRecord = getProcessedRecord(partitionColumns, gr, dropPartitionColumns)
               val eventTime = getEventTime(processedRecord, eventTimeField)


### PR DESCRIPTION
- Make `eventTime` passed in via constructor for `DefaultHoodiePayload` and `OverwriteWithLatestAvroPayload`
- Remove extraction logic out of `getInsertValue()` and `combineAndGetUpdateValue()`


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
