### PR TITLE
[HUDI-3947] Fixing Hive conf usage in HoodieSparkSqlWriter

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -21,7 +21,6 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toProperties
 import org.apache.hudi.HoodieWriterUtils._
@@ -619,11 +618,8 @@ object HoodieSparkSqlWriter {
       properties.put(HoodieSyncConfig.META_SYNC_SPARK_VERSION.key, SPARK_VERSION)
       properties.put(HoodieSyncConfig.META_SYNC_USE_FILE_LISTING_FROM_METADATA.key, hoodieConfig.getBoolean(HoodieMetadataConfig.ENABLE))
 
-      val hiveConf: HiveConf = new HiveConf()
-      hiveConf.addResource(fs.getConf)
-
       syncClientToolClassSet.foreach(impl => {
-        SyncUtilHelpers.runHoodieMetaSync(impl.trim, properties, hiveConf, fs, basePath.toString, baseFileFormat)
+        SyncUtilHelpers.runHoodieMetaSync(impl.trim, properties, fs.getConf, fs, basePath.toString, baseFileFormat)
       })
     }
     true


### PR DESCRIPTION
## What is the purpose of the pull request

HiveConf is getting eagerly loaded when HoodieSparkSqlWriter is touched. Strangely this happens only with spark2 and scala12 and not w/ any other profiles. And after inspecting the usages, looks like we don't really need to use HiveConfig in HoodieSparkSqlWriter, all we need is HadoopConf. So, have fixed the usage. 

## Brief change log

- Removed unintended usage of HiveConf in HoodieSparkSqlWriter. 

## Verify this pull request

This pull request is already covered by existing tests.
Ran quick start locally and verified that w/ the patch, it succeeds. and w/o the patch, we get failure w/ spark2 and scala12.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
