### PR TITLE
[HUDI-4326] add updateTableSerDeInfo for HiveSyncTool

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -290,6 +290,9 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
         // Sync the table properties if the schema has changed
         if (config.getString(HIVE_TABLE_PROPERTIES) != null || config.getBoolean(HIVE_SYNC_AS_DATA_SOURCE_TABLE)) {
           syncClient.updateTableProperties(tableName, tableProperties);
+          HoodieFileFormat baseFileFormat = HoodieFileFormat.valueOf(config.getStringOrDefault(META_SYNC_BASE_FILE_FORMAT).toUpperCase());
+          String serDeFormatClassName = HoodieInputFormatUtils.getSerDeClassName(baseFileFormat);
+          syncClient.updateTableSerDeInfo(tableName, serDeFormatClassName, serdeProperties);
           LOG.info("Sync table properties for " + tableName + ", table properties is: " + tableProperties);
         }
         schemaChanged = true;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -353,4 +353,11 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     }
   }
 
+  Table getTable(String tableName) {
+    try {
+      return client.getTable(databaseName, tableName);
+    } catch (TException e) {
+      throw new HoodieHiveSyncException(String.format("Database: %s, Table: %s  does not exist", databaseName, tableName), e);
+    }
+  }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -34,6 +34,8 @@ import org.apache.hudi.sync.common.model.Partition;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.log4j.LogManager;
@@ -124,6 +126,41 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
       client.alter_table(databaseName, tableName, table);
     } catch (Exception e) {
       throw new HoodieHiveSyncException("Failed to update table properties for table: "
+          + tableName, e);
+    }
+  }
+
+  /**
+   * Update the table serde properties to the table.
+   */
+  @Override
+  public void updateTableSerDeInfo(String tableName, String serdeClass, Map<String, String> serdeProperties) {
+    if (serdeProperties == null || serdeProperties.isEmpty()) {
+      return;
+    }
+    try {
+      Table table = client.getTable(databaseName, tableName);
+      serdeProperties.put("serialization.format", "1");
+      StorageDescriptor storageDescriptor = table.getSd();
+      SerDeInfo serdeInfo = storageDescriptor.getSerdeInfo();
+      if (serdeInfo != null && serdeInfo.getParametersSize() == serdeProperties.size()) {
+        Map<String, String> parameters = serdeInfo.getParameters();
+        boolean same = true;
+        for (String key : serdeProperties.keySet()) {
+          if (!parameters.containsKey(key) | !parameters.get(key).equals(serdeProperties.get(key))) {
+            same = false;
+            break;
+          }
+        }
+        if (same) {
+          LOG.debug("Table " + tableName + " serdeProperties already up to date, skip update");
+          return;
+        }
+      }
+      storageDescriptor.setSerdeInfo(new SerDeInfo(null, serdeClass, serdeProperties));
+      client.alter_table(databaseName, tableName, table);
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException("Failed to update table serde info for table: "
           + tableName, e);
     }
   }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -159,6 +159,9 @@ public class TestHiveSyncTool {
 
     assertTrue(hiveClient.tableExists(HiveTestUtil.TABLE_NAME),
         "Table " + HiveTestUtil.TABLE_NAME + " should exist after sync completes");
+    assertEquals("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+      hiveClient.getTable(HiveTestUtil.TABLE_NAME).getSd().getSerdeInfo().getSerializationLib(),
+      "SerDe info not updated or does not match");
     assertEquals(hiveClient.getMetastoreSchema(HiveTestUtil.TABLE_NAME).size(),
         hiveClient.getStorageSchema().getColumns().size() + 1,
         "Hive Schema should match the table schema + partition field");

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
@@ -174,6 +174,12 @@ public interface HoodieMetaSyncOperations {
   }
 
   /**
+   * Update the table SerDeInfo in metastore.
+   */
+  default void updateTableSerDeInfo(String tableName, String serdeClass, Map<String, String> serdeProperties) {
+  }
+
+  /**
    * Get the timestamp of last replication.
    */
   default Option<String> getLastReplicatedTime(String tableName) {


### PR DESCRIPTION
## What is the purpose of the pull request

* This pull request fix https://github.com/apache/hudi/issues/5861*
* The issue is caused by after changing the table to spark data source table, the table SerDeInfo is missing. *

## Brief change log
  - add updateTableSerDeInfo for HiveSyncTool

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
