### PR TITLE
[HUDI-4227] Strip extra spaces when creating new configuration

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -823,7 +823,9 @@ public class FlinkOptions extends HoodieConfig {
    */
   public static Configuration fromMap(Map<String, String> map) {
     final Configuration configuration = new Configuration();
-    map.forEach(configuration::setString);
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      configuration.setString(entry.getKey().trim(), entry.getValue());
+    }
     return configuration;
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

This pull request strip extra spaces when creating new configuration.

When using flink-sql to create a table, if the key of an option contains spaces, the option will be invalid.

Example：
If option ‘hive_sync.mode’ has more spaces, the table will not be sync with hms.
![image](https://user-images.githubusercontent.com/10494131/173331502-ec9099b0-30cc-49bd-ac51-82414730b40e.png)

## Brief change log

  - Modify `fromMap` function in `FlinkOptions` class.

## Verify this pull request

This pull request is a trivial rework without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
