### PR TITLE
[MINOR] Fix the issue when handling conf hoodie.datasource.write.operation=bulk_insert in sql mode

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.types.StructType
 
 import java.util
 import java.util.Locale
+
 import scala.collection.JavaConverters._
 
 trait ProvidesHoodieConfig extends Logging {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hudi
 
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.common.config.TypedProperties
-import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload
+import org.apache.hudi.common.model.{OverwriteWithLatestAvroPayload, WriteOperationType}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
 import org.apache.hudi.config.{HoodieIndexConfig, HoodieWriteConfig}
@@ -40,7 +40,6 @@ import org.apache.spark.sql.types.StructType
 
 import java.util
 import java.util.Locale
-
 import scala.collection.JavaConverters._
 
 trait ProvidesHoodieConfig extends Logging {
@@ -129,7 +128,8 @@ trait ProvidesHoodieConfig extends Logging {
       .getOrElse(classOf[ComplexKeyGenerator].getCanonicalName)
 
     val enableBulkInsert = parameters.getOrElse(DataSourceWriteOptions.SQL_ENABLE_BULK_INSERT.key,
-      DataSourceWriteOptions.SQL_ENABLE_BULK_INSERT.defaultValue()).toBoolean
+      DataSourceWriteOptions.SQL_ENABLE_BULK_INSERT.defaultValue()).toBoolean ||
+      parameters.get(DataSourceWriteOptions.OPERATION.key).exists(_.equalsIgnoreCase(WriteOperationType.BULK_INSERT.value))
     val dropDuplicate = sparkSession.conf
       .getOption(INSERT_DROP_DUPS.key).getOrElse(INSERT_DROP_DUPS.defaultValue).toBoolean
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
Currently we only accept hoodie.sql.bulk.insert.enable to control whether bulk_insert is enabled or not in spark sql mode, so during building buildHoodieInsertConfig(https://github.com/apache/hudi/blob/f30b3aef3e5e12e9119d6b5294c94a0282719e00/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala#L97), we use this param to decide insert operation. But it could be overridden at last: https://github.com/apache/hudi/blob/f30b3aef3e5e12e9119d6b5294c94a0282719e00/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala#L177

So if we set hoodie.datasource.write.operation=bulk_insert, **enableBulkInset is still false**, and this will set ENABLE_ROW_WRITER to false too.
https://github.com/apache/hudi/blob/f30b3aef3e5e12e9119d6b5294c94a0282719e00/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala#L131
but method withSparkConf could override this, which change OPERATION.key back to bulk_insert
https://github.com/apache/hudi/blob/f30b3aef3e5e12e9119d6b5294c94a0282719e00/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala#L251

So as a result, the operation is still bulk insert, but doesn't use spark row writer.

## Brief change log
Here we accept both hoodie.sql.bulk.insert.enable and hoodie.datasource.write.operation=bulk_insert to control whether we should allow bulk insert or not in sql mode .

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
