### PR TITLE
[HUDI-3569] Introduce ChainedJsonKafkaSourePostProcessor to support setting multi processors at one time

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/ChainedJsonKafkaSourcePostProcessor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/ChainedJsonKafkaSourcePostProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.processor;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.apache.spark.api.java.JavaRDD;
+
+import java.util.List;
+
+/**
+ * A {@link JsonKafkaSourcePostProcessor} to chain other {@link JsonKafkaSourcePostProcessor}s and apply sequentially.
+ */
+public class ChainedJsonKafkaSourcePostProcessor extends JsonKafkaSourcePostProcessor {
+
+  private final List<JsonKafkaSourcePostProcessor> processors;
+
+  public ChainedJsonKafkaSourcePostProcessor(List<JsonKafkaSourcePostProcessor> processors, TypedProperties props) {
+    super(props);
+    this.processors = processors;
+  }
+
+  @Override
+  public JavaRDD<String> process(JavaRDD<String> inputJsonRecords) {
+    JavaRDD<String> targetRDD = inputJsonRecords;
+    for (JsonKafkaSourcePostProcessor processor : processors) {
+      targetRDD = processor.process(targetRDD);
+    }
+    return targetRDD;
+  }
+}


### PR DESCRIPTION
…etting multi processors at once

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Introduce ChainedJsonKafkaSourePostProcessor to support setting multi processors at once

## Verify this pull request


This pull request is already covered by existing tests
org.apache.hudi.utilities.sources.TestJsonKafkaSourcePostProcessor#testChainedJsonKafkaSourcePostProcessor


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
