### PR TITLE
[HUDI-4165] Support Create/Show/Drop Index for Spark SQL

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/index/SecondaryIndexField.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/SecondaryIndexField.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.index;
+
+public class SecondaryIndexField {
+  private String indexName;
+  private String indexColumn;
+  private SecondaryIndexType indexType;
+
+  public SecondaryIndexField() {
+  }
+
+  public SecondaryIndexField(String indexName, String indexColumn, SecondaryIndexType indexType) {
+    this.indexName = indexName;
+    this.indexColumn = indexColumn;
+    this.indexType = indexType;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String getIndexColumn() {
+    return indexColumn;
+  }
+
+  public SecondaryIndexType getIndexType() {
+    return indexType;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String toString() {
+    return "SecondaryIndexField{"
+        + "indexName='" + indexName + '\''
+        + ", indexColumn='" + indexColumn + '\''
+        + ", indexType=" + indexType
+        + '}';
+  }
+
+  public static class Builder {
+    private String indexName;
+    private String indexColumn;
+    private SecondaryIndexType indexType;
+
+    public Builder setIndexName(String indexName) {
+      this.indexName = indexName;
+      return this;
+    }
+
+    public Builder setIndexColumn(String indexColumn) {
+      this.indexColumn = indexColumn;
+      return this;
+    }
+
+    public Builder setIndexType(String indexType) {
+      this.indexType = SecondaryIndexType.of(indexType);
+      return this;
+    }
+
+    public SecondaryIndexField build() {
+      return new SecondaryIndexField(indexName, indexColumn, indexType);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/SecondaryIndexType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/SecondaryIndexType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.index;
+
+import org.apache.hudi.exception.HoodieSecondaryIndexException;
+
+import java.util.Arrays;
+
+public enum SecondaryIndexType {
+  LUCENE((byte) 1);
+
+  private final byte type;
+
+  SecondaryIndexType(byte type) {
+    this.type = type;
+  }
+
+  public byte getValue() {
+    return type;
+  }
+
+  public static SecondaryIndexType of(byte indexType) {
+    return Arrays.stream(SecondaryIndexType.values())
+        .filter(t -> t.type == indexType)
+        .findAny()
+        .orElseThrow(() ->
+            new HoodieSecondaryIndexException("Unknown secondary index type:" + indexType)
+        );
+  }
+
+  public static SecondaryIndexType of(String indexType) {
+    return Arrays.stream(SecondaryIndexType.values())
+        .filter(t -> t.name().equals(indexType.toUpperCase()))
+        .findAny()
+        .orElseThrow(() ->
+            new HoodieSecondaryIndexException("Unknown secondary index type:" + indexType)
+        );
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -44,14 +44,14 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.TableNotFoundException;
+import org.apache.hudi.hadoop.CachingPath;
+import org.apache.hudi.hadoop.SerializablePath;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.apache.hudi.hadoop.CachingPath;
-import org.apache.hudi.hadoop.SerializablePath;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -741,6 +741,7 @@ public class HoodieTableMetaClient implements Serializable {
     private Boolean shouldDropPartitionColumns;
     private String metadataPartitions;
     private String inflightMetadataPartitions;
+    private String secondaryIndexFields;
 
     /**
      * Persist the configs that is written at the first time, and should not be changed.
@@ -875,6 +876,11 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
+    public PropertyBuilder setSecondaryIndexFields(String secondaryIndexFields) {
+      this.secondaryIndexFields = secondaryIndexFields;
+      return this;
+    }
+
     public PropertyBuilder set(String key, Object value) {
       if (HoodieTableConfig.PERSISTED_CONFIG_LIST.contains(key)) {
         this.others.put(key, value);
@@ -883,7 +889,7 @@ public class HoodieTableMetaClient implements Serializable {
     }
 
     public PropertyBuilder set(Map<String, Object> props) {
-      for (String key: HoodieTableConfig.PERSISTED_CONFIG_LIST) {
+      for (String key : HoodieTableConfig.PERSISTED_CONFIG_LIST) {
         Object value = props.get(key);
         if (value != null) {
           set(key, value);
@@ -982,6 +988,9 @@ public class HoodieTableMetaClient implements Serializable {
       if (hoodieConfig.contains(HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT)) {
         setInflightMetadataPartitions(hoodieConfig.getString(HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT));
       }
+      if (hoodieConfig.contains(HoodieTableConfig.SECONDARY_INDEX_FIELDS)) {
+        setSecondaryIndexFields(hoodieConfig.getString(HoodieTableConfig.SECONDARY_INDEX_FIELDS));
+      }
       return this;
     }
 
@@ -1071,6 +1080,9 @@ public class HoodieTableMetaClient implements Serializable {
       }
       if (null != inflightMetadataPartitions) {
         tableConfig.setValue(HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT, inflightMetadataPartitions);
+      }
+      if (null != secondaryIndexFields) {
+        tableConfig.setValue(HoodieTableConfig.SECONDARY_INDEX_FIELDS, secondaryIndexFields);
       }
       return tableConfig.getProps();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieSecondaryIndexException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieSecondaryIndexException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.exception;
+
+public class HoodieSecondaryIndexException extends HoodieException {
+  public HoodieSecondaryIndexException() {
+    super();
+  }
+
+  public HoodieSecondaryIndexException(String message) {
+    super(message);
+  }
+
+  public HoodieSecondaryIndexException(String message, Throwable t) {
+    super(message, t);
+  }
+
+  public HoodieSecondaryIndexException(Throwable t) {
+    super(t);
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateIndex.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * The logical plan for CREATE INDEX command
+ *
+ * The syntax of this command is:
+ * {{{
+ *   CREATE INDEX indexName ON table (col) AS indexType
+ * }}}
+ *
+ */
+case class CreateIndex(
+    indexName: String,
+    table: LogicalPlan,
+    indexColumn: String,
+    indexType: String,
+    override val output: Seq[Attribute] = CreateIndex.getOutputAttrs)
+    extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): CreateIndex = {
+    copy(table = newChildren.head)
+  }
+}
+
+object CreateIndex {
+  def getOutputAttrs: Seq[Attribute] = Seq.empty
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DropIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DropIndex.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * The logical plan for DROP INDEX command
+ *
+ * The syntax of this command is:
+ * {{{
+ *   DROP INDEX indexName ON table
+ * }}}
+ */
+case class DropIndex(
+    indexName: String,
+    table: LogicalPlan,
+    override val output: Seq[Attribute] = DropIndex.getOutputAttrs)
+    extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): DropIndex = {
+    copy(table = newChildren.head)
+  }
+}
+
+object DropIndex {
+  def getOutputAttrs: Seq[Attribute] = Seq.empty
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ShowIndexes.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ShowIndexes.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.StringType
+
+/**
+ * The logical plan for SHOW INDEXES command
+ *
+ * The syntax of this command is:
+ * {{{
+ *   SHOW INDEXES (FROM | IN) table
+ * }}}
+ */
+case class ShowIndexes(
+    table: LogicalPlan,
+    override val output: Seq[Attribute] = ShowIndexes.getOutputAttrs)
+    extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): ShowIndexes = {
+    copy(table = newChildren.head)
+  }
+}
+
+object ShowIndexes {
+  def getOutputAttrs: Seq[Attribute] = Seq(
+    AttributeReference("index_name", StringType, nullable = false)(),
+    AttributeReference("col_name", StringType, nullable = false)(),
+    AttributeReference("index_type", StringType, nullable = false)()
+  )
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/index/SecondaryIndexBaseCmd.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/index/SecondaryIndexBaseCmd.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import com.fasterxml.jackson.annotation.{JsonAutoDetect, PropertyAccessor}
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import org.apache.hadoop.fs.Path
+import org.apache.hudi.common.index.SecondaryIndexField
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.exception.HoodieSecondaryIndexException
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.getTableLocation
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+
+import java.util.Properties
+import scala.collection.JavaConversions
+
+trait SecondaryIndexBaseCmd extends Logging {
+
+  def createSecondaryIndex(
+      sparkSession: SparkSession,
+      indexName: String,
+      tableId: TableIdentifier,
+      colName: String,
+      indexType: String): Seq[InternalRow] = {
+    val metaClient = createHoodieTableMetaClient(tableId, sparkSession)
+    val indexFields = toScalaOption(metaClient.getTableConfig.getSecondaryIndexFields)
+    if (indexExists(indexFields, indexName, Some(colName))) {
+      throw new HoodieSecondaryIndexException("Secondary index already exists:" + indexName)
+    }
+
+    val newIndexField = SecondaryIndexField.builder()
+        .setIndexName(indexName)
+        .setIndexColumn(colName)
+        .setIndexType(indexType)
+        .build()
+
+    val newIndexFields = indexFields.map(_ :+ newIndexField).getOrElse(Array(newIndexField))
+    val updatedProps = new Properties()
+    updatedProps.put(HoodieTableConfig.SECONDARY_INDEX_FIELDS.key(),
+      getObjectMapper.writeValueAsString(newIndexFields.sortBy(_.getIndexName)))
+    HoodieTableConfig.update(metaClient.getFs, new Path(metaClient.getMetaPath), updatedProps)
+    logInfo(s"Success to create secondary index: $newIndexField")
+
+    Seq.empty
+  }
+
+  def showSecondaryIndexes(
+      sparkSession: SparkSession,
+      tableId: TableIdentifier): Seq[InternalRow] = {
+    val metaClient = createHoodieTableMetaClient(tableId, sparkSession)
+    val indexFields = metaClient.getTableConfig.getSecondaryIndexFields
+
+    toScalaOption(indexFields).map(_.map(i =>
+      InternalRow(
+        UTF8String.fromString(i.getIndexName),
+        UTF8String.fromString(i.getIndexColumn),
+        UTF8String.fromString(i.getIndexType.name().toLowerCase)
+      )
+    ).toSeq).getOrElse(Seq.empty[InternalRow])
+  }
+
+  def dropSecondaryIndex(
+      sparkSession: SparkSession,
+      indexName: String,
+      tableId: TableIdentifier): Seq[InternalRow] = {
+    val metaClient = createHoodieTableMetaClient(tableId, sparkSession)
+    val indexFields = toScalaOption(metaClient.getTableConfig.getSecondaryIndexFields)
+    if (!indexExists(indexFields, indexName)) {
+      throw new HoodieSecondaryIndexException("Secondary index not exists:" + indexName)
+    }
+
+    val indexFieldsToKeep =
+      indexFields.map(_.filter(!_.getIndexName.equals(indexName))).filter(!_.isEmpty)
+    if (indexFieldsToKeep.nonEmpty) {
+      val updatedProps = new Properties()
+      updatedProps.put(HoodieTableConfig.SECONDARY_INDEX_FIELDS.key(),
+        getObjectMapper.writeValueAsString(indexFieldsToKeep.get.sortBy(_.getIndexName)))
+      HoodieTableConfig.update(metaClient.getFs, new Path(metaClient.getMetaPath), updatedProps)
+    } else {
+      HoodieTableConfig.delete(metaClient.getFs, new Path(metaClient.getMetaPath),
+        JavaConversions.setAsJavaSet(Set(HoodieTableConfig.SECONDARY_INDEX_FIELDS.key())))
+    }
+
+    // TODO: need to delete index files safely(index files maybe used by running queries)
+    logInfo(s"Success to drop secondary index: ${indexName}")
+
+    Seq.empty
+  }
+
+  /**
+   * Create hoodie table meta client according to given table identifier and
+   * spark session
+   *
+   * @param tableId      The table identifier
+   * @param sparkSession The spark session
+   * @return The hoodie table meta client
+   */
+  def createHoodieTableMetaClient(
+      tableId: TableIdentifier,
+      sparkSession: SparkSession): HoodieTableMetaClient = {
+    val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(tableId)
+    val basePath = getTableLocation(catalogTable, sparkSession)
+
+    HoodieTableMetaClient.builder()
+        .setConf(sparkSession.sqlContext.sparkContext.hadoopConfiguration)
+        .setBasePath(basePath)
+        .build()
+  }
+
+  /**
+   * Check secondary index exists. In secondary index definition, index name
+   * must be unique, so the index name will be checked firstly,
+   *
+   * @param indexFields Current secondary indexes
+   * @param indexName   The index name to check
+   * @param indexColumn The column name to check
+   * @return true if the secondary index exists
+   */
+  def indexExists(
+      indexFields: Option[Array[SecondaryIndexField]],
+      indexName: String,
+      indexColumn: Option[String] = None): Boolean = {
+    indexFields.exists(i => {
+      i.exists(_.getIndexName.equals(indexName)) ||
+          // Column name need to be checked if it's given
+          indexColumn.exists(column => i.exists(_.getIndexColumn.equals(column)))
+    })
+  }
+
+  protected def toScalaOption[T](opt: org.apache.hudi.common.util.Option[T]): Option[T] =
+    if (opt.isPresent) Some(opt.get) else None
+
+  protected def getObjectMapper: ObjectMapper = {
+    val mapper = new ObjectMapper
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+    mapper
+  }
+
+  def toStructType: Seq[Attribute] => StructType = (attrs: Seq[Attribute]) =>
+    StructType(attrs.map(f => StructField(f.name, f.dataType, f.nullable, f.metadata)).toArray)
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSparkSessionExtension.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/HoodieSparkSessionExtension.scala
@@ -48,5 +48,11 @@ class HoodieSparkSessionExtension extends (SparkSessionExtensions => Unit)
         rule(session)
       }
     }
+
+    HoodieAnalysis.extraPlanStrategies().foreach { strategy =>
+      extensions.injectPlannerStrategy { session =>
+        strategy(session)
+      }
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/CreateIndexCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/CreateIndexCommand.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand
+import org.apache.spark.sql.{Row, SparkSession}
+
+case class CreateIndexCommand(
+    indexName: String,
+    tableId: TableIdentifier,
+    colName: String,
+    indexType: String,
+    override val output: Seq[Attribute])
+    extends HoodieLeafRunnableCommand with SecondaryIndexBaseCmd {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val structType = toStructType.apply(output)
+    createSecondaryIndex(sparkSession, indexName, tableId, colName, indexType).map(i =>
+      Row.fromSeq(i.toSeq(structType))
+    )
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/DropIndexCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/DropIndexCommand.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand
+import org.apache.spark.sql.{Row, SparkSession}
+
+case class DropIndexCommand(
+    indexName: String,
+    tableId: TableIdentifier,
+    override val output: Seq[Attribute])
+    extends HoodieLeafRunnableCommand with SecondaryIndexBaseCmd {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val structType = toStructType.apply(output)
+    dropSecondaryIndex(sparkSession, indexName, tableId).map(i =>
+      Row.fromSeq(i.toSeq(structType))
+    )
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/ShowIndexesCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/index/ShowIndexesCommand.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand
+import org.apache.spark.sql.{Row, SparkSession}
+
+case class ShowIndexesCommand(
+    tableId: TableIdentifier,
+    override val output: Seq[Attribute])
+    extends HoodieLeafRunnableCommand with SecondaryIndexBaseCmd {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val structType = toStructType.apply(output)
+    showSecondaryIndexes(sparkSession, tableId).map(i =>
+      Row.fromSeq(i.toSeq(structType))
+    )
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -46,6 +46,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
         spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
         spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
         spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+        spark.sql(s"select version()").show()
         checkAnswer(s"show indexes from default.$tableName")()
 
         checkAnswer(s"create index idx_name on $tableName (name) as lucene")()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.hudi.{HoodieSparkSqlTestBase}
+
+class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+  test("Test Create/Show/Drop Secondary Index") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by(ts)
+             | location '$basePath'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+        checkAnswer(s"show indexes from default.$tableName")()
+
+        checkAnswer(s"create index idx_name on $tableName (name) as lucene")()
+        checkAnswer(s"create index idx_price on $tableName (price) as lucene")()
+
+        checkException(s"create index idx_price on $tableName (price) as lucene")("Secondary index already exists:idx_price")
+        checkException(s"create index idx_price_1 on $tableName (price) as lucene")("Secondary index already exists:idx_price_1")
+
+        spark.sql(s"show indexes from $tableName").show()
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("idx_name", "name", "lucene"),
+          Seq("idx_price", "price", "lucene")
+        )
+
+        checkAnswer(s"drop index idx_name on $tableName")()
+        checkException(s"drop index idx_name on $tableName")("Secondary index not exists:idx_name")
+
+        spark.sql(s"show indexes from $tableName").show()
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("idx_price", "price", "lucene")
+        )
+
+        checkAnswer(s"drop index idx_price on $tableName")()
+        checkAnswer(s"show indexes from $tableName")()
+
+        checkException(s"drop index idx_price on $tableName")("Secondary index not exists:idx_price")
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark2/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark2/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlBase.g4
@@ -27,6 +27,11 @@ statement
     : mergeInto                                                        #mergeIntoTable
     | updateTableStmt                                                  #updateTable
     | deleteTableStmt                                                  #deleteTable
+    | CREATE INDEX indexName=identifier
+          ON tableIdentifier ('(' indexColumn=identifier ')')
+          AS indexType=identifier                                      #createIndex
+    | SHOW INDEXES (FROM | IN) tableIdentifier                         #showIndex
+    | DROP INDEX indexName=identifier ON tableIdentifier               #dropIndex
     | .*?                                                              #passThrough
     ;
 

--- a/hudi-spark-datasource/hudi-spark3/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlBase.g4
@@ -29,5 +29,10 @@ statement
     | createTableHeader ('(' colTypeList ')')? tableProvider?
         createTableClauses
         (AS? query)?                                                   #createTable
+    | CREATE INDEX indexName=identifier
+          ON multipartIdentifier ('(' indexColumn=identifier ')')
+          AS indexType=identifier                                      #createIndex
+    | SHOW INDEXES (FROM | IN) multipartIdentifier                     #showIndex
+    | DROP INDEX indexName=identifier ON multipartIdentifier           #dropIndex
     | .*?                                                              #passThrough
     ;

--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
@@ -80,6 +80,7 @@ case class HoodieInternalV2Table(spark: SparkSession,
     }.toArray
   }
 
+  lazy val getTableIdentifier: TableIdentifier = hoodieCatalogTable.table.identifier
 }
 
 private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,

--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/HoodieSpark3PlanStrategy.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/HoodieSpark3PlanStrategy.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.execution
+
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable
+import org.apache.spark.sql.catalyst.plans.logical.{CreateIndex, DropIndex, LogicalPlan, ShowIndexes}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
+import org.apache.spark.sql.hudi.execution.datasources.{CreateIndexExec, DropIndexExec, ShowIndexesExec}
+import org.apache.spark.sql.{SparkSession, Strategy}
+
+class HoodieSpark3PlanStrategy(session: SparkSession) extends Strategy with SparkAdapterSupport {
+
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case CreateIndex(indexName, t@ResolvedTable(_, _, table, _), colName, indexType, output)
+      if t.resolved && table.isInstanceOf[HoodieInternalV2Table] =>
+      val tableId = table.asInstanceOf[HoodieInternalV2Table].getTableIdentifier
+      CreateIndexExec(indexName, tableId, colName, indexType, output) :: Nil
+
+    case ShowIndexes(t@ResolvedTable(_, _, table, _), output)
+      if t.resolved && table.isInstanceOf[HoodieInternalV2Table] =>
+      val tableId = table.asInstanceOf[HoodieInternalV2Table].getTableIdentifier
+      ShowIndexesExec(tableId, output) :: Nil
+
+    case DropIndex(indexName, t@ResolvedTable(_, _, table, _), output)
+      if t.resolved && table.isInstanceOf[HoodieInternalV2Table] =>
+      val tableId = table.asInstanceOf[HoodieInternalV2Table].getTableIdentifier
+      DropIndexExec(indexName, tableId, output) :: Nil
+
+    case _ => Nil
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/datasources/CreateIndexExec.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/datasources/CreateIndexExec.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.execution.datasources
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
+import org.apache.spark.sql.hudi.command.index.SecondaryIndexBaseCmd
+
+/**
+ * Physical plan node for create index
+ */
+case class CreateIndexExec(
+    indexName: String,
+    tableId: TableIdentifier,
+    colName: String,
+    indexType: String,
+    override val output: Seq[Attribute])
+    extends LeafV2CommandExec with SecondaryIndexBaseCmd {
+
+  override protected def run(): Seq[InternalRow] = {
+    createSecondaryIndex(session, indexName, tableId, colName, indexType)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/datasources/DropIndexExec.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/datasources/DropIndexExec.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.execution.datasources
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
+import org.apache.spark.sql.hudi.command.index.SecondaryIndexBaseCmd
+
+/**
+ * Physical plan node for drop index
+ */
+case class DropIndexExec(
+    indexName: String,
+    tableId: TableIdentifier,
+    override val output: Seq[Attribute])
+    extends LeafV2CommandExec with SecondaryIndexBaseCmd {
+
+  override protected def run(): Seq[InternalRow] = {
+    dropSecondaryIndex(session, indexName, tableId)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/datasources/ShowIndexesExec.scala
+++ b/hudi-spark-datasource/hudi-spark3/src/main/scala/org/apache/spark/sql/hudi/execution/datasources/ShowIndexesExec.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.execution.datasources
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
+import org.apache.spark.sql.hudi.command.index.SecondaryIndexBaseCmd
+
+/**
+ * Physical plan node for show indexes
+ */
+case class ShowIndexesExec(
+    tableId: TableIdentifier,
+    override val output: Seq[Attribute])
+    extends LeafV2CommandExec with SecondaryIndexBaseCmd {
+
+  override protected def run(): Seq[InternalRow] = {
+    showSecondaryIndexes(session, tableId)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Support Create/Show/Drop Index for Spark SQL
```
-- Create index on specific column
CREATE INDEX indexName ON table (col) AS indexType

-- Show indexes from specific table
SHOW INDEXES (FROM | IN) table

-- Drop specific index
DROP INDEX indexName ON table 
```

Reference：

Hive sql index syntax：
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/AlterIndex
 

MySQL index syntax：
https://dev.mysql.com/doc/refman/8.0/en/create-index.html
https://dev.mysql.com/doc/refman/8.0/en/show-index.html
https://dev.mysql.com/doc/refman/8.0/en/drop-index.html

## Brief change log

- Add ``CreateIndex/CreateIndexCommand/CreateIndexExec/ShowIndexes/ShowIndexesCommand/ShowIndexesExec/DropIndex/DropIndexCommand/DropIndexExec``
- Add ``HoodieSpark3PlanStrategy``
- Modify ``HoodieAnalaysis/*AstBuilder``
- Add ``TestSecondaryIndex``

## Verify this pull request

  - *Added TestSecondaryIndex to verify the change.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
