### PR TITLE
[HUDI-3104] Kafka-connect support hadoop config environments and properties

### DIFF
--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectConfigs.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectConfigs.java
@@ -93,6 +93,17 @@ public class KafkaConnectConfigs extends HoodieConfig {
       .defaultValue(true)
       .withDocumentation("Commit even when some records failed to be written");
 
+  // Reference https://docs.confluent.io/kafka-connect-hdfs/current/configuration_options.html#hdfs
+  public static final ConfigProperty<String> HADOOP_CONF_DIR = ConfigProperty
+          .key("hadoop.conf.dir")
+          .noDefaultValue()
+          .withDocumentation("The Hadoop configuration directory.");
+
+  public static final ConfigProperty<String> HADOOP_HOME = ConfigProperty
+          .key("hadoop.home")
+          .noDefaultValue()
+          .withDocumentation("The Hadoop home directory.");
+
   protected KafkaConnectConfigs() {
     super();
   }
@@ -145,6 +156,14 @@ public class KafkaConnectConfigs extends HoodieConfig {
     return getBoolean(ALLOW_COMMIT_ON_ERRORS);
   }
 
+  public String getHadoopConfDir() {
+    return getString(HADOOP_CONF_DIR);
+  }
+
+  public String getHadoopConfHome() {
+    return getString(HADOOP_HOME);
+  }
+
   public static class Builder {
 
     protected final KafkaConnectConfigs connectConfigs = new KafkaConnectConfigs();
@@ -182,6 +201,16 @@ public class KafkaConnectConfigs extends HoodieConfig {
 
     public Builder withProperties(Properties properties) {
       connectConfigs.getProps().putAll(properties);
+      return this;
+    }
+
+    public Builder withHadoopConfDir(String hadoopConfDir) {
+      connectConfigs.setValue(HADOOP_CONF_DIR, String.valueOf(hadoopConfDir));
+      return this;
+    }
+
+    public Builder withHadoopHome(String hadoopHome) {
+      connectConfigs.setValue(HADOOP_HOME, String.valueOf(hadoopHome));
       return this;
     }
 

--- a/hudi-kafka-connect/src/test/java/org/apache/hudi/connect/TestHdfsConfiguration.java
+++ b/hudi-kafka-connect/src/test/java/org/apache/hudi/connect/TestHdfsConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.connect;
+
+import org.apache.hudi.connect.utils.KafkaConnectUtils;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hudi.connect.writers.KafkaConnectConfigs;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public class TestHdfsConfiguration {
+
+  private boolean checkFiles(List<Path> paths) {
+    paths.removeIf(p -> {
+      String fileName = p.toFile().getName();
+      return fileName.equals("core-site.xml") || fileName.equals("hdfs-site.xml");
+    });
+    return paths.isEmpty();
+  }
+
+  @Test
+  public void testHadoopConfigEnvs() throws Exception {
+    List<Path> paths = KafkaConnectUtils.getHadoopConfigFiles(
+        "src/test/resources/hadoop_conf", "");
+    assertEquals(paths.size(), 2);
+    assertTrue(checkFiles(paths));
+  }
+
+  @Test
+  public void testHadoopHomeEnvs() throws Exception {
+    List<Path> paths = KafkaConnectUtils.getHadoopConfigFiles(
+        "","src/test/resources/hadoop_home");
+    assertEquals(paths.size(), 2);
+    assertTrue(checkFiles(paths));
+  }
+
+  @Test
+  public void testKafkaConfig() throws Exception {
+    KafkaConnectConfigs connectConfigs = KafkaConnectConfigs.newBuilder()
+        .withHadoopHome("src/test/resources/hadoop_home")
+        .build();
+    List<Path> paths = KafkaConnectUtils.getHadoopConfigFiles(
+        connectConfigs.getHadoopConfDir(),
+        connectConfigs.getHadoopConfHome()
+    );
+    assertEquals(paths.size(), 2);
+    assertTrue(checkFiles(paths));
+  }
+}

--- a/hudi-kafka-connect/src/test/resources/hadoop_conf/core-site.xml
+++ b/hudi-kafka-connect/src/test/resources/hadoop_conf/core-site.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://test-hudi-path:9000</value>
+        <description>The name of the default file system.  A URI whose
+            scheme and authority determine the FileSystem implementation.  The
+            uri's scheme determines the config property (fs.SCHEME.impl) naming
+            the FileSystem implementation class.  The uri's authority is used to
+            determine the host, port, etc. for a filesystem.</description>
+    </property>
+
+</configuration>

--- a/hudi-kafka-connect/src/test/resources/hadoop_conf/hdfs-site.xml
+++ b/hudi-kafka-connect/src/test/resources/hadoop_conf/hdfs-site.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>dfs.namenode.http-address</name>
+        <value>http://test-hudi-path:50070</value>
+        <description>
+            The address and the base port where the dfs namenode web ui will listen on.
+        </description>
+    </property>
+
+</configuration>

--- a/hudi-kafka-connect/src/test/resources/hadoop_home/etc/hadoop/core-site.xml
+++ b/hudi-kafka-connect/src/test/resources/hadoop_home/etc/hadoop/core-site.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://test-hudi-path:9000</value>
+        <description>The name of the default file system.  A URI whose
+            scheme and authority determine the FileSystem implementation.  The
+            uri's scheme determines the config property (fs.SCHEME.impl) naming
+            the FileSystem implementation class.  The uri's authority is used to
+            determine the host, port, etc. for a filesystem.</description>
+    </property>
+
+</configuration>

--- a/hudi-kafka-connect/src/test/resources/hadoop_home/etc/hadoop/hdfs-site.xml
+++ b/hudi-kafka-connect/src/test/resources/hadoop_home/etc/hadoop/hdfs-site.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>dfs.namenode.http-address</name>
+        <value>http://test-hudi-path:50070</value>
+        <description>
+            The address and the base port where the dfs namenode web ui will listen on.
+        </description>
+    </property>
+
+</configuration>


### PR DESCRIPTION
## What is the purpose of the pull request

Let kafka-connect support hadoop config environments/properties 

## Brief change log

  - Support hadoop config environments  `HADOOP_CONF_DIR` and `HADOOP_HOME`
  - Support hadoop config properties  `hadoop.conf.dir` and `hadoop.home`

## Verify this pull request

This change added tests and can be verified as follows:

  - *Added TestHdfsConfiguration to verify the change.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
