### PR TITLE
[HUDI-4056] Refine partition matching in when drop / truncate partition.

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -25,7 +25,6 @@ import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.timeline.{HoodieActiveTimeline, HoodieInstantTimeGenerator}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
-import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.{AvroConversionUtils, SparkAdapterSupport}
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -40,8 +39,14 @@ import org.apache.spark.sql.{AnalysisException, Column, DataFrame, SparkSession}
 import java.net.URI
 import java.text.SimpleDateFormat
 import java.util.{Locale, Properties}
+
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Map
+
+import org.apache.hudi.DataSourceWriteOptions.{HIVE_STYLE_PARTITIONING, URL_ENCODE_PARTITIONING}
+import org.apache.hudi.common.util.PartitionPathEncodeUtils.{escapePartitionValue, unescapePathName}
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+import org.apache.spark.sql.util.SchemaUtils
 
 object HoodieSqlCommonUtils extends SparkAdapterSupport {
   // NOTE: {@code SimpleDataFormat} is NOT thread-safe
@@ -319,56 +324,71 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
     }
   }
 
+  /**
+   * Normalizes partition specifications with partition columns of table.
+   */
   def normalizePartitionSpec[T](
-                                 partitionSpec: Map[String, T],
-                                 partColNames: Seq[String],
-                                 tblName: String,
-                                 resolver: Resolver): Map[String, T] = {
+      partitionSpec: Map[String, T],
+      partColNames: Seq[String],
+      tblName: String,
+      resolver: Resolver): Map[String, T] = {
     val normalizedPartSpec = partitionSpec.toSeq.map { case (key, value) =>
       val normalizedKey = partColNames.find(resolver(_, key)).getOrElse {
         throw new AnalysisException(s"$key is not a valid partition column in table $tblName.")
       }
       normalizedKey -> value
     }
-
-    if (normalizedPartSpec.size < partColNames.size) {
-      throw new AnalysisException(
-        "All partition columns need to be specified for Hoodie's partition")
-    }
-
-    val lowerPartColNames = partColNames.map(_.toLowerCase)
-    if (lowerPartColNames.distinct.length != lowerPartColNames.length) {
-      val duplicateColumns = lowerPartColNames.groupBy(identity).collect {
-        case (x, ys) if ys.length > 1 => s"`$x`"
-      }
-      throw new AnalysisException(
-        s"Found duplicate column(s) in the partition schema: ${duplicateColumns.mkString(", ")}")
-    }
-
+    SchemaUtils.checkColumnNameDuplication(
+      normalizedPartSpec.map(_._1), "in the partition schema", resolver)
     normalizedPartSpec.toMap
   }
 
