### PR TITLE
[HUDI-3412] TypedProperties no need to create new set when check key …

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -44,14 +43,9 @@ public class TypedProperties extends Properties implements Serializable {
   }
 
   private void checkKey(String property) {
-    if (!keyExists(property)) {
+    if (!containsKey(property)) {
       throw new IllegalArgumentException("Property " + property + " not found");
     }
-  }
-
-  private boolean keyExists(String property) {
-    Set<String> keys = super.stringPropertyNames();
-    return keys.contains(property);
   }
 
   public String getString(String property) {
@@ -60,11 +54,11 @@ public class TypedProperties extends Properties implements Serializable {
   }
 
   public String getString(String property, String defaultValue) {
-    return keyExists(property) ? getProperty(property) : defaultValue;
+    return containsKey(property) ? getProperty(property) : defaultValue;
   }
 
   public List<String> getStringList(String property, String delimiter, List<String> defaultVal) {
-    if (!keyExists(property)) {
+    if (!containsKey(property)) {
       return defaultVal;
     }
     return Arrays.stream(getProperty(property).split(delimiter)).map(String::trim).collect(Collectors.toList());
@@ -76,7 +70,7 @@ public class TypedProperties extends Properties implements Serializable {
   }
 
   public int getInteger(String property, int defaultValue) {
-    return keyExists(property) ? Integer.parseInt(getProperty(property)) : defaultValue;
+    return containsKey(property) ? Integer.parseInt(getProperty(property)) : defaultValue;
   }
 
   public long getLong(String property) {
@@ -85,7 +79,7 @@ public class TypedProperties extends Properties implements Serializable {
   }
 
   public long getLong(String property, long defaultValue) {
-    return keyExists(property) ? Long.parseLong(getProperty(property)) : defaultValue;
+    return containsKey(property) ? Long.parseLong(getProperty(property)) : defaultValue;
   }
 
   public boolean getBoolean(String property) {
@@ -94,7 +88,7 @@ public class TypedProperties extends Properties implements Serializable {
   }
 
   public boolean getBoolean(String property, boolean defaultValue) {
-    return keyExists(property) ? Boolean.parseBoolean(getProperty(property)) : defaultValue;
+    return containsKey(property) ? Boolean.parseBoolean(getProperty(property)) : defaultValue;
   }
 
   public double getDouble(String property) {
@@ -103,6 +97,6 @@ public class TypedProperties extends Properties implements Serializable {
   }
 
   public double getDouble(String property, double defaultValue) {
-    return keyExists(property) ? Double.parseDouble(getProperty(property)) : defaultValue;
+    return containsKey(property) ? Double.parseDouble(getProperty(property)) : defaultValue;
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

TypedProperties.keyExist has a very bad performance because it copy all properties during check, actually this is unnecessary after this pr: [HUDI-1943](https://issues.apache.org/jira/browse/HUDI-1943)
For example, when doing bulk insert, can see flame graph below:
![Screen Shot 2022-02-11 at 4 53 14 PM](https://user-images.githubusercontent.com/10115332/153563449-3e7f8672-035c-47b7-add0-05666983b0d8.png)

After the patch, the time spent of our internal job reduced to 10min compared to several hours before.
## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
