### PR TITLE
[MINOR] Add configuration to enable/disable common prefix for all met…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1561,6 +1561,10 @@ public class HoodieWriteConfig extends HoodieConfig {
         getStringOrDefault(HoodieMetricsConfig.EXECUTOR_METRICS_ENABLE, "false"));
   }
 
+  public boolean isMetricsCommonPrefixEnabled() {
+    return getBooleanOrDefault(HoodieMetricsConfig.ENABLE_COMMON_PREFIX);
+  }
+
   public MetricsReporterType getMetricsReporterType() {
     return MetricsReporterType.valueOf(getString(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE));
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -84,6 +84,13 @@ public class HoodieMetricsConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("");
 
+  public static final ConfigProperty<Boolean> ENABLE_COMMON_PREFIX = ConfigProperty
+      .key(METRIC_PREFIX + ".common_prefix.enable")
+      .defaultValue(true)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Turn on/off common prefix for all metrics. Table name is used as the common prefix and its "
+          + "on by default");
+
   /**
    * @deprecated Use {@link #TURN_METRICS_ON} and its methods instead
    */
@@ -161,6 +168,11 @@ public class HoodieMetricsConfig extends HoodieConfig {
 
     public Builder withExecutorMetrics(boolean enable) {
       hoodieMetricsConfig.setValue(EXECUTOR_METRICS_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withCommonPrefix(boolean enable) {
+      hoodieMetricsConfig.setValue(ENABLE_COMMON_PREFIX, String.valueOf(enable));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -225,6 +225,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       builder.withMetricsConfig(HoodieMetricsConfig.newBuilder()
           .withReporterType(writeConfig.getMetricsReporterType().toString())
           .withExecutorMetrics(writeConfig.isExecutorMetricsEnabled())
+          .withCommonPrefix(writeConfig.isMetricsCommonPrefixEnabled())
           .on(true).build());
       switch (writeConfig.getMetricsReporterType()) {
         case GRAPHITE:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -215,7 +215,13 @@ public class HoodieMetrics {
   }
 
   String getMetricsName(String action, String metric) {
-    return config == null ? null : String.format("%s.%s.%s", config.getMetricReporterMetricsNamePrefix(), action, metric);
+    if (config == null) {
+      return null;
+    }
+    if (config.isMetricsCommonPrefixEnabled()) {
+      return String.format("%s.%s.%s", tableName, action, metric);
+    }
+    return String.format("%s.%s", action, metric);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -46,7 +46,7 @@ public class Metrics {
 
   private Metrics(HoodieWriteConfig metricConfig) {
     registry = new MetricRegistry();
-    commonMetricPrefix = metricConfig.getMetricReporterMetricsNamePrefix();
+    commonMetricPrefix = metricConfig.isMetricsCommonPrefixEnabled() ? metricConfig.getTableName() : "";
     reporter = MetricsReporterFactory.createReporter(metricConfig, registry);
     if (reporter == null) {
       throw new RuntimeException("Cannot initialize Reporter.");
@@ -116,7 +116,7 @@ public class Metrics {
   }
 
   public static void registerGauges(Map<String, Long> metricsMap, Option<String> prefix) {
-    String metricPrefix = prefix.isPresent() ? prefix.get() + "." : "";
+    String metricPrefix = prefix.isPresent() && !prefix.get().isEmpty() ? prefix.get() + "." : "";
     metricsMap.forEach((k, v) -> registerGauge(metricPrefix + k, v));
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerMetrics.java
@@ -74,7 +74,13 @@ public class HoodieDeltaStreamerMetrics implements Serializable {
   }
 
   String getMetricsName(String action, String metric) {
-    return config == null ? null : String.format("%s.%s.%s", config.getMetricReporterMetricsNamePrefix(), action, metric);
+    if (config == null) {
+      return null;
+    }
+    if (config.isMetricsCommonPrefixEnabled()) {
+      return String.format("%s.%s.%s", tableName, action, metric);
+    }
+    return String.format("%s.%s", action, metric);
   }
 
   public void updateDeltaStreamerMetrics(long durationInNs) {


### PR DESCRIPTION
…rics

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

As of now all metrics created by hudi has table name prefixed by default. This pr aims to put that behavior behind a configuration and allows the user to disable it.

For example lets say we have 2 hudi tables `customers` and `loan_accounts`. Right now the metrics in prometheus will come like this
```
customers_TimelineService_TOTAL_HANDLE_TIME{job="customers"} 589
loan_accounts_TimelineService_TOTAL_HANDLE_TIME{job="loan_accounts"} 642
```
Its conventional in prometheus to have consistent metric name with differences in labels. After the changes in this pr, metrics will come like this which is much simpler to plot across lets say 100s of hudi tables with each having 100s of metrics.

```
TimelineService_TOTAL_HANDLE_TIME{job="customers"} 589
TimelineService_TOTAL_HANDLE_TIME{job="loan_accounts"} 642
```
## Brief change log

Added configuration `hoodie.metrics.common_prefix.enable`
This configuration is true by default and which doesnt change any behavior for existing users.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
