### PR TITLE
[HUDI-3736] Fix default dynamodblock url default value

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -103,8 +103,8 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> DYNAMODB_ENDPOINT_URL = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "endpoint_url")
-      .defaultValue("us-east-1")
-      .sinceVersion("0.11.0")
+      .noDefaultValue()
+      .sinceVersion("0.10.1")
       .withDocumentation("For DynamoDB based lock provider, the url endpoint used for Amazon DynamoDB service."
                          + " Useful for development with a local dynamodb instance.");
 }


### PR DESCRIPTION
The config has a bad default value which prevent to turn it to null and lead to a NPE when no endpoint_url is specified.

This PR removes the default value

fixes #4904