### PR TITLE
[HUDI-3432] Fixing restore with metadata enabled

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -577,6 +577,8 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         TimelineLayoutVersion.CURR_VERSION).build();
     client = getHoodieWriteClient(newConfig);
 
+    client.savepoint("004", "user1","comment1");
+
     client.restoreToInstant("004");
 
     assertFalse(metaClient.reloadActiveTimeline().getRollbackTimeline().lastInstant().isPresent());

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -88,7 +88,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "default" : null
         },
         {
             "doc": "Metadata Index of column statistics for all data files in the user table",
@@ -163,7 +164,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "default" : null
         }
     ]
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDD.scala
@@ -20,9 +20,8 @@ package org.apache.hudi
 
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
-
 import org.apache.hadoop.conf.Configuration
-
+import org.apache.hadoop.fs.Path
 import org.apache.hudi.HoodieDataSourceHelper._
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner
@@ -30,7 +29,6 @@ import org.apache.hudi.config.HoodiePayloadConfig
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.hadoop.config.HoodieRealtimeConfig
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.HOODIE_RECORD_KEY_COL_POS
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.avro.{HoodieAvroDeserializer, HoodieAvroSerializer}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -40,7 +38,6 @@ import org.apache.spark.{Partition, SerializableWritable, SparkContext, TaskCont
 
 import java.io.Closeable
 import java.util.Properties
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Try
@@ -325,6 +322,7 @@ private object HoodieMergeOnReadRDD {
 
   def scanLog(split: HoodieMergeOnReadFileSplit, logSchema: Schema, config: Configuration): HoodieMergedLogRecordScanner = {
     val fs = FSUtils.getFs(split.tablePath, config)
+    val partitionPath = new Path(split.logPaths.get.asJava.get(0)).getParent.getName
     HoodieMergedLogRecordScanner.newBuilder()
       .withFileSystem(fs)
       .withBasePath(split.tablePath)
@@ -343,6 +341,7 @@ private object HoodieMergeOnReadRDD {
       .withSpillableMapBasePath(
         config.get(HoodieRealtimeConfig.SPILLABLE_MAP_BASE_PATH_PROP,
           HoodieRealtimeConfig.DEFAULT_SPILLABLE_MAP_BASE_PATH))
+      .withPartition(partitionPath)
       .build()
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

- Found couple of issues while testing restore w/ metadata enabled (COW and MOR table). 
- avro schema for metadata payload did not have default set to null for colsStats and bloomFilterMetadata that got added recently. Was running into issues with avro deserialization. 
- While reading logs for metadata table, partition name was not set with MergedLogRecordScanner. Have created a follow [ticket](https://issues.apache.org/jira/browse/HUDI-3454) to chase all such code paths and fix. 

## Verify this pull request

- Tested restore for COW and MOR table for few scenarios. restore succeeded and validated the table after restore to ensure table record count matched the restored commit. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
