### PR TITLE
[HUDI-3450] Avoid passing empty string spark master to hudi cli

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -79,7 +79,9 @@ public class SparkUtil {
     if (properties.getProperty(HoodieCliSparkConfig.CLI_SPARK_MASTER) != null) {
       sparkMasterNode = properties.getProperty(HoodieCliSparkConfig.CLI_SPARK_MASTER);
     }
-    sparkMasterNode = sparkMaster.orElse(sparkMasterNode);
+    if (sparkMaster.isPresent() && !sparkMaster.get().trim().isEmpty()) {
+      sparkMasterNode = sparkMaster.orElse(sparkMasterNode);
+    }
     sparkConf.setMaster(sparkMasterNode);
 
     // Configure driver

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/SparkUtilTest.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/testutils/SparkUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.cli.testutils;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.cli.utils.SparkUtil;
+import org.apache.spark.SparkConf;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SparkUtilTest {
+  @Test
+  public void testGetDefaultSparkConf() {
+    SparkConf sparkConf = SparkUtil.getDefaultConf("test-spark-app", Option.of(""));
+    assertEquals(SparkUtil.DEFAULT_SPARK_MASTER, sparkConf.get("spark.master"));
+  }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

When not passing SparkMaster, by default Hudi CLI should use [SparkUtil.DEFAULT_SPARK_MASTER](https://github.com/apache/hudi/blob/release-0.10.0/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java#L44). However, w/ a recent [code change](https://github.com/apache/hudi/commit/445208a0d20b457daeeb5f70995302c92dd19f31) in OSS, when SparkMaster is not passed, it would set Spark master to "" which causes the following exception when initializing a Hudi CLI job:


```
{{org.apache.spark.SparkException: Could not parse Master URL: ''at org.apache.spark.SparkContext$.org$apache$spark$SparkContext$$createTaskScheduler(SparkContext.scala:2999)

at org.apache.spark.SparkContext.<init>(SparkContext.scala:567)

at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
```

## Brief change log


## Verify this pull request

This change added tests and can be verified as follows:

  - *Added testGetDefaultSparkConf to verify the change.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
