### PR TITLE
[HUDI-4168] Add Call Procedure for marker deletion

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -45,7 +45,7 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
     val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
-    val basePath: String = getBasePath(tableName)
+    val basePath = getBasePath(tableName)
 
     val result = Try {
       val client = createHoodieClient(jsc, basePath)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi.command.procedures
 
+import org.apache.hudi.common.engine.HoodieEngineContext
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.table.marker.WriteMarkersFactory
 import org.apache.spark.internal.Logging
@@ -51,7 +52,7 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
       val client = createHoodieClient(jsc, basePath)
       val config = client.getConfig
       val context = client.getEngineContext
-      val table = HoodieSparkTable.create(config, context, true)
+      val table = HoodieSparkTable.create(config, context : HoodieEngineContext, true)
       WriteMarkersFactory.get(config.getMarkersType, table, instantTime)
         .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism)
     } match {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -17,11 +17,7 @@
 
 package org.apache.spark.sql.hudi.command.procedures
 
-import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.engine.HoodieEngineContext
-import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion
-import org.apache.hudi.common.util.Option
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.table.marker.WriteMarkersFactory
 import org.apache.spark.internal.Logging
@@ -55,14 +51,8 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
     val result = Try {
       val client = createHoodieClient(jsc, basePath)
       val config = client.getConfig
-      val context = client.getEngineContext
-      val metaClient = HoodieTableMetaClient.builder()
-        .setConf(context.getHadoopConf.get).setBasePath(config.getBasePath)
-        .setLoadActiveTimelineOnLoad(true).setConsistencyGuardConfig(config.getConsistencyGuardConfig)
-        .setLayoutVersion(Option.of(new TimelineLayoutVersion(config.getTimelineLayoutVersion)))
-        .setFileSystemRetryConfig(config.getFileSystemRetryConfig).setProperties(config.getProps)
-        .build
-      val table = HoodieSparkTable.create(config, context.asInstanceOf[HoodieSparkEngineContext], metaClient, true)
+      val context: HoodieEngineContext = client.getEngineContext
+      val table = HoodieSparkTable.create(config, context, java.lang.Boolean.TRUE)
       WriteMarkersFactory.get(config.getMarkersType, table, instantTime)
         .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism)
     } match {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -17,7 +17,11 @@
 
 package org.apache.spark.sql.hudi.command.procedures
 
+import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.engine.HoodieEngineContext
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion
+import org.apache.hudi.common.util.Option
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.table.marker.WriteMarkersFactory
 import org.apache.spark.internal.Logging
@@ -52,7 +56,13 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
       val client = createHoodieClient(jsc, basePath)
       val config = client.getConfig
       val context = client.getEngineContext
-      val table = HoodieSparkTable.create(config, context : HoodieEngineContext, true)
+      val metaClient = HoodieTableMetaClient.builder()
+        .setConf(context.getHadoopConf.get).setBasePath(config.getBasePath)
+        .setLoadActiveTimelineOnLoad(true).setConsistencyGuardConfig(config.getConsistencyGuardConfig)
+        .setLayoutVersion(Option.of(new TimelineLayoutVersion(config.getTimelineLayoutVersion)))
+        .setFileSystemRetryConfig(config.getFileSystemRetryConfig).setProperties(config.getProps)
+        .build
+      val table = HoodieSparkTable.create(config, context.asInstanceOf[HoodieSparkEngineContext], metaClient, true)
       WriteMarkersFactory.get(config.getMarkersType, table, instantTime)
         .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism)
     } match {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.hudi.table.HoodieSparkTable
+import org.apache.hudi.table.marker.WriteMarkersFactory
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import java.util.function.Supplier
+import scala.util.{Failure, Success, Try}
+
+class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Logging {
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(1, "instant_Time", DataTypes.StringType, None)
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("delete_marker_result", DataTypes.BooleanType, nullable = true, Metadata.empty))
+  )
+
+  def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  def outputType: StructType = OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
+    val basePath: String = getBasePath(tableName)
+
+    val result = Try {
+      val client = createHoodieClient(jsc, basePath)
+      val config = client.getConfig
+      val context = client.getEngineContext
+      val table = HoodieSparkTable.create(config, context, true)
+      WriteMarkersFactory.get(config.getMarkersType, table, instantTime)
+        .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism)
+    } match {
+      case Success(_) =>
+        logInfo(s"Marker $instantTime deleted.")
+        true
+      case Failure(e) =>
+        logWarning(s"Failed: Could not clean marker instantTime: $instantTime.", e)
+        false
+    }
+
+    Seq(Row(result))
+  }
+
+  override def build: Procedure = new DeleteMarkerProcedure()
+}
+
+object DeleteMarkerProcedure {
+  val NAME: String = "delete_marker"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get(): DeleteMarkerProcedure = new DeleteMarkerProcedure()
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hudi.command.procedures
 
-import org.apache.hudi.common.engine.HoodieEngineContext
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.table.marker.WriteMarkersFactory
 import org.apache.spark.internal.Logging
@@ -51,8 +50,8 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
     val result = Try {
       val client = createHoodieClient(jsc, basePath)
       val config = client.getConfig
-      val context: HoodieEngineContext = client.getEngineContext
-      val table = HoodieSparkTable.create(config, context, java.lang.Boolean.TRUE)
+      val context = client.getEngineContext
+      val table = HoodieSparkTable.create(config, context)
       WriteMarkersFactory.get(config.getMarkersType, table, instantTime)
         .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism)
     } match {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
@@ -44,6 +44,7 @@ object HoodieProcedures {
     mapBuilder.put(ShowCommitsProcedure.NAME, ShowCommitsProcedure.builder)
     mapBuilder.put(ShowCommitsMetadataProcedure.NAME, ShowCommitsMetadataProcedure.builder)
     mapBuilder.put(ShowSavepointsProcedure.NAME, ShowSavepointsProcedure.builder)
+    mapBuilder.put(DeleteMarkerProcedure.NAME, DeleteMarkerProcedure.builder)
     mapBuilder.build
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

This change add `DeleteMarker` procedure to Hudi Spark's call procedure supprot.

## Brief change log

- Add `DeleteMarkerProcedure` class to support `call delete_marker` SQL command.

## Verify this pull request


This change added tests and can be verified as follows:

- Added UT “Test Call delete_marker Procedure” in `TestCallProcedure`.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
