### PR TITLE
[HUDI-3451] Delete metadata table when the write client disables MDT

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -806,10 +806,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
   }
 
   /**
-   * Initialize hoodie.table.metadata.enable in hoodie.properties;
-   * Check if current metadata table flag in hoodieWriteConfig is the same as recorded in hoodie.properties:
-   * 1. If the flag in hoodie.properties is true but it is false in hoodieWriteConfig, It means users turn off MDT and we need to clean up MDT.
-   * 2. Update hoodie.table.metadata.enable in hoodie.properties based on HoodieWriteConfig if the value is different.
+   * Deletes the metadata table if the writer disables metadata table with hoodie.metadata.enable=false
    */
   public void maybeDeleteMetadataTable() {
     if (shouldExecuteMetadataTableDeletion()) {
@@ -820,7 +817,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
           LOG.info("Deleting metadata table because it is disabled in writer.");
           fileSystem.delete(mdtBasePath, true);
         }
-        updateMetadataTableConfig();
+        clearMetadataTablePartitionsConfig();
       } catch (IOException ioe) {
         throw new HoodieIOException("Failed to delete metadata table.", ioe);
       }
@@ -841,10 +838,10 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
   }
 
   /**
-   * update METADATA_TABLE_ENABLE.key() in hoodie.properties based on HoodieWriteConfig
+   * Clears hoodie.table.metadata.partitions in hoodie.properties
    */
