### PR TITLE
[HUDI-3402] Set hoodie.parquet.outputtimestamptype to TIMESTAMP_MICROS by default

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieStorageConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieStorageConfig.java
@@ -127,7 +127,7 @@ public class HoodieStorageConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> PARQUET_OUTPUT_TIMESTAMP_TYPE = ConfigProperty
           .key("hoodie.parquet.outputtimestamptype")
-          .defaultValue("TIMESTAMP_MILLIS")
+          .defaultValue("TIMESTAMP_MICROS")
           .withDocumentation("Sets spark.sql.parquet.outputTimestampType. Parquet timestamp type to use when Spark writes data to Parquet files.");
 
   public static final ConfigProperty<String> HFILE_COMPRESSION_ALGORITHM_NAME = ConfigProperty


### PR DESCRIPTION

Hoodie converts `Timestamp` to TIMESTAMP_MICROS format when upsert and other operations, except `bulk_insert`.

And `bulk_insert` enables `hoodie.datasource.write.row.writer.enable`, and use `HoodieRowParquetWriteSupport` to write datas. 

For the issue #4552 , that will cause problems by default. So i suggest to modify the `hoodie.parquet.outputtimestamptype` default value to TIMESTAMP_MICROS so that it will be convenience to users.