### PR TITLE
[HUDI-3912] Fix lose data when rollback in flink async compact

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -109,11 +109,11 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
       return;
     }
     if (event.isFailed()) {
+      this.hasFailedEvent = true;
       // handle failure case
       CompactionUtil.rollbackCompaction(table, instant);
       // remove commitBuffer avoid commit with preview fileId
       this.commitBuffer.remove(instant);
-      this.hasFailedEvent = true;
       return;
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.exception.HoodieCompactException;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.table.HoodieFlinkTable;
@@ -129,7 +128,7 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
       return;
     }
 
-    if(events.stream().anyMatch(CompactionCommitEvent::isFailed)) {
+    if (events.stream().anyMatch(CompactionCommitEvent::isFailed)) {
       // handle failure case
       CompactionUtil.rollbackCompaction(table, instant);
       // remove commitBuffer avoid commit with preview fileId

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -104,6 +104,8 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
     if (event.isFailed()) {
       // handle failure case
       CompactionUtil.rollbackCompaction(table, event.getInstant());
+      // remove commitBuffer avoid commit with preview fileId
+      this.commitBuffer.remove(event.getInstant());
       return;
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieCompactException;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.table.HoodieFlinkTable;
@@ -105,8 +106,7 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
       // handle failure case
       CompactionUtil.rollbackCompaction(table, event.getInstant());
       // remove commitBuffer avoid commit with preview fileId
-      this.commitBuffer.remove(event.getInstant());
-      return;
+      throw new HoodieCompactException("compact meet error fail fast");
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
         .put(event.getFileId(), event);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -133,7 +133,7 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
       // handle failure case
       CompactionUtil.rollbackCompaction(table, instant);
       // remove commitBuffer avoid commit with preview fileId
-      this.commitBuffer.remove(instant);
+      reset(instant);
       return;
     }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -128,6 +128,7 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
     if (!isReady) {
       return;
     }
+
     if(events.stream().anyMatch(CompactionCommitEvent::isFailed)) {
       // handle failure case
       CompactionUtil.rollbackCompaction(table, instant);
@@ -135,6 +136,7 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
       this.commitBuffer.remove(instant);
       return;
     }
+
     try {
       doCommit(instant, events);
     } catch (Throwable throwable) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -129,11 +129,14 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
     }
 
     if (events.stream().anyMatch(CompactionCommitEvent::isFailed)) {
-      // handle failure case
-      CompactionUtil.rollbackCompaction(table, instant);
-      // remove commitBuffer avoid commit with preview fileId
-      reset(instant);
-      return;
+      try {
+        // handle failure case
+        CompactionUtil.rollbackCompaction(table, instant);
+      } finally {
+        // remove commitBuffer to avoid obsolete metadata commit
+        reset(instant);
+        return;
+      }
     }
 
     try {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Currently when rollback a compact action it just revert the request instant to inflight

But in CompactionCommitSink it keep the preview compact event when rollback

It will cause commit too fast before all next real compact events come and use wrong fileId

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
