### PR TITLE
[HUDI-3418] Save timeout option for remote RemoteFileSystemView

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -112,8 +112,12 @@ public class EmbeddedTimelineService {
     FileSystemViewStorageType viewStorageType = writeConfig.getClientSpecifiedViewStorageConfig()
         .shouldEnableBackupForRemoteFileSystemView()
         ? FileSystemViewStorageType.REMOTE_FIRST : FileSystemViewStorageType.REMOTE_ONLY;
-    return FileSystemViewStorageConfig.newBuilder().withStorageType(viewStorageType)
-        .withRemoteServerHost(hostAddr).withRemoteServerPort(serverPort).build();
+    return FileSystemViewStorageConfig.newBuilder()
+        .withStorageType(viewStorageType)
+        .withRemoteServerHost(hostAddr)
+        .withRemoteServerPort(serverPort)
+        .withRemoteTimelineClientTimeoutSecs(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientTimeoutSecs())
+        .build();
   }
 
   public FileSystemViewManager getViewManager() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -240,7 +240,7 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withRemoteTimelineClientTimeoutSecs(Long timelineClientTimeoutSecs) {
+    public Builder withRemoteTimelineClientTimeoutSecs(Integer timelineClientTimeoutSecs) {
       fileSystemViewStorageConfig.setValue(REMOTE_TIMEOUT_SECS, timelineClientTimeoutSecs.toString());
       return this;
     }

--- a/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -406,7 +406,9 @@ public class StreamerUtil {
     FileSystemViewStorageConfig rebuilt = FileSystemViewStorageConfig.newBuilder()
         .withStorageType(viewStorageConfig.getStorageType())
         .withRemoteServerHost(viewStorageConfig.getRemoteViewServerHost())
-        .withRemoteServerPort(viewStorageConfig.getRemoteViewServerPort()).build();
+        .withRemoteServerPort(viewStorageConfig.getRemoteViewServerPort())
+        .withRemoteTimelineClientTimeoutSecs(viewStorageConfig.getRemoteTimelineClientTimeoutSecs())
+        .build();
     ViewStorageProperties.createProperties(conf.getString(FlinkOptions.PATH), rebuilt);
     return writeClient;
   }

--- a/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -397,6 +397,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
 
   @Test
   public void testReuseEmbeddedServer() throws IOException {
+    conf.setInteger("hoodie.filesystem.view.remote.timeout.secs", 500);
     HoodieFlinkWriteClient writeClient = StreamerUtil.createWriteClient(conf);
     FileSystemViewStorageConfig viewStorageConfig = writeClient.getConfig().getViewStorageConfig();
 
@@ -406,6 +407,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
     writeClient = StreamerUtil.createWriteClient(conf);
     assertSame(writeClient.getConfig().getViewStorageConfig().getStorageType(), FileSystemViewStorageType.REMOTE_FIRST);
     assertEquals(viewStorageConfig.getRemoteViewServerPort(), writeClient.getConfig().getViewStorageConfig().getRemoteViewServerPort());
+    assertEquals(viewStorageConfig.getRemoteTimelineClientTimeoutSecs(), 500);
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

When the EmbeddedTimelineService started and update `ViewStorageConfig` to `RemoteFileSystemViewConfig`, the `hoodie.filesystem.view.remote.timeout.secs` option is not in `RemoteFileSystemViewConfig`.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
