### PR TITLE
[HUDI-3818] encode bytes column value when generate HoodieKey

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -20,6 +20,8 @@ package org.apache.hudi.common.util;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -88,6 +90,11 @@ public class StringUtils {
   }
 
   public static String objToString(@Nullable Object obj) {
+    if (obj != null && obj instanceof ByteBuffer) {
+      ByteBuffer byteBuffer = (ByteBuffer) obj;
+      return Base64.getEncoder().encodeToString(byteBuffer.array());
+    }
+
     return obj == null ? null : obj.toString();
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/TestComplexKeyGenerator.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/TestComplexKeyGenerator.java
@@ -125,6 +125,18 @@ public class TestComplexKeyGenerator extends KeyGeneratorTestUtilities {
   }
 
   @Test
+  public void testBytesValueKeyGenerator() {
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "nation");
+    properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "timestamp");
+    ComplexKeyGenerator compositeKeyGenerator = new ComplexKeyGenerator(properties);
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+    GenericRecord record = dataGenerator.generateGenericRecords(1).get(0);
+    HoodieKey hoodieKey = compositeKeyGenerator.getKey(record);
+    assertEquals("nation:Q2FuYWRh", hoodieKey.getRecordKey());
+  }
+
+  @Test
   public void testMultipleValueKeyGenerator() {
     TypedProperties properties = new TypedProperties();
     properties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key,timestamp");


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*  This pr is to solve the problem that hudi incorrectly generates the key of the bytes column value, More details could be found in [HUDI-3818](https://issues.apache.org/jira/browse/HUDI-3818).

## Brief change log

* encode bytes column value which are represented as bytebuffer

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
