### PR TITLE
[HUDI-3400] Avoid throw exception when create hoodie table

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.sink.compact.FlinkCompactionConfig;
 import org.apache.hudi.table.HoodieFlinkTable;
@@ -115,7 +116,8 @@ public class CompactionUtil {
    */
   public static void inferChangelogMode(Configuration conf, HoodieTableMetaClient metaClient) throws Exception {
     TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
-    Schema tableAvroSchema = tableSchemaResolver.getTableAvroSchemaFromDataFile();
+    Schema tableAvroSchema = tableSchemaResolver.getTableAvroSchemaFromDataFile().orElseThrow(
+        () -> new HoodieException("Failed to get table avro schema"));
     if (tableAvroSchema.getField(HoodieRecord.OPERATION_METADATA_FIELD) != null) {
       conf.setBoolean(FlinkOptions.CHANGELOG_ENABLED, true);
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestTableSchemaResolverWithSparkSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestTableSchemaResolverWithSparkSQL.scala
@@ -223,7 +223,7 @@ class TestTableSchemaResolverWithSparkSQL {
     metaClient.reloadActiveTimeline()
     var tableSchemaResolverParsingException: Exception = null
     try {
-      val schemaFromData = new TableSchemaResolver(metaClient).getTableAvroSchemaFromDataFile
+      val schemaFromData = new TableSchemaResolver(metaClient).getTableAvroSchemaFromDataFile.get
       val structFromData = AvroConversionUtils.convertAvroSchemaToStructType(HoodieAvroUtils.removeMetadataFields(schemaFromData))
       val schemeDesign = new Schema.Parser().parse(schemaString)
       val structDesign = AvroConversionUtils.convertAvroSchemaToStructType(schemeDesign)


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*Now, when create a hudi table, IllegalArgumentException will be thrown because of there is no data file, but has no effect on result, this PR will fix it.*

Link: [HUDI-3400](https://issues.apache.org/jira/browse/HUDI-3400)

## Brief change log

  - *Check whether data file exist in `TableSchemaResolver#hasOperationField` when init TableSchemaResolver*

## Verify this pull request

This pull request is already covered by existing tests, such as *TestCreateTable*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
