### PR TITLE
[HUDI-4192] HoodieHFileReader scan top cells after bottom cells throw…

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/storage/TestHoodieHFileReaderWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/storage/TestHoodieHFileReaderWriter.java
@@ -294,6 +294,38 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
         StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
             .collect(Collectors.toList());
     assertEquals(Collections.emptyList(), recordsByPrefix);
+
+    // filter for "key50" and "key1" : entries from key50 and 'key10 to key19' should be matched.
+    List<GenericRecord> expectedKey50and1s = allRecords.stream().filter(entry -> (entry.get("_row_key").toString()).contains("key1")
+        || (entry.get("_row_key").toString()).contains("key50")).collect(Collectors.toList());
+    iterator =
+        hfileReader.getRecordsByKeyPrefixIterator(Arrays.asList("key50", "key1"), avroSchema);
+    recordsByPrefix =
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+            .collect(Collectors.toList());
+    assertEquals(expectedKey50and1s, recordsByPrefix);
+
+    // filter for "key50" and "key0" : entries from key50 and 'key00 to key09' should be matched.
+    List<GenericRecord> expectedKey50and0s = allRecords.stream().filter(entry -> (entry.get("_row_key").toString()).contains("key0")
+        || (entry.get("_row_key").toString()).contains("key50")).collect(Collectors.toList());
+    iterator =
+        hfileReader.getRecordsByKeyPrefixIterator(Arrays.asList("key50", "key0"), avroSchema);
+    recordsByPrefix =
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+            .collect(Collectors.toList());
+    assertEquals(expectedKey50and0s, recordsByPrefix);
+
+    // filter for "key1" and "key0" : entries from 'key10 to key19' and 'key00 to key09' should be matched.
+    List<GenericRecord> expectedKey1sand0s = expectedKey1s;
+    expectedKey1sand0s.addAll(allRecords.stream()
+        .filter(entry -> (entry.get("_row_key").toString()).contains("key0"))
+        .collect(Collectors.toList()));
+    iterator =
+        hfileReader.getRecordsByKeyPrefixIterator(Arrays.asList("key1", "key0"), avroSchema);
+    recordsByPrefix =
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+            .collect(Collectors.toList());
+    assertEquals(expectedKey1sand0s, recordsByPrefix);
   }
 
   @ParameterizedTest

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
@@ -258,6 +258,12 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
       if (!scanner.next()) {
         return Collections.emptyIterator();
       }
+    } else if (val == -1) {
+      // If scanner is aleady on the top of hfile. avoid trigger seekTo again.
+      Option<Cell> headerCell = Option.fromJavaOptional(scanner.getReader().getFirstKey());
+      if (headerCell.isPresent() && !headerCell.get().equals(scanner.getCell())) {
+        scanner.seekTo();
+      }
     }
 
     class KeyPrefixIterator implements Iterator<GenericRecord> {


### PR DESCRIPTION
… NullPointerException

## What is the purpose of the pull request

This PR addresses the NullPointerException when HoodieHFileReader scan top cells after bottom cells. reported by HUDI-4192. https://issues.apache.org/jira/browse/HUDI-4192

## Brief change log
When bottom cells are scanned, trigger seekTo() to make scanner reseekTo the header of HFile, which make the top cells readable.

## Verify this pull request

This change added tests and can be verified as follows:
  - *Added serveral testcases in TestHoodieHFileReaderWriter to verify the change.*
  - *Manually verified the change by running a job of cluster.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
