### PR TITLE
[MINOR] Fix the check condition in the `readFromVector` method to alway true

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
@@ -494,7 +494,6 @@ public class AvroOrcUtils {
       case SHORT:
         return (short) ((LongColumnVector) colVector).vector[vectorPos];
       case INT:
-      case DATE:
         return (int) ((LongColumnVector) colVector).vector[vectorPos];
       case LONG:
         return ((LongColumnVector) colVector).vector[vectorPos];
@@ -522,6 +521,9 @@ public class AvroOrcUtils {
         } else {
           return ((BytesColumnVector) colVector).toString(vectorPos);
         }
+      case DATE:
+        // convert to daysSinceEpoch for LogicalType.Date
+        return (int) ((LongColumnVector) colVector).vector[vectorPos];
       case TIMESTAMP:
         // The unit of time in ORC is millis. Convert (time,nanos) to the desired unit per logicalType
         long time = ((TimestampColumnVector) colVector).time[vectorPos];

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/AvroOrcUtils.java
@@ -494,6 +494,7 @@ public class AvroOrcUtils {
       case SHORT:
         return (short) ((LongColumnVector) colVector).vector[vectorPos];
       case INT:
+      case DATE:
         return (int) ((LongColumnVector) colVector).vector[vectorPos];
       case LONG:
         return ((LongColumnVector) colVector).vector[vectorPos];
@@ -511,8 +512,8 @@ public class AvroOrcUtils {
           throw new HoodieIOException("CHAR/VARCHAR has length " + result.length() + " greater than Max Length allowed");
         }
       case STRING:
-        String stringType = avroSchema.getProp(GenericData.STRING_PROP);
-        if (stringType == null || !stringType.equals(StringType.String)) {
+        String stringType = avroSchema != null ? avroSchema.getProp(GenericData.STRING_PROP) : null;
+        if (!StringType.String.name().equals(stringType)) {
           int stringLength = ((BytesColumnVector) colVector).length[vectorPos];
           int stringOffset = ((BytesColumnVector) colVector).start[vectorPos];
           byte[] stringBytes = new byte[stringLength];
@@ -521,9 +522,6 @@ public class AvroOrcUtils {
         } else {
           return ((BytesColumnVector) colVector).toString(vectorPos);
         }
-      case DATE:
-        // convert to daysSinceEpoch for LogicalType.Date
-        return (int) ((LongColumnVector) colVector).vector[vectorPos];
       case TIMESTAMP:
         // The unit of time in ORC is millis. Convert (time,nanos) to the desired unit per logicalType
         long time = ((TimestampColumnVector) colVector).time[vectorPos];


### PR DESCRIPTION

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

`if (stringType == null || !stringType.equals(StringType.String)) {`  
This condition, one is an enumeration type and the other is a string type, the result is always true

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
