### PR TITLE
[HUDI-3812] Fixing Data Skipping configuration to respect Metadata Table configs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -50,8 +50,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Enable the internal metadata table which serves table metadata like level file listings");
 
-  // TODO rectify
-  public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = true;
+  public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = false;
 
   // Enable metrics for internal Metadata Table
   public static final ConfigProperty<Boolean> METRICS_ENABLE = ConfigProperty

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -50,7 +50,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Enable the internal metadata table which serves table metadata like level file listings");
 
-  public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = false;
+  // TODO rectify
+  public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = true;
 
   // Enable metrics for internal Metadata Table
   public static final ConfigProperty<Boolean> METRICS_ENABLE = ConfigProperty

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -68,7 +68,7 @@ trait ColumnStatsIndexSupport extends SparkAdapterSupport {
       if (targetColumns.nonEmpty) {
         readColumnStatsIndexForColumnsInternal(spark, targetColumns, metadataConfig, tableBasePath)
       } else {
-        readFullColumnStatsIndexInternal(spark, tableBasePath)
+        readFullColumnStatsIndexInternal(spark, metadataConfig, tableBasePath)
       }
     }
 
@@ -181,10 +181,11 @@ trait ColumnStatsIndexSupport extends SparkAdapterSupport {
     spark.createDataFrame(transposedRDD, indexSchema)
   }
 
