### PR TITLE
[HUDI-2761] Fixing unnecessary refreshing of timeline in Timelineserver

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
@@ -269,7 +269,7 @@ public class FileSystemViewCommand implements CommandMarker {
     }
 
     HoodieTimeline filteredTimeline = new HoodieDefaultTimeline(instantsStream,
-        (Function<HoodieInstant, Option<byte[]>> & Serializable) metaClient.getActiveTimeline()::getInstantDetails);
+        (Function<HoodieInstant, Option<byte[]>> & Serializable) metaClient.getActiveTimeline()::getInstantDetails, timeline.getLastUpdateTime());
     return new HoodieTableFileSystemView(metaClient, filteredTimeline, statuses.toArray(new FileStatus[0]));
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTimelineArchiveLog.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTimelineArchiveLog.java
@@ -491,7 +491,7 @@ public class HoodieTimelineArchiveLog<T extends HoodieAvroPayload, I, K, O> {
           metaClient.scanHoodieInstantsFromFileSystem(
               new Path(metaClient.getMetaAuxiliaryPath()),
               HoodieActiveTimeline.VALID_EXTENSIONS_IN_ACTIVE_TIMELINE,
-              false);
+              false).getKey();
     } catch (FileNotFoundException e) {
       /*
        * On some FSs deletion of all files in the directory can auto remove the directory itself.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -118,7 +118,8 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     // Filter all the filter in the metapath and include only the extensions passed and
     // convert them into HoodieInstant
     try {
-      this.setInstants(metaClient.scanHoodieInstantsFromFileSystem(includedExtensions, applyLayoutFilters));
+      Pair<List<HoodieInstant>, Long> instantsResult = metaClient.scanHoodieInstantsFromFileSystem(includedExtensions, applyLayoutFilters);
+      this.setInstants(instantsResult.getKey(), instantsResult.getValue());
     } catch (IOException e) {
       throw new HoodieIOException("Failed to scan metadata", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -282,6 +282,8 @@ public interface HoodieTimeline extends Serializable {
    */
   Option<byte[]> getInstantDetails(HoodieInstant instant);
 
+  long getLastUpdateTime();
+
   boolean isEmpty(HoodieInstant instant);
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/TimelineDTO.java
@@ -37,15 +37,19 @@ public class TimelineDTO {
   @JsonProperty("instants")
   List<InstantDTO> instants;
 
+  @JsonProperty("lastUpdatedTime")
+  Long lastUpdatedTime;
+
   public static TimelineDTO fromTimeline(HoodieTimeline timeline) {
     TimelineDTO dto = new TimelineDTO();
     dto.instants = timeline.getInstants().map(InstantDTO::fromInstant).collect(Collectors.toList());
+    dto.lastUpdatedTime = timeline.getLastUpdateTime();
     return dto;
   }
 
   public static HoodieTimeline toTimeline(TimelineDTO dto, HoodieTableMetaClient metaClient) {
     // TODO: For Now, we will assume, only active-timeline will be transferred.
     return new HoodieDefaultTimeline(dto.instants.stream().map(InstantDTO::toInstant),
-        metaClient.getActiveTimeline()::getInstantDetails);
+        metaClient.getActiveTimeline()::getInstantDetails, dto.lastUpdatedTime);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -118,7 +118,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
   public static final String TIMELINE_HASH = "timelinehash";
   public static final String REFRESH_OFF = "refreshoff";
   public static final String INCLUDE_FILES_IN_PENDING_COMPACTION_PARAM = "includependingcompaction";
-
+  public static final String TIMELINE_LAST_UPDATED_TIME = "timelinelastupdatedtime";
 
   private static final Logger LOG = LogManager.getLogger(RemoteHoodieTableFileSystemView.class);
 
@@ -162,6 +162,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     // Adding mandatory parameters - Last instants affecting file-slice
     timeline.lastInstant().ifPresent(instant -> builder.addParameter(LAST_INSTANT_TS, instant.getTimestamp()));
     builder.addParameter(TIMELINE_HASH, timeline.getTimelineHash());
+    builder.addParameter(TIMELINE_LAST_UPDATED_TIME, Long.toString(timeline.getLastUpdateTime()));
 
     String url = builder.toString();
     LOG.info("Sending request : (" + url + ")");

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -748,7 +748,7 @@ public class HoodieTableMetadataUtil {
     if (timeline.empty()) {
       final HoodieInstant instant = new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION,
           HoodieActiveTimeline.createNewInstantTime());
-      timeline = new HoodieDefaultTimeline(Arrays.asList(instant).stream(), metaClient.getActiveTimeline()::getInstantDetails);
+      timeline = new HoodieDefaultTimeline(Arrays.asList(instant).stream(), metaClient.getActiveTimeline()::getInstantDetails, metaClient.getActiveTimeline().getLastUpdateTime());
     }
     return new HoodieTableFileSystemView(metaClient, timeline);
   }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -42,9 +42,6 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
 
   private static final Logger LOG = LogManager.getLogger(TestRemoteHoodieTableFileSystemView.class);
 
-  private TimelineService server;
-  private RemoteHoodieTableFileSystemView view;
-
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) {
     FileSystemViewStorageConfig sConf =
         FileSystemViewStorageConfig.newBuilder().withStorageType(FileSystemViewStorageType.SPILLABLE_DISK).build();
@@ -52,6 +49,7 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
     HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().build();
     HoodieLocalEngineContext localEngineContext = new HoodieLocalEngineContext(metaClient.getHadoopConf());
 
+    TimelineService server;
     try {
       server = new TimelineService(localEngineContext, new Configuration(),
           TimelineService.Config.builder().serverPort(0).build(), FileSystem.get(new Configuration()),
@@ -61,7 +59,6 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
       throw new RuntimeException(ex);
     }
     LOG.info("Connecting to Timeline Server :" + server.getServerPort());
-    view = new RemoteHoodieTableFileSystemView("localhost", server.getServerPort(), metaClient);
-    return view;
+    return new RemoteHoodieTableFileSystemView("localhost", server.getServerPort(), metaClient);
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

Timeline server when serving remote requests, has a logic to refresh its local view of the timeline based on timeline hash. Client sends a timeline hash and timeline server compares with its local timeline hash and if they differ, a refresh of timeline happens before serving the request. But this refresh gets triggered even if the client is behind, but the server is already caught up. This could have severe perf impact with async table services and spark streaming pipeline use-cases where commit throughput is high. So, adding a new value to be maintained by the timeline for lastUpdatedTime. and the same will be sent as param with remote request as well. 

Fix: So, the fix ensures that timeline server triggers a refresh of local timeline only if its lastUpdatedTime < client's lastUpdatedTime. 

To discuss: 
Clocks could differ in timeline server compared to that of the executor (client) and there could be drift as well. So, not very sure if we can rely on the exact comparison of last updated time between client and server. 

Another option: I am wondering if we can rely on lastKnownInstant(HoodieInstant) from client and compare it w/ that of timeline in timeline server and decide whether to refresh or not instead of the lastUpdatedTime. 

## Brief change log

- Added lastUpdatedTime to HoodieTimeline which gets refreshed whenever the timeline is updated. The same value is sent via remote requests to Timeline server. 
- Timeline server triggers a refresh of its local timeline only if its lastUpdatedTime < client's lastUpdatedTime in addition to  timeline hash mismatch. 

Thanks to [guanziyue](https://github.com/guanziyue) who helped us with the fix. 

## Verify this pull request

- Couple of users in the community actually tested this and contributed the patch. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
