### PR TITLE
[HUDI-3681] Provision additional hudi-spark-bundle with different versions

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 11
+      max-parallel: 8
       matrix:
         include:
           # Spark 2.4.4, scala 2.11
@@ -53,18 +53,6 @@ jobs:
             sparkProfile: "spark3.2"
             sparkVersion: "3.2.1"
 
-          # Alias
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3"
-            sparkVersion: "3.2.1"
-
-          - scalaProfile: "scala-2.11"
-            sparkProfile: "spark2"
-            sparkVersion: "2.4.4"
-
-          - scalaProfile: "scala-2.11"
-            sparkProfile: "spark"
-            sparkVersion: "2.4.4"
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -14,39 +14,57 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 7
+      max-parallel: 11
       matrix:
         include:
-          # Spark 2.4.4
+          # Spark 2.4.4, scala 2.11
           - scalaProfile: "scala-2.11"
-            sparkProfile: "spark2"
+            sparkProfile: "spark2.4"
+            sparkVersion: "2.4.4"
+
+          # Spark 2.4.4, scala 2.12
+          - scalaProfile: "scala-2.12"
+            sparkProfile: "spark2.4"
             sparkVersion: "2.4.4"
 
           # Spark 3.1.x
           - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.1.x"
+            sparkProfile: "spark3.1"
             sparkVersion: "3.1.0"
 
           - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.1.x"
+            sparkProfile: "spark3.1"
             sparkVersion: "3.1.1"
 
           - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.1.x"
+            sparkProfile: "spark3.1"
             sparkVersion: "3.1.2"
 
           - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.1.x"
+            sparkProfile: "spark3.1"
             sparkVersion: "3.1.3"
 
           # Spark 3.2.x
           - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.2.0"
+            sparkProfile: "spark3.2"
             sparkVersion: "3.2.0"
 
           - scalaProfile: "scala-2.12"
+            sparkProfile: "spark3.2"
+            sparkVersion: "3.2.1"
+
+          # Alias
+          - scalaProfile: "scala-2.12"
             sparkProfile: "spark3"
             sparkVersion: "3.2.1"
+
+          - scalaProfile: "scala-2.11"
+            sparkProfile: "spark2"
+            sparkVersion: "2.4.4"
+
+          - scalaProfile: "scala-2.11"
+            sparkProfile: "spark"
+            sparkVersion: "2.4.4"
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8

--- a/README.md
+++ b/README.md
@@ -70,24 +70,33 @@ To build the Javadoc for all Java and Scala classes:
 mvn clean javadoc:aggregate -Pjavadocs
 ```
 
-### Build with Scala 2.12
+### Build with Different Spark versions
 
-The default Scala version supported is 2.11. To build for Scala 2.12 version, build using `scala-2.12` profile
+The default Spark version supported is 2.4.4. To build for different Spark versions and Scala 2.12, use the
+corresponding profile
 
+| Label | Artifact Name for Spark Bundle | Maven Profile Option | Notes |
+|--|--|--|--|
+| Spark 2.4, Scala 2.11  | hudi-spark2.4-bundle_2.11 | `-Pspark2.4` | For Spark 2.4.4, which is the same as the default  |
+| Spark 2.4, Scala 2.12 | hudi-spark2.4-bundle_2.12 | `-Pspark2.4,scala-2.12` | For Spark 2.4.4, which is the same as the default and Scala 2.12 |
+| Spark 3.1, Scala 2.12 | hudi-spark3.1-bundle_2.12 | `-Pspark3.1` | For Spark 3.1.x |
+| Spark 3.2, Scala 2.12 | hudi-spark3.2-bundle_2.12 | `-Pspark3.2` | For Spark 3.2.x |
+| Spark 2, Scala 2.11 | hudi-spark2-bundle_2.11 | `-Pspark2` | This is the same as `Spark 2.4, Scala 2.11` |
+| Spark 2, Scala 2.12 | hudi-spark2-bundle_2.12 | `-Pspark2,scala-2.12` | This is the same as `Spark 2.4, Scala 2.12` |
+| Spark 3, Scala 2.12 | hudi-spark3-bundle_2.12 | `-Pspark3` | This is the same as `Spark 3.2, Scala 2.12` |
+| Spark, Scala 2.11 | hudi-spark-bundle_2.11 | Default | The default profile, supporting Spark 2.4.4 |
+| Spark, Scala 2.12 | hudi-spark-bundle_2.12 | `-Pscala-2.12` | The default profile (for Spark 2.4.x) with Scala 2.12 |
+
+For example,
 ```
