### PR TITLE
[HUDI-3621] Fixing NullPointerException in DeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -910,6 +910,10 @@ public class DeltaSync implements Serializable {
    * @return Requested clustering instant.
    */
   public Option<String> getClusteringInstantOpt() {
-    return writeClient.scheduleClustering(Option.empty());
+    if (writeClient != null) {
+      return writeClient.scheduleClustering(Option.empty());
+    } else {
+      return Option.empty();
+    }
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

- In continuous mode when async clustering is enabled, and if there is no new data to consume for the first time, deltastreamer throws NPE while trying to invoke clustering. bcoz, the writeClient itself is not initialized. 

## Brief change log

- Fixed fetching of clustering instant in deltastreamer to return Option.empty if writeclient is not initialized. 

## Verify this pull request

- Tested manually with local deltastreamer. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
