### PR TITLE
[HUDI-3743] Support DELETE_PARTITION for metadata table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -102,5 +102,5 @@ public interface HoodieTableMetadataWriter extends Serializable, AutoCloseable {
    * @param partitions - list of {@link MetadataPartitionType} to drop
    * @throws IOException
    */
-  void dropPartitions(String instantTime, List<MetadataPartitionType> partitions);
+  void deletePartitions(String instantTime, List<MetadataPartitionType> partitions);
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -94,4 +94,13 @@ public interface HoodieTableMetadataWriter extends Serializable, AutoCloseable {
    * @param instantTime      instant time of the commit.
    */
   void update(HoodieRollbackMetadata rollbackMetadata, String instantTime);
+
+  /**
+   * Drop the given metadata indexes. This path reuses DELETE_PARTITION operation.
+   *
+   * @param instantTime - instant time when replacecommit corresponding to the drop will be recorded in the metadata timeline
+   * @param indexesToDrop - list of {@link MetadataPartitionType} to drop
+   * @throws IOException
+   */
+  void dropIndex(String instantTime, List<MetadataPartitionType> indexesToDrop);
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 
@@ -96,11 +95,10 @@ public interface HoodieTableMetadataWriter extends Serializable, AutoCloseable {
   void update(HoodieRollbackMetadata rollbackMetadata, String instantTime);
 
   /**
-   * Drop the given metadata partitions. This path reuses DELETE_PARTITION operation.
+   * Deletes the given metadata partitions. This path reuses DELETE_PARTITION operation.
    *
    * @param instantTime - instant time when replacecommit corresponding to the drop will be recorded in the metadata timeline
    * @param partitions - list of {@link MetadataPartitionType} to drop
-   * @throws IOException
    */
   void deletePartitions(String instantTime, List<MetadataPartitionType> partitions);
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -96,11 +96,11 @@ public interface HoodieTableMetadataWriter extends Serializable, AutoCloseable {
   void update(HoodieRollbackMetadata rollbackMetadata, String instantTime);
 
   /**
-   * Drop the given metadata indexes. This path reuses DELETE_PARTITION operation.
+   * Drop the given metadata partitions. This path reuses DELETE_PARTITION operation.
    *
    * @param instantTime - instant time when replacecommit corresponding to the drop will be recorded in the metadata timeline
-   * @param indexesToDrop - list of {@link MetadataPartitionType} to drop
+   * @param partitions - list of {@link MetadataPartitionType} to drop
    * @throws IOException
    */
-  void dropIndex(String instantTime, List<MetadataPartitionType> indexesToDrop);
+  void dropPartitions(String instantTime, List<MetadataPartitionType> partitions);
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -18,19 +18,6 @@
 
 package org.apache.hudi.table.action.clean;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -59,8 +46,23 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieSavepointException;
 import org.apache.hudi.metadata.FileSystemBackedTableMetadata;
 import org.apache.hudi.table.HoodieTable;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Cleaner is responsible for garbage collecting older files in a given partition path. Such that
@@ -201,7 +203,6 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
   /**
    * Scan and list all partitions for cleaning.
    * @return all partitions paths for the dataset.
-   * @throws IOException
    */
   private List<String> getPartitionPathsForFullCleaning() {
     // Go to brute force mode of scanning all partitions
@@ -476,7 +477,7 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
 
   /**
    * Determine if file slice needed to be preserved for pending compaction.
-   * 
+   *
    * @param fileSlice File Slice
    * @return true if file slice needs to be preserved, false otherwise.
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -278,6 +278,9 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
    * retain 10 commits, and commit batch time is 30 mins, then you have 5 hrs of lookback)
    * <p>
    * This policy is the default.
+   *
+   * @return A {@link Pair} whose left is boolean indicating whether partition itself needs to be deleted,
+   *         and right is a list of {@link CleanFileInfo} about the files in the partition that needs to be deleted.
    */
   private Pair<Boolean, List<CleanFileInfo>> getFilesToCleanKeepingLatestCommits(String partitionPath, int commitsRetained, HoodieCleaningPolicy policy) {
     LOG.info("Cleaning " + partitionPath + ", retaining latest " + commitsRetained + " commits. ");

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -164,7 +164,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  public void dropIndex(String instantTime, List<MetadataPartitionType> indexesToDrop) {
+  public void dropPartitions(String instantTime, List<MetadataPartitionType> partitions) {
     throw new HoodieNotSupportedException("Dropping metadata index not supported for Flink metadata table yet.");
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.exception.HoodieNotSupportedException;
 
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.hadoop.conf.Configuration;
@@ -160,5 +161,10 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     // Update total size of the metadata and count of base/log files
     metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata));
+  }
+
+  @Override
+  public void dropIndex(String instantTime, List<MetadataPartitionType> indexesToDrop) {
+    throw new HoodieNotSupportedException("Dropping metadata index not supported for Flink metadata table yet.");
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -164,7 +164,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  public void dropPartitions(String instantTime, List<MetadataPartitionType> partitions) {
+  public void deletePartitions(String instantTime, List<MetadataPartitionType> partitions) {
     throw new HoodieNotSupportedException("Dropping metadata index not supported for Flink metadata table yet.");
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -25,8 +25,11 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -43,6 +46,7 @@ import org.apache.spark.api.java.JavaRDD;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetadataWriter {
 
@@ -176,5 +180,17 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     // Update total size of the metadata and count of base/log files
     metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata));
+  }
+
+  @Override
+  public void dropIndex(String instantTime, List<MetadataPartitionType> indexesToDrop) {
+    List<String> partitionsToDrop = indexesToDrop.stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList());
+    LOG.warn("Deleting Metadata Table partitions: " + partitionsToDrop);
+
+    try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, metadataWriteConfig, true)) {
+      String actionType = CommitUtils.getCommitActionType(WriteOperationType.DELETE_PARTITION, HoodieTableType.MERGE_ON_READ);
+      writeClient.startCommitWithTime(instantTime, actionType);
+      writeClient.deletePartitions(partitionsToDrop, instantTime);
+    }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -183,8 +183,8 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  public void dropIndex(String instantTime, List<MetadataPartitionType> indexesToDrop) {
-    List<String> partitionsToDrop = indexesToDrop.stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList());
+  public void dropPartitions(String instantTime, List<MetadataPartitionType> partitions) {
+    List<String> partitionsToDrop = partitions.stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList());
     LOG.warn("Deleting Metadata Table partitions: " + partitionsToDrop);
 
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, metadataWriteConfig, true)) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -183,9 +183,9 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  public void dropPartitions(String instantTime, List<MetadataPartitionType> partitions) {
+  public void deletePartitions(String instantTime, List<MetadataPartitionType> partitions) {
     List<String> partitionsToDrop = partitions.stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList());
-    LOG.warn("Deleting Metadata Table partitions: " + partitionsToDrop);
+    LOG.info("Deleting Metadata Table partitions: " + partitionsToDrop);
 
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, metadataWriteConfig, true)) {
       String actionType = CommitUtils.getCommitActionType(WriteOperationType.DELETE_PARTITION, HoodieTableType.MERGE_ON_READ);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -1827,7 +1827,6 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       newCommitTime = HoodieActiveTimeline.createNewInstantTime(5000);
       client.startCommitWithTime(newCommitTime);
       client.deletePartitions(singletonList(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH), newCommitTime);
-      validateMetadata(client);
 
       // add 1 more commit
       newCommitTime = HoodieActiveTimeline.createNewInstantTime(5000);
@@ -1842,7 +1841,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       writeStatuses = client.upsert(jsc.parallelize(upsertRecords, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
 
-      // trigger clean which will actually triggger deletion of the partition
+      // trigger clean which will actually trigger deletion of the partition
       newCommitTime = HoodieActiveTimeline.createNewInstantTime(5000);
       HoodieCleanMetadata cleanMetadata = client.clean(newCommitTime);
       validateMetadata(client);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -488,7 +488,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // metadata writer to delete column_stats partition
       HoodieBackedTableMetadataWriter metadataWriter = metadataWriter(client);
       assertNotNull(metadataWriter, "MetadataWriter should have been initialized");
-      metadataWriter.dropIndex("0000003", Arrays.asList(MetadataPartitionType.COLUMN_STATS));
+      metadataWriter.dropPartitions("0000003", Arrays.asList(MetadataPartitionType.COLUMN_STATS));
 
       HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(metadataTableBasePath).build();
       List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient.getBasePath(), false, false);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -483,12 +483,11 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       records = dataGen.generateInserts(newCommitTime, 10);
       writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
       assertNoWriteErrors(writeStatuses);
-      validateMetadata(client);
 
       // metadata writer to delete column_stats partition
       HoodieBackedTableMetadataWriter metadataWriter = metadataWriter(client);
       assertNotNull(metadataWriter, "MetadataWriter should have been initialized");
-      metadataWriter.dropPartitions("0000003", Arrays.asList(MetadataPartitionType.COLUMN_STATS));
+      metadataWriter.deletePartitions("0000003", Arrays.asList(MetadataPartitionType.COLUMN_STATS));
 
       HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder().setConf(hadoopConf).setBasePath(metadataTableBasePath).build();
       List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient.getBasePath(), false, false);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -18,13 +18,6 @@
 
 package org.apache.hudi.metadata;
 
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.avro.model.HoodieMetadataBloomFilter;
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
@@ -41,6 +34,14 @@ import org.apache.hudi.common.util.hash.FileIndexID;
 import org.apache.hudi.common.util.hash.PartitionIndexID;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.io.storage.HoodieHFileReader;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -240,6 +240,23 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   }
 
   /**
+   * Create and return a {@code HoodieMetadataPayload} to save list of partitions.
+   *
+   * @param partitionsAdded   The list of added partitions
+   * @param partitionsDeleted The list of deleted partitions
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createPartitionListRecord(List<String> partitionsAdded, List<String> partitionsDeleted) {
+    Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
+    partitionsAdded.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L, false)));
+    partitionsDeleted.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L, true)));
+
+    HoodieKey key = new HoodieKey(RECORDKEY_PARTITION_LIST, MetadataPartitionType.FILES.getPartitionPath());
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), METADATA_TYPE_PARTITION_LIST,
+        fileInfo);
+    return new HoodieAvroRecord<>(key, payload);
+  }
+
+  /**
    * Create and return a {@code HoodieMetadataPayload} to save list of files within a partition.
    *
    * @param partition    The name of the partition

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -195,7 +195,7 @@ public class HoodieTableMetadataUtil {
     List<HoodieRecord> records = new ArrayList<>(commitMetadata.getPartitionToWriteStats().size());
 
     // Add record bearing added partitions list
-    ArrayList<String> partitionsAdded = new ArrayList<>(commitMetadata.getPartitionToWriteStats().keySet());
+    List<String> partitionsAdded = new ArrayList<>(commitMetadata.getPartitionToWriteStats().keySet());
 
     records.add(HoodieMetadataPayload.createPartitionListRecord(partitionsAdded));
 
@@ -371,7 +371,7 @@ public class HoodieTableMetadataUtil {
       records.add(HoodieMetadataPayload.createPartitionListRecord(deletedPartitions, true));
     }
     LOG.info("Updating at " + instantTime + " from Clean. #partitions_updated=" + records.size()
-        + ", #files_deleted=" + fileDeleteCount[0]);
+        + ", #files_deleted=" + fileDeleteCount[0] + ", #partitions_deleted=" + deletedPartitions.size());
     return records;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -18,41 +18,6 @@
 
 package org.apache.hudi.metadata;
 
-import static org.apache.hudi.avro.HoodieAvroUtils.addMetadataFields;
-import static org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldValAsString;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.COLUMN_RANGE_MERGE_FUNCTION;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.MAX;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.MIN;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.NULL_COUNT;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.TOTAL_SIZE;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.TOTAL_UNCOMPRESSED_SIZE;
-import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.VALUE_COUNT;
-import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
-import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
-import static org.apache.hudi.metadata.HoodieTableMetadata.EMPTY_PARTITION_NAME;
-import static org.apache.hudi.metadata.HoodieTableMetadata.NON_PARTITIONED_NAME;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
@@ -90,8 +55,47 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.avro.HoodieAvroUtils.addMetadataFields;
+import static org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldValAsString;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.COLUMN_RANGE_MERGE_FUNCTION;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.MAX;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.MIN;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.NULL_COUNT;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.TOTAL_SIZE;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.TOTAL_UNCOMPRESSED_SIZE;
+import static org.apache.hudi.common.model.HoodieColumnRangeMetadata.Stats.VALUE_COUNT;
+import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+import static org.apache.hudi.metadata.HoodieTableMetadata.EMPTY_PARTITION_NAME;
+import static org.apache.hudi.metadata.HoodieTableMetadata.NON_PARTITIONED_NAME;
 
 /**
  * A utility to convert timeline information to metadata table records.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -45,11 +45,8 @@ import org.apache.hudi.sync.common.HoodieSyncConfig
 import org.apache.hudi.sync.common.util.SyncUtilHelpers
 import org.apache.hudi.table.BulkInsertPartitioner
 import org.apache.log4j.LogManager
-import org.apache.spark.SPARK_VERSION
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql._
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.types.StructType

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -222,7 +222,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         val tablePath = s"${tmp.getCanonicalPath}/$tableName"
 
         import spark.implicits._
-        val df = Seq((1, "z3", "v1", "2021", "10", "01"), (2, "l4", "v1", "2021", "10","02"))
+        val df = Seq((1, "z3", "v1", "2021", "10", "01"), (2, "l4", "v1", "2021", "10", "02"))
           .toDF("id", "name", "ts", "year", "month", "day")
 
         df.write.format("hudi")
@@ -273,7 +273,7 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         val tablePath = s"${tmp.getCanonicalPath}/$tableName"
 
         import spark.implicits._
-        val df = Seq((1, "z3", "v1", "2021", "10", "01"), (2, "l4", "v1", "2021", "10","02"))
+        val df = Seq((1, "z3", "v1", "2021", "10", "01"), (2, "l4", "v1", "2021", "10", "02"))
           .toDF("id", "name", "ts", "year", "month", "day")
 
         df.write.format("hudi")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -120,12 +120,15 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         checkAnswer(s"select dt from $tableName")(Seq(s"2021/10/02"))
         assertResult(true)(existsPath(s"${tmp.getCanonicalPath}/$tableName/$partitionPath"))
 
+        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
+        //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
+        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        if (urlencode) {
+        /*if (urlencode) {
           checkAnswer(s"show partitions $tableName")(Seq(PartitionPathEncodeUtils.escapePathName("2021/10/02")))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }
+        }*/
       }
     }
   }
