### PR TITLE
[HUDI-3404] Automatically adjust write configs based on metadata table and write concurrency mode

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -908,7 +908,8 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public HoodieTableType getTableType() {
-    return HoodieTableType.valueOf(getString(HoodieTableConfig.TYPE).toUpperCase());
+    return HoodieTableType.valueOf(getStringOrDefault(
+        HoodieTableConfig.TYPE, HoodieTableConfig.TYPE.defaultValue().name()).toUpperCase());
   }
 
   public String getPreCombineField() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.fs.FileSystemRetryConfig;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -66,6 +67,8 @@ import org.apache.hudi.table.action.compact.strategy.CompactionStrategy;
 import org.apache.hudi.table.storage.HoodieStorageLayout;
 
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.apache.orc.CompressionKind;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -93,6 +96,7 @@ import java.util.stream.Collectors;
         + "higher level frameworks (e.g Spark datasources, Flink sink) and utilities (e.g DeltaStreamer).")
 public class HoodieWriteConfig extends HoodieConfig {
 
+  private static final Logger LOG = LogManager.getLogger(HoodieWriteConfig.class);
   private static final long serialVersionUID = 0L;
 
   // This is a constant as is should never be changed via config (will invalidate previous commits)
@@ -901,6 +905,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public String getTableName() {
     return getString(TBL_NAME);
+  }
+
+  public HoodieTableType getTableType() {
+    return HoodieTableType.valueOf(getString(HoodieTableConfig.TYPE).toUpperCase());
   }
 
   public String getPreCombineField() {
@@ -1930,7 +1938,9 @@ public class HoodieWriteConfig extends HoodieConfig {
    * @return True if any table services are configured to run async, false otherwise.
    */
   public Boolean areAnyTableServicesAsync() {
-    return isAsyncClusteringEnabled() || !inlineCompactionEnabled() || isAsyncClean() || isAsyncArchive();
+    return isAsyncClusteringEnabled()
+        || (getTableType() == HoodieTableType.MERGE_ON_READ && !inlineCompactionEnabled())
+        || isAsyncClean() || isAsyncArchive();
   }
 
   public Boolean areAnyTableServicesScheduledInline() {
@@ -2390,18 +2400,55 @@ public class HoodieWriteConfig extends HoodieConfig {
           HoodieLayoutConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultValue(TIMELINE_LAYOUT_VERSION_NUM, String.valueOf(TimelineLayoutVersion.CURR_VERSION));
 
-      // Async table services can update the metadata table and a lock provider is
-      // needed to guard against any concurrent table write operations. If user has
-      // not configured any lock provider, let's use the InProcess lock provider.
+      autoAdjustConfigsForConcurrencyMode();
+    }
+
+    private void autoAdjustConfigsForConcurrencyMode() {
+      boolean isMetadataTableEnabled = writeConfig.getBoolean(HoodieMetadataConfig.ENABLE);
       final TypedProperties writeConfigProperties = writeConfig.getProps();
       final boolean isLockProviderPropertySet = writeConfigProperties.containsKey(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME)
           || writeConfigProperties.containsKey(HoodieLockConfig.LOCK_PROVIDER_CLASS_PROP);
+      
       if (!isLockConfigSet) {
         HoodieLockConfig.Builder lockConfigBuilder = HoodieLockConfig.newBuilder().fromProperties(writeConfig.getProps());
-        if (!isLockProviderPropertySet && writeConfig.areAnyTableServicesAsync()) {
-          lockConfigBuilder.withLockProvider(InProcessLockProvider.class);
-        }
         writeConfig.setDefault(lockConfigBuilder.build());
+      }
+
+      if (isMetadataTableEnabled) {
+        // When metadata table is enabled, optimistic concurrency control must be used for
+        // single writer with async table services.
+        // Async table services can update the metadata table and a lock provider is
+        // needed to guard against any concurrent table write operations. If user has
+        // not configured any lock provider, let's use the InProcess lock provider.
+        boolean areTableServicesEnabled = writeConfig.areTableServicesEnabled();
+        boolean areAsyncTableServicesEnabled = writeConfig.areAnyTableServicesAsync();
+
+        if (!isLockProviderPropertySet && areTableServicesEnabled && areAsyncTableServicesEnabled) {
+          // This is targeted at Single writer with async table services
+          // If user does not set the lock provider, likely that the concurrency mode is not set either
+          // Override the configs for metadata table
+          writeConfig.setValue(WRITE_CONCURRENCY_MODE.key(),
+              WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.value());
+          writeConfig.setValue(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
+              InProcessLockProvider.class.getName());
+          LOG.info(String.format("Automatically set %s=%s and %s=%s since user has not set the "
+                  + "lock provider for single writer with async table services",
+              WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.value(),
+              HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(), InProcessLockProvider.class.getName()));
+        }
+      }
+
+      // We check if "hoodie.cleaner.policy.failed.writes"
+      // is properly set to LAZY for optimistic concurrency control
+      String writeConcurrencyMode = writeConfig.getString(WRITE_CONCURRENCY_MODE);
+      if (WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.value()
+          .equalsIgnoreCase(writeConcurrencyMode)) {
+        // In this case, we assume that the user takes care of setting the lock provider used
+        writeConfig.setValue(HoodieCompactionConfig.FAILED_WRITES_CLEANER_POLICY.key(),
+            HoodieFailedWritesCleaningPolicy.LAZY.name());
+        LOG.info(String.format("Automatically set %s=%s since optimistic concurrency control is used",
+            HoodieCompactionConfig.FAILED_WRITES_CLEANER_POLICY.key(),
+            HoodieFailedWritesCleaningPolicy.LAZY.name()));
       }
     }
 
@@ -2411,9 +2458,9 @@ public class HoodieWriteConfig extends HoodieConfig {
       new TimelineLayoutVersion(Integer.parseInt(layoutVersion));
       Objects.requireNonNull(writeConfig.getString(BASE_PATH));
       if (writeConfig.getString(WRITE_CONCURRENCY_MODE)
-          .equalsIgnoreCase(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name())) {
-        ValidationUtils.checkArgument(writeConfig.getString(HoodieCompactionConfig.FAILED_WRITES_CLEANER_POLICY)
-            != HoodieFailedWritesCleaningPolicy.EAGER.name(), "To enable optimistic concurrency control, set hoodie.cleaner.policy.failed.writes=LAZY");
+          .equalsIgnoreCase(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.value())) {
+        ValidationUtils.checkArgument(!writeConfig.getString(HoodieCompactionConfig.FAILED_WRITES_CLEANER_POLICY)
+            .equals(HoodieFailedWritesCleaningPolicy.EAGER.name()), "To enable optimistic concurrency control, set hoodie.cleaner.policy.failed.writes=LAZY");
       }
     }
 


### PR DESCRIPTION
## What is the purpose of the pull request

This PR adds logic to automatically adjust write configs based on metadata table enablement and write concurrency mode, to prevent possible missing configs that are required for enabling metadata table and multi-writer.  Write configs in scope are:
```
hoodie.metadata.enable (read-only in the new logic)
hoodie.write.concurrency.mode (can be auto updated in the new logic)
hoodie.write.lock.provider (can be auto updated in the new logic)
hoodie.cleaner.policy.failed.writes (can be auto updated in the new logic)
```
The following scenarios are checked:
| Metadata Table | Async Table Services | Lock Provider Set by User | Action |
| ----------- | ----------- | ----------- | ----------- |
| Enabled      | Enabled     |  No | Set `hoodie.write.concurrency.mode=optimistic_concurrency_control`, `hoodie.write.lock.provider=org.apache.hudi.client.transaction.lock.InProcessLockProvider` and `hoodie.cleaner.policy.failed.writes=LAZY`  |
| Enabled   | Enabled        | Yes | Set `hoodie.cleaner.policy.failed.writes=LAZY` if user has set `hoodie.write.concurrency.mode=optimistic_concurrency_control` |
| Enabled   | Disabled        | Yes/No | Set `hoodie.cleaner.policy.failed.writes=LAZY` if user has set `hoodie.write.concurrency.mode=optimistic_concurrency_control` |
| Disabled   | Enabled/Disabled        | Yes/No | Set `hoodie.cleaner.policy.failed.writes=LAZY` if user has set `hoodie.write.concurrency.mode=optimistic_concurrency_control` |

Note that the logic also depends on Hudi table type, since by default, MOR table has async compaction enabled, while COW table has all inline table services.

## Brief change log

- Adds auto config adjustment to in `HoodieWriteConfig`.
- Adds unit tests for different user-defined config scenarios in `TestHoodieWriteConfig` to make sure the logic is correct.

## Verify this pull request

This change adds tests in `TestHoodieWriteConfig` to verify the logic.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
