### PR TITLE
[MINOR] Fix docs build due to std-env

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "std-env": "3.0.1",
     "url-loader": "^4.1.1",
     "yarn": "^1.22.11"
   },


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the docs build due to the latest std-env 3.1.1 release.  

## Brief change log

  - Uses "std-env" module from 3.0.1 release (one version older) instead in package.json.

## Verify this pull request

The website can successfully be built after the fix.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
