### PR TITLE
[HUDI-3773] Fix parallelism used for metadata table bloom filter index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1563,6 +1563,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getMetadataConfig().getIndexingCheckTimeoutSeconds();
   }
 
+  public int getMetadataBloomFilterIndexParallelism() {
+    return metadataConfig.getBloomFilterIndexParallelism();
+  }
+
   public int getColumnStatsIndexParallelism() {
     return metadataConfig.getColumnStatsIndexParallelism();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -704,7 +704,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   private MetadataRecordsGenerationParams getRecordsGenerationParams() {
     return new MetadataRecordsGenerationParams(
         dataMetaClient, enabledPartitionTypes, dataWriteConfig.getBloomFilterType(),
-        dataWriteConfig.getBloomIndexParallelism(),
+        dataWriteConfig.getMetadataBloomFilterIndexParallelism(),
         dataWriteConfig.isMetadataColumnStatsIndexEnabled(),
         dataWriteConfig.getColumnStatsIndexParallelism(),
         StringUtils.toList(dataWriteConfig.getColumnsEnabledForColumnStatsIndex()),

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -151,6 +151,12 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "log files and read parallelism in the bloom filter index partition. The recommendation is to size the "
           + "file group count such that the base files are under 1GB.");
 
+  public static final ConfigProperty<Integer> BLOOM_FILTER_INDEX_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".index.bloom.filter.parallelism")
+      .defaultValue(200)
+      .sinceVersion("0.11.0")
+      .withDocumentation("Parallelism to use for generating bloom filter index in metadata table.");
+
   public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_COLUMN_STATS = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.enable")
       .defaultValue(false)
@@ -263,6 +269,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getIntOrDefault(METADATA_INDEX_COLUMN_STATS_FILE_GROUP_COUNT);
   }
 
+  public int getBloomFilterIndexParallelism() {
+    return getIntOrDefault(BLOOM_FILTER_INDEX_PARALLELISM);
+  }
+
   public int getColumnStatsIndexParallelism() {
     return getIntOrDefault(COLUMN_STATS_INDEX_PARALLELISM);
   }
@@ -320,6 +330,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withMetadataIndexBloomFilterFileGroups(int fileGroupCount) {
       metadataConfig.setValue(METADATA_INDEX_BLOOM_FILTER_FILE_GROUP_COUNT, String.valueOf(fileGroupCount));
+      return this;
+    }
+
+    public Builder withBloomFilterIndexParallelism(int parallelism) {
+      metadataConfig.setValue(BLOOM_FILTER_INDEX_PARALLELISM, String.valueOf(parallelism));
       return this;
     }
 


### PR DESCRIPTION
## What is the purpose of the pull request

Before this change, `hoodie.bloom.index.parallelism` is used as the parallelism for generating bloom filter index in metadata table.  Since the default value of the config is 0, when generating the metadata bloom filter records, the method below always uses parallelism as 1, which does not work well for large batch ingestion.  The reason why it has default of 0 is that in the non-metadata-table bloom filter flow, the parallelism can be automatically figured out based on the shuffle parallelism.

`HoodieTableMetadataUtil.convertMetadataToBloomFilterRecords()`:
```
final int parallelism = Math.max(Math.min(allWriteStats.size(), recordsGenerationParams.getBloomIndexParallelism()), 1);
HoodieData<HoodieWriteStat> allWriteStatsRDD = context.parallelize(allWriteStats, parallelism);
return allWriteStatsRDD.flatMap(hoodieWriteStat -> {<bloom filter records>})
```

This PR adds a separate parallelism config, `hoodie.metadata.index.bloom.filter.parallelism`, for generating bloom filter index in metadata table, since the shuffle parallelism cannot be infered here.

## Brief change log

  - Adds `hoodie.metadata.index.bloom.filter.parallelism` config and passes that to the `MetadataRecordsGenerationParams`

## Verify this pull request

This PR is verified by running a Deltastreamer ingesting 10GB data with bulk insert, with bloom filter partition enabled in metadata table.  Without this change, the job cannot finish due to OOM.  With this change, from the Spark UI, there's parallelism when generating bloom filter records in the metadata table and the job succeeds. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
