### PR TITLE
[HUDI-4177] Fix hudi-cli rollback with rollbackUsingMarkers method call

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -451,7 +451,7 @@ public class SparkMain {
   }
 
   private static int rollback(JavaSparkContext jsc, String instantTime, String basePath, Boolean rollbackUsingMarkers) throws Exception {
-    SparkRDDWriteClient client = createHoodieClient(jsc, basePath, rollbackUsingMarkers);
+    SparkRDDWriteClient client = createHoodieClient(jsc, basePath, rollbackUsingMarkers, false);
     if (client.rollback(instantTime)) {
       LOG.info(String.format("The commit \"%s\" rolled back.", instantTime));
       return 0;

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
@@ -125,5 +125,22 @@ public class ITTestCommitsCommand extends HoodieCLIIntegrationTestBase {
 
     HoodieActiveTimeline timeline2 = metaClient.reloadActiveTimeline();
     assertEquals(1, timeline2.getCommitsTimeline().countInstants(), "There should have 1 instants.");
+
+    // rollback with rollbackUsingMarkers==false
+    CommandResult cr3 = getShell().executeCommand(
+        String.format("commit rollback --commit %s --rollbackUsingMarkers false --sparkMaster %s --sparkMemory %s",
+        "100", "local", "4G"));
+
+    assertAll("Command run failed",
+        () -> assertTrue(cr3.isSuccess()),
+        () -> assertEquals("Commit 100 rolled back", cr3.getResult().toString()));
+
+    metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
+
+    HoodieActiveTimeline rollbackTimeline3 = new RollbacksCommand.RollbackTimeline(metaClient);
+    assertEquals(3, rollbackTimeline3.getRollbackTimeline().countInstants(), "There should have 3 rollback instant.");
+
+    HoodieActiveTimeline timeline3 = metaClient.reloadActiveTimeline();
+    assertEquals(0, timeline3.getCommitsTimeline().countInstants(), "There should have 0 instants.");
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fix hudi-cli rollback failure with rollbackUsingMarkers option

## Brief change log

*(for example:)*
  - Call the correct method in SparkMain when rollbackUsingMarkers option is provided

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
