### PR TITLE
[HUDI-4087] Support dropping RO and RT table in DropHoodieTableCommand

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/DropHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/DropHoodieTableCommand.scala
@@ -95,10 +95,10 @@ extends HoodieLeafRunnableCommand {
 
     var rtTableOpt: Option[CatalogTable] = None
     var roTableOpt: Option[CatalogTable] = None
-    if (catalog.tableExists(roIdt)) {
+    if (catalog.tableExists(rtIdt)) {
       val rtTable = catalog.getTableMetadata(rtIdt)
       if (rtTable.storage.locationUri.equals(hoodieTable.table.storage.locationUri)) {
-        rtTable.properties.get(ConfigUtils.IS_QUERY_AS_RO_TABLE) match {
+        rtTable.storage.properties.get(ConfigUtils.IS_QUERY_AS_RO_TABLE) match {
           case Some(v) if v.equalsIgnoreCase("false") => rtTableOpt = Some(rtTable)
           case _ => // do-nothing
         }
@@ -107,7 +107,7 @@ extends HoodieLeafRunnableCommand {
     if (catalog.tableExists(roIdt)) {
       val roTable = catalog.getTableMetadata(roIdt)
       if (roTable.storage.locationUri.equals(hoodieTable.table.storage.locationUri)) {
-        roTable.properties.get(ConfigUtils.IS_QUERY_AS_RO_TABLE) match {
+        roTable.storage.properties.get(ConfigUtils.IS_QUERY_AS_RO_TABLE) match {
           case Some(v) if v.equalsIgnoreCase("true") => roTableOpt = Some(roTable)
           case _ => // do-nothing
         }


### PR DESCRIPTION
## What is the purpose of the pull request

For a MOR table 'mor_simple' and its RO table 'mor_simple_ro' and RT table 'mor_simple_rt', if user drops 'mor_simple_ro' without purging. There might be issue. Reproduce like below:
```
1. Create table as below:
CREATE TABLE mor_simple (
  `id` INT,
  `name` STRING,
  `price` DOUBLE)
USING hudi
location '/user/hive/warehous/mor_simple'
OPTIONS(
  'type' = 'mor',
  'primaryKey' = 'id',
  'hoodie.table.precombine.field' = 'id'
); 

2. Trigger hive-sync by inserting values 
 insert into mor_simple values (1, 'z3', 1)

3. 'show tables' -- we will find mor_simple_rt and mor_simple_ro show up;

4. 'drop table mor_simple_ro' and 'show tables' -- we will find mor_simple is dropped but mor_simple_ro can never be dropped.
```
This PR refines DropHoodieTableCommand and takes more consideration of identifier of RO/RT.

## Brief change log

  - *DropHoodieTableCommand*

## Verify this pull request

  - *Added tests in TestDropTable.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
