### PR TITLE
[HUDI-3183] Wrong result of HoodieArchivedTimeline loadInstants with TimeRangeFilter

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -265,7 +265,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     // generate data and metadata
     Map<String, Integer[]> data = new LinkedHashMap<>();
 
-    for (int i = 194 ; i >= 154 ; i--) {
+    for (int i = 194; i >= 154; i--) {
       data.put(String.valueOf(i), new Integer[] {i, i});
     }
 
@@ -289,7 +289,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
         "There should 3 instants not be archived!");
 
     Map<String, Integer[]> data2 = new LinkedHashMap<>();
-    for (int i = 174 ; i >= 161 ; i--) {
+    for (int i = 174; i >= 161; i--) {
       data2.put(String.valueOf(i), new Integer[] {i, i});
     }
     String expected = generateExpectData(1, data2);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -251,6 +251,53 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     assertEquals(expected, got);
   }
 
+  @Test
+  public void testShowArchivedCommitsWithMultiCommitsFile() throws Exception {
+    // Generate archive
+    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath1)
+        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder().retainCommits(1).archiveCommitsWith(2, 3).build())
+        .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+            .withRemoteServerPort(timelineServicePort).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .forTable("test-trip-table").build();
+
+    // generate data and metadata
+    Map<String, Integer[]> data = new LinkedHashMap<>();
+
+    for (int i = 194 ; i >= 154 ; i--) {
+      data.put(String.valueOf(i), new Integer[] {i, i});
+    }
+
+    for (Map.Entry<String, Integer[]> entry : data.entrySet()) {
+      String key = entry.getKey();
+      Integer[] value = entry.getValue();
+      HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath1, key, hadoopConf(),
+          Option.of(value[0]), Option.of(value[1]));
+      // archive
+      metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
+      HoodieSparkTable table = HoodieSparkTable.create(cfg, context(), metaClient);
+
+      // need to create multi archive files
+      HoodieTimelineArchiveLog archiveLog = new HoodieTimelineArchiveLog(cfg, table);
+      archiveLog.archiveIfRequired(context());
+    }
+
+    CommandResult cr = shell().executeCommand(String.format("commits showarchived --startTs %s --endTs %s", "160", "174"));
+    assertTrue(cr.isSuccess());
+    assertEquals(3, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
+        "There should 3 instants not be archived!");
+
+    Map<String, Integer[]> data2 = new LinkedHashMap<>();
+    for (int i = 174 ; i >= 161 ; i--) {
+      data2.put(String.valueOf(i), new Integer[] {i, i});
+    }
+    String expected = generateExpectData(1, data2);
+    expected = removeNonWordAndStripSpace(expected);
+    String got = removeNonWordAndStripSpace(cr.getResult().toString());
+    assertEquals(expected, got);
+  }
+
   /**
    * Test case of 'commit showpartitions' command.
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
  */
 public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
   private static final Pattern ARCHIVE_FILE_PATTERN =
-      Pattern.compile("^\\.commits_\\.archive\\.([0-9]*)$");
+      Pattern.compile("^\\.commits_\\.archive\\.([0-9]+).*");
 
   private static final String HOODIE_COMMIT_ARCHIVE_LOG_FILE_PREFIX = "commits";
   private static final String ACTION_TYPE_KEY = "actionType";


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HUDI-3183
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
Hoodie use `ArchiveFileVersionComparator ` to sort archive files as an optimization to skip reading unnecessary archived files.
But with the wrong regex pattern, there's no sort actually(always return 0) and lead to a wrong loadInstants result.

https://github.com/apache/hudi/blob/b5f05fd153df29a8be377404a14a0ced2f00b4bf/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java#L219

https://github.com/apache/hudi/blob/b5f05fd153df29a8be377404a14a0ced2f00b4bf/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java#L297

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
