### PR TITLE
[HUDI-3685] Revert "[HUDI-3559] Flink bucket index with COW table throws NoSuchElementException

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkWriteHelper.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkWriteHelper.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieUpsertException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.HoodieTable;
@@ -90,11 +91,13 @@ public class FlinkWriteHelper<T extends HoodieRecordPayload, R> extends BaseWrit
   @Override
   public List<HoodieRecord<T>> deduplicateRecords(
       List<HoodieRecord<T>> records, HoodieIndex<?, ?> index, int parallelism) {
-    // If index used is global, then records are expected to differ in their partitionPath
-    Map<Object, List<HoodieRecord<T>>> keyedRecords = records.stream()
-        .collect(Collectors.groupingBy(record -> record.getKey().getRecordKey()));
+    Map<Object, List<Pair<Object, HoodieRecord<T>>>> keyedRecords = records.stream().map(record -> {
+      // If index used is global, then records are expected to differ in their partitionPath
+      final Object key = record.getKey().getRecordKey();
+      return Pair.of(key, record);
+    }).collect(Collectors.groupingBy(Pair::getLeft));
 
-    return keyedRecords.values().stream().map(x -> x.stream().reduce((rec1, rec2) -> {
+    return keyedRecords.values().stream().map(x -> x.stream().map(Pair::getRight).reduce((rec1, rec2) -> {
       final T data1 = rec1.getData();
       final T data2 = rec2.getData();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
@@ -20,7 +20,6 @@ package org.apache.hudi.sink;
 
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.sink.transform.ChainedTransformer;
 import org.apache.hudi.sink.transform.Transformer;
@@ -93,20 +92,8 @@ public class ITTestDataStreamWrite extends TestLogger {
   @TempDir
   File tempFile;
 
-  @ParameterizedTest
-  @ValueSource(strings = {"BUCKET", "FLINK_STATE"})
-  public void testWriteCopyOnWrite(String indexType) throws Exception {
-    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
-    conf.setString(FlinkOptions.INDEX_TYPE, indexType);
-    conf.setInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 1);
-    conf.setString(FlinkOptions.INDEX_KEY_FIELD, "id");
-    conf.setBoolean(FlinkOptions.PRE_COMBINE,true);
-
-    testWriteToHoodie(conf, "cow_write", 1, EXPECTED);
-  }
-
   @Test
-  public void testWriteCopyOnWriteWithTransformer() throws Exception {
+  public void testTransformerBeforeWriting() throws Exception {
     Transformer transformer = (ds) -> ds.map((rowdata) -> {
       if (rowdata instanceof GenericRowData) {
         GenericRowData genericRD = (GenericRowData) rowdata;
@@ -118,63 +105,97 @@ public class ITTestDataStreamWrite extends TestLogger {
       }
     });
 
-    testWriteToHoodie(transformer, "cow_write_with_transformer", EXPECTED_TRANSFORMER);
+    testWriteToHoodie(transformer, EXPECTED_TRANSFORMER);
   }
 
   @Test
-  public void testWriteCopyOnWriteWithChainedTransformer() throws Exception {
-    Transformer t1 = (ds) -> ds.map(rowData -> {
-      if (rowData instanceof GenericRowData) {
-        GenericRowData genericRD = (GenericRowData) rowData;
+  public void testChainedTransformersBeforeWriting() throws Exception {
+    Transformer t1 = (ds) -> ds.map((rowdata) -> {
+      if (rowdata instanceof GenericRowData) {
+        GenericRowData genericRD = (GenericRowData) rowdata;
         //update age field to age + 1
         genericRD.setField(2, genericRD.getInt(2) + 1);
         return genericRD;
       } else {
-        throw new RuntimeException("Unrecognized row type : " + rowData.getClass().getSimpleName());
+        throw new RuntimeException("Unrecognized row type : " + rowdata.getClass().getSimpleName());
       }
     });
 
     ChainedTransformer chainedTransformer = new ChainedTransformer(Arrays.asList(t1, t1));
 
-    testWriteToHoodie(chainedTransformer, "cow_write_with_chained_transformer", EXPECTED_CHAINED_TRANSFORMER);
+    testWriteToHoodie(chainedTransformer, EXPECTED_CHAINED_TRANSFORMER);
+  }
+
+  @Test
+  public void testWriteToHoodieWithoutTransformer() throws Exception {
+    testWriteToHoodie(null, EXPECTED);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"BUCKET", "FLINK_STATE"})
-  public void testWriteMergeOnReadWithCompaction(String indexType) throws Exception {
+  public void testMergeOnReadWriteWithCompaction(String indexType) throws Exception {
+    int parallelism = 4;
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     conf.setString(FlinkOptions.INDEX_TYPE, indexType);
     conf.setInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 4);
     conf.setString(FlinkOptions.INDEX_KEY_FIELD, "id");
     conf.setInteger(FlinkOptions.COMPACTION_DELTA_COMMITS, 1);
     conf.setString(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
+    StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+    execEnv.getConfig().disableObjectReuse();
+    execEnv.setParallelism(parallelism);
+    // set up checkpoint interval
+    execEnv.enableCheckpointing(4000, CheckpointingMode.EXACTLY_ONCE);
+    execEnv.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 
-    testWriteToHoodie(conf, "mor_write_with_compact", 1, EXPECTED);
+    // Read from file source
+    RowType rowType =
+        (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf))
+            .getLogicalType();
+
+    JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
+        rowType,
+        InternalTypeInfo.of(rowType),
+        false,
+        true,
+        TimestampFormat.ISO_8601
+    );
+    String sourcePath = Objects.requireNonNull(Thread.currentThread()
+        .getContextClassLoader().getResource("test_source.data")).toString();
+
+    TextInputFormat format = new TextInputFormat(new Path(sourcePath));
+    format.setFilesFilter(FilePathFilter.createDefaultFilter());
+    TypeInformation<String> typeInfo = BasicTypeInfo.STRING_TYPE_INFO;
+    format.setCharsetName("UTF-8");
+
+    DataStream<RowData> dataStream = execEnv
+        // use PROCESS_CONTINUOUSLY mode to trigger checkpoint
+        .readFile(format, sourcePath, FileProcessingMode.PROCESS_CONTINUOUSLY, 1000, typeInfo)
+        .map(record -> deserializationSchema.deserialize(record.getBytes(StandardCharsets.UTF_8)))
+        .setParallelism(parallelism);
+
+    DataStream<HoodieRecord> hoodieRecordDataStream = Pipelines.bootstrap(conf, rowType, parallelism, dataStream);
+    DataStream<Object> pipeline = Pipelines.hoodieStreamWrite(conf, parallelism, hoodieRecordDataStream);
+    Pipelines.clean(conf, pipeline);
+    Pipelines.compact(conf, pipeline);
+    JobClient client = execEnv.executeAsync("mor-write-with-compact");
+    if (client.getJobStatus().get() != JobStatus.FAILED) {
+      try {
+        TimeUnit.SECONDS.sleep(20); // wait long enough for the compaction to finish
+        client.cancel();
+      } catch (Throwable var1) {
+        // ignored
+      }
+    }
+
+    TestData.checkWrittenFullData(tempFile, EXPECTED);
   }
 
   private void testWriteToHoodie(
       Transformer transformer,
-      String jobName,
-      Map<String, List<String>> expected) throws Exception {
-    testWriteToHoodie(TestConfigurations.getDefaultConf(tempFile.getAbsolutePath()),
-        Option.of(transformer), jobName, 2, expected);
-  }
-
-  private void testWriteToHoodie(
-      Configuration conf,
-      String jobName,
-      int checkpoints,
-      Map<String, List<String>> expected) throws Exception {
-    testWriteToHoodie(conf, Option.empty(), jobName, checkpoints, expected);
-  }
-
-  private void testWriteToHoodie(
-      Configuration conf,
-      Option<Transformer> transformer,
-      String jobName,
-      int checkpoints,
       Map<String, List<String>> expected) throws Exception {
 
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     execEnv.getConfig().disableObjectReuse();
     execEnv.setParallelism(4);
@@ -197,32 +218,16 @@ public class ITTestDataStreamWrite extends TestLogger {
     String sourcePath = Objects.requireNonNull(Thread.currentThread()
         .getContextClassLoader().getResource("test_source.data")).toString();
 
-    boolean isMor = conf.getString(FlinkOptions.TABLE_TYPE).equals(HoodieTableType.MERGE_ON_READ.name());
+    DataStream<RowData> dataStream = execEnv
+        // use continuous file source to trigger checkpoint
+        .addSource(new ContinuousFileSource.BoundedSourceFunction(new Path(sourcePath), 2))
+        .name("continuous_file_source")
+        .setParallelism(1)
+        .map(record -> deserializationSchema.deserialize(record.getBytes(StandardCharsets.UTF_8)))
+        .setParallelism(4);
 
-    DataStream<RowData> dataStream;
-    if (isMor) {
-      TextInputFormat format = new TextInputFormat(new Path(sourcePath));
-      format.setFilesFilter(FilePathFilter.createDefaultFilter());
-      TypeInformation<String> typeInfo = BasicTypeInfo.STRING_TYPE_INFO;
-      format.setCharsetName("UTF-8");
-
-      dataStream = execEnv
-          // use PROCESS_CONTINUOUSLY mode to trigger checkpoint
-          .readFile(format, sourcePath, FileProcessingMode.PROCESS_CONTINUOUSLY, 1000, typeInfo)
-          .map(record -> deserializationSchema.deserialize(record.getBytes(StandardCharsets.UTF_8)))
-          .setParallelism(1);
-    } else {
-      dataStream = execEnv
-          // use continuous file source to trigger checkpoint
-          .addSource(new ContinuousFileSource.BoundedSourceFunction(new Path(sourcePath), checkpoints))
-          .name("continuous_file_source")
-          .setParallelism(1)
-          .map(record -> deserializationSchema.deserialize(record.getBytes(StandardCharsets.UTF_8)))
-          .setParallelism(4);
-    }
-
-    if (transformer.isPresent()) {
-      dataStream = transformer.get().apply(dataStream);
+    if (transformer != null) {
+      dataStream = transformer.apply(dataStream);
     }
 
     int parallelism = execEnv.getParallelism();
@@ -230,24 +235,9 @@ public class ITTestDataStreamWrite extends TestLogger {
     DataStream<Object> pipeline = Pipelines.hoodieStreamWrite(conf, parallelism, hoodieRecordDataStream);
     execEnv.addOperator(pipeline.getTransformation());
 
-    if (isMor) {
-      Pipelines.clean(conf, pipeline);
-      Pipelines.compact(conf, pipeline);
-    }
-    JobClient client = execEnv.executeAsync(jobName);
-    if (isMor) {
-      if (client.getJobStatus().get() != JobStatus.FAILED) {
-        try {
-          TimeUnit.SECONDS.sleep(20); // wait long enough for the compaction to finish
-          client.cancel();
-        } catch (Throwable var1) {
-          // ignored
-        }
-      }
-    } else {
-      // wait for the streaming job to finish
-      client.getJobExecutionResult().get();
-    }
+    JobClient client = execEnv.executeAsync(conf.getString(FlinkOptions.TABLE_NAME));
+    // wait for the streaming job to finish
+    client.getJobExecutionResult().get();
 
     TestData.checkWrittenFullData(tempFile, expected);
 


### PR DESCRIPTION

This reverts commit 26e5d2e6fcc399e7886594a5454a16d29aaa8702.

CI is failing consistently from this commit. to unblock CI as we are nearing code freeze, will go ahead and revert this commit for now. 

<img width="1501" alt="Screen Shot 2022-03-22 at 12 06 25 PM" src="https://user-images.githubusercontent.com/513218/159556912-1522dbba-2b32-459f-b09f-e9f5d2c11b36.png">

@wxplovecc @danny0405 : I am reverting the aforementioned commit. can you folks put up a new PR and ensure CI succeeds. 

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
