### PR TITLE
HUDI-4044 When reading data from flink-hudi to external storage, the …

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -226,7 +226,7 @@ public class IncrementalInputSplits implements Serializable {
               String basePath = fileSlice.getBaseFile().map(BaseFile::getPath).orElse(null);
               return new MergeOnReadInputSplit(cnt.getAndAdd(1),
                   basePath, logPaths, endInstant,
-                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, instantRange);
+                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, instantRange,fileSlice.getFileId());
             }).collect(Collectors.toList()))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -226,7 +226,7 @@ public class IncrementalInputSplits implements Serializable {
               String basePath = fileSlice.getBaseFile().map(BaseFile::getPath).orElse(null);
               return new MergeOnReadInputSplit(cnt.getAndAdd(1),
                   basePath, logPaths, endInstant,
-                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, instantRange,fileSlice.getFileId());
+                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, instantRange, fileSlice.getFileId());
             }).collect(Collectors.toList()))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -182,8 +182,8 @@ public class HoodieTableSource implements
           OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory((MergeOnReadInputFormat) inputFormat);
           SingleOutputStreamOperator<RowData> source = execEnv.addSource(monitoringFunction, getSourceOperatorName("split_monitor"))
               .setParallelism(1)
-                  .keyBy((KeySelector<MergeOnReadInputSplit, String>) mos -> mos.getFileId())
-                  .transform("split_reader", typeInfo, factory)
+              .keyBy(inputSplit -> inputSplit.getFileId())
+              .transform("split_reader", typeInfo, factory)
               .setParallelism(conf.getInteger(FlinkOptions.READ_TASKS));
           return new DataStreamSource<>(source);
         } else {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.table;
 
-import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.HoodieLogFile;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -182,7 +182,7 @@ public class HoodieTableSource implements
           OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory((MergeOnReadInputFormat) inputFormat);
           SingleOutputStreamOperator<RowData> source = execEnv.addSource(monitoringFunction, getSourceOperatorName("split_monitor"))
               .setParallelism(1)
-                  .keyBy((KeySelector<MergeOnReadInputSplit, String>) mos -> String.valueOf(mos.getFileId()))
+                  .keyBy((KeySelector<MergeOnReadInputSplit, String>) mos -> mos.getFileId())
                   .transform("split_reader", typeInfo, factory)
               .setParallelism(conf.getInteger(FlinkOptions.READ_TASKS));
           return new DataStreamSource<>(source);
@@ -318,7 +318,7 @@ public class HoodieTableSource implements
                   .map(logFile -> logFile.getPath().toString())
                   .collect(Collectors.toList()));
               return new MergeOnReadInputSplit(cnt.getAndAdd(1), basePath, logPaths, latestCommit,
-                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, null,fileSlice.getFileId());
+                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, null, fileSlice.getFileId());
             }).collect(Collectors.toList()))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
