### PR TITLE
[HUDI-4247] Upgrading protocol buffers version for presto bundle

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -315,7 +315,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.5.0</version>
+      <version>3.17.3</version>
       <scope>${presto.bundle.bootstrap.scope}</scope>
     </dependency>
 


### PR DESCRIPTION
## What is the purpose of the pull request

- Upgrading protocol buffers version in presto bundle due to security vulnerability. 
- [CVE-2015-5237](https://github.com/advisories/GHSA-jwvw-v7c5-m82h) [CVE-2021-22570](https://github.com/advisories/GHSA-77rm-9x9h-xj3g) [CVE-2021-22569](https://github.com/advisories/GHSA-wrvw-hg22-4m67)

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