@@ -171,12 +174,15 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         checkAnswer(s"select dt from $tableName")(Seq(s"2021/10/02"))
         assertResult(false)(existsPath(s"${tmp.getCanonicalPath}/$tableName/$partitionPath"))
 
+        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
+        //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
+        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        if (urlencode) {
+        /*if (urlencode) {
           checkAnswer(s"show partitions $tableName")(Seq(PartitionPathEncodeUtils.escapePathName("2021/10/02")))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }
+        }*/
       }
     }
   }
@@ -211,8 +217,11 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
 
     checkAnswer(s"select id, name, ts, dt from $tableName")(Seq(2, "l4", "v1", "2021-10-02"))
 
+    // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
+    //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
+    //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
     // show partitions
-    checkAnswer(s"show partitions $tableName")(Seq("dt=2021-10-02"))
+    // checkAnswer(s"show partitions $tableName")(Seq("dt=2021-10-02"))
   }
 
   Seq(false, true).foreach { hiveStyle =>
@@ -256,12 +265,15 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
           Seq(2, "l4", "v1", "2021", "10", "02")
         )
 
+        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
+        //  cleaner will delete the partition when it kicks in, however the replacecommit gets written in the timeline.
+        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        if (hiveStyle) {
+        /*if (hiveStyle) {
           checkAnswer(s"show partitions $tableName")(Seq("year=2021/month=10/day=02"))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }
+        }*/
       }
     }
   }
