### PR TITLE
[HUDI-3367] Adding scheduling configs support to spark streaming

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/SparkSchedulerConfGenerator.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/SparkSchedulerConfGenerator.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.SparkConf;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.hudi.SparkSchedulerConfigs.COMPACT_POOL_NAME;
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY;
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_FAIR_MODE;
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_MODE_KEY;
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULING_PATTERN;
+
+/**
+ * Utility Class to generate Spark Scheduling allocation file. This kicks in only when user sets
+ * spark.scheduler.mode=FAIR at spark-submit time
+ */
+public class SparkSchedulerConfGenerator {
+
+  private static final Logger LOG = LogManager.getLogger(SparkSchedulerConfGenerator.class);
+
+  /**
+   * Helper to generate spark scheduling configs in XML format with input params.
+   *
+   * @param sparkDataSourceWritesWeight   Scheduling weight for spark data source write
+   * @param compactionWeight              Scheduling weight for compaction
+   * @param sparkDatasourceWritesMinShare Minshare for spark data source writes
+   * @param compactionMinShare            Minshare for compaction
+   * @return Spark scheduling configs
+   */
+  private static String generateConfig(Integer sparkDataSourceWritesWeight, Integer compactionWeight, Integer sparkDatasourceWritesMinShare,
+                                       Integer compactionMinShare) {
+    return String.format(SPARK_SCHEDULING_PATTERN, DataSourceWriteOptions.SPARK_DATASOURCE_WRITER_POOL_NAME(), SPARK_SCHEDULER_FAIR_MODE,
+        sparkDataSourceWritesWeight.toString(), sparkDatasourceWritesMinShare.toString(), COMPACT_POOL_NAME, SPARK_SCHEDULER_FAIR_MODE,
+        compactionWeight.toString(), compactionMinShare.toString());
+  }
+
+  /**
+   * Helper to set Spark Scheduling Configs dynamically.
+   */
+  public static Map<String, String> getSparkSchedulingConfigs(TypedProperties typedProperties, HoodieTableType tableType, SparkConf sparkConf) throws Exception {
+    scala.Option<String> scheduleModeKeyOption = sparkConf.getOption(SPARK_SCHEDULER_MODE_KEY);
+    final Option<String> sparkSchedulerMode =
+        scheduleModeKeyOption.isDefined() ? Option.of(scheduleModeKeyOption.get()) : Option.empty();
+
+    Map<String, String> additionalSparkConfigs = new HashMap<>(1);
+    if (sparkSchedulerMode.isPresent() && SPARK_SCHEDULER_FAIR_MODE.equals(sparkSchedulerMode.get()) && tableType == HoodieTableType.MERGE_ON_READ) {
+      String sparkSchedulingConfFile = generateAndStoreConfig(typedProperties.getInteger(DataSourceWriteOptions.SPARK_DATASOURCE_WRITES_SCHEDULING_WEIGHT().key(),
+              (Integer) DataSourceWriteOptions.SPARK_DATASOURCE_WRITES_SCHEDULING_WEIGHT().defaultValue()),
+          typedProperties.getInteger(DataSourceWriteOptions.COMPACTION_SCHEDULING_WEIGHT().key(),
+              (Integer) DataSourceWriteOptions.COMPACTION_SCHEDULING_WEIGHT().defaultValue()),
+          typedProperties.getInteger(DataSourceWriteOptions.SPARK_DATASOURCE_WRITES_SCHEDULING_MIN_SHARE().key(),
+              (Integer) DataSourceWriteOptions.SPARK_DATASOURCE_WRITES_SCHEDULING_MIN_SHARE().defaultValue()),
+          typedProperties.getInteger(DataSourceWriteOptions.COMPACTION_SCHEDULING_MIN_SHARE().key(),
+              (Integer) DataSourceWriteOptions.COMPACTION_SCHEDULING_MIN_SHARE().defaultValue()));
+      additionalSparkConfigs.put(SPARK_SCHEDULER_ALLOCATION_FILE_KEY, sparkSchedulingConfFile);
+    } else {
+      LOG.warn("Job Scheduling Configs will not be in effect as spark.scheduler.mode "
+          + "is not set to FAIR at instantiation time. Continuing without scheduling configs");
+    }
+    return additionalSparkConfigs;
+  }
+
+  /**
+   * Generate spark scheduling configs and store it to a randomly generated tmp file.
+   *
+   * @param sparkDataSourceWritesWeight   Scheduling weight for delta sync
+   * @param compactionWeight              Scheduling weight for compaction
+   * @param sparkDataSourceWritesMinShare Minshare for delta sync
+   * @param compactionMinShare            Minshare for compaction
+   * @return Return the absolute path of the tmp file which stores the spark schedule configs
+   * @throws IOException Throws an IOException when write configs to file failed
+   */
+  private static String generateAndStoreConfig(Integer sparkDataSourceWritesWeight, Integer compactionWeight,
+                                               Integer sparkDataSourceWritesMinShare, Integer compactionMinShare) throws IOException {
+    File tempConfigFile = File.createTempFile(UUID.randomUUID().toString(), ".xml");
+    BufferedWriter bw = new BufferedWriter(new FileWriter(tempConfigFile));
+    bw.write(generateConfig(sparkDataSourceWritesWeight, compactionWeight, sparkDataSourceWritesMinShare, compactionMinShare));
+    bw.close();
+    LOG.info("Configs written to file" + tempConfigFile.getAbsolutePath());
+    return tempConfigFile.getAbsolutePath();
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/SparkSchedulerConfigs.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/SparkSchedulerConfigs.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi;
+
+import org.apache.hudi.async.AsyncCompactService;
+
+/**
+ * Utility Class to hold spark scheduler configs.
+ */
+public class SparkSchedulerConfigs {
+
+  public static final String COMPACT_POOL_NAME = AsyncCompactService.COMPACT_POOL_NAME;
+  public static final String SPARK_SCHEDULER_MODE_KEY = "spark.scheduler.mode";
+  public static final String SPARK_SCHEDULER_FAIR_MODE = "FAIR";
+  public static final String SPARK_SCHEDULER_ALLOCATION_FILE_KEY = "spark.scheduler.allocation.file";
+
+  public static final String SPARK_SCHEDULING_PATTERN =
+      "<?xml version=\"1.0\"?>\n<allocations>\n  <pool name=\"%s\">\n"
+          + "    <schedulingMode>%s</schedulingMode>\n    <weight>%s</weight>\n    <minShare>%s</minShare>\n"
+          + "  </pool>\n  <pool name=\"%s\">\n    <schedulingMode>%s</schedulingMode>\n"
+          + "    <weight>%s</weight>\n    <minShare>%s</minShare>\n  </pool>\n</allocations>";
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -579,6 +579,35 @@ object DataSourceWriteOptions {
     .withDocumentation("When set to true, will not write the partition columns into hudi. " +
       "By default, false.")
 
+  val SPARK_DATASOURCE_WRITER_POOL_NAME = "sparkdatasourcewrite"
+
+  val SPARK_DATASOURCE_WRITES_SCHEDULING_WEIGHT: ConfigProperty[Int] = ConfigProperty
+    .key("spark.datasource.writes.scheduling.weight")
+    .defaultValue(1)
+    .withDocumentation("Scheduling weight for spark datasource writes as defined in https://spark.apache.org/docs/latest/job-scheduling.html. " +
+      "spark.scheduler.mode should be set to FAIR to leverage this config");
+
+
+  val COMPACTION_SCHEDULING_WEIGHT: ConfigProperty[Int] = ConfigProperty
+    .key("compaction.scheduling.weight")
+    .defaultValue(1)
+    .withDocumentation("Scheduling weight for async compaction as defined in https://spark.apache.org/docs/latest/job-scheduling.html. " +
+      "spark.scheduler.mode should be set to FAIR to leverage this config");
+
+
+  val SPARK_DATASOURCE_WRITES_SCHEDULING_MIN_SHARE: ConfigProperty[Int] = ConfigProperty
+    .key("spark.datasource.writes.scheduling.min.share")
+    .defaultValue(0)
+    .withDocumentation("Scheduling min share for spark datasource writes as defined in https://spark.apache.org/docs/latest/job-scheduling.html. " +
+      "spark.scheduler.mode should be set to FAIR to leverage this config");
+
+
+  val COMPACTION_SCHEDULING_MIN_SHARE: ConfigProperty[Int] = ConfigProperty
+    .key("compaction.scheduling.min.share")
+    .defaultValue(0)
+    .withDocumentation("Scheduling min share for async compaction as defined in https://spark.apache.org/docs/latest/job-scheduling.html. " +
+      "spark.scheduler.mode should be set to FAIR to leverage this config");
+
   /** @deprecated Use {@link HIVE_ASSUME_DATE_PARTITION} and its methods instead */
   @Deprecated
   val HIVE_ASSUME_DATE_PARTITION_OPT_KEY = HIVE_ASSUME_DATE_PARTITION.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -117,6 +117,11 @@ object HoodieSparkSqlWriter {
     }
 
     val jsc = new JavaSparkContext(sparkContext)
+    if (asyncCompactionTriggerFn.isDefined) {
+      val sparkAdditionalConfigs = SparkSchedulerConfGenerator.getSparkSchedulingConfigs(hoodieConfig.getProps, tableType, jsc.getConf)
+      sparkAdditionalConfigs.foreach(kv => jsc.setLocalProperty(kv._1, kv._2))
+      jsc.setLocalProperty("spark.scheduler.pool", DataSourceWriteOptions.SPARK_DATASOURCE_WRITER_POOL_NAME)
+    }
     val instantTime = HoodieActiveTimeline.createNewInstantTime()
     val keyGenerator = HoodieSparkKeyGeneratorFactory.createKeyGenerator(new TypedProperties(hoodieConfig.getProps))
 

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/internal/TestSparkSchedulerConfGenerator.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/internal/TestSparkSchedulerConfGenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.internal;
+
+import org.apache.hudi.SparkSchedulerConfGenerator;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieTableType;
+
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY;
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_MODE_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestSparkSchedulerConfGenerator {
+
+  @Test
+  public void testGenerateSparkSchedulingConf() throws Exception {
+    TypedProperties typedProperties = new TypedProperties();
+    SparkConf sparkConf = new SparkConf();
+    Map<String, String> configs = SparkSchedulerConfGenerator.getSparkSchedulingConfigs(typedProperties, HoodieTableType.COPY_ON_WRITE, sparkConf);
+    assertNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "spark.scheduler.mode not set");
+
+    sparkConf.set(SPARK_SCHEDULER_MODE_KEY, "FAIR");
+    configs = SparkSchedulerConfGenerator.getSparkSchedulingConfigs(typedProperties, HoodieTableType.COPY_ON_WRITE, sparkConf);
+    assertNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "table type is not MERGE_ON_READ");
+
+    configs = SparkSchedulerConfGenerator.getSparkSchedulingConfigs(typedProperties, HoodieTableType.MERGE_ON_READ, sparkConf);
+    assertNotNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "all satisfies");
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -505,7 +505,7 @@ public class HoodieDeltaStreamer implements Serializable {
 
   public static void main(String[] args) throws Exception {
     final Config cfg = getConfig(args);
-    Map<String, String> additionalSparkConfigs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
+    Map<String, String> additionalSparkConfigs = DeltastreamerSchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
     JavaSparkContext jssc =
         UtilHelpers.buildSparkContext("delta-streamer-" + cfg.targetTableName, cfg.sparkMaster, additionalSparkConfigs);
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltastreamerSchedulerConfGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltastreamerSchedulerConfGenerator.java
@@ -24,30 +24,32 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY;
+import static org.apache.hudi.SparkSchedulerConfigs.SPARK_SCHEDULER_MODE_KEY;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class TestSchedulerConfGenerator {
+public class TestDeltastreamerSchedulerConfGenerator {
 
   @Test
   public void testGenerateSparkSchedulingConf() throws Exception {
     HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
-    Map<String, String> configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "spark.scheduler.mode not set");
+    Map<String, String> configs = DeltastreamerSchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
+    assertNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "spark.scheduler.mode not set");
 
-    System.setProperty(SchedulerConfGenerator.SPARK_SCHEDULER_MODE_KEY, "FAIR");
+    System.setProperty(SPARK_SCHEDULER_MODE_KEY, "FAIR");
     cfg.continuousMode = false;
-    configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "continuousMode is false");
+    configs = DeltastreamerSchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
+    assertNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "continuousMode is false");
 
     cfg.continuousMode = true;
     cfg.tableType = HoodieTableType.COPY_ON_WRITE.name();
-    configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY),
+    configs = DeltastreamerSchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
+    assertNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY),
         "table type is not MERGE_ON_READ");
 
     cfg.tableType = HoodieTableType.MERGE_ON_READ.name();
-    configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNotNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "all satisfies");
+    configs = DeltastreamerSchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
+    assertNotNull(configs.get(SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "all satisfies");
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

- Adding support to set scheduling configs to spark streaming writes. With async compaction and spark streaming writes, users can set diff weights and shares across these. 

## Brief change log

- Added configs to DatasSourceWriteOptions for weights and min share for spark datatsource writes and compaction.
- Added support to set up spark scheduling configs to HoodieSparkStreaming writes. 

## Verify this pull request

This change added tests and can be verified as follows:

- Added TestSparkSchedulerConfGenerator to test our spark scheduling configs. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
