### PR TITLE
[HUDI-3607] Support backend switch in HoodieFlinkStreamer

### DIFF
--- a/hudi-flink/pom.xml
+++ b/hudi-flink/pom.xml
@@ -174,6 +174,12 @@
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.streamer;
 
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.hudi.client.utils.OperationConverter;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -25,6 +27,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
+import org.apache.hudi.util.FlinkStateBackendConverter;
 import org.apache.hudi.util.StreamerUtil;
 
 import com.beust.jcommander.Parameter;
@@ -52,6 +55,10 @@ public class FlinkStreamerConfig extends Configuration {
 
   @Parameter(names = {"--flink-checkpoint-path"}, description = "Flink checkpoint path.")
   public String flinkCheckPointPath;
+
+  @Parameter(names = {"--flink-state-backend-type"}, description = "Flink state backend type : HashMapStateBackend " +
+          "(default).", converter = FlinkStateBackendConverter.class)
+  public StateBackend stateBackend = new HashMapStateBackend();
 
   @Parameter(names = {"--instant-retry-times"}, description = "Times to retry when latest instant has not completed.")
   public String instantRetryTimes = "10";

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
@@ -56,8 +56,8 @@ public class FlinkStreamerConfig extends Configuration {
   @Parameter(names = {"--flink-checkpoint-path"}, description = "Flink checkpoint path.")
   public String flinkCheckPointPath;
 
-  @Parameter(names = {"--flink-state-backend-type"}, description = "Flink state backend type : HashMapStateBackend "
-          + "(default).", converter = FlinkStateBackendConverter.class)
+  @Parameter(names = {"--flink-state-backend-type"}, description = "Flink state backend type, support only hashmap and rocksdb by now,"
+          + " default hashmap.", converter = FlinkStateBackendConverter.class)
   public StateBackend stateBackend = new HashMapStateBackend();
 
   @Parameter(names = {"--instant-retry-times"}, description = "Times to retry when latest instant has not completed.")

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
@@ -56,8 +56,8 @@ public class FlinkStreamerConfig extends Configuration {
   @Parameter(names = {"--flink-checkpoint-path"}, description = "Flink checkpoint path.")
   public String flinkCheckPointPath;
 
-  @Parameter(names = {"--flink-state-backend-type"}, description = "Flink state backend type : HashMapStateBackend " +
-          "(default).", converter = FlinkStateBackendConverter.class)
+  @Parameter(names = {"--flink-state-backend-type"}, description = "Flink state backend type : HashMapStateBackend "
+          + "(default).", converter = FlinkStateBackendConverter.class)
   public StateBackend stateBackend = new HashMapStateBackend();
 
   @Parameter(names = {"--instant-retry-times"}, description = "Times to retry when latest instant has not completed.")

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
@@ -32,7 +32,6 @@ import com.beust.jcommander.JCommander;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
-import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;

--- a/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/streamer/HoodieFlinkStreamer.java
@@ -61,8 +61,9 @@ public class HoodieFlinkStreamer {
     // There can only be one checkpoint at one time.
     env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 
+    env.setStateBackend(cfg.stateBackend);
     if (cfg.flinkCheckPointPath != null) {
-      env.setStateBackend(new FsStateBackend(cfg.flinkCheckPointPath));
+      env.getCheckpointConfig().setCheckpointStorage(cfg.flinkCheckPointPath);
     }
 
     TypedProperties kafkaProps = DFSPropertiesConfiguration.getGlobalProps();

--- a/hudi-flink/src/main/java/org/apache/hudi/util/FlinkStateBackendConverter.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/FlinkStateBackendConverter.java
@@ -35,7 +35,7 @@ public class FlinkStateBackendConverter implements IStringConverter<StateBackend
       case "hashmap" : return new HashMapStateBackend();
       case "rocksdb" : return new EmbeddedRocksDBStateBackend();
       default:
-        throw new HoodieException("Can not convert flink state backend.");
+        throw new HoodieException(String.format("Unknown flink state backend %s.", value));
     }
   }
 }

--- a/hudi-flink/src/main/java/org/apache/hudi/util/FlinkStateBackendConverter.java
+++ b/hudi-flink/src/main/java/org/apache/hudi/util/FlinkStateBackendConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.hudi.exception.HoodieException;
+
+/**
+ * Converter that converts a string into Flink StateBackend.
+ */
+public class FlinkStateBackendConverter implements IStringConverter<StateBackend> {
+  @Override
+  public StateBackend convert(String value) throws ParameterException {
+    switch (value) {
+      case "hashmap" : return new HashMapStateBackend();
+      case "rocksdb" : return new EmbeddedRocksDBStateBackend();
+      default:
+        throw new HoodieException("Can not convert flink state backend.");
+    }
+  }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Now, HoodieFlinkStreamer utility only support one backend - FsStateBackend.

I think it's not flexible for the application configuration. Could we make backend configurable?

Moreover, for flink version 1.14, FsStateBackend is deprecated in favor of org.apache.flink.runtime.state.hashmap.HashMapStateBackend and org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
