### PR TITLE
[HUDI-3724] Fixing closure of ParquetReader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetReaderIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetReaderIterator.java
@@ -21,6 +21,8 @@ package org.apache.hudi.common.util;
 import org.apache.hudi.common.util.queue.BoundedInMemoryQueue;
 import org.apache.hudi.exception.HoodieException;
 
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.apache.parquet.hadoop.ParquetReader;
 
 import java.io.IOException;
@@ -30,6 +32,8 @@ import java.io.IOException;
  * {@link BoundedInMemoryQueue}
  */
 public class ParquetReaderIterator<T> implements ClosableIterator<T> {
+
+  private static final Logger LOG = LogManager.getLogger(ParquetReaderIterator.class);
 
   // Parquet reader for an existing parquet file
   private final ParquetReader<T> parquetReader;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetReaderIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetReaderIterator.java
@@ -21,8 +21,6 @@ package org.apache.hudi.common.util;
 import org.apache.hudi.common.util.queue.BoundedInMemoryQueue;
 import org.apache.hudi.exception.HoodieException;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.apache.parquet.hadoop.ParquetReader;
 
 import java.io.IOException;
@@ -32,8 +30,6 @@ import java.io.IOException;
  * {@link BoundedInMemoryQueue}
  */
 public class ParquetReaderIterator<T> implements ClosableIterator<T> {
-
-  private static final Logger LOG = LogManager.getLogger(ParquetReaderIterator.class);
 
   // Parquet reader for an existing parquet file
   private final ParquetReader<T> parquetReader;

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetReader.java
@@ -33,15 +33,11 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.util.BaseFileUtils;
 import org.apache.hudi.common.util.ParquetReaderIterator;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.hadoop.ParquetReader;
 
 public class HoodieParquetReader<R extends IndexedRecord> implements HoodieFileReader<R> {
-
-  private static final Logger LOG = LogManager.getLogger(HoodieParquetReader.class);
   
   private final Path path;
   private final Configuration conf;

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetReader.java
@@ -19,7 +19,9 @@
 package org.apache.hudi.io.storage;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.avro.Schema;
@@ -30,14 +32,21 @@ import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.util.BaseFileUtils;
 import org.apache.hudi.common.util.ParquetReaderIterator;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.hadoop.ParquetReader;
 
 public class HoodieParquetReader<R extends IndexedRecord> implements HoodieFileReader<R> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieParquetReader.class);
+  
   private final Path path;
   private final Configuration conf;
   private final BaseFileUtils parquetUtils;
+  private List<ParquetReaderIterator> readerIterators = new ArrayList<>();
 
   public HoodieParquetReader(Configuration configuration, Path path) {
     this.conf = configuration;
@@ -64,7 +73,9 @@ public class HoodieParquetReader<R extends IndexedRecord> implements HoodieFileR
   public Iterator<R> getRecordIterator(Schema schema) throws IOException {
     AvroReadSupport.setAvroReadSchema(conf, schema);
     ParquetReader<R> reader = AvroParquetReader.<R>builder(path).withConf(conf).build();
-    return new ParquetReaderIterator<>(reader);
+    ParquetReaderIterator parquetReaderIterator = new ParquetReaderIterator<>(reader);
+    readerIterators.add(parquetReaderIterator);
+    return parquetReaderIterator;
   }
 
   @Override
@@ -74,6 +85,7 @@ public class HoodieParquetReader<R extends IndexedRecord> implements HoodieFileR
 
   @Override
   public void close() {
+    readerIterators.forEach(entry -> entry.close());
   }
 
   @Override


### PR DESCRIPTION
## What is the purpose of the pull request

We were running integration tests against hudi and in recent times we are seeing "too many open files" and the spark long running COW tests fails. Looks like we don't close the parquet reader in couple of places. Fixing the closure in this patch. 

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
