### PR TITLE
[HUDI-4158] Add reader heartbeat for cleaning strategy

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -21,7 +21,7 @@ package org.apache.hudi.client;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
+import org.apache.hudi.client.heartbeat.WriterHeartbeat;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
@@ -49,7 +49,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
   protected final transient Configuration hadoopConf;
   protected final HoodieWriteConfig config;
   protected final String basePath;
-  protected final HoodieHeartbeatClient heartbeatClient;
+  protected final WriterHeartbeat writerHeartbeat;
 
   /**
    * Timeline Server has the same lifetime as that of Client. Any operations done on the same timeline service will be
@@ -72,7 +72,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
     this.config = clientConfig;
     this.timelineServer = timelineServer;
     shouldStopTimelineServer = !timelineServer.isPresent();
-    this.heartbeatClient = new HoodieHeartbeatClient(this.fs, this.basePath,
+    this.writerHeartbeat = new WriterHeartbeat(this.fs, this.basePath,
         clientConfig.getHoodieClientHeartbeatIntervalInMs(), clientConfig.getHoodieClientHeartbeatTolerableMisses());
     startEmbeddedServerView();
     initWrapperFSMetrics();
@@ -143,7 +143,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
     return timelineServer;
   }
 
-  public HoodieHeartbeatClient getHeartbeatClient() {
-    return heartbeatClient;
+  public WriterHeartbeat getWriterHeartbeat() {
+    return writerHeartbeat;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/ReaderHeartbeat.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/ReaderHeartbeat.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.heartbeat;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class creates heartbeat for hudi reader.
+ *
+ * <p>This heartbeat is used to ascertain whether an instant is currently consumed by reader.
+ * An instant can be seen as a consuming offset, the instant data files should not be cleaned if a reader
+ * is consuming from the instant.
+ */
+public class ReaderHeartbeat extends BaseHoodieHeartbeat {
+  private static final Logger LOG = LoggerFactory.getLogger(ReaderHeartbeat.class);
+
+  private static final String OFFSET_EARLIEST = "earliest";
+
+  private ReaderHeartbeat(FileSystem fs, String basePath,
+                         Long heartbeatIntervalInMs, Integer numTolerableHeartbeatMisses) {
+    super(fs, basePath, heartbeatIntervalInMs, numTolerableHeartbeatMisses);
+  }
+
+  public static ReaderHeartbeat create(FileSystem fs, HoodieWriteConfig writeConfig) {
+    return new ReaderHeartbeat(fs, writeConfig.getBasePath(), writeConfig.getHoodieReaderHeartbeatIntervalInMs(),
+        writeConfig.getHoodieReaderHeartbeatTolerableMisses());
+  }
+
+  // visible for testing
+  public static ReaderHeartbeat create(FileSystem fs, String basePath,
+                                       Long heartbeatIntervalInMs, Integer numTolerableHeartbeatMisses) {
+    return new ReaderHeartbeat(fs, basePath, heartbeatIntervalInMs, numTolerableHeartbeatMisses);
+  }
+
+  @Override
+  protected String getHeartbeatFolderPath(String basePath) {
+    return HoodieTableMetaClient.getReaderHeartbeatFolderPath(basePath);
+  }
+
+  @Override
+  protected void deleteHeartbeatFile(FileSystem fs, String basePath, String instantTime) {
+    HeartbeatUtils.deleteReaderHeartbeatFile(fs, basePath, instantTime);
+  }
+
+  @Override
+  public void stop(String instantTime) throws HoodieException {
+    super.stop(instantTime);
+    this.instantToHeartbeatMap.remove(instantTime);
+  }
+
+  public static Boolean heartbeatExists(FileSystem fs, String basePath, String instantTime) throws IOException {
+    Path heartbeatFilePath = new Path(HoodieTableMetaClient.getReaderHeartbeatFolderPath(basePath) + Path.SEPARATOR + instantTime);
+    return fs.exists(heartbeatFilePath);
+  }
+
+  public Heartbeats getValidReaderHeartbeats() {
+    List<String> allHeartbeatInstants = Collections.emptyList();
+    try {
+      allHeartbeatInstants = getAllExistingHeartbeatInstants();
+    } catch (IOException e) {
+      LOG.warn("Exception while fetching the existing heartbeat instants, ignore the heartbeats");
+    }
+    List<String> validHeartbeatInstants = allHeartbeatInstants.stream().filter(instant -> {
+      try {
+        return !isHeartbeatExpired(instant);
+      } catch (IOException e) {
+        e.printStackTrace();
+        return false;
+      }
+    }).collect(Collectors.toList());
+    return Heartbeats.create(validHeartbeatInstants);
+  }
+
+  // -------------------------------------------------------------------------
+  //  Inner Classes
+  // -------------------------------------------------------------------------
+  public static class Heartbeats {
+    private final List<String> instants;
+    private final boolean consumingFromEarliest;
+
+    private Heartbeats(List<String> instants) {
+      this.instants = new ArrayList<>(instants);
+      this.consumingFromEarliest = this.instants.contains(OFFSET_EARLIEST);
+      if (consumingFromEarliest) {
+        this.instants.remove(OFFSET_EARLIEST);
+      }
+      this.instants.sort(Comparator.naturalOrder());
+    }
+
+    public static Heartbeats create(List<String> instants) {
+      return new Heartbeats(instants);
+    }
+
+    public boolean isConsumingFromEarliest() {
+      return consumingFromEarliest;
+    }
+
+    public Option<String> getEarliestConsumingInstant() {
+      return instants.isEmpty() ? Option.empty() : Option.of(instants.get(0));
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/WriterHeartbeat.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/WriterHeartbeat.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.heartbeat;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * This class creates heartbeat for hudi client.
+ * This heartbeat is used to ascertain whether the running job is or not.
+ */
+public class WriterHeartbeat extends BaseHoodieHeartbeat {
+
+  public WriterHeartbeat(FileSystem fs, String basePath, Long heartbeatIntervalInMs,
+                         Integer numTolerableHeartbeatMisses) {
+    super(fs, basePath, heartbeatIntervalInMs, numTolerableHeartbeatMisses);
+  }
+
+  @Override
+  protected String getHeartbeatFolderPath(String basePath) {
+    return HoodieTableMetaClient.getWriterHeartbeatFolderPath(basePath);
+  }
+
+  @Override
+  protected void deleteHeartbeatFile(FileSystem fs, String basePath, String instantTime) {
+    HeartbeatUtils.deleteWriterHeartbeatFile(fs, basePath, instantTime);
+  }
+
+  public static Boolean heartbeatExists(FileSystem fs, String basePath, String instantTime) throws IOException {
+    Path heartbeatFilePath = new Path(HoodieTableMetaClient.getWriterHeartbeatFolderPath(basePath) + Path.SEPARATOR + instantTime);
+    return fs.exists(heartbeatFilePath);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -411,6 +411,18 @@ public class HoodieWriteConfig extends HoodieConfig {
       .defaultValue(2)
       .withDocumentation("Number of heartbeat misses, before a writer is deemed not alive and all pending writes are aborted.");
 
+  public static final ConfigProperty<Integer> READER_HEARTBEAT_INTERVAL_IN_MS = ConfigProperty
+      .key("hoodie.reader.heartbeat.interval_in_ms")
+      .defaultValue(60 * 1000)
+      .sinceVersion("0.11.1")
+      .withDocumentation("Readers perform heartbeats to indicate consuming offsets. Controls how often (in ms), such heartbeats are registered to lake storage.");
+
+  public static final ConfigProperty<Integer> READER_HEARTBEAT_NUM_TOLERABLE_MISSES = ConfigProperty
+      .key("hoodie.reader.heartbeat.tolerable.misses")
+      .defaultValue(2)
+      .sinceVersion("0.11.1")
+      .withDocumentation("Number of heartbeat misses, before a reader is deemed not alive and the consuming instant can be safely cleaned.");
+
   public static final ConfigProperty<String> WRITE_CONCURRENCY_MODE = ConfigProperty
       .key("hoodie.write.concurrency.mode")
       .defaultValue(WriteConcurrencyMode.SINGLE_WRITER.name())
@@ -1967,6 +1979,14 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES);
   }
 
+  public Long getHoodieReaderHeartbeatIntervalInMs() {
+    return getLong(READER_HEARTBEAT_INTERVAL_IN_MS);
+  }
+
+  public Integer getHoodieReaderHeartbeatTolerableMisses() {
+    return getInt(READER_HEARTBEAT_NUM_TOLERABLE_MISSES);
+  }
+
   /**
    * File listing metadata configs.
    */
@@ -2456,6 +2476,16 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withHeartbeatTolerableMisses(Integer heartbeatTolerableMisses) {
       writeConfig.setValue(CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES, String.valueOf(heartbeatTolerableMisses));
+      return this;
+    }
+
+    public Builder withReaderHeartbeatIntervalInMs(Integer heartbeatIntervalInMs) {
+      writeConfig.setValue(READER_HEARTBEAT_INTERVAL_IN_MS, String.valueOf(heartbeatIntervalInMs));
+      return this;
+    }
+
+    public Builder withReaderHeartbeatTolerableMisses(Integer heartbeatTolerableMisses) {
+      writeConfig.setValue(READER_HEARTBEAT_NUM_TOLERABLE_MISSES, String.valueOf(heartbeatTolerableMisses));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -20,7 +20,7 @@ package org.apache.hudi.table.action.rollback;
 
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
-import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
+import org.apache.hudi.client.heartbeat.WriterHeartbeat;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex;
@@ -176,7 +176,7 @@ public abstract class BaseRollbackActionExecutor<T extends HoodieRecordPayload, 
           && !commitTimeline.findInstantsAfter(instantTimeToRollback, Integer.MAX_VALUE).empty()) {
         // check if remnants are from a previous LAZY rollback config, if yes, let out of order rollback continue
         try {
-          if (!HoodieHeartbeatClient.heartbeatExists(table.getMetaClient().getFs(),
+          if (!WriterHeartbeat.heartbeatExists(table.getMetaClient().getFs(),
               config.getBasePath(), instantTimeToRollback)) {
             throw new HoodieRollbackException(
                 "Found commits after time :" + instantTimeToRollback + ", please rollback greater commits first");

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestReaderHeartbeat.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestReaderHeartbeat.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.heartbeat;
+
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link ReaderHeartbeat}.
+ */
+public class TestReaderHeartbeat extends HoodieCommonTestHarness {
+
+  @BeforeEach
+  public void init() throws IOException {
+    initMetaClient();
+  }
+
+  @Test
+  public void testIsHeartbeatExpired() {
+    ReaderHeartbeat readerHeartbeat = ReaderHeartbeat.create(metaClient.getFs(), metaClient.getBasePath(), 1000L, 1);
+    readerHeartbeat.start("100");
+    readerHeartbeat.stop("100");
+
+    readerHeartbeat.start("earliest");
+    readerHeartbeat.start("101");
+    readerHeartbeat.start("102");
+    readerHeartbeat.start("103");
+
+    ReaderHeartbeat.Heartbeats heartbeats = readerHeartbeat.getValidReaderHeartbeats();
+    assertTrue(heartbeats.isConsumingFromEarliest());
+    assertThat(heartbeats.getEarliestConsumingInstant().get(), is("101"));
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestWriterHeartbeat.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestWriterHeartbeat.java
@@ -31,7 +31,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
+public class TestWriterHeartbeat extends HoodieCommonTestHarness {
 
   private static String instantTime1 = "100";
   private static String instantTime2 = "101";
@@ -45,49 +45,49 @@ public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
 
   @Test
   public void testStartHeartbeat() throws IOException {
-    HoodieHeartbeatClient hoodieHeartbeatClient =
-        new HoodieHeartbeatClient(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
-    hoodieHeartbeatClient.start(instantTime1);
-    FileStatus [] fs = metaClient.getFs().listStatus(new Path(hoodieHeartbeatClient.getHeartbeatFolderPath()));
+    WriterHeartbeat writerHeartbeat =
+        new WriterHeartbeat(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
+    writerHeartbeat.start(instantTime1);
+    FileStatus [] fs = metaClient.getFs().listStatus(new Path(writerHeartbeat.getHeartbeatFolderPath()));
     assertTrue(fs.length == 1);
     assertTrue(fs[0].getPath().toString().contains(instantTime1));
   }
 
   @Test
   public void testStopHeartbeat() {
-    HoodieHeartbeatClient hoodieHeartbeatClient =
-        new HoodieHeartbeatClient(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
-    hoodieHeartbeatClient.start(instantTime1);
-    hoodieHeartbeatClient.stop(instantTime1);
-    await().atMost(5, SECONDS).until(() -> hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats() > 0);
-    Integer numHeartBeats = hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats();
+    WriterHeartbeat writerHeartbeat =
+        new WriterHeartbeat(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
+    writerHeartbeat.start(instantTime1);
+    writerHeartbeat.stop(instantTime1);
+    await().atMost(5, SECONDS).until(() -> writerHeartbeat.getHeartbeat(instantTime1).getNumHeartbeats() > 0);
+    Integer numHeartBeats = writerHeartbeat.getHeartbeat(instantTime1).getNumHeartbeats();
     assertTrue(numHeartBeats == 1);
   }
 
   @Test
   public void testIsHeartbeatExpired() throws IOException {
-    HoodieHeartbeatClient hoodieHeartbeatClient =
-        new HoodieHeartbeatClient(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
-    hoodieHeartbeatClient.start(instantTime1);
-    hoodieHeartbeatClient.stop(instantTime1);
-    assertFalse(hoodieHeartbeatClient.isHeartbeatExpired(instantTime1));
+    WriterHeartbeat writerHeartbeat =
+        new WriterHeartbeat(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
+    writerHeartbeat.start(instantTime1);
+    writerHeartbeat.stop(instantTime1);
+    assertFalse(writerHeartbeat.isHeartbeatExpired(instantTime1));
   }
 
   @Test
   public void testNumHeartbeatsGenerated() {
     Long heartBeatInterval = 5000L;
-    HoodieHeartbeatClient hoodieHeartbeatClient =
-        new HoodieHeartbeatClient(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
-    hoodieHeartbeatClient.start("100");
-    await().atMost(5, SECONDS).until(() -> hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats() >= 1);
+    WriterHeartbeat writerHeartbeat =
+        new WriterHeartbeat(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
+    writerHeartbeat.start("100");
+    await().atMost(5, SECONDS).until(() -> writerHeartbeat.getHeartbeat(instantTime1).getNumHeartbeats() >= 1);
   }
 
   @Test
-  public void testDeleteWrongHeartbeat() throws IOException {
-    HoodieHeartbeatClient hoodieHeartbeatClient =
-        new HoodieHeartbeatClient(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
-    hoodieHeartbeatClient.start(instantTime1);
-    hoodieHeartbeatClient.stop(instantTime1);
-    assertFalse(HeartbeatUtils.deleteHeartbeatFile(metaClient.getFs(), basePath, instantTime2));
+  public void testDeleteWrongHeartbeat() {
+    WriterHeartbeat writerHeartbeat =
+        new WriterHeartbeat(metaClient.getFs(), metaClient.getBasePath(), heartBeatInterval, numTolerableMisses);
+    writerHeartbeat.start(instantTime1);
+    writerHeartbeat.stop(instantTime1);
+    assertFalse(HeartbeatUtils.deleteWriterHeartbeatFile(metaClient.getFs(), basePath, instantTime2));
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -341,7 +341,7 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
           .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism());
       autoArchiveOnCommit(table, acquireLockForArchival);
     } finally {
-      this.heartbeatClient.stop(instantTime);
+      this.writerHeartbeat.stop(instantTime);
     }
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -142,7 +142,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
         // The metadata writer uses LAZY cleaning strategy without auto commit,
         // write client then checks the heartbeat expiration when committing the instant,
         // sets up the heartbeat explicitly to make the check pass.
-        writeClient.getHeartbeatClient().start(instantTime);
+        writeClient.getWriterHeartbeat().start(instantTime);
       }
 
       List<WriteStatus> statuses = preppedRecordList.size() > 0

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -2305,7 +2305,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     // Await till enough time passes such that the first 2 failed commits heartbeats are expired
     boolean conditionMet = false;
     while (!conditionMet) {
-      conditionMet = client.getHeartbeatClient().isHeartbeatExpired("300");
+      conditionMet = client.getWriterHeartbeat().isHeartbeatExpired("300");
       Thread.sleep(2000);
     }
     client = new SparkRDDWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, populateMetaFields));
@@ -2376,7 +2376,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     // Await till enough time passes such that the 2 failed commits heartbeats are expired
     boolean conditionMet = false;
     while (!conditionMet) {
-      conditionMet = client.getHeartbeatClient().isHeartbeatExpired("400");
+      conditionMet = client.getWriterHeartbeat().isHeartbeatExpired("400");
       Thread.sleep(2000);
     }
     client.clean();
@@ -2442,7 +2442,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     // Await till enough time passes such that the first 2 failed commits heartbeats are expired
     boolean conditionMet = false;
     while (!conditionMet) {
-      conditionMet = client.getHeartbeatClient().isHeartbeatExpired("300");
+      conditionMet = client.getWriterHeartbeat().isHeartbeatExpired("300");
       Thread.sleep(2000);
     }
     Future<JavaRDD<WriteStatus>> commit4 = service.submit(() -> writeBatch(new SparkRDDWriteClient(context, getParallelWritingWriteConfig(cleaningPolicy, true)),

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -205,7 +205,7 @@ public class TestCleaner extends HoodieClientTestBase {
     // Verify there are no errors
     assertNoWriteErrors(statuses.collect());
     // Don't invoke commit to simulate failed write
-    client.getHeartbeatClient().stop(newCommitTime);
+    client.getWriterHeartbeat().stop(newCommitTime);
     return Pair.of(newCommitTime, statuses);
   }
 
@@ -607,7 +607,7 @@ public class TestCleaner extends HoodieClientTestBase {
         insertFirstFailedBigBatchForClientCleanerTest(cfg, client, recordInsertGenWrappedFunction, insertFn,
         HoodieCleaningPolicy.KEEP_LATEST_COMMITS);
     // Await till enough time passes such that the last failed commits heartbeats are expired
-    await().atMost(10, TimeUnit.SECONDS).until(() -> client.getHeartbeatClient()
+    await().atMost(10, TimeUnit.SECONDS).until(() -> client.getWriterHeartbeat()
         .isHeartbeatExpired(ret.getLeft()));
     List<HoodieCleanStat> cleanStats = runCleaner(cfg);
     assertEquals(0, cleanStats.size(), "Must not clean any files");
@@ -1348,7 +1348,7 @@ public class TestCleaner extends HoodieClientTestBase {
           HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS);
 
       // Await till enough time passes such that the last failed commits heartbeats are expired
-      await().atMost(10, TimeUnit.SECONDS).until(() -> client.getHeartbeatClient()
+      await().atMost(10, TimeUnit.SECONDS).until(() -> client.getWriterHeartbeat()
           .isHeartbeatExpired(ret.getLeft()));
 
       List<HoodieCleanStat> cleanStats = runCleaner(cfg);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -86,6 +86,7 @@ public class HoodieTableMetaClient implements Serializable {
   public static final String AUXILIARYFOLDER_NAME = METAFOLDER_NAME + Path.SEPARATOR + ".aux";
   public static final String BOOTSTRAP_INDEX_ROOT_FOLDER_PATH = AUXILIARYFOLDER_NAME + Path.SEPARATOR + ".bootstrap";
   public static final String HEARTBEAT_FOLDER_NAME = METAFOLDER_NAME + Path.SEPARATOR + ".heartbeat";
+  public static final String READER_HEARTBEAT_FOLDER_NAME = HEARTBEAT_FOLDER_NAME + Path.SEPARATOR + ".reader";
   public static final String METADATA_TABLE_FOLDER_PATH = METAFOLDER_NAME + Path.SEPARATOR + "metadata";
   public static final String HASHING_METADATA_FOLDER_NAME = ".bucket_index" + Path.SEPARATOR + "consistent_hashing_metadata";
   public static final String BOOTSTRAP_INDEX_BY_PARTITION_FOLDER_PATH = BOOTSTRAP_INDEX_ROOT_FOLDER_PATH
@@ -247,10 +248,17 @@ public class HoodieTableMetaClient implements Serializable {
   }
 
   /**
-   * @return Heartbeat folder path.
+   * @return Writer heartbeat folder path.
    */
-  public static String getHeartbeatFolderPath(String basePath) {
+  public static String getWriterHeartbeatFolderPath(String basePath) {
     return String.format("%s%s%s", basePath, Path.SEPARATOR, HEARTBEAT_FOLDER_NAME);
+  }
+
+  /**
+   * @return Reader heartbeat folder path.
+   */
+  public static String getReaderHeartbeatFolderPath(String basePath) {
+    return String.format("%s%s%s", basePath, Path.SEPARATOR, READER_HEARTBEAT_FOLDER_NAME);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -183,7 +183,7 @@ public class HoodieTableSource implements
           StreamReadMonitoringFunction monitoringFunction = new StreamReadMonitoringFunction(
               conf, FilePathUtils.toFlinkPath(path), maxCompactionMemoryInBytes, getRequiredPartitionPaths());
           InputFormat<RowData, ?> inputFormat = getInputFormat(true);
-          OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory((MergeOnReadInputFormat) inputFormat);
+          OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory(conf, (MergeOnReadInputFormat) inputFormat);
           SingleOutputStreamOperator<RowData> source = execEnv.addSource(monitoringFunction, getSourceOperatorName("split_monitor"))
               .setParallelism(1)
               .keyBy(inputSplit -> inputSplit.getFileId())

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -21,6 +21,7 @@ package org.apache.hudi.util;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.client.heartbeat.ReaderHeartbeat;
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;
@@ -524,5 +525,13 @@ public class StreamerUtil {
   public static Schema getTableAvroSchema(HoodieTableMetaClient metaClient, boolean includeMetadataFields) throws Exception {
     TableSchemaResolver schemaUtil = new TableSchemaResolver(metaClient);
     return schemaUtil.getTableAvroSchema(includeMetadataFields);
+  }
+
+  /**
+   * Creates a reader heartbeat client with given configuration.
+   */
+  public static ReaderHeartbeat createReaderHeartbeat(Configuration conf) {
+    FileSystem fs = FSUtils.getFs(conf.getString(FlinkOptions.PATH), HadoopConfigurations.getHadoopConf(conf));
+    return ReaderHeartbeat.create(fs, getHoodieClientConfig(conf, false));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadOperator.java
@@ -270,7 +270,7 @@ public class TestStreamReadOperator {
         .emitDelete(true)
         .build();
 
-    OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory(inputFormat);
+    OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory(conf, inputFormat);
     OneInputStreamOperatorTestHarness<MergeOnReadInputSplit, RowData> harness = new OneInputStreamOperatorTestHarness<>(
         factory, 1, 1, 0);
     harness.getStreamConfig().setTimeCharacteristic(TimeCharacteristic.ProcessingTime);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Nowadays, more and more users use hudi as a pipeline storage(something like Apache Kafka), for streaming read or for incremental read. One important property for queue consumption is the data TTL, in case of consumption latency, the storage needs some mechanism to avoid exception while the readers read latency out of the TTL.

Say Kafka has a strategy for their consumers, if people configure their TTL as 7 days, and one consumer consumes records before that time because it can not catch up with the producer. Kafka can give some strategies here:

1. read directly from the latest offset
2. throws error

While hudi has two problems for this scenario here:

1. we can not configure the TTL as 7 days like Kafka for two reasons:
    1.1 the archiving/cleaning strategy force the clean retain commits number must be greater than the archiving min commits,
     this restriction means a 7 days TTL(if we configure num commits cleaning strategy), would result in too many metadata 
     files on the active timeline, which is a pressure for the storage and for scanning performance
    1.2 the data files are multi versioned, 7 days means there are too many redundant data files for the data set, which would  
    cost too much money
2. while the consumer is consuming a file but the cleaner removes it, a FileNotFoundException throws but no good way to 
    recover the job.

## Brief change log


## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
