### PR TITLE
[HUDI-3675] Adding post write termination strategy to deltastreamer continuous mode

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/NoNewDataTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/NoNewDataTerminationStrategy.java
@@ -22,7 +22,6 @@ package org.apache.hudi.utilities.deltastreamer;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/NoNewDataTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/NoNewDataTerminationStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+
+/**
+ * Post writer termination strategy for deltastreamer in continuous mode. This strategy is based on no new data for consecutive number of times.
+ */
+public class NoNewDataTerminationStrategy implements PostWriteTerminationStrategy {
+
+  private static final Logger LOG = LogManager.getLogger(NoNewDataTerminationStrategy.class);
+
+  public static final String NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN = "no.new.data.termination.strategy.num.times.no.new.data.to.shutdown";
+  public static final int DEFAULT_NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN = 3;
+
+  private final int numTimesNoNewDataToShutdown;
+  private int numTimesNoNewData = 0;
+
+  public NoNewDataTerminationStrategy(TypedProperties properties) {
+    numTimesNoNewDataToShutdown = properties.getInteger(NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN, DEFAULT_NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN);
+  }
+
+  @Override
+  public boolean shouldShutdown(Option<Pair<Option<String>, JavaRDD<WriteStatus>>> scheduledCompactionInstantAndWriteStatuses) {
+    numTimesNoNewData = scheduledCompactionInstantAndWriteStatuses.isPresent() ? 0 : numTimesNoNewData + 1;
+    if (numTimesNoNewData >= numTimesNoNewDataToShutdown) {
+      LOG.info("Shutting down on continuous mode as there is no new data for " + numTimesNoNewData);
+      return true;
+    }
+    return false;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/NoNewDataTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/NoNewDataTerminationStrategy.java
@@ -35,19 +35,19 @@ public class NoNewDataTerminationStrategy implements PostWriteTerminationStrateg
 
   private static final Logger LOG = LogManager.getLogger(NoNewDataTerminationStrategy.class);
 
-  public static final String NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN = "no.new.data.termination.strategy.num.times.no.new.data.to.shutdown";
-  public static final int DEFAULT_NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN = 3;
+  public static final String MAX_ROUNDS_WITHOUT_NEW_DATA_TO_SHUTDOWN = "max.rounds.without.new.data.to.shutdown";
+  public static final int DEFAULT_MAX_ROUNDS_WITHOUT_NEW_DATA_TO_SHUTDOWN = 3;
 
   private final int numTimesNoNewDataToShutdown;
   private int numTimesNoNewData = 0;
 
   public NoNewDataTerminationStrategy(TypedProperties properties) {
-    numTimesNoNewDataToShutdown = properties.getInteger(NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN, DEFAULT_NUM_TIMES_NO_NEW_DATA_TO_SHUTDOWN);
+    numTimesNoNewDataToShutdown = properties.getInteger(MAX_ROUNDS_WITHOUT_NEW_DATA_TO_SHUTDOWN, DEFAULT_MAX_ROUNDS_WITHOUT_NEW_DATA_TO_SHUTDOWN);
   }
 
   @Override
-  public boolean shouldShutdown(Option<Pair<Option<String>, JavaRDD<WriteStatus>>> scheduledCompactionInstantAndWriteStatuses) {
-    numTimesNoNewData = scheduledCompactionInstantAndWriteStatuses.isPresent() ? 0 : numTimesNoNewData + 1;
+  public boolean shouldShutdown(Option<JavaRDD<WriteStatus>> writeStatuses) {
+    numTimesNoNewData = writeStatuses.isPresent() ? 0 : numTimesNoNewData + 1;
     if (numTimesNoNewData >= numTimesNoNewDataToShutdown) {
       LOG.info("Shutting down on continuous mode as there is no new data for " + numTimesNoNewData);
       return true;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/PostWriteTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/PostWriteTerminationStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.spark.api.java.JavaRDD;
+
+/**
+ * Post write termination strategy for deltastreamer in continuous mode.
+ */
+public interface PostWriteTerminationStrategy {
+
+  /**
+   * Returns whether deltastreamer needs to be shutdown.
+   * @param scheduledCompactionInstantAndWriteStatuses optional pair of scheduled compaction instant and write statuses.
+   * @return true if deltastreamer has to be shutdown. false otherwise.
+   */
+  boolean shouldShutdown(Option<Pair<Option<String>, JavaRDD<WriteStatus>>> scheduledCompactionInstantAndWriteStatuses);
+
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/PostWriteTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/PostWriteTerminationStrategy.java
@@ -32,9 +32,9 @@ public interface PostWriteTerminationStrategy {
 
   /**
    * Returns whether deltastreamer needs to be shutdown.
-   * @param scheduledCompactionInstantAndWriteStatuses optional pair of scheduled compaction instant and write statuses.
+   * @param writeStatuses optional pair of scheduled compaction instant and write statuses.
    * @return true if deltastreamer has to be shutdown. false otherwise.
    */
-  boolean shouldShutdown(Option<Pair<Option<String>, JavaRDD<WriteStatus>>> scheduledCompactionInstantAndWriteStatuses);
+  boolean shouldShutdown(Option<JavaRDD<WriteStatus>> writeStatuses);
 
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/PostWriteTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/PostWriteTerminationStrategy.java
@@ -21,7 +21,6 @@ package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.spark.api.java.JavaRDD;
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/TerminationStrategyUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/TerminationStrategyUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.exception.HoodieException;
+
+public class TerminationStrategyUtils {
+
+  /**
+   * Create a PostWriteTerminationStrategy class via reflection,
+   * <br>
+   * if the class name of PostWriteTerminationStrategy is configured through the {@link HoodieDeltaStreamer.Config#postWriteTerminationStrategyClass}.
+   */
+  public static Option<PostWriteTerminationStrategy> createPostWriteTerminationStrategy(TypedProperties properties, String postWriteTerminationStrategyClass)
+      throws HoodieException {
+    try {
+      return StringUtils.isNullOrEmpty(postWriteTerminationStrategyClass)
+          ? Option.empty() :
+          Option.of((PostWriteTerminationStrategy) ReflectionUtils.loadClass(postWriteTerminationStrategyClass, properties));
+    } catch (Throwable e) {
+      throw new HoodieException("Could not create PostWritTerminationStrategy class " + postWriteTerminationStrategyClass, e);
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -761,7 +761,6 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.UPSERT);
     cfg.continuousMode = true;
     if (testShutdownGracefully) {
-      cfg.enablePostWriteTerminationStrategy = true;
       cfg.postWriteTerminationStrategyClass = NoNewDataTerminationStrategy.class.getName();
     }
     cfg.tableType = tableType.name();
@@ -798,7 +797,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       }
     });
     TestHelpers.waitTillCondition(condition, dsFuture, 360);
-    if (cfg.enablePostWriteTerminationStrategy) {
+    if (!cfg.postWriteTerminationStrategyClass.isEmpty()) {
       awaitDeltaStreamerShutdown(ds);
     } else {
       ds.shutdownGracefully();
@@ -810,7 +809,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     // await until deltastreamer shuts down on its own
     boolean shutDownRequested = false;
     int timeSoFar = 0;
-    while(!shutDownRequested) {
+    while (!shutDownRequested) {
       shutDownRequested = ds.getDeltaSyncService().isShutdownRequested();
       Thread.sleep(500);
       timeSoFar += 500;
@@ -819,7 +818,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       }
     }
     boolean shutdownComplete = false;
-    while(!shutdownComplete) {
+    while (!shutdownComplete) {
       shutdownComplete = ds.getDeltaSyncService().isShutdown();
       Thread.sleep(500);
       timeSoFar += 500;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -797,7 +797,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       }
     });
     TestHelpers.waitTillCondition(condition, dsFuture, 360);
-    if (!cfg.postWriteTerminationStrategyClass.isEmpty()) {
+    if (cfg != null && !cfg.postWriteTerminationStrategyClass.isEmpty()) {
       awaitDeltaStreamerShutdown(ds);
     } else {
       ds.shutdownGracefully();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 public class TestDataSource extends AbstractBaseTestSource {
 
   private static final Logger LOG = LogManager.getLogger(TestDataSource.class);
+  public static transient boolean returnEmptyBatch = false;
+  private static int counter = 0;
 
   public TestDataSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
       SchemaProvider schemaProvider) {
@@ -54,9 +56,13 @@ public class TestDataSource extends AbstractBaseTestSource {
     LOG.info("Source Limit is set to " + sourceLimit);
 
     // No new data.
-    if (sourceLimit <= 0) {
+    if (sourceLimit <= 0 || returnEmptyBatch) {
+      LOG.warn("Return no new data from Test Data source " + counter + ", source limit " + sourceLimit);
       return new InputBatch<>(Option.empty(), lastCheckpointStr.orElse(null));
+    } else {
+      LOG.warn("REturning valid data from Test Data source " + counter + ", source limit " + sourceLimit);
     }
+    counter++;
 
     List<GenericRecord> records =
         fetchNextBatch(props, (int) sourceLimit, instantTime, DEFAULT_PARTITION_NUM).collect(Collectors.toList());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
@@ -39,13 +39,14 @@ import java.util.stream.Collectors;
 public class TestDataSource extends AbstractBaseTestSource {
 
   private static final Logger LOG = LogManager.getLogger(TestDataSource.class);
-  public static transient boolean returnEmptyBatch = false;
+  public static boolean returnEmptyBatch = false;
   private static int counter = 0;
 
   public TestDataSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
       SchemaProvider schemaProvider) {
     super(props, sparkContext, sparkSession, schemaProvider);
     initDataGen();
+    returnEmptyBatch = false;
   }
 
   @Override

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
@@ -60,7 +60,7 @@ public class TestDataSource extends AbstractBaseTestSource {
       LOG.warn("Return no new data from Test Data source " + counter + ", source limit " + sourceLimit);
       return new InputBatch<>(Option.empty(), lastCheckpointStr.orElse(null));
     } else {
-      LOG.warn("REturning valid data from Test Data source " + counter + ", source limit " + sourceLimit);
+      LOG.warn("Returning valid data from Test Data source " + counter + ", source limit " + sourceLimit);
     }
     counter++;
 


### PR DESCRIPTION
## What is the purpose of the pull request

With continuous mode deltastreamer, there is no way to trigger gracefull shutdown. This patch is adding a post write termination strategy giving an option to users to trigger shutdown if need be. For eg, if there is no new data to consume from source, users may wish to shutdown the continuous mode and restart the pipeline after sometime instead of having the pipeline running all the time. For instance, users can configure graceful shutdown if there is no new data from source for 5 consecutive times. Here is the interface for the termination strategy. 

Also, this might help in bootstrapping new a new table. instead of doing one bulk load or bulk_insert leverage a large cluster for a large input of data, one could start deltastreamer on continuous mode and add a shutdown strategy to terminate once all data has been bootstrapped. this way, each batch could be smaller and may not need a large cluster to bootstrap data. 

```
/**
 * Post write termination strategy for deltastreamer in continuous mode.
 */
public interface PostWriteTerminationStrategy {

  /**
   * Returns whether deltastreamer needs to be shutdown.
   * @param scheduledCompactionInstantAndWriteStatuses optional pair of scheduled compaction instant and write statuses.
   * @return true if deltastreamer has to be shutdown. false otherwise.
   */
  boolean shouldShutdown(Option<Pair<Option<String>, JavaRDD<WriteStatus>>> scheduledCompactionInstantAndWriteStatuses);

}
```

Adding NoNewDataTerminationStrategy as one of the concrete impl.

## Brief change log

- Added a postWriteTerminationStrategy to deltastreamer continuous mode. One can enable by setting the appropriate termination strategy using `DeltastreamerConfig.postWriteTerminationStrategyClass`. If not, continuous mode is expected to run forever. 
- Added one concrete impl for termination strategy as NoNewDataTerminationStrategy which shuts down deltastreamer if there is no new data to consume from source for N consecutive rounds. 

## Verify this pull request

This change added tests and can be verified as follows:

- Added tests to TestHoodieDetalStreamer

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
