### PR TITLE
[HUDI-3849]  AvroDeserializer supports AVRO_REBASE_MODE_IN_READ configuration

### DIFF
--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/avro/HoodieSpark3_2AvroDeserializer.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/avro/HoodieSpark3_2AvroDeserializer.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.avro
 
 import org.apache.avro.Schema
-import org.apache.hudi.HoodieSparkUtils
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
 
 class HoodieSpark3_2AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType)
   extends HoodieAvroDeserializer {
 
-  private val avroDeserializer = new AvroDeserializer(rootAvroType, rootCatalystType, "EXCEPTION")
+  private val avroDeserializer = new AvroDeserializer(rootAvroType, rootCatalystType,
+    SQLConf.get.getConf(SQLConf.AVRO_REBASE_MODE_IN_READ))
 
   def deserialize(data: Any): Option[Any] = avroDeserializer.deserialize(data)
 }


### PR DESCRIPTION
## What is the purpose of the pull request

Now the `datetimeRebaseMode` of `AvroDeserializer` is hardcode and the value is "EXCEPTION".    

We can support reading the configuration `AVRO_REBASE_MODE_IN_READ` of SQLCONf to switch the behavior of read.

## Brief change log

  - AvroDeserializer supports AVRO_REBASE_MODE_IN_READ configuration

## Verify this pull request

This pull request is already covered by existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
