### PR TITLE
[HUDI-3945] After the async compaction operation is complete, the task should exit

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -171,13 +171,15 @@ public class HoodieCompactor {
       System.exit(1);
     }
     final JavaSparkContext jsc = UtilHelpers.buildSparkContext("compactor-" + cfg.tableName, cfg.sparkMaster, cfg.sparkMemory);
+    int ret = 0;
     try {
       HoodieCompactor compactor = new HoodieCompactor(jsc, cfg);
-      compactor.compact(cfg.retry);
+      ret = compactor.compact(cfg.retry);
     } catch (Throwable throwable) {
       LOG.error("Fail to run compaction for " + cfg.tableName, throwable);
     } finally {
       jsc.stop();
+      System.exit(ret);
     }
   }
 


### PR DESCRIPTION
…k should exit.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*After the async compaction operation is complete, the task should exit.*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
