### PR TITLE
[HUDI-3759] hive-exec shade is lost in flink-bundle-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -977,14 +977,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>*</artifactId>
           </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-exec</artifactId>
-        <version>${hive.version}</version>
-        <scope>provided</scope>
-        <exclusions>
           <exclusion>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>


### PR DESCRIPTION
## What is the purpose of the pull request

Solve [HUDI-3759](https://issues.apache.org/jira/browse/HUDI-3759)  Problem

## Brief change log

 - Modify pom.xml, merge two hive-exec to one. Avoid transitivity scope provided to hudi-flink-bundle module.

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
