### PR TITLE
[HUDI-52] Enabling savepoint and restore for MOR table

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SavepointsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SavepointsCommand.java
@@ -26,6 +26,7 @@ import org.apache.hudi.cli.utils.SparkUtil;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -78,8 +79,10 @@ public class SavepointsCommand implements CommandMarker {
       throws Exception {
     HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();
     HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
-    HoodieTimeline timeline = activeTimeline.getCommitTimeline().filterCompletedInstants();
-    HoodieInstant commitInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, commitTime);
+    HoodieTimeline timeline = activeTimeline.getCommitsTimeline().filterCompletedInstants();
+    HoodieInstant commitInstant = new HoodieInstant(false,
+        metaClient.getTableConfig().getTableType() == HoodieTableType.COPY_ON_WRITE ? HoodieTimeline.COMMIT_ACTION : HoodieTimeline.DELTA_COMMIT_ACTION,
+        commitTime);
 
     if (!timeline.containsInstant(commitInstant)) {
       return "Commit " + commitTime + " not found in Commits " + timeline;
@@ -112,8 +115,10 @@ public class SavepointsCommand implements CommandMarker {
       throw new HoodieException("There are no completed instants to run rollback");
     }
     HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
-    HoodieTimeline timeline = activeTimeline.getCommitTimeline().filterCompletedInstants();
-    HoodieInstant commitInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime);
+    HoodieTimeline timeline = activeTimeline.getCommitsTimeline().filterCompletedInstants();
+    HoodieInstant commitInstant = new HoodieInstant(false,
+        metaClient.getTableConfig().getTableType() == HoodieTableType.COPY_ON_WRITE ? HoodieTimeline.COMMIT_ACTION : HoodieTimeline.DELTA_COMMIT_ACTION,
+        instantTime);
 
     if (!timeline.containsInstant(commitInstant)) {
       return "Commit " + instantTime + " not found in Commits " + timeline;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -65,11 +65,9 @@ public class SavepointActionExecutor<T extends HoodieRecordPayload, I, K, O> ext
 
   @Override
   public HoodieSavepointMetadata execute() {
-    if (table.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ) {
-      throw new UnsupportedOperationException("Savepointing is not supported or MergeOnRead table types");
-    }
     Option<HoodieInstant> cleanInstant = table.getCompletedCleanTimeline().lastInstant();
-    HoodieInstant commitInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, instantTime);
+    HoodieInstant commitInstant = new HoodieInstant(false, this.table.getMetaClient().getTableConfig().getTableType() == HoodieTableType.COPY_ON_WRITE
+        ? HoodieTimeline.COMMIT_ACTION : HoodieTimeline.DELTA_COMMIT_ACTION, instantTime);
     if (!table.getCompletedCommitsTimeline().containsInstant(commitInstant)) {
       throw new HoodieSavepointException("Could not savepoint non-existing commit " + commitInstant);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecordPayload;
-import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
@@ -66,10 +65,8 @@ public class SavepointActionExecutor<T extends HoodieRecordPayload, I, K, O> ext
   @Override
   public HoodieSavepointMetadata execute() {
     Option<HoodieInstant> cleanInstant = table.getCompletedCleanTimeline().lastInstant();
-    HoodieInstant commitInstant = new HoodieInstant(false, this.table.getMetaClient().getTableConfig().getTableType() == HoodieTableType.COPY_ON_WRITE
-        ? HoodieTimeline.COMMIT_ACTION : HoodieTimeline.DELTA_COMMIT_ACTION, instantTime);
-    if (!table.getCompletedCommitsTimeline().containsInstant(commitInstant)) {
-      throw new HoodieSavepointException("Could not savepoint non-existing commit " + commitInstant);
+    if (!table.getCompletedCommitsTimeline().containsInstant(instantTime)) {
+      throw new HoodieSavepointException("Could not savepoint non-existing commit " + instantTime);
     }
 
     try {


### PR DESCRIPTION
## What is the purpose of the pull request

Adding/Enabling restore for MOR table

## Brief change log

- Enabling restore for MOR table. 

## Verify this pull request

This change added tests and can be verified as follows:

- TestHoodieSparkMergeOnReadTableRollback.testMORTableRestore

- Verified the below cases manually (without metadata enabled) via hudi-cli
a. insert, upsert, upsert, savepoint, upsert, rollback. validate records. 
b. insert, upsert, upsert, savepoint, upsert, upsert, rollback. validate records. 
c. insert, upsert, upsert, savepoint, upsert, insert, rollback. validate records. 
d. insert, upsert, upsert, savepoint, upsert, upsert, compact, rollback. validate records. 
e. insert, upsert, upsert, savepoint, upsert, upsert, compact, upsert, rollback. validate records. upsert, validate records. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
