### PR TITLE
[MINOR][DOCS] Document alter table unset tblproperties comand

### DIFF
--- a/website/versioned_docs/version-0.10.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.10.1/quick-start-guide.md
@@ -1058,6 +1058,7 @@ ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 
 -- Alter table properties
 ALTER TABLE tableIdentifier SET TBLPROPERTIES (key = 'value')
+ALTER TABLE tableIdentifier UNSET TBLPROPERTIES [ IF EXISTS ] ( key1, key2, ... )
 ```
 **Examples**
 ```sql
@@ -1072,6 +1073,9 @@ ALTER TABLE hudi_cow_nonpcf_tbl2 change column uuid uuid bigint;
 
 --set properties;
 alter table hudi_cow_nonpcf_tbl2 set tblproperties (hoodie.keep.max.commits = '10');
+  
+--unset properties;
+alter table hudi_cow_nonpcf_tbl2 unset tblproperties (hoodie.keep.max.commits)
 ```
 ### Partition SQL Command
 **Syntax**


### PR DESCRIPTION
Hi team, 
I wanted to add unset documentation for hudi spark sql, which I was searching for, so this might be useful for others.
I tried it on my tables and worked perfectly fine as this is the syntax from spark sql documentation.

Will this be merged to 0.11 docs or should I open a new PR?

## What is the purpose of the pull request

This pull request modifies quick-start document

## Brief change log

Add alter table unset tblproperties command documentation.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework  of spark guide.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ x] Commit message is descriptive of the change
 
 - [ x] CI is green

 - [ x] Necessary doc changes done or have another open PR
       
 - [ x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
