### PR TITLE
[HUDI-4166] Added SimpleClient plugin for integ test bundle

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -174,6 +174,12 @@
                   <include>org.apache.curator:curator-framework</include>
                   <include>org.apache.curator:curator-client</include>
                   <include>org.apache.curator:curator-recipes</include>
+
+                  <include>io.prometheus:simpleclient</include>
+                  <include>io.prometheus:simpleclient_httpserver</include>
+                  <include>io.prometheus:simpleclient_dropwizard</include>
+                  <include>io.prometheus:simpleclient_pushgateway</include>
+                  <include>io.prometheus:simpleclient_common</include>
                 </includes>
               </artifactSet>
               <relocations>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*To enable the pushgetway for Hudi metrics*

## Brief change log


  - *Added simpleclient artifactset for hudi-integ-test-bundle/pom.xml*

## Verify this pull request


This change added tests and can be verified as follows:
  - *Run the test for integ test bundle and build the jar*
  - *setup the prometheus/pushgsteway*
  - *Run the integ test , you should be able to see the hudi metrics without any issue .

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