-mvn clean package -DskipTests -Dscala-2.12
-```
+# Build against Spark 3.2.x (the default build shipped with the public Spark 3 bundle)
+mvn clean package -DskipTests -Pspark3.2
 
-### Build with Spark 3
+# Build against Spark 3.1.x
+mvn clean package -DskipTests -Pspark3.1
 
-The default Spark version supported is 2.4.4. To build for different Spark 3 versions, use the corresponding profile
-
-```
-# Build against Spark 3.2.1 (the default build shipped with the public Spark 3 bundle)
-mvn clean package -DskipTests -Dspark3
-
-# Build against Spark 3.1.2
-mvn clean package -DskipTests -Dspark3.1.x
+# Build against Spark 2.4.4 and Scala 2.12
+mvn clean package -DskipTests -Pspark2.4,scala-2.12
 ```
 
 ### What about "spark-avro" module? 

--- a/README.md
+++ b/README.md
@@ -81,11 +81,9 @@ corresponding profile
 | Spark 2.4, Scala 2.12 | hudi-spark2.4-bundle_2.12 | `-Pspark2.4,scala-2.12` | For Spark 2.4.4, which is the same as the default and Scala 2.12 |
 | Spark 3.1, Scala 2.12 | hudi-spark3.1-bundle_2.12 | `-Pspark3.1` | For Spark 3.1.x |
 | Spark 3.2, Scala 2.12 | hudi-spark3.2-bundle_2.12 | `-Pspark3.2` | For Spark 3.2.x |
-| Spark 2, Scala 2.11 | hudi-spark2-bundle_2.11 | `-Pspark2` | This is the same as `Spark 2.4, Scala 2.11` |
-| Spark 2, Scala 2.12 | hudi-spark2-bundle_2.12 | `-Pspark2,scala-2.12` | This is the same as `Spark 2.4, Scala 2.12` |
 | Spark 3, Scala 2.12 | hudi-spark3-bundle_2.12 | `-Pspark3` | This is the same as `Spark 3.2, Scala 2.12` |
 | Spark, Scala 2.11 | hudi-spark-bundle_2.11 | Default | The default profile, supporting Spark 2.4.4 |
-| Spark, Scala 2.12 | hudi-spark-bundle_2.12 | `-Pscala-2.12` | The default profile (for Spark 2.4.x) with Scala 2.12 |
+| Spark, Scala 2.12 | hudi-spark-bundle_2.12 | `-Pscala-2.12` | The default profile (for Spark 2.4.4) with Scala 2.12 |
 
 For example,
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -1589,21 +1589,9 @@
       </build>
     </profile>
 
-    <!-- Default spark is an alias of spark2, and spark2 is an alias of spark2.4 -->
+    <!-- Default is spark2 profile, and spark2 is an alias of spark2.4 -->
     <profile>
       <id>spark2</id>
-      <properties>
-        <sparkbundle.version>2</sparkbundle.version>
-      </properties>
-      <activation>
-        <property>
-          <name>spark2</name>
-        </property>
-      </activation>
-    </profile>
-
-    <profile>
-      <id>spark2.x</id>
       <modules>
         <module>hudi-spark-datasource/hudi-spark2</module>
         <module>hudi-spark-datasource/hudi-spark2-common</module>
@@ -1611,7 +1599,7 @@
       <activation>
         <activeByDefault>true</activeByDefault>
         <property>
-          <name>spark2.x</name>
+          <name>spark2</name>
           <!-- add spark2 moudule to all profile -->
           <value>!disabled</value>
         </property>
@@ -1620,6 +1608,10 @@
 
     <profile>
       <id>spark2.4</id>
+      <modules>
+        <module>hudi-spark-datasource/hudi-spark2</module>
+        <module>hudi-spark-datasource/hudi-spark2-common</module>
+      </modules>
       <properties>
         <sparkbundle.version>2.4</sparkbundle.version>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1723,37 +1723,6 @@
     </profile>
 
     <profile>
-      <id>spark3.1.x</id>
-      <properties>
-        <spark3.version>3.1.3</spark3.version>
-        <spark.version>${spark3.version}</spark.version>
-        <sparkbundle.version>${spark3.version}</sparkbundle.version>
-        <scala.version>${scala12.version}</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
-        <hudi.spark.module>hudi-spark3.1.x</hudi.spark.module>
-        <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
-        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
-        <kafka.version>${kafka.spark3.version}</kafka.version>
-        <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
-        <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
-        <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
-        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
-        </fasterxml.jackson.dataformat.yaml.version>
-        <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
-        <skipITs>true</skipITs>
-      </properties>
-      <modules>
-        <module>hudi-spark-datasource/hudi-spark3.1.x</module>
-        <module>hudi-spark-datasource/hudi-spark3-common</module>
-      </modules>
-      <activation>
-        <property>
-          <name>spark3.1.x</name>
-        </property>
-      </activation>
-    </profile>
-
-    <profile>
       <id>flink1.14</id>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -1589,7 +1589,7 @@
       </build>
     </profile>
 
-    <!-- hudi-spark2-bundle is an alias for hudi-spark-bundle -->
+    <!-- Default spark is an alias of spark2, and spark2 is an alias of spark2.4 -->
     <profile>
       <id>spark2</id>
       <properties>
@@ -1618,7 +1618,6 @@
       </activation>
     </profile>
 
-    <!-- hudi-spark2.4-bundle is an alias for hudi-spark-bundle -->
     <profile>
       <id>spark2.4</id>
       <properties>
@@ -1631,7 +1630,7 @@
       </activation>
     </profile>
 
-    <!-- hudi-spark3-bundle is an alias for hudi-spark3.2-bundle -->
+    <!-- spark3 is an alias of spark3.2 -->
     <profile>
       <id>spark3</id>
       <properties>
@@ -1727,37 +1726,6 @@
       <activation>
         <property>
           <name>spark3.2</name>
-        </property>
-      </activation>
-    </profile>
-
-    <profile>
-      <id>spark3.2.0</id>
-      <properties>
-        <spark3.version>3.2.0</spark3.version>
-        <spark.version>${spark3.version}</spark.version>
-        <sparkbundle.version>${spark3.version}</sparkbundle.version>
-        <scala.version>${scala12.version}</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
-        <hudi.spark.module>hudi-spark3</hudi.spark.module>
-        <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
-        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
-        <kafka.version>${kafka.spark3.version}</kafka.version>
-        <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
-        <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
-        <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
-        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
-        </fasterxml.jackson.dataformat.yaml.version>
-        <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
-        <skipITs>true</skipITs>
-      </properties>
-      <modules>
-        <module>hudi-spark-datasource/hudi-spark3</module>
-        <module>hudi-spark-datasource/hudi-spark3-common</module>
-      </modules>
-      <activation>
-        <property>
-          <name>spark3.2.0</name>
         </property>
       </activation>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <fasterxml.jackson.dataformat.yaml.version>2.7.4</fasterxml.jackson.dataformat.yaml.version>
     <fasterxml.spark3.version>2.10.0</fasterxml.spark3.version>
     <kafka.version>2.0.0</kafka.version>
+    <kafka.spark3.version>2.4.1</kafka.spark3.version>
     <pulsar.version>2.8.1</pulsar.version>
     <confluent.version>5.3.4</confluent.version>
     <glassfish.version>2.17</glassfish.version>
@@ -134,6 +135,7 @@
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <scala-maven-plugin.version>3.3.1</scala-maven-plugin.version>
     <scalatest.version>3.0.1</scalatest.version>
+    <scalatest.spark3.version>3.1.0</scalatest.spark3.version>
     <surefire-log4j.file>file://${project.basedir}/src/test/resources/log4j-surefire.properties</surefire-log4j.file>
     <thrift.version>0.12.0</thrift.version>
     <jetty.version>9.4.15.v20190215</jetty.version>
@@ -1587,8 +1589,21 @@
       </build>
     </profile>
 
+    <!-- hudi-spark2-bundle is an alias for hudi-spark-bundle -->
     <profile>
       <id>spark2</id>
+      <properties>
+        <sparkbundle.version>2</sparkbundle.version>
+      </properties>
+      <activation>
+        <property>
+          <name>spark2</name>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>spark2.x</id>
       <modules>
         <module>hudi-spark-datasource/hudi-spark2</module>
         <module>hudi-spark-datasource/hudi-spark2-common</module>
@@ -1596,31 +1611,46 @@
       <activation>
         <activeByDefault>true</activeByDefault>
         <property>
-          <name>spark2</name>
+          <name>spark2.x</name>
           <!-- add spark2 moudule to all profile -->
           <value>!disabled</value>
         </property>
       </activation>
     </profile>
+
+    <!-- hudi-spark2.4-bundle is an alias for hudi-spark-bundle -->
+    <profile>
+      <id>spark2.4</id>
+      <properties>
+        <sparkbundle.version>2.4</sparkbundle.version>
+      </properties>
+      <activation>
+        <property>
+          <name>spark2.4</name>
+        </property>
+      </activation>
+    </profile>
+
     <profile>
       <id>spark3</id>
       <properties>
         <spark3.version>3.2.1</spark3.version>
         <spark.version>${spark3.version}</spark.version>
-        <sparkbundle.version>${spark3.version}</sparkbundle.version>
+        <sparkbundle.version>3</sparkbundle.version>
         <scala.version>${scala12.version}</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <hudi.spark.module>hudi-spark3</hudi.spark.module>
         <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
-        <scalatest.version>3.1.0</scalatest.version>
-        <kafka.version>2.4.1</kafka.version>
+        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
+        <kafka.version>${kafka.spark3.version}</kafka.version>
         <parquet.version>1.12.2</parquet.version>
         <avro.version>1.10.2</avro.version>
         <orc.version>1.6.12</orc.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
-        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
+        </fasterxml.jackson.dataformat.yaml.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
       </properties>
@@ -1636,6 +1666,71 @@
     </profile>
 
     <profile>
+      <id>spark3.1</id>
+      <properties>
+        <spark3.version>3.1.3</spark3.version>
+        <spark.version>${spark3.version}</spark.version>
+        <sparkbundle.version>3.1</sparkbundle.version>
+        <scala.version>${scala12.version}</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <hudi.spark.module>hudi-spark3.1.x</hudi.spark.module>
+        <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
+        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
+        <kafka.version>${kafka.spark3.version}</kafka.version>
+        <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
+        <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
+        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
+        </fasterxml.jackson.dataformat.yaml.version>
+        <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
+        <skipITs>true</skipITs>
+      </properties>
+      <modules>
+        <module>hudi-spark-datasource/hudi-spark3.1.x</module>
+        <module>hudi-spark-datasource/hudi-spark3-common</module>
+      </modules>
+      <activation>
+        <property>
+          <name>spark3.1</name>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>spark3.2</id>
+      <properties>
+        <spark3.version>3.2.1</spark3.version>
+        <spark.version>${spark3.version}</spark.version>
+        <sparkbundle.version>3.2</sparkbundle.version>
+        <scala.version>${scala12.version}</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <hudi.spark.module>hudi-spark3</hudi.spark.module>
+        <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
+        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
+        <kafka.version>${kafka.spark3.version}</kafka.version>
+        <parquet.version>1.12.2</parquet.version>
+        <avro.version>1.10.2</avro.version>
+        <orc.version>1.6.12</orc.version>
+        <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
+        <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
+        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
+        </fasterxml.jackson.dataformat.yaml.version>
+        <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
+        <skipITs>true</skipITs>
+      </properties>
+      <modules>
+        <module>hudi-spark-datasource/hudi-spark3</module>
+        <module>hudi-spark-datasource/hudi-spark3-common</module>
+      </modules>
+      <activation>
+        <property>
+          <name>spark3.2</name>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
       <id>spark3.2.0</id>
       <properties>
         <spark3.version>3.2.0</spark3.version>
@@ -1645,12 +1740,13 @@
         <scala.binary.version>2.12</scala.binary.version>
         <hudi.spark.module>hudi-spark3</hudi.spark.module>
         <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
-        <scalatest.version>3.1.0</scalatest.version>
-        <kafka.version>2.4.1</kafka.version>
+        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
+        <kafka.version>${kafka.spark3.version}</kafka.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
-        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
+        </fasterxml.jackson.dataformat.yaml.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
       </properties>
@@ -1675,12 +1771,13 @@
         <scala.binary.version>2.12</scala.binary.version>
         <hudi.spark.module>hudi-spark3.1.x</hudi.spark.module>
         <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
-        <scalatest.version>3.1.0</scalatest.version>
-        <kafka.version>2.4.1</kafka.version>
+        <scalatest.version>${scalatest.spark3.version}</scalatest.version>
+        <kafka.version>${kafka.spark3.version}</kafka.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
-        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}
+        </fasterxml.jackson.dataformat.yaml.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1631,6 +1631,7 @@
       </activation>
     </profile>
 
+    <!-- hudi-spark3-bundle is an alias for hudi-spark3.2-bundle -->
     <profile>
       <id>spark3</id>
       <properties>


### PR DESCRIPTION
## What is the purpose of the pull request

To follow the updated model of compatibility with Spark, we need to provision additional Hudi Spark bundles as part of the 0.11 release referencing Spark minor version in the bundle name, "spark3.1", "spark3.2", "spark2.4".  Aliases are also created for backward compatibility.  Specifically,

| Label | Artifact Name | Maven Profile Option | Notes |
|--|--|--|--|
| Spark 2.4, Scala 2.11  | hudi-spark2.4-bundle_2.11 | `-Pspark2.4` | For Spark 2.4.4, which is the same as the default  |
| Spark 2.4, Scala 2.12 | hudi-spark2.4-bundle_2.12 | `-Pspark2.4,scala-2.12` | For Spark 2.4.4, which is the same as the default and Scala 2.12 |
| Spark 3.1, Scala 2.12 | hudi-spark3.1-bundle_2.12 | `-Pspark3.1` | For Spark 3.1.x |
| Spark 3.2, Scala 2.12 | hudi-spark3.2-bundle_2.12 | `-Pspark3.2` | For Spark 3.2.x |
| Spark 3, Scala 2.12 | hudi-spark3-bundle_2.12 | `-Pspark3` | This is the same as `Spark 3.2, Scala 2.12` |
| Spark, Scala 2.11 | hudi-spark-bundle_2.11 | Default | The default profile, supporting Spark 2.4.4 |
| Spark, Scala 2.12 | hudi-spark-bundle_2.12 | `-Pscala-2.12` | The default profile (for Spark 2.4.4) with Scala 2.12 |

## Brief change log

  - Adds and adjusts maven profiles for hudi-spark-bundle
  - Adjusts Github checks for different Spark versions

## Verify this pull request

This pull request is already covered by existing tests.

Each hudi-spark-bundle artifact is generated locally and tested against the corresponding Spark Shell with both COW and MOR tables from Docker Demo.  All Spark bundle jars pass the tests.

Build (examples with two profiles):
```
# Spark 2.4, Scala 2.12
mvn clean package -Pspark2.4,scala-2.12 -DskipTests -pl packaging/hudi-spark-bundle -am
# Spark 3.2
mvn clean package -Pspark3.2 -DskipTests -pl packaging/hudi-spark-bundle -am
```
Start the Spark Shell:
```
export SPARK_HOME=/path/to/lib/spark-3.1.3-bin-hadoop3.2
spark-3.1.3-bin-hadoop3.2/bin/spark-shell \
  --master local[4] \
  --num-executors 4 --executor-cores 1 \
  --driver-memory 4g \
  --executor-memory 1g \
  --conf spark.ui.port=5555 \
  --conf spark.driver.maxResultSize=1g \
  --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
  --conf spark.sql.catalogImplementation=hive \
  --conf spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.DefaultAWSCredentialsProviderChain \
  --packages org.apache.spark:spark-avro_2.12:3.1.3 \
  --jars hudi-spark3.1-bundle_2.12-0.11.0-SNAPSHOT.jar
```
Run queries (examples):
```
val cow1 = spark.read.format("hudi").load("/path/to/hudi/docker-demo-tables/stock_ticks_cow1")
cow1.registerTempTable("table_cow1")
spark.sql("select symbol, max(ts) from table_cow1 group by symbol HAVING symbol = 'GOOG'").show(100, false)
spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close  from table_cow1 where  symbol = 'GOOG'").show(100, false)
```
## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
