### PR TITLE
[HUDI-3663] Fixing Column Stats index to properly handle first Data Table commit

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -461,11 +461,9 @@ public class HoodieTableConfig extends HoodieConfig {
   }
 
   public Option<String[]> getRecordKeyFields() {
-    if (contains(RECORDKEY_FIELDS)) {
-      return Option.of(Arrays.stream(getString(RECORDKEY_FIELDS).split(","))
-          .filter(p -> p.length() > 0).collect(Collectors.toList()).toArray(new String[] {}));
-    }
-    return Option.empty();
+    String keyFieldsValue = getStringOrDefault(RECORDKEY_FIELDS, HoodieRecord.RECORD_KEY_METADATA_FIELD);
+    return Option.of(Arrays.stream(keyFieldsValue.split(","))
+        .filter(p -> p.length() > 0).collect(Collectors.toList()).toArray(new String[] {}));
   }
 
   public Option<String[]> getPartitionFields() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Option.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Option.java
@@ -34,7 +34,7 @@ public final class Option<T> implements Serializable {
 
   private static final long serialVersionUID = 0L;
 
-  private static final Option<?> NULL_VAL = new Option<>();
+  private static final Option<?> EMPTY = new Option<>();
 
   private final T val;
 
@@ -67,8 +67,9 @@ public final class Option<T> implements Serializable {
     this.val = val;
   }
 
+  @SuppressWarnings("unchecked")
   public static <T> Option<T> empty() {
-    return (Option<T>) NULL_VAL;
+    return (Option<T>) EMPTY;
   }
 
   public static <T> Option<T> of(T value) {
@@ -105,6 +106,17 @@ public final class Option<T> implements Serializable {
       return empty();
     } else {
       return Option.ofNullable(mapper.apply(val));
+    }
+  }
+
+  public <U> Option<U> flatMap(Function<? super T, Option<U>> mapper) {
+    if (null == mapper) {
+      throw new NullPointerException("mapper should not be null");
+    }
+    if (!isPresent()) {
+      return empty();
+    } else {
+      return Objects.requireNonNull(mapper.apply(val));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -384,7 +384,7 @@ public class HoodieTableMetadataUtil {
     HoodieTableMetaClient dataTableMetaClient = recordsGenerationParams.getDataMetaClient();
 
     List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
-        dataTableMetaClient.getTableConfig(), tryFetchSchemaFromCommit(dataTableMetaClient));
+        dataTableMetaClient.getTableConfig(), tryResolveSchemaForTable(dataTableMetaClient));
 
     if (columnsToIndex.isEmpty()) {
       // In case there are no columns to index, bail
@@ -712,7 +712,7 @@ public class HoodieTableMetadataUtil {
     HoodieTableMetaClient dataTableMetaClient = recordsGenerationParams.getDataMetaClient();
 
     final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
-        dataTableMetaClient.getTableConfig(), tryFetchSchemaFromCommit(dataTableMetaClient));
+        dataTableMetaClient.getTableConfig(), tryResolveSchemaForTable(dataTableMetaClient));
 
     if (columnsToIndex.isEmpty()) {
       // In case there are no columns to index, bail
@@ -1060,8 +1060,7 @@ public class HoodieTableMetadataUtil {
     });
   }
 
-  @Nonnull
-  private static Option<Schema> tryFetchSchemaFromCommit(HoodieTableMetaClient dataTableMetaClient) {
+  private static Option<Schema> tryResolveSchemaForTable(HoodieTableMetaClient dataTableMetaClient) {
     if (dataTableMetaClient.getCommitsTimeline().filterCompletedInstants().countInstants() == 0) {
       return Option.empty();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -386,6 +386,11 @@ public class HoodieTableMetadataUtil {
     List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
         dataTableMetaClient.getTableConfig(), tryFetchSchemaFromCommit(dataTableMetaClient));
 
+    if (columnsToIndex.isEmpty()) {
+      // In case there are no columns to index, bail
+      return engineContext.emptyHoodieData();
+    }
+
     int parallelism = Math.max(Math.min(deleteFileList.size(), recordsGenerationParams.getColumnStatsIndexParallelism()), 1);
     return engineContext.parallelize(deleteFileList, parallelism)
         .flatMap(deleteFileInfoPair -> {
@@ -709,6 +714,11 @@ public class HoodieTableMetadataUtil {
     final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
         dataTableMetaClient.getTableConfig(), tryFetchSchemaFromCommit(dataTableMetaClient));
 
+    if (columnsToIndex.isEmpty()) {
+      // In case there are no columns to index, bail
+      return engineContext.emptyHoodieData();
+    }
+
     final List<Pair<String, List<String>>> partitionToDeletedFilesList = partitionToDeletedFiles.entrySet()
         .stream().map(e -> Pair.of(e.getKey(), e.getValue())).collect(Collectors.toList());
     int parallelism = Math.max(Math.min(partitionToDeletedFilesList.size(), recordsGenerationParams.getColumnStatsIndexParallelism()), 1);
@@ -864,6 +874,11 @@ public class HoodieTableMetadataUtil {
       List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
           dataTableMetaClient.getTableConfig(), writerSchema);
 
+      if (columnsToIndex.isEmpty()) {
+        // In case there are no columns to index, bail
+        return engineContext.emptyHoodieData();
+      }
+
       int parallelism = Math.max(Math.min(allWriteStats.size(), recordsGenerationParams.getColumnStatsIndexParallelism()), 1);
       return engineContext.parallelize(allWriteStats, parallelism)
           .flatMap(writeStat ->
@@ -884,7 +899,9 @@ public class HoodieTableMetadataUtil {
       return Arrays.asList(tableConfig.getRecordKeyFields().get());
     }
 
-    return writerSchema.map(schema -> schema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList()))
+    return writerSchema.map(schema ->
+            schema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList())
+        )
         .orElse(Collections.emptyList());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -88,6 +88,7 @@ import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.NULL_
 import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.TOTAL_SIZE;
 import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.TOTAL_UNCOMPRESSED_SIZE;
 import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.VALUE_COUNT;
+import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 import static org.apache.hudi.metadata.HoodieTableMetadata.EMPTY_PARTITION_NAME;
 import static org.apache.hudi.metadata.HoodieTableMetadata.NON_PARTITIONED_NAME;
 
@@ -867,7 +868,10 @@ public class HoodieTableMetadataUtil {
     try {
       Option<Schema> writerSchema =
           Option.ofNullable(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY))
-              .map(writerSchemaStr -> new Schema.Parser().parse(writerSchemaStr));
+              .flatMap(writerSchemaStr ->
+                  isNullOrEmpty(writerSchemaStr)
+                    ? Option.empty()
+                    : Option.of(new Schema.Parser().parse(writerSchemaStr)));
 
       HoodieTableMetaClient dataTableMetaClient = recordsGenerationParams.getDataMetaClient();
 
@@ -1039,7 +1043,7 @@ public class HoodieTableMetadataUtil {
       columnStats.put(TOTAL_SIZE, Long.parseLong(columnStats.getOrDefault(TOTAL_SIZE, 0).toString()) + fieldSize);
       columnStats.put(TOTAL_UNCOMPRESSED_SIZE, Long.parseLong(columnStats.getOrDefault(TOTAL_UNCOMPRESSED_SIZE, 0).toString()) + fieldSize);
 
-      if (!StringUtils.isNullOrEmpty(fieldVal)) {
+      if (!isNullOrEmpty(fieldVal)) {
         // set the min value of the field
         if (!columnStats.containsKey(MIN)) {
           columnStats.put(MIN, fieldVal);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -379,7 +380,7 @@ public class HoodieTableMetadataUtil {
       deletedFiles.forEach(entry -> deleteFileList.add(Pair.of(partition, entry)));
     });
 
-    final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams.getDataMetaClient(), recordsGenerationParams.isAllColumnStatsIndexEnabled());
+    final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams, recordsGenerationParams.getDataMetaClient(), Option.empty());
     final int parallelism = Math.max(Math.min(deleteFileList.size(), recordsGenerationParams.getColumnStatsIndexParallelism()), 1);
     HoodieData<Pair<String, String>> deleteFileListRDD = engineContext.parallelize(deleteFileList, parallelism);
     return deleteFileListRDD.flatMap(deleteFileInfoPair -> {
@@ -698,7 +699,8 @@ public class HoodieTableMetadataUtil {
                                                                           Map<String, Map<String, Long>> partitionToAppendedFiles,
                                                                           MetadataRecordsGenerationParams recordsGenerationParams) {
     HoodieData<HoodieRecord> allRecordsRDD = engineContext.emptyHoodieData();
-    final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams.getDataMetaClient(), recordsGenerationParams.isAllColumnStatsIndexEnabled());
+    final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
+        recordsGenerationParams.getDataMetaClient(), Option.empty());
 
     final List<Pair<String, List<String>>> partitionToDeletedFilesList = partitionToDeletedFiles.entrySet()
         .stream().map(e -> Pair.of(e.getKey(), e.getValue())).collect(Collectors.toList());
@@ -838,55 +840,48 @@ public class HoodieTableMetadataUtil {
   public static HoodieData<HoodieRecord> convertMetadataToColumnStatsRecords(HoodieCommitMetadata commitMetadata,
                                                                              HoodieEngineContext engineContext,
                                                                              MetadataRecordsGenerationParams recordsGenerationParams) {
-    try {
-      List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
-          .flatMap(entry -> entry.stream()).collect(Collectors.toList());
-      return HoodieTableMetadataUtil.createColumnStatsFromWriteStats(engineContext, allWriteStats, recordsGenerationParams);
-    } catch (Exception e) {
-      throw new HoodieException("Failed to generate column stats records for metadata table ", e);
-    }
-  }
+    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+        .flatMap(Collection::stream).collect(Collectors.toList());
 
-  /**
-   * Create column stats from write status.
-   *
-   * @param engineContext           - Engine context
-   * @param allWriteStats           - Write status to convert
-   * @param recordsGenerationParams - Parameters for columns stats record generation
-   */
-  public static HoodieData<HoodieRecord> createColumnStatsFromWriteStats(HoodieEngineContext engineContext,
-                                                                         List<HoodieWriteStat> allWriteStats,
-                                                                         MetadataRecordsGenerationParams recordsGenerationParams) {
     if (allWriteStats.isEmpty()) {
       return engineContext.emptyHoodieData();
     }
-    final List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams.getDataMetaClient(), recordsGenerationParams.isAllColumnStatsIndexEnabled());
-    final int parallelism = Math.max(Math.min(allWriteStats.size(), recordsGenerationParams.getColumnStatsIndexParallelism()), 1);
-    HoodieData<HoodieWriteStat> allWriteStatsRDD = engineContext.parallelize(allWriteStats, parallelism);
-    return allWriteStatsRDD.flatMap(writeStat -> translateWriteStatToColumnStats(writeStat, recordsGenerationParams.getDataMetaClient(), columnsToIndex).iterator());
+
+    try {
+      Option<Schema> writerSchema =
+          Option.ofNullable(commitMetadata.getExtraMetadata().get(HoodieCommitMetadata.SCHEMA_KEY))
+              .map(writerSchemaStr -> new Schema.Parser().parse(writerSchemaStr));
+
+      List<String> columnsToIndex = getColumnsToIndex(recordsGenerationParams,
+          recordsGenerationParams.getDataMetaClient(), writerSchema);
+
+      int parallelism = Math.max(Math.min(allWriteStats.size(), recordsGenerationParams.getColumnStatsIndexParallelism()), 1);
+      return engineContext.parallelize(allWriteStats, parallelism)
+          .flatMap(writeStat ->
+              translateWriteStatToColumnStats(writeStat, recordsGenerationParams.getDataMetaClient(), columnsToIndex).iterator());
+    } catch (Exception e) {
+      throw new HoodieException("Failed to generate column stats records for metadata table", e);
+    }
   }
 
   /**
    * Get the latest columns for the table for column stats indexing.
    *
-   * @param datasetMetaClient                   - Data table meta client
-   * @param isMetaIndexColumnStatsForAllColumns - Is column stats indexing enabled for all columns
+   * @param dataTableMetaClient - Data table meta client
    */
-  private static List<String> getColumnsToIndex(HoodieTableMetaClient datasetMetaClient, boolean isMetaIndexColumnStatsForAllColumns) {
-    if (!isMetaIndexColumnStatsForAllColumns
-        || datasetMetaClient.getCommitsTimeline().filterCompletedInstants().countInstants() < 1) {
-      return Arrays.asList(datasetMetaClient.getTableConfig().getRecordKeyFieldProp().split(","));
+  private static List<String> getColumnsToIndex(MetadataRecordsGenerationParams recordsGenParams,
+                                                HoodieTableMetaClient dataTableMetaClient,
+                                                Option<Schema> writerSchema) {
+    if (!recordsGenParams.isAllColumnStatsIndexEnabled()) {
+      // TODO why are we only indexing primary key? revisit fallback
+      return Arrays.asList(dataTableMetaClient.getTableConfig().getRecordKeyFields().get());
     }
 
-    TableSchemaResolver schemaResolver = new TableSchemaResolver(datasetMetaClient);
-    // consider nested fields as well. if column stats is enabled only for a subset of columns,
-    // directly use them instead of all columns from the latest table schema
-    try {
-      return schemaResolver.getTableAvroSchema().getFields().stream()
-          .map(entry -> entry.name()).collect(Collectors.toList());
-    } catch (Exception e) {
-      throw new HoodieException("Failed to get latest columns for " + datasetMetaClient.getBasePath());
-    }
+    return writerSchema.orElseGet(() -> fetchSchemaFromCommit(dataTableMetaClient))
+        .getFields()
+        .stream()
+        .map(Schema.Field::name)
+        .collect(Collectors.toList());
   }
 
   public static HoodieMetadataColumnStats mergeColumnStats(HoodieMetadataColumnStats oldColumnStats, HoodieMetadataColumnStats newColumnStats) {
@@ -914,7 +909,7 @@ public class HoodieTableMetadataUtil {
       List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList = new ArrayList<>(columnRangeMap.values());
       return HoodieMetadataPayload.createColumnStatsRecords(writeStat.getPartitionPath(), columnRangeMetadataList, false);
     }
-    return getColumnStats(writeStat.getPartitionPath(), writeStat.getPath(), datasetMetaClient, columnsToIndex,false);
+    return getColumnStats(writeStat.getPartitionPath(), writeStat.getPath(), datasetMetaClient, columnsToIndex, false);
   }
 
   private static Stream<HoodieRecord> getColumnStats(final String partitionPath, final String filePathWithPartition,
@@ -1042,5 +1037,15 @@ public class HoodieTableMetadataUtil {
         columnStats.put(NULL_COUNT, Long.parseLong(columnStats.getOrDefault(NULL_COUNT, 0).toString()) + 1);
       }
     });
+  }
+
+  @Nonnull
+  private static Schema fetchSchemaFromCommit(HoodieTableMetaClient dataTableMetaClient) {
+    TableSchemaResolver schemaResolver = new TableSchemaResolver(dataTableMetaClient);
+    try {
+      return schemaResolver.getTableAvroSchema();
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get latest columns for " + dataTableMetaClient.getBasePath(), e);
+    }
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Currently, Column Stats is not able to properly index first commit in the table b/c it uses `TableSchemaResolver`, which is not able to fetch schema for empty tables.

Instead, we should leverage writer's schema provided w/in `HoodieCommitMetadata`

Fixing Column Stats index to properly handle first Data Table commit

## Brief change log

See above 

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
