### PR TITLE
[HUDI-3487] The global index is enabled regardless of changlog

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
@@ -107,8 +107,7 @@ public class BucketAssignFunction<K, I, O extends HoodieRecord<?>>
     this.conf = conf;
     this.isChangingRecords = WriteOperationType.isChangingRecords(
         WriteOperationType.fromValue(conf.getString(FlinkOptions.OPERATION)));
-    this.globalIndex = conf.getBoolean(FlinkOptions.INDEX_GLOBAL_ENABLED)
-        && !conf.getBoolean(FlinkOptions.CHANGELOG_ENABLED);
+    this.globalIndex = conf.getBoolean(FlinkOptions.INDEX_GLOBAL_ENABLED);
   }
 
   @Override


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Handling the logic error of global index startup leads to the problem of partition table data redundancy when both changglobal and global index are enabled. Reference issue #4868 

## Brief change log

  - *Modify BucketAssignFunction Constructor  in org.apache.hudi.sink.partitioner.BucketAssignFunction*

## Verify this pull request

It can solve issue #4868 
### before
![image](https://user-images.githubusercontent.com/59957056/155245820-de49ad72-6f55-4695-a36d-b560dab1d041.png)

### update the data
`
update users_cdc3 
set date_str = '2022-1-25' , name3  = 'ccccccddddeee'
where id = 462;
`

### result
![image](https://user-images.githubusercontent.com/59957056/155245879-3f231eba-6be2-476a-847c-16e93cf212ab.png)

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [Y ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
