### PR TITLE
[HUDI-3800] Fixed preserve commit metadata for compaction for untouched records

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
@@ -90,7 +90,7 @@ public class HoodieSortedMergeHandle<T extends HoodieRecordPayload, I, K, O> ext
         throw new HoodieUpsertException("Insert/Update not in sorted order");
       }
       try {
-        if (useWriterSchema) {
+        if (useWriterSchemaForCompaction) {
           writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(tableSchemaWithMetaFields, config.getProps()));
         } else {
           writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(tableSchema, config.getProps()));
@@ -113,7 +113,7 @@ public class HoodieSortedMergeHandle<T extends HoodieRecordPayload, I, K, O> ext
         String key = newRecordKeysSorted.poll();
         HoodieRecord<T> hoodieRecord = keyToNewRecords.get(key);
         if (!writtenRecordKeys.contains(hoodieRecord.getRecordKey())) {
-          if (useWriterSchema) {
+          if (useWriterSchemaForCompaction) {
             writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(tableSchemaWithMetaFields, config.getProps()));
           } else {
             writeRecord(hoodieRecord, hoodieRecord.getData().getInsertValue(tableSchema, config.getProps()));


### PR DESCRIPTION
## What is the purpose of the pull request

- During compaction, updates are present in logs, where as those records that are not updated are in base files. With compaction and preserving commit metadata, we did fix the code path for records that are updated, but those from previous base files were not fixed for file names. Infact, we had this inconsistency even before adding support for preserve commit metadata. i.e. with 0.9.0, after compaction, some records will have meta fields untouched (from previous base file), but those from logs will have all meta files re-written. We are fixing that w/ this patch.

## Brief change log

- Fixing HoodieMergeHandle to fix preserve commit metadata for untouched records from previous base file.

## Verify this pull request

- Verified manually. 
before fix
```
spark.sql("select _hoodie_file_name, count(*) from hudi_trips_snapshot  where partitionpath = 'americas/united_states/san_francisco' group by 1").show(false)
+--------------------------------------------------------------------------+--------+
|_hoodie_file_name                                                         |count(1)|
+--------------------------------------------------------------------------+--------+
|f0a22491-f000-42ad-ad7a-8093c9dfa3ad-0_1-34-40_20220405134801234.parquet  |2       |
|f0a22491-f000-42ad-ad7a-8093c9dfa3ad-0_0-164-583_20220405135013266.parquet|6       |
+--------------------------------------------------------------------------+--------+
```

after fix 
```
spark.sql("select _hoodie_file_name, count(*) from hudi_trips_snapshot  where partitionpath = 'americas/united_states/san_francisco' group by 1").show(false)
+--------------------------------------------------------------------------+--------+
|_hoodie_file_name                                                         |count(1)|
+--------------------------------------------------------------------------+--------+
|60ccb4d1-6eec-4290-bc57-a67a3d7cb11f-0_0-162-581_20220405135643929.parquet|8       |
+--------------------------------------------------------------------------+--------+
```


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
