### PR TITLE
[HUDI-3264]: made schema registry urls configurable with MTDS

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -50,7 +50,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
   public static class Config {
 
     public static final String SRC_SCHEMA_REGISTRY_URL_PROP = "hoodie.deltastreamer.schemaprovider.registry.url";
-    private static final String TARGET_SCHEMA_REGISTRY_URL_PROP =
+    public static final String TARGET_SCHEMA_REGISTRY_URL_PROP =
         "hoodie.deltastreamer.schemaprovider.registry.targetUrl";
   }
 

--- a/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
@@ -23,3 +23,5 @@ hoodie.deltastreamer.keygen.timebased.timestamp.type=UNIX_TIMESTAMP
 hoodie.deltastreamer.keygen.timebased.input.dateformat=yyyy-MM-dd HH:mm:ss.S
 hoodie.datasource.hive_sync.table=short_trip_uber_hive_dummy_table
 hoodie.datasource.write.keygenerator.class=org.apache.hudi.utilities.functional.TestHoodieDeltaStreamer$TestTableLevelGenerator
+hoodie.deltastreamer.schemaprovider.registry.baseUrl=http://localhost:8081/subjects/
+hoodie.deltastreamer.schemaprovider.registry.urlSuffix=-value/versions/latest

--- a/hudi-utilities/src/test/resources/delta-streamer-config/uber_config.properties
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/uber_config.properties
@@ -23,3 +23,5 @@ hoodie.deltastreamer.keygen.timebased.timestamp.type=UNIX_TIMESTAMP
 hoodie.deltastreamer.keygen.timebased.input.dateformat=yyyy-MM-dd HH:mm:ss.S
 hoodie.datasource.hive_sync.database=uber_hive_db
 hoodie.datasource.hive_sync.table=uber_hive_dummy_table
+hoodie.deltastreamer.schemaprovider.registry.url=http://localhost:8081/subjects/random-value/versions/latest
+hoodie.deltastreamer.schemaprovider.registry.targetUrl=http://localhost:8081/subjects/random-value/versions/latest


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Made schema registry url configs more flexible as per the request in https://github.com/apache/hudi/issues/4585

## Brief change log

- Added a check for source and target schema registry urls in table overridden properties
- Added test cases

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
