### PR TITLE
[HUDI-4221] Fixing getAllPartitionPaths perf hit w/ FileSystemBackedMetadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -93,7 +93,7 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
       // if current dictionary does not contain PartitionMetadata, add it to queue
       dirToFileListing.forEach(p -> {
         Option<FileStatus> partitionMetaFile = Option.fromJavaOptional(Arrays.stream(p.getRight()).parallel()
-            .filter(fileStatus -> fileStatus.getPath().getName().equals(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX))
+            .filter(fileStatus -> fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX))
             .findFirst());
 
         if (partitionMetaFile.isPresent()) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -68,13 +68,14 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
 
   @Override
   public List<String> getAllPartitionPaths() throws IOException {
-    FileSystem fs = new Path(datasetBasePath).getFileSystem(hadoopConf.get());
+    Path basePath = new Path(datasetBasePath);
+    FileSystem fs = basePath.getFileSystem(hadoopConf.get());
     if (assumeDatePartitioning) {
       return FSUtils.getAllPartitionFoldersThreeLevelsDown(fs, datasetBasePath);
     }
 
     List<Path> pathsToList = new CopyOnWriteArrayList<>();
-    pathsToList.add(new Path(datasetBasePath));
+    pathsToList.add(basePath);
     List<String> partitionPaths = new CopyOnWriteArrayList<>();
 
     while (!pathsToList.isEmpty()) {
@@ -97,7 +98,7 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
 
         if (partitionMetaFile.isPresent()) {
           // Is a partition.
-          String partitionName = FSUtils.getRelativePartitionPath(new Path(datasetBasePath), p.getLeft());
+          String partitionName = FSUtils.getRelativePartitionPath(basePath, p.getLeft());
           partitionPaths.add(partitionName);
         } else {
           // Add sub-dirs to the queue


### PR DESCRIPTION
## What is the purpose of the pull request

- Looks like getAllPartitionPaths have regressed in perf from 0.9.0 to 0.11.0. I could able to triage it to newly written code where in "isExists()" is called to determine Hoodie partition metadata. So, reverting the change to how it was before. 

Offending commit is https://github.com/apache/hudi/pull/4643

I tried listing a table with 10k partitions. 0.9.0 is taking 85 to 90 secs, while 0.11.0 took ~800 secs. 
HoodiePartitionMetadata.hasPartitionMetadata is taking roughly 50 to 60% when profiled. With the fix in this patch, listing took ~90 secs. 

![Screen Shot 2022-06-10 at 12 35 28 AM](https://user-images.githubusercontent.com/513218/172991214-5c70a81e-9099-4555-aabb-4cf16926f1ca.png)



## Brief change log

- Fixing getAllPartitionPaths for FileSystemBackedMetadata.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
