### PR TITLE
[HUDI-4165] Support Create/Drop/Show/Refresh Index Syntax for Spark SQL

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/index/HoodieIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/HoodieIndex.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class HoodieIndex {
+  private String indexName;
+  private String[] colNames;
+  private HoodieIndexType indexType;
+  private Map<String, Map<String, String>> colOptions;
+  private Map<String, String> options;
+
+  public HoodieIndex() {
+  }
+
+  public HoodieIndex(
+      String indexName,
+      String[] colNames,
+      HoodieIndexType indexType,
+      Map<String, Map<String, String>> colOptions,
+      Map<String, String> options) {
+    this.indexName = indexName;
+    this.colNames = colNames;
+    this.indexType = indexType;
+    this.colOptions = colOptions;
+    this.options = options;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String[] getColNames() {
+    return colNames;
+  }
+
+  public HoodieIndexType getIndexType() {
+    return indexType;
+  }
+
+  public Map<String, Map<String, String>> getColOptions() {
+    return colOptions;
+  }
+
+  public Map<String, String> getOptions() {
+    return options;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieIndex{"
+        + "indexName='" + indexName + '\''
+        + ", colNames='" + Arrays.toString(colNames) + '\''
+        + ", indexType=" + indexType
+        + ", colOptions=" + colOptions
+        + ", options=" + options
+        + '}';
+  }
+
+  public static class Builder {
+    private String indexName;
+    private String[] colNames;
+    private HoodieIndexType indexType;
+    private Map<String, Map<String, String>> colOptions;
+    private Map<String, String> options;
+
+    public Builder setIndexName(String indexName) {
+      this.indexName = indexName;
+      return this;
+    }
+
+    public Builder setColNames(String[] colNames) {
+      this.colNames = colNames;
+      return this;
+    }
+
+    public Builder setIndexType(String indexType) {
+      this.indexType = HoodieIndexType.of(indexType);
+      return this;
+    }
+
+    public Builder setColOptions(Map<String, Map<String, String>> colOptions) {
+      this.colOptions = colOptions;
+      return this;
+    }
+
+    public Builder setOptions(Map<String, String> options) {
+      this.options = options;
+      return this;
+    }
+
+    public HoodieIndex build() {
+      return new HoodieIndex(indexName, colNames, indexType, colOptions, options);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/HoodieIndexType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/HoodieIndexType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index;
+
+import org.apache.hudi.exception.HoodieIndexException;
+
+import java.util.Arrays;
+
+public enum HoodieIndexType {
+  LUCENE((byte) 1);
+
+  private final byte type;
+
+  HoodieIndexType(byte type) {
+    this.type = type;
+  }
+
+  public byte getValue() {
+    return type;
+  }
+
+  public static HoodieIndexType of(byte indexType) {
+    return Arrays.stream(HoodieIndexType.values())
+        .filter(t -> t.type == indexType)
+        .findAny()
+        .orElseThrow(() ->
+            new HoodieIndexException("Unknown hoodie index type:" + indexType));
+  }
+
+  public static HoodieIndexType of(String indexType) {
+    return Arrays.stream(HoodieIndexType.values())
+        .filter(t -> t.name().equals(indexType.toUpperCase()))
+        .findAny()
+        .orElseThrow(() ->
+            new HoodieIndexException("Unknown hoodie index type:" + indexType));
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4
+++ b/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4
@@ -48,6 +48,13 @@
  statement
     : compactionStatement                                                       #compactionCommand
     | CALL multipartIdentifier '(' (callArgument (',' callArgument)*)? ')'      #call
+    | CREATE INDEX (IF NOT EXISTS)? identifier ON TABLE?
+          tableIdentifier (USING indexType=identifier)?
+          LEFT_PAREN columns=multipartIdentifierPropertyList RIGHT_PAREN
+          (OPTIONS indexOptions=propertyList)?                                  #createIndex
+    | DROP INDEX (IF EXISTS)? identifier ON TABLE? tableIdentifier              #dropIndex
+    | SHOW INDEXES (FROM | IN) TABLE? tableIdentifier                           #showIndexes
+    | REFRESH INDEX identifier ON TABLE? tableIdentifier                        #refreshIndex
     | .*?                                                                       #passThrough
     ;
 
@@ -99,6 +106,14 @@
     | MINUS? BIGDECIMAL_LITERAL       #bigDecimalLiteral
     ;
 
+ multipartIdentifierPropertyList
+     : multipartIdentifierProperty (COMMA multipartIdentifierProperty)*
+     ;
+
+ multipartIdentifierProperty
+     : multipartIdentifier (OPTIONS options=propertyList)?
+     ;
+
  multipartIdentifier
     : parts+=identifier ('.' parts+=identifier)*
     ;
@@ -114,8 +129,52 @@
     ;
 
  nonReserved
-     : CALL | COMPACTION | RUN | SCHEDULE | ON | SHOW | LIMIT
+     : CALL
+     | COMPACTION
+     | CREATE
+     | DROP
+     | EXISTS
+     | FROM
+     | IN
+     | INDEX
+     | INDEXES
+     | IF
+     | LIMIT
+     | NOT
+     | ON
+     | OPTIONS
+     | REFRESH
+     | RUN
+     | SCHEDULE
+     | SHOW
+     | TABLE
+     | USING
      ;
+
+ propertyList
+     : LEFT_PAREN property (COMMA property)* RIGHT_PAREN
+     ;
+
+ property
+     : key=propertyKey (EQ? value=propertyValue)?
+     ;
+
+ propertyKey
+     : identifier (DOT identifier)*
+     | STRING
+     ;
+
+ propertyValue
+     : INTEGER_VALUE
+     | DECIMAL_VALUE
+     | booleanValue
+     | STRING
+     ;
+
+ LEFT_PAREN: '(';
+ RIGHT_PAREN: ')';
+ COMMA: ',';
+ DOT: '.';
 
  ALL: 'ALL';
  AT: 'AT';
@@ -132,6 +191,21 @@
  FALSE: 'FALSE';
  INTERVAL: 'INTERVAL';
  TO: 'TO';
+ CREATE: 'CREATE';
+ INDEX: 'INDEX';
+ INDEXES: 'INDEXES';
+ IF: 'IF';
+ NOT: 'NOT';
+ EXISTS: 'EXISTS';
+ TABLE: 'TABLE';
+ USING: 'USING';
+ OPTIONS: 'OPTIONS';
+ DROP: 'DROP';
+ FROM: 'FROM';
+ IN: 'IN';
+ REFRESH: 'REFRESH';
+
+ EQ: '=' | '==';
 
  PLUS: '+';
  MINUS: '-';

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.StringType
+
+/**
+ * The logical plan of the CREATE INDEX command.
+ */
+case class CreateIndex(
+    table: LogicalPlan,
+    indexName: String,
+    indexType: String,
+    ignoreIfExists: Boolean,
+    columns: Seq[(Attribute, Map[String, String])],
+    properties: Map[String, String],
+    override val output: Seq[Attribute] = CreateIndex.getOutputAttrs) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override lazy val resolved: Boolean = table.resolved && columns.forall(_._1.resolved)
+
+  def withNewChildrenInternal(newChild: IndexedSeq[LogicalPlan]): CreateIndex = {
+    copy(table = newChild.head)
+  }
+}
+
+object CreateIndex {
+  def getOutputAttrs: Seq[Attribute] = Seq.empty
+}
+
+/**
+ * The logical plan of the DROP INDEX command.
+ */
+case class DropIndex(
+    table: LogicalPlan,
+    indexName: String,
+    ignoreIfNotExists: Boolean,
+    override val output: Seq[Attribute] = DropIndex.getOutputAttrs) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  def withNewChildrenInternal(newChild: IndexedSeq[LogicalPlan]): DropIndex = {
+    copy(table = newChild.head)
+  }
+}
+
+object DropIndex {
+  def getOutputAttrs: Seq[Attribute] = Seq.empty
+}
+
+/**
+ * The logical plan of the SHOW INDEXES command.
+ */
+case class ShowIndexes(
+    table: LogicalPlan,
+    override val output: Seq[Attribute] = ShowIndexes.getOutputAttrs) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  def withNewChildrenInternal(newChild: IndexedSeq[LogicalPlan]): ShowIndexes = {
+    copy(table = newChild.head)
+  }
+}
+
+object ShowIndexes {
+  def getOutputAttrs: Seq[Attribute] = Seq(
+    AttributeReference("index_name", StringType, nullable = false)(),
+    AttributeReference("col_name", StringType, nullable = false)(),
+    AttributeReference("index_type", StringType, nullable = false)(),
+    AttributeReference("col_options", StringType, nullable = true)(),
+    AttributeReference("options", StringType, nullable = true)()
+  )
+}
+
+/**
+ * The logical plan of the REFRESH INDEX command.
+ */
+case class RefreshIndex(
+    table: LogicalPlan,
+    indexName: String,
+    override val output: Seq[Attribute] = RefreshIndex.getOutputAttrs) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  def withNewChildrenInternal(newChild: IndexedSeq[LogicalPlan]): RefreshIndex = {
+    copy(table = newChild.head)
+  }
+}
+
+object RefreshIndex {
+  def getOutputAttrs: Seq[Attribute] = Seq.empty
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -147,6 +147,28 @@ case class HoodieAnalysis(sparkSession: SparkSession) extends Rule[LogicalPlan]
         } else {
           c
         }
+
+      // Convert to CreateIndexCommand
+      case CreateIndex(table, indexName, indexType, ignoreIfExists, columns, properties, output)
+        if table.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
+        CreateIndexCommand(
+          getTableIdentifier(table), indexName, indexType, ignoreIfExists, columns, properties, output)
+
+      // Convert to DropIndexCommand
+      case DropIndex(table, indexName, ignoreIfNotExists, output)
+        if table.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
+        DropIndexCommand(getTableIdentifier(table), indexName, ignoreIfNotExists, output)
+
+      // Convert to ShowIndexesCommand
+      case ShowIndexes(table, output)
+        if table.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
+        ShowIndexesCommand(getTableIdentifier(table), output)
+
+      // Covert to RefreshCommand
+      case RefreshIndex(table, indexName, output)
+        if table.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
+        RefreshIndexCommand(getTableIdentifier(table), indexName, output)
+
       case _ => plan
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command
+
+import org.apache.hudi.common.index.HoodieIndex
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.{Row, SparkSession}
+
+case class CreateIndexCommand(
+    tableId: TableIdentifier,
+    indexName: String,
+    indexType: String,
+    ignoreIfExists: Boolean,
+    columns: Seq[(Attribute, Map[String, String])],
+    properties: Map[String, String],
+    override val output: Seq[Attribute]) extends IndexBaseCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    // The implementation for different index type
+    Seq.empty
+  }
+}
+
+case class DropIndexCommand(
+    tableId: TableIdentifier,
+    indexName: String,
+    ignoreIfNotExists: Boolean,
+    override val output: Seq[Attribute]) extends IndexBaseCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    // The implementation for different index type
+    Seq.empty
+  }
+}
+
+case class ShowIndexesCommand(
+    tableId: TableIdentifier,
+    override val output: Seq[Attribute]) extends IndexBaseCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    // The implementation for different index type
+    Seq.empty
+  }
+}
+
+case class RefreshIndexCommand(
+    tableId: TableIdentifier,
+    indexName: String,
+    override val output: Seq[Attribute]) extends IndexBaseCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    // The implementation for different index type
+    Seq.empty
+  }
+}
+
+abstract class IndexBaseCommand extends HoodieLeafRunnableCommand with Logging {
+
+  /**
+   * Check hoodie index exists. In a hoodie table, hoodie index name
+   * must be unique, so the index name will be checked firstly,
+   *
+   * @param secondaryIndexes Current hoodie indexes
+   * @param indexName        The index name to be checked
+   * @param colNames         The column names to be checked
+   * @return true if the index exists
+   */
+  def indexExists(
+      secondaryIndexes: Option[Array[HoodieIndex]],
+      indexName: String,
+      indexType: Option[String] = None,
+      colNames: Option[Array[String]] = None): Boolean = {
+    secondaryIndexes.exists(i => {
+      i.exists(_.getIndexName.equals(indexName)) ||
+          // Index type and column name need to be checked if present
+          indexType.exists(t =>
+            colNames.exists(c =>
+              i.exists(index =>
+                index.getIndexType.name().equalsIgnoreCase(t) && index.getColNames.sameElements(c))))
+    })
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
@@ -25,8 +25,6 @@ import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase
 import org.apache.spark.sql.hudi.command.{CreateIndexCommand, DropIndexCommand, ShowIndexesCommand}
 
 class TestIndexSyntax extends HoodieSparkSqlTestBase {
-  private val sqlParser: ParserInterface = spark.sessionState.sqlParser
-  private val analyzer: Analyzer = spark.sessionState.analyzer
 
   test("Test Create/Drop/Show/Refresh Index") {
     withTempDir { tmp =>
@@ -52,6 +50,9 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
         spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
         spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
         spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+
+        val sqlParser: ParserInterface = spark.sessionState.sqlParser
+        val analyzer: Analyzer = spark.sessionState.analyzer
 
         var logicalPlan = sqlParser.parsePlan(s"show indexes from default.$tableName")
         var resolvedLogicalPlan = analyzer.execute(logicalPlan)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.catalyst.analysis.Analyzer
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.command.{CreateIndexCommand, DropIndexCommand, ShowIndexesCommand}
+
+class TestIndexSyntax extends HoodieSparkSqlTestBase {
+  private val sqlParser: ParserInterface = spark.sessionState.sqlParser
+  private val analyzer: Analyzer = spark.sessionState.analyzer
+
+  test("Test Create/Drop/Show/Refresh Index") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by(ts)
+             | location '$basePath'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+
+        var logicalPlan = sqlParser.parsePlan(s"show indexes from default.$tableName")
+        var resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertResult(s"`default`.`$tableName`")(resolvedLogicalPlan.asInstanceOf[ShowIndexesCommand].tableId.toString())
+
+        logicalPlan = sqlParser.parsePlan(s"create index idx_name on $tableName using lucene (name) options(block_size=1024)")
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertResult(s"`default`.`$tableName`")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].tableId.toString())
+        assertResult("idx_name")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+        assertResult("lucene")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+        assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
+        assertResult(Map("block_size" -> "1024"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].properties)
+
+        logicalPlan = sqlParser.parsePlan(s"create index if not exists idx_price on $tableName using lucene (price options(order='desc')) options(block_size=512)")
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertResult(s"`default`.`$tableName`")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].tableId.toString())
+        assertResult("idx_price")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+        assertResult("lucene")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+        assertResult(Map("order" -> "desc"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].columns.head._2)
+        assertResult(Map("block_size" -> "512"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].properties)
+
+        logicalPlan = sqlParser.parsePlan(s"drop index if exists idx_name on $tableName")
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertResult(s"`default`.`$tableName`")(resolvedLogicalPlan.asInstanceOf[DropIndexCommand].tableId.toString())
+        assertResult("idx_name")(resolvedLogicalPlan.asInstanceOf[DropIndexCommand].indexName)
+        assertResult(true)(resolvedLogicalPlan.asInstanceOf[DropIndexCommand].ignoreIfNotExists)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Support Create/Drop/Show/Refresh Index Syntax for Spark SQL, SQL Syntax:

```sql
-- Create Index
CREATE INDEX [IF NOT EXISTS] index_name ON [TABLE] table_name 
[USING index_type] 
(column_name1 [OPTIONS(key1=value1, key2=value2, ...)], column_name2 [OPTIONS(key1=value1, key2=value2, ...)], ...) 
[OPTIONS (key1=value1, key2=value2, ...)]

-- Drop Index
DROP INDEX [IF EXISTS] index_name ON [TABLE] table_name

-- Show Indexes
SHOW INDEXES {FROM | IN} [TABLE] table_name

-- Refresh Index
REFRESH INDEX index_name ON [TABLE] table_name
```
 
Notice:
- Create/Drop Index Syntax are forked from Spark 3.3.0-rc3, https://github.com/apache/spark/blob/branch-3.3/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
 

Reference：
- Hive sql index syntax：
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/AlterIndex
 
- MySQL index syntax：
https://dev.mysql.com/doc/refman/8.0/en/create-index.html
https://dev.mysql.com/doc/refman/8.0/en/show-index.html
https://dev.mysql.com/doc/refman/8.0/en/drop-index.html

Jira: [HUDI-4165](https://issues.apache.org/jira/browse/HUDI-4165)

## Brief change log

  - *Modify ``HoodieSqlCommon.g4`` to add index syntax from multiple spark version*
  - *Modify ``HoodieSqlCommonAstBuilder`` to parse index AST*
  - *Modify ``HoodieAnalysis`` to resolve index logical plans*
  - *Add ``Index``, ``IndexCommands``, ``HoodieIndex``, ``HoodieIndexType``, ``TestIndexSyntax``*

## Verify this pull request

  - *Added ``TestIndexSyntax`` to verify the change.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