-  private def readFullColumnStatsIndexInternal(spark: SparkSession, tableBasePath: String) = {
+  private def readFullColumnStatsIndexInternal(spark: SparkSession, metadataConfig: HoodieMetadataConfig, tableBasePath: String): DataFrame = {
     val metadataTablePath = HoodieTableMetadata.getMetadataTableBasePath(tableBasePath)
     // Read Metadata Table's Column Stats Index into Spark's [[DataFrame]]
     spark.read.format("org.apache.hudi")
+      .options(metadataConfig.getProps.asScala)
       .load(s"$metadataTablePath/${MetadataPartitionType.COLUMN_STATS.getPartitionPath}")
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -199,7 +199,7 @@ case class HoodieFileIndex(spark: SparkSession,
     //          nothing CSI in particular could be applied for)
     lazy val queryReferencedColumns = collectReferencedColumns(spark, queryFilters, schema)
 
-    if (!isMetadataTableEnabled || !isColumnStatsIndexEnabled || !isColumnStatsIndexAvailable || !isDataSkippingEnabled) {
+    if (!isMetadataTableEnabled || !isColumnStatsIndexAvailable || !isDataSkippingEnabled) {
       validateConfig()
       Option.empty
     } else if (queryFilters.isEmpty || queryReferencedColumns.isEmpty) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -399,7 +399,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase {
       val allFilesPartitions = fileIndex.listFiles(Seq(), Seq())
       assertEquals(10, allFilesPartitions.head.files.length)
 
-      if (testCase.enableDataSkipping && testCase.enableMetadata && testCase.enableColumnStats) {
+      if (testCase.enableDataSkipping && testCase.enableMetadata) {
         // We're selecting a single file that contains "id" == 1 row, which there should be
         // strictly 1. Given that 1 is minimal possible value, Data Skipping should be able to
         // truncate search space to just a single file

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -420,13 +420,14 @@ object TestHoodieFileIndex {
                                   enableColumnStats: Boolean,
                                   enableDataSkipping: Boolean)
 
-  def testDataSkippingWhileFileListingParams: Seq[DataSkippingTestCase] =
-    DataSkippingTestCase(enableMetadata = false, enableColumnStats = false, enableDataSkipping = false) ::
-      DataSkippingTestCase(enableMetadata = false, enableColumnStats = false, enableDataSkipping = true) ::
-      DataSkippingTestCase(enableMetadata = true, enableColumnStats = false, enableDataSkipping = true) ::
-      DataSkippingTestCase(enableMetadata = false, enableColumnStats = true, enableDataSkipping = true) ::
-      DataSkippingTestCase(enableMetadata = true, enableColumnStats = true, enableDataSkipping = true) ::
-      Nil
+  def testDataSkippingWhileFileListingParams: java.util.stream.Stream[Arguments] =
+    java.util.stream.Stream.of(
+      Arguments.arguments(DataSkippingTestCase(enableMetadata = false, enableColumnStats = false, enableDataSkipping = false)),
+      Arguments.arguments(DataSkippingTestCase(enableMetadata = false, enableColumnStats = false, enableDataSkipping = true)),
+      Arguments.arguments(DataSkippingTestCase(enableMetadata = true, enableColumnStats = false, enableDataSkipping = true)),
+      Arguments.arguments(DataSkippingTestCase(enableMetadata = false, enableColumnStats = true, enableDataSkipping = true)),
+      Arguments.arguments(DataSkippingTestCase(enableMetadata = true, enableColumnStats = true, enableDataSkipping = true))
+    )
 
   def keyGeneratorParameters(): java.util.stream.Stream[Arguments] = {
     java.util.stream.Stream.of(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -19,7 +19,7 @@
 package org.apache.hudi.functional
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path}
+import org.apache.hadoop.fs.{LocatedFileStatus, Path}
 import org.apache.hudi.ColumnStatsIndexSupport.composeIndexSchema
 import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD}
 import org.apache.hudi.HoodieConversionUtils.toProperties
@@ -27,6 +27,7 @@ import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.util.ParquetUtils
 import org.apache.hudi.config.{HoodieStorageConfig, HoodieWriteConfig}
+import org.apache.hudi.functional.TestColumnStatsIndex.ColumnStatsTestCase
 import org.apache.hudi.testutils.HoodieClientTestBase
 import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions}
 import org.apache.spark.sql._
@@ -35,7 +36,7 @@ import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api._
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.MethodSource
 
 import java.math.BigInteger
 import java.sql.{Date, Timestamp}
@@ -72,8 +73,8 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = Array(true, false))
-  def testMetadataColumnStatsIndex(forceFullLogScan: Boolean): Unit = {
+  @MethodSource(Array("testMetadataColumnStatsIndexParams"))
+  def testMetadataColumnStatsIndex(testCase: ColumnStatsTestCase): Unit = {
     val opts = Map(
       "hoodie.insert.shuffle.parallelism" -> "4",
       "hoodie.upsert.shuffle.parallelism" -> "4",
@@ -82,7 +83,10 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
       PRECOMBINE_FIELD.key -> "c1",
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true",
-      HoodieMetadataConfig.ENABLE_FULL_SCAN_LOG_FILES.key -> forceFullLogScan.toString,
+      // NOTE: Currently only this setting is used like following by different MT partitions:
+      //          - Files: using it
+      //          - Column Stats: NOT using it (defaults to doing "point-lookups")
+      HoodieMetadataConfig.ENABLE_FULL_SCAN_LOG_FILES.key -> testCase.forceFullLogScan.toString,
       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
     )
 
@@ -111,7 +115,14 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
       .fromProperties(toProperties(opts))
       .build()
 
-    val colStatsDF = readColumnStatsIndex(spark, basePath, metadataConfig, sourceTableSchema.fieldNames)
+    val targetColumnsToRead: Seq[String] = {
+      // Providing empty seq of columns to [[readColumnStatsIndex]] will lead to the whole
+      // MT to be read, and subsequently filtered
+      if (testCase.readFullMetadataTable) Seq.empty
+      else sourceTableSchema.fieldNames
+    }
+
+    val colStatsDF = readColumnStatsIndex(spark, basePath, metadataConfig, targetColumnsToRead)
     val transposedColStatsDF = transposeColumnStatsIndex(spark, colStatsDF, sourceTableSchema.fieldNames, sourceTableSchema)
 
     val expectedColStatsSchema = composeIndexSchema(sourceTableSchema.fieldNames, sourceTableSchema)
@@ -151,7 +162,7 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
 
     metaClient = HoodieTableMetaClient.reload(metaClient)
 
-    val updatedColStatsDF = readColumnStatsIndex(spark, basePath, metadataConfig, sourceTableSchema.fieldNames)
+    val updatedColStatsDF = readColumnStatsIndex(spark, basePath, metadataConfig, targetColumnsToRead)
     val transposedUpdatedColStatsDF = transposeColumnStatsIndex(spark, updatedColStatsDF, sourceTableSchema.fieldNames, sourceTableSchema)
 
     val expectedColStatsIndexUpdatedDF =
@@ -243,26 +254,6 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
     )
   }
 
-  def bootstrapParquetInputTableFromJSON(sourceJSONTablePath: String, targetParquetTablePath: String): Unit = {
-    val jsonInputDF =
-    // NOTE: Schema here is provided for validation that the input date is in the appropriate format
-      spark.read
-        .schema(sourceTableSchema)
-        .json(sourceJSONTablePath)
-
-    jsonInputDF
-      .sort("c1")
-      .repartition(4, new Column("c1"))
-      .write
-      .format("parquet")
-      .mode("overwrite")
-      .save(targetParquetTablePath)
-
-    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
-    // Have to cleanup additional artefacts of Spark write
-    fs.delete(new Path(targetParquetTablePath, "_SUCCESS"), false)
-  }
-
   private def generateRandomDataFrame(spark: SparkSession): DataFrame = {
     val sourceTableSchema =
       new StructType()
@@ -315,4 +306,14 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
       .sort("c1_maxValue", "c1_minValue")
   }
 
+}
+
+object TestColumnStatsIndex {
+
+  case class ColumnStatsTestCase(forceFullLogScan: Boolean, readFullMetadataTable: Boolean)
+
+  private def testMetadataColumnStatsIndexParams: Seq[ColumnStatsTestCase] =
+    ColumnStatsTestCase(forceFullLogScan = false, readFullMetadataTable = false) ::
+    ColumnStatsTestCase(forceFullLogScan = true, readFullMetadataTable = true) ::
+    Nil
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -75,20 +75,23 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
   @ParameterizedTest
   @MethodSource(Array("testMetadataColumnStatsIndexParams"))
   def testMetadataColumnStatsIndex(testCase: ColumnStatsTestCase): Unit = {
+    val metadataOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
+    )
+
     val opts = Map(
       "hoodie.insert.shuffle.parallelism" -> "4",
       "hoodie.upsert.shuffle.parallelism" -> "4",
       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
       RECORDKEY_FIELD.key -> "c1",
       PRECOMBINE_FIELD.key -> "c1",
-      HoodieMetadataConfig.ENABLE.key -> "true",
-      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true",
       // NOTE: Currently only this setting is used like following by different MT partitions:
       //          - Files: using it
       //          - Column Stats: NOT using it (defaults to doing "point-lookups")
       HoodieMetadataConfig.ENABLE_FULL_SCAN_LOG_FILES.key -> testCase.forceFullLogScan.toString,
       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
-    )
+    ) ++ metadataOpts
 
     setTableName("hoodie_test")
     initMetaClient()
@@ -112,7 +115,7 @@ class TestColumnStatsIndex extends HoodieClientTestBase with ColumnStatsIndexSup
     metaClient = HoodieTableMetaClient.reload(metaClient)
 
     val metadataConfig = HoodieMetadataConfig.newBuilder()
-      .fromProperties(toProperties(opts))
+      .fromProperties(toProperties(metadataOpts))
       .build()
 
     val targetColumnsToRead: Seq[String] = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api._
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 
 import java.math.BigInteger
 import java.sql.{Date, Timestamp}
@@ -312,8 +312,9 @@ object TestColumnStatsIndex {
 
   case class ColumnStatsTestCase(forceFullLogScan: Boolean, readFullMetadataTable: Boolean)
 
-  private def testMetadataColumnStatsIndexParams: Seq[ColumnStatsTestCase] =
-    ColumnStatsTestCase(forceFullLogScan = false, readFullMetadataTable = false) ::
-    ColumnStatsTestCase(forceFullLogScan = true, readFullMetadataTable = true) ::
-    Nil
+  private def testMetadataColumnStatsIndexParams: java.util.stream.Stream[Arguments] =
+    java.util.stream.Stream.of(
+      Arguments.arguments(ColumnStatsTestCase(forceFullLogScan = false, readFullMetadataTable = false)),
+      Arguments.arguments(ColumnStatsTestCase(forceFullLogScan = true, readFullMetadataTable = true))
+    )
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -312,7 +312,7 @@ object TestColumnStatsIndex {
 
   case class ColumnStatsTestCase(forceFullLogScan: Boolean, readFullMetadataTable: Boolean)
 
-  private def testMetadataColumnStatsIndexParams: java.util.stream.Stream[Arguments] =
+  def testMetadataColumnStatsIndexParams: java.util.stream.Stream[Arguments] =
     java.util.stream.Stream.of(
       Arguments.arguments(ColumnStatsTestCase(forceFullLogScan = false, readFullMetadataTable = false)),
       Arguments.arguments(ColumnStatsTestCase(forceFullLogScan = true, readFullMetadataTable = true))


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Addressing the problem of Data Skipping not respecting Metadata Table configs which might differ b/w write/read paths. More details could be found in HUDI-3812.

## Brief change log

 - Fixing Data Skipping configuration to respect MT configs (on the Read path)
 - Tightening up DS handling of cases when no top-level columns are in the target query
 - Enhancing tests to cover all possible cases

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.
This change added tests and can be verified as follows:

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