-  def getPartitionPathToDrop(
-                              hoodieCatalogTable: HoodieCatalogTable,
-                              normalizedSpecs: Seq[Map[String, String]]): String = {
-    val table = hoodieCatalogTable.table
-    val allPartitionPaths = hoodieCatalogTable.getPartitionPaths
-    val enableHiveStylePartitioning = isHiveStyledPartitioning(allPartitionPaths, table)
-    val enableEncodeUrl = isUrlEncodeEnabled(allPartitionPaths, table)
-    val partitionsToDrop = normalizedSpecs.map { spec =>
-      hoodieCatalogTable.partitionFields.map { partitionColumn =>
-        val encodedPartitionValue = if (enableEncodeUrl) {
-          PartitionPathEncodeUtils.escapePathName(spec(partitionColumn))
-        } else {
-          spec(partitionColumn)
+  /**
+   * Returns hudi partition(s) which match at least one of [[specs]]. [[specs]] passed in should
+   * always be normalized by [[normalizePartitionSpec]]. Note that the results respect config of
+   * [[HIVE_STYLE_PARTITIONING]] and [[URL_ENCODE_PARTITIONING]].
+   */
+  def getMatchingPartitions(
+      hoodieCatalogTable: HoodieCatalogTable,
+      specs: Seq[Map[String, String]]): Seq[String] = {
+
+    val isHiveStyledPartitioning = hoodieCatalogTable.tableConfig.getBoolean(HIVE_STYLE_PARTITIONING)
+    val isUrlEncodePartitioning = hoodieCatalogTable.tableConfig.getBoolean(URL_ENCODE_PARTITIONING)
+
+    // All partition candidates.
+    val candidates: Seq[Seq[(String, String)]] = hoodieCatalogTable.getPartitionPaths.map(path => {
+      if (isHiveStyledPartitioning) {
+        PartitioningUtils.parsePathFragmentAsSeq(path)
+      } else {
+        val partitionFields = hoodieCatalogTable.partitionFields
+        val partitionValues = path.split("/")
+        if (partitionValues.length != partitionFields.length) {
+          throw new AnalysisException(s"Table of ${hoodieCatalogTable.table.identifier} has" +
+            s" incompatible partition fields (${partitionFields}) and partition values" +
+            s" (${partitionValues}).")
         }
-        if (enableHiveStylePartitioning) {
-          partitionColumn + "=" + encodedPartitionValue
+        partitionFields.zip(partitionValues).toSeq
+      }
+    })
+    
+    val checkIfSatisfied = (candidate: Seq[(String, String)], condition: Map[String, String]) => {
+      candidate.forall(kv => {
+        val expectedValueOpt = if (isUrlEncodePartitioning) {
+          condition.get(kv._1).map(escapePartitionValue)
         } else {
-          encodedPartitionValue
+          condition.get(kv._1)
         }
-      }.mkString("/")
-    }.mkString(",")
-    partitionsToDrop
+        expectedValueOpt.isEmpty || expectedValueOpt.get == kv._2
+      })
+    }
+    candidates.filter(candidate => {
+      specs.exists(checkIfSatisfied(candidate, _))
+    }).map(kvs => {
+      if (isHiveStyledPartitioning) {
+        kvs.map(kv => kv._1 + "=" + kv._2).mkString("/")
+      } else {
+        kvs.map(kv => kv._2).mkString("/")
+      }
+    })
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/TruncateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/TruncateHoodieTableCommand.scala
@@ -25,12 +25,12 @@ import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, HoodieCatalogTable}
-import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{getPartitionPathToDrop, normalizePartitionSpec}
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{getMatchingPartitions, normalizePartitionSpec}
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.{AnalysisException, Row, SaveMode, SparkSession}
 
 /**
- * Command for truncate hudi table.
+ * Command for truncating hudi table.
  */
 case class TruncateHoodieTableCommand(
    tableIdentifier: TableIdentifier,
@@ -83,7 +83,7 @@ case class TruncateHoodieTableCommand(
       }.get)
 
       // drop partitions to lazy clean
-      val partitionsToDrop = getPartitionPathToDrop(hoodieCatalogTable, normalizedSpecs)
+      val partitionsToDrop = getMatchingPartitions(hoodieCatalogTable, normalizedSpecs).mkString(",")
       val parameters = buildHoodieDropPartitionsConfig(sparkSession, hoodieCatalogTable, partitionsToDrop)
       HoodieSparkSqlWriter.write(
         sparkSession.sqlContext,


### PR DESCRIPTION
## What is the purpose of the pull request

In current code, AlterHoodieTableDropPartitionCommand and TruncateHoodieTableCommand require all partition fields should be specified when droping / truncating partitions(s), otherwise complain with AnalyisException (HoodieSqlCommonUtils#normalizePartitionSpec).

But native Spark/Hive SQL have no such limitations – – partition matching is provided as a functionality helping user to manage partition(s) in an easy way. Say dropping partitions with a single SQL "alter table test drop partition (year='2020')", but rather to specify all the partitions from (year='2020', month='01', day='01') to (year='2020', month='12', day='31')

This PR propose to refine the partition matching logic when drop / truncate partition and remove the limitation mentioned above.

## Brief change log

  - Refine HoodieSqlCommonUtils#normalizePartitionSpec -- Reuse Spark utilities for column verifying;
  - HoodieSqlCommonUtils#getMatchingPartitions provides  as a utility for partition matching;
  - Corresponding change in AlterHoodieTableDropPartitionCommand and TruncateHoodieTableCommand

## Verify this pull request

  - Added tests in TestAlterTableDropPartition and TestTruncateTable

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit

 - [ ] Commit message is descriptive of the change

 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.