### PR TITLE
[HUDI-1891] Jetty Dependency conflict when upgrade to hive3.1.1 and hadoop3.0.0

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -377,6 +377,12 @@
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-service</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>${spark.bundle.hive.scope}</scope>
     </dependency>
 
@@ -405,6 +411,12 @@
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-common</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>${spark.bundle.hive.scope}</scope>
     </dependency>
 


### PR DESCRIPTION
## What is the purpose of the pull request

Fix Jetty Dependency conflict with hive3.1

## Brief change log

Jetty version of hive3 is 9.3.20.v20170531, while the version in hudi is 9.4.15.v20190215. And there are some changes in org.apache.jetty.server.session.SessionHandler. The way Jetty is introduced is also changed.  So exclude Jetty in hive when packaging.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
