### PR TITLE
[HUDI-3858] Shade javax.servlet for hudi-spark-bundle

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <checkstyle.skip>true</checkstyle.skip>
     <main.basedir>${project.parent.basedir}</main.basedir>
+    <javax.servlet.version>3.1.0</javax.servlet.version>
   </properties>
 
   <build>
@@ -80,6 +81,7 @@
                   <include>org.apache.hudi:hudi-timeline-service</include>
                   <include>org.apache.hudi:hudi-aws</include>
 
+                  <include>javax.servlet:javax.servlet-api</include>
                   <include>com.beust:jcommander</include>
                   <include>io.javalin:javalin</include>
                   <!-- Spark only has mortbay jetty -->
@@ -138,6 +140,10 @@
                 <!-- NOTE: We have to relocate all classes w/in org.apache.spark.sql.avro to avoid
                            potential classpath collisions in case users would like to also use "spark-avro" w/in
                            their runtime, since Hudi carries some of the same classes as "spark-avro" -->
+                <relocation>
+                  <pattern>javax.servlet.</pattern>
+                  <shadedPattern>org.apache.hudi.javax.servlet.</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>org.apache.spark.sql.avro.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.spark.sql.avro.</shadedPattern>
@@ -378,6 +384,12 @@
       <artifactId>hive-service</artifactId>
       <version>${hive.version}</version>
       <scope>${spark.bundle.hive.scope}</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+          <groupId>javax.servlet</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -426,6 +438,13 @@
       <artifactId>curator-recipes</artifactId>
       <version>${zk-curator.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${javax.servlet.version}</version>
+    </dependency>
+
     <!-- TODO: Reinvestigate PR 633 -->
   </dependencies>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HUDI-3858

## What is the purpose of the pull request

Users use hudi-spark-bundle will meet exception 
```
25826 [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Finished Loading Table of type MERGE_ON_READ(version=1, baseFileFormat=HFILE) from file:///var/folders/61/77xdhf3x0x9g3t_vdd1c9_nwr4wznp/T/junit4739117508195793393/hudi_test_batch/.hoodie/metadata
25826 [main] INFO  org.apache.hudi.common.table.view.FileSystemViewManager  - Creating View Manager with storage type :REMOTE_FIRST
25826 [main] INFO  org.apache.hudi.common.table.view.FileSystemViewManager  - Creating remote first table view
25826 [main] INFO  org.apache.hudi.common.table.view.FileSystemViewManager  - Creating remote view for basePath file:/var/folders/61/77xdhf3x0x9g3t_vdd1c9_nwr4wznp/T/junit4739117508195793393/hudi_test_batch. Server=localhost:53359, Timeout=300
25826 [main] INFO  org.apache.hudi.common.table.view.FileSystemViewManager  - Creating InMemory based view for basePath file:/var/folders/61/77xdhf3x0x9g3t_vdd1c9_nwr4wznp/T/junit4739117508195793393/hudi_test_batch
25827 [main] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Took 0 ms to read  0 instants, 0 replaced file groups
25827 [main] INFO  org.apache.hudi.common.util.ClusteringUtils  - Found 0 files in pending clustering operations
25829 [main] INFO  org.apache.hudi.common.table.timeline.HoodieActiveTimeline  - Loaded instants upto : Option{val=[20220412113736537__commit__COMPLETED]}
25840 [main] INFO  org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView  - Sending request : (http://localhost:53359/v1/hoodie/view/refresh/?basepath=file%3A%2Fvar%2Ffolders%2F61%2F77xdhf3x0x9g3t_vdd1c9_nwr4wznp%2FT%2Fjunit4739117508195793393%2Fhudi_test_batch&lastinstantts=20220412113736537&timelinehash=03e963184c528f34bb48c1ebd199f388419ac73bd9a9ee647416772866b63ca4)
26117 [qtp1920021004-72] ERROR io.javalin.Javalin  - Exception occurred while servicing http-request
java.lang.NoSuchMethodError: io.javalin.core.CachedRequestWrapper.getContentLengthLong()J
	at io.javalin.core.CachedRequestWrapper.<init>(CachedRequestWrapper.kt:22)
	at io.javalin.core.JavalinServlet.service(JavalinServlet.kt:34)
	at io.javalin.core.util.JettyServerUtil$initialize$httpHandler$1.doHandle(JettyServerUtil.kt:72)
	at org.apache.hudi.org.apache.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.apache.hudi.org.apache.jetty.servlet.ServletHandler.doScope(ServletHandler.java:480)
	at org.apache.hudi.org.apache.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1668)
	at org.apache.hudi.org.apache.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.apache.hudi.org.apache.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1247)
	at org.apache.hudi.org.apache.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.apache.hudi.org.apache.jetty.server.handler.HandlerList.handle(HandlerList.java:61)
	at org.apache.hudi.org.apache.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:174)
	at org.apache.hudi.org.apache.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.apache.hudi.org.apache.jetty.server.Server.handle(Server.java:502)
	at org.apache.hudi.org.apache.jetty.server.HttpChannel.handle(HttpChannel.java:370)
	at org.apache.hudi.org.apache.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
	at org.apache.hudi.org.apache.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
	at org.apache.hudi.org.apache.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.apache.hudi.org.apache.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.apache.hudi.org.apache.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:765)
	at org.apache.hudi.org.apache.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:683)
	at java.lang.Thread.run(Thread.java:748)
26135 [main] INFO  org.apache.hudi.client.BaseHoodieClient  - Stopping Timeline service !!
26135 [main] INFO  org.apache.hudi.client.embedded.EmbeddedTimelineService  - Closing Timeline server
26135 [main] INFO  org.apache.hudi.timeline.service.TimelineService  - Closing Timeline Service
26135 [main] INFO  io.javalin.Javalin  - Stopping Javalin ...
26148 [main] INFO  io.javalin.Javalin  - Javalin has stopped
```

One possible way is resolving conflicts or adding mentioned dependency in user's application.
```
        <dependency>
            <groupId>javax.servlet</groupId>
            <artifactId>javax.servlet-api</artifactId>
            <version>3.1.0</version>
        </dependency>
```

but maybe we need to solve this problem in hudi-spark-bundle.

This PR is tested on local env.

Linked https://github.com/apache/hudi/pull/3807

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
