### PR TITLE
[HUDI-3193] Decouple hudi-aws from hudi-client-common

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/cloudwatch/CloudWatchReporter.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/cloudwatch/CloudWatchReporter.java
@@ -74,7 +74,7 @@ public class CloudWatchReporter extends ScheduledReporter {
   }
 
   public static class Builder {
-    private MetricRegistry registry;
+    private final MetricRegistry registry;
     private Clock clock;
     private String prefix;
     private TimeUnit rateUnit;

--- a/hudi-client/hudi-client-common/pom.xml
+++ b/hudi-client/hudi-client-common/pom.xml
@@ -40,6 +40,7 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-aws</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.metrics.HoodieMetricsCloudWatchConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsDatadogConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsGraphiteConfig;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsCloudWatchConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsCloudWatchConfig.java
@@ -7,16 +7,17 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
-package org.apache.hudi.config;
+package org.apache.hudi.config.metrics;
 
 import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
@@ -36,22 +37,22 @@ public class HoodieMetricsCloudWatchConfig extends HoodieConfig {
   public static final String CLOUDWATCH_PREFIX = "hoodie.metrics.cloudwatch";
 
   public static final ConfigProperty<Integer> REPORT_PERIOD_SECONDS = ConfigProperty
-          .key(CLOUDWATCH_PREFIX + ".report.period.seconds")
-          .defaultValue(60)
-          .sinceVersion("0.10.0")
-          .withDocumentation("Reporting interval in seconds");
+      .key(CLOUDWATCH_PREFIX + ".report.period.seconds")
+      .defaultValue(60)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Reporting interval in seconds");
 
   public static final ConfigProperty<String> METRIC_PREFIX = ConfigProperty
-          .key(CLOUDWATCH_PREFIX + ".metric.prefix")
-          .defaultValue("")
-          .sinceVersion("0.10.0")
-          .withDocumentation("Metric prefix of reporter");
+      .key(CLOUDWATCH_PREFIX + ".metric.prefix")
+      .defaultValue("")
+      .sinceVersion("0.10.0")
+      .withDocumentation("Metric prefix of reporter");
 
   public static final ConfigProperty<String> METRIC_NAMESPACE = ConfigProperty
-          .key(CLOUDWATCH_PREFIX + ".namespace")
-          .defaultValue("Hudi")
-          .sinceVersion("0.10.0")
-          .withDocumentation("Namespace of reporter");
+      .key(CLOUDWATCH_PREFIX + ".namespace")
+      .defaultValue("Hudi")
+      .sinceVersion("0.10.0")
+      .withDocumentation("Namespace of reporter");
   /*
   Amazon CloudWatch allows a maximum of 20 metrics per request. Choosing this as the default maximum.
   Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html
@@ -66,13 +67,13 @@ public class HoodieMetricsCloudWatchConfig extends HoodieConfig {
     super();
   }
 
-  public static HoodieMetricsCloudWatchConfig.Builder newBuilder() {
-    return new HoodieMetricsCloudWatchConfig.Builder();
+  static Builder newBuilder() {
+    return new Builder();
   }
 
-  public static class Builder {
+  static class Builder {
 
-    private HoodieMetricsCloudWatchConfig hoodieMetricsCloudWatchConfig = new HoodieMetricsCloudWatchConfig();
+    private final HoodieMetricsCloudWatchConfig hoodieMetricsCloudWatchConfig = new HoodieMetricsCloudWatchConfig();
 
     public HoodieMetricsCloudWatchConfig.Builder fromProperties(Properties props) {
       this.hoodieMetricsCloudWatchConfig.getProps().putAll(props);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.config.HoodieMetricsCloudWatchConfig;
 import org.apache.hudi.metrics.MetricsReporterType;
 
 import javax.annotation.concurrent.Immutable;

--- a/hudi-flink-datasource/hudi-flink/pom.xml
+++ b/hudi-flink-datasource/hudi-flink/pom.xml
@@ -91,6 +91,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-aws</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-flink-client</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
## What is the purpose of the pull request

This PR attempts to decouple `hudi-aws` from `hudi-client-common`. It is being used in two places:

1. During building of hoodie write config (metrics config) for commit executors or metadata writer.
2. During meta-sync in hudi-flink if sync mode uses Glue.

## Brief change log

* Make hudi-aws a runtime dependency in hudi-client-common and hudi-flink.
* Add builder for AwsGlueCatalogSyncTool.

## Verify this pull request

*(Please pick either of the following options)*

This PR is mainly refactoring and dependency changes and it should be covered with existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
