### PR TITLE
[HUDI-4137] SnowflakeSyncTool MVP implementation to integrate with Snowflake

### DIFF
--- a/hudi-snowflake/pom.xml
+++ b/hudi-snowflake/pom.xml
@@ -51,8 +51,16 @@
 
     <!-- Logging -->
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
     </dependency>
 
     <dependency>
@@ -71,14 +79,43 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <version>3.3.3</version>
-          <scope>test</scope>
-      </dependency>
-  </dependencies>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <resources>

--- a/hudi-snowflake/pom.xml
+++ b/hudi-snowflake/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hudi</artifactId>
+    <groupId>org.apache.hudi</groupId>
+    <version>0.12.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hudi-snowflake</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <!-- Hoodie -->
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-sync-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Snowflake -->
+    <dependency>
+      <groupId>com.snowflake</groupId>
+      <artifactId>snowpark</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+
+    <!-- Hadoop -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>3.3.3</version>
+          <scope>test</scope>
+      </dependency>
+  </dependencies>
+
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/hudi-snowflake/src/assembly/src.xml
+++ b/hudi-snowflake/src/assembly/src.xml
@@ -1,0 +1,46 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>jar-with-dependencies</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+      <excludes>
+        <exclude>junit:junit</exclude>
+        <exclude>com.google.code.findbugs:*</exclude>
+        <exclude>org.apache.hbase:*</exclude>
+      </excludes>
+    </dependencySet>
+
+    <dependencySet>
+      <unpack>true</unpack>
+      <scope>provided</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/HoodieSnowflakeSyncClient.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/HoodieSnowflakeSyncClient.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.snowflake.sync;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.sync.common.AbstractSyncHoodieClient;
+
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.types.StructField;
+import com.snowflake.snowpark_java.types.StructType;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/*
+ * Snowflake Hudi client to perform all the table operations on Snowflake Cloud Platform.
+ */
+public class HoodieSnowflakeSyncClient extends AbstractSyncHoodieClient {
+  private static final Logger LOG = LogManager.getLogger(HoodieSnowflakeSyncClient.class);
+  private final SnowflakeSyncConfig syncConfig;
+  private transient Session snowflakeSession;
+
+  public HoodieSnowflakeSyncClient(final SnowflakeSyncConfig syncConfig, final FileSystem fs) {
+    super(syncConfig.basePath, syncConfig.assumeDatePartitioning, syncConfig.useFileListingFromMetadata,
+        false, fs);
+    this.syncConfig = syncConfig;
+    this.createSnowflakeConnection();
+  }
+
+  private void createSnowflakeConnection() {
+    if (snowflakeSession == null) {
+      try {
+        // Initialize client that will be used to send requests. This client only needs to be created
+        // once, and can be reused for multiple requests.
+        snowflakeSession = Session.builder().configFile(syncConfig.propertiesFile).create();
+        LOG.info("Successfully established Snowflake connection.");
+      } catch (Exception e) {
+        throw new HoodieSnowflakeSyncException("Cannot create snowflake connection ", e);
+      }
+    }
+  }
+
+  @Override
+  public void createTable(final String tableName, final MessageType storageSchema, final String inputFormatClass,
+                          final String outputFormatClass, final String serdeClass,
+                          final Map<String, String> serdeProperties, final Map<String, String> tableProperties) {
+    // snowflake create table arguments are different, so do nothing.
+  }
+
+  public void createStage(String stageName, String basePath, String storageIntegration) {
+    try {
+      String query = "CREATE OR REPLACE STAGE " + stageName
+          + " url='" + basePath.replace("gs://", "gcs://")
+          + "' STORAGE_INTEGRATION = " + storageIntegration;
+      snowflakeSession.sql(query).show();
+      LOG.info("Manifest External table created.");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Manifest External table was not created ", e);
+    }
+  }
+
+  public void createManifestTable(String stageName, String tableName) {
+    try {
+      String query = "CREATE OR REPLACE EXTERNAL TABLE " + tableName + " ("
+          + "    filename VARCHAR AS split_part(VALUE:c1, '/', -1)"
+          + "  )"
+          + "WITH LOCATION = @" + stageName + "/.hoodie/manifest/"
+          + "  FILE_FORMAT = (TYPE = CSV)"
+          + "  AUTO_REFRESH = False";
+      snowflakeSession.sql(query).show();
+      LOG.info("Manifest External table created.");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Manifest External table was not created ", e);
+    }
+  }
+
+  private void createCustomFileFormat(String fileFormatName) {
+    try {
+      String query = "CREATE OR REPLACE FILE FORMAT " + fileFormatName + " TYPE = '" + syncConfig.baseFileFormat + "';";
+      snowflakeSession.sql(query).show();
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Custom file format was not created. ", e);
+    }
+  }
+
+  private List<String> generateSchemaWithoutPartitionColumns(String stageName, String fileFormatName) {
+    try {
+      String query = "SELECT"
+          + "  generate_column_description(array_agg(object_construct(*)), 'external_table') as columns"
+          + " FROM"
+          + "  table("
+          + "    infer_schema("
+          + "      location => '@" + stageName + "',"
+          + "      file_format => '" + fileFormatName + "'"
+          + "    )"
+          + ")";
+      Optional<Row> row = snowflakeSession.sql(query).first();
+      String columns = row.get().get(0).toString();
+      if (columns.isEmpty()) {
+        throw new HoodieSnowflakeSyncException("Unable to infer the schema with the given data files.");
+      }
+      return Arrays.asList(columns.split(",", -1));
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Unable to infer the schema with the given data files. ", e);
+    }
+  }
+
+  public void createVersionsTable(String stageName, String tableName, List<String> partitionFields, List<String> partitionExtractExpr) {
+    try {
+      String fileFormatName = "my_custom_file_format";
+      createCustomFileFormat(fileFormatName);
+      List<String> inferredColumns = new ArrayList<String>();
+      inferredColumns.addAll(generateSchemaWithoutPartitionColumns(stageName, fileFormatName));
+      String query = "";
+      if (partitionFields.isEmpty()) {
+        query = "CREATE OR REPLACE EXTERNAL TABLE " + tableName + "("
+            + String.join(", ", inferredColumns) + ") ";
+      } else {
+        // Configuring partitioning options for partitioned table.
+        inferredColumns.addAll(partitionExtractExpr);
+        String partitionFieldsStr = partitionFields.stream()
+            .map(s -> "\"" + s + "\"")
+            .collect(Collectors.joining(", "));
+        query = "CREATE OR REPLACE EXTERNAL TABLE " + tableName + "("
+            + String.join(", ", inferredColumns)
+            + ") PARTITION BY (" + partitionFieldsStr + ") ";
+      }
+      query += " WITH LOCATION = @" + stageName
+          + "  FILE_FORMAT = (TYPE = " + syncConfig.baseFileFormat + ")"
+          + "  PATTERN = '.*[.]" + syncConfig.baseFileFormat.toLowerCase() + "'"
+          + "  AUTO_REFRESH = false";
+      snowflakeSession.sql(query).show();
+      LOG.info("External versions table created.");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("External versions table was not created ", e);
+    }
+  }
+
+  public void createSnapshotView(String viewName, String versionsTableName, String manifestTableName) {
+    try {
+      String query = "CREATE OR REPLACE VIEW " + viewName + " AS"
+          + " SELECT * FROM " + versionsTableName
+          + " WHERE \"_hoodie_file_name\" IN (SELECT filename FROM " + manifestTableName + ")";
+      snowflakeSession.sql(query).show();
+      LOG.info("View created successfully");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("View was not created ", e);
+    }
+  }
+
+  @Override
+  public Map<String, String> getTableSchema(String tableName) {
+    try {
+      StructType schema = snowflakeSession.table(tableName).schema();
+      Map<String, String> columnsMap =  new HashMap<>();
+      for (StructField field: schema) {
+        columnsMap.put(
+            field.name(),
+            field.dataType().toString());
+      }
+      return columnsMap;
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Unable to infer schema: ", e);
+    }
+  }
+
+  @Override
+  public void addPartitionsToTable(final String tableName, final List<String> partitionsToAdd) {
+    try {
+      String query = "ALTER EXTERNAL TABLE " + tableName + " REFRESH";
+      snowflakeSession.sql(query).show();
+      LOG.info("Table metadata refreshed successfully");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Table metadata not refreshed ", e);
+    }
+  }
+
+  @Override
+  public boolean doesTableExist(final String tableName) {
+    return tableExists(tableName);
+  }
+
+  @Override
+  public boolean tableExists(String tableName) {
+    try {
+      StructType schema = snowflakeSession.table(tableName).schema();
+      return true;
+    } catch (Exception e) {
+      LOG.info("Table doesn't exist " + tableName);
+      return false;
+    }
+  }
+
+  @Override
+  public Option<String> getLastCommitTimeSynced(final String tableName) {
+    // snowflake doesn't support tblproperties, so do nothing.
+    throw new UnsupportedOperationException("Not support getLastCommitTimeSynced yet.");
+  }
+
+  @Override
+  public void updateLastCommitTimeSynced(final String tableName) {
+    // snowflake doesn't support tblproperties, so do nothing.
+    throw new UnsupportedOperationException("No support for updateLastCommitTimeSynced yet.");
+  }
+
+  @Override
+  public Option<String> getLastReplicatedTime(String tableName) {
+    // snowflake doesn't support tblproperties, so do nothing.
+    throw new UnsupportedOperationException("Not support getLastReplicatedTime yet.");
+  }
+
+  @Override
+  public void updateLastReplicatedTimeStamp(String tableName, String timeStamp) {
+    // snowflake doesn't support tblproperties, so do nothing.
+    throw new UnsupportedOperationException("No support for updateLastReplicatedTimeStamp yet.");
+  }
+
+  @Override
+  public void deleteLastReplicatedTimeStamp(String tableName) {
+    // snowflake doesn't support tblproperties, so do nothing.
+    throw new UnsupportedOperationException("No support for deleteLastReplicatedTimeStamp yet.");
+  }
+
+  @Override
+  public void updatePartitionsToTable(final String tableName, final List<String> changedPartitions) {
+    try {
+      String query = "ALTER EXTERNAL TABLE " + tableName + " REFRESH";
+      snowflakeSession.sql(query).show();
+      LOG.info("Table metadata refreshed successfully");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Table metadata not refreshed ", e);
+    }
+  }
+
+  @Override
+  public void dropPartitions(String tableName, List<String> partitionsToDrop) {
+    try {
+      String query = "ALTER EXTERNAL TABLE " + tableName + " REFRESH";
+      snowflakeSession.sql(query).show();
+      LOG.info("Table metadata refreshed successfully");
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Table metadata not refreshed ", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    snowflakeSession.close();
+  }
+}

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/HoodieSnowflakeSyncClient.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/HoodieSnowflakeSyncClient.java
@@ -48,8 +48,7 @@ public class HoodieSnowflakeSyncClient extends AbstractSyncHoodieClient {
   private transient Session snowflakeSession;
 
   public HoodieSnowflakeSyncClient(final SnowflakeSyncConfig syncConfig, final FileSystem fs) {
-    super(syncConfig.basePath, syncConfig.assumeDatePartitioning, syncConfig.useFileListingFromMetadata,
-        false, fs);
+    super(syncConfig.basePath, false, false, false, fs);
     this.syncConfig = syncConfig;
     this.createSnowflakeConnection();
   }

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/HoodieSnowflakeSyncException.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/HoodieSnowflakeSyncException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.snowflake.sync;
+
+public class HoodieSnowflakeSyncException extends RuntimeException {
+
+  public HoodieSnowflakeSyncException() {
+    super();
+  }
+
+  public HoodieSnowflakeSyncException(String message) {
+    super(message);
+  }
+
+  public HoodieSnowflakeSyncException(String message, Throwable t) {
+    super(message, t);
+  }
+
+  public HoodieSnowflakeSyncException(Throwable t) {
+    super(t);
+  }
+
+  protected static String format(String message, Object... args) {
+    return String.format(String.valueOf(message), args);
+  }
+}

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncConfig.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncConfig.java
@@ -19,90 +19,95 @@
 
 package org.apache.hudi.snowflake.sync;
 
-import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.sync.common.HoodieSyncConfig;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 /**
  * Configs needed to sync data into Snowflake.
  */
-public class SnowflakeSyncConfig implements Serializable {
-  public static final String SNOWFLAKE_SYNC_PROPERTIES_FILE = "hoodie.snowflake.sync.properties_file";
-  public static final String SNOWFLAKE_SYNC_STORAGE_INTEGRATION = "hoodie.snowflake.sync.storage_integration";
-  public static final String SNOWFLAKE_SYNC_TABLE_NAME = "hoodie.snowflake.sync.table_name";
-  public static final String SNOWFLAKE_SYNC_SYNC_BASE_PATH = "hoodie.snowflake.sync.base_path";
-  public static final String SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT = "hoodie.snowflake.sync.base_file_format";
-  public static final String SNOWFLAKE_SYNC_PARTITION_FIELDS = "hoodie.snowflake.sync.partition_fields";
-  public static final String SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION = "hoodie.snowflake.sync.partition_extract_expression";
+public class SnowflakeSyncConfig extends HoodieSyncConfig implements Serializable {
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_PROPERTIES_FILE = ConfigProperty
+      .key("hoodie.snowflake.sync.properties_file")
+      .noDefaultValue()
+      .withDocumentation("Name of the snowflake properties file");
 
-  @Parameter(names = {"--properties-file"}, description = "name of the snowflake profile properties file.", required = true)
-  public String propertiesFile;
-  @Parameter(names = {"--storage-integration"}, description = "name of the storage integration in snowflake", required = true)
-  public String storageIntegration;
-  @Parameter(names = {"--table-name"}, description = "name of the target table in snowflake", required = true)
-  public String tableName;
-  @Parameter(names = {"--base-path"}, description = "Base path of the hoodie table to sync", required = true)
-  public String basePath;
-  @Parameter(names = {"--base-file-format"}, description = "Base path of the hoodie table to sync")
-  public String baseFileFormat = "PARQUET";
-  @Parameter(names = {"--partitioned-by"}, description = "Comma-delimited partition fields. Default to non-partitioned.")
-  public List<String> partitionFields = new ArrayList<>();
-  @Parameter(names = {"--partition-extract-expr"}, description = "Comma-delimited partition extract expression. Default to non-partitioned.")
-  public List<String> partitionExtractExpr = new ArrayList<>();
-  @Parameter(names = {"--help", "-h"}, help = true)
-  public Boolean help = false;
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_STORAGE_INTEGRATION = ConfigProperty
+      .key("hoodie.snowflake.sync.storage_integration")
+      .noDefaultValue()
+      .withDocumentation("Name of the snowflake storage integration");
 
-  public static SnowflakeSyncConfig copy(SnowflakeSyncConfig cfg) {
-    SnowflakeSyncConfig newConfig = new SnowflakeSyncConfig();
-    newConfig.propertiesFile = cfg.propertiesFile;
-    newConfig.storageIntegration = cfg.storageIntegration;
-    newConfig.tableName = cfg.tableName;
-    newConfig.basePath = cfg.basePath;
-    newConfig.baseFileFormat = cfg.baseFileFormat;
-    newConfig.partitionFields = cfg.partitionFields;
-    newConfig.partitionExtractExpr = cfg.partitionExtractExpr;
-    newConfig.help = cfg.help;
-    return newConfig;
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_TABLE_NAME = ConfigProperty
+      .key("hoodie.snowflake.sync.table_name")
+      .noDefaultValue()
+      .withDocumentation("Name of the target table in Snowflake");
+
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_SYNC_BASE_PATH = ConfigProperty
+      .key("hoodie.snowflake.sync.base_path")
+      .noDefaultValue()
+      .withDocumentation("Base path of the hoodie table to sync.");
+
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT = ConfigProperty
+      .key("hoodie.snowflake.sync.base_file_format")
+      .noDefaultValue()
+      .withDocumentation("Name of the file format");
+
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_PARTITION_FIELDS = ConfigProperty
+      .key("hoodie.snowflake.sync.partition_fields")
+      .noDefaultValue()
+      .withDocumentation("Comma-delimited partition fields. Default to non-partitioned.");
+
+  public static final ConfigProperty<String> SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION = ConfigProperty
+      .key("hoodie.snowflake.sync.partition_extract_expression")
+      .noDefaultValue()
+      .withDocumentation("Comma-delimited partition extract expression. Default to non-partitioned.");
+
+  public SnowflakeSyncConfig(final Properties props) {
+    super(props);
   }
 
-  public TypedProperties toProps() {
-    TypedProperties properties = new TypedProperties();
-    properties.put(SNOWFLAKE_SYNC_PROPERTIES_FILE, propertiesFile);
-    properties.put(SNOWFLAKE_SYNC_STORAGE_INTEGRATION, storageIntegration);
-    properties.put(SNOWFLAKE_SYNC_TABLE_NAME, tableName);
-    properties.put(SNOWFLAKE_SYNC_SYNC_BASE_PATH, basePath);
-    properties.put(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT, baseFileFormat);
-    properties.put(SNOWFLAKE_SYNC_PARTITION_FIELDS, String.join(",", partitionFields));
-    properties.put(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, String.join(",", partitionExtractExpr));
-    return properties;
-  }
+  public static class SnowflakeSyncConfigParams {
 
-  public static SnowflakeSyncConfig fromProps(TypedProperties props) {
-    SnowflakeSyncConfig config = new SnowflakeSyncConfig();
-    config.propertiesFile = props.getString(SNOWFLAKE_SYNC_PROPERTIES_FILE);
-    config.storageIntegration = props.getString(SNOWFLAKE_SYNC_STORAGE_INTEGRATION);
-    config.tableName = props.getString(SNOWFLAKE_SYNC_TABLE_NAME);
-    config.basePath = props.getString(SNOWFLAKE_SYNC_SYNC_BASE_PATH);
-    config.baseFileFormat = props.getString(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT);
-    config.partitionFields = props.getStringList(SNOWFLAKE_SYNC_PARTITION_FIELDS, ",", Collections.emptyList());
-    config.partitionExtractExpr = props.getStringList(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, ",", Collections.emptyList());
-    return config;
-  }
+    @ParametersDelegate()
+    public final HoodieSyncConfigParams hoodieSyncConfigParams = new HoodieSyncConfigParams();
+    @Parameter(names = {"--properties-file"}, description = "name of the snowflake profile properties file.", required = true)
+    public String propertiesFile;
+    @Parameter(names = {"--storage-integration"}, description = "name of the storage integration in snowflake", required = true)
+    public String storageIntegration;
+    @Parameter(names = {"--table-name"}, description = "name of the target table in snowflake", required = true)
+    public String tableName;
+    @Parameter(names = {"--base-path"}, description = "Base path of the hoodie table to sync", required = true)
+    public String basePath;
+    @Parameter(names = {"--base-file-format"}, description = "Base path of the hoodie table to sync")
+    public String baseFileFormat = "PARQUET";
+    @Parameter(names = {"--partitioned-by"}, description = "Comma-delimited partition fields. Default to non-partitioned.")
+    public List<String> partitionFields = new ArrayList<>();
+    @Parameter(names = {"--partition-extract-expr"}, description = "Comma-delimited partition extract expression. Default to non-partitioned.")
+    public List<String> partitionExtractExpr = new ArrayList<>();
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
 
-  @Override
-  public String toString() {
-    return "SnowflakeSyncConfig{propertiesFile='" + propertiesFile
-        + "', storageIntegration'" + storageIntegration
-        + "', tableName='" + tableName
-        + "', basePath='" + basePath
-        + "', baseFileFormat='" + baseFileFormat
-        + "', partitionFields='" + partitionFields
-        + "', partitionExtractExpr='" + partitionExtractExpr
-        + "', help=" + help + "}";
+    public Properties toProps() {
+      final Properties props = hoodieSyncConfigParams.toProps();
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_PROPERTIES_FILE, this.propertiesFile);
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_STORAGE_INTEGRATION, this.storageIntegration);
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_TABLE_NAME, this.tableName);
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_PATH, this.basePath);
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT, this.baseFileFormat);
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_FIELDS, String.join(",", this.partitionFields));
+      props.put(SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, String.join(",", this.partitionExtractExpr));
+      return props;
+    }
+
+    public boolean isHelp() {
+      return hoodieSyncConfigParams.isHelp();
+    }
   }
 }

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncConfig.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncConfig.java
@@ -32,15 +32,13 @@ import java.util.List;
  * Configs needed to sync data into Snowflake.
  */
 public class SnowflakeSyncConfig implements Serializable {
-  public static String SNOWFLAKE_SYNC_PROPERTIES_FILE = "hoodie.snowflake.sync.properties_file";
-  public static String SNOWFLAKE_SYNC_STORAGE_INTEGRATION = "hoodie.snowflake.sync.storage_integration";
-  public static String SNOWFLAKE_SYNC_TABLE_NAME = "hoodie.snowflake.sync.table_name";
-  public static String SNOWFLAKE_SYNC_SYNC_BASE_PATH = "hoodie.snowflake.sync.base_path";
-  public static String SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT = "hoodie.snowflake.sync.base_file_format";
-  public static String SNOWFLAKE_SYNC_PARTITION_FIELDS = "hoodie.snowflake.sync.partition_fields";
-  public static String SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION = "hoodie.snowflake.sync.partition_extract_expression";
-  public static String SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA = "hoodie.snowflake.sync.use_file_listing_from_metadata";
-  public static String SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING = "hoodie.snowflake.sync.assume_date_partitioning";
+  public static final String SNOWFLAKE_SYNC_PROPERTIES_FILE = "hoodie.snowflake.sync.properties_file";
+  public static final String SNOWFLAKE_SYNC_STORAGE_INTEGRATION = "hoodie.snowflake.sync.storage_integration";
+  public static final String SNOWFLAKE_SYNC_TABLE_NAME = "hoodie.snowflake.sync.table_name";
+  public static final String SNOWFLAKE_SYNC_SYNC_BASE_PATH = "hoodie.snowflake.sync.base_path";
+  public static final String SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT = "hoodie.snowflake.sync.base_file_format";
+  public static final String SNOWFLAKE_SYNC_PARTITION_FIELDS = "hoodie.snowflake.sync.partition_fields";
+  public static final String SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION = "hoodie.snowflake.sync.partition_extract_expression";
 
   @Parameter(names = {"--properties-file"}, description = "name of the snowflake profile properties file.", required = true)
   public String propertiesFile;
@@ -56,11 +54,6 @@ public class SnowflakeSyncConfig implements Serializable {
   public List<String> partitionFields = new ArrayList<>();
   @Parameter(names = {"--partition-extract-expr"}, description = "Comma-delimited partition extract expression. Default to non-partitioned.")
   public List<String> partitionExtractExpr = new ArrayList<>();
-  @Parameter(names = {"--use-file-listing-from-metadata"}, description = "Fetch file listing from Hudi's metadata")
-  public Boolean useFileListingFromMetadata = false;
-  @Parameter(names = {"--assume-date-partitioning"}, description = "Assume standard yyyy/mm/dd partitioning, this"
-      + " exists to support backward compatibility. If you use hoodie 0.3.x, do not set this parameter")
-  public Boolean assumeDatePartitioning = false;
   @Parameter(names = {"--help", "-h"}, help = true)
   public Boolean help = false;
 
@@ -73,8 +66,6 @@ public class SnowflakeSyncConfig implements Serializable {
     newConfig.baseFileFormat = cfg.baseFileFormat;
     newConfig.partitionFields = cfg.partitionFields;
     newConfig.partitionExtractExpr = cfg.partitionExtractExpr;
-    newConfig.useFileListingFromMetadata = cfg.useFileListingFromMetadata;
-    newConfig.assumeDatePartitioning = cfg.assumeDatePartitioning;
     newConfig.help = cfg.help;
     return newConfig;
   }
@@ -88,8 +79,6 @@ public class SnowflakeSyncConfig implements Serializable {
     properties.put(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT, baseFileFormat);
     properties.put(SNOWFLAKE_SYNC_PARTITION_FIELDS, String.join(",", partitionFields));
     properties.put(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, String.join(",", partitionExtractExpr));
-    properties.put(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA, useFileListingFromMetadata);
-    properties.put(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING, assumeDatePartitioning);
     return properties;
   }
 
@@ -102,8 +91,6 @@ public class SnowflakeSyncConfig implements Serializable {
     config.baseFileFormat = props.getString(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT);
     config.partitionFields = props.getStringList(SNOWFLAKE_SYNC_PARTITION_FIELDS, ",", Collections.emptyList());
     config.partitionExtractExpr = props.getStringList(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, ",", Collections.emptyList());
-    config.useFileListingFromMetadata = props.getBoolean(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA, false);
-    config.assumeDatePartitioning = props.getBoolean(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING, false);
     return config;
   }
 
@@ -116,8 +103,6 @@ public class SnowflakeSyncConfig implements Serializable {
         + "', baseFileFormat='" + baseFileFormat
         + "', partitionFields='" + partitionFields
         + "', partitionExtractExpr='" + partitionExtractExpr
-        + "', useFileListingFromMetadata='" + useFileListingFromMetadata
-        + "', assumeDataPartitioning='" + assumeDatePartitioning
         + "', help=" + help + "}";
   }
 }

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncConfig.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncConfig.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.snowflake.sync;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import com.beust.jcommander.Parameter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configs needed to sync data into Snowflake.
+ */
+public class SnowflakeSyncConfig implements Serializable {
+  public static String SNOWFLAKE_SYNC_PROPERTIES_FILE = "hoodie.snowflake.sync.properties_file";
+  public static String SNOWFLAKE_SYNC_STORAGE_INTEGRATION = "hoodie.snowflake.sync.storage_integration";
+  public static String SNOWFLAKE_SYNC_TABLE_NAME = "hoodie.snowflake.sync.table_name";
+  public static String SNOWFLAKE_SYNC_SYNC_BASE_PATH = "hoodie.snowflake.sync.base_path";
+  public static String SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT = "hoodie.snowflake.sync.base_file_format";
+  public static String SNOWFLAKE_SYNC_PARTITION_FIELDS = "hoodie.snowflake.sync.partition_fields";
+  public static String SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION = "hoodie.snowflake.sync.partition_extract_expression";
+  public static String SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA = "hoodie.snowflake.sync.use_file_listing_from_metadata";
+  public static String SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING = "hoodie.snowflake.sync.assume_date_partitioning";
+
+  @Parameter(names = {"--properties-file"}, description = "name of the snowflake profile properties file.", required = true)
+  public String propertiesFile;
+  @Parameter(names = {"--storage-integration"}, description = "name of the storage integration in snowflake", required = true)
+  public String storageIntegration;
+  @Parameter(names = {"--table-name"}, description = "name of the target table in snowflake", required = true)
+  public String tableName;
+  @Parameter(names = {"--base-path"}, description = "Base path of the hoodie table to sync", required = true)
+  public String basePath;
+  @Parameter(names = {"--base-file-format"}, description = "Base path of the hoodie table to sync")
+  public String baseFileFormat = "PARQUET";
+  @Parameter(names = {"--partitioned-by"}, description = "Comma-delimited partition fields. Default to non-partitioned.")
+  public List<String> partitionFields = new ArrayList<>();
+  @Parameter(names = {"--partition-extract-expr"}, description = "Comma-delimited partition extract expression. Default to non-partitioned.")
+  public List<String> partitionExtractExpr = new ArrayList<>();
+  @Parameter(names = {"--use-file-listing-from-metadata"}, description = "Fetch file listing from Hudi's metadata")
+  public Boolean useFileListingFromMetadata = false;
+  @Parameter(names = {"--assume-date-partitioning"}, description = "Assume standard yyyy/mm/dd partitioning, this"
+      + " exists to support backward compatibility. If you use hoodie 0.3.x, do not set this parameter")
+  public Boolean assumeDatePartitioning = false;
+  @Parameter(names = {"--help", "-h"}, help = true)
+  public Boolean help = false;
+
+  public static SnowflakeSyncConfig copy(SnowflakeSyncConfig cfg) {
+    SnowflakeSyncConfig newConfig = new SnowflakeSyncConfig();
+    newConfig.propertiesFile = cfg.propertiesFile;
+    newConfig.storageIntegration = cfg.storageIntegration;
+    newConfig.tableName = cfg.tableName;
+    newConfig.basePath = cfg.basePath;
+    newConfig.baseFileFormat = cfg.baseFileFormat;
+    newConfig.partitionFields = cfg.partitionFields;
+    newConfig.partitionExtractExpr = cfg.partitionExtractExpr;
+    newConfig.useFileListingFromMetadata = cfg.useFileListingFromMetadata;
+    newConfig.assumeDatePartitioning = cfg.assumeDatePartitioning;
+    newConfig.help = cfg.help;
+    return newConfig;
+  }
+
+  public TypedProperties toProps() {
+    TypedProperties properties = new TypedProperties();
+    properties.put(SNOWFLAKE_SYNC_PROPERTIES_FILE, propertiesFile);
+    properties.put(SNOWFLAKE_SYNC_STORAGE_INTEGRATION, storageIntegration);
+    properties.put(SNOWFLAKE_SYNC_TABLE_NAME, tableName);
+    properties.put(SNOWFLAKE_SYNC_SYNC_BASE_PATH, basePath);
+    properties.put(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT, baseFileFormat);
+    properties.put(SNOWFLAKE_SYNC_PARTITION_FIELDS, String.join(",", partitionFields));
+    properties.put(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, String.join(",", partitionExtractExpr));
+    properties.put(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA, useFileListingFromMetadata);
+    properties.put(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING, assumeDatePartitioning);
+    return properties;
+  }
+
+  public static SnowflakeSyncConfig fromProps(TypedProperties props) {
+    SnowflakeSyncConfig config = new SnowflakeSyncConfig();
+    config.propertiesFile = props.getString(SNOWFLAKE_SYNC_PROPERTIES_FILE);
+    config.storageIntegration = props.getString(SNOWFLAKE_SYNC_STORAGE_INTEGRATION);
+    config.tableName = props.getString(SNOWFLAKE_SYNC_TABLE_NAME);
+    config.basePath = props.getString(SNOWFLAKE_SYNC_SYNC_BASE_PATH);
+    config.baseFileFormat = props.getString(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT);
+    config.partitionFields = props.getStringList(SNOWFLAKE_SYNC_PARTITION_FIELDS, ",", Collections.emptyList());
+    config.partitionExtractExpr = props.getStringList(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION, ",", Collections.emptyList());
+    config.useFileListingFromMetadata = props.getBoolean(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA, false);
+    config.assumeDatePartitioning = props.getBoolean(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING, false);
+    return config;
+  }
+
+  @Override
+  public String toString() {
+    return "SnowflakeSyncConfig{propertiesFile='" + propertiesFile
+        + "', storageIntegration'" + storageIntegration
+        + "', tableName='" + tableName
+        + "', basePath='" + basePath
+        + "', baseFileFormat='" + baseFileFormat
+        + "', partitionFields='" + partitionFields
+        + "', partitionExtractExpr='" + partitionExtractExpr
+        + "', useFileListingFromMetadata='" + useFileListingFromMetadata
+        + "', assumeDataPartitioning='" + assumeDatePartitioning
+        + "', help=" + help + "}";
+  }
+}

--- a/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncTool.java
+++ b/hudi-snowflake/src/main/java/org/apache/hudi/snowflake/sync/SnowflakeSyncTool.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.snowflake.sync;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.sync.common.AbstractSyncTool;
+import org.apache.hudi.sync.common.util.ManifestFileWriter;
+
+import com.beust.jcommander.JCommander;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+/**
+ * Tool to sync a hoodie table with a snowflake table. Either use it as an api
+ * SnowflakeSyncTool.syncHoodieTable(SnowflakeSyncConfig) or as a command line java -cp hoodie-hive.jar SnowflakeSyncTool [args]
+ * <p>
+ * This utility will get the schema from the latest commit and will sync snowflake table schema.
+ *
+ * @Experimental
+ */
+public class SnowflakeSyncTool extends AbstractSyncTool {
+
+  private static final Logger LOG = LogManager.getLogger(SnowflakeSyncTool.class);
+
+  public final SnowflakeSyncConfig cfg;
+  public final String stageName;
+  public final String manifestTableName;
+  public final String versionsTableName;
+  public final String snapshotViewName;
+
+  public SnowflakeSyncTool(TypedProperties properties, Configuration conf, FileSystem fs) {
+    super(properties, conf, fs);
+    cfg = SnowflakeSyncConfig.fromProps(properties);
+    stageName = cfg.tableName + "_stage";
+    manifestTableName = cfg.tableName + "_manifest";
+    versionsTableName = cfg.tableName + "_versions";
+    snapshotViewName = cfg.tableName;
+  }
+
+  @Override
+  public void syncHoodieTable() {
+    try (HoodieSnowflakeSyncClient snowSyncClient = new HoodieSnowflakeSyncClient(SnowflakeSyncConfig.fromProps(props), fs)) {
+      switch (snowSyncClient.getTableType()) {
+        case COPY_ON_WRITE:
+          syncCoWTable(snowSyncClient);
+          break;
+        case MERGE_ON_READ:
+        default:
+          throw new UnsupportedOperationException(snowSyncClient.getTableType() + " table type is not supported yet.");
+      }
+    } catch (Exception e) {
+      throw new HoodieSnowflakeSyncException("Got runtime exception when snowflake syncing " + cfg.tableName, e);
+    }
+  }
+
+  private void syncCoWTable(HoodieSnowflakeSyncClient snowSyncClient) {
+    ValidationUtils.checkState(snowSyncClient.getTableType() == HoodieTableType.COPY_ON_WRITE);
+    LOG.info("Sync hoodie table " + snapshotViewName + " at base path " + snowSyncClient.getBasePath());
+
+    ManifestFileWriter manifestFileWriter = ManifestFileWriter.builder()
+        .setConf(conf)
+        .setBasePath(cfg.basePath)
+        .setUseFileListingFromMetadata(cfg.useFileListingFromMetadata)
+        .setAssumeDatePartitioning(cfg.assumeDatePartitioning)
+        .build();
+    manifestFileWriter.writeManifestFile();
+
+    snowSyncClient.createStage(stageName, cfg.basePath, cfg.storageIntegration);
+    LOG.info("External temporary stage creation complete for " + stageName);
+    snowSyncClient.createManifestTable(stageName, manifestTableName);
+    LOG.info("Manifest table creation complete for " + manifestTableName);
+    snowSyncClient.createVersionsTable(stageName, versionsTableName, cfg.partitionFields, cfg.partitionExtractExpr);
+    LOG.info("Versions table creation complete for " + versionsTableName);
+    snowSyncClient.createSnapshotView(snapshotViewName, versionsTableName, manifestTableName);
+    LOG.info("Snapshot view creation complete for " + snapshotViewName);
+    LOG.info("Snowflake sync complete for " + snapshotViewName);
+  }
+
+  public static void main(String[] args) {
+    SnowflakeSyncConfig cfg = new SnowflakeSyncConfig();
+    JCommander cmd = new JCommander(cfg, null, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+    FileSystem fs = FSUtils.getFs(cfg.basePath, new Configuration());
+    new SnowflakeSyncTool(cfg.toProps(), fs.getConf(), fs).syncHoodieTable();
+  }
+}

--- a/hudi-snowflake/src/test/java/org/apache/hudi/snowflake/sync/TestSnowflakeSyncConfig.java
+++ b/hudi-snowflake/src/test/java/org/apache/hudi/snowflake/sync/TestSnowflakeSyncConfig.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING;
+
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION;
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_FIELDS;
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PROPERTIES_FILE;
@@ -34,9 +34,7 @@ import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT;
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_PATH;
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_TABLE_NAME;
-import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 /*
  * Test class to test all the snowflake sync configs.
  */
@@ -56,8 +54,6 @@ public class TestSnowflakeSyncConfig {
     syncConfig.partitionExtractExpr = Arrays.asList(
         "\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD')",
         "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')");
-    syncConfig.useFileListingFromMetadata = true;
-    syncConfig.assumeDatePartitioning = true;
     syncConfig.help = true;
   }
 
@@ -71,8 +67,6 @@ public class TestSnowflakeSyncConfig {
     assertEquals(copied.baseFileFormat, syncConfig.baseFileFormat);
     assertEquals(copied.partitionFields, syncConfig.partitionFields);
     assertEquals(copied.partitionExtractExpr, syncConfig.partitionExtractExpr);
-    assertEquals(copied.useFileListingFromMetadata, syncConfig.useFileListingFromMetadata);
-    assertEquals(copied.assumeDatePartitioning, syncConfig.assumeDatePartitioning);
     assertEquals(copied.help, syncConfig.help);
   }
 
@@ -88,8 +82,6 @@ public class TestSnowflakeSyncConfig {
     assertEquals("\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD'),"
         + "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')",
         props.getString(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION));
-    assertEquals("true", props.getString(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA));
-    assertEquals("true", props.getString(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING));
   }
 
   @Test
@@ -103,8 +95,6 @@ public class TestSnowflakeSyncConfig {
     props.put(SNOWFLAKE_SYNC_PARTITION_FIELDS, "date,symbol");
     props.put(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION,
         "\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD'),\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')");
-    props.put(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA, true);
-    props.put(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING, true);
     SnowflakeSyncConfig cfg = SnowflakeSyncConfig.fromProps(props);
 
     assertEquals(syncConfig.propertiesFile, cfg.propertiesFile);
@@ -114,7 +104,5 @@ public class TestSnowflakeSyncConfig {
     assertEquals(syncConfig.baseFileFormat, cfg.baseFileFormat);
     assertEquals(syncConfig.partitionFields.toString(), cfg.partitionFields.toString());
     assertEquals(syncConfig.partitionExtractExpr.toString(), cfg.partitionExtractExpr.toString());
-    assertEquals(syncConfig.useFileListingFromMetadata, cfg.useFileListingFromMetadata);
-    assertEquals(syncConfig.assumeDatePartitioning, cfg.assumeDatePartitioning);
   }
 }

--- a/hudi-snowflake/src/test/java/org/apache/hudi/snowflake/sync/TestSnowflakeSyncConfig.java
+++ b/hudi-snowflake/src/test/java/org/apache/hudi/snowflake/sync/TestSnowflakeSyncConfig.java
@@ -19,13 +19,11 @@
 
 package org.apache.hudi.snowflake.sync;
 
-import org.apache.hudi.common.config.TypedProperties;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-
+import java.util.Properties;
 
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION;
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_FIELDS;
@@ -35,6 +33,7 @@ import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_PATH;
 import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /*
  * Test class to test all the snowflake sync configs.
  */
@@ -44,65 +43,30 @@ public class TestSnowflakeSyncConfig {
 
   @BeforeEach
   void setUp() {
-    syncConfig = new SnowflakeSyncConfig();
-    syncConfig.propertiesFile = "/var/demo/config/snowflake.properties";
-    syncConfig.storageIntegration = "hudi_gcp_integration";
-    syncConfig.tableName = "stock_ticks";
-    syncConfig.basePath = "gcs://hudi-demo/dwh/stock_ticks";
-    syncConfig.baseFileFormat = "PARQUET";
-    syncConfig.partitionFields = Arrays.asList("date", "symbol");
-    syncConfig.partitionExtractExpr = Arrays.asList(
+    Properties props = new Properties();
+    props.setProperty(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION.key(),
+        "\"\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD')\","
+            + "\"\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')\"");
+    props.setProperty(SNOWFLAKE_SYNC_PARTITION_FIELDS.key(), "date,symbol");
+    props.setProperty(SNOWFLAKE_SYNC_PROPERTIES_FILE.key(), "/var/demo/config/snowflake.properties");
+    props.setProperty(SNOWFLAKE_SYNC_STORAGE_INTEGRATION.key(), "hudi_gcp_integration");
+    props.setProperty(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT.key(), "PARQUET");
+    props.setProperty(SNOWFLAKE_SYNC_SYNC_BASE_PATH.key(), "gcs://hudi-demo/dwh/stock_ticks");
+    props.setProperty(SNOWFLAKE_SYNC_TABLE_NAME.key(), "stock_ticks");
+    syncConfig = new SnowflakeSyncConfig(props);
+  }
+
+  @Test
+  public void testGetConfigs() {
+    assertEquals(Arrays.asList(
         "\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD')",
-        "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')");
-    syncConfig.help = true;
-  }
-
-  @Test
-  public void testCopy() {
-    SnowflakeSyncConfig copied = SnowflakeSyncConfig.copy(syncConfig);
-    assertEquals(copied.propertiesFile, syncConfig.propertiesFile);
-    assertEquals(copied.storageIntegration, syncConfig.storageIntegration);
-    assertEquals(copied.tableName, syncConfig.tableName);
-    assertEquals(copied.basePath, syncConfig.basePath);
-    assertEquals(copied.baseFileFormat, syncConfig.baseFileFormat);
-    assertEquals(copied.partitionFields, syncConfig.partitionFields);
-    assertEquals(copied.partitionExtractExpr, syncConfig.partitionExtractExpr);
-    assertEquals(copied.help, syncConfig.help);
-  }
-
-  @Test
-  public void testToProps() {
-    TypedProperties props = syncConfig.toProps();
-    assertEquals("/var/demo/config/snowflake.properties", props.getString(SNOWFLAKE_SYNC_PROPERTIES_FILE));
-    assertEquals("hudi_gcp_integration", props.getString(SNOWFLAKE_SYNC_STORAGE_INTEGRATION));
-    assertEquals("stock_ticks", props.getString(SNOWFLAKE_SYNC_TABLE_NAME));
-    assertEquals("gcs://hudi-demo/dwh/stock_ticks", props.getString(SNOWFLAKE_SYNC_SYNC_BASE_PATH));
-    assertEquals("PARQUET", props.getString(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT));
-    assertEquals("date,symbol", props.getString(SNOWFLAKE_SYNC_PARTITION_FIELDS));
-    assertEquals("\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD'),"
-        + "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')",
-        props.getString(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION));
-  }
-
-  @Test
-  public void fromProps() {
-    TypedProperties props = new TypedProperties();
-    props.put(SNOWFLAKE_SYNC_PROPERTIES_FILE, "/var/demo/config/snowflake.properties");
-    props.put(SNOWFLAKE_SYNC_STORAGE_INTEGRATION, "hudi_gcp_integration");
-    props.put(SNOWFLAKE_SYNC_TABLE_NAME, "stock_ticks");
-    props.put(SNOWFLAKE_SYNC_SYNC_BASE_PATH, "gcs://hudi-demo/dwh/stock_ticks");
-    props.put(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT, "PARQUET");
-    props.put(SNOWFLAKE_SYNC_PARTITION_FIELDS, "date,symbol");
-    props.put(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION,
-        "\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD'),\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')");
-    SnowflakeSyncConfig cfg = SnowflakeSyncConfig.fromProps(props);
-
-    assertEquals(syncConfig.propertiesFile, cfg.propertiesFile);
-    assertEquals(syncConfig.storageIntegration, cfg.storageIntegration);
-    assertEquals(syncConfig.tableName, cfg.tableName);
-    assertEquals(syncConfig.basePath, cfg.basePath);
-    assertEquals(syncConfig.baseFileFormat, cfg.baseFileFormat);
-    assertEquals(syncConfig.partitionFields.toString(), cfg.partitionFields.toString());
-    assertEquals(syncConfig.partitionExtractExpr.toString(), cfg.partitionExtractExpr.toString());
+        "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')"
+    ), syncConfig.getString(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION));
+    assertEquals(Arrays.asList("date", "symbol"), syncConfig.getString(SNOWFLAKE_SYNC_PARTITION_FIELDS));
+    assertEquals("/var/demo/config/snowflake.properties", syncConfig.getString(SNOWFLAKE_SYNC_PROPERTIES_FILE));
+    assertEquals("hudi_gcp_integration", syncConfig.getString(SNOWFLAKE_SYNC_STORAGE_INTEGRATION));
+    assertEquals("PARQUET", syncConfig.getString(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT));
+    assertEquals("gcs://hudi-demo/dwh/stock_ticks", syncConfig.getString(SNOWFLAKE_SYNC_SYNC_BASE_PATH));
+    assertEquals("stock_ticks", syncConfig.getString(SNOWFLAKE_SYNC_TABLE_NAME));
   }
 }

--- a/hudi-snowflake/src/test/java/org/apache/hudi/snowflake/sync/TestSnowflakeSyncConfig.java
+++ b/hudi-snowflake/src/test/java/org/apache/hudi/snowflake/sync/TestSnowflakeSyncConfig.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.snowflake.sync;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PARTITION_FIELDS;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_PROPERTIES_FILE;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_STORAGE_INTEGRATION;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_SYNC_BASE_PATH;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_TABLE_NAME;
+import static org.apache.hudi.snowflake.sync.SnowflakeSyncConfig.SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/*
+ * Test class to test all the snowflake sync configs.
+ */
+public class TestSnowflakeSyncConfig {
+
+  SnowflakeSyncConfig syncConfig;
+
+  @BeforeEach
+  void setUp() {
+    syncConfig = new SnowflakeSyncConfig();
+    syncConfig.propertiesFile = "/var/demo/config/snowflake.properties";
+    syncConfig.storageIntegration = "hudi_gcp_integration";
+    syncConfig.tableName = "stock_ticks";
+    syncConfig.basePath = "gcs://hudi-demo/dwh/stock_ticks";
+    syncConfig.baseFileFormat = "PARQUET";
+    syncConfig.partitionFields = Arrays.asList("date", "symbol");
+    syncConfig.partitionExtractExpr = Arrays.asList(
+        "\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD')",
+        "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')");
+    syncConfig.useFileListingFromMetadata = true;
+    syncConfig.assumeDatePartitioning = true;
+    syncConfig.help = true;
+  }
+
+  @Test
+  public void testCopy() {
+    SnowflakeSyncConfig copied = SnowflakeSyncConfig.copy(syncConfig);
+    assertEquals(copied.propertiesFile, syncConfig.propertiesFile);
+    assertEquals(copied.storageIntegration, syncConfig.storageIntegration);
+    assertEquals(copied.tableName, syncConfig.tableName);
+    assertEquals(copied.basePath, syncConfig.basePath);
+    assertEquals(copied.baseFileFormat, syncConfig.baseFileFormat);
+    assertEquals(copied.partitionFields, syncConfig.partitionFields);
+    assertEquals(copied.partitionExtractExpr, syncConfig.partitionExtractExpr);
+    assertEquals(copied.useFileListingFromMetadata, syncConfig.useFileListingFromMetadata);
+    assertEquals(copied.assumeDatePartitioning, syncConfig.assumeDatePartitioning);
+    assertEquals(copied.help, syncConfig.help);
+  }
+
+  @Test
+  public void testToProps() {
+    TypedProperties props = syncConfig.toProps();
+    assertEquals("/var/demo/config/snowflake.properties", props.getString(SNOWFLAKE_SYNC_PROPERTIES_FILE));
+    assertEquals("hudi_gcp_integration", props.getString(SNOWFLAKE_SYNC_STORAGE_INTEGRATION));
+    assertEquals("stock_ticks", props.getString(SNOWFLAKE_SYNC_TABLE_NAME));
+    assertEquals("gcs://hudi-demo/dwh/stock_ticks", props.getString(SNOWFLAKE_SYNC_SYNC_BASE_PATH));
+    assertEquals("PARQUET", props.getString(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT));
+    assertEquals("date,symbol", props.getString(SNOWFLAKE_SYNC_PARTITION_FIELDS));
+    assertEquals("\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD'),"
+        + "\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')",
+        props.getString(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION));
+    assertEquals("true", props.getString(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA));
+    assertEquals("true", props.getString(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING));
+  }
+
+  @Test
+  public void fromProps() {
+    TypedProperties props = new TypedProperties();
+    props.put(SNOWFLAKE_SYNC_PROPERTIES_FILE, "/var/demo/config/snowflake.properties");
+    props.put(SNOWFLAKE_SYNC_STORAGE_INTEGRATION, "hudi_gcp_integration");
+    props.put(SNOWFLAKE_SYNC_TABLE_NAME, "stock_ticks");
+    props.put(SNOWFLAKE_SYNC_SYNC_BASE_PATH, "gcs://hudi-demo/dwh/stock_ticks");
+    props.put(SNOWFLAKE_SYNC_SYNC_BASE_FILE_FORMAT, "PARQUET");
+    props.put(SNOWFLAKE_SYNC_PARTITION_FIELDS, "date,symbol");
+    props.put(SNOWFLAKE_SYNC_PARTITION_EXTRACT_EXPRESSION,
+        "\"date\" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD'),\"symbol\" text as to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')");
+    props.put(SNOWFLAKE_SYNC_USE_FILE_LISTING_FROM_METADATA, true);
+    props.put(SNOWFLAKE_SYNC_ASSUME_DATE_PARTITIONING, true);
+    SnowflakeSyncConfig cfg = SnowflakeSyncConfig.fromProps(props);
+
+    assertEquals(syncConfig.propertiesFile, cfg.propertiesFile);
+    assertEquals(syncConfig.storageIntegration, cfg.storageIntegration);
+    assertEquals(syncConfig.tableName, cfg.tableName);
+    assertEquals(syncConfig.basePath, cfg.basePath);
+    assertEquals(syncConfig.baseFileFormat, cfg.baseFileFormat);
+    assertEquals(syncConfig.partitionFields.toString(), cfg.partitionFields.toString());
+    assertEquals(syncConfig.partitionExtractExpr.toString(), cfg.partitionExtractExpr.toString());
+    assertEquals(syncConfig.useFileListingFromMetadata, cfg.useFileListingFromMetadata);
+    assertEquals(syncConfig.assumeDatePartitioning, cfg.assumeDatePartitioning);
+  }
+}

--- a/hudi-snowflake/src/test/resources/log4j-surefire-quiet.properties
+++ b/hudi-snowflake/src/test/resources/log4j-surefire-quiet.properties
@@ -1,0 +1,29 @@
+###
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+log4j.rootLogger=ERROR, CONSOLE
+log4j.logger.org.apache.hudi=ERROR
+
+# CONSOLE is set to be a ConsoleAppender.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+# CONSOLE uses PatternLayout.
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=[%-5p] %d %c %x - %m%n
+log4j.appender.CONSOLE.filter.a=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CONSOLE.filter.a.AcceptOnMatch=true
+log4j.appender.CONSOLE.filter.a.LevelMin=WARN
+log4j.appender.CONSOLE.filter.a.LevelMax=FATAL

--- a/hudi-snowflake/src/test/resources/log4j-surefire.properties
+++ b/hudi-snowflake/src/test/resources/log4j-surefire.properties
@@ -1,0 +1,29 @@
+###
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+log4j.rootLogger=WARN, CONSOLE
+log4j.logger.org.apache.hudi=INFO
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+# A1 uses PatternLayout.
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.CONSOLE.filter.a=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CONSOLE.filter.a.AcceptOnMatch=true
+log4j.appender.CONSOLE.filter.a.LevelMin=WARN
+log4j.appender.CONSOLE.filter.a.LevelMax=FATAL

--- a/packaging/hudi-snowflake-bundle/pom.xml
+++ b/packaging/hudi-snowflake-bundle/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.  
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hudi</artifactId>
+    <groupId>org.apache.hudi</groupId>
+    <version>0.12.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>hudi-snowflake-bundle</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <checkstyle.skip>true</checkstyle.skip>
+    <main.basedir>${project.parent.basedir}</main.basedir>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.apache.hudi.snowflake.bigquery.BigQuerySyncTool</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createSourcesJar>${shadeSources}</createSourcesJar>
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+              </dependencyReducedPomLocation>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                  <addHeader>true</addHeader>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/LICENSE</resource>
+                  <file>target/classes/META-INF/LICENSE</file>
+                </transformer>
+              </transformers>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.hudi:hudi-common</include>
+                  <include>org.apache.hudi:hudi-hadoop-mr</include>
+                  <include>org.apache.hudi:hudi-sync-common</include>
+                  <include>org.apache.hudi:hudi-snowflake</include>
+
+                  <include>com.google.cloud:google-cloud-bigquery</include>
+                  <include>com.beust:jcommander</include>
+                </includes>
+              </artifactSet>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/services/javax.*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <finalName>${project.artifactId}-${project.version}</finalName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/test/resources</directory>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <!-- Hoodie -->
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hadoop-mr-bundle</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-sync-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-snowflake</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Snowflake -->
+    <dependency>
+      <groupId>com.snowflake</groupId>
+      <artifactId>snowpark</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+
+    <!-- Parquet -->
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>${parquet.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Avro -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/packaging/hudi-snowflake-bundle/src/main/java/org/apache/hudi/snowflake/sync/bundle/Main.java
+++ b/packaging/hudi-snowflake-bundle/src/main/java/org/apache/hudi/snowflake/sync/bundle/Main.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.snowflake.sync.bundle;
+
+import org.apache.hudi.common.util.ReflectionUtils;
+
+/**
+ * A simple main class to dump all classes loaded in current classpath.
+ *
+ * This is a workaround for generating sources and javadoc jars for packaging modules. The maven plugins for generating
+ * javadoc and sources plugins do not generate corresponding jars if there are no source files.
+ *
+ * This class does not have anything to do with Hudi but is there to keep mvn javadocs/source plugin happy.
+ */
+public class Main {
+
+  public static void main(String[] args) {
+    ReflectionUtils.getTopLevelClassesInClasspath(Main.class).forEach(System.out::println);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <module>hudi-client</module>
     <module>hudi-aws</module>
     <module>hudi-gcp</module>
+    <module>hudi-snowflake</module>
     <module>hudi-hadoop-mr</module>
     <module>hudi-spark-datasource</module>
     <module>hudi-timeline-service</module>
@@ -50,6 +51,7 @@
     <module>packaging/hudi-hive-sync-bundle</module>
     <module>packaging/hudi-aws-bundle</module>
     <module>packaging/hudi-gcp-bundle</module>
+    <module>packaging/hudi-snowflake-bundle</module>
     <module>packaging/hudi-spark-bundle</module>
     <module>packaging/hudi-presto-bundle</module>
     <module>packaging/hudi-utilities-bundle</module>

--- a/style/checkstyle-suppressions.xml
+++ b/style/checkstyle-suppressions.xml
@@ -29,6 +29,7 @@
   <!-- java.util.Optional part of DataSource V2 API signature -->
   <suppress checks="IllegalImport" files="DefaultSource.java" />
   <suppress checks="IllegalImport" files="HoodieTableSource.java" />
+  <suppress checks="IllegalImport" files="HoodieSnowflakeSyncClient.java" />
   <suppress checks="IllegalTokenText" files="FilePathUtils.java"/>
   <suppress checks="IllegalTokenText" files="PartitionPathEncodeUtils.java"/>
 </suppressions>


### PR DESCRIPTION
## What is the purpose of the pull request
This pull request adds the Snowflake Sync feature, this is a requirement to read Hudi tables on the Snowflake warehouse.


## Brief change log

  - *Added SnowflakeSyncTool to sync Hudi dataset to Snowflake cloud data warehouse.*

## Verify this pull request

This change added tests and can be verified as follows:

*(example:)*
  - *Manually verified the change by running a job locally.*

1. Use the docker demo steps to set up the stock_ticks_cow table on google cloud storage.
2. Create showflake_profile.properties file with the following configs:
```
URL = https://el36491.us-central1.gcp.snowflakecomputing.com:443
USER = hudidemo
PRIVATE_KEY_FILE = /Users/username/.ssh/rsa_key.p8
ROLE = ACCOUNTADMIN
WAREHOUSE = COMPUTE_WH
DB = hudi
SCHEMA = dwh
``` 
3. Run the following command to sync the table to snowflake
```
java -cp guava-25.1-jre.jar:hadoop-auth-2.4.1.jar:commons-configuration-1.9.jar:commons-collections-3.2.1.jar:guava-r05.jar:woodstox-core-5.3.0.jar:stax2-api-4.2.jar:hadoop-common-2.7.3.jar:hudi-spark-bundle_2.12-0.12.0-SNAPSHOT.jar:hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar:gcs-connector-hadoop2-latest.jar org.apache.hudi.snowflake.sync.SnowflakeSyncTool --properties-file ~/snowflake_profile.properties --base-path gs://hudi-demo/stock_ticks_cow --table-name stock_ticks_cow --storage-integration hudi_demo_int --partitioned-by "date" --partition-extract-expr "\"date\" date as to_date(substr(metadata\$filename, 22, 10), 'YYYY-MM-DD')"
0    [main] WARN  org.apache.hadoop.util.NativeCodeLoader  - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
735  [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Loading HoodieTableMetaClient from gs://hudi-demo/stock_ticks_cow
3537 [main] INFO  org.apache.hudi.common.table.HoodieTableConfig  - Loading table properties from gs://hudi-demo/stock_ticks_cow/.hoodie/hoodie.properties
3853 [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Finished Loading Table of type COPY_ON_WRITE(version=1, baseFileFormat=PARQUET) from gs://hudi-demo/stock_ticks_cow
3853 [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Loading Active commit timeline for gs://hudi-demo/stock_ticks_cow
3977 [main] INFO  org.apache.hudi.common.table.timeline.HoodieActiveTimeline  - Loaded instants upto : Option{val=[20220427145307547__commit__COMPLETED]}
[main] INFO com.snowflake.snowpark.Session - Closing stderr and redirecting to stdout
[main] INFO com.snowflake.snowpark.Session - Done closing stderr and redirecting to stdout
[main] INFO com.snowflake.snowpark.internal.ParameterUtils - set JDBC client memory limit to 10240
[main] INFO com.snowflake.snowpark.Session - Snowpark Session information: {
 "snowpark.version" : "1.4.0",
 "java.version" : "1.8.0_282",
 "scala.version" : "2.12.11",
 "jdbc.session.id" : "229321189576710",
 "os.name" : "Mac OS X",
 "jdbc.version" : "3.13.14",
 "snowpark.library" : "/Users/vinothg/oss/dbt-spark/docker/jars/hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar",
 "scala.library" : "/Users/vinothg/oss/dbt-spark/docker/jars/hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar",
 "jdbc.library" : "/Users/vinothg/oss/dbt-spark/docker/jars/hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar"
}
7803 [main] INFO  org.apache.hudi.snowflake.sync.HoodieSnowflakeSyncClient  - Successfully established Snowflake connection.
7803 [main] INFO  org.apache.hudi.snowflake.sync.SnowflakeSyncTool  - Sync hoodie table stock_ticks_cow at base path gs://hudi-demo/stock_ticks_cow
7804 [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Loading HoodieTableMetaClient from gs://hudi-demo/stock_ticks_cow
7959 [main] INFO  org.apache.hudi.common.table.HoodieTableConfig  - Loading table properties from gs://hudi-demo/stock_ticks_cow/.hoodie/hoodie.properties
8277 [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Finished Loading Table of type COPY_ON_WRITE(version=1, baseFileFormat=PARQUET) from gs://hudi-demo/stock_ticks_cow
8277 [main] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Loading Active commit timeline for gs://hudi-demo/stock_ticks_cow
8376 [main] INFO  org.apache.hudi.common.table.timeline.HoodieActiveTimeline  - Loaded instants upto : Option{val=[20220427145307547__commit__COMPLETED]}
9358 [main] INFO  org.apache.hudi.sync.common.util.ManifestFileWriter  - Retrieve all partitions: 3
9375 [main] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Took 2 ms to read  0 instants, 0 replaced file groups
9375 [ForkJoinPool.commonPool-worker-2] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Took 2 ms to read  0 instants, 0 replaced file groups
9375 [ForkJoinPool.commonPool-worker-9] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Took 2 ms to read  0 instants, 0 replaced file groups
9488 [ForkJoinPool.commonPool-worker-2] INFO  org.apache.hudi.common.util.ClusteringUtils  - Found 0 files in pending clustering operations
9489 [ForkJoinPool.commonPool-worker-2] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Building file system view for partition (date=2020-08-31)
9538 [main] INFO  org.apache.hudi.common.util.ClusteringUtils  - Found 0 files in pending clustering operations
9539 [main] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Building file system view for partition (date=2019-08-31)
9549 [ForkJoinPool.commonPool-worker-9] INFO  org.apache.hudi.common.util.ClusteringUtils  - Found 0 files in pending clustering operations
9549 [ForkJoinPool.commonPool-worker-9] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - Building file system view for partition (date=2018-08-31)
9594 [ForkJoinPool.commonPool-worker-2] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - addFilesToView: NumFiles=3, NumFileGroups=2, FileGroupsCreationTime=6, StoreTimeTaken=1
9634 [ForkJoinPool.commonPool-worker-9] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - addFilesToView: NumFiles=2, NumFileGroups=2, FileGroupsCreationTime=0, StoreTimeTaken=0
9723 [main] INFO  org.apache.hudi.common.table.view.AbstractTableFileSystemView  - addFilesToView: NumFiles=2, NumFileGroups=2, FileGroupsCreationTime=1, StoreTimeTaken=0
9723 [main] INFO  org.apache.hudi.sync.common.util.ManifestFileWriter  - Writing base file names to manifest file: 3
[main] INFO com.snowflake.snowpark.internal.ServerConnection - Actively querying parameter QUERY_TAG from server.
[main] INFO com.snowflake.snowpark.internal.ServerConnection - Execute query [queryID: 01a47eb9-0000-8e15-0000-d09100066006] CREATE OR REPLACE STAGE stock_ticks_cow_stage url='gcs://hudi-demo/stock_ticks_cow' STORAGE_INTEGRATION = hudi_demo_int
------------------------------------------------------
|"status"                                            |
------------------------------------------------------
|Stage area STOCK_TICKS_COW_STAGE successfully c...  |
------------------------------------------------------

11467 [main] INFO  org.apache.hudi.snowflake.sync.HoodieSnowflakeSyncClient  - Manifest External table created.
11467 [main] INFO  org.apache.hudi.snowflake.sync.SnowflakeSyncTool  - External temporary stage creation complete for stock_ticks_cow_stage
[main] ERROR com.snowflake.snowpark.internal.ServerConnection - Failed to analyze schema of query:
 SELECT  *  FROM (stock_ticks_cow_manifest)
11662 [main] INFO  org.apache.hudi.snowflake.sync.HoodieSnowflakeSyncClient  - Table doesn't exist stock_ticks_cow_manifest
[main] INFO com.snowflake.snowpark.internal.ServerConnection - Execute query [queryID: 01a47eb9-0000-8e15-0000-d0910006600e] CREATE OR REPLACE EXTERNAL TABLE stock_ticks_cow_manifest (    filename VARCHAR AS split_part(VALUE:c1, '/', -1)  )WITH LOCATION = @stock_ticks_cow_stage/.hoodie/manifest/  FILE_FORMAT = (TYPE = CSV)  AUTO_REFRESH = False
------------------------------------------------------
|"status"                                            |
------------------------------------------------------
|Table STOCK_TICKS_COW_MANIFEST successfully cre...  |
------------------------------------------------------

12521 [main] INFO  org.apache.hudi.snowflake.sync.HoodieSnowflakeSyncClient  - Manifest External table created.
12521 [main] INFO  org.apache.hudi.snowflake.sync.SnowflakeSyncTool  - Manifest table creation complete for stock_ticks_cow_manifest
[main] ERROR com.snowflake.snowpark.internal.ServerConnection - Failed to analyze schema of query:
 SELECT  *  FROM (stock_ticks_cow_versions)
12741 [main] INFO  org.apache.hudi.snowflake.sync.HoodieSnowflakeSyncClient  - Table doesn't exist stock_ticks_cow_versions
[main] INFO com.snowflake.snowpark.internal.ServerConnection - Execute query [queryID: 01a47eb9-0000-8e17-0000-d0910006700a] CREATE OR REPLACE FILE FORMAT my_custom_file_format TYPE = 'PARQUET';
------------------------------------------------------
|"status"                                            |
------------------------------------------------------
|File format MY_CUSTOM_FILE_FORMAT successfully ...  |
------------------------------------------------------

[main] INFO com.snowflake.snowpark.internal.ServerConnection - Execute query [queryID: 01a47eb9-0000-8e02-0000-d0910006500a]  SELECT  *  FROM (SELECT  generate_column_description(array_agg(object_construct(*)), 'external_table') as columns FROM  table(    infer_schema(      location => '@stock_ticks_cow_stage',      file_format => 'my_custom_file_format'    ))) LIMIT 1
[main] INFO com.snowflake.snowpark.internal.ServerConnection - Execute query [queryID: 01a47eb9-0000-8e02-0000-d0910006500e] CREATE OR REPLACE EXTERNAL TABLE stock_ticks_cow_versions("_hoodie_file_name" TEXT AS ($1:_hoodie_file_name::TEXT),
"_hoodie_commit_time" TEXT AS ($1:_hoodie_commit_time::TEXT),
"_hoodie_partition_path" TEXT AS ($1:_hoodie_partition_path::TEXT),
"high" REAL AS ($1:high::REAL),
"low" REAL AS ($1:low::REAL),
"close" REAL AS ($1:close::REAL),
"day" TEXT AS ($1:day::TEXT),
"_hoodie_record_key" TEXT AS ($1:_hoodie_record_key::TEXT),
"_hoodie_commit_seqno" TEXT AS ($1:_hoodie_commit_seqno::TEXT),
"volume" NUMBER(38,  0) AS ($1:volume::NUMBER(38,  0)),
"symbol" TEXT AS ($1:symbol::TEXT),
"year" NUMBER(38,  0) AS ($1:year::NUMBER(38,  0)),
"ts" TEXT AS ($1:ts::TEXT),
"key" TEXT AS ($1:key::TEXT),
"month" TEXT AS ($1:month::TEXT),
"dummyint" NUMBER(38,  0) AS ($1:dummyint::NUMBER(38,  0)),
"open" REAL AS ($1:open::REAL), "date" date as to_date(substr(metadata$filename, 22, 10), 'YYYY-MM-DD')) PARTITION BY ("date")  WITH LOCATION = @stock_ticks_cow_stage  FILE_FORMAT = (TYPE = PARQUET)  PATTERN = '.*[.]parquet'  AUTO_REFRESH = false
------------------------------------------------------
|"status"                                            |
------------------------------------------------------
|Table STOCK_TICKS_COW_VERSIONS successfully cre...  |
------------------------------------------------------

17170 [main] INFO  org.apache.hudi.snowflake.sync.HoodieSnowflakeSyncClient  - External versions table created.
17170 [main] INFO  org.apache.hudi.snowflake.sync.SnowflakeSyncTool  - Versions table creation complete for stock_ticks_cow_versions
17721 [main] INFO  org.apache.hudi.snowflake.sync.SnowflakeSyncTool  - Sync table complete for stock_ticks_cow
[main] INFO com.snowflake.snowpark.Session - Closing session: {
 "snowpark.version" : "1.4.0",
 "java.version" : "1.8.0_282",
 "scala.version" : "2.12.11",
 "jdbc.session.id" : "229321189576710",
 "os.name" : "Mac OS X",
 "jdbc.version" : "3.13.14",
 "snowpark.library" : "/Users/vinothg/oss/dbt-spark/docker/jars/hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar",
 "scala.library" : "/Users/vinothg/oss/dbt-spark/docker/jars/hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar",
 "jdbc.library" : "/Users/vinothg/oss/dbt-spark/docker/jars/hudi-snowflake-bundle-0.12.0-SNAPSHOT-jar-with-dependencies.jar"
}
[main] INFO com.snowflake.snowpark.Session - Canceling all running query
[main] INFO com.snowflake.snowpark.internal.ServerConnection - Execute query [queryID: 01a47eb9-0000-8e17-0000-d09100067012] select system$cancel_all_queries(229321189576710)
```

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
