### PR TITLE
[MINOR] Add hive-standalone-metastore dependency to hudi-flink-bundle module

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -136,7 +136,8 @@
                   <include>org.apache.hive:hive-common</include>
                   <include>org.apache.hive:hive-service</include>
                   <include>org.apache.hive:hive-service-rpc</include>
-                  <include>org.apache.hive:hive-exec</include>
+		  <include>org.apache.hive:hive-exec</include>
+		  <include>org.apache.hive:hive-standalone-metastore</include>
                   <include>org.apache.hive:hive-metastore</include>
                   <include>org.apache.hive:hive-jdbc</include>
                   <include>org.datanucleus:datanucleus-core</include>
@@ -640,6 +641,12 @@
         <dependency>
           <groupId>${hive.groupid}</groupId>
           <artifactId>hive-service-rpc</artifactId>
+          <version>${hive.version}</version>
+          <scope>${flink.bundle.hive.scope}</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive.groupid}</groupId>
+          <artifactId>hive-standalone-metastore</artifactId>
           <version>${hive.version}</version>
           <scope>${flink.bundle.hive.scope}</scope>
         </dependency>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Solve the problem of "Caused by: java.lang.ClassNotFoundException: org.apache.hudi.org.apache.hadoop.hive.metastore.api.NoSuchObjectException
" in hive 3.

## Brief change log

add dependency

```xml
        <dependency>
          <groupId>org.apache.hive</groupId>
          <artifactId>hive-standalone-metastore</artifactId>
          <version>${hive.version}</version>
          <scope>${flink.bundle.hive.scope}</scope>
        </dependency>
```

to hudi-flink-bundle module

## Verify this pull request

*(Please pick either of the following options)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

I compile the source code of hudi with hive 3, and succeed in synchronizing the data to hive;

The test tutorial: 

```sql
CREATE TABLE sourceT (
  uuid varchar(20),
  name varchar(10),
  age int,
  ts timestamp(3),
  `partition` varchar(20)
) WITH (
  'connector' = 'datagen',
  'rows-per-second' = '1'
);

create table t2(
  uuid varchar(20),
  name varchar(10),
  age int,
  ts timestamp(3),
  `partition` varchar(20)
)
with (
  'connector' = 'hudi',
  'path' = 'hdfs://host146:8020/hudi/t4', -- $HUDI_DEMO 替换成的绝对路径
  'table.type' = 'MERGE_ON_READ',
  'write.bucket_assign.tasks' = '2',
  'write.tasks' = '2',
  'hive_sync.enable' = 'true',
  'hive_sync.mode' = 'hms',
  'hive_sync.metastore.uris' = 'thrift://host145:9083' -- ip 替换成 HMS 的地址
);

insert into t2 select * from sourceT;
```

Test result:

![image](https://user-images.githubusercontent.com/46479816/155126847-b36463d0-2372-41d8-9c99-56554a7f753b.png)


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [✔ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
