### PR TITLE
[HUDI-3982] Comprehensive schema evolution in flink when read/batch/cow/snapshot

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
@@ -100,7 +100,7 @@ public class InternalSchemaCache {
     }
   }
 
-  private static TreeMap<Long, InternalSchema> getHistoricalSchemas(HoodieTableMetaClient metaClient) {
+  public static TreeMap<Long, InternalSchema> getHistoricalSchemas(HoodieTableMetaClient metaClient) {
     TreeMap<Long, InternalSchema> result = new TreeMap<>();
     FileBasedInternalSchemaStorageManager schemasManager = new FileBasedInternalSchemaStorageManager(metaClient);
     String historySchemaStr = schemasManager.getHistorySchemaStr();

--- a/hudi-flink-datasource/hudi-flink/pom.xml
+++ b/hudi-flink-datasource/hudi-flink/pom.xml
@@ -265,6 +265,64 @@
 
         <!-- Test dependencies -->
 
+        <!-- Spark test -->
+        <!-- Spark testkit is used to prepare test data for schema evolution (with changed types, renamed columns, and so on). -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.orbit</groupId>
+                    <artifactId>javax.servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>chill-java</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-spark_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-spark_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Junit 5 dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -89,6 +89,12 @@ public class FlinkOptions extends HoodieConfig {
           + "The semantics is best effort because the compaction job would finally merge all changes of a record into one.\n"
           + " default false to have UPSERT semantics");
 
+  public static final ConfigOption<Boolean> SCHEMA_EVOLUTION_ENABLED = ConfigOptions
+          .key(HoodieWriteConfig.SCHEMA_EVOLUTION_ENABLE.key())
+          .booleanType()
+          .defaultValue(HoodieWriteConfig.SCHEMA_EVOLUTION_ENABLE.defaultValue())
+          .withDescription(HoodieWriteConfig.SCHEMA_EVOLUTION_ENABLE.doc());
+
   // ------------------------------------------------------------------------
   //  Metadata table Options
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -453,15 +453,15 @@ public class HoodieTableSource implements
     return HoodieAvroUtils.addMetadataFields(schema, conf.getBoolean(FlinkOptions.CHANGELOG_ENABLED));
   }
 
-  private SchemaEvoContext getSchemaEvoContext() {
-    if (!conf.getBoolean(FlinkOptions.SCHEMA_EVOLUTION_ENABLED)) {
-      return new SchemaEvoContext(false, null, null);
+  private Option<SchemaEvoContext> getSchemaEvoContext() {
+    if (!conf.getBoolean(FlinkOptions.SCHEMA_EVOLUTION_ENABLED) || metaClient == null) {
+      return Option.empty();
     }
     TreeMap<Long, InternalSchema> schemas = InternalSchemaCache.getHistoricalSchemas(metaClient);
     InternalSchema querySchema = schemas.isEmpty()
         ? AvroInternalSchemaConverter.convert(getTableAvroSchema())
         : schemas.lastEntry().getValue();
-    return new SchemaEvoContext(true, querySchema, metaClient);
+    return Option.of(new SchemaEvoContext(querySchema, metaClient));
   }
 
   @VisibleForTesting

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format;
+
+import org.apache.avro.Schema;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.util.Preconditions;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.Type;
+import org.apache.hudi.internal.schema.Types;
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.hudi.internal.schema.utils.InternalSchemaUtils;
+import org.apache.hudi.util.AvroSchemaConverter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DATE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DOUBLE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.FLOAT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
+import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS;
+
+/**
+ * CastMap is responsible for type conversion when full schema evolution enabled.
+ */
+public final class CastMap {
+  // Maps position (column number) to corresponding cast
+  private final Map<Integer, Cast> castMap = new HashMap<>();
+
+  /**
+   * Creates CastMap by comparing two schemes. Cast of a specific column is created if its type has changed.
+   */
+  public static CastMap of(String tableName, InternalSchema querySchema, InternalSchema actualSchema) {
+    DataType queryType = internalSchemaToDataType(tableName, querySchema);
+    DataType actualType = internalSchemaToDataType(tableName, actualSchema);
+    int metaColumnsSize = HOODIE_META_COLUMNS.size();
+    CastMap castMap = new CastMap();
+    InternalSchemaUtils.collectTypeChangedCols(querySchema, actualSchema).entrySet()
+            .stream()
+            .filter(e -> e.getKey() >= metaColumnsSize)
+            .filter(e -> !isSameType(e.getValue().getLeft(), e.getValue().getRight()))
+            .forEach(e -> {
+              int pos = e.getKey();
+              LogicalType target = queryType.getChildren().get(pos).getLogicalType();
+              LogicalType actual = actualType.getChildren().get(pos).getLogicalType();
+              castMap.add(pos - metaColumnsSize, actual, target);
+            });
+    return castMap;
+  }
+
+  public Object castIfNeed(int pos, Object val) {
+    Cast cast = castMap.get(pos);
+    if (cast == null) {
+      return val;
+    }
+    return cast(val, cast.from(), cast.to());
+  }
+
+  private Object cast(Object val, LogicalType fromType, LogicalType toType) {
+    LogicalTypeRoot from = fromType.getTypeRoot();
+    LogicalTypeRoot to = toType.getTypeRoot();
+    switch (to) {
+      case BIGINT: {
+        // Integer => Long
+        if (from == INTEGER) {
+          return ((Number) val).longValue();
+        }
+        break;
+      }
+      case FLOAT: {
+        // Integer => Float
+        // Long => Float
+        if (from == INTEGER || from == BIGINT) {
+          return ((Number) val).floatValue();
+        }
+        break;
+      }
+      case DOUBLE: {
+        // Integer => Double
+        // Long => Double
+        if (from == INTEGER || from == BIGINT) {
+          return ((Number) val).doubleValue();
+        }
+        // Float => Double
+        if (from == FLOAT) {
+          return Double.parseDouble(val.toString());
+        }
+        break;
+      }
+      case DECIMAL: {
+        // Integer => Decimal
+        // Long => Decimal
+        // Double => Decimal
+        if (from == INTEGER || from == BIGINT || from == DOUBLE) {
+          return toDecimalData((Number) val, toType);
+        }
+        // Float => Decimal
+        if (from == FLOAT) {
+          return toDecimalData(Double.parseDouble(val.toString()), toType);
+        }
+        // String => Decimal
+        if (from == VARCHAR) {
+          return toDecimalData(Double.parseDouble(val.toString()), toType);
+        }
+        // Decimal => Decimal
+        if (from == DECIMAL) {
+          return toDecimalData(((DecimalData) val).toBigDecimal(), toType);
+        }
+        break;
+      }
+      case VARCHAR: {
+        // Integer => String
+        // Long => String
+        // Float => String
+        // Double => String
+        // Decimal => String
+        if (from == INTEGER
+            || from == BIGINT
+            || from == FLOAT
+            || from == DOUBLE
+            || from == DECIMAL) {
+          return new BinaryStringData(String.valueOf(val));
+        }
+        // Date => String
+        if (from == DATE) {
+          return new BinaryStringData(LocalDate.ofEpochDay(((Integer) val).longValue()).toString());
+        }
+        break;
+      }
+      case DATE: {
+        // String => Date
+        if (from == VARCHAR) {
+          return (int) LocalDate.parse(val.toString()).toEpochDay();
+        }
+        break;
+      }
+      default:
+    }
+    return val;
+  }
+
+  public boolean containsAnyPos(int... positions) {
+    return Arrays.stream(positions).anyMatch(castMap.keySet()::contains);
+  }
+
+  public CastMap rearrange(int[] oldIndexes, int[] newIndexes) {
+    Preconditions.checkArgument(oldIndexes.length == newIndexes.length);
+    CastMap newCastMap = new CastMap();
+    for (int i = 0; i < oldIndexes.length; i++) {
+      Cast cast = castMap.get(oldIndexes[i]);
+      if (cast != null) {
+        newCastMap.add(newIndexes[i], cast.from(), cast.to());
+      }
+    }
+    return newCastMap;
+  }
+
+  @VisibleForTesting
+  void add(int pos, LogicalType from, LogicalType to) {
+    castMap.put(pos, new Cast(from, to));
+  }
+
+  private DecimalData toDecimalData(Number val, LogicalType decimalType) {
+    BigDecimal valAsDecimal = BigDecimal.valueOf(val.doubleValue());
+    return toDecimalData(valAsDecimal, decimalType);
+  }
+
+  private DecimalData toDecimalData(BigDecimal valAsDecimal, LogicalType decimalType) {
+    return DecimalData.fromBigDecimal(
+            valAsDecimal,
+            ((DecimalType) decimalType).getPrecision(),
+            ((DecimalType) decimalType).getScale());
+  }
+
+  private static boolean isSameType(Type left, Type right) {
+    if (left instanceof Types.DecimalType && right instanceof Types.DecimalType) {
+      return left.equals(right);
+    }
+    return left.typeId().equals(right.typeId());
+  }
+
+  private static DataType internalSchemaToDataType(String tableName, InternalSchema internalSchema) {
+    Schema schema = AvroInternalSchemaConverter.convert(internalSchema, tableName);
+    return AvroSchemaConverter.convertToDataType(schema);
+  }
+
+  private static final class Cast {
+    private final LogicalType from;
+    private final LogicalType to;
+
+    Cast(LogicalType from, LogicalType to) {
+      this.from = from;
+      this.to = to;
+    }
+
+    LogicalType from() {
+      return from;
+    }
+
+    LogicalType to() {
+      return to;
+    }
+
+    @Override
+    public String toString() {
+      return from + " => " + to;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return castMap.entrySet().stream()
+            .map(e -> e.getKey() + ": " + e.getValue())
+            .collect(Collectors.joining(", ", "{", "}"));
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/SchemaEvoContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/SchemaEvoContext.java
@@ -59,13 +59,13 @@ public final class SchemaEvoContext implements Serializable {
     this.metaClient = metaClient;
   }
 
-  public void getActualFields(String fileName, int[] selectedFields) {
+  public void evalActualFields(String fileName, int[] selectedFields) {
     InternalSchema mergedSchema = getMergedSchema(fileName);
     List<DataType> fieldTypesWithMeta = AvroSchemaConverter.convertToDataType(AvroInternalSchemaConverter.convert(mergedSchema, tableName())).getChildren();
     List<Integer> selectedFieldsList = getSelectedFields(selectedFields);
     RowDataProjection projection = getProjection(mergedSchema, fieldTypesWithMeta, selectedFieldsList);
     List<String> fieldNamesWithMeta = mergedSchema.columns().stream().map(Types.Field::name).collect(Collectors.toList());
-    getActualFields(fieldNamesWithMeta, fieldTypesWithMeta, projection);
+    setActualFields(fieldNamesWithMeta, fieldTypesWithMeta, projection);
   }
 
   public String[] fieldNames() {
@@ -109,7 +109,7 @@ public final class SchemaEvoContext implements Serializable {
     return null;
   }
 
-  private void getActualFields(List<String> fieldNames, List<DataType> fieldTypes, RowDataProjection projection) {
+  private void setActualFields(List<String> fieldNames, List<DataType> fieldTypes, RowDataProjection projection) {
     this.fieldNames = fieldNames.subList(HOODIE_META_COLUMNS.size(), fieldNames.size());
     this.fieldTypes = fieldTypes.subList(HOODIE_META_COLUMNS.size(), fieldTypes.size());
     this.projection = projection;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/SchemaEvoContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/SchemaEvoContext.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.internal.schema.InternalSchema;
+
+import java.io.Serializable;
+
+/**
+ * Data class to pass schema evolution info from table source to input format.
+ */
+public final class SchemaEvoContext implements Serializable {
+  private final boolean enabled;
+  private final InternalSchema querySchema;
+  private final HoodieTableMetaClient metaClient;
+
+  public SchemaEvoContext(boolean enabled, InternalSchema querySchema, HoodieTableMetaClient metaClient) {
+    this.enabled = enabled;
+    this.querySchema = querySchema;
+    this.metaClient = metaClient;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public InternalSchema querySchema() {
+    return querySchema;
+  }
+
+  public HoodieTableMetaClient metaClient() {
+    return metaClient;
+  }
+
+  public String tableName() {
+    return metaClient.getTableConfig().getTableName();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/SchemaEvoContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/SchemaEvoContext.java
@@ -18,38 +18,104 @@
 
 package org.apache.hudi.table.format;
 
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.InternalSchemaCache;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.Types;
+import org.apache.hudi.internal.schema.action.InternalSchemaMerger;
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.hudi.util.AvroSchemaConverter;
+import org.apache.hudi.util.RowDataCastProjection;
+import org.apache.hudi.util.RowDataProjection;
+
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS;
 
 /**
- * Data class to pass schema evolution info from table source to input format.
+ * This class is responsible for calculating names and types of fields that are actual at a certain point in time.
+ * If field is renamed in queried schema, its old name will be returned, which is relevant at the provided time.
+ * If type of field is changed, its old type will be returned, and projection will be created that will convert the old type to the queried one.
  */
 public final class SchemaEvoContext implements Serializable {
-  private final boolean enabled;
   private final InternalSchema querySchema;
   private final HoodieTableMetaClient metaClient;
+  private List<String> fieldNames;
+  private List<DataType> fieldTypes;
+  private RowDataProjection projection;
 
-  public SchemaEvoContext(boolean enabled, InternalSchema querySchema, HoodieTableMetaClient metaClient) {
-    this.enabled = enabled;
+  public SchemaEvoContext(InternalSchema querySchema, HoodieTableMetaClient metaClient) {
     this.querySchema = querySchema;
     this.metaClient = metaClient;
   }
 
-  public boolean isEnabled() {
-    return enabled;
+  public void getActualFields(String fileName, int[] selectedFields) {
+    InternalSchema mergedSchema = getMergedSchema(fileName);
+    List<DataType> fieldTypesWithMeta = AvroSchemaConverter.convertToDataType(AvroInternalSchemaConverter.convert(mergedSchema, tableName())).getChildren();
+    List<Integer> selectedFieldsList = getSelectedFields(selectedFields);
+    RowDataProjection projection = getProjection(mergedSchema, fieldTypesWithMeta, selectedFieldsList);
+    List<String> fieldNamesWithMeta = mergedSchema.columns().stream().map(Types.Field::name).collect(Collectors.toList());
+    getActualFields(fieldNamesWithMeta, fieldTypesWithMeta, projection);
   }
 
-  public InternalSchema querySchema() {
-    return querySchema;
+  public String[] fieldNames() {
+    return fieldNames.toArray(new String[0]);
   }
 
-  public HoodieTableMetaClient metaClient() {
-    return metaClient;
+  public DataType[] fieldTypes() {
+    return fieldTypes.toArray(new DataType[0]);
   }
 
-  public String tableName() {
+  public Option<RowDataProjection> projection() {
+    return Option.ofNullable(projection);
+  }
+
+  private List<Integer> getSelectedFields(int[] selectedFields) {
+    return Arrays.stream(selectedFields)
+            .boxed()
+            .map(pos -> pos + HOODIE_META_COLUMNS.size())
+            .collect(Collectors.toList());
+  }
+
+  private InternalSchema getMergedSchema(String fileName) {
+    long commitTime = Long.parseLong(FSUtils.getCommitTime(fileName));
+    InternalSchema fileSchema = InternalSchemaCache.searchSchemaAndCache(commitTime, metaClient, false);
+    return new InternalSchemaMerger(fileSchema, querySchema, true, true).mergeSchema();
+  }
+
+  private RowDataProjection getProjection(InternalSchema mergedSchema, List<DataType> actualFieldTypesWithMeta, List<Integer> selectedFields) {
+    CastMap castMap = CastMap.of(tableName(), querySchema, mergedSchema);
+    if (castMap.containsAnyPos(selectedFields)) {
+      List<LogicalType> readType = new ArrayList<>(selectedFields.size());
+      for (int pos : selectedFields) {
+        readType.add(actualFieldTypesWithMeta.get(pos).getLogicalType());
+      }
+      return new RowDataCastProjection(
+              readType.toArray(new LogicalType[0]),
+              IntStream.range(0, selectedFields.size()).toArray(),
+              castMap.rearrange(selectedFields, IntStream.range(0, selectedFields.size()).boxed().collect(Collectors.toList()))
+      );
+    }
+    return null;
+  }
+
+  private void getActualFields(List<String> fieldNames, List<DataType> fieldTypes, RowDataProjection projection) {
+    this.fieldNames = fieldNames.subList(HOODIE_META_COLUMNS.size(), fieldNames.size());
+    this.fieldTypes = fieldTypes.subList(HOODIE_META_COLUMNS.size(), fieldTypes.size());
+    this.projection = projection;
+  }
+
+  private String tableName() {
     return metaClient.getTableConfig().getTableName();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -116,7 +116,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     String[] actualFieldNames = fullFieldNames;
     DataType[] actualFieldTypes = fullFieldTypes;
     if (schemaEvoContext.isPresent()) {
-      schemaEvoContext.get().getActualFields(fileSplit.getPath().getName(), selectedFields);
+      schemaEvoContext.get().evalActualFields(fileSplit.getPath().getName(), selectedFields);
       actualFieldNames = schemaEvoContext.get().fieldNames();
       actualFieldTypes = schemaEvoContext.get().fieldTypes();
       projection = schemaEvoContext.get().projection();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -120,6 +120,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       actualFieldNames = schemaEvoContext.get().fieldNames();
       actualFieldTypes = schemaEvoContext.get().fieldTypes();
       projection = schemaEvoContext.get().projection();
+    } else {
+      projection = Option.empty();
     }
 
     // generate partition specs.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/RowDataCastProjection.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/RowDataCastProjection.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.table.format.CastMap;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
+
+/**
+ * As well as {@link RowDataProjection} projects the row data.
+ * In addition, fields are converted according to the CastMap.
+ */
+public final class RowDataCastProjection extends RowDataProjection {
+  private static final long serialVersionUID = 1L;
+
+  private final CastMap castMap;
+
+  public RowDataCastProjection(LogicalType[] types, int[] positions, CastMap castMap) {
+    super(types, positions);
+    this.castMap = castMap;
+  }
+
+  @Override
+  public RowData project(RowData rowData) {
+    RowData.FieldGetter[] fields = fieldGetters();
+    GenericRowData genericRowData = new GenericRowData(fields.length);
+    for (int i = 0; i < fields.length; i++) {
+      Object val = fields[i].getFieldOrNull(rowData);
+      if (val != null) {
+        val = castMap.castIfNeed(i, val);
+      }
+      genericRowData.setField(i, val);
+    }
+    return genericRowData;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/schemaevo/ITTestReadWithSchemaEvo.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/schemaevo/ITTestReadWithSchemaEvo.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.schemaevo;
+
+import org.apache.flink.table.api.TableResult;
+import org.apache.spark.sql.SparkSession;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.hudi.config.HoodieWriteConfig.SCHEMA_EVOLUTION_ENABLE;
+
+/**
+ * Tests of reading when schema evolution enabled.
+ */
+@SuppressWarnings({"SqlNoDataSourceInspection", "SqlDialectInspection"})
+public class ITTestReadWithSchemaEvo extends TestSchemaEvoBase {
+
+  @TestWhenSparkGreaterThan31
+  public void testReadSnapshotBatchCOW() throws ExecutionException, InterruptedException {
+    String tablePath = tempFile.getAbsolutePath();
+    try (SparkSession spark = spark()) {
+      spark.sql(String.format("set %s=true", SCHEMA_EVOLUTION_ENABLE.key()));
+      createAndPreparePartitionTable(spark, "t1", tablePath, "cow");
+      spark.sql("alter table t1 add columns(newCol1 boolean after col4)");
+      spark.sql("alter table t1 rename column col1 to renamedCol1");
+      spark.sql("alter table t1 drop column col3");
+      spark.sql("alter table t1 alter column col6 type string");
+      spark.sql("alter table t1 add columns(newCol2 int after col8)");
+      spark.sql("insert into t1 values (1,1,11,100001,101.01,100001.0001,true,'a000001','date->string','2021-12-25 12:01:01',true,10,'a01','2021-12-25')");
+    }
+    //language=SQL
+    tEnv.executeSql(
+            "create table t1 ("
+              + "  id int,"
+              + "  comb int,"
+              + "  col0 int,"
+              + "  renamedCol1 bigint,"
+              + "  col2 float,"
+              + "  col4 decimal(10,4),"
+              + "  newCol1 boolean,"
+              + "  col5 string,"
+              + "  col6 string,"
+              + "  col7 timestamp,"
+              + "  col8 boolean,"
+              + "  newCol2 int,"
+              + "  col9 binary,"
+              + "  par date"
+              + " )"
+              + " partitioned by (par) with ("
+              + "  'connector' = 'hudi',"
+              + "  'path' = '" + tablePath + "',"
+              + "  'table.type' = 'COPY_ON_WRITE',"
+              + "  'read.streaming.enabled' = 'false',"
+              + "  'read.tasks' = '1',"
+              + "  'hoodie.datasource.query.type' = 'snapshot',"
+              + "  'hoodie.datasource.write.recordkey.field' = 'id',"
+              + "  'hoodie.datasource.write.hive_style_partitioning' = 'true',"
+              + "  'hoodie.datasource.write.keygenerator.type' = 'COMPLEX',"
+              + "  'hoodie.schema.on.read.enable' = 'true'"
+              + ")"
+      ).await();
+    TableResult tableResult = tEnv.executeSql("select par, newCol2, col6, newCol1, col4, renamedCol1, id from t1");
+    checkAnswer(
+            tableResult,
+            "+I[2021-12-25, 10, date->string, true, 100001.0001, 100001, 1]",
+            "+I[2021-12-25, null, 2021-12-25, null, 100002.0002, 100002, 2]",
+            "+I[2021-12-25, null, 2021-12-25, null, 100003.0003, 100003, 3]",
+            "+I[2021-12-26, null, 2021-12-26, null, 100004.0004, 100004, 4]",
+            "+I[2021-12-26, null, 2021-12-26, null, 100005.0005, 100005, 5]"
+    );
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/schemaevo/TestSchemaEvoBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/schemaevo/TestSchemaEvoBase.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.schemaevo;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.hudi.HoodieSparkUtils;
+import org.apache.spark.sql.hudi.TestSpark3DDL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+public class TestSchemaEvoBase extends TestSpark3DDL {
+
+  @TempDir
+  File tempFile;
+
+  StreamExecutionEnvironment env;
+  StreamTableEnvironment tEnv;
+
+  @BeforeEach
+  public void setUp() {
+    env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    tEnv = StreamTableEnvironment.create(env);
+  }
+
+  public void checkAnswer(TableResult actualResult, String... expectedResult) {
+    try (CloseableIterator<Row> iterator = actualResult.collect()) {
+      Set<String> expected = new HashSet<>(Arrays.asList(expectedResult));
+      Set<String> actual = new HashSet<>(expected.size());
+      for (int i = 0; i < expected.size() && iterator.hasNext(); i++) {
+        actual.add(iterator.next().toString());
+      }
+      assertEquals(expected, actual);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @ExtendWith(ITTestReadWithSchemaEvo.WhenSparkGreaterThan31.class)
+  @Test
+  public @interface TestWhenSparkGreaterThan31 {}
+
+  public static final class WhenSparkGreaterThan31 implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+      java.util.Optional<ITTestReadWithSchemaEvo.TestWhenSparkGreaterThan31> annotation = findAnnotation(context.getElement(), ITTestReadWithSchemaEvo.TestWhenSparkGreaterThan31.class);
+      if (annotation.isPresent() && !HoodieSparkUtils.gteqSpark3_1()) {
+        return ConditionEvaluationResult.disabled("Spark version should be greater than 3.1");
+      }
+      return ConditionEvaluationResult.enabled("OK");
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format;
+
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link CastMap}.
+ */
+public class TestCastMap {
+
+  @Test
+  public void testCastInt() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new IntType(), new BigIntType());
+    castMap.add(1, new IntType(), new FloatType());
+    castMap.add(2, new IntType(), new DoubleType());
+    castMap.add(3, new IntType(), new DecimalType());
+    castMap.add(4, new IntType(), new VarCharType());
+    int val = 1;
+    assertEquals(1L, castMap.castIfNeed(0, val));
+    assertEquals(1.0F, castMap.castIfNeed(1, val));
+    assertEquals(1.0, castMap.castIfNeed(2, val));
+    assertEquals(DecimalData.fromBigDecimal(BigDecimal.ONE, 1, 0), castMap.castIfNeed(3, val));
+    assertEquals(BinaryStringData.fromString("1"), castMap.castIfNeed(4, val));
+  }
+
+  @Test
+  public void testCastLong() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new BigIntType(), new FloatType());
+    castMap.add(1, new BigIntType(), new DoubleType());
+    castMap.add(2, new BigIntType(), new DecimalType());
+    castMap.add(3, new BigIntType(), new VarCharType());
+    long val = 1L;
+    assertEquals(1.0F, castMap.castIfNeed(0, val));
+    assertEquals(1.0, castMap.castIfNeed(1, val));
+    assertEquals(DecimalData.fromBigDecimal(BigDecimal.ONE, 1, 0), castMap.castIfNeed(2, val));
+    assertEquals(BinaryStringData.fromString("1"), castMap.castIfNeed(3, val));
+  }
+
+  @Test
+  public void testCastFloat() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new FloatType(), new DoubleType());
+    castMap.add(1, new FloatType(), new DecimalType());
+    castMap.add(2, new FloatType(), new VarCharType());
+    float val = 1F;
+    assertEquals(1.0, castMap.castIfNeed(0, val));
+    assertEquals(DecimalData.fromBigDecimal(BigDecimal.ONE, 1, 0), castMap.castIfNeed(1, val));
+    assertEquals(BinaryStringData.fromString("1.0"), castMap.castIfNeed(2, val));
+  }
+
+  @Test
+  public void testCastDouble() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new DoubleType(), new DecimalType());
+    castMap.add(1, new DoubleType(), new VarCharType());
+    double val = 1;
+    assertEquals(DecimalData.fromBigDecimal(BigDecimal.ONE, 1, 0), castMap.castIfNeed(0, val));
+    assertEquals(BinaryStringData.fromString("1.0"), castMap.castIfNeed(1, val));
+  }
+
+  @Test
+  public void testCastDecimal() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new DecimalType(2, 1), new DecimalType(3, 2));
+    castMap.add(1, new DecimalType(), new VarCharType());
+    DecimalData val = DecimalData.fromBigDecimal(BigDecimal.ONE, 2, 1);
+    assertEquals(DecimalData.fromBigDecimal(BigDecimal.ONE, 3, 2), castMap.castIfNeed(0, val));
+    assertEquals(BinaryStringData.fromString("1.0"), castMap.castIfNeed(1, val));
+  }
+
+  @Test
+  public void testCastString() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new VarCharType(), new DecimalType());
+    castMap.add(1, new VarCharType(), new DateType());
+    assertEquals(DecimalData.fromBigDecimal(BigDecimal.ONE, 1, 0), castMap.castIfNeed(0, BinaryStringData.fromString("1.0")));
+    assertEquals((int) LocalDate.parse("2022-05-12").toEpochDay(), castMap.castIfNeed(1, BinaryStringData.fromString("2022-05-12")));
+  }
+
+  @Test
+  public void testCastDate() {
+    CastMap castMap = new CastMap();
+    castMap.add(0, new DateType(), new VarCharType());
+    assertEquals(BinaryStringData.fromString("2022-05-12"), castMap.castIfNeed(0, (int) LocalDate.parse("2022-05-12").toEpochDay()));
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

This PR adds support of reading by flink when comprehensive schema evolution(RFC-33) enabled and there were some operations *add column*, *rename column*, *change type of column*, *drop column*.
Supported mode: batch/cow/snapshot

## Brief change log

  - Added new option to enable comprehensive schema evolution in flink
  - Key changes are made inside `CopyOnWriteInputFormat`. Now, during the opening, it calculates schema of file, if this schema differs from queried schema, it creates cast map. After reading file, type conversion is performed according to constructed map.

## Verify this pull request

This change added tests and can be verified as follows:
  - Added unit test `TestCastMap` to verify that type conversion is correct
  - Added integration test `ITTestReadWithSchemaEvo` to verify that table with added, renamed, casted, dropped columns is read as expected. This test uses `TestSpark3DDL` to prepare data, so it works only with `-P scala-2.12,spark3.2`, since `TestSpark3DDL` works only with it.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
