### PR TITLE
[HUDI-3528] Fix String convert issue and overwrite putAll method in Typed…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
@@ -25,6 +25,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -63,9 +64,20 @@ public class TypedProperties extends Properties implements Serializable {
   public Set<String> stringPropertyNames() {
     Set<String> set = new LinkedHashSet<>();
     for (Object key : this.keys) {
-      set.add((String) key);
+      if (key instanceof String) {
+        set.add((String) key);
+      }
     }
     return set;
+  }
+
+  public synchronized void putAll(Properties t) {
+    for (Map.Entry<?, ?> e : t.entrySet()) {
+      if (!containsKey(String.valueOf(e.getKey()))) {
+        keys.add(e.getKey());
+      }
+      super.put(e.getKey(), e.getValue());
+    }
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
@@ -99,8 +99,37 @@ public class TestTypedProperties {
     properties.put("key9", "true");
 
     TypedProperties typedProperties = new TypedProperties(properties);
+    assertTypeProperties(typedProperties, 0);
+  }
+
+  @Test
+  void testPutAllProperties() {
+    Properties firstProp = new TypedProperties();
+    firstProp.put("key0", "true");
+    firstProp.put("key1", "false");
+    firstProp.put("key2", "true");
+
+    TypedProperties firstProperties = new TypedProperties(firstProp);
+    assertTypeProperties(firstProperties, 0);
+
+    TypedProperties secondProperties = new TypedProperties();
+    secondProperties.put("key3", "true");
+    secondProperties.put("key4", "false");
+    secondProperties.put("key5", "true");
+    assertTypeProperties(secondProperties, 3);
+
+    TypedProperties thirdProperties = new TypedProperties();
+    thirdProperties.putAll(firstProp);
+    thirdProperties.putAll(secondProperties);
+
+    assertEquals(3, firstProp.stringPropertyNames().size());
+    assertEquals(3, secondProperties.stringPropertyNames().size());
+    assertEquals(6, thirdProperties.stringPropertyNames().size());
+  }
+
+  private void assertTypeProperties(TypedProperties typedProperties, int start) {
     String[] props = typedProperties.stringPropertyNames().toArray(new String[0]);
-    for (int i = 0; i < props.length; i++) {
+    for (int i = start; i < props.length; i++) {
       assertEquals(String.format("key%d", i), props[i]);
     }
   }


### PR DESCRIPTION
…Properties.java

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

I'm running Flink with Hudi in Java 11 environment(Even through I know Hudi might only support Java8/9/10), But we cannot change our JDK version. Based on this situation, We meet a NPE problem during `HoodieWriteConfig.getIndexType()`, but I test that it works in my local Java 8 environment. It seems that we implemented a `TypedProperties` class inherit  from `java.util.Properties` class, and overwrite `stringPropertyNames` method & `put` method from this [PR](https://github.com/apache/hudi/pull/4712).

There are some difference of `Properties.putAll(Map<?,?> t)` between Java 8 and Java 11. 

*Java 8*: `TypedProperties`  will use HashTable's `putAll` method, which will call `TypedProperties.put` method, and the latter will add the incoming keys in `TypedProperties.keys` field.
```
public synchronized void putAll(Map<? extends K, ? extends V> t) {
        for (Map.Entry<? extends K, ? extends V> e : t.entrySet())
            put(e.getKey(), e.getValue());
    }
```

*Java 11*: `Properties` overwrite `putAll` method, and delegate the  incoming map to `ConcurrentHashMap`. It won't call `TypedProperties.put` method anymore, which lead the `TypedProperties.keys` fields miss some keys, and then it cause that we miss the `hoodie.index.type` configuration.
```
@Override
    public synchronized void putAll(Map<?, ?> t) {
        map.putAll(t);
    }
```

So we also need to overwrite `putAll` method to better  suitable high Java version runtime.

The exception trace with Java 11 runtime.
```
Caused by: java.lang.NullPointerException: Name is null
	at java.base/java.lang.Enum.valueOf(Enum.java:238)
	at org.apache.hudi.index.HoodieIndex$IndexType.valueOf(HoodieIndex.java:143)
	at org.apache.hudi.config.HoodieWriteConfig.getIndexType(HoodieWriteConfig.java:1347)
	at org.apache.hudi.index.FlinkHoodieIndexFactory.createIndex(FlinkHoodieIndexFactory.java:47)
	at org.apache.hudi.client.HoodieFlinkWriteClient.createIndex(HoodieFlinkWriteClient.java:105)
	at org.apache.hudi.client.BaseHoodieWriteClient.<init>(BaseHoodieWriteClient.java:145)
	at org.apache.hudi.client.BaseHoodieWriteClient.<init>(BaseHoodieWriteClient.java:131)
	at org.apache.hudi.client.HoodieFlinkWriteClient.<init>(HoodieFlinkWriteClient.java:96)
	at org.apache.hudi.util.StreamerUtil.createWriteClient(StreamerUtil.java:402)
	at org.apache.hudi.sink.StreamWriteOperatorCoordinator.start(StreamWriteOperatorCoordinator.java:166)
	at org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder.start(OperatorCoordinatorHolder.java:194)
	at org.apache.flink.runtime.scheduler.DefaultOperatorCoordinatorHandler.startAllOperatorCoordinators(DefaultOperatorCoordinatorHandler.java:85)
```

## Brief change log

  - *Overwrite `putAll` method in `TypedPropertis`*
  - *Add class type checking before convert to String hardly*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Add unit test case to test `putAll` cases in TestTypedProperties.java*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
