### PR TITLE
[HUDI-3961] New Key Generator Option: NanoidKeyGenerator

### DIFF
--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -434,6 +434,12 @@
       <version>${zk-curator.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.aventrix.jnanoid</groupId>
+      <artifactId>jnanoid</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+
     <!-- Hoodie - Test -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/NanoidKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/NanoidKeyGenerator.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command
+
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils
+import org.apache.avro.generic.GenericRecord
+import org.apache.hudi.common.config.TypedProperties
+import org.apache.spark.sql.Row
+
+/**
+ * A KeyGenerator which use the NanoId as the record key.
+ */
+class NanoidKeyGenerator(props: TypedProperties) extends SqlKeyGenerator(props) {
+
+  override def getRecordKey(record: GenericRecord): String = NanoIdUtils.randomNanoId()
+
+  override def getRecordKey(row: Row): String = NanoIdUtils.randomNanoId()
+}

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
     <trino.bundle.bootstrap.shade.prefix>org.apache.hudi.</trino.bundle.bootstrap.shade.prefix>
     <shadeSources>true</shadeSources>
     <zk-curator.version>2.7.1</zk-curator.version>
+    <jnanoid.version>2.0.0</jnanoid.version>
     <antlr.version>4.7</antlr.version>
     <aws.sdk.version>1.12.22</aws.sdk.version>
     <proto.version>3.17.3</proto.version>
@@ -1065,6 +1066,12 @@
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-recipes</artifactId>
         <version>${zk-curator.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.aventrix.jnanoid</groupId>
+        <artifactId>jnanoid</artifactId>
+        <version>${jnanoid.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HUDI-3916

This NanoidKeyGenerator is useful when users ingest aggregation data into hudi without unique key.

Compared with UuidKeyGenerator, nanoid may get 60% performance tuning based on https://blog.bitsrc.io/why-is-nanoid-replacing-uuid-1b5100e62ed2#:~:text=NanoID%20is%20Only%20108%20bytes,on%20size%20of%20the%20data.

Here is the record example for UuidKeyGenerator which _hoodie_record_key is `23a1b150-70d3-4bc3-9960-d2fca503e20c`
```
+-------------------+---------------------+------------------------------------+----------------------+--------------------------------------------------------------------------+---+----+-----+----+----------+
|_hoodie_commit_time|_hoodie_commit_seqno |_hoodie_record_key                  |_hoodie_partition_path|_hoodie_file_name                                                         |id |name|value|ts  |dt        |
+-------------------+---------------------+------------------------------------+----------------------+--------------------------------------------------------------------------+---+----+-----+----+----------+
|20220419151435454  |20220419151435454_0_1|23a1b150-70d3-4bc3-9960-d2fca503e20c|2021-10-16            |a1832b18-159b-482c-9391-39b1c4be1dc7-0_0-34-1617_20220419151435454.parquet|1  |a1  |10   |1000|2021-10-16|
+-------------------+---------------------+------------------------------------+----------------------+--------------------------------------------------------------------------+---+----+-----+----+----------+
```

Here is the record example for NanoidKeyGenerator which _hoodie_record_key is `OcZ_9Rn8wLpIc7W1sHGOL`
```
+-------------------+---------------------+---------------------+----------------------+--------------------------------------------------------------------------+---+----+-----+----+----------+
|_hoodie_commit_time|_hoodie_commit_seqno |_hoodie_record_key   |_hoodie_partition_path|_hoodie_file_name                                                         |id |name|value|ts  |dt        |
+-------------------+---------------------+---------------------+----------------------+--------------------------------------------------------------------------+---+----+-----+----+----------+
|20220419150944483  |20220419150944483_0_1|OcZ_9Rn8wLpIc7W1sHGOL|2021-10-16            |01183dc0-7121-479d-8e30-030838236b51-0_0-34-1617_20220419150944483.parquet|1  |a1  |10   |1000|2021-10-16|
+-------------------+---------------------+---------------------+----------------------+--------------------------------------------------------------------------+---+----+-----+----+----------+
```

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
