### PR TITLE
[HUDI-3118] Add default HUDI_DIR in setupKafka.sh

### DIFF
--- a/hudi-kafka-connect/demo/setupKafka.sh
+++ b/hudi-kafka-connect/demo/setupKafka.sh
@@ -48,6 +48,10 @@ if [ $# -lt 1 ]; then
   exit 0
 fi
 
+if [ ! $HUDI_DIR ]; then
+  export HUDI_DIR=$(dirname "$(dirname $PWD)")
+fi
+
 ## defaults
 rawDataFile=${HUDI_DIR}/docker/demo/data/batch_1.json
 kafkaBrokerHostname=localhost


### PR DESCRIPTION
## What is the purpose of the pull request
Add default HUDI_DIR in setupKafka.sh when $HUDI_DIR is not set

## Brief change log

  - If $HUDI_DIR is not set, export $HUDI_DIR to hudi base dictionary

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
