### PR TITLE
[HUDI-3742] Enable parquet enableVectorizedReader for spark inc query to improve peformance

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -154,7 +154,7 @@ object DataSourceReadOptions {
 
   val INCREMENTAL_VECTORIZED_READER_ENABLE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.incr.vectorized.reader.enable")
-    .defaultValue("false")
+    .defaultValue("true")
     .withDocumentation("Enable vectorized reader for mor table incremental query.")
 
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -152,6 +152,11 @@ object DataSourceReadOptions {
 
   val SCHEMA_EVOLUTION_ENABLED: ConfigProperty[Boolean] = HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE
 
+  val INCREMENTAL_VECTORIZED_READER_ENABLE: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.read.incr.vectorized.reader.enable")
+    .defaultValue("false")
+    .withDocumentation("Enable vectorized reader for mor table incremental query.")
+
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */
   @Deprecated
   val QUERY_TYPE_OPT_KEY = QUERY_TYPE.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -312,9 +312,13 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
    * NOTE: DO NOT OVERRIDE THIS METHOD
    */
   override final def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
+<<<<<<< 509a45ed9a51bab0f909baabaf8b491faf19559b
     // NOTE: PLEAS READ CAREFULLY BEFORE MAKING CHANGES
     //
     //       In case list of requested columns doesn't contain the Primary Key one, we
+=======
+    // NOTE: In case list of requested columns doesn't contain the Primary Key one, we
+>>>>>>> add config to control logical
     //       have to add it explicitly so that
     //          - Merging could be performed correctly
     //          - In case 0 columns are to be fetched (for ex, when doing {@code count()} on Spark's [[Dataset]],
@@ -347,12 +351,23 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
     if (fileSplits.isEmpty) {
       sparkSession.sparkContext.emptyRDD
     } else {
-      val rdd = composeRDD(fileSplits, tableSchema, requiredSchema, targetColumns, filters)
+      val rdd = postOperationOnComposeRDD(composeRDD(fileSplits, partitionSchema, tableSchema, requiredSchema, filters), requiredSchema)
 
       // Here we rely on a type erasure, to workaround inherited API restriction and pass [[RDD[InternalRow]]] back as [[RDD[Row]]]
       // Please check [[needConversion]] scala-doc for more details
       rdd.asInstanceOf[RDD[Row]]
     }
+  }
+
+  /**
+    * Post operation on ComposeRDD, data filters to be applied.
+    *
+    * @param rdd file splits to be handled by the RDD
+    * @param requiredSchema  projected schema required by the reader
+    * @return handled RDD
+    */
+  protected def postOperationOnComposeRDD(rdd: RDD[InternalRow], requiredSchema: HoodieTableSchema): RDD[Row] = {
+    rdd.asInstanceOf[RDD[Row]]
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -312,13 +312,9 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
    * NOTE: DO NOT OVERRIDE THIS METHOD
    */
   override final def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
-<<<<<<< 509a45ed9a51bab0f909baabaf8b491faf19559b
     // NOTE: PLEAS READ CAREFULLY BEFORE MAKING CHANGES
     //
     //       In case list of requested columns doesn't contain the Primary Key one, we
-=======
-    // NOTE: In case list of requested columns doesn't contain the Primary Key one, we
->>>>>>> add config to control logical
     //       have to add it explicitly so that
     //          - Merging could be performed correctly
     //          - In case 0 columns are to be fetched (for ex, when doing {@code count()} on Spark's [[Dataset]],
@@ -351,7 +347,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
     if (fileSplits.isEmpty) {
       sparkSession.sparkContext.emptyRDD
     } else {
-      val rdd = postOperationOnComposeRDD(composeRDD(fileSplits, partitionSchema, tableSchema, requiredSchema, filters), requiredSchema)
+      val rdd = postOperationOnComposeRDD(composeRDD(fileSplits, tableSchema, requiredSchema, targetColumns, filters), requiredSchema)
 
       // Here we rely on a type erasure, to workaround inherited API restriction and pass [[RDD[InternalRow]]] back as [[RDD[Row]]]
       // Please check [[needConversion]] scala-doc for more details


### PR DESCRIPTION
### Change Logs
add config to enable parquet enableVectorizedReader for spark inc query
### Impact
improve incremental query for spark.

### Risk level (write none, low medium or high below)
low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
