### PR TITLE
[HUDI-3486] Fix wrong field order for constructing HoodieMetadataColumnStats

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -157,16 +157,16 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
         if (v == null) {
           throw new HoodieMetadataException("Valid " + SCHEMA_FIELD_ID_COLUMN_STATS + " record expected for type: " + METADATA_TYPE_COLUMN_STATS);
         }
-        columnStatMetadata = new HoodieMetadataColumnStats(
-            (String) v.get(COLUMN_STATS_FIELD_RESOURCE_NAME),
-            (String) v.get(COLUMN_STATS_FIELD_MIN_VALUE),
-            (String) v.get(COLUMN_STATS_FIELD_MAX_VALUE),
-            (Long) v.get(COLUMN_STATS_FIELD_NULL_COUNT),
-            (Long) v.get(COLUMN_STATS_FIELD_VALUE_COUNT),
-            (Long) v.get(COLUMN_STATS_FIELD_TOTAL_SIZE),
-            (Long) v.get(COLUMN_STATS_FIELD_TOTAL_UNCOMPRESSED_SIZE),
-            (Boolean) v.get(COLUMN_STATS_FIELD_IS_DELETED)
-        );
+        columnStatMetadata = HoodieMetadataColumnStats.newBuilder()
+            .setFileName((String) v.get(COLUMN_STATS_FIELD_RESOURCE_NAME))
+            .setMinValue((String) v.get(COLUMN_STATS_FIELD_MIN_VALUE))
+            .setMaxValue((String) v.get(COLUMN_STATS_FIELD_MAX_VALUE))
+            .setValueCount((Long) v.get(COLUMN_STATS_FIELD_VALUE_COUNT))
+            .setNullCount((Long) v.get(COLUMN_STATS_FIELD_NULL_COUNT))
+            .setTotalSize((Long) v.get(COLUMN_STATS_FIELD_TOTAL_SIZE))
+            .setTotalUncompressedSize((Long) v.get(COLUMN_STATS_FIELD_TOTAL_UNCOMPRESSED_SIZE))
+            .setIsDeleted((Boolean) v.get(COLUMN_STATS_FIELD_IS_DELETED))
+            .build();
       }
     }
   }


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the problem of incorrect value and null count read from column stats in metadata table.  The root cause is the wrong order of arguments passed to the constructor of `HoodieMetadataColumnStats`.  The constructor is:
```
  public HoodieMetadataColumnStats(java.lang.String fileName, java.lang.String minValue, java.lang.String maxValue, java.lang.Long valueCount, java.lang.Long nullCount, java.lang.Long totalSize, java.lang.Long totalUncompressedSize, java.lang.Boolean isDeleted) {
```
and the original init is 
```
columnStatMetadata = new HoodieMetadataColumnStats(
            (String) v.get(COLUMN_STATS_FIELD_RESOURCE_NAME),
            (String) v.get(COLUMN_STATS_FIELD_MIN_VALUE),
            (String) v.get(COLUMN_STATS_FIELD_MAX_VALUE),
            (Long) v.get(COLUMN_STATS_FIELD_NULL_COUNT),
            (Long) v.get(COLUMN_STATS_FIELD_VALUE_COUNT),
            (Long) v.get(COLUMN_STATS_FIELD_TOTAL_SIZE),
            (Long) v.get(COLUMN_STATS_FIELD_TOTAL_UNCOMPRESSED_SIZE),
            (Boolean) v.get(COLUMN_STATS_FIELD_IS_DELETED)
        );
```
The actual values of `valueCount` and `nullCount` passed in are switched.

(Below screenshot shows the diff of column stats from validation: left: from metadata table, right: from base files (ground truth))

<img width="1906" alt="Screen Shot 2022-02-22 at 16 07 32" src="https://user-images.githubusercontent.com/2497195/155242751-8c12e336-9ab7-42e6-beb9-d9913c8a14a3.png">

## Brief change log

  - Uses builder of `HoodieMetadataColumnStats` in `HoodieMetadataPayload` to set each field explicitly.

## Verify this pull request

Runs Hudi Deltastreamer continuous mode writing MOR table, async compaction, cleaner, all multi-modal indexing enabled and verifies that after the fix, the column stats from metadata table is correct compared to the ground truth from base files.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
