### PR TITLE
[MINOR] Prevent async service from starting twice

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
@@ -125,6 +125,10 @@ public abstract class HoodieAsyncService implements Serializable {
    * @param onShutdownCallback
    */
   public void start(Function<Boolean, Boolean> onShutdownCallback) {
+    if (started) {
+      LOG.warn("The async service already started.");
+      return;
+    }
     Pair<CompletableFuture, ExecutorService> res = startService();
     future = res.getKey();
     executor = res.getValue();


### PR DESCRIPTION
Check `started` flag before starting async service.