### PR TITLE
[WIP] Fixing unnecessary deserialization loop for DataSource V2 batch-writing API

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/ColumnStatsIndexSupport.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{DataFrame, HoodieUnsafeRDDUtils, Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, HoodieUnsafeCatalystUtils, Row, SparkSession}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeSet
@@ -250,7 +250,7 @@ trait ColumnStatsIndexSupport extends SparkAdapterSupport {
         }
       }
 
-      HoodieUnsafeRDDUtils.createDataFrame(spark, catalystRowsRDD, metadataRecordStructType)
+      HoodieUnsafeCatalystUtils.createDataFrame(spark, catalystRowsRDD, metadataRecordStructType)
     }
     metadataTableDF
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/HoodieUnsafeCatalystUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/HoodieUnsafeCatalystUtils.scala
@@ -27,9 +27,20 @@ import org.apache.spark.util.MutablePair
 /**
  * Suite of utilities helping in handling instances of [[HoodieUnsafeRDD]]
  */
-object HoodieUnsafeRDDUtils {
+object HoodieUnsafeCatalystUtils {
 
-  // TODO scala-doc
+  /**
+   * Creates [[DataFrame]] from the [[RDD]] of [[InternalRow]] avoiding de-/serialization penalty of
+   * deserializing [[InternalRow]] to [[Row]] and back when using [[SparkSession.createDataFrame(RDD[Row], StructType)]]
+   *
+   * NOTE: No schema validation is performed, and it's up to the user of this API to make sure that
+   *       [[InternalRow]] adheres to provided schema.
+   *
+   * @param spark target Spark session
+   * @param rdd RDD bearing [[InternalRow]]s to create [[DataFrame]] from
+   * @param structType schema of the target [[DataFrame]]
+   * @return [[DataFrame]]
+   */
   def createDataFrame(spark: SparkSession, rdd: RDD[InternalRow], structType: StructType): DataFrame =
     spark.internalCreateDataFrame(rdd, structType)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/HoodieUnsafeCatalystUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/HoodieUnsafeCatalystUtils.scala
@@ -30,6 +30,16 @@ import org.apache.spark.util.MutablePair
 object HoodieUnsafeCatalystUtils {
 
   /**
+   * Unsafe version of [[RDD.map]] that avoids deserialization of [[InternalRow]] into [[Row]]
+   *
+   * @param rdd RDD to apply mapper to
+   * @param f mapper
+   * @return RDD holding mapped [[InternalRow]]s
+   */
+  def mapInternal(rdd: RDD[InternalRow])(f: InternalRow => InternalRow): RDD[InternalRow] =
+    rdd.mapPartitionsInternal(_.map(f))
+
+  /**
    * Creates [[DataFrame]] from the [[RDD]] of [[InternalRow]] avoiding de-/serialization penalty of
    * deserializing [[InternalRow]] to [[Row]] and back when using [[SparkSession.createDataFrame(RDD[Row], StructType)]]
    *

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
@@ -29,7 +29,7 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, DefaultSo
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.{Dataset, HoodieUnsafeRDDUtils, Row, SaveMode}
+import org.apache.spark.sql.{Dataset, HoodieUnsafeCatalystUtils, Row, SaveMode}
 import org.junit.jupiter.api.Assertions.{assertEquals, fail}
 import org.junit.jupiter.api.{Disabled, Tag, Test}
 
@@ -315,7 +315,7 @@ class TestParquetColumnProjection extends SparkClientFunctionalTestHarness with 
 
       val (rows, bytesRead) = measureBytesRead { () =>
         val rdd = relation.buildScan(targetColumns, Array.empty).asInstanceOf[HoodieUnsafeRDD]
-        HoodieUnsafeRDDUtils.collect(rdd)
+        HoodieUnsafeCatalystUtils.collect(rdd)
       }
 
       val targetRecordCount = tableState.targetRecordCount;


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fixing unnecessary deserialization loop for DataSource V2 batch-writing API: it previously was relying on the API that was triggering the de-/serialization loop (from `InternalRow` to `Row` and back). 

## Brief change log

 - Adding `mapInternal` util to `HoodieUnsafeCatalystUtil`
 - Fixed perf hit in Spark DataSource V2 w/ avoidable de/-serialization loop
 - Tidying up

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
