### PR TITLE
[MINOR] Fixing parquet reader iterator close 

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -335,13 +335,7 @@ object HoodieBaseRelation {
     partitionedFile => {
       val extension = FSUtils.getFileExtension(partitionedFile.filePath)
       if (HoodieFileFormat.PARQUET.getFileExtension.equals(extension)) {
-        val iter = parquetReader.apply(partitionedFile)
-        if (iter.isInstanceOf[Closeable]) {
-          // register a callback to close parquetReader which will be executed on task completion.
-          // when tasks finished, this method will be called, and release resources.
-          Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.asInstanceOf[Closeable].close()))
-        }
-        iter
+        parquetReader.apply(partitionedFile)
       } else if (HoodieFileFormat.HFILE.getFileExtension.equals(extension)) {
         hfileReader.apply(partitionedFile)
       } else {


### PR DESCRIPTION
## What is the purpose of the pull request

After saw a comment on https://github.com/apache/hudi/commit/f2a93ead3b5a6964a72b3543ada58aa334edef9c#r69671705 regarding the closable and autoClosable, I went back to check the code. We use https://github.com/apache/spark/blob/ef8fb9b9d84b6adfe5a4e03b6e775e709d624144/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala#L200 which returns an iterator and not an instance of Closable or AutoClosable. But guarding it using AutoClosable. 

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
