### PR TITLE
[HUDI-3408] fixed the bug that BUCKET_INDEX cannot process special ch…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -43,7 +43,7 @@ public class BucketIdentifier {
     } else {
       Map<String, String> recordKeyPairs = Arrays.stream(hoodieKey.getRecordKey().split(","))
           .map(p -> p.split(":"))
-          .collect(Collectors.toMap(p -> p[0], p -> p[1]));
+          .collect(Collectors.toMap(p -> p[0], p -> p.length == 1 ? "" : p[1]));
       hashKeyFields = Arrays.stream(indexKeyFields.split(","))
           .map(f -> recordKeyPairs.get(f))
           .collect(Collectors.toList());

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -630,4 +630,31 @@ class TestInsertTable extends TestHoodieSqlBase {
       }
     }
   }
+
+  test("Test insert for bucket index") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+      spark.sql(
+        s"""
+          |create table $tableName (
+          |id int, comb int, col1 string
+          |) using hudi
+          |location '${tablePath}'
+          |options (
+          |primaryKey = 'id,col1',
+          |preCombineField = 'comb',
+          |hoodie.index.type = 'BUCKET',
+          |hoodie.bucket.index.num.buckets = '100',
+          |hoodie.storage.layout.type = 'BUCKET'
+          |)
+        """.stripMargin)
+
+      spark.sql(
+        s"""
+          |insert into $tableName values
+          |(1, 1, ':::')
+        """.stripMargin)
+    }
+  }
 }


### PR DESCRIPTION
…aracters

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
BucketIdentifier use split(":") to split  recordKeyName and recordKeyValue,  if current recordKeyValue is  ":::"  ,  above split give a wrong result.
test code： 

   ``` withTempDir { tmp =>
      Seq("mor").foreach { tableType =>
        val tableName = generateTableName
        val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
        spark.sql(
          s"""
             |create table $tableName (
             |  id int, comb int, col0 int, col1 bigint, col2 float, col3 double, col4 decimal(10,4), col5 string, col6 date, col7 timestamp, col8 boolean, col9 binary, par date
             |) using hudi
             | location '$tablePath'
             | options (
             |  type = '$tableType',
             |  primaryKey = 'id,col0,col5',
             |  preCombineField = 'comb',
             |  hoodie.index.type = 'BUCKET',
             |  hoodie.bucket.index.num.buckets = '900'
             | )
             | partitioned by (par)
             """.stripMargin)
        spark.sql(
          s"""
             | insert into $tableName values
             | (1,1,11,100001,101.01,1001.0001,100001.0001,':::','2021-12-25','2021-12-25 12:01:01',true,'a01','2021-12-25'),
             | (2,2,12,100002,102.02,1002.0002,100002.0002,'a000002','2021-12-25','2021-12-25 12:02:02',true,'a02','2021-12-25'),
             | (3,3,13,100003,103.03,1003.0003,100003.0003,'a000003','2021-12-25','2021-12-25 12:03:03',false,'a03','2021-12-25'),
             | (4,4,14,100004,104.04,1004.0004,100004.0004,'a000004','2021-12-26','2021-12-26 12:04:04',true,'a04','2021-12-26'),
             | (5,5,15,100005,105.05,1005.0005,100005.0005,'a000005','2021-12-26','2021-12-26 12:05:05',false,'a05','2021-12-26')
             |""".stripMargin)
      }
    }
  }```

Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
	at org.apache.hudi.index.bucket.BucketIdentifier.lambda$getBucketId$2(BucketIdentifier.java:46)
	at java.util.stream.Collectors.lambda$toMap$58(Collectors.java:1321)
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at org.apache.hudi.index.bucket.BucketIdentifier.getBucketId(BucketIdentifier.java:46)
	at org.apache.hudi.index.bucket.BucketIdentifier.getBucketId(BucketIdentifier.java:36)
	at org.apache.hudi.index.bucket.SparkBucketIndex$1.computeNext(SparkBucketIndex.java:80)
	at org.apache.hudi.index.bucket.SparkBucketIndex$1.computeNext(SparkBucketIndex.java:70)
	at org.apache.hudi.client.utils.LazyIterableIterator.next(LazyIterableIterator.java:125)
	... 25 more

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
