### PR TITLE
[HUDI-4278] Add skip AWS Glue archive option in Hive sync

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -775,6 +775,13 @@ public class FlinkOptions extends HoodieConfig {
       .noDefaultValue()
       .withDescription("The hive configuration directory, where the hive-site.xml lies in, the file should be put on the client machine");
 
+  public static final ConfigOption<Boolean> HIVE_SYNC_AWS_GLUE_SKIP_ARCHIVE = ConfigOptions
+      .key("hive_sync.skip_aws_glue_archive")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("When using AWS Glue as the data catalog, decide whether to archive old versions of the Hudi table,"
+          + " default false. Note that this option won't work for AWS EMR 5.x clusters");
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -98,6 +98,7 @@ public class HiveSyncContext {
     hiveSyncConfig.skipROSuffix = conf.getBoolean(FlinkOptions.HIVE_SYNC_SKIP_RO_SUFFIX);
     hiveSyncConfig.assumeDatePartitioning = conf.getBoolean(FlinkOptions.HIVE_SYNC_ASSUME_DATE_PARTITION);
     hiveSyncConfig.withOperationField = conf.getBoolean(FlinkOptions.CHANGELOG_ENABLED);
+    hiveSyncConfig.skipAWSGlueArchive = conf.getBoolean(FlinkOptions.HIVE_SYNC_AWS_GLUE_SKIP_ARCHIVE);
     return hiveSyncConfig;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
@@ -336,6 +336,9 @@ public class FlinkStreamerConfig extends Configuration {
       + "Disabled by default for backward compatibility.")
   public Boolean hiveSyncSupportTimestamp = false;
 
+  @Parameter(names = {"--hive-sync-skip-aws-glue-archive"}, description = "When using AWS Glue as the data catalog, decide whether to archive old "
+      + "versions of the Hudi table, default false.")
+  public Boolean hiveSyncSkipAWSGlueArchive = false;
 
   /**
    * Transforms a {@code HoodieFlinkStreamer.Config} into {@code Configuration}.
@@ -424,6 +427,7 @@ public class FlinkStreamerConfig extends Configuration {
     conf.setBoolean(FlinkOptions.HIVE_SYNC_IGNORE_EXCEPTIONS, config.hiveSyncIgnoreExceptions);
     conf.setBoolean(FlinkOptions.HIVE_SYNC_SKIP_RO_SUFFIX, config.hiveSyncSkipRoSuffix);
     conf.setBoolean(FlinkOptions.HIVE_SYNC_SUPPORT_TIMESTAMP, config.hiveSyncSupportTimestamp);
+    conf.setBoolean(FlinkOptions.HIVE_SYNC_AWS_GLUE_SKIP_ARCHIVE, config.hiveSyncSkipAWSGlueArchive);
     return conf;
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -324,6 +324,8 @@ public class DataSourceUtils {
     }
     hiveSyncConfig.syncComment = Boolean.valueOf(props.getString(DataSourceWriteOptions.HIVE_SYNC_COMMENT().key(),
             DataSourceWriteOptions.HIVE_SYNC_COMMENT().defaultValue()));
+    hiveSyncConfig.skipAWSGlueArchive = Boolean.valueOf(props.getString(DataSourceWriteOptions.AWS_GLUE_SKIP_ARCHIVE().key(),
+        DataSourceWriteOptions.AWS_GLUE_SKIP_ARCHIVE().defaultValue()));
     return hiveSyncConfig;
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -483,6 +483,8 @@ object DataSourceWriteOptions {
   @Deprecated
   val HIVE_SYNC_COMMENT: ConfigProperty[String] = HiveSyncConfig.HIVE_SYNC_COMMENT;
 
+  val AWS_GLUE_SKIP_ARCHIVE: ConfigProperty[String] = HiveSyncConfig.HIVE_SKIP_AWS_GLUE_ARCHIVE;
+
   // Async Compaction - Enabled by default for MOR
   val ASYNC_COMPACT_ENABLE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.compaction.async.enable")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -82,6 +82,7 @@ object HoodieWriterUtils {
     hoodieConfig.setDefaultValue(HiveSyncConfig.HIVE_USE_JDBC)
     hoodieConfig.setDefaultValue(HiveSyncConfig.HIVE_CREATE_MANAGED_TABLE)
     hoodieConfig.setDefaultValue(HiveSyncConfig.HIVE_SYNC_AS_DATA_SOURCE_TABLE)
+    hoodieConfig.setDefaultValue(AWS_GLUE_SKIP_ARCHIVE)
     hoodieConfig.setDefaultValue(ASYNC_COMPACT_ENABLE)
     hoodieConfig.setDefaultValue(INLINE_CLUSTERING_ENABLE)
     hoodieConfig.setDefaultValue(ASYNC_CLUSTERING_ENABLE)

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -98,6 +98,9 @@ public class HiveSyncConfig extends HoodieSyncConfig {
   @Parameter(names = {"--sync-comment"}, description = "synchronize table comments to hive")
   public boolean syncComment = false;
 
+  @Parameter(names = {"--skip-aws-glue-archive"}, description = "When using AWS Glue as the data catalog, decide whether to archive old versions of the Hudi table")
+  public Boolean skipAWSGlueArchive = false;
+
   // HIVE SYNC SPECIFIC CONFIGS
   // NOTE: DO NOT USE uppercase for the keys as they are internally lower-cased. Using upper-cases causes
   // unexpected issues with config getting reset
@@ -127,6 +130,11 @@ public class HiveSyncConfig extends HoodieSyncConfig {
       .withDocumentation("Flag to choose InputFormat under com.uber.hoodie package instead of org.apache.hudi package. "
           + "Use this when you are in the process of migrating from "
           + "com.uber.hoodie to org.apache.hudi. Stop using this after you migrated the table definition to org.apache.hudi input format");
+
+  public static final ConfigProperty<String> HIVE_SKIP_AWS_GLUE_ARCHIVE = ConfigProperty
+      .key("hoodie.datasource.hive_sync.skip_aws_glue_archive")
+      .defaultValue("false")
+      .withDocumentation("When using AWS Glue as the data catalog, decide whether to archive old versions of the Hudi table");
 
   /**
    * @deprecated Use {@link #HIVE_SYNC_MODE} instead of this config from 0.9.0
@@ -242,6 +250,7 @@ public class HiveSyncConfig extends HoodieSyncConfig {
     this.createManagedTable = getBooleanOrDefault(HIVE_CREATE_MANAGED_TABLE);
     this.bucketSpec = getStringOrDefault(HIVE_SYNC_BUCKET_SYNC_SPEC);
     this.syncComment = getBooleanOrDefault(HIVE_SYNC_COMMENT);
+    this.skipAWSGlueArchive = getBooleanOrDefault(HIVE_SKIP_AWS_GLUE_ARCHIVE);
   }
 
   @Override
@@ -277,6 +286,7 @@ public class HiveSyncConfig extends HoodieSyncConfig {
       + ", isConditionalSync=" + isConditionalSync
       + ", sparkVersion=" + sparkVersion
       + ", syncComment=" + syncComment
+      + ", skipAWSGlueArchive=" + skipAWSGlueArchive
       + '}';
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/replication/GlobalHiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/replication/GlobalHiveSyncConfig.java
@@ -51,6 +51,7 @@ public class GlobalHiveSyncConfig extends HiveSyncConfig {
     newConfig.decodePartition = cfg.decodePartition;
     newConfig.batchSyncNum = cfg.batchSyncNum;
     newConfig.globallyReplicatedTimeStamp = cfg.globallyReplicatedTimeStamp;
+    newConfig.skipAWSGlueArchive = cfg.skipAWSGlueArchive;
     return newConfig;
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
The issue is each time when Hudi upserts records, it would sync to the catalog and update last_commit_time_sync for the Glue table. Each time it updates this property, Glue by default would create a new table version and archive old versions. So the problem is if customers update the Hudi table frequently, eventually they would hit the Glue table version limit.

So here inside Hudi, we pass a parameter `skipGlueArchive` to the environment context to finally pass it to AWS Glue metadata service, so AWS Glue client has an option to decide whether to skip archive or not.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
