### PR TITLE
[HUDI-3185] HoodieConfig#getBoolean should return false when default …

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -146,6 +146,9 @@ public class HoodieConfig implements Serializable {
   }
 
   public <T> Boolean getBoolean(ConfigProperty<T> configProperty) {
+    if (configProperty.hasDefaultValue()) {
+      return getBooleanOrDefault(configProperty);
+    }
     Option<Object> rawValue = getRawValue(configProperty);
     return rawValue.map(v -> Boolean.parseBoolean(v.toString())).orElse(null);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestConfigProperty.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestConfigProperty.java
@@ -40,6 +40,11 @@ public class TestConfigProperty extends HoodieConfig {
       .defaultValue("false")
       .withDocumentation("Fake config only for testing");
 
+  public static ConfigProperty<String> FAKE_BOOLEAN_CONFIG_NO_DEFAULT = ConfigProperty
+      .key("test.fake.boolean.config")
+      .noDefaultValue()
+      .withDocumentation("Fake config only for testing");
+
   public static ConfigProperty<Integer> FAKE_INTEGER_CONFIG = ConfigProperty
       .key("test.fake.integer.config")
       .defaultValue(0)
@@ -58,9 +63,21 @@ public class TestConfigProperty extends HoodieConfig {
     hoodieConfig.setValue(FAKE_STRING_CONFIG, "5");
     assertEquals(5, hoodieConfig.getInt(FAKE_STRING_CONFIG));
 
-    assertNull(hoodieConfig.getBoolean(FAKE_BOOLEAN_CONFIG));
+    assertEquals(false, hoodieConfig.getBoolean(FAKE_BOOLEAN_CONFIG));
     hoodieConfig.setValue(FAKE_BOOLEAN_CONFIG, "true");
     assertEquals(true, hoodieConfig.getBoolean(FAKE_BOOLEAN_CONFIG));
+  }
+
+  @Test
+  public void testGetBooleanShouldReturnFalseWhenDefaultValueFalseButNotSet() {
+    HoodieConfig hoodieConfig = new HoodieConfig();
+    assertEquals(false, hoodieConfig.getBoolean(FAKE_BOOLEAN_CONFIG));
+  }
+
+  @Test
+  public void testGetBooleanShouldReturnNullWhenNoDefaultValuePresent() {
+    HoodieConfig hoodieConfig = new HoodieConfig();
+    assertNull(hoodieConfig.getBoolean(FAKE_BOOLEAN_CONFIG_NO_DEFAULT));
   }
 
   @Test


### PR DESCRIPTION
…not set

## What is the purpose of the pull request

If user has not set a config and `setDefaults()` is not called before checking the config, then `getBoolean` (or getString, getInt) returns null which can cause NPE. At least, for boolean configs we should return default value if it is provided in config declaration. This does not change the behavior. For string or int configs, we should let it return null because there can be checks in the code based on null or empty. In that case we don't want to set some value.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