@@ -305,12 +317,15 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         assertResult(false)(existsPath(
           s"${tmp.getCanonicalPath}/$tableName/year=2021/month=10/day=01"))
 
+        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
+        //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
+        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        if (hiveStyle) {
+        /*if (hiveStyle) {
           checkAnswer(s"show partitions $tableName")(Seq("year=2021/month=10/day=02"))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }
+        }*/
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -120,15 +120,12 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         checkAnswer(s"select dt from $tableName")(Seq(s"2021/10/02"))
         assertResult(true)(existsPath(s"${tmp.getCanonicalPath}/$tableName/$partitionPath"))
 
-        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
-        //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
-        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        /*if (urlencode) {
+        if (urlencode) {
           checkAnswer(s"show partitions $tableName")(Seq(PartitionPathEncodeUtils.escapePathName("2021/10/02")))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }*/
+        }
       }
     }
   }
@@ -174,15 +171,12 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         checkAnswer(s"select dt from $tableName")(Seq(s"2021/10/02"))
         assertResult(false)(existsPath(s"${tmp.getCanonicalPath}/$tableName/$partitionPath"))
 
-        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
-        //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
-        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        /*if (urlencode) {
+        if (urlencode) {
           checkAnswer(s"show partitions $tableName")(Seq(PartitionPathEncodeUtils.escapePathName("2021/10/02")))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }*/
