### PR TITLE
[HUDI-3166] Hoodie Index Type Metadata Bloom implementation

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndex.java
@@ -144,6 +144,6 @@ public abstract class HoodieIndex<T extends HoodieRecordPayload, I, K, O> implem
   }
 
   public enum IndexType {
-    HBASE, INMEMORY, BLOOM, GLOBAL_BLOOM, SIMPLE, GLOBAL_SIMPLE, BUCKET
+    HBASE, INMEMORY, BLOOM, GLOBAL_BLOOM, SIMPLE, GLOBAL_SIMPLE, BUCKET, METADATA_BLOOM
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBaseBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBaseBloomIndex.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ImmutablePair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.index.HoodieIndexUtils;
+
+/**
+ * Base class for the bloom index implementations.
+ */
+public abstract class HoodieBaseBloomIndex<T extends HoodieRecordPayload<T>> extends HoodieIndex<T, Object, Object, Object> {
+
+  protected HoodieBaseBloomIndex(HoodieWriteConfig config) {
+    super(config);
+  }
+
+  /**
+   * Tag the <rowKey, filename> back to the original HoodieRecord List.
+   */
+  protected HoodieData<HoodieRecord<T>> tagLocationBackToRecords(
+      HoodiePairData<HoodieKey, HoodieRecordLocation> keyFilenamePair,
+      HoodieData<HoodieRecord<T>> records) {
+    HoodiePairData<HoodieKey, HoodieRecord<T>> keyRecordPairs =
+        records.mapToPair(record -> new ImmutablePair<>(record.getKey(), record));
+    // Here as the records might have more data than keyFilenamePairs
+    // (some row keys' fileId is null), so we do left outer join.
+    return keyRecordPairs.leftOuterJoin(keyFilenamePair).values()
+        .map(v -> HoodieIndexUtils.getTaggedRecord(v.getLeft(), Option.ofNullable(v.getRight().orElse(null))));
+  }
+
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieGlobalBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieGlobalBloomIndex.java
@@ -96,7 +96,7 @@ public class HoodieGlobalBloomIndex<T extends HoodieRecordPayload<T>> extends Ho
    * Tagging for global index should only consider the record key.
    */
   @Override
-  protected HoodieData<HoodieRecord<T>> tagLocationBacktoRecords(
+  protected HoodieData<HoodieRecord<T>> tagLocationBackToRecords(
       HoodiePairData<HoodieKey, HoodieRecordLocation> keyLocationPairs,
       HoodieData<HoodieRecord<T>> records) {
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomIndex.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.ImmutablePair;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Metadata table based bloom filter and column stats indexing. This index implementation
+ * queries the metadata table for the base file column stats index for range pruning and
+ * the bloom filters index to find the candidate keys.
+ */
+public class HoodieMetadataBloomIndex<T extends HoodieRecordPayload<T>> extends HoodieBaseBloomIndex<T> {
+  private static final Logger LOG = LogManager.getLogger(HoodieMetadataBloomIndex.class);
+
+  private final MetadataBaseHoodieBloomIndexHelper bloomIndexHelper;
+
+  public HoodieMetadataBloomIndex(HoodieWriteConfig config, MetadataBaseHoodieBloomIndexHelper bloomIndexHelper) {
+    super(config);
+    this.bloomIndexHelper = bloomIndexHelper;
+  }
+
+  @Override
+  public HoodieData<HoodieRecord<T>> tagLocation(HoodieData<HoodieRecord<T>> records, HoodieEngineContext context,
+                                                 HoodieTable hoodieTable) throws HoodieIndexException {
+    final HoodiePairData<HoodieKey, HoodieRecordLocation> keyFilenamePairs = lookupIndex(records, context, hoodieTable);
+    return tagLocationBackToRecords(keyFilenamePairs, records);
+  }
+
+  @Override
+  public HoodieData<WriteStatus> updateLocation(HoodieData<WriteStatus> writeStatuses, HoodieEngineContext context,
+                                                HoodieTable hoodieTable) throws HoodieIndexException {
+    return writeStatuses;
+  }
+
+  @Override
+  public boolean rollbackCommit(String instantTime) {
+    return true;
+  }
+
+  @Override
+  public boolean isGlobal() {
+    return false;
+  }
+
+  @Override
+  public boolean canIndexLogFiles() {
+    return false;
+  }
+
+  @Override
+  public boolean isImplicitWithStorage() {
+    return true;
+  }
+
+  /**
+   * Lookup columns stats and bloom filters index for the existence of a record.
+   *
+   * @param records     - Records to lookup
+   * @param context     - Engine context
+   * @param hoodieTable - Table reference
+   * @return Pair data of key and its current record location for the already existing keys
+   */
+  private HoodiePairData<HoodieKey, HoodieRecordLocation> lookupIndex(HoodieData<HoodieRecord<T>> records,
+                                                                      final HoodieEngineContext context,
+                                                                      final HoodieTable hoodieTable) {
+    setContextDetails(context, "Extract partition paths from records");
+    HoodiePairData<String, String> partitionRecordKeyPairs = records.mapToPair(
+        record -> new ImmutablePair<>(record.getPartitionPath(), record.getRecordKey()));
+
+    setContextDetails(context, "Build IntervalTree for the affected partitions from column range index");
+    HoodieData<Pair<String, IndexFileFilter>> partitionIndexFileFilter =
+        bloomIndexHelper.buildPartitionIndexFileFilter(config, context, hoodieTable, partitionRecordKeyPairs);
+
+    setContextDetails(context, "Find candidate files and record keys from range pruning");
+    HoodieData<ImmutablePair<String, HoodieKey>> fileCandidateKeysPairs =
+        findCandidateFilesForRecordKeys(partitionIndexFileFilter, partitionRecordKeyPairs);
+
+    setContextDetails(context, "Find matching files for record keys");
+    return bloomIndexHelper.findMatchingFilesForRecordKeys(config, context, hoodieTable,
+        partitionRecordKeyPairs, fileCandidateKeysPairs);
+  }
+
+  /**
+   * For each record key, use the partition IndexFileFilter to get its
+   * list of candidate files where the records might be available.
+   */
+  HoodieData<ImmutablePair<String, HoodieKey>> findCandidateFilesForRecordKeys(
+      final HoodieData<Pair<String, IndexFileFilter>> partitionIndexFileFilter,
+      HoodiePairData<String, String> partitionRecordKeyPairs) {
+    final Map<String, IndexFileFilter> partitionFileFilters = partitionIndexFileFilter.collectAsList()
+        .stream().collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+    return partitionRecordKeyPairs.map(partitionRecordKeyPair -> {
+      String recordKey = partitionRecordKeyPair.getRight();
+      String partitionPath = partitionRecordKeyPair.getLeft();
+      ValidationUtils.checkState(partitionFileFilters.containsKey(partitionPath));
+
+      final IndexFileFilter indexFileFilter = partitionFileFilters.get(partitionPath);
+      return indexFileFilter.getMatchingFilesAndPartition(partitionPath, recordKey).stream()
+          .map(partitionFileIdPair -> new ImmutablePair<>(partitionFileIdPair.getRight(),
+              new HoodieKey(recordKey, partitionPath)));
+    }).flatMap(list -> list.iterator());
+  }
+
+  private void setContextDetails(final HoodieEngineContext context, final String message) {
+    context.setJobStatus(this.getClass().getName(), "MetadataBloomIndex: " + message);
+  }
+}
+
+

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/MetadataBaseHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/MetadataBaseHoodieBloomIndexHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.util.collection.ImmutablePair;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+
+import java.io.Serializable;
+
+/**
+ * Helper for {@link HoodieMetadataBloomIndex} containing engine-specific logic.
+ */
+public abstract class MetadataBaseHoodieBloomIndexHelper implements Serializable {
+  /**
+   * Build the IndexFileFilter for all the affected partitions from the column stats index.
+   *
+   * @param config                  - Write config
+   * @param context                 - {@link HoodieEngineContext} instance to use
+   * @param hoodieTable             - {@link HoodieTable} instance to use
+   * @param partitionRecordKeyPairs - Partition and record key pairs
+   * @return Partition and its IndexFileFilter pair data
+   */
+  protected abstract HoodieData<Pair<String, IndexFileFilter>> buildPartitionIndexFileFilter(
+      HoodieWriteConfig config, HoodieEngineContext context, HoodieTable hoodieTable,
+      HoodiePairData<String, String> partitionRecordKeyPairs);
+
+  /**
+   * Find HoodieKey and its record location for the requested keys.
+   *
+   * @param config                  - Write config
+   * @param context                 - {@link HoodieEngineContext} instance to use
+   * @param hoodieTable             - {@link HoodieTable} instance to use
+   * @param partitionRecordKeyPairs - Pairs of partition path and record key
+   * @param fileCandidateKeyPairs   - Pairs of filename and record key
+   * @return {@link HoodiePairData} of {@link HoodieKey} and {@link HoodieRecordLocation} pairs
+   */
+  public abstract HoodiePairData<HoodieKey, HoodieRecordLocation> findMatchingFilesForRecordKeys(
+      HoodieWriteConfig config, HoodieEngineContext context, HoodieTable hoodieTable,
+      HoodiePairData<String, String> partitionRecordKeyPairs,
+      HoodieData<ImmutablePair<String, HoodieKey>> fileCandidateKeyPairs);
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/SparkHoodieIndexFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/SparkHoodieIndexFactory.java
@@ -27,7 +27,9 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.index.bloom.HoodieBloomIndex;
 import org.apache.hudi.index.bloom.HoodieGlobalBloomIndex;
+import org.apache.hudi.index.bloom.HoodieMetadataBloomIndex;
 import org.apache.hudi.index.bloom.SparkHoodieBloomIndexHelper;
+import org.apache.hudi.index.bloom.SparkHoodieMetadataBloomIndexHelper;
 import org.apache.hudi.index.bucket.HoodieBucketIndex;
 import org.apache.hudi.index.hbase.SparkHoodieHBaseIndex;
 import org.apache.hudi.index.inmemory.HoodieInMemoryHashIndex;
@@ -60,6 +62,8 @@ public final class SparkHoodieIndexFactory {
         return new HoodieBucketIndex(config);
       case BLOOM:
         return new HoodieBloomIndex<>(config, SparkHoodieBloomIndexHelper.getInstance());
+      case METADATA_BLOOM:
+        return new HoodieMetadataBloomIndex<>(config, SparkHoodieMetadataBloomIndexHelper.getInstance());
       case GLOBAL_BLOOM:
         return new HoodieGlobalBloomIndex<>(config, SparkHoodieBloomIndexHelper.getInstance());
       case SIMPLE:

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieMetadataBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieMetadataBloomIndexHelper.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.collection.ImmutablePair;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.data.HoodieJavaPairRDD;
+import org.apache.hudi.data.HoodieJavaRDD;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.exception.MetadataNotFoundException;
+import org.apache.hudi.index.HoodieIndexUtils;
+import org.apache.hudi.io.HoodieKeyLookupResult;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Helper for {@link HoodieBloomIndex} containing Spark-specific logic.
+ */
+public class SparkHoodieMetadataBloomIndexHelper extends MetadataBaseHoodieBloomIndexHelper {
+
+  private static final Logger LOG = LogManager.getLogger(SparkHoodieMetadataBloomIndexHelper.class);
+  private static final SparkHoodieMetadataBloomIndexHelper SINGLETON_INSTANCE =
+      new SparkHoodieMetadataBloomIndexHelper();
+
+  private SparkHoodieMetadataBloomIndexHelper() {
+  }
+
+  public static SparkHoodieMetadataBloomIndexHelper getInstance() {
+    return SINGLETON_INSTANCE;
+  }
+
+  protected HoodieData<Pair<String, IndexFileFilter>> buildPartitionIndexFileFilter(
+      HoodieWriteConfig config, final HoodieEngineContext context, final HoodieTable hoodieTable,
+      HoodiePairData<String, String> partitionRecordKeyPairs) {
+    final String keyField = hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
+    final int inputParallelism = HoodieJavaPairRDD.getJavaPairRDD(partitionRecordKeyPairs).partitions().size();
+    final int joinParallelism = Math.max(inputParallelism, config.getBloomIndexParallelism());
+    LOG.info("Building partition index file filter, input parallelism: " + inputParallelism
+        + ", bloom index parallelism: " + config.getBloomIndexParallelism());
+    JavaRDD<String> partitionsRDD = HoodieJavaPairRDD.getJavaPairRDD(partitionRecordKeyPairs).keys().distinct().repartition(joinParallelism);
+
+    JavaRDD<Pair<String, IndexFileFilter>> partitionIndexFileFilterRDD = partitionsRDD.mapPartitionsWithIndex(
+        new Function2<Integer, Iterator<String>, Iterator<Pair<String, IndexFileFilter>>>() {
+          @Override
+          public Iterator<Pair<String, IndexFileFilter>> call(Integer integer, Iterator<String> partitionItr) throws Exception {
+            HoodieTimer timer = new HoodieTimer().startTimer();
+            final List<Pair<String, IndexFileFilter>> result = new ArrayList<>();
+            final List<Pair<String, String>> columnStatKeys = new ArrayList<>();
+            long partitionCount = 0;
+            while (partitionItr.hasNext()) {
+              String partitionName = partitionItr.next();
+              List<String> partitionFileNameList = HoodieIndexUtils.getLatestBaseFilesForPartition(partitionName,
+                      hoodieTable).stream().map(baseFile -> baseFile.getFileName())
+                  .collect(toList());
+              partitionCount++;
+
+              if (partitionFileNameList.isEmpty()) {
+                result.add(new ImmutablePair<String, IndexFileFilter>(partitionName,
+                    new IntervalTreeBasedIndexFileFilter(partitionName, Collections.emptyList())));
+                continue;
+              }
+
+              for (String fileName : partitionFileNameList) {
+                Pair<String, String> partitionFileNameKey = Pair.of(partitionName, fileName);
+                columnStatKeys.add(partitionFileNameKey);
+              }
+            }
+            LOG.debug("Loaded base files for " + partitionCount + " partitons, time taken: " + timer.endTimer());
+
+            try {
+              timer = new HoodieTimer().startTimer();
+              Map<Pair<String, String>, HoodieMetadataColumnStats> fileToColumnStatMap = hoodieTable
+                  .getMetadataTable().getColumnStats(columnStatKeys, keyField);
+              LOG.debug("Loaded column ranges for " + columnStatKeys.size() + " keys, time taken: " + timer.endTimer());
+
+              Map<String, List<BloomIndexFileInfo>> partitionToFilesBloomInfoMap = fileToColumnStatMap.entrySet()
+                  .stream().map(entry -> {
+                    final BloomIndexFileInfo bloomIndexFileInfo = new BloomIndexFileInfo(
+                        FSUtils.getFileId(entry.getKey().getRight()),
+                        entry.getValue().getMinValue(),
+                        entry.getValue().getMaxValue());
+                    return new ImmutablePair<>(entry.getKey().getLeft(), bloomIndexFileInfo);
+                  }).collect(Collectors.groupingBy(p -> p.getKey(), Collectors.mapping(p -> p.getValue(), toList())));
+
+              result.addAll(partitionToFilesBloomInfoMap.entrySet().stream().map(entry -> {
+                return new ImmutablePair<String, IndexFileFilter>(entry.getKey(),
+                    new IntervalTreeBasedIndexFileFilter(entry.getKey(), entry.getValue()));
+              }).collect(Collectors.toList()));
+            } catch (MetadataNotFoundException me) {
+              throw new HoodieMetadataException("Unable to find column range metadata!", me);
+            }
+            return result.iterator();
+          }
+        }, true);
+    return HoodieJavaRDD.of(partitionIndexFileFilterRDD);
+  }
+
+  @Override
+  public HoodiePairData<HoodieKey, HoodieRecordLocation> findMatchingFilesForRecordKeys(
+      HoodieWriteConfig config, HoodieEngineContext context, HoodieTable hoodieTable,
+      HoodiePairData<String, String> partitionRecordKeyPairs,
+      HoodieData<ImmutablePair<String, HoodieKey>> fileCandidateKeyPairs) {
+    JavaRDD<Tuple2<String, HoodieKey>> fileComparisonsRDD =
+        HoodieJavaRDD.getJavaRDD(fileCandidateKeyPairs)
+            .map(pair -> new Tuple2<>(pair.getLeft(), pair.getRight()));
+
+    final int inputParallelism = HoodieJavaPairRDD.getJavaPairRDD(partitionRecordKeyPairs).partitions().size();
+    final int joinParallelism = Math.max(inputParallelism, config.getBloomIndexParallelism());
+    LOG.debug("Find matching files from bloom filter index, input parallelism: " + inputParallelism
+        + ", bloom index parallelism: " + config.getBloomIndexParallelism());
+
+    // Step 1: Sort by file id
+    JavaRDD<Tuple2<String, HoodieKey>> sortedFileIdAndKeyPairs =
+        fileComparisonsRDD.sortBy(Tuple2::_1, true, joinParallelism);
+
+    // Step 2: Use bloom filter to filter and the actual log file to get the record location
+    JavaRDD<List<HoodieKeyLookupResult>> keyLookupResultRDD = sortedFileIdAndKeyPairs.mapPartitionsWithIndex(
+        new HoodieMetadataBloomIndexCheckFunction(hoodieTable), true);
+
+    // Step 3: Do the actual key check in the file
+    return HoodieJavaPairRDD.of(keyLookupResultRDD.flatMap(List::iterator)
+        .filter(lr -> lr.getMatchingRecordKeys().size() > 0)
+        .flatMapToPair(lookupResult -> lookupResult.getMatchingRecordKeys().stream()
+            .map(recordKey -> new Tuple2<>(new HoodieKey(recordKey, lookupResult.getPartitionPath()),
+                new HoodieRecordLocation(lookupResult.getBaseInstantTime(), lookupResult.getFileId())))
+            .collect(Collectors.toList()).iterator()));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -130,6 +130,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -383,12 +384,23 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     assertEquals(tableMetadata.getLatestCompactionTime().get(), "0000003001");
   }
 
+  private static Stream<Arguments> metadataIndexTypeParams() {
+    Object[][] data = new Object[][]{
+        {COPY_ON_WRITE, HoodieIndex.IndexType.BLOOM},
+        {MERGE_ON_READ, HoodieIndex.IndexType.BLOOM},
+        {COPY_ON_WRITE, HoodieIndex.IndexType.METADATA_BLOOM},
+        {MERGE_ON_READ, HoodieIndex.IndexType.METADATA_BLOOM},
+    };
+    return Stream.of(data).map(Arguments::of);
+  }
+
   @ParameterizedTest
-  @EnumSource(HoodieTableType.class)
-  public void testTableOperationsWithMetadataIndex(HoodieTableType tableType) throws Exception {
+  @MethodSource("metadataIndexTypeParams")
+  public void testTableOperationsWithMetadataIndex(HoodieTableType tableType, HoodieIndex.IndexType indexType) throws Exception {
     initPath();
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
         .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .withIndexType(indexType)
             .bloomIndexBucketizedChecking(false)
             .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()


### PR DESCRIPTION
## What is the purpose of the pull request

New Hoodie Index Type - Metadata Bloom implementation. This is based out of the bloom filters and column stats index maintained under the metadata table. 

## Brief change log

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
