### PR TITLE
[HUDI-3651] optimize the hoodie hive client and ddl executor code wit…

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/DDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/DDLExecutor.java
@@ -18,9 +18,16 @@
 
 package org.apache.hudi.hive.ddl;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.parquet.schema.MessageType;
+import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
@@ -34,7 +41,7 @@ public interface DDLExecutor {
   /**
    * @param databaseName name of database to be created.
    */
-  public void createDatabase(String databaseName);
+  void createDatabase(String databaseName);
 
   /**
    * Creates a table with the following properties.
@@ -47,7 +54,7 @@ public interface DDLExecutor {
    * @param serdeProperties
    * @param tableProperties
    */
-  public void createTable(String tableName, MessageType storageSchema, String inputFormatClass,
+  void createTable(String tableName, MessageType storageSchema, String inputFormatClass,
                           String outputFormatClass, String serdeClass,
                           Map<String, String> serdeProperties, Map<String, String> tableProperties);
 
@@ -57,7 +64,7 @@ public interface DDLExecutor {
    * @param tableName
    * @param newSchema
    */
-  public void updateTableDefinition(String tableName, MessageType newSchema);
+  void updateTableDefinition(String tableName, MessageType newSchema);
 
   /**
    * Fetches tableSchema for a table.
@@ -65,7 +72,7 @@ public interface DDLExecutor {
    * @param tableName
    * @return
    */
-  public Map<String, String> getTableSchema(String tableName);
+  Map<String, String> getTableSchema(String tableName);
 
   /**
    * Adds partition to table.
@@ -73,7 +80,7 @@ public interface DDLExecutor {
    * @param tableName
    * @param partitionsToAdd
    */
-  public void addPartitionsToTable(String tableName, List<String> partitionsToAdd);
+  void addPartitionsToTable(String tableName, List<String> partitionsToAdd);
 
   /**
    * Updates partitions for a given table.
@@ -81,7 +88,7 @@ public interface DDLExecutor {
    * @param tableName
    * @param changedPartitions
    */
-  public void updatePartitionsToTable(String tableName, List<String> changedPartitions);
+  void updatePartitionsToTable(String tableName, List<String> changedPartitions);
 
   /**
    * Drop partitions for a given table.
@@ -89,15 +96,112 @@ public interface DDLExecutor {
    * @param tableName
    * @param partitionsToDrop
    */
-  public void dropPartitionsToTable(String tableName, List<String> partitionsToDrop);
+  void dropPartitionsToTable(String tableName, List<String> partitionsToDrop);
 
   /**
-   * update table comments
+   * update table comments.
    *
    * @param tableName
    * @param newSchema
    */
-  public void updateTableComments(String tableName, Map<String, ImmutablePair<String,String>> newSchema);
+  void updateTableComments(String tableName, Map<String, ImmutablePair<String,String>> newSchema);
 
-  public void close();
+  /**
+   * close ddl executor such as close connection.
+   */
+  void close();
+
+  /**
+   *  extract partition value from storage partition path.
+   * @param storagePartition
+   * @return
+   */
+  List<String> extractPartitionValuesInPath(String storagePartition);
+
+  /**
+   *  scan table partitions.
+   * @param databaseName
+   * @param tableName
+   * @return
+   * @throws TException
+   */
+  List<Partition> scanTablePartitions(String databaseName, String tableName) throws TException;
+
+  /**
+   *  check table exist under a specified database.
+   * @param databaseName
+   * @param tableName
+   * @return
+   */
+  boolean doesTableExist(String databaseName, String tableName);
+
+  /**
+   *  get last sync committed time from table.
+   * @param databaseName
+   * @param tableName
+   * @return
+   */
+  Option<String> getLastCommitTimeSynced(String databaseName, String tableName);
+
+  /**
+   *  get last replicated time from table.
+   * @param databaseName
+   * @param tableName
+   * @return
+   */
+  Option<String> getLastReplicatedTime(String databaseName, String tableName);
+
+  /**
+   *  update last replicated time to table.
+   * @param activeTimeline
+   * @param databaseName
+   * @param tableName
+   * @param timeStamp
+   */
+  void updateLastReplicatedTimeStamp(HoodieTimeline activeTimeline, String databaseName, String tableName, String timeStamp);
+
+  /**
+   * delete last replicated time from table.
+   * @param databaseName
+   * @param tableName
+   */
+  void deleteLastReplicatedTimeStamp(String databaseName, String tableName);
+
+  /**
+   *  update last committed time to table.
+   * @param activeTimeline
+   * @param databaseName
+   * @param tableName
+   */
+  void updateLastCommitTimeSynced(HoodieTimeline activeTimeline, String databaseName, String tableName);
+
+  /**
+   *  get avro schema.
+   * @param metaClient
+   * @return
+   */
+  Schema getAvroSchemaWithoutMetadataFields(HoodieTableMetaClient metaClient);
+
+  /**
+   * use table comment.
+   * @param databaseName
+   * @param tableName
+   * @return
+   */
+  List<FieldSchema> getTableCommentUsingMetastoreClient(String databaseName, String tableName);
+
+  /**
+   *  check whether a database exist with specified name.
+   * @param databaseName
+   * @return
+   */
+  boolean doesDataBaseExist(String databaseName);
+
+  /**
+   * update table properties.
+   * @param databaseName
+   * @param tableName
+   * @param tableProperties
+   */
+  void updateTableProperties(String databaseName, String tableName, Map<String, String> tableProperties);
 }


### PR DESCRIPTION
currently. HoodieHiveClient both have DDLExecutor and IMetaStoreClient instance, some ddl executor implemented such as HMSDDLExecutor and HiveQueryDDLExecutor will create IMetaStoreClient instance again. some method in HoodieHiveClient operate HMS both use ddl executor and IMetaStoreClient instance. it look not a clear style. we do some change here.

1.HoodieHiveClient operate HMS only via DDLExecutor instance.

2.Only create IMetaStoreClient instance one time, and pass to ddl executor

3.no need create partitionValueExtractor in HoodieHiveClient, use DDLExecutor's partitionValueExtractor

4.no need public declaration of interface(DDLExecutor) method ,remove it

5.remove some unused import