### PR TITLE
[MINOR] fix get builtin function issue from Hudi catalog

### DIFF
--- a/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -376,7 +376,7 @@ public class HoodieCatalog extends AbstractCatalog {
   @Override
   public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec catalogPartitionSpec)
       throws PartitionNotExistException, CatalogException {
-    return null;
+    throw new PartitionNotExistException(getName(), tablePath, catalogPartitionSpec);
   }
 
   @Override
@@ -409,7 +409,7 @@ public class HoodieCatalog extends AbstractCatalog {
 
   @Override
   public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
-    return null;
+    throw new FunctionNotExistException(getName(), functionPath);
   }
 
   @Override

--- a/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -64,12 +64,12 @@ public class TestConfigurations {
       .map(RowType.RowField::asSummaryString).collect(Collectors.toList());
 
   public static final DataType ROW_DATA_TYPE_WIDER = DataTypes.ROW(
-          DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),// record key
-          DataTypes.FIELD("name", DataTypes.VARCHAR(10)),
-          DataTypes.FIELD("age", DataTypes.INT()),
-          DataTypes.FIELD("salary", DataTypes.DOUBLE()),
-          DataTypes.FIELD("ts", DataTypes.TIMESTAMP(3)), // precombine field
-          DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
+      DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),// record key
+      DataTypes.FIELD("name", DataTypes.VARCHAR(10)),
+      DataTypes.FIELD("age", DataTypes.INT()),
+      DataTypes.FIELD("salary", DataTypes.DOUBLE()),
+      DataTypes.FIELD("ts", DataTypes.TIMESTAMP(3)), // precombine field
+      DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
       .notNull();
 
   public static final RowType ROW_TYPE_WIDER = (RowType) ROW_DATA_TYPE_WIDER.getLogicalType();
@@ -108,6 +108,15 @@ public class TestConfigurations {
         + "  'connector' = '").append(connector).append("'");
     options.forEach((k, v) -> builder.append(",\n")
         .append("  '").append(k).append("' = '").append(v).append("'"));
+    builder.append("\n)");
+    return builder.toString();
+  }
+
+  public static String getCreateHudiCatalogDDL(final String catalogName, final String catalogPath) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("create catalog ").append(catalogName).append(" with (\n");
+    builder.append("  'type' = 'hudi',\n"
+        + "  'catalog.path' = '").append(catalogPath).append("'");
     builder.append("\n)");
     return builder.toString();
   }
@@ -222,6 +231,10 @@ public class TestConfigurations {
     return new Sql(tableName);
   }
 
+  public static Catalog catalog(String catalogName) {
+    return new Catalog(catalogName);
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------
@@ -283,6 +296,24 @@ public class TestConfigurations {
       }
       return TestConfigurations.getCreateHoodieTableDDL(this.tableName, this.fields, options,
           this.withPartition, this.pkField, this.partitionField);
+    }
+  }
+
+  public static class Catalog {
+    private final String catalogName;
+    private String catalogPath = ".";
+
+    public Catalog(String catalogName) {
+      this.catalogName = catalogName;
+    }
+
+    public Catalog catalogPath(String catalogPath) {
+      this.catalogPath = catalogPath;
+      return this;
+    }
+
+    public String end() {
+      return TestConfigurations.getCreateHudiCatalogDDL(catalogName, catalogPath);
     }
   }
 }

--- a/hudi-flink/src/test/java/org/apache/hudi/utils/factory/ContinuousFileSourceFactory.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/utils/factory/ContinuousFileSourceFactory.java
@@ -53,7 +53,7 @@ public class ContinuousFileSourceFactory implements DynamicTableSourceFactory {
     Configuration conf = (Configuration) helper.getOptions();
     Path path = new Path(conf.getOptional(FlinkOptions.PATH).orElseThrow(() ->
         new ValidationException("Option [path] should be not empty.")));
-    return new ContinuousFileSource(context.getCatalogTable().getSchema(), path, conf);
+    return new ContinuousFileSource(context.getCatalogTable().getResolvedSchema(), path, conf);
   }
 
   @Override

--- a/hudi-flink/src/test/java/org/apache/hudi/utils/source/ContinuousFileSource.java
+++ b/hudi-flink/src/test/java/org/apache/hudi/utils/source/ContinuousFileSource.java
@@ -18,15 +18,15 @@
 
 package org.apache.hudi.utils.source;
 
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
-import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -59,12 +59,12 @@ import static org.apache.hudi.utils.factory.ContinuousFileSourceFactory.CHECKPOI
  */
 public class ContinuousFileSource implements ScanTableSource {
 
-  private final TableSchema tableSchema;
+  private final ResolvedSchema tableSchema;
   private final Path path;
   private final Configuration conf;
 
   public ContinuousFileSource(
-      TableSchema tableSchema,
+      ResolvedSchema tableSchema,
       Path path,
       Configuration conf) {
     this.tableSchema = tableSchema;
@@ -83,7 +83,7 @@ public class ContinuousFileSource implements ScanTableSource {
 
       @Override
       public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
-        final RowType rowType = (RowType) tableSchema.toRowDataType().getLogicalType();
+        final RowType rowType = (RowType) tableSchema.toSourceRowDataType().getLogicalType();
         JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
             rowType,
             InternalTypeInfo.of(rowType),
@@ -178,7 +178,7 @@ public class ContinuousFileSource implements ScanTableSource {
     }
 
     @Override
-    public void notifyCheckpointComplete(long l) throws Exception {
+    public void notifyCheckpointComplete(long l) {
       this.currentCP.incrementAndGet();
     }
   }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

* Fix NPE problem during search Flink builtin function `TO_DATE('xxx')` while enable `Hudi` catalog, because the original logic of `getPartition(ObjectPath tablePath, CatalogPartitionSpec catalogPartitionSpec)` is return null, which will caused NPE problem.
* 
![image](https://user-images.githubusercontent.com/13775334/155873786-12a209b4-982e-4b27-b45f-901e596296a5.png)


## Brief change log
  - *Replace `null` with FunctionNotExistException of getFunction method in HoodieCatalog.java*
  - *Replace `null` with PartitionNotExistException of getPartition method in HoodieCatalog.java*
  - *Add a IT case to test get builtin function*
  - *Change `TableSchema` to `ResolveSchema` in ContinousFileSource.java*

## Verify this pull request

  - *Added integration tests(`testBuiltinFunctionWithCatalog`) in HoodieDataSourceITCase.java*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