@@ -48,24 +48,7 @@ public class MergeOnReadInputSplit implements InputSplit {
   // which is the start of next round reading.
   private long consumed = NUM_NO_CONSUMPTION;
 
-  public MergeOnReadInputSplit(
-      int splitNum,
-      @Nullable String basePath,
-      Option<List<String>> logPaths,
-      String latestCommit,
-      String tablePath,
-      long maxCompactionMemoryInBytes,
-      String mergeType,
-      @Nullable InstantRange instantRange) {
-    this.splitNum = splitNum;
-    this.basePath = Option.ofNullable(basePath);
-    this.logPaths = logPaths;
-    this.latestCommit = latestCommit;
-    this.tablePath = tablePath;
-    this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
-    this.mergeType = mergeType;
-    this.instantRange = Option.ofNullable(instantRange);
-  }
+
 
   public MergeOnReadInputSplit(
           int splitNum,
@@ -75,7 +58,8 @@ public class MergeOnReadInputSplit implements InputSplit {
           String tablePath,
           long maxCompactionMemoryInBytes,
           String mergeType,
-          @Nullable InstantRange instantRange,String fileId ) {
+          @Nullable InstantRange instantRange,
+          String fileId) {
     this.splitNum = splitNum;
     this.basePath = Option.ofNullable(basePath);
     this.logPaths = logPaths;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
@@ -18,13 +18,11 @@
 
 package org.apache.hudi.table.format.mor;
 
+import org.apache.flink.core.io.InputSplit;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.util.Option;
 
-import org.apache.flink.core.io.InputSplit;
-
 import javax.annotation.Nullable;
-
 import java.util.List;
 
 /**
@@ -43,6 +41,8 @@ public class MergeOnReadInputSplit implements InputSplit {
   private final long maxCompactionMemoryInBytes;
   private final String mergeType;
   private final Option<InstantRange> instantRange;
+  private String fileId;
+
 
   // for streaming reader to record the consumed offset,
   // which is the start of next round reading.
@@ -65,6 +65,34 @@ public class MergeOnReadInputSplit implements InputSplit {
     this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
     this.mergeType = mergeType;
     this.instantRange = Option.ofNullable(instantRange);
+  }
+
+  public MergeOnReadInputSplit(
+          int splitNum,
+          @Nullable String basePath,
+          Option<List<String>> logPaths,
+          String latestCommit,
+          String tablePath,
+          long maxCompactionMemoryInBytes,
+          String mergeType,
+          @Nullable InstantRange instantRange,String fileId ) {
+    this.splitNum = splitNum;
+    this.basePath = Option.ofNullable(basePath);
+    this.logPaths = logPaths;
+    this.latestCommit = latestCommit;
+    this.tablePath = tablePath;
+    this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
+    this.mergeType = mergeType;
+    this.instantRange = Option.ofNullable(instantRange);
+    this.fileId = fileId;
+  }
+
+  public String getFileId() {
+    return fileId;
+  }
+
+  public void setFileId(String fileId) {
+    this.fileId = fileId;
   }
 
   public Option<String> getBasePath() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
@@ -45,12 +45,9 @@ public class MergeOnReadInputSplit implements InputSplit {
   private final Option<InstantRange> instantRange;
   private String fileId;
 
-
   // for streaming reader to record the consumed offset,
   // which is the start of next round reading.
   private long consumed = NUM_NO_CONSUMPTION;
-
-
 
   public MergeOnReadInputSplit(
       int splitNum,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputSplit.java
@@ -18,11 +18,13 @@
 
 package org.apache.hudi.table.format.mor;
 
-import org.apache.flink.core.io.InputSplit;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.util.Option;
 
+import org.apache.flink.core.io.InputSplit;
+
 import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -51,15 +53,15 @@ public class MergeOnReadInputSplit implements InputSplit {
 
 
   public MergeOnReadInputSplit(
-          int splitNum,
-          @Nullable String basePath,
-          Option<List<String>> logPaths,
-          String latestCommit,
-          String tablePath,
-          long maxCompactionMemoryInBytes,
-          String mergeType,
-          @Nullable InstantRange instantRange,
-          String fileId) {
+      int splitNum,
+      @Nullable String basePath,
+      Option<List<String>> logPaths,
+      String latestCommit,
+      String tablePath,
+      long maxCompactionMemoryInBytes,
+      String mergeType,
+      @Nullable InstantRange instantRange,
+      String fileId) {
     this.splitNum = splitNum;
     this.basePath = Option.ofNullable(basePath);
     this.logPaths = logPaths;


### PR DESCRIPTION

## What is the purpose of the pull request

When reading data from flink-hudi to external storage, the result is incorrect  because of concurrency issues：

## Brief change log
  - Add fileId in class  MergeOnReadInputSplit ;
  - modify inputSplits method in class IncrementalInputSplits;
  - add keyBy fileId in class HoodieTableSource;

## Committer checklist

 - [HUDI-4044] Has a corresponding JIRA in PR title & commit


When reading data from flink-hudi to external storage, the result is incorrect  because of concurrency issues：
 
Here's the  case:
 
There is a split_monitor task that listens for changes on the TimeLine every N seconds; There are four split_reader tasks for processing changing data and sinking data to external storage:
 
(1) First,split_monitor listens to Instance1 changes , and the corresponding fileId is log1. Split_monitor distributes the fileId information to split_reader task 1 in Rebanlance mode for processing.
 
(2) then,split_monitor listens for Instance2 change . The corresponding fileId is log1 (assuming that the changed data have the same primary key ). The split_monitor task distributes fileId information to split_reader task 2 in Rebanlance mode for processing.
 
(3) Split_reader task 1 and split_reader task 2 process the same primary key data, and their processing speeds are inconsistent. As a result, the sequence of data sink to external storage is inconsistent. The data modified earlier overwrites the data modified later, resulting in incorrect data.
 
 
Solution:
After the split_monitor task monitors the data changes, it distributes them to the split_reader task through the FileId Hash mode to ensure that the same FileId files are processed in the same split_reader task, thus solving this problem .
 
