### PR TITLE
[HUDI-3886] Adding default null for some of the fields in col stats in MDT schema

### DIFF
--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -107,7 +107,8 @@
                             "type": [
                                 "null",
                                 "string"
-                            ]
+                            ],
+                            "default" : null
                         },
                         {
                             "doc": "Column name for which this column statistics applies",
@@ -318,7 +319,8 @@
                             "type": [
                                 "null",
                                 "long"
-                            ]
+                            ],
+                            "default": null
                         },
                         {
                             "doc": "Total count of null values",
@@ -326,7 +328,8 @@
                             "type": [
                                 "null",
                                 "long"
-                            ]
+                            ],
+                            "default": null
                         },
                         {
                             "doc": "Total storage size on disk",
@@ -334,7 +337,8 @@
                             "type": [
                                 "null",
                                 "long"
-                            ]
+                            ],
+                            "default": null
                         },
                         {
                             "doc": "Total uncompressed storage size on disk",
@@ -342,7 +346,8 @@
                             "type": [
                                 "null",
                                 "long"
-                            ]
+                            ],
+                            "default": null
                         },
                         {
                             "doc": "Column range entry valid/deleted flag",


### PR DESCRIPTION
## What is the purpose of the pull request

Adding default null for some of the fields in col stats in MDT schema

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
