### PR TITLE
[HUDI-4258] Fix when HoodieTable removes data file before the end of Flink job

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -285,7 +285,8 @@ public class StreamWriteOperatorCoordinator
 
     if (event.isEndInput()) {
       // handle end input event synchronously
-      handleEndInputEvent(event);
+      // wrap handleEndInputEvent in executeSync to preserve the order of events
+      executor.executeSync(() -> handleEndInputEvent(event), "handle end input event for instant %s", this.instant);
     } else {
       executor.execute(
           () -> {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/WriteMetadataEvent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/WriteMetadataEvent.java
@@ -168,7 +168,7 @@ public class WriteMetadataEvent implements OperatorEvent {
     return "WriteMetadataEvent{"
         + "writeStatusesSize=" + writeStatuses.size()
         + ", taskID=" + taskID
-        + ", instantTime=" + instantTime
+        + ", instantTime='" + instantTime + '\''
         + ", lastBatch=" + lastBatch
         + ", endInput=" + endInput
         + ", bootstrap=" + bootstrap

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/WriteMetadataEvent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/WriteMetadataEvent.java
@@ -163,6 +163,18 @@ public class WriteMetadataEvent implements OperatorEvent {
     return lastBatch && this.instantTime.equals(currentInstant);
   }
 
+  @Override
+  public String toString() {
+    return "WriteMetadataEvent{"
+        + "writeStatusesSize=" + writeStatuses.size()
+        + ", taskID=" + taskID
+        + ", instantTime='" + instantTime + '\''
+        + ", lastBatch=" + lastBatch
+        + ", endInput=" + endInput
+        + ", bootstrap=" + bootstrap
+        + '}';
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/WriteMetadataEvent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/WriteMetadataEvent.java
@@ -168,7 +168,7 @@ public class WriteMetadataEvent implements OperatorEvent {
     return "WriteMetadataEvent{"
         + "writeStatusesSize=" + writeStatuses.size()
         + ", taskID=" + taskID
-        + ", instantTime='" + instantTime + '\''
+        + ", instantTime=" + instantTime
         + ", lastBatch=" + lastBatch
         + ", endInput=" + endInput
         + ", bootstrap=" + bootstrap


### PR DESCRIPTION
## What is the purpose of the pull request

Fix concurrency issue when endInput event is handled before the previous events. It could lead to removal of data files before the end of Flink job.

## Brief change log
  - added new method `executeSync` to `NonThrownExecutor`
  - endInput is handled using `executeSync` in `StreamWriteOperatorCoordinator` now

## Verify this pull request

This change added tests and can be verified as follows:
  - added unit test to `TestStreamWriteOperatorCoordinator` 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
