### PR TITLE
[HUDI-3946] Validate option path in flink hudi sink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -20,6 +20,7 @@ package org.apache.hudi.table;
 
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieValidationException;
@@ -53,6 +54,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
 /**
  * Hoodie data source/sink factory.
  */
@@ -81,6 +84,8 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     Configuration conf = FlinkOptions.fromMap(context.getCatalogTable().getOptions());
+    checkArgument(!StringUtils.isNullOrEmpty(conf.getString(FlinkOptions.PATH)),
+        "Option [path] should not be empty.");
     ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
     sanityCheck(conf, schema);
     setupConfOptions(conf, context.getObjectIdentifier().getObjectName(), context.getCatalogTable(), schema);


### PR DESCRIPTION
## What is the purpose of the pull request
We should do a non-null check on option 'path' in flink hudi sink so that flink can expose the 'path' problem as early as possible, instead of throwing the error at runtime.
```
Caused by: java.lang.IllegalArgumentException: Can not create a Path from a null string
        at org.apache.hadoop.fs.Path.checkPathArg(Path.java:122) ~[hadoop-common-2.7.6.jar:?]
        at org.apache.hadoop.fs.Path.<init>(Path.java:134) ~[hadoop-common-2.7.6.jar:?]
        at org.apache.hudi.common.fs.FSUtils.getFs(FSUtils.java:103) ~[hudi-flink1.14-bundle_2.11-0.11.0-rc1.jar:0.11.0-rc1]
        at org.apache.hudi.util.StreamerUtil.tableExists(StreamerUtil.java:289) ~[hudi-flink1.14-bundle_2.11-0.11.0-rc1.jar:0.11.0-rc1]
        at org.apache.hudi.util.StreamerUtil.initTableIfNotExists(StreamerUtil.java:258) ~[hudi-flink1.14-bundle_2.11-0.11.0-rc1.jar:0.11.0-rc1]
        at org.apache.hudi.sink.StreamWriteOperatorCoordinator.start(StreamWriteOperatorCoordinator.java:172) ~[hudi-flink1.14-bundle_2.11-0.11.0-rc1.jar:0.11.0-rc1]
        at org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder.start(OperatorCoordinatorHolder.java:194) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.scheduler.DefaultOperatorCoordinatorHandler.startAllOperatorCoordinators(DefaultOperatorCoordinatorHandler.java:85) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.scheduler.SchedulerBase.startScheduling(SchedulerBase.java:584) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.jobmaster.JobMaster.startScheduling(JobMaster.java:965) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.jobmaster.JobMaster.startJobExecution(JobMaster.java:882) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.jobmaster.JobMaster.onStart(JobMaster.java:389) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.rpc.RpcEndpoint.internalCallOnStart(RpcEndpoint.java:181) ~[flink-dist_2.11-1.14.2.jar:1.14.2]
        at org.apache.flink.runtime.rpc.akka.AkkaRpcActor$StoppedState.lambda$start$0(AkkaRpcActor.java:624) ~[flink-rpc-akka_a8af7b4c-9c0c-4ac4-a1b1-1690068e50df.jar:1.14.2]
        at org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:68) ~[flink-rpc-akka_a8af7b4c-9c0c-4ac4-a1b1-1690068e50df.jar:1.14.2]
        at org.apache.flink.runtime.rpc.akka.AkkaRpcActor$StoppedState.start(AkkaRpcActor.java:623) ~[flink-rpc-akka_a8af7b4c-9c0c-4ac4-a1b1-1690068e50df.jar:1.14.2]
        ... 20 more 
```
more [detial](https://issues.apache.org/jira/browse/HUDI-3946?jql=project%20%3D%20HUDI%20ORDER%20BY%20created%20DESC)

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
