### PR TITLE
fallback to HadoopFsRelation

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
@@ -20,13 +20,14 @@ package org.apache.hudi
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.hudi.HoodieBaseRelation.createBaseFileReader
+import org.apache.hudi.common.model.HoodieFileFormat
 import org.apache.hudi.common.table.HoodieTableMetaClient
-
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.hive.orc.OrcFileFormat
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
 
@@ -100,5 +101,18 @@ class BaseFileOnlyRelation(sqlContext: SQLContext,
     val maxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
 
     sparkAdapter.getFilePartitions(sparkSession, fileSplits, maxSplitBytes).map(HoodieBaseFileSplit.apply)
+  }
+
+  def toHadoopFsRelation: HadoopFsRelation = {
+    HadoopFsRelation(
+      fileIndex,
+      fileIndex.partitionSchema,
+      fileIndex.dataSchema,
+      bucketSpec = None,
+      fileFormat = metaClient.getTableConfig.getBaseFileFormat match {
+        case HoodieFileFormat.PARQUET => new ParquetFileFormat
+        case HoodieFileFormat.ORC => new OrcFileFormat
+      },
+      optParams)(sparkSession)
   }
 }


### PR DESCRIPTION
If schema on read is not enabled, use `HadoopFsRelation`.

BaseFileOnlyRelation is not able to read nested field; it reads the whole struct field like `ReadSchema: struct<repo:struct<id:bigint,name:string,url:string>>`

HadoopFsRelation reads `ReadSchema: struct<repo:struct<name:string>>`