### PR TITLE
[HUDI-3994] - Added support for initializing DeltaStreamer without a …

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -285,6 +285,24 @@ public class UtilHelpers {
     return SparkRDDWriteClient.registerClasses(sparkConf);
   }
 
+  private static SparkConf buildSparkConf(String appName, Map<String, String> additionalConfigs) {
+    final SparkConf sparkConf = new SparkConf().setAppName(appName);
+    sparkConf.set("spark.ui.port", "8090");
+    sparkConf.setIfMissing("spark.driver.maxResultSize", "2g");
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+    sparkConf.set("spark.hadoop.mapred.output.compress", "true");
+    sparkConf.set("spark.hadoop.mapred.output.compression.codec", "true");
+    sparkConf.set("spark.hadoop.mapred.output.compression.codec", "org.apache.hadoop.io.compress.GzipCodec");
+    sparkConf.set("spark.hadoop.mapred.output.compression.type", "BLOCK");
+
+    additionalConfigs.forEach(sparkConf::set);
+    return SparkRDDWriteClient.registerClasses(sparkConf);
+  }
+
+  public static JavaSparkContext buildSparkContext(String appName, Map<String, String> configs) {
+    return new JavaSparkContext(buildSparkConf(appName, configs));
+  }
+
   public static JavaSparkContext buildSparkContext(String appName, String defaultMaster, Map<String, String> configs) {
     return new JavaSparkContext(buildSparkConf(appName, defaultMaster, configs));
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -355,8 +355,10 @@ public class HoodieMultiTableDeltaStreamer {
         description = "the min sync interval of each sync in continuous mode")
     public Integer minSyncIntervalSeconds = 0;
 
-    @Parameter(names = {"--spark-master"}, description = "spark master to use.")
-    public String sparkMaster = "local[2]";
+    @Parameter(names = {"--spark-master"},
+        description = "spark master to use, if not defined inherits from your environment taking into "
+            + "account Spark Configuration priority rules (e.g. not using spark-submit command).")
+    public String sparkMaster = "";
 
     @Parameter(names = {"--commit-on-errors"}, description = "Commit even when some records failed to be written")
     public Boolean commitOnErrors = false;


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Added support for initializing DeltaStreamer without a defined Spark Master. That will enable the usage of DeltaStreamer on environments such as AWS Glue or other serverless environments where the spark master is inherited and we do not have access to it.

## Brief change log

 - Modify HoodieDeltaStreamer class in order to have an option to inherit Spark Master.
 - Modify UtilHelpers class to have an option to start the Spark Context without defined Master.
 - Modify HoodieMultiTableDeltaStreamer to have the same default Spark Master( although right now is not used).

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
