### PR TITLE
[HUDI-3708] Fix failure with HoodieMetadataRecord due to schema compatibility check

### DIFF
--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -115,7 +115,8 @@
                             "type": [
                                 "null",
                                 "string"
-                            ]
+                            ],
+                            "default" : null
                         },
                         {
                             "doc": "Minimum value in the range. Based on user data table schema, we can convert this to appropriate type",


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the schema validation failure due to newly added field in #4948.  The failure happens when the table is written by a 0.11.0-SNAPSHOT release before that change with metadata table enabled, and later written with an updated 0.11.0-SNAPSHOT release using the new schema.  The failure is due to no default value set for the field.

## Brief change log

- Adds default value in the avro schema.

## Verify this pull request

Tested locally and in staging that the schema compatibility check can pass.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
