### PR TITLE
[HUDI-3640] Set SimpleKeyGenerator as default in 2to3 table upgrade for Spark engine

### DIFF
--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/JavaSortAndSizeExecutionStrategy.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/JavaSortAndSizeExecutionStrategy.java
@@ -19,8 +19,8 @@
 
 package org.apache.hudi.client.clustering.run.strategy;
 
-import org.apache.avro.Schema;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -30,6 +30,8 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.io.CreateHandleFactory;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.commit.JavaBulkInsertHelper;
+
+import org.apache.avro.Schema;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -63,7 +65,8 @@ public class JavaSortAndSizeExecutionStrategy<T extends HoodieRecordPayload<T>>
     // We are calling another action executor - disable auto commit. Strategy is only expected to write data in new files.
     props.put(HoodieWriteConfig.AUTO_COMMIT_ENABLE.key(), Boolean.FALSE.toString());
     props.put(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE.key(), String.valueOf(getWriteConfig().getClusteringTargetFileMaxBytes()));
-    HoodieWriteConfig newConfig = HoodieWriteConfig.newBuilder().withProps(props).build();
+    HoodieWriteConfig newConfig = HoodieWriteConfig.newBuilder()
+        .withEngineType(EngineType.JAVA).withProps(props).build();
     return (List<WriteStatus>) JavaBulkInsertHelper.newInstance().bulkInsert(inputRecords, instantTime, getHoodieTable(), newConfig,
         false, getPartitioner(strategyParams, schema), true, numOutputGroups, new CreateHandleFactory(preserveHoodieMetadata));
   }


### PR DESCRIPTION
## What is the purpose of the pull request

By default, for Deltastreamer and Spark datasource, if the key generator class is not configured by the user, the `SimpleKeyGenerator` is used by default.  However, the table upgrade from v2 to v3 still expects explicit key generator class config for Spark and fails if not set.  This PR sets the key generator class to `org.apache.hudi.keygen.SimpleKeyGenerator` for Spark client if it is not set in the write configs, so that the table upgrade can succeed without the following validation error.
```
22/03/14 12:28:10 ERROR HoodieDeltaStreamer: Shutting down delta-sync due to exception
java.lang.IllegalStateException: Missing config: Key: 'hoodie.table.keygenerator.class' , default: null description: Key Generator class property for the hoodie table since version: version is not defined deprecated after: version is not defined) or Key: 'hoodie.datasource.write.keygenerator.class' , default: null description: Key generator class, that implements `org.apache.hudi.keygen.KeyGenerator` extract a key out of incoming records. since version: version is not defined deprecated after: version is not defined)
```

## Brief change log
- Adds logic of setting default key generator class for Spark client in `TwoToThreeUpgradeHandler` 
- Adds tests in `TestTwoToThreeUpgradeHandler` (`hudi-client-common`) and `TestUpgradeDowngrade` (`hudi-spark-client`)

## Verify this pull request

This change adds tests in `TestTwoToThreeUpgradeHandler` (`hudi-client-common`) and `TestUpgradeDowngrade` (`hudi-spark-client`) for spark client to verify the upgrade logic is expected.

I also tested this PR by writing a MOR table with Hudi 0.9.0 deltastreamer without setting `hoodie.datasource.write.keygenerator.class` first, and then using the build from this PR to continue writing the same table with the same configs.  The ingestion can continue and the table upgrade is successful (before this change the table upgrade failed).

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
