### PR TITLE
[MINOR]flink ParquetSchemaConverter timestamp(3) should converted as TIMESTAMP_MILLIS for bulk_insert

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
@@ -604,6 +604,7 @@ public class ParquetSchemaConverter {
         TimestampType timestampType = (TimestampType) type;
         if (timestampType.getPrecision() == 3) {
           return Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition)
+              .as(OriginalType.TIMESTAMP_MILLIS)
               .named(name);
         } else {
           return Types.primitive(PrimitiveType.PrimitiveTypeName.INT96, repetition)

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
@@ -46,7 +46,6 @@ public class TestParquetSchemaConverter {
             "  optional int96 ts9;\n" +
             "}\n";
     assertThat(messageType.toString(), is(expected));
-    System.out.println(messageType.toString());
   }
 
   @Test

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
@@ -30,6 +30,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Test cases for {@link ParquetSchemaConverter}.
  */
 public class TestParquetSchemaConverter {
+
+  @Test
+  void testTimestampConvert(){
+    DataType dataType = DataTypes.ROW(
+            DataTypes.FIELD("ts",DataTypes.TIMESTAMP(3)),
+            DataTypes.FIELD("ts6",DataTypes.TIMESTAMP(6)),
+            DataTypes.FIELD("ts9",DataTypes.TIMESTAMP(9))
+    );
+    org.apache.parquet.schema.MessageType messageType =
+            ParquetSchemaConverter.convertToParquetMessageType("converted", (RowType) dataType.getLogicalType());
+    final String expected = "message converted {\n" +
+            "  optional int64 ts (TIMESTAMP_MILLIS);\n" +
+            "  optional int96 ts6;\n" +
+            "  optional int96 ts9;\n" +
+            "}\n";
+    assertThat(messageType.toString(), is(expected));
+    System.out.println(messageType.toString());
+  }
+
   @Test
   void testConvertComplexTypes() {
     DataType dataType = DataTypes.ROW(


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
