### PR TITLE
[HUDI-3373] Add zero value metrics for empty data source and PROMETHEUS_PUSHGATEWAY reporter

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -130,6 +130,26 @@ public class HoodieMetrics {
     return indexTimer == null ? null : indexTimer.time();
   }
 
+  public void updateMetricsForEmptyData(String actionType) {
+    if (!config.isMetricsOn() || !config.getMetricsReporterType().equals(MetricsReporterType.PROMETHEUS_PUSHGATEWAY)) {
+      // No-op if metrics are not of type PROMETHEUS_PUSHGATEWAY.
+      return;
+    }
+    Metrics.registerGauge(getMetricsName(actionType, "totalPartitionsWritten"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalFilesInsert"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalFilesUpdate"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalRecordsWritten"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalUpdateRecordsWritten"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalInsertRecordsWritten"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalBytesWritten"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalScanTime"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalCreateTime"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalUpsertTime"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalCompactedRecordsUpdated"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesCompacted"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesSize"), 0);
+  }
+
   public void updateCommitMetrics(long commitEpochTimeInMs, long durationInMs, HoodieCommitMetadata metadata,
       String actionType) {
     updateCommitTimingMetrics(commitEpochTimeInMs, durationInMs, metadata, actionType);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -58,6 +58,7 @@ import org.apache.hudi.keygen.KeyGenerator;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory;
+import org.apache.hudi.metrics.HoodieMetrics;
 import org.apache.hudi.sync.common.AbstractSyncTool;
 import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.callback.kafka.HoodieWriteCommitKafkaCallback;
@@ -213,6 +214,8 @@ public class DeltaSync implements Serializable {
 
   private transient HoodieDeltaStreamerMetrics metrics;
 
+  private transient HoodieMetrics hoodieMetrics;
+
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
                    TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
                    Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
@@ -233,6 +236,7 @@ public class DeltaSync implements Serializable {
     this.transformer = UtilHelpers.createTransformer(cfg.transformerClassNames);
 
     this.metrics = new HoodieDeltaStreamerMetrics(getHoodieClientConfig(this.schemaProvider));
+    this.hoodieMetrics = new HoodieMetrics(getHoodieClientConfig(this.schemaProvider));
 
     this.formatAdapter = new SourceFormatAdapter(
         UtilHelpers.createSource(cfg.sourceClassName, props, jssc, sparkSession, schemaProvider, metrics));
@@ -325,6 +329,8 @@ public class DeltaSync implements Serializable {
       result = writeToSink(srcRecordsWithCkpt.getRight().getRight(),
           srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
     }
+    String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
+    hoodieMetrics.updateMetricsForEmptyData(commitActionType);
 
     metrics.updateDeltaStreamerSyncMetrics(System.currentTimeMillis());
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -329,8 +329,6 @@ public class DeltaSync implements Serializable {
       result = writeToSink(srcRecordsWithCkpt.getRight().getRight(),
           srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
     }
-    String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
-    hoodieMetrics.updateMetricsForEmptyData(commitActionType);
 
     metrics.updateDeltaStreamerSyncMetrics(System.currentTimeMillis());
 
@@ -465,6 +463,8 @@ public class DeltaSync implements Serializable {
     if (Objects.equals(checkpointStr, resumeCheckpointStr.orElse(null))) {
       LOG.info("No new data, source checkpoint has not changed. Nothing to commit. Old checkpoint=("
           + resumeCheckpointStr + "). New Checkpoint=(" + checkpointStr + ")");
+      String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
+      hoodieMetrics.updateMetricsForEmptyData(commitActionType);
       return null;
     }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Prometheus [Pushgateway](https://prometheus.io/docs/practices/pushing/) never forgets series pushed to it and will expose them to Prometheus forever unless those series are manually deleted via the Pushgateway's API. When deltastreamer finds that there are no new records to be read from the source since the last checkpoint it doesn't emit a metric because the write path is not triggered and leads to a graph like below in case of PushGateway metrics reporter. For other metrics reporter it would be a null value and no data will be shown in the graph.

`22/02/07 11:23:10 INFO DeltaSync: No new data, source checkpoint has not changed. Nothing to commit. Old checkpoint=(Option{val=20220207062847034}). New Checkpoint=(20220207062847034)`

![image](https://user-images.githubusercontent.com/16958856/152838666-da7e30b0-0cfb-4e19-97e5-131220cc60e5.png)

To give a better representation of the actual metrics for Prometheus PushGateway, the counter metrics have to be updated with zero value so that it's better than having stale data which was ingested as part of the last checkpoint.
![image](https://user-images.githubusercontent.com/16958856/152838714-39576af8-622b-4208-8981-414451c34028.png)

This is an issue only w/ continuous mode. 


## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
