### PR TITLE
[HUDI-3198] Improve Spark SQL create table from existing hudi table

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -164,12 +164,20 @@ class HoodieCatalogTable(val spark: SparkSession, val table: CatalogTable) exten
     val properties = new Properties()
     properties.putAll(tableConfigs.asJava)
 
-    HoodieTableMetaClient.withPropertyBuilder()
-      .fromProperties(properties)
-      .setTableName(table.identifier.table)
-      .setTableCreateSchema(SchemaConverters.toAvroType(finalSchema).toString())
-      .setPartitionFields(table.partitionColumnNames.mkString(","))
-      .initTable(hadoopConf, tableLocation)
+    if (hoodieTableExists) {
+      // just persist hoodie.table.create.schema
+      HoodieTableMetaClient.withPropertyBuilder()
+        .fromProperties(properties)
+        .setTableCreateSchema(SchemaConverters.toAvroType(finalSchema).toString())
+        .initTable(hadoopConf, tableLocation)
+    } else {
+      HoodieTableMetaClient.withPropertyBuilder()
+        .fromProperties(properties)
+        .setTableName(table.identifier.table)
+        .setTableCreateSchema(SchemaConverters.toAvroType(finalSchema).toString())
+        .setPartitionFields(table.partitionColumnNames.mkString(","))
+        .initTable(hadoopConf, tableLocation)
+    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -61,6 +61,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
     val hoodieCatalogTable = HoodieCatalogTable(sparkSession, table)
     // check if there are conflict between table configs defined in hoodie table and properties defined in catalog.
     CreateHoodieTableCommand.validateTblProperties(hoodieCatalogTable)
+
     // init hoodie table
     hoodieCatalogTable.initHoodieTable()
 
@@ -129,12 +130,14 @@ object CreateHoodieTableCommand {
     val newTableIdentifier = table.identifier
       .copy(table = tablName, database = Some(newDatabaseName))
 
+    val partitionColumnNames = hoodieCatalogTable.partitionSchema.map(_.name)
     // append pk, preCombineKey, type to the properties of table
     val newTblProperties = hoodieCatalogTable.catalogProperties ++ HoodieOptionConfig.extractSqlOptions(properties)
     val newTable = table.copy(
       identifier = newTableIdentifier,
-      schema = hoodieCatalogTable.tableSchema,
       storage = newStorage,
+      schema = hoodieCatalogTable.tableSchema,
+      partitionColumnNames = partitionColumnNames,
       createVersion = SPARK_VERSION,
       properties = newTblProperties
     )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -100,11 +100,6 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         spark.sql(
           s"""
              |create table $tableName using hudi
-             |tblproperties (
-             | primaryKey = 'id',
-             | preCombineField = 'ts'
-             |)
-             |partitioned by (dt)
              |location '$tablePath'
              |""".stripMargin)
 
@@ -149,11 +144,6 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         spark.sql(
           s"""
              |create table $tableName using hudi
-             |tblproperties (
-             | primaryKey = 'id',
-             | preCombineField = 'ts'
-             |)
-             |partitioned by (dt)
              |location '$tablePath'
              |""".stripMargin)
 
@@ -210,7 +200,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
 
         import spark.implicits._
         val df = Seq((1, "z3", "v1", "2021", "10", "01"), (2, "l4", "v1", "2021", "10","02"))
-        .toDF("id", "name", "ts", "year", "month", "day")
+          .toDF("id", "name", "ts", "year", "month", "day")
 
         df.write.format("hudi")
           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
@@ -229,11 +219,6 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         spark.sql(
           s"""
              |create table $tableName using hudi
-             |tblproperties (
-             | primaryKey = 'id',
-             | preCombineField = 'ts'
-             |)
-             |partitioned by (year, month, day)
              |location '$tablePath'
              |""".stripMargin)
 
@@ -278,11 +263,6 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         spark.sql(
           s"""
              |create table $tableName using hudi
-             |tblproperties (
-             | primaryKey = 'id',
-             | preCombineField = 'ts'
-             |)
-             |partitioned by (year, month, day)
              |location '$tablePath'
              |""".stripMargin)
 


### PR DESCRIPTION
To modify SQL statement for creating hudi table based on an existing hudi path.

From:

```sql
create table hudi_tbl using hudi tblproperties (primaryKey='id', preCombineField='ts', type='cow') partitioned by (pt) location '/path/to/hudi'
```

To:
```sql
create table hudi_tbl using hudi location '/path/to/hudi'
```