### PR TITLE
[HUDI-3604] Adjust the order of timeline changes in rollbacks

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/CopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/CopyOnWriteRollbackActionExecutor.java
@@ -67,7 +67,6 @@ public class CopyOnWriteRollbackActionExecutor<T extends HoodieRecordPayload, I,
 
     List<HoodieRollbackStat> stats = new ArrayList<>();
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
-    HoodieInstant resolvedInstant = instantToRollback;
 
     if (instantToRollback.isCompleted()) {
       LOG.info("Unpublishing instant " + instantToRollback);
@@ -86,8 +85,6 @@ public class CopyOnWriteRollbackActionExecutor<T extends HoodieRecordPayload, I,
 
     dropBootstrapIndexIfNeeded(instantToRollback);
 
-    // Delete Inflight instant if enabled
-    deleteInflightAndRequestedInstant(deleteInstants, activeTimeline, resolvedInstant);
     LOG.info("Time(in ms) taken to finish rollback " + rollbackTimer.endTimer());
     return stats;
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MergeOnReadRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MergeOnReadRollbackActionExecutor.java
@@ -67,7 +67,6 @@ public class MergeOnReadRollbackActionExecutor<T extends HoodieRecordPayload, I,
 
     LOG.info("Rolling back instant " + instantToRollback);
 
-    HoodieInstant resolvedInstant = instantToRollback;
     // Atomically un-publish all non-inflight commits
     if (instantToRollback.isCompleted()) {
       LOG.info("Un-publishing instant " + instantToRollback + ", deleteInstants=" + deleteInstants);
@@ -93,8 +92,6 @@ public class MergeOnReadRollbackActionExecutor<T extends HoodieRecordPayload, I,
 
     dropBootstrapIndexIfNeeded(resolvedInstant);
 
-    // Delete Inflight instants if enabled
-    deleteInflightAndRequestedInstant(deleteInstants, table.getActiveTimeline(), resolvedInstant);
     LOG.info("Time(in ms) taken to finish rollback " + rollbackTimer.endTimer());
     return allRollbackStats;
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -83,10 +83,10 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     HoodieWriteConfig writeConfig = getConfigBuilder().withRollbackUsingMarkers(false).build();
     HoodieTable table = this.getHoodieTable(metaClient, writeConfig);
     HoodieInstant needRollBackInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "002");
-
+    String rollbackInstant = "003";
     // execute CopyOnWriteRollbackActionExecutor with filelisting mode
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
-        new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, "003", needRollBackInstant, false,
+        new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, rollbackInstant, needRollBackInstant, false,
             table.getConfig().shouldRollbackUsingMarkers());
     HoodieRollbackPlan rollbackPlan = (HoodieRollbackPlan) copyOnWriteRollbackPlanActionExecutor.execute().get();
     CopyOnWriteRollbackActionExecutor copyOnWriteRollbackActionExecutor = new CopyOnWriteRollbackActionExecutor(context, table.getConfig(), table, "003", needRollBackInstant, true,
@@ -125,7 +125,9 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     assertTrue(testTable.commitExists("001"));
     assertTrue(testTable.baseFileExists(p1, "001", "id11"));
     assertTrue(testTable.baseFileExists(p2, "001", "id12"));
-    assertFalse(testTable.inflightCommitExists("002"));
+    // Note that executeRollback() does not delete inflight instant files
+    // The deletion is done in finishRollback() called by runRollback()
+    assertTrue(testTable.inflightCommitExists("002"));
     assertFalse(testTable.commitExists("002"));
     assertFalse(testTable.baseFileExists(p1, "002", "id21"));
     assertFalse(testTable.baseFileExists(p2, "002", "id22"));


### PR DESCRIPTION
## What is the purpose of the pull request

Before this change, the sequence of changes in the rollback action are:
(1) Get the instant (C1) to roll back.  If there is already a pending rollback (RB_C1) for the same instant (C1) in the active timeline, the same rollback instant (RB_C1) and the rollback plan are reused.  Otherwise, schedule a new rollback instant.
(2) Transition C1 to inflight if completed.
(3) Delete data files written by C1.
(4) Delete instant files (C1) in the data table timeline.
(5) Commit changes from the rollback (RB_C1) to metadata table
(6) Transition the rollback instant (RB_C1) from inflight to complete on data table timeline.

By design, we should only change data table timeline after committing the changes to the metadata table.  This PR changes the order of timeline changes as below, switching the order of (4) and (5) above:
(1) Get the instant (C1) to roll back.  If there is already a pending rollback (RB_C1) for the same instant (C1) in the active timeline, the same rollback instant (RB_C1) and the rollback plan is reused.  Otherwise, schedule a new rollback instant.
(2) Transition C1 to inflight if completed.
(3) Delete data files written by C1.
***(4) Commit changes from the rollback (RB_C1) to metadata table***
***(5) Delete instant files (C1) in the data table timeline.***
(6) Transition the rollback instant (RB_C1) from inflight to complete on data table timeline.

## Brief change log

  - Changes the order of timeline change in `BaseRollbackActionExecutor`, by first applying the rollback metadata to the metadata table, then deleting the instant files of the instant to rollback in the data table timeline, and finally transiting the inflight rollback to complete in the data table timeline.

## Verify this pull request

This pull request is already covered by existing tests around rollbacks.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
