### PR TITLE
[HUDI-3103] Enable MultiTableDeltaStreamer to update a single target table from multiple source tables.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -374,11 +374,9 @@ public class UtilHelpers {
         try (ResultSet rs = statement.executeQuery()) {
           StructType structType;
           if (Boolean.parseBoolean(options.get("nullable"))) {
-            structType = "org.apache.hive.jdbc.HiveDriver".equals(options.get("driver")) ? JdbcUtils.getHiveSchema(rs,
-              dialect, true) : JdbcUtils.getSchema(rs, dialect, true);
+            structType = JdbcUtils.getSchema(rs, dialect, true);
           } else {
-            structType = "org.apache.hive.jdbc.HiveDriver".equals(options.get("driver")) ? JdbcUtils.getHiveSchema(rs,
-              dialect, false) : JdbcUtils.getSchema(rs, dialect, false);
+            structType = JdbcUtils.getSchema(rs, dialect, false);
           }
           return AvroConversionUtils.convertStructTypeToAvroSchema(structType, table, "hoodie." + table);
         }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -374,9 +374,11 @@ public class UtilHelpers {
         try (ResultSet rs = statement.executeQuery()) {
           StructType structType;
           if (Boolean.parseBoolean(options.get("nullable"))) {
-            structType = JdbcUtils.getSchema(rs, dialect, true);
+            structType = "org.apache.hive.jdbc.HiveDriver".equals(options.get("driver")) ? JdbcUtils.getHiveSchema(rs,
+              dialect, true) : JdbcUtils.getSchema(rs, dialect, true);
           } else {
-            structType = JdbcUtils.getSchema(rs, dialect, false);
+            structType = "org.apache.hive.jdbc.HiveDriver".equals(options.get("driver")) ? JdbcUtils.getHiveSchema(rs,
+              dialect, false) : JdbcUtils.getSchema(rs, dialect, false);
           }
           return AvroConversionUtils.convertStructTypeToAvroSchema(structType, table, "hoodie." + table);
         }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
+import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceUtils;
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.HoodieSparkUtils;
@@ -63,6 +64,7 @@ import org.apache.hudi.utilities.callback.kafka.HoodieWriteCommitKafkaCallbackCo
 import org.apache.hudi.utilities.callback.pulsar.HoodieWriteCommitPulsarCallback;
 import org.apache.hudi.utilities.callback.pulsar.HoodieWriteCommitPulsarCallbackConfig;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.Config;
+import org.apache.hudi.utilities.deltastreamer.HoodieMultiTableDeltaStreamer.Constants;
 import org.apache.hudi.utilities.exception.HoodieDeltaStreamerException;
 import org.apache.hudi.utilities.schema.DelegatingSchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaProvider;
@@ -85,6 +87,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.avro.SchemaConverters;
+import org.apache.spark.sql.types.StructType;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.deltastreamer;
 
 import com.beust.jcommander.Parameter;
+
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.client.utils.OperationConverter;
 import org.apache.hudi.common.fs.FSUtils;
@@ -31,6 +32,7 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.utilities.IdentitySplitter;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.hudi.utilities.schema.JdbcbasedSchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
 
 import com.beust.jcommander.JCommander;
@@ -61,8 +63,11 @@ public class HoodieMultiTableDeltaStreamer {
   private static Logger logger = LogManager.getLogger(HoodieMultiTableDeltaStreamer.class);
 
   private List<TableExecutionContext> tableExecutionContexts;
+
   private transient JavaSparkContext jssc;
+
   private Set<String> successTables;
+
   private Set<String> failedTables;
 
   public HoodieMultiTableDeltaStreamer(Config config, JavaSparkContext jssc) throws IOException {
@@ -78,7 +83,12 @@ public class HoodieMultiTableDeltaStreamer {
     configFolder = configFolder.charAt(configFolder.length() - 1) == '/' ? configFolder.substring(0, configFolder.length() - 1) : configFolder;
     checkIfPropsFileAndConfigFolderExist(commonPropsFile, configFolder, fs);
     TypedProperties commonProperties = UtilHelpers.readConfig(fs.getConf(), new Path(commonPropsFile), new ArrayList<String>()).getProps();
-    //get the tables to be ingested and their corresponding config files from this properties instance
+    // get the schema of target table from hive database by jdbc
+    if (commonProperties.getProperty(Constants.SOURCE_SCHEMA_JDBC_CONNECTION_URL) != null) {
+      JdbcbasedSchemaProvider jsp = new JdbcbasedSchemaProvider(commonProperties, jssc);
+      commonProperties.setProperty("targetSchema", jsp.getTargetSchema().toString());
+    }
+    // get the tables to be ingested and their corresponding config files from this properties instance
     populateTableExecutionContextList(commonProperties, configFolder, fs, config);
   }
 
@@ -104,41 +114,114 @@ public class HoodieMultiTableDeltaStreamer {
     }
   }
 
-  //commonProps are passed as parameter which contain table to config file mapping
+  // commonProps are passed as parameter which contain table to config file mapping
   private void populateTableExecutionContextList(TypedProperties properties, String configFolder, FileSystem fs, Config config) throws IOException {
-    List<String> tablesToBeIngested = getTablesToBeIngested(properties);
-    logger.info("tables to be ingested via MultiTableDeltaStreamer : " + tablesToBeIngested);
-    TableExecutionContext executionContext;
-    for (String table : tablesToBeIngested) {
-      String[] tableWithDatabase = table.split("\\.");
-      String database = tableWithDatabase.length > 1 ? tableWithDatabase[0] : "default";
-      String currentTable = tableWithDatabase.length > 1 ? tableWithDatabase[1] : table;
-      String configProp = Constants.INGESTION_PREFIX + database + Constants.DELIMITER + currentTable + Constants.INGESTION_CONFIG_SUFFIX;
-      String configFilePath = properties.getString(configProp, Helpers.getDefaultConfigFilePath(configFolder, database, currentTable));
-      checkIfTableConfigFileExists(configFolder, fs, configFilePath);
-      TypedProperties tableProperties = UtilHelpers.readConfig(fs.getConf(), new Path(configFilePath), new ArrayList<String>()).getProps();
-      properties.forEach((k, v) -> {
-        if (tableProperties.get(k) == null) {
-          tableProperties.setProperty(k.toString(), v.toString());
-        }
-      });
-      final HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
-      //copy all the values from config to cfg
-      String targetBasePath = resetTarget(config, database, currentTable);
-      Helpers.deepCopyConfigs(config, cfg);
-      String overriddenTargetBasePath = tableProperties.getString(Constants.TARGET_BASE_PATH_PROP, "");
-      cfg.targetBasePath = StringUtils.isNullOrEmpty(overriddenTargetBasePath) ? targetBasePath : overriddenTargetBasePath;
-      if (cfg.enableMetaSync && StringUtils.isNullOrEmpty(tableProperties.getString(DataSourceWriteOptions.HIVE_TABLE().key(), ""))) {
-        throw new HoodieException("Meta sync table field not provided!");
+    // Parameter SOURCES_TO_BE_BOUND indicates that multiple sources update the same target.
+    String sourcesToBeBound = properties.getProperty(Constants.SOURCES_TO_BE_BOUND);
+    if (!StringUtils.isNullOrEmpty(sourcesToBeBound)) {
+      // populate the table execution context by traversing source tables
+      List<String> sourcesToBeBonded = getSourcesToBeBound(properties);
+      logger.info("Source tables to be bound via MultiTableDeltaStreamer : " + sourcesToBeBonded);
+
+      String tableToBeIngested = getTableToBeIngested(properties);
+      String[] targetTableWithDataBase = tableToBeIngested.split("\\.");
+      String targetDataBase = targetTableWithDataBase.length > 1 ? targetTableWithDataBase[0] : "default";
+      String targetTable = targetTableWithDataBase.length > 1 ? targetTableWithDataBase[1] : targetTableWithDataBase[0];
+      String targetBasePath = resetTarget(config, targetDataBase, targetTable);
+
+      for (String source : sourcesToBeBonded) {
+        String[] tableWithDatabase = source.split("\\.");
+        String currentSourceDataBase = tableWithDatabase.length > 1 ? tableWithDatabase[0] : "default";
+        String currentSourceTable = tableWithDatabase.length > 1 ? tableWithDatabase[1] : source;
+        String configProp = Constants.SOURCE_PREFIX + currentSourceDataBase + Constants.PATH_CUR_DIR + currentSourceTable + Constants.INGESTION_CONFIG_SUFFIX;
+        TableExecutionContext executionContext = populateTableExecutionContext(properties, configFolder, fs, config, configProp, currentSourceDataBase, currentSourceTable, targetBasePath);
+        this.tableExecutionContexts.add(executionContext);
       }
-      populateSchemaProviderProps(cfg, tableProperties);
-      executionContext = new TableExecutionContext();
-      executionContext.setProperties(tableProperties);
-      executionContext.setConfig(cfg);
-      executionContext.setDatabase(database);
-      executionContext.setTableName(currentTable);
-      this.tableExecutionContexts.add(executionContext);
+    } else {
+      // populate the table execution context by traversing target tables
+      List<String> tablesToBeIngested = getTablesToBeIngested(properties);
+      logger.info("Tables to be ingested via MultiTableDeltaStreamer : " + tablesToBeIngested);
+
+      for (String table : tablesToBeIngested) {
+        String[] tableWithDatabase = table.split("\\.");
+        String database = tableWithDatabase.length > 1 ? tableWithDatabase[0] : "default";
+        String currentTable = tableWithDatabase.length > 1 ? tableWithDatabase[1] : table;
+        String configProp = Constants.INGESTION_PREFIX + database + Constants.PATH_CUR_DIR + currentTable + Constants.INGESTION_CONFIG_SUFFIX;
+        TableExecutionContext executionContext = populateTableExecutionContext(properties, configFolder, fs, config, configProp, database, currentTable, null);
+        this.tableExecutionContexts.add(executionContext);
+      }
     }
+  }
+
+  private TableExecutionContext populateTableExecutionContext(TypedProperties properties, String configFolder,
+      FileSystem fs, Config config, String configProp, String database, String currentTable, String targetBasePath) throws IOException {
+    // copy all common properties to current table properties
+    TypedProperties currentTableProperties = getCurrentTableProperties(properties, configFolder, fs, configProp, database,
+        currentTable, targetBasePath);
+
+    // copy all the values from config to cfg
+    final HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
+    Helpers.deepCopyConfigs(config, cfg);
+
+    // calculate the value of targetBasePath which is a property of cfg
+    calculateTargetBasePath(config, database, currentTable, targetBasePath, currentTableProperties, cfg);
+
+    if (cfg.enableHiveSync && StringUtils.isNullOrEmpty(currentTableProperties.getString(DataSourceWriteOptions.HIVE_TABLE().key()))) {
+      throw new HoodieException("Hive sync table field not provided!");
+    }
+
+    populateSchemaProviderProps(cfg, currentTableProperties);
+    TableExecutionContext executionContext = new TableExecutionContext();
+    executionContext.setProperties(currentTableProperties);
+    executionContext.setConfig(cfg);
+    executionContext.setDatabase(database);
+    executionContext.setTableName(currentTable);
+    return executionContext;
+  }
+
+  private TypedProperties getCurrentTableProperties(TypedProperties properties, String configFolder, FileSystem fs,
+      String configProp, String database, String currentTable, String targetBasePath) throws IOException {
+
+    String configFilePath = properties.getString(configProp, Helpers.getDefaultConfigFilePath(configFolder, database, currentTable));
+    checkIfTableConfigFileExists(configFolder, fs, configFilePath);
+
+    TypedProperties tableProperties = UtilHelpers.readConfig(fs.getConf(), new Path(configFilePath), new ArrayList<String>()).getProps();
+    properties.forEach((k, v) -> {
+      if (tableProperties.get(k) == null) {
+        tableProperties.setProperty(k.toString(), v.toString());
+      }
+    });
+    // These two properties are required only when the mode is populating the table execution context by traversing source tables.
+    if (!StringUtils.isNullOrEmpty(targetBasePath)) {
+      tableProperties.setProperty("currentSourceDataBase", database);
+      tableProperties.setProperty("currentSourceTable", currentTable);
+    }
+    return tableProperties;
+  }
+
+  private void calculateTargetBasePath(Config config, String database, String currentTable, String targetBasePath,
+      TypedProperties currentTableProperties, HoodieDeltaStreamer.Config cfg) {
+
+    String overriddenTargetBasePath = currentTableProperties.getString(Constants.TARGET_BASE_PATH_PROP, "");
+
+    if (StringUtils.isNullOrEmpty(targetBasePath)) {
+      targetBasePath = resetTarget(config, database, currentTable);
+    }
+
+    cfg.targetBasePath = StringUtils.isNullOrEmpty(overriddenTargetBasePath)
+      ? targetBasePath
+      : overriddenTargetBasePath;
+  }
+
+  private List<String> getSourcesToBeBound(TypedProperties properties) {
+    String combinedSourcesString = properties.getString(Constants.SOURCES_TO_BE_BOUND, null);
+    return StringUtils.isNullOrEmpty(combinedSourcesString)
+      ? new ArrayList<>()
+      : Arrays.asList(combinedSourcesString.split(Constants.COMMA_SEPARATOR));
+  }
+
+  private String getTableToBeIngested(TypedProperties properties) {
+    return properties.getString(Constants.TABLES_TO_BE_INGESTED_PROP);
   }
 
   private List<String> getTablesToBeIngested(TypedProperties properties) {
@@ -166,16 +249,17 @@ public class HoodieMultiTableDeltaStreamer {
       typedProperties.setProperty(Constants.SOURCE_SCHEMA_REGISTRY_URL_PROP, schemaRegistryBaseUrl + typedProperties.getString(Constants.KAFKA_TOPIC_PROP) + sourceSchemaRegistrySuffix);
       typedProperties.setProperty(Constants.TARGET_SCHEMA_REGISTRY_URL_PROP, schemaRegistryBaseUrl + typedProperties.getString(Constants.KAFKA_TOPIC_PROP) + targetSchemaRegistrySuffix);
     }
+
   }
 
   public static class Helpers {
 
     static String getDefaultConfigFilePath(String configFolder, String database, String currentTable) {
-      return configFolder + Constants.FILE_DELIMITER + database + Constants.UNDERSCORE + currentTable + Constants.DEFAULT_CONFIG_FILE_NAME_SUFFIX;
+      return configFolder + Constants.PATH_SEPARATOR + database + Constants.UNDERSCORE + currentTable + Constants.DEFAULT_CONFIG_FILE_NAME_SUFFIX;
     }
 
     static String getTableWithDatabase(TableExecutionContext context) {
-      return context.getDatabase() + Constants.DELIMITER + context.getTableName();
+      return context.getDatabase() + Constants.PATH_CUR_DIR + context.getTableName();
     }
 
     static void deepCopyConfigs(Config globalConfig, HoodieDeltaStreamer.Config tableConfig) {
@@ -250,7 +334,7 @@ public class HoodieMultiTableDeltaStreamer {
 
     @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
         + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
-            splitter = IdentitySplitter.class)
+        splitter = IdentitySplitter.class)
     public List<String> configs = new ArrayList<>();
 
     @Parameter(names = {"--source-class"},
@@ -308,7 +392,7 @@ public class HoodieMultiTableDeltaStreamer {
 
     @Parameter(names = {"--max-pending-clustering"},
         description = "Maximum number of outstanding inflight/requested clustering. Delta Sync will not happen unless"
-            + "outstanding clustering is less than this number")
+        + "outstanding clustering is less than this number")
     public Integer maxPendingClustering = 5;
 
     @Parameter(names = {"--continuous"}, description = "Delta Streamer runs in continuous mode running"
@@ -370,8 +454,8 @@ public class HoodieMultiTableDeltaStreamer {
   private static String resetTarget(Config configuration, String database, String tableName) {
     String basePathPrefix = configuration.basePathPrefix;
     basePathPrefix = basePathPrefix.charAt(basePathPrefix.length() - 1) == '/' ? basePathPrefix.substring(0, basePathPrefix.length() - 1) : basePathPrefix;
-    String targetBasePath = basePathPrefix + Constants.FILE_DELIMITER + database + Constants.FILE_DELIMITER + tableName;
-    configuration.targetTableName = database + Constants.DELIMITER + tableName;
+    String targetBasePath = basePathPrefix + Constants.PATH_SEPARATOR + database + Constants.PATH_SEPARATOR + tableName;
+    configuration.targetTableName = database + Constants.PATH_CUR_DIR + tableName;
     return targetBasePath;
   }
 
@@ -379,41 +463,110 @@ public class HoodieMultiTableDeltaStreamer {
    * Creates actual HoodieDeltaStreamer objects for every table/topic and does incremental sync.
    */
   public void sync() {
+    List<HoodieDeltaStreamer> hdsObjectList = new ArrayList<>();
+
+    // The sync function is not executed when multiple sources update the same target.
     for (TableExecutionContext context : tableExecutionContexts) {
       try {
-        new HoodieDeltaStreamer(context.getConfig(), jssc, Option.ofNullable(context.getProperties())).sync();
+        HoodieDeltaStreamer hds = new HoodieDeltaStreamer(context.getConfig(), jssc, Option.ofNullable(context.getProperties()));
+
+        // Add object of HoodieDeltaStreamer temporarily to hdsObjectList when multiple sources update the same target.
+        if (!StringUtils.isNullOrEmpty(context.getProperties().getProperty(Constants.SOURCES_TO_BE_BOUND))) {
+          hdsObjectList.add(hds);
+          continue;
+        }
+
+        hds.sync();
         successTables.add(Helpers.getTableWithDatabase(context));
       } catch (Exception e) {
-        logger.error("error while running MultiTableDeltaStreamer for table: " + context.getTableName(), e);
+        logger.error("Error while running MultiTableDeltaStreamer for table: " + context.getTableName(), e);
         failedTables.add(Helpers.getTableWithDatabase(context));
       }
     }
 
-    logger.info("Ingestion was successful for topics: " + successTables);
-    if (!failedTables.isEmpty()) {
-      logger.info("Ingestion failed for topics: " + failedTables);
+    // If hdsObjectList is empty, it indicates that all source sync operations have been completed. In this case, directly return.
+    if (hdsObjectList.isEmpty()) {
+      logger.info("Ingestion was successful for topics: " + successTables);
+      if (!failedTables.isEmpty()) {
+        logger.info("Ingestion failed for topics: " + failedTables);
+      }
+      return;
     }
+
+    // The sync function is executing here when multiple sources update the same target.
+    boolean isContinuousMode = hdsObjectList.get(0).cfg.continuousMode;
+    do {
+      // Executing sync function by traversing hdsObjectList when multiple sources update the same target.
+      for (int i = 0; i < hdsObjectList.size(); i++) {
+        // Threads cannot be started when multiple sources update the same target.
+        if (isContinuousMode) {
+          hdsObjectList.get(i).cfg.continuousMode = false;
+        }
+
+        try {
+          hdsObjectList.get(i).sync();
+          successTables.add(Helpers.getTableWithDatabase(tableExecutionContexts.get(i)));
+        } catch (Exception e) {
+          logger.error("Error while running MultiTableDeltaStreamer for table: "
+              + tableExecutionContexts.get(i).getTableName(), e);
+          failedTables.add(Helpers.getTableWithDatabase(tableExecutionContexts.get(i)));
+          break;
+        }
+      }
+
+      logger.info("Ingestion was successful for topics: " + successTables);
+      if (!failedTables.isEmpty()) {
+        logger.info("Ingestion failed for topics: " + failedTables);
+        break;
+      }
+      successTables.clear();
+    } while (isContinuousMode);
   }
 
   public static class Constants {
+    private static final String SOURCE_SCHEMA_JDBC_CONNECTION_URL = "hoodie.deltastreamer.schemaprovider.source.schema.jdbc.connection.url";
+
     public static final String KAFKA_TOPIC_PROP = "hoodie.deltastreamer.source.kafka.topic";
+
     private static final String SOURCE_SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.url";
+
     private static final String TARGET_SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.targetUrl";
+
     public static final String HIVE_SYNC_TABLE_PROP = "hoodie.datasource.hive_sync.table";
+
     private static final String SCHEMA_REGISTRY_BASE_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.baseUrl";
+
     private static final String SCHEMA_REGISTRY_URL_SUFFIX_PROP = "hoodie.deltastreamer.schemaprovider.registry.urlSuffix";
+
     private static final String SCHEMA_REGISTRY_SOURCE_URL_SUFFIX = "hoodie.deltastreamer.schemaprovider.registry.sourceUrlSuffix";
+
     private static final String SCHEMA_REGISTRY_TARGET_URL_SUFFIX = "hoodie.deltastreamer.schemaprovider.registry.targetUrlSuffix";
+
     private static final String TABLES_TO_BE_INGESTED_PROP = "hoodie.deltastreamer.ingestion.tablesToBeIngested";
+
+    private static final String SOURCES_TO_BE_BOUND = "hoodie.deltastreamer.source.sourcesToBeBound";
+
+    private static final String SOURCE_PREFIX = "hoodie.deltastreamer.source.";
+
+    public static final String ASSOCIATED_TABLES = "hoodie.deltastreamer.associated.tables";
+
     private static final String INGESTION_PREFIX = "hoodie.deltastreamer.ingestion.";
+
     private static final String INGESTION_CONFIG_SUFFIX = ".configFile";
+
     private static final String DEFAULT_CONFIG_FILE_NAME_SUFFIX = "_config.properties";
+
     private static final String TARGET_BASE_PATH_PROP = "hoodie.deltastreamer.ingestion.targetBasePath";
+
     private static final String LOCAL_SPARK_MASTER = "local[2]";
-    private static final String FILE_DELIMITER = "/";
-    private static final String DELIMITER = ".";
+
+    public static final String PATH_SEPARATOR = "/";
+
+    private static final String PATH_CUR_DIR = ".";
+
     private static final String UNDERSCORE = "_";
-    private static final String COMMA_SEPARATOR = ",";
+
+    public static final String COMMA_SEPARATOR = ",";
   }
 
   public Set<String> getSuccessTables() {


### PR DESCRIPTION
## Brief change log
  - Modify the HoodieMultiTableDeltaStreamer file so that it can generate the execution context of table based on source tables.
  - Modify the DeltaSync.java file so that it can associate the source table with other tables.
  - Modify the UtilHelpers.java file so that it can read the schema of the target table from Hive.