### PR TITLE
[Minor]change log info and if-else logic in metadata table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -535,7 +535,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * All FileGroups for a given metadata partition has a fixed prefix as per the {@link MetadataPartitionType#getFileIdPrefix()}.
    * Each file group is suffixed with 4 digits with increments of 1 starting with 0000.
    *
-   * Lets say we configure 10 file groups for record level index partittion, and prefix as "record-index-bucket-"
+   * Lets say we configure 10 file groups for record level index partition, and prefix as "record-index-bucket-"
    * File groups will be named as :
    *    record-index-bucket-0000, .... -> ..., record-index-bucket-0009
    */

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -231,18 +231,18 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
   }
 
   /**
-   * May be handle spurious deletes. Depending on config, throw an exception or log a warn msg.
+   * Maybe handle spurious deletes. Depending on config, throw an exception or log a warn msg.
    * @param hoodieRecord instance of {@link HoodieRecord} of interest.
    * @param partitionName partition name of interest.
    */
   private void mayBeHandleSpuriousDeletes(Option<HoodieRecord<HoodieMetadataPayload>> hoodieRecord, String partitionName) {
     if (!hoodieRecord.get().getData().getDeletions().isEmpty()) {
-      if (!metadataConfig.ignoreSpuriousDeletes()) {
+      if (metadataConfig.ignoreSpuriousDeletes()) {
+        LOG.warn("Metadata record for " + partitionName + " encountered some files to be deleted which was not added before. "
+            + "Ignoring the spurious deletes as the `" + HoodieMetadataConfig.IGNORE_SPURIOUS_DELETES.key() + "` config is set to true");
+      } else {
         throw new HoodieMetadataException("Metadata record for " + partitionName + " is inconsistent: "
             + hoodieRecord.get().getData());
-      } else {
-        LOG.warn("Metadata record for " + partitionName + " encountered some files to be deleted which was not added before. "
-            + "Ignoring the spurious deletes as the `" + HoodieMetadataConfig.IGNORE_SPURIOUS_DELETES.key() + "` config is set to false");
       }
     }
   }


### PR DESCRIPTION
A little change want to do during reading meta data table related code.
1. Wrong describe for  warn log `HoodieMetadataConfig.IGNORE_SPURIOUS_DELETES.key() + " config is set to false"` ->  `HoodieMetadataConfig.IGNORE_SPURIOUS_DELETES.key() + " config is set to true"`
2. do `metadataConfig.ignoreSpuriousDeletes()` instead of `!metadataConfig.ignoreSpuriousDeletes()` (a little confusing). Maybe can just ignore when set ignore true.
3. some typos.
## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
