### PR TITLE
Fix hadoop 3 compile Error, use FSDataOutputStream(OutputStream out, FileSystem.Statistics stats) instead of FSDataOutputStream(OutputStream out)

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
@@ -109,7 +109,7 @@ public class HoodieParquetDataBlock extends HoodieDataBlock {
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-    try (FSDataOutputStream outputStream = new FSDataOutputStream(baos)) {
+    try (FSDataOutputStream outputStream = new FSDataOutputStream(baos, null)) {
       try (HoodieParquetStreamWriter<IndexedRecord> parquetWriter = new HoodieParquetStreamWriter<>(outputStream, avroParquetConfig)) {
         for (IndexedRecord record : records) {
           String recordKey = getRecordKey(record).orElse(null);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fix hadoop 3 compile error.

Compile hudi with hadoop3, there arouse the following errors:

![微信图片_20220407194206](https://user-images.githubusercontent.com/46479816/162191266-a87fdd64-7b14-4a02-b1cf-624609946e69.png)

The reason is that, Hadoop3 delete FSDataOutputStream(OutputStream out) constructor of FSDataOutputStream

## Brief change log

use FSDataOutputStream(OutputStream out, FileSystem.Statistics stats) instead of FSDataOutputStream(OutputStream out) in HoodieParquetDataBlock 

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist
 
 - [ ] Commit message is descriptive of the change
