### PR TITLE
[WIP] Adjusting `DeltaStreamer` shutdown sequence to avoid awaiting for 24h

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncTableService.java
@@ -41,10 +41,10 @@ public abstract class HoodieAsyncTableService extends HoodieAsyncService impleme
   }
 
   @Override
-  public void start(Function<Boolean, Boolean> onShutdownCallback) {
+  public void start(Function<Boolean, Boolean> onCompleteCallback) {
     if (!tableServicesEnabled(writeConfig)) {
       return;
     }
-    super.start(onShutdownCallback);
+    super.start(onCompleteCallback);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
@@ -64,7 +64,7 @@ public class EmbeddedTimelineServerHelper {
   private static EmbeddedTimelineService startTimelineService(
       HoodieEngineContext context, HoodieWriteConfig config) throws IOException {
     // Run Embedded Timeline Server
-    LOG.info("Starting Timeline service !!");
+    LOG.info("Starting Timeline service");
     Option<String> hostAddr = context.getProperty(EngineProperty.EMBEDDED_SERVER_HOST);
     EmbeddedTimelineService timelineService = new EmbeddedTimelineService(
         context, hostAddr.orElse(null), config);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -133,11 +133,11 @@ public class EmbeddedTimelineService {
 
   public void stop() {
     if (null != server) {
-      LOG.info("Closing Timeline server");
+      LOG.info("Shutting down Embedded Timeline service");
       this.server.close();
       this.server = null;
       this.viewManager = null;
-      LOG.info("Closed Timeline server");
+      LOG.info("Shutdown Embedded Timeline service");
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -42,11 +42,11 @@ public class Metrics {
 
   private final MetricRegistry registry;
   private MetricsReporter reporter;
-  private final String commonMetricPrefix;
+  private final Option<String> commonMetricPrefix;
 
   private Metrics(HoodieWriteConfig metricConfig) {
     registry = new MetricRegistry();
-    commonMetricPrefix = metricConfig.getMetricReporterMetricsNamePrefix();
+    commonMetricPrefix = Option.ofNullable(metricConfig.getMetricReporterMetricsNamePrefix());
     reporter = MetricsReporterFactory.createReporter(metricConfig, registry);
     if (reporter == null) {
       throw new RuntimeException("Cannot initialize Reporter.");
@@ -80,7 +80,7 @@ public class Metrics {
   }
 
   private void registerHoodieCommonMetrics() {
-    registerGauges(Registry.getAllMetrics(true, true), Option.of(commonMetricPrefix));
+    registerGauges(Registry.getAllMetrics(true, true), commonMetricPrefix);
   }
 
   public static Metrics getInstance() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
@@ -103,9 +103,11 @@ public class HdfsTestService {
 
   public void stop() {
     LOG.info("HDFS Minicluster service being shut down.");
-    miniDfsCluster.shutdown();
-    miniDfsCluster = null;
     hadoopConf = null;
+    if (miniDfsCluster != null) {
+      miniDfsCluster.shutdown();
+      miniDfsCluster = null;
+    }
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -211,9 +211,9 @@ public class DeltaSync implements Serializable {
    */
   private transient SparkRDDWriteClient writeClient;
 
-  private transient HoodieDeltaStreamerMetrics metrics;
+  private final transient HoodieDeltaStreamerMetrics metrics;
 
-  private transient HoodieMetrics hoodieMetrics;
+  private final transient HoodieMetrics hoodieMetrics;
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
                    TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
@@ -745,7 +745,7 @@ public class DeltaSync implements Serializable {
       }
     }
 
-    if (null != writeClient) {
+    if (writeClient != null) {
       // Close Write client.
       writeClient.close();
     }
@@ -866,15 +866,12 @@ public class DeltaSync implements Serializable {
    * Close all resources.
    */
   public void close() {
-    if (null != writeClient) {
+    if (writeClient != null) {
       writeClient.close();
       writeClient = null;
     }
 
-    LOG.info("Shutting down embedded timeline server");
-    if (embeddedTimelineService.isPresent()) {
-      embeddedTimelineService.get().stop();
-    }
+    embeddedTimelineService.ifPresent(EmbeddedTimelineService::stop);
   }
 
   public FileSystem getFs() {
@@ -899,7 +896,7 @@ public class DeltaSync implements Serializable {
    *
    * @return Requested clustering instant.
    */
-  public Option<String> getClusteringInstantOpt() {
+  public Option<String> scheduleClustering() {
     if (writeClient != null) {
       return writeClient.scheduleClustering(Option.empty());
     } else {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -803,13 +803,16 @@ public class HoodieDeltaStreamer implements Serializable {
       return true;
     }
 
-    /**
-     * Close all resources.
-     */
-    public void close() {
-      if (null != deltaSync) {
+    @Override
+    public void shutdown(boolean force) {
+      // NOTE: We're shutting down in a sequence which is inverse of the initialization one
+      if (deltaSync != null) {
         deltaSync.close();
       }
+
+      super.shutdown(force);
+
+      LOG.info("Shutdown DeltaSync Service");
     }
 
     public SchemaProvider getSchemaProvider() {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Right now, any `HoodieAsyncService` would be awaiting for 24h for its executor to shutdown gracefully. This however poses a problem in cases when such executor is spinning non-daemon threads, as this might prevent JVM from shutting down for those 24h, in cases when executors continue running (for ex, in a crash loop).

## Brief change log

 - Reducing executor graceful shutdown timeout to 1m from 24h
 - Fixed `DeltaSyncService` to properly override `shutdown` method and invoke one from super-class for proper shutting down
 - Cleaning up some NPEs previously observed in tests
 - Tidying up

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
This pull request is already covered by existing tests, such as *(please describe tests)*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
