### PR TITLE
[DOCS] Pull up Blog into top navigation items

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -133,10 +133,6 @@ module.exports = {
           position: 'left',
           items: [
             {
-              label: 'Blog',
-              to: '/blog',
-            },
-            {
               label: 'Talks & Articles',
               to: 'talks-articles',
             },
@@ -194,6 +190,7 @@ module.exports = {
             }
           ],
         },
+        {to: '/blog', label: "Blog", position: 'left'},
         {to: '/powered-by', label: "Who's Using", position: 'left'},
         {to: '/roadmap', label: "Roadmap", position: 'left'},
         {to: '/releases/download', label: 'Download', position: 'left'},


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
*(For example: This pull request adds quick-start document.)*
Pull up Blog into one of the top items

## Brief change log
Currently Blogs are nested under Learn tab. We want o pull this to top items for better discoverability

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
