### PR TITLE
[HUDI-3636] Create new write clients for async table services in DeltaStreamer and Spark streaming sink

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncArchiveService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncArchiveService.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -42,7 +43,7 @@ public class AsyncArchiveService extends HoodieAsyncTableService {
   private final transient ExecutorService executor = Executors.newSingleThreadExecutor();
 
   protected AsyncArchiveService(BaseHoodieWriteClient writeClient) {
-    super(writeClient.getConfig());
+    super(writeClient.getConfig(), Option.empty());
     this.writeClient = writeClient;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCleanerService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCleanerService.java
@@ -21,6 +21,7 @@ package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -43,7 +44,7 @@ public class AsyncCleanerService extends HoodieAsyncTableService {
   private final transient ExecutorService executor = Executors.newSingleThreadExecutor();
 
   protected AsyncCleanerService(BaseHoodieWriteClient writeClient) {
-    super(writeClient.getConfig());
+    super(writeClient.getConfig(), Option.empty());
     this.writeClient = writeClient;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
@@ -50,6 +50,7 @@ public abstract class AsyncClusteringService extends HoodieAsyncTableService {
   private static final Logger LOG = LogManager.getLogger(AsyncClusteringService.class);
   private final int maxConcurrentClustering;
   protected transient HoodieEngineContext context;
+  // will be reinstantiated if write config is updated by external caller.
   private BaseClusterer clusteringClient;
 
   public AsyncClusteringService(HoodieEngineContext context, HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
@@ -81,6 +82,7 @@ public abstract class AsyncClusteringService extends HoodieAsyncTableService {
           if (null != instant) {
             LOG.info("Starting clustering for instant " + instant);
             synchronized (writeConfigUpdateLock) {
+              // re-instantiate only for first time or if write config is updated externally
               if (clusteringClient == null || isWriteConfigUpdated.get()) {
                 if (clusteringClient != null) {
                   clusteringClient.close();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
@@ -92,10 +92,13 @@ public abstract class AsyncClusteringService extends HoodieAsyncTableService {
               }
             }
             clusteringClient.cluster(instant);
-            LOG.info("Finished clustering for instant " + instant);
-            clusteringClient.close();
-            clusteringClient = null;
+            LOG.info("Completed Clustering for " + instant);
           }
+        }
+
+        if (clusteringClient != null) {
+          clusteringClient.close();
+          clusteringClient = null;
         }
         LOG.info("Clustering executor shutting down properly");
       } catch (InterruptedException ie) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
@@ -18,12 +18,12 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseCompactor;
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.engine.EngineProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.CustomizedThreadFactory;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.log4j.LogManager;
@@ -47,21 +47,21 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LogManager.getLogger(AsyncCompactService.class);
   private final int maxConcurrentCompaction;
+  private final Object writeConfigUpdateLock = new Object();
   protected transient HoodieEngineContext context;
-  private transient BaseCompactor compactor;
+  protected HoodieWriteConfig writeConfig;
 
-  public AsyncCompactService(HoodieEngineContext context, BaseHoodieWriteClient client) {
-    this(context, client, false);
+  public AsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
+    this(context, writeConfig, false);
   }
 
-  public AsyncCompactService(HoodieEngineContext context, BaseHoodieWriteClient client, boolean runInDaemonMode) {
-    super(client.getConfig(), runInDaemonMode);
+  public AsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig, boolean runInDaemonMode) {
+    super(writeConfig, runInDaemonMode);
     this.context = context;
-    this.compactor = createCompactor(client);
     this.maxConcurrentCompaction = 1;
   }
 
-  protected abstract BaseCompactor createCompactor(BaseHoodieWriteClient client);
+  protected abstract BaseCompactor createCompactor();
 
   /**
    * Start Compaction Service.
@@ -71,6 +71,7 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
     ExecutorService executor = Executors.newFixedThreadPool(maxConcurrentCompaction,
         new CustomizedThreadFactory("async_compact_thread", isRunInDaemonMode()));
     return Pair.of(CompletableFuture.allOf(IntStream.range(0, maxConcurrentCompaction).mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+      BaseCompactor compactor = null;
       try {
         // Set Compactor Pool Name for allowing users to prioritize compaction
         LOG.info("Setting pool name for compaction to " + COMPACT_POOL_NAME);
@@ -81,8 +82,13 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
 
           if (null != instant) {
             LOG.info("Starting Compaction for instant " + instant);
+            synchronized (writeConfigUpdateLock) {
+              compactor = createCompactor();
+            }
             compactor.compact(instant);
             LOG.info("Finished Compaction for instant " + instant);
+            compactor.close();
+            compactor = null;
           }
         }
         LOG.info("Compactor shutting down properly!!");
@@ -97,21 +103,12 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
         hasError = true;
         LOG.error("Compactor executor failed", e);
         throw e;
+      } finally {
+        if (compactor != null) {
+          compactor.close();
+        }
       }
       return true;
     }, executor)).toArray(CompletableFuture[]::new)), executor);
-  }
-
-  /**
-   * Check whether compactor thread needs to be stopped.
-   *
-   * @return
-   */
-  protected boolean shouldStopCompactor() {
-    return false;
-  }
-
-  public synchronized void updateWriteClient(BaseHoodieWriteClient writeClient) {
-    this.compactor.updateWriteClient(writeClient);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
@@ -52,6 +52,7 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
   private final Object writeConfigUpdateLock = new Object();
   protected transient HoodieEngineContext context;
   protected HoodieWriteConfig writeConfig;
+  // will be reinstantiated if write config is updated by external caller.
   private BaseCompactor compactor;
 
   public AsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
@@ -85,6 +86,7 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
           if (null != instant) {
             LOG.info("Starting Compaction for instant " + instant);
             synchronized (writeConfigUpdateLock) {
+              // re-instantiate only for first time or if write config is updated externally
               if (compactor == null || isWriteConfigUpdated.get()) {
                 if (compactor != null) {
                   compactor.close();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
@@ -20,25 +20,32 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.RunsTableService;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 public abstract class HoodieAsyncTableService extends HoodieAsyncService implements RunsTableService {
 
   protected final Object writeConfigUpdateLock = new Object();
   protected HoodieWriteConfig writeConfig;
+  protected Option<EmbeddedTimelineService> embeddedTimelineService;
+  protected AtomicBoolean isWriteConfigUpdated = new AtomicBoolean(false);
 
   protected HoodieAsyncTableService() {
   }
 
-  protected HoodieAsyncTableService(HoodieWriteConfig writeConfig) {
+  protected HoodieAsyncTableService(HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
     this.writeConfig = writeConfig;
+    this.embeddedTimelineService = embeddedTimelineService;
   }
 
-  protected HoodieAsyncTableService(HoodieWriteConfig writeConfig, boolean runInDaemonMode) {
+  protected HoodieAsyncTableService(HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService, boolean runInDaemonMode) {
     super(runInDaemonMode);
     this.writeConfig = writeConfig;
+    this.embeddedTimelineService = embeddedTimelineService;
   }
 
   @Override
@@ -52,6 +59,7 @@ public abstract class HoodieAsyncTableService extends HoodieAsyncService impleme
   public void updateWriteConfig(HoodieWriteConfig writeConfig) {
     synchronized (writeConfigUpdateLock) {
       this.writeConfig = writeConfig;
+      isWriteConfigUpdated.set(true);
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 
 public abstract class HoodieAsyncTableService extends HoodieAsyncService implements RunsTableService {
 
+  protected final Object writeConfigUpdateLock = new Object();
   protected HoodieWriteConfig writeConfig;
 
   protected HoodieAsyncTableService() {
@@ -46,5 +47,11 @@ public abstract class HoodieAsyncTableService extends HoodieAsyncService impleme
       return;
     }
     super.start(onShutdownCallback);
+  }
+
+  public void updateWriteConfig(HoodieWriteConfig writeConfig) {
+    synchronized (writeConfigUpdateLock) {
+      this.writeConfig = writeConfig;
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.RunsTableService;
+import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -44,8 +45,12 @@ public abstract class HoodieAsyncTableService extends HoodieAsyncService impleme
 
   protected HoodieAsyncTableService(HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService, boolean runInDaemonMode) {
     super(runInDaemonMode);
-    this.writeConfig = writeConfig;
     this.embeddedTimelineService = embeddedTimelineService;
+    if (embeddedTimelineService.isPresent()) {
+      this.writeConfig = EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
+    } else {
+      this.writeConfig = writeConfig;
+    }
   }
 
   @Override
@@ -58,7 +63,7 @@ public abstract class HoodieAsyncTableService extends HoodieAsyncService impleme
 
   public void updateWriteConfig(HoodieWriteConfig writeConfig) {
     synchronized (writeConfigUpdateLock) {
-      this.writeConfig = writeConfig;
+      this.writeConfig = EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
       isWriteConfigUpdated.set(true);
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
 /**
  * Client will run one round of clustering.
  */
-public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> implements Serializable {
+public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> implements Serializable, AutoCloseable {
 
   private static final long serialVersionUID = 1L;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
@@ -24,8 +24,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Client will run one round of clustering.
@@ -34,12 +32,7 @@ public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> impl
 
   private static final long serialVersionUID = 1L;
 
-  protected final transient Object writeClientUpdateLock = new Object();
-  protected final transient List<BaseHoodieWriteClient<T, I, K, O>> oldClusteringClientList = new ArrayList<>();
-
   protected transient BaseHoodieWriteClient<T, I, K, O> clusteringClient;
-
-  protected boolean isClusterRunning = false;
 
   public BaseClusterer(BaseHoodieWriteClient<T, I, K, O> clusteringClient) {
     this.clusteringClient = clusteringClient;
@@ -53,20 +46,9 @@ public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> impl
    */
   public abstract void cluster(HoodieInstant instant) throws IOException;
 
-  /**
-   * Update the write client used by async clustering.
-   * @param writeClient
-   */
-  public void updateWriteClient(BaseHoodieWriteClient<T, I, K, O> writeClient) {
-    synchronized (writeClientUpdateLock) {
-      if (!isClusterRunning) {
-        this.clusteringClient.close();
-      } else {
-        // Store the old clustering client so that they can be closed
-        // at the end of the clustering execution
-        this.oldClusteringClientList.add(this.clusteringClient);
-      }
-      this.clusteringClient = writeClient;
+  public void close() {
+    if (clusteringClient != null) {
+      clusteringClient.close();
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseClusterer.java
@@ -24,6 +24,8 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Client will run one round of clustering.
@@ -32,7 +34,12 @@ public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> impl
 
   private static final long serialVersionUID = 1L;
 
+  protected final transient Object writeClientUpdateLock = new Object();
+  protected final transient List<BaseHoodieWriteClient<T, I, K, O>> oldClusteringClientList = new ArrayList<>();
+
   protected transient BaseHoodieWriteClient<T, I, K, O> clusteringClient;
+
+  protected boolean isClusterRunning = false;
 
   public BaseClusterer(BaseHoodieWriteClient<T, I, K, O> clusteringClient) {
     this.clusteringClient = clusteringClient;
@@ -40,6 +47,7 @@ public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> impl
 
   /**
    * Run clustering for the instant.
+   *
    * @param instant
    * @throws IOException
    */
@@ -50,6 +58,15 @@ public abstract class BaseClusterer<T extends HoodieRecordPayload, I, K, O> impl
    * @param writeClient
    */
   public void updateWriteClient(BaseHoodieWriteClient<T, I, K, O> writeClient) {
-    this.clusteringClient = writeClient;
+    synchronized (writeClientUpdateLock) {
+      if (!isClusterRunning) {
+        this.clusteringClient.close();
+      } else {
+        // Store the old clustering client so that they can be closed
+        // at the end of the clustering execution
+        this.oldClusteringClientList.add(this.clusteringClient);
+      }
+      this.clusteringClient = writeClient;
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseCompactor.java
@@ -23,8 +23,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Run one round of compaction.
@@ -33,12 +31,7 @@ public abstract class BaseCompactor<T extends HoodieRecordPayload, I, K, O> impl
 
   private static final long serialVersionUID = 1L;
 
-  protected final transient Object writeClientUpdateLock = new Object();
-  protected final transient List<BaseHoodieWriteClient<T, I, K, O>> oldCompactionClientList = new ArrayList<>();
-
   protected transient BaseHoodieWriteClient<T, I, K, O> compactionClient;
-
-  protected boolean isCompactionRunning = false;
 
   public BaseCompactor(BaseHoodieWriteClient<T, I, K, O> compactionClient) {
     this.compactionClient = compactionClient;
@@ -46,17 +39,9 @@ public abstract class BaseCompactor<T extends HoodieRecordPayload, I, K, O> impl
 
   public abstract void compact(HoodieInstant instant) throws IOException;
 
-  public void updateWriteClient(BaseHoodieWriteClient<T, I, K, O> writeClient) {
-    synchronized (writeClientUpdateLock) {
-      if (!isCompactionRunning) {
-        this.compactionClient.close();
-      } else {
-        // Store the old compaction client so that they can be closed
-        // at the end of the compaction execution
-        this.oldCompactionClientList.add(this.compactionClient);
-      }
-      this.compactionClient = writeClient;
+  public void close() {
+    if (compactionClient != null) {
+      compactionClient.close();
     }
   }
-
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseCompactor.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
 /**
  * Run one round of compaction.
  */
-public abstract class BaseCompactor<T extends HoodieRecordPayload, I, K, O> implements Serializable {
+public abstract class BaseCompactor<T extends HoodieRecordPayload, I, K, O> implements Serializable, AutoCloseable {
 
   private static final long serialVersionUID = 1L;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -83,7 +83,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
    */
   @Override
   public void close() {
-    stopEmbeddedServerView(true);
+    stopEmbeddedServerView(shouldStopTimelineServer);
     this.context.setJobStatus("", "");
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
@@ -78,11 +78,12 @@ public class EmbeddedTimelineServerHelper {
    * @param timelineServer Embedded Timeline Server
    * @param config  Hoodie Write Config
    */
-  public static void updateWriteConfigWithTimelineServer(EmbeddedTimelineService timelineServer,
+  public static HoodieWriteConfig updateWriteConfigWithTimelineServer(EmbeddedTimelineService timelineServer,
       HoodieWriteConfig config) {
     // Allow executor to find this newly instantiated timeline service
     if (config.isEmbeddedTimelineServerEnabled()) {
       config.setViewStorageConfig(timelineServer.getRemoteFileSystemViewConfig());
     }
+    return config;
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/async/TestHoodieAsyncTableService.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/async/TestHoodieAsyncTableService.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.async;
 
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 
@@ -47,7 +48,7 @@ class TestHoodieAsyncTableService {
   private static class DummyAsyncTableService extends HoodieAsyncTableService {
 
     protected DummyAsyncTableService(HoodieWriteConfig writeConfig) {
-      super(writeConfig);
+      super(writeConfig, Option.empty());
     }
 
     @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncClusteringService.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncClusteringService.java
@@ -22,7 +22,9 @@ package org.apache.hudi.async;
 import org.apache.hudi.client.BaseClusterer;
 import org.apache.hudi.client.HoodieSparkClusteringClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 /**
@@ -30,12 +32,12 @@ import org.apache.hudi.config.HoodieWriteConfig;
  */
 public class SparkAsyncClusteringService extends AsyncClusteringService {
 
-  public SparkAsyncClusteringService(HoodieEngineContext engineContext, HoodieWriteConfig writeConfig) {
-    super(engineContext, writeConfig);
+  public SparkAsyncClusteringService(HoodieEngineContext engineContext, HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
+    super(engineContext, writeConfig, embeddedTimelineService);
   }
 
   @Override
   protected BaseClusterer createClusteringClient() {
-    return new HoodieSparkClusteringClient(new SparkRDDWriteClient<>(context, writeConfig));
+    return new HoodieSparkClusteringClient(new SparkRDDWriteClient<>(context, writeConfig, embeddedTimelineService));
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncClusteringService.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncClusteringService.java
@@ -20,21 +20,22 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseClusterer;
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieSparkClusteringClient;
+import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.config.HoodieWriteConfig;
 
 /**
  * Async clustering service for Spark datasource.
  */
 public class SparkAsyncClusteringService extends AsyncClusteringService {
 
-  public SparkAsyncClusteringService(HoodieEngineContext engineContext, BaseHoodieWriteClient writeClient) {
-    super(engineContext, writeClient);
+  public SparkAsyncClusteringService(HoodieEngineContext engineContext, HoodieWriteConfig writeConfig) {
+    super(engineContext, writeConfig);
   }
 
   @Override
-  protected BaseClusterer createClusteringClient(BaseHoodieWriteClient client) {
-    return new HoodieSparkClusteringClient(client);
+  protected BaseClusterer createClusteringClient() {
+    return new HoodieSparkClusteringClient(new SparkRDDWriteClient<>(context, writeConfig));
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncCompactService.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncCompactService.java
@@ -19,18 +19,19 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseCompactor;
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieSparkCompactor;
+import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.config.HoodieWriteConfig;
 
 public class SparkAsyncCompactService extends AsyncCompactService {
 
-  public SparkAsyncCompactService(HoodieEngineContext context, BaseHoodieWriteClient client) {
-    super(context, client);
+  public SparkAsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
+    super(context, writeConfig);
   }
 
   @Override
-  protected BaseCompactor createCompactor(BaseHoodieWriteClient client) {
-    return new HoodieSparkCompactor(client, this.context);
+  protected BaseCompactor createCompactor() {
+    return new HoodieSparkCompactor(new SparkRDDWriteClient<>(context, writeConfig), this.context);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncCompactService.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/async/SparkAsyncCompactService.java
@@ -21,17 +21,19 @@ package org.apache.hudi.async;
 import org.apache.hudi.client.BaseCompactor;
 import org.apache.hudi.client.HoodieSparkCompactor;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 public class SparkAsyncCompactService extends AsyncCompactService {
 
-  public SparkAsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
-    super(context, writeConfig);
+  public SparkAsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
+    super(context, writeConfig, embeddedTimelineService);
   }
 
   @Override
   protected BaseCompactor createCompactor() {
-    return new HoodieSparkCompactor(new SparkRDDWriteClient<>(context, writeConfig), this.context);
+    return new HoodieSparkCompactor(new SparkRDDWriteClient<>(context, writeConfig, embeddedTimelineService), this.context);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -42,6 +42,7 @@ import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.config.HoodieStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.table.BulkInsertPartitioner;
@@ -224,7 +225,8 @@ public class DataSourceUtils {
           try {
             embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(new HoodieSparkEngineContext(jssc), writeConfig);
           } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Failed to create timeline server ", e);
+            throw new HoodieIOException("Failed to create timeline server ", e);
           }
         } else {
           EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -201,7 +201,8 @@ public class DataSourceUtils {
     if (embeddedTimelineServiceHandler.isPresent())  {
       embeddedTimelineServiceHandler.get().onInstantiation(writeConfig);
     }
-    return new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineServiceHandler.isPresent() ? embeddedTimelineServiceHandler.get().getEmbeddedTimelineService() : Option.empty());
+    return new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineServiceHandler.isPresent()
+        ? embeddedTimelineServiceHandler.get().getEmbeddedTimelineService() : Option.empty());
   }
 
   /**
@@ -218,14 +219,16 @@ public class DataSourceUtils {
     }
 
     public void onInstantiation(HoodieWriteConfig writeConfig) {
-      if (!embeddedTimelineService.isPresent() && writeConfig.isEmbeddedTimelineServerEnabled()) {
-        try {
-          embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(new HoodieSparkEngineContext(jssc), writeConfig);
-        } catch (IOException e) {
-          e.printStackTrace();
+      if (writeConfig.isEmbeddedTimelineServerEnabled()) {
+        if (!embeddedTimelineService.isPresent()) {
+          try {
+            embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(new HoodieSparkEngineContext(jssc), writeConfig);
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+        } else {
+          EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
         }
-      } else {
-        EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
       }
     }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncClusteringService.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncClusteringService.java
@@ -20,9 +20,10 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseClusterer;
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieSparkClusteringClient;
+import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.config.HoodieWriteConfig;
 
 /**
  * Async clustering service for Spark structured streaming.
@@ -32,12 +33,12 @@ public class SparkStreamingAsyncClusteringService extends AsyncClusteringService
 
   private static final long serialVersionUID = 1L;
 
-  public SparkStreamingAsyncClusteringService(HoodieEngineContext context, BaseHoodieWriteClient writeClient) {
-    super(context, writeClient, true);
+  public SparkStreamingAsyncClusteringService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
+    super(context, writeConfig, true);
   }
 
   @Override
-  protected BaseClusterer createClusteringClient(BaseHoodieWriteClient client) {
-    return new HoodieSparkClusteringClient(client);
+  protected BaseClusterer createClusteringClient() {
+    return new HoodieSparkClusteringClient(new SparkRDDWriteClient<>(context, writeConfig));
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncClusteringService.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncClusteringService.java
@@ -22,7 +22,9 @@ package org.apache.hudi.async;
 import org.apache.hudi.client.BaseClusterer;
 import org.apache.hudi.client.HoodieSparkClusteringClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 /**
@@ -34,7 +36,11 @@ public class SparkStreamingAsyncClusteringService extends AsyncClusteringService
   private static final long serialVersionUID = 1L;
 
   public SparkStreamingAsyncClusteringService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
-    super(context, writeConfig, true);
+    this(context, writeConfig, Option.empty());
+  }
+
+  public SparkStreamingAsyncClusteringService(HoodieEngineContext context, HoodieWriteConfig writeConfig,  Option<EmbeddedTimelineService> embeddedTimelineService) {
+    super(context, writeConfig, embeddedTimelineService, true);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncCompactService.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncCompactService.java
@@ -19,9 +19,10 @@
 package org.apache.hudi.async;
 
 import org.apache.hudi.client.BaseCompactor;
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieSparkCompactor;
+import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.config.HoodieWriteConfig;
 
 /**
  * Async Compaction Service used by Structured Streaming. Here, async compaction is run in daemon mode to prevent
@@ -31,12 +32,12 @@ public class SparkStreamingAsyncCompactService extends AsyncCompactService {
 
   private static final long serialVersionUID = 1L;
 
-  public SparkStreamingAsyncCompactService(HoodieEngineContext context, BaseHoodieWriteClient client) {
-    super(context, client, true);
+  public SparkStreamingAsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
+    super(context, writeConfig, true);
   }
 
   @Override
-  protected BaseCompactor createCompactor(BaseHoodieWriteClient client) {
-    return new HoodieSparkCompactor(client, this.context);
+  protected BaseCompactor createCompactor() {
+    return new HoodieSparkCompactor(new SparkRDDWriteClient<>(context, writeConfig), this.context);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncCompactService.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/async/SparkStreamingAsyncCompactService.java
@@ -21,7 +21,9 @@ package org.apache.hudi.async;
 import org.apache.hudi.client.BaseCompactor;
 import org.apache.hudi.client.HoodieSparkCompactor;
 import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 /**
@@ -33,7 +35,11 @@ public class SparkStreamingAsyncCompactService extends AsyncCompactService {
   private static final long serialVersionUID = 1L;
 
   public SparkStreamingAsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
-    super(context, writeConfig, true);
+    this(context, writeConfig, Option.empty());
+  }
+
+  public SparkStreamingAsyncCompactService(HoodieEngineContext context, HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
+    super(context, writeConfig, embeddedTimelineService, true);
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -75,7 +75,8 @@ object HoodieSparkSqlWriter {
             hoodieWriteClient: Option[SparkRDDWriteClient[HoodieRecordPayload[Nothing]]] = Option.empty,
             asyncCompactionTriggerFn: Option[SparkRDDWriteClient[HoodieRecordPayload[Nothing]] => Unit] = Option.empty,
             asyncClusteringTriggerFn: Option[SparkRDDWriteClient[HoodieRecordPayload[Nothing]] => Unit] = Option.empty,
-            embeddedTimelineServiceHandler : org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler] = org.apache.hudi.common.util.Option.empty)
+            embeddedTimelineServiceHandler : org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler]
+            = org.apache.hudi.common.util.Option.empty().asInstanceOf[org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler]])
   : (Boolean, common.util.Option[String], common.util.Option[String], common.util.Option[String],
     SparkRDDWriteClient[HoodieRecordPayload[Nothing]], HoodieTableConfig) = {
 
@@ -430,7 +431,8 @@ object HoodieSparkSqlWriter {
                 df: DataFrame,
                 hoodieTableConfigOpt: Option[HoodieTableConfig] = Option.empty,
                 hoodieWriteClient: Option[SparkRDDWriteClient[HoodieRecordPayload[Nothing]]] = Option.empty,
-                embeddedTimelineServiceHandler : org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler] = org.apache.hudi.common.util.Option.empty): Boolean = {
+                embeddedTimelineServiceHandler : org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler]
+                = org.apache.hudi.common.util.Option.empty().asInstanceOf[org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler]]): Boolean = {
 
     assert(optParams.get("path").exists(!StringUtils.isNullOrEmpty(_)), "'path' must be set")
     val path = optParams("path")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -67,6 +67,7 @@ object HoodieSparkSqlWriter {
   private var asyncCompactionTriggerFnDefined: Boolean = false
   private var asyncClusteringTriggerFnDefined: Boolean = false
 
+  // scalastyle:off
   def write(sqlContext: SQLContext,
             mode: SaveMode,
             optParams: Map[String, String],
@@ -79,7 +80,7 @@ object HoodieSparkSqlWriter {
             = org.apache.hudi.common.util.Option.empty().asInstanceOf[org.apache.hudi.common.util.Option[EmbeddedTimelineServiceHandler]])
   : (Boolean, common.util.Option[String], common.util.Option[String], common.util.Option[String],
     SparkRDDWriteClient[HoodieRecordPayload[Nothing]], HoodieTableConfig) = {
-
+    // scalastyle:on
     assert(optParams.get("path").exists(!StringUtils.isNullOrEmpty(_)), "'path' must be set")
     val path = optParams("path")
     val basePath = new Path(path)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
@@ -112,12 +112,8 @@ class HoodieStreamingSink(sqlContext: SQLContext,
       return
     }
 
-    // Override to use direct markers. In Structured streaming, timeline server is closed after
-    // first micro-batch and subsequent micro-batches do not have timeline server running.
-    // Thus, we can't use timeline-server-based markers.
-    var updatedOptions = options.updated(HoodieWriteConfig.MARKERS_TYPE.key(), MarkerType.DIRECT.name())
     // we need auto adjustment enabled for streaming sink since async table services are feasible within the same JVM.
-    updatedOptions = updatedOptions.updated(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key, "true")
+    var updatedOptions = options.updated(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key, "true")
     // Add batchId as checkpoint to the extra metadata. To enable same checkpoint metadata structure for multi-writers,
     // SINK_CHECKPOINT_KEY holds a map of batchId to writer context (composed of applicationId and queryId), e.g.
     // "_hudi_streaming_sink_checkpoint" : "{\"$batchId\":\"${sqlContext.sparkContext.applicationId}-$queryId\"}"

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
@@ -226,8 +226,9 @@ class HoodieStreamingSink(sqlContext: SQLContext,
   protected def triggerAsyncCompactor(client: SparkRDDWriteClient[HoodieRecordPayload[Nothing]]): Unit = {
     if (null == asyncCompactorService) {
       log.info("Triggering Async compaction !!")
-      asyncCompactorService = new SparkStreamingAsyncCompactService(new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
-        client)
+      asyncCompactorService = new SparkStreamingAsyncCompactService(
+        new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
+        client.getConfig)
       asyncCompactorService.start(new Function[java.lang.Boolean, java.lang.Boolean] {
         override def apply(errored: lang.Boolean): lang.Boolean = {
           log.info(s"Async Compactor shutdown. Errored ? $errored")
@@ -256,7 +257,7 @@ class HoodieStreamingSink(sqlContext: SQLContext,
     if (null == asyncClusteringService) {
       log.info("Triggering async clustering!")
       asyncClusteringService = new SparkStreamingAsyncClusteringService(new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
-        client)
+        client.getConfig)
       asyncClusteringService.start(new Function[java.lang.Boolean, java.lang.Boolean] {
         override def apply(errored: lang.Boolean): lang.Boolean = {
           log.info(s"Async clustering service shutdown. Errored ? $errored")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.async.{AsyncClusteringService, AsyncCompactService, SparkStreamingAsyncClusteringService, SparkStreamingAsyncCompactService}
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.client.embedded.EmbeddedTimelineService
 import org.apache.hudi.common.model.HoodieRecordPayload
 import org.apache.hudi.common.table.marker.MarkerType
 import org.apache.hudi.common.table.timeline.HoodieInstant.State
@@ -227,8 +228,7 @@ class HoodieStreamingSink(sqlContext: SQLContext,
     if (null == asyncCompactorService) {
       log.info("Triggering Async compaction !!")
       asyncCompactorService = new SparkStreamingAsyncCompactService(
-        new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
-        client.getConfig)
+        new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)), client.getConfig)
       asyncCompactorService.start(new Function[java.lang.Boolean, java.lang.Boolean] {
         override def apply(errored: lang.Boolean): lang.Boolean = {
           log.info(s"Async Compactor shutdown. Errored ? $errored")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -42,6 +42,7 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.CommitUtils;
+import org.apache.hudi.common.util.Functions;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -103,7 +104,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import scala.collection.JavaConversions;
@@ -189,9 +189,9 @@ public class DeltaSync implements Serializable, Closeable {
   private final TypedProperties props;
 
   /**
-   * Callback when a new write client is created.
+   * Callback when a new write client is created with regular writer.
    */
-  private transient Function<HoodieWriteConfig, Boolean> onUpdatingWriteConfig;
+  private transient Functions.Function2<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean> onUpdatingWriteConfig;
 
   /**
    * Timeline with completed commits.
@@ -223,7 +223,7 @@ public class DeltaSync implements Serializable, Closeable {
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
                    TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                   Function<HoodieWriteConfig, Boolean> onUpdatingWriteConfig) throws IOException {
+                   Functions.Function2<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean> onUpdatingWriteConfig) throws IOException {
 
     this.cfg = cfg;
     this.jssc = jssc;
@@ -756,7 +756,7 @@ public class DeltaSync implements Serializable, Closeable {
       writeClient.close();
     }
     writeClient = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineService);
-    onUpdatingWriteConfig.apply(writeConfig);
+    onUpdatingWriteConfig.apply(writeConfig, embeddedTimelineService);
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -103,7 +103,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import scala.collection.JavaConversions;
@@ -191,7 +191,7 @@ public class DeltaSync implements Serializable, Closeable {
   /**
    * Callback when a new write client is created.
    */
-  private transient BiFunction<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean> onCreatingNewWriteClient;
+  private transient Function<HoodieWriteConfig, Boolean> onUpdatingWriteConfig;
 
   /**
    * Timeline with completed commits.
@@ -223,13 +223,13 @@ public class DeltaSync implements Serializable, Closeable {
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
                    TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                   BiFunction<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean> onCreatingNewWriteClient) throws IOException {
+                   Function<HoodieWriteConfig, Boolean> onUpdatingWriteConfig) throws IOException {
 
     this.cfg = cfg;
     this.jssc = jssc;
     this.sparkSession = sparkSession;
     this.fs = fs;
-    this.onCreatingNewWriteClient = onCreatingNewWriteClient;
+    this.onUpdatingWriteConfig = onUpdatingWriteConfig;
     this.props = props;
     this.userProvidedSchemaProvider = schemaProvider;
     this.processedSchema = new SchemaSet();
@@ -756,7 +756,7 @@ public class DeltaSync implements Serializable, Closeable {
       writeClient.close();
     }
     writeClient = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineService);
-    onCreatingNewWriteClient.apply(writeConfig, embeddedTimelineService);
+    onUpdatingWriteConfig.apply(writeConfig);
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -747,7 +747,7 @@ public class DeltaSync implements Serializable, Closeable {
       if (!embeddedTimelineService.isPresent()) {
         embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(new HoodieSparkEngineContext(jssc), writeConfig);
       } else {
-        EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
+        writeConfig = EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
       }
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -781,9 +781,11 @@ public class HoodieDeltaStreamer implements Serializable {
     protected Boolean onUpdatingWriteConfig(HoodieWriteConfig writeConfig, Option<EmbeddedTimelineService> embeddedTimelineService) {
       if (cfg.isAsyncCompactionEnabled()) {
         if (asyncCompactService.isPresent()) {
+          LOG.warn("onUpdatingWriteConfig : Notifying async compactor service on write config update");
           // Update the write client used by Async Compactor.
           asyncCompactService.get().updateWriteConfig(writeConfig);
         } else {
+          LOG.warn("onUpdatingWriteConfig: No async compact service found. Creating a new one");
           asyncCompactService = Option.ofNullable(new SparkAsyncCompactService(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineService));
           // Enqueue existing pending compactions first
           HoodieTableMetaClient meta =
@@ -804,8 +806,10 @@ public class HoodieDeltaStreamer implements Serializable {
       // start async clustering if required
       if (HoodieClusteringConfig.from(props).isAsyncClusteringEnabled()) {
         if (asyncClusteringService.isPresent()) {
+          LOG.warn("onUpdatingWriteConfig : Notifying async clustering service on write config update");
           asyncClusteringService.get().updateWriteConfig(writeConfig);
         } else {
+          LOG.warn("onUpdatingWriteConfig: No async clustering service found. Creating a new one");
           asyncClusteringService = Option.ofNullable(new SparkAsyncClusteringService(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineService));
           HoodieTableMetaClient meta = HoodieTableMetaClient.builder()
               .setConf(new Configuration(jssc.hadoopConfiguration()))

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -21,7 +21,7 @@ package org.apache.hudi.utilities.functional;
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceWriteOptions;
-import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.HoodieConfig;
@@ -130,6 +130,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -2196,7 +2197,8 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
     public TestDeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,
                          JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                         Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+                         BiFunction<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean>
+                             onInitializingHoodieWriteClient) throws IOException {
       super(cfg, sparkSession, schemaProvider, props, jssc, fs, conf, onInitializingHoodieWriteClient);
     }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -21,7 +21,6 @@ package org.apache.hudi.utilities.functional;
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceWriteOptions;
-import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.HoodieConfig;
@@ -45,9 +44,9 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.config.HoodieClusteringConfig;
-import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieArchivalConfig;
+import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -130,7 +129,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -2197,7 +2195,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
     public TestDeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,
                          JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                         BiFunction<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean>
+                         Function<HoodieWriteConfig, Boolean>
                              onInitializingHoodieWriteClient) throws IOException {
       super(cfg, sparkSession, schemaProvider, props, jssc, fs, conf, onInitializingHoodieWriteClient);
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.functional;
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.HoodieConfig;
@@ -42,6 +43,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Functions;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieArchivalConfig;
@@ -2195,7 +2197,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
     public TestDeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,
                          JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                         Function<HoodieWriteConfig, Boolean>
+                         Functions.Function2<HoodieWriteConfig, Option<EmbeddedTimelineService>, Boolean>
                              onInitializingHoodieWriteClient) throws IOException {
       super(cfg, sparkSession, schemaProvider, props, jssc, fs, conf, onInitializingHoodieWriteClient);
     }


### PR DESCRIPTION
## What is the purpose of the pull request

- In Deltastreamer, we re-instantiate WriteClient whenever schema changes. Same write client is used by all async table services as well. This poses an issue, because the new write client when re-instantiated is intimated to the async table service. but if the async table service is in the middle of compaction, uses a local copy of write client. and hence may not be able to reach the timeline server and will run into connection issues. We are fixing this in this patch. 
- We have a singleton instance of embedded timeline service which regular writers and all table services will use. And within async table services, we will listen to write config changes and re-instantiate write client before any new compaction execution. 
- Even between multiple re-instantiations of write clients for regular writer (due to schema change), uses the same singleton embedded timeline server. 
- Previously embedded timeline server was shutdown when write client was shutdown. Fixed that in this patch, so that a single instantiation and tear down of embedded timeline server will span entire process start and stop. 
- This also fixes a long standing issue w/ spark structured streaming. Apparently, this is what is happening in spark structured streaming flow. We start a new write client during first batch and close it at the end. But keep re-using the same instance of writeClient for subsequent batches. Only core entity that is impacted here was the embedded timeline server since we were closing it when write client was closed. So, after batch1, if timeline server was enabled, pipeline will fail since timeline server is shutdown. So, in this patch we are fixing that as well. Embedded timeline server is externally instantiated and so writeClient.close() will not shutdown the timeline server. We have a singleton instance of timeline server through entire pipeline. Previously we hard coded DIRECT style markers for spark streaming, but after this patch, we should be able to relax that. 


## Brief change log

- Fixed Deltastreamer and Spark streaking sink to ensure timeline server sustains multiple instantiations of write client by different wriiters. 

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by running a job locally.*
  - For structured streaming, existing tests cover all flows. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
