### PR TITLE
[HUDI-3683] Support evolved schema for HFile Reader

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/storage/TestHoodieHFileReaderWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/storage/TestHoodieHFileReaderWriter.java
@@ -198,13 +198,6 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     }
   }
 
-  @Override
-  @Test
-  public void testWriteReadWithEvolvedSchema() throws Exception {
-    // Disable the test with evolved schema for HFile since it's not supported
-    // TODO(HUDI-3683): fix the schema evolution for HFile
-  }
-
   @Test
   public void testReadHFileFormatRecords() throws Exception {
     writeFileWithSimpleSchema();

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
@@ -349,9 +349,9 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
     rRecord.getSchema().getFields().forEach(field -> rRecord.put(field.name(), wRecord.get(field.name())));
 
     getKeySchema(readerSchema).ifPresent(keyFieldSchema -> {
-      final Object keyObject = wRecord.get(keyFieldSchema.pos());
+      final Object keyObject = wRecord.get(keyFieldSchema.name());
       if (keyObject != null && keyObject.toString().isEmpty()) {
-        rRecord.put(keyFieldSchema.pos(), new String(keyBytes));
+        rRecord.put(keyFieldSchema.name(), new String(keyBytes));
       }
     });
 


### PR DESCRIPTION
## What is the purpose of the pull request

Currently, HoodieHFileReader checks the writer and reader schema strictly, if the default value of an added field in the reader Schema is missing，the reader will throw an exception, even if the field type is ["someType", "null"].

There are two ways to solve the problem:
1. add default values to added field in the reader schema, and fix some asserts in the UT
2. get the raw data and then construct the record with the new schema

To be consistent with ORC reader, I picked the 2nd.

## Brief change log

hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java

## Verify this pull request


This pull request is already covered by existing tests, such as TestHoodieReaderWriterBase.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
