### PR TITLE
[HUDI-3346] Fixing non existant marker dir handling in TwoToOne downgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/TwoToOneDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/TwoToOneDowngradeHandler.java
@@ -115,9 +115,11 @@ public class TwoToOneDowngradeHandler implements DowngradeHandler {
               + "\" is not supported for rollback.");
       }
     } else {
-      // In case of partial failures during downgrade, there is a chance that marker type file was deleted,
-      // but timeline server based marker files are left.  So deletes them if any
-      deleteTimelineBasedMarkerFiles(context, markerDir, fileSystem, parallelism);
+      if (fileSystem.exists(new Path(markerDir))) {
+        // In case of partial failures during downgrade, there is a chance that marker type file was deleted,
+        // but timeline server based marker files are left.  So deletes them if any
+        deleteTimelineBasedMarkerFiles(context, markerDir, fileSystem, parallelism);
+      }
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

when marker directory does not exists, two to one downgrade fails w/ exception. 
https://github.com/apache/hudi/issues/4666

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
