### PR TITLE
[HUDI-3383] Sync column comments while syncing a hive table, especially using spark datasource api

### DIFF
--- a/hudi-common/src/test/resources/simple-test-doced.avsc
+++ b/hudi-common/src/test/resources/simple-test-doced.avsc
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+"namespace": "example.avro",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "name", "type": "string","doc":"name_comment"},
+     {"name": "favorite_number",  "type": "int","doc":"favorite_number_comment"},
+     {"name": "favorite_color", "type": "string"}
+ ]
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -316,6 +316,8 @@ public class DataSourceUtils {
     if (props.containsKey(HiveExternalCatalog.CREATED_SPARK_VERSION())) {
       hiveSyncConfig.sparkVersion = props.getString(HiveExternalCatalog.CREATED_SPARK_VERSION());
     }
+    hiveSyncConfig.syncComment = Boolean.valueOf(props.getString(DataSourceWriteOptions.HIVE_SYNC_COMMENT().key(),
+            DataSourceWriteOptions.HIVE_SYNC_COMMENT().defaultValue()));
     return hiveSyncConfig;
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -555,6 +555,11 @@ object DataSourceWriteOptions {
     .withDocumentation("Whether sync hive metastore bucket specification when using bucket index." +
       "The specification is 'CLUSTERED BY (trace_id) SORTED BY (trace_id ASC) INTO 65536 BUCKETS'")
 
+  val HIVE_SYNC_COMMENT: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.hive_sync.sync_comment")
+    .defaultValue("false")
+    .withDocumentation("Whether to sync the table column comments while syncing the table.")
+
   // Async Compaction - Enabled by default for MOR
   val ASYNC_COMPACT_ENABLE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.compaction.async.enable")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -600,6 +600,7 @@ object HoodieSparkSqlWriter {
     hiveSyncConfig.serdeProperties = hoodieConfig.getString(HIVE_TABLE_SERDE_PROPERTIES)
     hiveSyncConfig.tableProperties = hoodieConfig.getString(HIVE_TABLE_PROPERTIES)
     hiveSyncConfig.sparkVersion = SPARK_VERSION
+    hiveSyncConfig.syncComment = hoodieConfig.getStringOrDefault(HIVE_SYNC_COMMENT).toBoolean
     hiveSyncConfig
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
@@ -161,4 +161,220 @@ class TestAvroConversionUtils extends FunSuite with Matchers {
 
     assert(avroSchema.equals(expectedAvroSchema))
   }
+
+  test("test convertStructTypeToAvroSchema with Nested StructField comment") {
+    val mapType = DataTypes.createMapType(StringType, new StructType().add("mapKey", "string", false, "mapKeyComment").add("mapVal", "integer", true))
+    val arrayType =  ArrayType(new StructType().add("arrayKey", "string", false).add("arrayVal", "integer", true, "arrayValComment"))
+    val innerStruct = new StructType().add("innerKey","string",false, "innerKeyComment").add("value", "long", true, "valueComment")
+
+    val struct = new StructType().add("key", "string", false).add("version", "string", true, "versionComment")
+      .add("data1",innerStruct,false).add("data2",innerStruct,true)
+      .add("nullableMap", mapType, true).add("map",mapType,false)
+      .add("nullableArray", arrayType, true).add("array",arrayType,false)
+
+    val avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(struct, "SchemaName", "SchemaNS")
+
+    val expectedSchemaStr = s"""
+        {
+          "type": "record",
+          "name": "SchemaName",
+          "namespace": "SchemaNS",
+          "fields": [
+            {
+              "name": "key",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": [
+                "null",
+                "string"
+              ],
+              "doc": "versionComment",
+              "default": null
+            },
+            {
+              "name": "data1",
+              "type": {
+                "type": "record",
+                "name": "data1",
+                "namespace": "SchemaNS.SchemaName",
+                "fields": [
+                  {
+                    "name": "innerKey",
+                    "type": "string",
+                    "doc": "innerKeyComment"
+                  },
+                  {
+                    "name": "value",
+                    "type": [
+                      "null",
+                      "long"
+                    ],
+                    "doc": "valueComment",
+                    "default": null
+                  }
+                ]
+              }
+            },
+            {
+              "name": "data2",
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "data2",
+                  "namespace": "SchemaNS.SchemaName",
+                  "fields": [
+                    {
+                      "name": "innerKey",
+                      "type": "string",
+                      "doc": "innerKeyComment"
+                    },
+                    {
+                      "name": "value",
+                      "type": [
+                        "null",
+                        "long"
+                      ],
+                      "doc": "valueComment",
+                      "default": null
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "nullableMap",
+              "type": [
+                "null",
+                {
+                  "type": "map",
+                  "values": [
+                    {
+                      "type": "record",
+                      "name": "nullableMap",
+                      "namespace": "SchemaNS.SchemaName",
+                      "fields": [
+                        {
+                          "name": "mapKey",
+                          "type": "string",
+                          "doc": "mapKeyComment"
+                        },
+                        {
+                          "name": "mapVal",
+                          "type": [
+                            "null",
+                            "int"
+                          ],
+                          "default": null
+                        }
+                      ]
+                    },
+                    "null"
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "map",
+              "type": {
+                "type": "map",
+                "values": [
+                  {
+                    "type": "record",
+                    "name": "map",
+                    "namespace": "SchemaNS.SchemaName",
+                    "fields": [
+                      {
+                        "name": "mapKey",
+                        "type": "string",
+                        "doc": "mapKeyComment"
+                      },
+                      {
+                        "name": "mapVal",
+                        "type": [
+                          "null",
+                          "int"
+                        ],
+                        "default": null
+                      }
+                    ]
+                  },
+                  "null"
+                ]
+              }
+            },
+            {
+              "name": "nullableArray",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "record",
+                      "name": "nullableArray",
+                      "namespace": "SchemaNS.SchemaName",
+                      "fields": [
+                        {
+                          "name": "arrayKey",
+                          "type": "string"
+                        },
+                        {
+                          "name": "arrayVal",
+                          "type": [
+                            "null",
+                            "int"
+                          ],
+                          "doc": "arrayValComment",
+                          "default": null
+                        }
+                      ]
+                    },
+                    "null"
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "array",
+              "type": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "record",
+                    "name": "array",
+                    "namespace": "SchemaNS.SchemaName",
+                    "fields": [
+                      {
+                        "name": "arrayKey",
+                        "type": "string"
+                      },
+                      {
+                        "name": "arrayVal",
+                        "type": [
+                          "null",
+                          "int"
+                        ],
+                        "doc": "arrayValComment",
+                        "default": null
+                      }
+                    ]
+                  },
+                  "null"
+                ]
+              }
+            }
+          ]
+        }}
+    """
+
+    val expectedAvroSchema = new Schema.Parser().parse(expectedSchemaStr)
+
+    assert(avroSchema.equals(expectedAvroSchema))
+  }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -132,6 +132,9 @@ public class HiveSyncConfig implements Serializable {
   @Parameter(names = {"--spark-version"}, description = "The spark version", required = false)
   public String sparkVersion;
 
+  @Parameter(names = {"--sync-comment"}, description = "synchronize table comments to hive")
+  public boolean syncComment = false;
+
   // enhance the similar function in child class
   public static HiveSyncConfig copy(HiveSyncConfig cfg) {
     HiveSyncConfig newConfig = new HiveSyncConfig();
@@ -159,6 +162,7 @@ public class HiveSyncConfig implements Serializable {
     newConfig.withOperationField = cfg.withOperationField;
     newConfig.isConditionalSync = cfg.isConditionalSync;
     newConfig.sparkVersion = cfg.sparkVersion;
+    newConfig.syncComment = cfg.syncComment;
     return newConfig;
   }
 
@@ -193,6 +197,7 @@ public class HiveSyncConfig implements Serializable {
       + ", sparkSchemaLengthThreshold=" + sparkSchemaLengthThreshold
       + ", withOperationField=" + withOperationField
       + ", isConditionalSync=" + isConditionalSync
+      + ", syncComment=" + syncComment
       + '}';
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/DDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/DDLExecutor.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.hive.ddl;
 
+import org.apache.hudi.common.util.collection.ImmutablePair;
+
 import org.apache.parquet.schema.MessageType;
 
 import java.util.List;
@@ -88,6 +90,14 @@ public interface DDLExecutor {
    * @param partitionsToDrop
    */
   public void dropPartitionsToTable(String tableName, List<String> partitionsToDrop);
+
+  /**
+   * update table comments
+   *
+   * @param tableName
+   * @param newSchema
+   */
+  public void updateTableComments(String tableName, Map<String, ImmutablePair<String,String>> newSchema);
 
   public void close();
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -18,9 +18,9 @@
 
 package org.apache.hudi.hive.ddl;
 
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.fs.StorageSchemes;
+import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HoodieHiveSyncException;
 import org.apache.hudi.hive.PartitionValueExtractor;
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.parquet.schema.MessageType;
@@ -244,6 +245,27 @@ public class HMSDDLExecutor implements DDLExecutor {
     } catch (TException e) {
       LOG.error(syncConfig.databaseName + "." + tableName + " drop partition failed", e);
       throw new HoodieHiveSyncException(syncConfig.databaseName + "." + tableName + " drop partition failed", e);
+    }
+  }
+
+  @Override
+  public void updateTableComments(String tableName, Map<String, ImmutablePair<String,String>> alterSchema) {
+    try {
+      Table table = client.getTable(syncConfig.databaseName, tableName);
+      StorageDescriptor sd = new StorageDescriptor(table.getSd());
+      for (FieldSchema fieldSchema : sd.getCols()) {
+        if (alterSchema.containsKey(fieldSchema.getName())) {
+          String comment = alterSchema.get(fieldSchema.getName()).getRight();
+          fieldSchema.setComment(comment);
+        }
+      }
+      table.setSd(sd);
+      EnvironmentContext environmentContext = new EnvironmentContext();
+      client.alter_table_with_environmentContext(syncConfig.databaseName, tableName, table, environmentContext);
+      sd.clear();
+    } catch (Exception e) {
+      LOG.error("Failed to update table comments for " + tableName, e);
+      throw new HoodieHiveSyncException("Failed to update table comments for " + tableName, e);
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

*The pr is syncing source table column comments to a hive table with syncing hudi to hive when users add column comments to datasource schema.*

## Brief change log

  - *Add a hive sync config(hoodie.datasource.hive_sync.sync_comment). This config is false by default.*
  - *While syncing data source to hudi, add table column comments to datasource avro schema, and if the sync_comment is true, syncing column comments to the hive table.*
  *(for example: using spark datasource)*
`StructType schema = new StructType().add("key", "string", false, "comment")`
`sparkSession.createDataFrame(rdd, schema)`
`.write().format("org.apache.hudi")`
`......`
`.option("hoodie.datasource.hive_sync.sync_comment","true")`
`......`
`.save("/xxxx");`

## Verify this pull request

*Run TestHiveSyncTool#testUpdateTableComments and TestHiveSyncTool#testSyncWithCommentedSchema successfully.*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
