### PR TITLE
[MINOR][UI]Resized the blog images , tags onHover:blue, readingTime only visible in blogs page

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -205,15 +205,18 @@ footer .container {
 }
 
 .blogThumbnail img {
-  height: auto;
-  width: 100%;
+  height:100%;
+  width: auto;
 }
-
+.tagRegular_node_modules-\@docusaurus-theme-classic-lib-next-theme-Tag-styles-module{
+  color:black
+}
 
 
 .blog-list-page article {
   display: inline-flex;
   width: 45%;
+ 
   margin: 1.2em;
   vertical-align: text-top;
   

--- a/website/src/theme/BlogPostItem/index.js
+++ b/website/src/theme/BlogPostItem/index.js
@@ -68,7 +68,7 @@
     return (
         <>
           <ul className={clsx(styles.tags, styles.authorTimeTags, 'padding--none', 'margin-left--sm')}>
-          <h4>Tags:</h4>
+         
             {tags.map(({label, permalink: tagPermalink}) => (
               <li key={tagPermalink} className={styles.tag}>
                 <Tag className={clsx(styles.greyLink)} name={label} permalink={tagPermalink} />
@@ -155,12 +155,12 @@ const AuthorsList = () => {
        {AuthorsList()}
          <div className={clsx(styles.blogPostData, 'margin-vert--md')}>
            
- 
+ {isBlogPostPage && <>
            {typeof readingTime !== 'undefined' && (
              <>
                {readingTimePlural(readingTime)}
              </>
-           )}
+           )}</>}
          </div>
 
          


### PR DESCRIPTION


## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
The images earlier had distorted width so fixed their sizing so that they look clear. 
<img width="1680" alt="Screenshot 2022-06-03 at 9 03 45 PM" src="https://user-images.githubusercontent.com/97013124/171902828-7306133c-6429-48b4-a78a-7f542fa00cdd.png">

Removed read time from blogs list page such that it will only be visible in the blogs page

Made the tags black by default and blue color when onHover. 

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
