### PR TITLE
[HUDI-3735] TestHoodieSparkMergeOnReadTableRollback is flaky

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -227,8 +227,8 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
         allFiles = listAllBaseFilesInPath(hoodieTable);
         // After rollback, there should be no base file with the failed commit time
         List<String> remainingFiles = Arrays.stream(allFiles).filter(file -> file.getPath().getName()
-            .contains(commitTime1)).map(fileStatus -> fileStatus.getPath().toString()).collect(Collectors.toList());
-        assertEquals(0, remainingFiles.size(), "There files should have been rolled-back "
+            .contains("_" + commitTime1)).map(fileStatus -> fileStatus.getPath().toString()).collect(Collectors.toList());
+        assertEquals(0, remainingFiles.size(), "These files should have been rolled-back "
             + "when rolling back commit " + commitTime1 + " but are still remaining. Files: " + remainingFiles);
         inputPaths = tableView.getLatestBaseFiles()
             .map(baseFile -> new Path(baseFile.getPath()).getParent().toString())
@@ -240,7 +240,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
       /*
        * Write 3 (inserts + updates - testing successful delta commit)
        */
-      final String commitTime2 = "003";
+      final String commitTime2 = "000000003";
       try (SparkRDDWriteClient thirdClient = getHoodieWriteClient(getHoodieWriteConfigWithSmallFileHandlingOff(true));) {
         thirdClient.startCommitWithTime(commitTime2);
 
@@ -265,8 +265,10 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
         thirdClient.rollback(commitTime2);
         allFiles = listAllBaseFilesInPath(hoodieTable);
         // After rollback, there should be no base file with the failed commit time
-        assertEquals(0, Arrays.stream(allFiles)
-            .filter(file -> file.getPath().getName().contains(commitTime2)).count());
+        List<String> remainingFiles = Arrays.stream(allFiles).filter(file -> file.getPath().getName()
+            .contains("_" + commitTime2)).map(fileStatus -> fileStatus.getPath().toString()).collect(Collectors.toList());
+        assertEquals(0, remainingFiles.size(), "These files should have been rolled-back "
+            + "when rolling back commit " + commitTime2 + " but are still remaining. Files: " + remainingFiles);
 
         metaClient = HoodieTableMetaClient.reload(metaClient);
         hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
@@ -282,7 +284,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
         /*
          * Write 4 (updates)
          */
-        newCommitTime = "004";
+        newCommitTime = "000000004";
         thirdClient.startCommitWithTime(newCommitTime);
 
         writeStatusJavaRDD = thirdClient.upsert(writeRecords, newCommitTime);


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

We check whether the rollback is successful by checking whether the file name contains commit instanceTime in testRollbackWithDeltaAndCompactionCommit, but the instanceTime string is too short, it may appear in the file name.

It's not easy to reproduce, this is the log I copy from Jira.
```
2022-03-29T01:30:26.3550882Z org.opentest4j.AssertionFailedError: There files should have been rolled-back when rolling back commit 002 but are still remaining. Files: [file:/tmp/junit5890929166894435504/2015/03/16/00264b80-ca3f-4aaa-80fc-fedfe4c72ee5-0_1-1393-4266_001.parquet] ==> expected: <0> but was: <1>
```

This fix lengthens the instanceTime string and  filters the file with _instanceTime.


## Brief change log

hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
