### PR TITLE
[HUDI-3551] Add the Oracle Cloud Infrastructure (oci) Object Storage URI scheme.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
@@ -67,7 +67,9 @@ public enum StorageSchemes {
   // JuiceFileSystem
   JFS("jfs", true),
   // Baidu Object Storage
-  BOS("bos", false);
+  BOS("bos", false),
+  // Oracle Cloud Infrastructure Object Storage
+  OCI("oci", false);
 
   private String scheme;
   private boolean supportsAppend;

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
@@ -49,6 +49,7 @@ public class TestStorageSchemes {
     assertFalse(StorageSchemes.isAppendSupported("bos"));
     assertFalse(StorageSchemes.isAppendSupported("ks3"));
     assertTrue(StorageSchemes.isAppendSupported("ofs"));
+    assertTrue(StorageSchemes.isAppendSupported("oci"));
     assertThrows(IllegalArgumentException.class, () -> {
       StorageSchemes.isAppendSupported("s2");
     }, "Should throw exception for unsupported schemes");


### PR DESCRIPTION
## What is the purpose of the pull request

This PR adds the "oci" scheme for using Hudi against Oracle Cloud Infrastructure using its HDFS Client.

I have documentation which I will put in another PR, apologies if I could have combined across branches I'm bad at git.

## Brief change log

Changes:
  - Registered OCI scheme, indicating appends are not supported.
  - Added a test similar to existing tests for other schemes.

## Verify this pull request

This pull request is pretty trivial. I validated it using the Hudi quickstart and results were the same as using a local path.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green - unknown. The build works locally.

 - [X] Necessary doc changes done or have another open PR
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