-  private void updateMetadataTableConfig() {
-    LOG.info("Update hoodie.table.metadata.enable in hoodie.properties to " + config.isMetadataTableEnabled());
+  private void clearMetadataTablePartitionsConfig() {
+    LOG.info("Clear hoodie.table.metadata.partitions in hoodie.properties");
     metaClient.getTableConfig().setValue(
         HoodieTableConfig.TABLE_METADATA_PARTITIONS.key(), StringUtils.EMPTY_STRING);
     HoodieTableConfig.update(metaClient.getFs(), new Path(metaClient.getMetaPath()), metaClient.getTableConfig().getProps());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -804,12 +804,12 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
   }
 
   /**
-   * Initialize hoodie.table.metadata.enable in hoodie.proterties;
-   * Check if current metadata table flag in hoodieWriteConfig is the same as recorded in hoodie.proterties:
-   *  1. If the flag in hoodie.proterties is true but it is false in hoodieWriteConfig, It means users turn off MDT and we need to clean up MDT.
-   *  2. Update hoodie.table.metadata.enable in hoodie.proterties based on HoodieWriteConfig if the value is different.
+   * Initialize hoodie.table.metadata.enable in hoodie.properties;
+   * Check if current metadata table flag in hoodieWriteConfig is the same as recorded in hoodie.properties:
+   *  1. If the flag in hoodie.properties is true but it is false in hoodieWriteConfig, It means users turn off MDT and we need to clean up MDT.
+   *  2. Update hoodie.table.metadata.enable in hoodie.properties based on HoodieWriteConfig if the value is different.
    */
-  protected void verifyMetadataTableInTableConfig() {
+  public void verifyMetadataTableInTableConfig() {
     // ignore the hoodie.properties in MDT
     if (metaClient.getBasePath().contains(HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH)) {
       return;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ThreeToFourUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ThreeToFourUpgradeHandler.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
 
 import java.util.Hashtable;
@@ -46,11 +45,6 @@ public class ThreeToFourUpgradeHandler implements UpgradeHandler {
     // schema for the files partition is same between the two versions
     if (config.isMetadataTableEnabled() && metadataPartitionExists(config.getBasePath(), context, MetadataPartitionType.FILES)) {
       tablePropsToAdd.put(TABLE_METADATA_PARTITIONS, MetadataPartitionType.FILES.getPartitionPath());
-    }
-    tablePropsToAdd.put(HoodieTableConfig.METADATA_TABLE_ENABLE, Boolean.toString(config.isMetadataTableEnabled()));
-    // trying to clean up MDT during upgrade when users disable metadata table.
-    if (!config.isMetadataTableEnabled()) {
-      HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
     }
     return tablePropsToAdd;
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ThreeToFourUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ThreeToFourUpgradeHandler.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
 
 import java.util.Hashtable;
@@ -45,6 +46,11 @@ public class ThreeToFourUpgradeHandler implements UpgradeHandler {
     // schema for the files partition is same between the two versions
     if (config.isMetadataTableEnabled() && metadataPartitionExists(config.getBasePath(), context, MetadataPartitionType.FILES)) {
       tablePropsToAdd.put(TABLE_METADATA_PARTITIONS, MetadataPartitionType.FILES.getPartitionPath());
+    }
+    tablePropsToAdd.put(HoodieTableConfig.METADATA_TABLE_ENABLE, Boolean.toString(config.isMetadataTableEnabled()));
+    // trying to clean up MDT during upgrade when users disable metadata table.
+    if (!config.isMetadataTableEnabled()) {
+      HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
     }
     return tablePropsToAdd;
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
@@ -103,6 +103,7 @@ public abstract class HoodieFlinkTable<T extends HoodieRecordPayload>
   @Override
   public <T extends SpecificRecordBase> Option<HoodieTableMetadataWriter> getMetadataWriter(String triggeringInstantTimestamp,
                                                                                             Option<T> actionMetadata) {
+    verifyMetadataTableInTableConfig();
     if (config.isMetadataTableEnabled()) {
       return Option.of(FlinkHoodieBackedTableMetadataWriter.create(context.getHadoopConf().get(), config,
           context, actionMetadata, Option.of(triggeringInstantTimestamp)));

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.table;
 
-import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.data.HoodieData;
@@ -36,6 +35,8 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.metadata.FlinkHoodieBackedTableMetadataWriter;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
+
+import org.apache.avro.specific.SpecificRecordBase;
 
 import java.util.List;
 
@@ -103,11 +104,11 @@ public abstract class HoodieFlinkTable<T extends HoodieRecordPayload>
   @Override
   public <T extends SpecificRecordBase> Option<HoodieTableMetadataWriter> getMetadataWriter(String triggeringInstantTimestamp,
                                                                                             Option<T> actionMetadata) {
-    verifyMetadataTableInTableConfig();
     if (config.isMetadataTableEnabled()) {
       return Option.of(FlinkHoodieBackedTableMetadataWriter.create(context.getHadoopConf().get(), config,
           context, actionMetadata, Option.of(triggeringInstantTimestamp)));
     } else {
+      maybeDeleteMetadataTable();
       return Option.empty();
     }
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
@@ -107,7 +107,6 @@ public abstract class HoodieSparkTable<T extends HoodieRecordPayload>
   @Override
   public <R extends SpecificRecordBase> Option<HoodieTableMetadataWriter> getMetadataWriter(String triggeringInstantTimestamp,
                                                                                             Option<R> actionMetadata) {
-    verifyMetadataTableInTableConfig();
     if (config.isMetadataTableEnabled()) {
       // Create the metadata table writer. First time after the upgrade this creation might trigger
       // metadata table bootstrapping. Bootstrapping process could fail and checking the table
@@ -123,6 +122,8 @@ public abstract class HoodieSparkTable<T extends HoodieRecordPayload>
       } catch (IOException e) {
         throw new HoodieMetadataException("Checking existence of metadata table failed", e);
       }
+    } else {
+      maybeDeleteMetadataTable();
     }
 
     return Option.empty();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkTable.java
@@ -107,6 +107,7 @@ public abstract class HoodieSparkTable<T extends HoodieRecordPayload>
   @Override
   public <R extends SpecificRecordBase> Option<HoodieTableMetadataWriter> getMetadataWriter(String triggeringInstantTimestamp,
                                                                                             Option<R> actionMetadata) {
+    verifyMetadataTableInTableConfig();
     if (config.isMetadataTableEnabled()) {
       // Create the metadata table writer. First time after the upgrade this creation might trigger
       // metadata table bootstrapping. Bootstrapping process could fail and checking the table

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -213,14 +213,15 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     metaForP1.createNewFile();
     metaForP2.createNewFile();
 
-    // sync to metadata table
+    // Sync to metadata table
     metaClient.reloadActiveTimeline();
     HoodieTable table = HoodieSparkTable.create(writeConfig, context, metaClient);
     Option metadataWriter = table.getMetadataWriter(instant1, Option.of(hoodieCommitMetadata));
     validateMetadata(testTable, true);
 
     assertTrue(metadataWriter.isPresent());
-    HoodieTableConfig hoodieTableConfig = new HoodieTableConfig(this.fs, metaClient.getMetaPath(), writeConfig.getPayloadClass());
+    HoodieTableConfig hoodieTableConfig =
+        new HoodieTableConfig(this.fs, metaClient.getMetaPath(), writeConfig.getPayloadClass());
     assertFalse(hoodieTableConfig.getMetadataPartitions().isEmpty());
 
     // Turn off metadata table
@@ -236,12 +237,15 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     Option metadataWriter2 = table2.getMetadataWriter(instant2, Option.of(hoodieCommitMetadata2));
     assertFalse(metadataWriter2.isPresent());
 
-    HoodieTableConfig hoodieTableConfig2 = new HoodieTableConfig(this.fs, metaClient.getMetaPath(), writeConfig2.getPayloadClass());
+    HoodieTableConfig hoodieTableConfig2 =
+        new HoodieTableConfig(this.fs, metaClient.getMetaPath(), writeConfig2.getPayloadClass());
     assertEquals(StringUtils.EMPTY_STRING, hoodieTableConfig2.getMetadataPartitions());
-    // assert MDT is deleted.
-    assertFalse(metaClient.getFs().exists(new Path(HoodieTableMetadata.getMetadataTableBasePath(writeConfig2.getBasePath()))));
+    // Assert metadata table folder is deleted
+    assertFalse(metaClient.getFs().exists(
+        new Path(HoodieTableMetadata.getMetadataTableBasePath(writeConfig2.getBasePath()))));
 
-    // enable MDT again and initial MDT through HoodieTable.getMetadataWriter() function
+    // Enable metadata table again and initialize metadata table through
+    // HoodieTable.getMetadataWriter() function
     HoodieWriteConfig writeConfig3 = HoodieWriteConfig.newBuilder()
         .withProperties(this.writeConfig.getProps())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).build())
@@ -255,7 +259,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     Option metadataWriter3 = table3.getMetadataWriter(instant3, Option.of(hoodieCommitMetadata3));
     validateMetadata(testTable, true);
     assertTrue(metadataWriter3.isPresent());
-    HoodieTableConfig hoodieTableConfig3 = new HoodieTableConfig(this.fs, metaClient.getMetaPath(), writeConfig.getPayloadClass());
+    HoodieTableConfig hoodieTableConfig3 =
+        new HoodieTableConfig(this.fs, metaClient.getMetaPath(), writeConfig.getPayloadClass());
     assertFalse(hoodieTableConfig3.getMetadataPartitions().isEmpty());
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.HoodieTimelineArchiver;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
@@ -174,6 +175,10 @@ public class TestHoodieMetadataBase extends HoodieClientTestHarness {
 
   protected void doWriteOperation(HoodieTestTable testTable, String commitTime, WriteOperationType operationType) throws Exception {
     testTable.doWriteOperation(commitTime, operationType, emptyList(), asList("p1", "p2"), 3);
+  }
+
+  protected HoodieCommitMetadata doWriteOperationWithMeta(HoodieTestTable testTable, String commitTime, WriteOperationType operationType) throws Exception {
+    return testTable.doWriteOperation(commitTime, operationType, emptyList(), asList("p1", "p2"), 3);
   }
 
   protected void doClean(HoodieTestTable testTable, String commitTime, List<String> commitsToClean) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
-import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.OrderedProperties;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieFileFormat;
@@ -223,11 +222,6 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("0.11.0")
       .withDocumentation("Comma-separated list of metadata partitions that have been completely built and in-sync with data table. "
           + "These partitions are ready for use by the readers");
-
-  public static final ConfigProperty<Boolean> METADATA_TABLE_ENABLE = ConfigProperty
-      .key("hoodie.table.metadata.enable")
-      .defaultValue(HoodieMetadataConfig.ENABLE.defaultValue())
-      .withDocumentation("Enable the internal metadata table which serves table metadata like level file listings.");
 
   private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
 
@@ -613,11 +607,7 @@ public class HoodieTableConfig extends HoodieConfig {
   public String getMetadataPartitions() {
     return getStringOrDefault(TABLE_METADATA_PARTITIONS, StringUtils.EMPTY_STRING);
   }
-
-  public Boolean getMetadataTableEnable() {
-    return getBooleanOrDefault(METADATA_TABLE_ENABLE);
-  }
-
+  
   public Map<String, String> propsMap() {
     return props.entrySet().stream()
         .collect(Collectors.toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue())));

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.OrderedProperties;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieFileFormat;
@@ -222,6 +223,11 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("0.11.0")
       .withDocumentation("Comma-separated list of metadata partitions that have been completely built and in-sync with data table. "
           + "These partitions are ready for use by the readers");
+
+  public static final ConfigProperty<Boolean> METADATA_TABLE_ENABLE = ConfigProperty
+      .key("hoodie.table.metadata.enable")
+      .defaultValue(HoodieMetadataConfig.ENABLE.defaultValue())
+      .withDocumentation("Enable the internal metadata table which serves table metadata like level file listings.");
 
   private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
 
@@ -606,6 +612,10 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public String getMetadataPartitions() {
     return getStringOrDefault(TABLE_METADATA_PARTITIONS, StringUtils.EMPTY_STRING);
+  }
+
+  public Boolean getMetadataTableEnable() {
+    return getBooleanOrDefault(METADATA_TABLE_ENABLE);
   }
 
   public Map<String, String> propsMap() {


### PR DESCRIPTION
## What is the purpose of the pull request

When the write client disables metadata table, the metadata table becomes out-of-sync after new commits.  This PR adds the logic to delete the metadata table when the write client disables metadata table updates.  The new deletion logic is only invoked if `hoodie.metadata.enable` in write config is false, and `hoodie.table.metadata.partitions` is either absent or non-empty, indicating that the metadata table might exist.  Note that the user should wait for the metadata table to be fully deleted before re-enabling metadata table on the write side.

## Brief change log

  - Adds logic in `HoodieTable` for deleting metadata table
  - Invokes the metadata table deletion upon getting metadata writer when metadata table is disabled.

## Verify this pull request

This change adds new tests in TestHoodieBackedMetadata to validate the flow of disabling and re-enabling metadata table.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
