### PR TITLE
[HUDI-4111] Bump ANTLR runtime version in Spark 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1657,6 +1657,7 @@
         <parquet.version>1.12.2</parquet.version>
         <avro.version>1.10.2</avro.version>
         <orc.version>1.6.12</orc.version>
+        <antlr.version>4.8</antlr.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
@@ -1722,6 +1723,7 @@
         <parquet.version>1.12.2</parquet.version>
         <avro.version>1.10.2</avro.version>
         <orc.version>1.6.12</orc.version>
+        <antlr.version>4.8</antlr.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1689,6 +1689,7 @@
         <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
         <scalatest.version>${scalatest.spark3.version}</scalatest.version>
         <kafka.version>${kafka.spark3.version}</kafka.version>
+        <antlr.version>4.8-1</antlr.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>


### PR DESCRIPTION
## What is the purpose of the pull request

Spark3.2 uses antlr version 4.8, Hudi uses 4.7, use the same version to avoid a log of antlr check versions.

org.antlr.v4.runtime.RuntimeMetaData#checkVersion
```
ANTLR Tool version 4.7 used for code generation does not match the current runtime version 4.8
```

Spark3.2.0 use 4.8
[[SPARK-35457](https://issues.apache.org/jira/browse/SPARK-35457)][BUILD] Bump ANTLR runtime version to 4.8

Spark3.1.0 use 4.8-1
[[SPARK-33475](https://issues.apache.org/jira/browse/SPARK-33475)][BUILD] Bump ANTLR runtime version to 4.8-1 

## Brief change log

  - *Bump ANTLR runtime version in Spark 3.x*

## Verify this pull request

This pull request is already covered by existing tests, such as *TestTimeTravelTable*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
