### PR TITLE
[HUDI-4118] fix sync hive Hive table already exists throw an exception

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -289,6 +289,10 @@
                   <shadedPattern>org.apache.hudi.org.apache.hadoop.metrics2.util.MetricSampleQuantiles
                   </shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop.hive.serde2.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.hadoop.hive.serde2.</shadedPattern>
+                </relocation>
               </relocations>
               <filters>
                 <filter>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

fix flink write hudi sync hive 
 if Hive table already exists throw an exception

## Brief change log


  - *Modify hudi-flink-bundle pom.xml*

Add 
`                <relocation>
                  <pattern>org.apache.hadoop.hive.serde2.</pattern>
                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.hadoop.hive.serde2.</shadedPattern>
                </relocation>`


## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:












