### PR TITLE
[HUDI-3494] Consider triggering condition of MOR compaction during archival

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.model.HoodieArchivedLogFile;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.HoodieLogFormat.Writer;
@@ -43,6 +44,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -52,6 +54,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.marker.WriteMarkers;
 import org.apache.hudi.table.marker.WriteMarkersFactory;
 
@@ -76,6 +79,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
 
 /**
@@ -395,6 +399,18 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
     // made after the first savepoint present.
     Option<HoodieInstant> firstSavepoint = table.getCompletedSavepointTimeline().firstInstant();
     if (!commitTimeline.empty() && commitTimeline.countInstants() > maxInstantsToKeep) {
+      // For Merge-On-Read table, inline or async compaction is enabled
+      // We need to make sure that there are enough delta commits in the active timeline
+      // to trigger compaction scheduling, when the trigger strategy of compaction is
+      // NUM_COMMITS or NUM_AND_TIME.
+      Option<HoodieInstant> oldestInstantToKeepForCompaction =
+          (metaClient.getTableType() == HoodieTableType.MERGE_ON_READ
+              && (config.getInlineCompactTriggerStrategy() == CompactionTriggerStrategy.NUM_COMMITS
+              || config.getInlineCompactTriggerStrategy() == CompactionTriggerStrategy.NUM_AND_TIME))
+              ? CompactionUtils.getOldestInstantToKeepForCompaction(
+              table.getActiveTimeline(), config.getInlineCompactDeltaCommitMax())
+              : Option.empty();
+
       // Actually do the commits
       Stream<HoodieInstant> instantToArchiveStream = commitTimeline.getInstants()
           .filter(s -> {
@@ -405,14 +421,21 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
             return oldestPendingCompactionAndReplaceInstant
                 .map(instant -> HoodieTimeline.compareTimestamps(instant.getTimestamp(), GREATER_THAN, s.getTimestamp()))
                 .orElse(true);
-          });
-      // We need this to ensure that when multiple writers are performing conflict resolution, eligible instants don't
-      // get archived, i.e, instants after the oldestInflight are retained on the timeline
-      if (config.getFailedWritesCleanPolicy() == HoodieFailedWritesCleaningPolicy.LAZY) {
-        instantToArchiveStream = instantToArchiveStream.filter(s -> oldestInflightCommitInstant.map(instant ->
-            HoodieTimeline.compareTimestamps(instant.getTimestamp(), GREATER_THAN, s.getTimestamp()))
-            .orElse(true));
-      }
+          }).filter(s -> {
+            // We need this to ensure that when multiple writers are performing conflict resolution, eligible instants don't
+            // get archived, i.e, instants after the oldestInflight are retained on the timeline
+            if (config.getFailedWritesCleanPolicy() == HoodieFailedWritesCleaningPolicy.LAZY) {
+              return oldestInflightCommitInstant.map(instant ->
+                      HoodieTimeline.compareTimestamps(instant.getTimestamp(), GREATER_THAN, s.getTimestamp()))
+                  .orElse(true);
+            }
+            return true;
+          }).filter(s ->
+              oldestInstantToKeepForCompaction.map(instantToKeep ->
+                      HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, instantToKeep.getTimestamp()))
+                  .orElse(true)
+          );
+
       return instantToArchiveStream.limit(commitTimeline.countInstants() - minInstantsToKeep);
     } else {
       return Stream.empty();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -403,11 +403,11 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
       // We need to make sure that there are enough delta commits in the active timeline
       // to trigger compaction scheduling, when the trigger strategy of compaction is
       // NUM_COMMITS or NUM_AND_TIME.
-      Option<HoodieInstant> oldestInstantToKeepForCompaction =
+      Option<HoodieInstant> oldestInstantToRetainForCompaction =
           (metaClient.getTableType() == HoodieTableType.MERGE_ON_READ
               && (config.getInlineCompactTriggerStrategy() == CompactionTriggerStrategy.NUM_COMMITS
               || config.getInlineCompactTriggerStrategy() == CompactionTriggerStrategy.NUM_AND_TIME))
-              ? CompactionUtils.getOldestInstantToKeepForCompaction(
+              ? CompactionUtils.getOldestInstantToRetainForCompaction(
               table.getActiveTimeline(), config.getInlineCompactDeltaCommitMax())
               : Option.empty();
 
@@ -431,8 +431,8 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
             }
             return true;
           }).filter(s ->
-              oldestInstantToKeepForCompaction.map(instantToKeep ->
-                      HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, instantToKeep.getTimestamp()))
+              oldestInstantToRetainForCompaction.map(instantToRetain ->
+                      HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, instantToRetain.getTimestamp()))
                   .orElse(true)
           );
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CompactionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CompactionUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.CompactionOperation;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
@@ -59,13 +60,13 @@ public class CompactionUtils {
   /**
    * Generate compaction operation from file-slice.
    *
-   * @param partitionPath Partition path
-   * @param fileSlice File Slice
+   * @param partitionPath          Partition path
+   * @param fileSlice              File Slice
    * @param metricsCaptureFunction Metrics Capture function
    * @return Compaction Operation
    */
   public static HoodieCompactionOperation buildFromFileSlice(String partitionPath, FileSlice fileSlice,
-      Option<Function<Pair<String, FileSlice>, Map<String, Double>>> metricsCaptureFunction) {
+                                                             Option<Function<Pair<String, FileSlice>, Map<String, Double>>> metricsCaptureFunction) {
     HoodieCompactionOperation.Builder builder = HoodieCompactionOperation.newBuilder();
     builder.setPartitionPath(partitionPath);
     builder.setFileId(fileSlice.getFileId());
@@ -87,12 +88,12 @@ public class CompactionUtils {
    * Generate compaction plan from file-slices.
    *
    * @param partitionFileSlicePairs list of partition file-slice pairs
-   * @param extraMetadata Extra Metadata
-   * @param metricsCaptureFunction Metrics Capture function
+   * @param extraMetadata           Extra Metadata
+   * @param metricsCaptureFunction  Metrics Capture function
    */
   public static HoodieCompactionPlan buildFromFileSlices(List<Pair<String, FileSlice>> partitionFileSlicePairs,
-      Option<Map<String, String>> extraMetadata,
-      Option<Function<Pair<String, FileSlice>, Map<String, Double>>> metricsCaptureFunction) {
+                                                         Option<Map<String, String>> extraMetadata,
+                                                         Option<Function<Pair<String, FileSlice>, Map<String, Double>>> metricsCaptureFunction) {
     HoodieCompactionPlan.Builder builder = HoodieCompactionPlan.newBuilder();
     extraMetadata.ifPresent(builder::setExtraMetadata);
 
@@ -195,10 +196,76 @@ public class CompactionUtils {
 
   /**
    * Return all pending compaction instant times.
-   * 
+   *
    * @return
    */
   public static List<HoodieInstant> getPendingCompactionInstantTimes(HoodieTableMetaClient metaClient) {
     return metaClient.getActiveTimeline().filterPendingCompactionTimeline().getInstants().collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a pair of (timeline containing the delta commits after the latest completed
+   * compaction commit, the completed compaction commit instant), if the latest completed
+   * compaction commit is present; a pair of (timeline containing all the delta commits,
+   * the first delta commit instant), if there is no completed compaction commit.
+   *
+   * @param activeTimeline Active timeline of a table.
+   * @return Pair of timeline containing delta commits and an instant.
+   */
+  public static Option<Pair<HoodieTimeline, HoodieInstant>> getDeltaCommitsSinceLatestCompaction(
+      HoodieActiveTimeline activeTimeline) {
+    Option<HoodieInstant> lastCompaction = activeTimeline.getCommitTimeline()
+        .filterCompletedInstants().lastInstant();
+    HoodieTimeline deltaCommits = activeTimeline.getDeltaCommitTimeline();
+
+    HoodieInstant latestInstant;
+    if (lastCompaction.isPresent()) {
+      latestInstant = lastCompaction.get();
+      // timeline containing the delta commits after the latest completed compaction commit,
+      // and the completed compaction commit instant
+      return Option.of(Pair.of(deltaCommits.findInstantsAfter(
+          latestInstant.getTimestamp(), Integer.MAX_VALUE), lastCompaction.get()));
+    } else {
+      if (deltaCommits.countInstants() > 0) {
+        latestInstant = deltaCommits.firstInstant().get();
+        // timeline containing all the delta commits, and the first delta commit instant
+        return Option.of(Pair.of(deltaCommits.findInstantsAfterOrEquals(
+            latestInstant.getTimestamp(), Integer.MAX_VALUE), latestInstant));
+      } else {
+        return Option.empty();
+      }
+    }
+  }
+
+  /**
+   * Gets the oldest instant to keep for MOR compaction.
+   * If there is no completed compaction,
+   * num delta commits >= "hoodie.compact.inline.max.delta.commits"
+   * If there is a completed compaction,
+   * num delta commits after latest completed compaction >= "hoodie.compact.inline.max.delta.commits"
+   *
+   * @param activeTimeline  Active timeline of a table.
+   * @param maxDeltaCommits Maximum number of delta commits that trigger the compaction plan,
+   *                        i.e., "hoodie.compact.inline.max.delta.commits".
+   * @return the oldest instant to keep for MOR compaction.
+   */
+  public static Option<HoodieInstant> getOldestInstantToKeepForCompaction(
+      HoodieActiveTimeline activeTimeline, int maxDeltaCommits) {
+    Option<Pair<HoodieTimeline, HoodieInstant>> deltaCommitsInfoOption =
+        CompactionUtils.getDeltaCommitsSinceLatestCompaction(activeTimeline);
+    if (deltaCommitsInfoOption.isPresent()) {
+      Pair<HoodieTimeline, HoodieInstant> deltaCommitsInfo = deltaCommitsInfoOption.get();
+      HoodieTimeline deltaCommitTimeline = deltaCommitsInfo.getLeft();
+      int numDeltaCommits = deltaCommitTimeline.countInstants();
+      if (numDeltaCommits < maxDeltaCommits) {
+        return Option.of(deltaCommitsInfo.getRight());
+      } else {
+        // delta commits with the last one to keep
+        List<HoodieInstant> instants = deltaCommitTimeline.getInstants()
+            .limit(numDeltaCommits - maxDeltaCommits + 1).collect(Collectors.toList());
+        return Option.of(instants.get(instants.size() - 1));
+      }
+    }
+    return Option.empty();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CompactionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CompactionUtils.java
@@ -238,7 +238,7 @@ public class CompactionUtils {
   }
 
   /**
-   * Gets the oldest instant to keep for MOR compaction.
+   * Gets the oldest instant to retain for MOR compaction.
    * If there is no completed compaction,
    * num delta commits >= "hoodie.compact.inline.max.delta.commits"
    * If there is a completed compaction,
@@ -249,7 +249,7 @@ public class CompactionUtils {
    *                        i.e., "hoodie.compact.inline.max.delta.commits".
    * @return the oldest instant to keep for MOR compaction.
    */
-  public static Option<HoodieInstant> getOldestInstantToKeepForCompaction(
+  public static Option<HoodieInstant> getOldestInstantToRetainForCompaction(
       HoodieActiveTimeline activeTimeline, int maxDeltaCommits) {
     Option<Pair<HoodieTimeline, HoodieInstant>> deltaCommitsInfoOption =
         CompactionUtils.getDeltaCommitsSinceLatestCompaction(activeTimeline);

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
@@ -285,7 +285,7 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
   @ValueSource(booleans = {true, false})
   public void testGetOldestInstantToKeepForCompaction(boolean hasCompletedCompaction) {
     HoodieActiveTimeline timeline = prepareTimeline(hasCompletedCompaction);
-    Option<HoodieInstant> actual = CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 20);
+    Option<HoodieInstant> actual = CompactionUtils.getOldestInstantToRetainForCompaction(timeline, 20);
 
     if (hasCompletedCompaction) {
       assertEquals(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "06"), actual.get());
@@ -293,17 +293,17 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
       assertEquals(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "01"), actual.get());
     }
 
-    actual = CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 3);
+    actual = CompactionUtils.getOldestInstantToRetainForCompaction(timeline, 3);
     assertEquals(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "07"), actual.get());
 
-    actual = CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 2);
+    actual = CompactionUtils.getOldestInstantToRetainForCompaction(timeline, 2);
     assertEquals(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "08"), actual.get());
   }
 
   @Test
   public void testGetOldestInstantToKeepForCompactionWithEmptyDeltaCommits() {
     HoodieActiveTimeline timeline = new MockHoodieActiveTimeline();
-    assertEquals(Option.empty(), CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 20));
+    assertEquals(Option.empty(), CompactionUtils.getOldestInstantToRetainForCompaction(timeline, 20));
   }
 
   private HoodieActiveTimeline prepareTimeline(boolean hasCompletedCompaction) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
