### PR TITLE
[HUDI-4079] Supports showing table comment for hudi with spark3

### DIFF
--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -89,19 +89,21 @@ class HoodieCatalog extends DelegatingCatalogExtension
   }
 
   override def loadTable(ident: Identifier): Table = {
-    try {
-      super.loadTable(ident) match {
-        case v1: V1Table if sparkAdapter.isHoodieTable(v1.catalogTable) =>
-          HoodieInternalV2Table(
-            spark,
-            v1.catalogTable.location.toString,
-            catalogTable = Some(v1.catalogTable),
-            tableIdentifier = Some(ident.toString))
-        case o => o
-      }
-    } catch {
-      case e: Exception =>
-        throw e
+    super.loadTable(ident) match {
+      case V1Table(catalogTable0) if sparkAdapter.isHoodieTable(catalogTable0) =>
+        val catalogTable = catalogTable0.comment match {
+          case Some(v) =>
+            val newProps = catalogTable0.properties + (TableCatalog.PROP_COMMENT -> v)
+            catalogTable0.copy(properties = newProps)
+          case _ =>
+            catalogTable0
+        }
+        HoodieInternalV2Table(
+          spark = spark,
+          path = catalogTable.location.toString,
+          catalogTable = Some(catalogTable),
+          tableIdentifier = Some(ident.toString))
+      case o => o
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request
When creating table like below with a 'comment' and check by "show create table", the comment is not shown
```
create table test(
  id int,
  name string,
  price double,
  ts long
 ) using hudi
 comment "This is a simple hudi table"
 tblproperties (
   primaryKey = 'id',
   preCombineField = 'ts'
 )
```
The cause is as below:
1. Current hudi & spark3 invokes ShowCreateTableExec when "show create ..."
2. ShowCreateTableExec checks table property of 'comment' for result
3. Spark HiveClientImpl hides property of 'comment', but set it to Catalog#comment when returning a CatalogTable (https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L487)

This PR targets to fix and give a support.

## Brief change log
  - *Restore table property of 'comment' when HoodieCatalog#loadTable*

## Verify this pull request
  - *Added a test*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
