### PR TITLE
[HUDI-3368] Revert "[HUDI-3306] Upgrade rocksdb version (#4663)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -689,7 +689,7 @@
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>6.27.3</version>
+        <version>5.17.2</version>
       </dependency>
 
       <!-- Httpcomponents -->


### PR DESCRIPTION
This reverts commit 6f1010799861b9e4b331d0bf5a473211200c15d1.

From azure pipeline runs, looks like there are lot of timeouts after the rocksdb version got upgraded. Testing out by reverting to see if this is the root cause. 
<img width="1483" alt="Screen Shot 2022-02-01 at 10 58 58 AM" src="https://user-images.githubusercontent.com/513218/152003700-d9ccf20b-c8b5-4f26-8552-903e6a9eeec8.png">



## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
