### PR TITLE
[HUDI-4156] Fixing file group count issues with metadata partitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1221,9 +1221,16 @@ public class HoodieTableMetadataUtil {
     if (isBootstrapCompleted) {
       final List<FileSlice> latestFileSlices = HoodieTableMetadataUtil
           .getPartitionLatestFileSlices(metaClient.get(), fsView, partitionType.getPartitionPath());
+      if (latestFileSlices.size() == 0 && !partitionType.getPartitionPath().equals(MetadataPartitionType.FILES.getPartitionPath())) {
+        return getFileGroupCount(partitionType, metadataConfig);
+      }
       return Math.max(latestFileSlices.size(), 1);
     }
 
+    return getFileGroupCount(partitionType, metadataConfig);
+  }
+
+  private static int getFileGroupCount(MetadataPartitionType partitionType, final HoodieMetadataConfig metadataConfig) {
     switch (partitionType) {
       case BLOOM_FILTERS:
         return metadataConfig.getBloomFilterIndexFileGroupCount();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -48,7 +48,7 @@ public enum MetadataPartitionType {
     return fileIdPrefix;
   }
 
-  void setFileGroupCount(final int fileGroupCount) {
+  public void setFileGroupCount(final int fileGroupCount) {
     this.fileGroupCount = fileGroupCount;
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

- Honoring file group count for metadata partitions w/ AsyncIndexing flow. Prior to this patch, file group count as per the config was not honored for non FILES partition. This patch fixes it. 

## Brief change log

- Fixed to honor the overriden file group count for non FILES partition in metadata table with Async Indexer. 

## Verify this pull request

- TestHoodieIndexer.testColStatsFileGroupCount
- Manually verified for synchronous code path for instantiating column stats that file group count was honored. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