@@ -27,6 +27,9 @@ import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.versioning.compaction.CompactionPlanMigrator;
 import org.apache.hudi.common.testutils.CompactionTestUtils.DummyHoodieBaseFile;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -35,15 +38,20 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.CompactionTestUtils.createCompactionPlan;
 import static org.apache.hudi.common.testutils.CompactionTestUtils.scheduleCompaction;
@@ -230,11 +238,95 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
     setupAndValidateCompactionOperations(metaClient, false, 0, 0, 0, 0);
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testGetDeltaCommitsSinceLatestCompaction(boolean hasCompletedCompaction) {
+    HoodieActiveTimeline timeline = prepareTimeline(hasCompletedCompaction);
+    Pair<HoodieTimeline, HoodieInstant> actual =
+        CompactionUtils.getDeltaCommitsSinceLatestCompaction(timeline).get();
+    if (hasCompletedCompaction) {
+      Stream<HoodieInstant> instants = actual.getLeft().getInstants();
+      assertEquals(
+          Stream.of(
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "07"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "08"),
+              new HoodieInstant(true, HoodieTimeline.DELTA_COMMIT_ACTION, "09"))
+              .collect(Collectors.toList()),
+          actual.getLeft().getInstants().collect(Collectors.toList()));
+      assertEquals(
+          new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "06"),
+          actual.getRight());
+    } else {
+      assertEquals(
+          Stream.of(
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "01"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "02"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "03"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "04"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "05"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "07"),
+              new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "08"),
+              new HoodieInstant(true, HoodieTimeline.DELTA_COMMIT_ACTION, "09"))
+              .collect(Collectors.toList()),
+          actual.getLeft().getInstants().collect(Collectors.toList()));
+      assertEquals(
+          new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "01"),
+          actual.getRight());
+    }
+  }
+
+  @Test
+  public void testGetDeltaCommitsSinceLatestCompactionWithEmptyDeltaCommits() {
+    HoodieActiveTimeline timeline = new MockHoodieActiveTimeline();
+    assertEquals(Option.empty(), CompactionUtils.getDeltaCommitsSinceLatestCompaction(timeline));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testGetOldestInstantToKeepForCompaction(boolean hasCompletedCompaction) {
+    HoodieActiveTimeline timeline = prepareTimeline(hasCompletedCompaction);
+    Option<HoodieInstant> actual = CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 20);
+
+    if (hasCompletedCompaction) {
+      assertEquals(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "06"), actual.get());
+    } else {
+      assertEquals(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "01"), actual.get());
+    }
+
+    actual = CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 3);
+    assertEquals(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "07"), actual.get());
+
+    actual = CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 2);
+    assertEquals(new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, "08"), actual.get());
+  }
+
+  @Test
+  public void testGetOldestInstantToKeepForCompactionWithEmptyDeltaCommits() {
+    HoodieActiveTimeline timeline = new MockHoodieActiveTimeline();
+    assertEquals(Option.empty(), CompactionUtils.getOldestInstantToKeepForCompaction(timeline, 20));
+  }
+
+  private HoodieActiveTimeline prepareTimeline(boolean hasCompletedCompaction) {
+    if (hasCompletedCompaction) {
+      return new MockHoodieActiveTimeline(
+          Stream.of("01", "02", "03", "04", "05", "07", "08"),
+          Stream.of("06"),
+          Stream.of(Pair.of("09", HoodieTimeline.DELTA_COMMIT_ACTION)));
+    } else {
+      return new MockHoodieActiveTimeline(
+          Stream.of("01", "02", "03", "04", "05", "07", "08"),
+          Stream.empty(),
+          Stream.of(
+              Pair.of("06", HoodieTimeline.COMMIT_ACTION),
+              Pair.of("09", HoodieTimeline.DELTA_COMMIT_ACTION)));
+    }
+  }
+
   /**
    * Validates if generated compaction plan matches with input file-slices.
    *
    * @param input File Slices with partition-path
-   * @param plan Compaction Plan
+   * @param plan  Compaction Plan
    */
   private void testFileSlicesCompactionPlanEquality(List<Pair<String, FileSlice>> input, HoodieCompactionPlan plan) {
     assertEquals(input.size(), plan.getOperations().size(), "All file-slices present");
@@ -245,12 +337,12 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
   /**
    * Validates if generated compaction operation matches with input file slice and partition path.
    *
-   * @param slice File Slice
-   * @param op HoodieCompactionOperation
+   * @param slice            File Slice
+   * @param op               HoodieCompactionOperation
    * @param expPartitionPath Partition path
    */
   private void testFileSliceCompactionOpEquality(FileSlice slice, HoodieCompactionOperation op, String expPartitionPath,
-      int version) {
+                                                 int version) {
     assertEquals(expPartitionPath, op.getPartitionPath(), "Partition path is correct");
     assertEquals(slice.getBaseInstantTime(), op.getBaseInstantTime(), "Same base-instant");
     assertEquals(slice.getFileId(), op.getFileId(), "Same file-id");
@@ -269,5 +361,25 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
   @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
+  }
+
+  class MockHoodieActiveTimeline extends HoodieActiveTimeline {
+
+    public MockHoodieActiveTimeline() {
+      super();
+      this.setInstants(new ArrayList<>());
+    }
+
+    public MockHoodieActiveTimeline(
+        Stream<String> completedDeltaCommits,
+        Stream<String> completedCompactionCommits,
+        Stream<Pair<String, String>> inflights) {
+      super();
+      this.setInstants(Stream.concat(
+          Stream.concat(completedDeltaCommits.map(s -> new HoodieInstant(false, DELTA_COMMIT_ACTION, s)),
+              completedCompactionCommits.map(s -> new HoodieInstant(false, COMMIT_ACTION, s))),
+              inflights.map(s -> new HoodieInstant(true, s.getRight(), s.getLeft())))
+          .sorted(Comparator.comparing(HoodieInstant::getFileName)).collect(Collectors.toList()));
+    }
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

For Hudi MOR table, the scheduling of compaction is triggered under certain conditions, configured by `hoodie.compact.inline.trigger.strategy`.  The default triggering condition is the number of delta commits, with the config of `hoodie.compact.inline.max.delta.commits`.  If this setting is larger than the archival config of `hoodie.keep.max.commits`, there is not enough delta commits in the active timeline and the compaction will never happen.

To guard around such configs, for MOR table with triggering strategy of `NUM_COMMITS` (trigger compaction when reach N delta commits) and `NUM_AND_TIME` (trigger compaction when both NUM_COMMITS and TIME_ELAPSED are satisfied), the archival always makes sure that there are enough delta commits in the active timeline to trigger compaction scheduling, besides other conditions.

## Brief change log

- Add new logic in `HoodieTimelineArchiver` to make sure that there are enough delta commits in the active timeline to trigger compaction scheduling, when the trigger strategy of compaction is NUM_COMMITS or NUM_AND_TIME.
- Add util methods in `CompactionUtils` and refactor `ScheduleCompactionActionExecutor` to use the same method for checking latest complete compaction and delta commits as `HoodieTimelineArchiver`
- Fix an issue of checking delta commits in active timeline when the timeline does not have any delta commit
- Add new tests for the new logic.

## Verify this pull request

This PR adds new tests in `TesthoodieTimelineArchiver` and `TestCompactionUtils` for the new logic.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
