### PR TITLE
[MINOR] Remove flaky assert in TestInLineFileSystem

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/TestInLineFileSystem.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/TestInLineFileSystem.java
@@ -369,7 +369,6 @@ public class TestInLineFileSystem {
   private void verifyFileStatus(FileStatus expected, Path inlinePath, long expectedLength, FileStatus actual) {
     assertEquals(inlinePath, actual.getPath());
     assertEquals(expectedLength, actual.getLen());
-    assertEquals(expected.getAccessTime(), actual.getAccessTime());
     assertEquals(expected.getBlockSize(), actual.getBlockSize());
     assertEquals(expected.getGroup(), actual.getGroup());
     assertEquals(expected.getModificationTime(), actual.getModificationTime());


### PR DESCRIPTION
## What is the purpose of the pull request

This PR removes the assert of `FileStatus::getAccessTime` which is flaky on rare occasions (the difference is in ms as shown below), since the access time can be changed when reading the file to get the file status for the expected and actual.  This only affects `testReadInlineFile()`.

```
[ERROR] org.apache.hudi.common.fs.inline.TestInLineFileSystem.testReadInlineFile
[ERROR]   Run 1: TestInLineFileSystem.testReadInlineFile:110->verifyFileStatus:372 expected: <1647752030224> but was: <1647752030244>
[ERROR]   Run 2: TestInLineFileSystem.testReadInlineFile:110->verifyFileStatus:372 expected: <1647752042953> but was: <1647752042973>
[ERROR]   Run 3: TestInLineFileSystem.testReadInlineFile:110->verifyFileStatus:372 expected: <1647752043009> but was: <1647752043029>
[ERROR]   Run 4: TestInLineFileSystem.testReadInlineFile:110->verifyFileStatus:372 expected: <1647752043061> but was: <1647752043081>
```

## Brief change log

- Removes flaky assert in TestInLineFileSystem.

## Verify this pull request

This pull request is already covered by existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
