### PR TITLE
[MINOR] Fix build of Hudi website

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.14",
     "@docusaurus/plugin-client-redirects": "2.0.0-beta.14",
-    "@docusaurus/plugin-sitemap": "^2.0.0-beta.14",
+    "@docusaurus/plugin-sitemap": "2.0.0-beta.14",
     "@docusaurus/preset-classic": "2.0.0-beta.14",
-    "@docusaurus/theme-search-algolia": "^2.0.0-beta.14",
+    "@docusaurus/theme-search-algolia": "2.0.0-beta.14",
     "@fontsource/comfortaa": "^4.5.0",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",

--- a/website/package.json
+++ b/website/package.json
@@ -14,11 +14,11 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.3",
-    "@docusaurus/plugin-client-redirects": "^2.0.0-beta.3",
-    "@docusaurus/plugin-sitemap": "^2.0.0-beta.3",
-    "@docusaurus/preset-classic": "^2.0.0-beta.3",
-    "@docusaurus/theme-search-algolia": "^2.0.0-beta.3",
+    "@docusaurus/core": "2.0.0-beta.14",
+    "@docusaurus/plugin-client-redirects": "2.0.0-beta.14",
+    "@docusaurus/plugin-sitemap": "^2.0.0-beta.14",
+    "@docusaurus/preset-classic": "2.0.0-beta.14",
+    "@docusaurus/theme-search-algolia": "^2.0.0-beta.14",
     "@fontsource/comfortaa": "^4.5.0",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",


### PR DESCRIPTION
## What is the purpose of the pull request

The build of Hudi website is broken due to the following error from `npm run build`:
```
(asf-site)> npm run build

> hudi@0.0.0 build
> docusaurus build

[INFO] Website will be built for all these locales: 
- en
- cn
[INFO] [en] Creating an optimized production build...

✔ Client
  
✖ Server
  Compiled with some errors in 2.64m

[ERROR] Docusaurus Node/SSR could not render static page with path / because of following error:
Error: Minified React error #130; visit https://reactjs.org/docs/error-decoder.html?invariant=130&args[]=object&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at a.b.render (main:115785:32)
    at a.b.read (main:115781:83)
    at Object.exports.renderToString (main:115792:138)
    at doRender (main:25801:356)
    at async serverEntry_render (main:25797:329)

Error: Server-side rendering fails due to the error above.
[ERROR] Unable to build website for locale en.
[ERROR] Error: Failed to compile with errors.
    at /Users/ethan/Work/repo/hudi-docs-8/website/node_modules/@docusaurus/core/lib/webpack/utils.js:207:24
    at /Users/ethan/Work/repo/hudi-docs-8/website/node_modules/webpack/lib/MultiCompiler.js:554:14
    at processQueueWorker (/Users/ethan/Work/repo/hudi-docs-8/website/node_modules/webpack/lib/MultiCompiler.js:491:6)
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
```

The root cause is that docusaurus versions specified in `website/package.json` are not honored.  Looking at the `website/package-lock.json` generated, `2.0.0-beta.15` is actually used instead of `^2.0.0-beta.3` (up to 2.0.0-beta.3) specified.  Another evidence of higher version already used is that `2.0.0-beta.14` shows up in generated content:

```
./content/docs/next/clustering/index.html:<meta name="generator" content="Docusaurus v2.0.0-beta.14">
```

The build failure is due to the recent new version, `2.0.0-beta.15` of docusaurus and related dependencies.

The fix is to bound the docusaurus version properly.

Note that the build failure can only be reproduced from a fresh clone of the branch from remote, with `npm install` and `npm run build` under `website` folder.  If there is a previous successful build and package info is cached, such build failure may not show up.

## Brief change log

  - Updates `website/package.json` to bound the docusaurus version properly.

## Verify this pull request

The change is verified by a fresh build of the website.  The website can be successfully launched after `npm start`.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
