### PR TITLE
[HUDI-4193] Upgrade Protobuf to 3.21.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,8 +192,8 @@
     <zk-curator.version>2.7.1</zk-curator.version>
     <antlr.version>4.7</antlr.version>
     <aws.sdk.version>1.12.22</aws.sdk.version>
-    <proto.version>3.17.3</proto.version>
-    <protoc.version>3.11.4</protoc.version>
+    <proto.version>3.21.5</proto.version>
+    <protoc.version>3.21.5</protoc.version>
     <dynamodb.lockclient.version>1.1.0</dynamodb.lockclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <dynamodb-local.port>8000</dynamodb-local.port>
@@ -1833,18 +1833,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>m1-mac</id>
-      <properties>
-        <protoc.version>3.17.3</protoc.version>
-      </properties>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
     </profile>
     <!-- Exists for backwards compatibility; profile doesn't do anything -->
     <profile>


### PR DESCRIPTION
## What is the purpose of the pull request

Upgrade Protobuf to latest available version

## Brief change log

  - Upgrade Protobuf to 3.21.5 to support project compilation on macOS M1 (aarm64).
  - [CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569) High - CVSS Score: 7.5, An implementation weakness in how unknown fields are parsed in Java. A small (~800 KB) malicious payload can occupy the parser for several minutes by creating large numbers of short-lived objects that cause frequent, repeated GC pauses.

## Verify this pull request

This pull request is already covered by existing tests

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
