### PR TITLE
[HUDI-3881] Implement index syntax for spark sql

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.hudi.index.HoodieIndex.IndexType
+import org.apache.spark.sql.hudi.command.index.HoodieTableIndexColumn
+
+case class CreateIndexCommand(
+    indexName: String,
+    table: LogicalPlan,
+    indexColumns: Array[HoodieTableIndexColumn],
+    allowExists: Boolean,
+    indexType: IndexType,
+    indexProperties: Option[Map[String, String]]) extends Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): CreateIndexCommand = {
+    this
+  }
+}
+
+case class DropIndexCommand(
+    indexName: String,
+    table: LogicalPlan,
+    allowExists: Boolean) extends Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): DropIndexCommand = {
+    this
+  }
+}
+
+case class RefreshIndexCommand(
+    indexName: String,
+    table: LogicalPlan) extends Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): RefreshIndexCommand = {
+    this
+  }
+}
+
+case class ShowIndexCommand(
+     indexName: Option[String],
+     table: LogicalPlan) extends Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): ShowIndexCommand = {
+    this
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/HoodieTableIndexColumn.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/HoodieTableIndexColumn.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+/**
+ * Identify a column for index definition, including column name and order
+ */
+private[sql] case class HoodieTableIndexColumn(columnName: String, isAscending: Boolean) {
+  override def toString: String = quotedString
+
+  def quotedString: String = s"`$columnName` ${if (isAscending) "ASC" else "DESC"}"
+
+  def unquotedString: String = s"$columnName ${if (isAscending) "ASC" else "DESC"}"
+}
+
+private[sql] object HoodieTableIndexColumn {
+  def apply(columnName: String, order: String): HoodieTableIndexColumn = order match {
+    case "ASC" => new HoodieTableIndexColumn(columnName, true)
+    case "DESC" => new HoodieTableIndexColumn(columnName, false)
+  }
+
+  def apply(columnName: String): HoodieTableIndexColumn = new HoodieTableIndexColumn(columnName, isAscending = true)
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/index/TestIndexCommandParser.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/index/TestIndexCommandParser.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.index
+
+import org.apache.hudi.index.HoodieIndex.IndexType
+import org.apache.spark.sql.catalyst.plans.logical.{CreateIndexCommand, DropIndexCommand, RefreshIndexCommand, ShowIndexCommand}
+import org.apache.spark.sql.hudi.TestHoodieSqlBase
+import org.apache.spark.sql.hudi.command.index.HoodieTableIndexColumn
+
+class TestIndexCommandParser extends TestHoodieSqlBase {
+  private val parser = spark.sessionState.sqlParser
+
+  test("Test create index command parser") {
+    var createIndex = parser.parsePlan(
+      s"""CREATE INDEX index1 ON db.hudi_table1 (a, b)
+         | USING BLOOM""".stripMargin
+    ).asInstanceOf[CreateIndexCommand]
+    assertResult("index1")(createIndex.indexName)
+    assertResult(IndexType.BLOOM)(createIndex.indexType)
+
+    createIndex = parser.parsePlan(
+      s"""CREATE INDEX index2 ON db.hudi_table1 (a, b)
+         | USING BLOOM PROPERTIES(a=1, b=2)""".stripMargin
+    ).asInstanceOf[CreateIndexCommand]
+    assertResult("index2")(createIndex.indexName)
+    assertResult(Set("a", "b"))(createIndex.indexProperties.get.keys)
+
+    createIndex = parser.parsePlan(
+      s"""CREATE INDEX IF NOT EXISTS index3 ON TABLE db.hudi_table1 (a, b)
+         | USING BLOOM PROPERTIES(a=1, b=2)""".stripMargin
+    ).asInstanceOf[CreateIndexCommand]
+    assertResult("index3")(createIndex.indexName)
+    assertResult(IndexType.BLOOM)(createIndex.indexType)
+    assertResult(createIndex.indexColumns)(Seq(
+      HoodieTableIndexColumn("a", isAscending = true),
+      HoodieTableIndexColumn("b", isAscending = true)))
+
+    createIndex = parser.parsePlan(
+      s"""CREATE INDEX IF NOT EXISTS index4 ON TABLE db.hudi_table1 (a ASC, b DESC)
+         | USING BLOOM PROPERTIES(a=1, b=2)""".stripMargin
+    ).asInstanceOf[CreateIndexCommand]
+    assertResult("index4")(createIndex.indexName)
+    assertResult(IndexType.BLOOM)(createIndex.indexType)
+    assertResult(createIndex.indexColumns)(Seq(
+      HoodieTableIndexColumn("a", isAscending = true),
+      HoodieTableIndexColumn("b", isAscending = false)))
+  }
+
+  test("Test drop index command parser") {
+    var dropIndex = parser.parsePlan(
+      s"""DROP INDEX index_a ON db.hudi_table1""".stripMargin
+    ).asInstanceOf[DropIndexCommand]
+    assertResult("index_a")(dropIndex.indexName)
+
+    dropIndex = parser.parsePlan(
+      s"""DROP INDEX IF EXISTS index_b ON TABLE db.hudi_table1""".stripMargin
+    ).asInstanceOf[DropIndexCommand]
+    assertResult("index_b")(dropIndex.indexName)
+
+    dropIndex = parser.parsePlan(
+      s"""DROP INDEX IF EXISTS index_c ON db.hudi_table1""".stripMargin
+    ).asInstanceOf[DropIndexCommand]
+    assertResult("index_c")(dropIndex.indexName)
+  }
+
+  test("Test refresh index command parser") {
+    var refreshIndex = parser.parsePlan(
+      s"""REFRESH INDEX index_a ON db.hudi_table1""".stripMargin
+    ).asInstanceOf[RefreshIndexCommand]
+    assertResult("index_a")(refreshIndex.indexName)
+
+    refreshIndex = parser.parsePlan(
+      s"""REFRESH INDEX index_b ON TABLE db.hudi_table1""".stripMargin
+    ).asInstanceOf[RefreshIndexCommand]
+    assertResult("index_b")(refreshIndex.indexName)
+
+    refreshIndex = parser.parsePlan(
+      s"""REFRESH INDEX index_c ON db.hudi_table1""".stripMargin
+    ).asInstanceOf[RefreshIndexCommand]
+    assertResult("index_c")(refreshIndex.indexName)
+  }
+
+  test("Test show index command parser") {
+    var showIndex = parser.parsePlan(
+      s"""SHOW INDEX ON db.hudi_table1""".stripMargin
+    ).asInstanceOf[ShowIndexCommand]
+    assertResult(true)(showIndex.indexName.isEmpty)
+
+    showIndex = parser.parsePlan(
+      s"""SHOW INDEX index_b ON db.hudi_table1""".stripMargin
+    ).asInstanceOf[ShowIndexCommand]
+    assertResult("index_b")(showIndex.indexName.get)
+
+    showIndex = parser.parsePlan(
+      s"""SHOW INDEX index_c ON TABLE db.hudi_table1""".stripMargin
+    ).asInstanceOf[ShowIndexCommand]
+    assertResult("index_c")(showIndex.indexName.get)
+  }
+}


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

link: [HUDI-3881](https://issues.apache.org/jira/browse/HUDI-3881)

1. Create Index
```
CREATE INDEX [IF NOT EXISTS] index_name
ON [TABLE] [db_name.]table_name (column_name [ASC|DESC], ...) 
USING [bloom/lucene]
[PROPERTIES ('key'='value')] 
```

2. Refresh Index
```
REFRESH INDEX index_name ON [TABLE] [db_name.]table_name
```

3. Drop Index 
```
DROP INDEX [IF EXISTS] index_name ON [TABLE] [db_name.]table_name
```

4. Show index
```
SHOW INDEX [index_name] ON [TABLE] [db_name.]table_name
```

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
