### PR TITLE
[HUDI-4281] Using hudi to build a large number of tables in spark on hive causes OOM

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/HiveClientUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/HiveClientUtils.scala
@@ -19,11 +19,25 @@ package org.apache.spark.sql.hive
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.client.HiveClient
 
 object HiveClientUtils {
 
+  /**
+   * A Hive client used to interact with the metastore.
+   */
+  @volatile private var client: HiveClient = null
+
   def newClientForMetadata(conf: SparkConf, hadoopConf: Configuration): HiveClient = {
     HiveUtils.newClientForMetadata(conf, hadoopConf)
+  }
+
+  def getSingletonClientForMetadata(sparkSession: SparkSession): HiveClient = synchronized {
+    if (client == null) {
+      client = HiveUtils.newClientForMetadata(sparkSession.sparkContext.conf,
+        sparkSession.sessionState.newHadoopConf())
+    }
+    client
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -190,8 +190,7 @@ object CreateHoodieTableCommand {
       table, table.schema)
 
     val tableWithDataSourceProps = table.copy(properties = dataSourceProps ++ table.properties)
-    val client = HiveClientUtils.newClientForMetadata(sparkSession.sparkContext.conf,
-      sparkSession.sessionState.newHadoopConf())
+    val client = HiveClientUtils.getSingletonClientForMetadata(sparkSession)
     // create hive table.
     client.createTable(tableWithDataSourceProps, ignoreIfExists = true)
   }


### PR DESCRIPTION
### Change Logs

The Hive Client adopts the singleton mode to avoid the oom caused by the IsolatedClientLoader object not being released.

### Impact

After this patch, IsolatedClientLoader objects will not be created in large numbers, which solves the oom caused by the unreleased IsolatedClientLoader object.

[HUDI-4281](https://issues.apache.org/jira/browse/HUDI-4281)

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
