### PR TITLE
[HUDI-3889] Do not validate table config if save mode is set to Overwrite

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -119,47 +119,56 @@ object HoodieWriterUtils {
     }
   }
 
+  def validateTableConfig(spark: SparkSession, params: Map[String, String],
+                          tableConfig: HoodieConfig): Unit = {
+    validateTableConfig(spark, params, tableConfig, false)
+  }
+
   /**
    * Detects conflicts between new parameters and existing table configurations
    */
   def validateTableConfig(spark: SparkSession, params: Map[String, String],
-      tableConfig: HoodieConfig): Unit = {
-    val resolver = spark.sessionState.conf.resolver
-    val diffConfigs = StringBuilder.newBuilder
-    params.foreach { case (key, value) =>
-      val existingValue = getStringFromTableConfigWithAlternatives(tableConfig, key)
-      if (null != existingValue && !resolver(existingValue, value)) {
-        diffConfigs.append(s"$key:\t$value\t${tableConfig.getString(key)}\n")
+      tableConfig: HoodieConfig, isOverWriteMode: Boolean): Unit = {
+    // If Overwrite is set as save mode, we don't need to do table config validation.
+    if (!isOverWriteMode) {
+      val resolver = spark.sessionState.conf.resolver
+      val diffConfigs = StringBuilder.newBuilder
+      params.foreach { case (key, value) =>
+        val existingValue = getStringFromTableConfigWithAlternatives(tableConfig, key)
+        if (null != existingValue && !resolver(existingValue, value)) {
+          diffConfigs.append(s"$key:\t$value\t${tableConfig.getString(key)}\n")
+        }
       }
-    }
 
-    if (null != tableConfig) {
-      val datasourceRecordKey = params.getOrElse(RECORDKEY_FIELD.key(), null)
-      val tableConfigRecordKey = tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS)
-      if (null != datasourceRecordKey && null != tableConfigRecordKey
+      if (null != tableConfig) {
+        val datasourceRecordKey = params.getOrElse(RECORDKEY_FIELD.key(), null)
+        val tableConfigRecordKey = tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS)
+        if (null != datasourceRecordKey && null != tableConfigRecordKey
           && datasourceRecordKey != tableConfigRecordKey) {
-        diffConfigs.append(s"RecordKey:\t$datasourceRecordKey\t$tableConfigRecordKey\n")
-      }
+          diffConfigs.append(s"RecordKey:\t$datasourceRecordKey\t$tableConfigRecordKey\n")
+        }
 
-      val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)
-      val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELD)
-      if (null != datasourcePreCombineKey && null != tableConfigPreCombineKey
+        val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)
+        val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELD)
+        if (null != datasourcePreCombineKey && null != tableConfigPreCombineKey
           && datasourcePreCombineKey != tableConfigPreCombineKey) {
-        diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
-      }
+          diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
+        }
 
-      val datasourceKeyGen = getOriginKeyGenerator(params)
-      val tableConfigKeyGen = tableConfig.getString(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME)
-      if (null != datasourceKeyGen && null != tableConfigKeyGen
+        val datasourceKeyGen = getOriginKeyGenerator(params)
+        val tableConfigKeyGen = tableConfig.getString(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME)
+        if (null != datasourceKeyGen && null != tableConfigKeyGen
           && datasourceKeyGen != tableConfigKeyGen) {
-        diffConfigs.append(s"KeyGenerator:\t$datasourceKeyGen\t$tableConfigKeyGen\n")
+          diffConfigs.append(s"KeyGenerator:\t$datasourceKeyGen\t$tableConfigKeyGen\n")
+        }
+      }
+
+      if (diffConfigs.nonEmpty) {
+        diffConfigs.insert(0, "\nConfig conflict(key\tcurrent value\texisting value):\n")
+        throw new HoodieException(diffConfigs.toString.trim)
       }
     }
 
-    if (diffConfigs.nonEmpty) {
-      diffConfigs.insert(0, "\nConfig conflict(key\tcurrent value\texisting value):\n")
-      throw new HoodieException(diffConfigs.toString.trim)
-    }
     // Check schema evolution for bootstrap table.
     // now we do not support bootstrap table.
     if (params.get(OPERATION.key).contains(BOOTSTRAP_OPERATION_OPT_VAL)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -273,8 +273,7 @@ class TestHoodieSparkSqlWriter {
   }
 
   /**
-    * Test case for throw hoodie exception when there already exist a table
-    * with different name with Append Save mode
+    * Test case for Do not validate table config if save mode is set to Overwrite
     */
   @Test
   def testValidateTableConfigWithOverwriteSaveMode(): Unit = {
@@ -282,9 +281,9 @@ class TestHoodieSparkSqlWriter {
     val tableModifier1 = Map("path" -> tempBasePath, HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
       "hoodie.datasource.write.recordkey.field" -> "uuid")
     val dataFrame = spark.createDataFrame(Seq(StringLongTest(UUID.randomUUID().toString, new Date().getTime)))
-    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, tableModifier1, dataFrame)
+    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, tableModifier1, dataFrame)
 
-    //on same path try write with different RECORDKEY_FIELD_NAME which and Append SaveMode should throw an exception
+    //on same path try write with different RECORDKEY_FIELD_NAME and Append SaveMode should throw an exception
     val tableModifier2 = Map("path" -> tempBasePath, HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
       "hoodie.datasource.write.recordkey.field" -> "ts")
     val dataFrame2 = spark.createDataFrame(Seq(StringLongTest(UUID.randomUUID().toString, new Date().getTime)))
@@ -292,7 +291,7 @@ class TestHoodieSparkSqlWriter {
     assert(hoodieException.getMessage.contains("Config conflict"))
     assert(hoodieException.getMessage.contains(s"RecordKey:\tts\tuuid"))
 
-    //on same path try write with different RECORDKEY_FIELD_NAME which and Overwrite SaveMode should be successful.
+    //on same path try write with different RECORDKEY_FIELD_NAME and Overwrite SaveMode should be successful.
     assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, tableModifier2, dataFrame2)._1)
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

Skip table config validatiton if save mode is set to Overwrite

## Brief change log

Check the save mode when doing validating

## Verify this pull request

This change added tests and can be verified as follows:
TestHoodieSparkSqlWriter. testValidateTableConfigWithOverwriteSaveMode

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
