### PR TITLE
[HUDI-4265] Deprecate useless targetTableName parameter in HoodieMultiTableDeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -235,15 +235,21 @@ public class HoodieMultiTableDeltaStreamer {
   public static void main(String[] args) throws IOException {
     final Config config = new Config();
 
-    if (config.enableHiveSync) {
-      logger.warn("--enable-hive-sync will be deprecated in a future release; please use --enable-sync instead for Hive syncing");
-    }
-
     JCommander cmd = new JCommander(config, null, args);
     if (config.help || args.length == 0) {
       cmd.usage();
       System.exit(1);
     }
+
+    if (config.enableHiveSync) {
+      logger.warn("--enable-hive-sync will be deprecated in a future release; please use --enable-sync instead for Hive syncing");
+    }
+
+    if (config.targetTableName != null) {
+      logger.warn(String.format("--target-table is deprecated and will be removed in a future release due to it's useless;"
+              + " please use %s to configure multiple target tables", Constants.TABLES_TO_BE_INGESTED_PROP));
+    }
+
     JavaSparkContext jssc = UtilHelpers.buildSparkContext("multi-table-delta-streamer", Constants.LOCAL_SPARK_MASTER);
     try {
       new HoodieMultiTableDeltaStreamer(config, jssc).sync();
@@ -258,7 +264,8 @@ public class HoodieMultiTableDeltaStreamer {
         description = "base path prefix for multi table support via HoodieMultiTableDeltaStreamer class")
     public String basePathPrefix;
 
-    @Parameter(names = {"--target-table"}, description = "name of the target table", required = true)
+    @Deprecated
+    @Parameter(names = {"--target-table"}, description = "name of the target table")
     public String targetTableName;
 
     @Parameter(names = {"--table-type"}, description = "Type of table. COPY_ON_WRITE (or) MERGE_ON_READ", required = true)


### PR DESCRIPTION
## What is the purpose of the pull request

Remove useless targetTableName parameter in HoodieMultiTableDeltaStreamer 

In `HoodieMultiTableDeltaStreamer`, multiple target table names are configured by the parameter `hoodie.deltastreamer.ingestion.tablesToBeIngested`, and the parameter `--target-table` is not actually used, but it is a required item, which is very confusing, so I think it is reasonable to remove this parameter

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
