### PR TITLE
[HUDI-3593] Restore TypedProperties and flush checksum in table config

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/OrderedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/OrderedProperties.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * An extension of {@link java.util.Properties} that maintains the order.
+ * The implementation is not thread-safe.
+ */
+public class OrderedProperties extends Properties {
+
+  private final HashSet<Object> keys = new LinkedHashSet<>();
+
+  public OrderedProperties() {
+    super(null);
+  }
+
+  public OrderedProperties(Properties defaults) {
+    if (Objects.nonNull(defaults)) {
+      for (String key : defaults.stringPropertyNames()) {
+        put(key, defaults.getProperty(key));
+      }
+    }
+  }
+
+  @Override
+  public Enumeration propertyNames() {
+    return Collections.enumeration(keys);
+  }
+
+  @Override
+  public synchronized Enumeration<Object> keys() {
+    return Collections.enumeration(keys);
+  }
+
+  @Override
+  public Set<String> stringPropertyNames() {
+    Set<String> set = new LinkedHashSet<>();
+    for (Object key : this.keys) {
+      if (key instanceof String) {
+        set.add((String) key);
+      }
+    }
+    return set;
+  }
+
+  public synchronized void putAll(Properties t) {
+    for (Map.Entry<?, ?> e : t.entrySet()) {
+      if (!containsKey(String.valueOf(e.getKey()))) {
+        keys.add(e.getKey());
+      }
+      super.put(e.getKey(), e.getValue());
+    }
+  }
+
+  @Override
+  public synchronized Object put(Object key, Object value) {
+    keys.remove(key);
+    keys.add(key);
+    return super.put(key, value);
+  }
+
+  public synchronized Object putIfAbsent(Object key, Object value) {
+    if (!containsKey(String.valueOf(key))) {
+      keys.add(key);
+    }
+    return super.putIfAbsent(key, value);
+  }
+
+  @Override
+  public Object remove(Object key) {
+    keys.remove(key);
+    return super.remove(key);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
@@ -20,23 +20,15 @@ package org.apache.hudi.common.config;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * Type-aware extension of {@link java.util.Properties}.
  */
 public class TypedProperties extends Properties implements Serializable {
-
-  private final HashSet<Object> keys = new LinkedHashSet<>();
 
   public TypedProperties() {
     super(null);
@@ -48,56 +40,6 @@ public class TypedProperties extends Properties implements Serializable {
         put(key, defaults.getProperty(key));
       }
     }
-  }
-
-  @Override
-  public Enumeration propertyNames() {
-    return Collections.enumeration(keys);
-  }
-
-  @Override
-  public synchronized Enumeration<Object> keys() {
-    return Collections.enumeration(keys);
-  }
-
-  @Override
-  public Set<String> stringPropertyNames() {
-    Set<String> set = new LinkedHashSet<>();
-    for (Object key : this.keys) {
-      if (key instanceof String) {
-        set.add((String) key);
-      }
-    }
-    return set;
-  }
-
-  public synchronized void putAll(Properties t) {
-    for (Map.Entry<?, ?> e : t.entrySet()) {
-      if (!containsKey(String.valueOf(e.getKey()))) {
-        keys.add(e.getKey());
-      }
-      super.put(e.getKey(), e.getValue());
-    }
-  }
-
-  @Override
-  public synchronized Object put(Object key, Object value) {
-    keys.remove(key);
-    keys.add(key);
-    return super.put(key, value);
-  }
-
-  public synchronized Object putIfAbsent(Object key, Object value) {
-    if (!containsKey(String.valueOf(key))) {
-      keys.add(key);
-    }
-    return super.putIfAbsent(key, value);
-  }
-
-  @Override
-  public Object remove(Object key) {
-    keys.remove(key);
-    return super.remove(key);
   }
 
   private void checkKey(String property) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/properties/TestOrderedProperties.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/properties/TestOrderedProperties.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.properties;
+
+import org.apache.hudi.common.config.OrderedProperties;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestOrderedProperties {
+
+  @Test
+  public void testPutPropertiesOrder() {
+    Properties properties = new OrderedProperties();
+    properties.put("key0", "true");
+    properties.put("key1", "false");
+    properties.put("key2", "true");
+    properties.put("key3", "false");
+    properties.put("key4", "true");
+    properties.put("key5", "true");
+    properties.put("key6", "false");
+    properties.put("key7", "true");
+    properties.put("key8", "false");
+    properties.put("key9", "true");
+
+    OrderedProperties typedProperties = new OrderedProperties(properties);
+    assertTypeProperties(typedProperties, 0);
+  }
+
+  @Test
+  void testPutAllPropertiesOrder() {
+    Properties firstProp = new OrderedProperties();
+    firstProp.put("key0", "true");
+    firstProp.put("key1", "false");
+    firstProp.put("key2", "true");
+
+    OrderedProperties firstProperties = new OrderedProperties(firstProp);
+    assertTypeProperties(firstProperties, 0);
+
+    OrderedProperties secondProperties = new OrderedProperties();
+    secondProperties.put("key3", "true");
+    secondProperties.put("key4", "false");
+    secondProperties.put("key5", "true");
+    assertTypeProperties(secondProperties, 3);
+
+    OrderedProperties thirdProperties = new OrderedProperties();
+    thirdProperties.putAll(firstProp);
+    thirdProperties.putAll(secondProperties);
+
+    assertEquals(3, firstProp.stringPropertyNames().size());
+    assertEquals(3, secondProperties.stringPropertyNames().size());
+    assertEquals(6, thirdProperties.stringPropertyNames().size());
+  }
+
+  private void assertTypeProperties(OrderedProperties typedProperties, int start) {
+    String[] props = typedProperties.stringPropertyNames().toArray(new String[0]);
+    for (int i = start; i < props.length; i++) {
+      assertEquals(String.format("key%d", i), props[i]);
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
@@ -22,10 +22,11 @@ import org.apache.hudi.common.config.TypedProperties;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTypedProperties {
   @Test
@@ -79,58 +80,8 @@ public class TestTypedProperties {
     properties.put("key1", "true");
 
     TypedProperties typedProperties = new TypedProperties(properties);
-    assertEquals(true, typedProperties.getBoolean("key1"));
-    assertEquals(true, typedProperties.getBoolean("key1", false));
-    assertEquals(false, typedProperties.getBoolean("key2", false));
-  }
-
-  @Test
-  public void testPropertiesOrder() throws IOException {
-    Properties properties = new TypedProperties();
-    properties.put("key0", "true");
-    properties.put("key1", "false");
-    properties.put("key2", "true");
-    properties.put("key3", "false");
-    properties.put("key4", "true");
-    properties.put("key5", "true");
-    properties.put("key6", "false");
-    properties.put("key7", "true");
-    properties.put("key8", "false");
-    properties.put("key9", "true");
-
-    TypedProperties typedProperties = new TypedProperties(properties);
-    assertTypeProperties(typedProperties, 0);
-  }
-
-  @Test
-  void testPutAllProperties() {
-    Properties firstProp = new TypedProperties();
-    firstProp.put("key0", "true");
-    firstProp.put("key1", "false");
-    firstProp.put("key2", "true");
-
-    TypedProperties firstProperties = new TypedProperties(firstProp);
-    assertTypeProperties(firstProperties, 0);
-
-    TypedProperties secondProperties = new TypedProperties();
-    secondProperties.put("key3", "true");
-    secondProperties.put("key4", "false");
-    secondProperties.put("key5", "true");
-    assertTypeProperties(secondProperties, 3);
-
-    TypedProperties thirdProperties = new TypedProperties();
-    thirdProperties.putAll(firstProp);
-    thirdProperties.putAll(secondProperties);
-
-    assertEquals(3, firstProp.stringPropertyNames().size());
-    assertEquals(3, secondProperties.stringPropertyNames().size());
-    assertEquals(6, thirdProperties.stringPropertyNames().size());
-  }
-
-  private void assertTypeProperties(TypedProperties typedProperties, int start) {
-    String[] props = typedProperties.stringPropertyNames().toArray(new String[0]);
-    for (int i = start; i < props.length; i++) {
-      assertEquals(String.format("key%d", i), props[i]);
-    }
+    assertTrue(typedProperties.getBoolean("key1"));
+    assertTrue(typedProperties.getBoolean("key1", false));
+    assertFalse(typedProperties.getBoolean("key2", false));
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

`TypedProperties#keys` is not thread-safe. It was added in #4712 to ensure insertion order of properties is maintained. It was done in order to add a table checksum config in the end which would be used to validate that `hoodie.properties` is not written partially. However, TypedProperties not being thread-safe could result in ConcurrentModificationException as there are places in clustering where write config is passed to spark executor and it might happen that while one thread is trying to serialize it the other is trying to modify it. However, the solution to original problem need not depend on ordering. We can just add table checksum in the end and then while reading `hoodie.properties` just ensure that prop exists.

## Brief change log

- Remove `TypedProperties#keys`
- Convert props to linked hashmap and then add table checksum config and then flush it to `hoodie.properties`.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
