### PR TITLE
[MINOR] fixing timeline server for integ tests

### DIFF
--- a/docker/demo/config/test-suite/test-aggressive-clean-archival-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-aggressive-clean-archival-inline-compact.properties
@@ -28,6 +28,7 @@ hoodie.keep.min.commits=12
 hoodie.keep.max.commits=14
 
 hoodie.compact.inline=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-aggressive-clean-archival.properties
+++ b/docker/demo/config/test-suite/test-aggressive-clean-archival.properties
@@ -26,6 +26,7 @@ hoodie.delete.shuffle.parallelism=25
 hoodie.cleaner.commits.retained=8
 hoodie.keep.min.commits=12
 hoodie.keep.max.commits=14
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-clustering-aggressive-clean-archival-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-clustering-aggressive-clean-archival-inline-compact.properties
@@ -24,6 +24,7 @@ hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
 hoodie.compact.inline=true
+hoodie.embed.timeline.server=false
 
 hoodie.cleaner.commits.retained=8
 hoodie.keep.min.commits=12

--- a/docker/demo/config/test-suite/test-clustering-aggressive-clean-archival.properties
+++ b/docker/demo/config/test-suite/test-clustering-aggressive-clean-archival.properties
@@ -26,6 +26,7 @@ hoodie.delete.shuffle.parallelism=25
 hoodie.cleaner.commits.retained=8
 hoodie.keep.min.commits=12
 hoodie.keep.max.commits=14
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-clustering-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-clustering-inline-compact.properties
@@ -23,6 +23,8 @@ hoodie.upsert.shuffle.parallelism=25
 hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
+hoodie.embed.timeline.server=false
+
 hoodie.compact.inline=true
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-clustering-metadata-aggressive-clean-archival-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-clustering-metadata-aggressive-clean-archival-inline-compact.properties
@@ -29,6 +29,7 @@ hoodie.keep.max.commits=14
 
 hoodie.compact.inline=true
 hoodie.metadata.enable=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-clustering-metadata-aggressive-clean-archival.properties
+++ b/docker/demo/config/test-suite/test-clustering-metadata-aggressive-clean-archival.properties
@@ -27,6 +27,7 @@ hoodie.cleaner.commits.retained=8
 hoodie.keep.min.commits=12
 hoodie.keep.max.commits=14
 
+hoodie.embed.timeline.server=false
 hoodie.metadata.enable=true
 
 hoodie.deltastreamer.source.test.num_partitions=100

--- a/docker/demo/config/test-suite/test-clustering.properties
+++ b/docker/demo/config/test-suite/test-clustering.properties
@@ -23,6 +23,8 @@ hoodie.upsert.shuffle.parallelism=25
 hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
+hoodie.embed.timeline.server=false
+
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false
 hoodie.deltastreamer.source.test.max_unique_records=100000000

--- a/docker/demo/config/test-suite/test-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-inline-compact.properties
@@ -25,6 +25,7 @@ hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=false
 hoodie.compact.inline=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-metadata-aggressive-clean-archival-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-metadata-aggressive-clean-archival-inline-compact.properties
@@ -27,6 +27,7 @@ hoodie.cleaner.commits.retained=8
 hoodie.keep.min.commits=12
 hoodie.keep.max.commits=14
 
+hoodie.embed.timeline.server=false
 hoodie.metadata.enable=true
 hoodie.compact.inline=true
 

--- a/docker/demo/config/test-suite/test-metadata-aggressive-clean-archival.properties
+++ b/docker/demo/config/test-suite/test-metadata-aggressive-clean-archival.properties
@@ -28,6 +28,7 @@ hoodie.keep.min.commits=12
 hoodie.keep.max.commits=14
 
 hoodie.metadata.enable=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-metadata-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-metadata-inline-compact.properties
@@ -25,6 +25,7 @@ hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=true
 hoodie.compact.inline=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-metadata.properties
+++ b/docker/demo/config/test-suite/test-metadata.properties
@@ -24,6 +24,7 @@ hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-nonpartitioned-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-nonpartitioned-inline-compact.properties
@@ -25,6 +25,7 @@ hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=false
 hoodie.compact.inline=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-nonpartitioned-metadata-inline-compact.properties
+++ b/docker/demo/config/test-suite/test-nonpartitioned-metadata-inline-compact.properties
@@ -25,6 +25,7 @@ hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=true
 hoodie.compact.inline=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-nonpartitioned-metadata.properties
+++ b/docker/demo/config/test-suite/test-nonpartitioned-metadata.properties
@@ -24,6 +24,7 @@ hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=true
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test-nonpartitioned.properties
+++ b/docker/demo/config/test-suite/test-nonpartitioned.properties
@@ -24,6 +24,7 @@ hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=false
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false

--- a/docker/demo/config/test-suite/test.properties
+++ b/docker/demo/config/test-suite/test.properties
@@ -21,6 +21,7 @@ hoodie.bulkinsert.shuffle.parallelism=25
 hoodie.delete.shuffle.parallelism=25
 
 hoodie.metadata.enable=false
+hoodie.embed.timeline.server=false
 
 hoodie.deltastreamer.source.test.num_partitions=100
 hoodie.deltastreamer.source.test.datagen.use_rocksdb_for_storing_existing_keys=false


### PR DESCRIPTION
## What is the purpose of the pull request

Enabling timeline server for integ tests does not shutdown the job fully in the end. Disabling it for now as we need to investigate this and re-enable it back later. Have created a follow up task for the investigation and re-enabling it https://issues.apache.org/jira/browse/HUDI-3852

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