+        }
       }
     }
   }
@@ -217,11 +211,8 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
 
     checkAnswer(s"select id, name, ts, dt from $tableName")(Seq(2, "l4", "v1", "2021-10-02"))
 
-    // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
-    //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
-    //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
     // show partitions
-    // checkAnswer(s"show partitions $tableName")(Seq("dt=2021-10-02"))
+    checkAnswer(s"show partitions $tableName")(Seq("dt=2021-10-02"))
   }
 
   Seq(false, true).foreach { hiveStyle =>
@@ -265,15 +256,12 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
           Seq(2, "l4", "v1", "2021", "10", "02")
         )
 
-        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
-        //  cleaner will delete the partition when it kicks in, however the replacecommit gets written in the timeline.
-        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        /*if (hiveStyle) {
+        if (hiveStyle) {
           checkAnswer(s"show partitions $tableName")(Seq("year=2021/month=10/day=02"))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }*/
+        }
       }
     }
   }
@@ -317,15 +305,12 @@ class TestAlterTableDropPartition extends TestHoodieSqlBase {
         assertResult(false)(existsPath(
           s"${tmp.getCanonicalPath}/$tableName/year=2021/month=10/day=01"))
 
-        // TODO (HUDI-3135): These validations are failing. Due to lazy deletion,
-        //  cleaner will delete the partition when it kicks in, however the replacecommit get written in the timeline.
-        //  We should check why FSUtils#getAllPartitionPaths does not exclude replaced filegroups.
         // show partitions
-        /*if (hiveStyle) {
+        if (hiveStyle) {
           checkAnswer(s"show partitions $tableName")(Seq("year=2021/month=10/day=02"))
         } else {
           checkAnswer(s"show partitions $tableName")(Seq("2021/10/02"))
-        }*/
+        }
       }
     }
   }


### PR DESCRIPTION
## What is the purpose of the pull request

In order to drop any metadata partition (index), we can reuse the DELETE_PARTITION operation in metadata table. Subsequent to this, we can support drop index (with table config update) for async metadata indexer.

## Brief change log

  - Add a new API in `HoodieTableMetadataWriter`
  - Current only supported for Spark metadata writer

## Verify this pull request

Added a unit test in TestHoodieBackedMetadata, which creates multiple metadata partitions and then drops one. Asserted that there are no file slice from the dropped partition.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
