### PR TITLE
[HUDI-3633] Allow non-string values to be set in TypedProperties

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.config;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -36,8 +37,8 @@ public class TypedProperties extends Properties implements Serializable {
 
   public TypedProperties(Properties defaults) {
     if (Objects.nonNull(defaults)) {
-      for (String key : defaults.stringPropertyNames()) {
-        put(key, defaults.getProperty(key));
+      for (Object key : Collections.list(defaults.propertyNames())) {
+        put(String.valueOf(key), String.valueOf(defaults.get(key)));
       }
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TypedProperties.java
@@ -20,7 +20,7 @@ package org.apache.hudi.common.config;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -37,10 +37,21 @@ public class TypedProperties extends Properties implements Serializable {
 
   public TypedProperties(Properties defaults) {
     if (Objects.nonNull(defaults)) {
-      for (Object key : Collections.list(defaults.propertyNames())) {
-        put(String.valueOf(key), String.valueOf(defaults.get(key)));
+      for (Enumeration<?> e = defaults.propertyNames(); e.hasMoreElements(); ) {
+        Object k = e.nextElement();
+        Object v = defaults.get(k);
+        if (v != null) {
+          put(k, v);
+        }
       }
     }
+  }
+
+  @Override
+  public String getProperty(String key) {
+    Object oval = super.get(key);
+    String sval = (oval != null) ? String.valueOf(oval) : null;
+    return ((sval == null) && (defaults != null)) ? defaults.getProperty(key) : sval;
   }
 
   private void checkKey(String property) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
@@ -83,5 +83,21 @@ public class TestTypedProperties {
     assertTrue(typedProperties.getBoolean("key1"));
     assertTrue(typedProperties.getBoolean("key1", false));
     assertFalse(typedProperties.getBoolean("key2", false));
+    // test getBoolean with non-string value for key2
+    properties.put("key2", true);
+    typedProperties = new TypedProperties(properties);
+    assertTrue(typedProperties.getBoolean("key1", false));
+    assertTrue(typedProperties.getBoolean("key2", false));
+  }
+
+  @Test
+  public void testTypedPropertiesWithNonStringValue() {
+    Properties properties = new Properties();
+    properties.put("key1", "1");
+    properties.put("key2", 2);
+
+    TypedProperties props = new TypedProperties(properties);
+    assertEquals(1, props.getInteger("key1"));
+    assertEquals(2, props.getInteger("key2"));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/properties/TestTypedProperties.java
@@ -88,6 +88,9 @@ public class TestTypedProperties {
     typedProperties = new TypedProperties(properties);
     assertTrue(typedProperties.getBoolean("key1", false));
     assertTrue(typedProperties.getBoolean("key2", false));
+    // put non-string value in TypedProperties
+    typedProperties.put("key3", true);
+    assertTrue(typedProperties.getBoolean("key3", false));
   }
 
   @Test
@@ -99,5 +102,8 @@ public class TestTypedProperties {
     TypedProperties props = new TypedProperties(properties);
     assertEquals(1, props.getInteger("key1"));
     assertEquals(2, props.getInteger("key2"));
+    // put non-string value in TypedProperties
+    props.put("key2", 3);
+    assertEquals(3, props.getInteger("key2"));
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

`TypedProperties` invokes `Properties#stringPropertynames()` which expects that key and values should be strings. It causes keys with non-string values to be not found. See #5026 . This PR fixes that behavior.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
