### PR TITLE
[HUDI-3233] Make metadata commit synchronous for flink batch

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -252,7 +252,7 @@ public class StreamWriteOperatorCoordinator
     WriteMetadataEvent event = (WriteMetadataEvent) operatorEvent;
 
     if (event.isEndInput()) {
-      // Process EndInputEvent synchronously
+      // process end input event synchronously
       handleEndInputEvent(event);
     } else {
       executor.execute(

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -248,7 +248,7 @@ public class StreamWriteOperatorCoordinator
   public void handleEventFromOperator(int i, OperatorEvent operatorEvent) {
     // no event to handle
     ValidationUtils.checkState(operatorEvent instanceof WriteMetadataEvent,
-            "The coordinator can only handle WriteMetaEvent");
+        "The coordinator can only handle WriteMetaEvent");
     WriteMetadataEvent event = (WriteMetadataEvent) operatorEvent;
 
     if (event.isEndInput()) {
@@ -256,13 +256,13 @@ public class StreamWriteOperatorCoordinator
       handleEndInputEvent(event);
     } else {
       executor.execute(
-              () -> {
-                if (event.isBootstrap()) {
-                  handleBootstrapEvent(event);
-                } else {
-                  handleWriteMetaEvent(event);
-                }
-              }, "handle write metadata event for instant %s", this.instant
+          () -> {
+            if (event.isBootstrap()) {
+              handleBootstrapEvent(event);
+            } else {
+              handleWriteMetaEvent(event);
+            }
+          }, "handle write metadata event for instant %s", this.instant
       );
     }
   }

--- a/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -390,7 +390,7 @@ public class StreamWriteOperatorCoordinator
       // The executor thread inherits the classloader of the #handleEventFromOperator
       // caller, which is a AppClassLoader.
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-      // sync Hive Synchronously if is enabled in batch mode.
+      // sync Hive synchronously if it is enabled in batch mode.
       syncHiveSynchronously();
     }
   }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
fix: https://github.com/apache/hudi/issues/4469.

handleEndInputEvent is executed synchronously,  asynchronous execution will cause the flink cluster to shut down early before time processing is complete.

## Brief change log
  *Modify:  org.apache.hudi.sink.StreamWriteOperatorCoordinator#handleEventFromOperator*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
