### PR TITLE
[HUDI-4002] Fix ClassCastException of HoodieWrapperFileSystem

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -633,6 +633,7 @@ public class FSUtils {
     String scheme = FSUtils.getFs(file.toString(), conf).getScheme();
     returnConf.set("fs." + HoodieWrapperFileSystem.getHoodieScheme(scheme) + ".impl",
         HoodieWrapperFileSystem.class.getName());
+    returnConf.setClassLoader(Thread.currentThread().getContextClassLoader());
     return returnConf;
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the ClassCastException of HoodieWrapperFileSystem.

## Brief change log

- Changes the context class loader to the one from the current thread when registering the file system.

## Verify this pull request

This pull request is already covered by existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
