### PR TITLE
[HUDI-4293] Implement Create/Drop/Show/Refresh Index Command for Secondary Index

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -235,6 +235,11 @@ public class HoodieTableConfig extends HoodieConfig {
       .withDocumentation("Comma-separated list of metadata partitions that have been completely built and in-sync with data table. "
           + "These partitions are ready for use by the readers");
 
+  public static final ConfigProperty<String> SECONDARY_INDEXES_METADATA = ConfigProperty
+      .key("hoodie.table.secondary.indexes.metadata")
+      .noDefaultValue()
+      .withDocumentation("The metadata of secondary indexes");
+
   private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
 
   public HoodieTableConfig(FileSystem fs, String metaPath, String payloadClassName) {
@@ -496,6 +501,14 @@ public class HoodieTableConfig extends HoodieConfig {
       return Option.of(Arrays.stream(getString(PARTITION_FIELDS).split(","))
           .filter(p -> p.length() > 0).collect(Collectors.toList()).toArray(new String[] {}));
     }
+    return Option.empty();
+  }
+
+  public Option<String> getSecondaryIndexesMetadata() {
+    if (contains(SECONDARY_INDEXES_METADATA)) {
+      return Option.of(getString(SECONDARY_INDEXES_METADATA));
+    }
+
     return Option.empty();
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -742,6 +742,7 @@ public class HoodieTableMetaClient implements Serializable {
     private Boolean shouldDropPartitionColumns;
     private String metadataPartitions;
     private String inflightMetadataPartitions;
+    private String secondaryIndexesMetadata;
 
     /**
      * Persist the configs that is written at the first time, and should not be changed.
@@ -876,6 +877,11 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
+    public PropertyBuilder setSecondaryIndexesMetadata(String secondaryIndexesMetadata) {
+      this.secondaryIndexesMetadata = secondaryIndexesMetadata;
+      return this;
+    }
+
     private void set(String key, Object value) {
       if (HoodieTableConfig.PERSISTED_CONFIG_LIST.contains(key)) {
         this.others.put(key, value);
@@ -883,7 +889,7 @@ public class HoodieTableMetaClient implements Serializable {
     }
 
     public PropertyBuilder set(Map<String, Object> props) {
-      for (String key: HoodieTableConfig.PERSISTED_CONFIG_LIST) {
+      for (String key : HoodieTableConfig.PERSISTED_CONFIG_LIST) {
         Object value = props.get(key);
         if (value != null) {
           set(key, value);
@@ -982,6 +988,9 @@ public class HoodieTableMetaClient implements Serializable {
       if (hoodieConfig.contains(HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT)) {
         setInflightMetadataPartitions(hoodieConfig.getString(HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT));
       }
+      if (hoodieConfig.contains(HoodieTableConfig.SECONDARY_INDEXES_METADATA)) {
+        setSecondaryIndexesMetadata(hoodieConfig.getString(HoodieTableConfig.SECONDARY_INDEXES_METADATA));
+      }
       return this;
     }
 
@@ -1071,6 +1080,9 @@ public class HoodieTableMetaClient implements Serializable {
       }
       if (null != inflightMetadataPartitions) {
         tableConfig.setValue(HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT, inflightMetadataPartitions);
+      }
+      if (null != secondaryIndexesMetadata) {
+        tableConfig.setValue(HoodieTableConfig.SECONDARY_INDEXES_METADATA, secondaryIndexesMetadata);
       }
       return tableConfig.getProps();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieSecondaryIndexException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieSecondaryIndexException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.exception;
+
+public class HoodieSecondaryIndexException extends HoodieException {
+  public HoodieSecondaryIndexException(String message) {
+    super(message);
+  }
+
+  public HoodieSecondaryIndexException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/secondary/index/SecondaryIndexManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/secondary/index/SecondaryIndexManager.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.secondary.index;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieSecondaryIndexException;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.secondary.index.SecondaryIndexUtils.getSecondaryIndexes;
+
+public class SecondaryIndexManager {
+  private static final Logger LOG = LoggerFactory.getLogger(SecondaryIndexManager.class);
+
+  private static volatile SecondaryIndexManager _instance;
+
+  private SecondaryIndexManager() {
+  }
+
+  public static SecondaryIndexManager getInstance() {
+    if (_instance == null) {
+      synchronized (SecondaryIndexManager.class) {
+        if (_instance == null) {
+          _instance = new SecondaryIndexManager();
+        }
+      }
+    }
+
+    return _instance;
+  }
+
+  /**
+   * Create a secondary index for hoodie table, two steps will be performed:
+   * 1. Add secondary index metadata to hoodie.properties
+   * 2. Trigger build secondary index
+   *
+   * @param metaClient     Hoodie table meta client
+   * @param indexName      The unique secondary index name
+   * @param indexType      Index type
+   * @param ignoreIfExists Whether ignore the creation if the specific secondary index exists
+   * @param columns        The columns referenced by this secondary index, each column
+   *                       has its own options
+   * @param options        Options for this secondary index
+   */
+  public void create(
+      HoodieTableMetaClient metaClient,
+      String indexName,
+      String indexType,
+      boolean ignoreIfExists,
+      LinkedHashMap<String, Map<String, String>> columns,
+      Map<String, String> options) {
+    Option<List<HoodieSecondaryIndex>> secondaryIndexes = getSecondaryIndexes(metaClient);
+    Set<String> colNames = columns.keySet();
+    Schema avroSchema;
+    try {
+      avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema(false);
+    } catch (Exception e) {
+      throw new HoodieSecondaryIndexException(
+          "Failed to get table avro schema: " + metaClient.getTableConfig().getTableName());
+    }
+
+    for (String col : colNames) {
+      if (avroSchema.getField(col) == null) {
+        throw new HoodieSecondaryIndexException("Field not exists: " + col);
+      }
+    }
+
+    if (indexExists(secondaryIndexes, indexName, Option.of(indexType), Option.of(colNames))) {
+      if (ignoreIfExists) {
+        return;
+      } else {
+        throw new HoodieSecondaryIndexException("Secondary index already exists: " + indexName);
+      }
+    }
+
+    HoodieSecondaryIndex secondaryIndexToAdd = HoodieSecondaryIndex.builder()
+        .setIndexName(indexName)
+        .setIndexType(indexType)
+        .setColumns(columns)
+        .setOptions(options)
+        .build();
+
+    List<HoodieSecondaryIndex> newSecondaryIndexes = secondaryIndexes.map(h -> {
+      h.add(secondaryIndexToAdd);
+      return h;
+    }).orElse(Collections.singletonList(secondaryIndexToAdd));
+    newSecondaryIndexes.sort(new HoodieSecondaryIndex.HoodieIndexCompactor());
+
+    // Persistence secondary indexes' metadata to hoodie.properties file
+    Properties updatedProps = new Properties();
+    updatedProps.put(HoodieTableConfig.SECONDARY_INDEXES_METADATA.key(),
+        SecondaryIndexUtils.toJsonString(newSecondaryIndexes));
+    HoodieTableConfig.update(metaClient.getFs(), new Path(metaClient.getMetaPath()), updatedProps);
+
+    LOG.info("Success to add secondary index metadata: {}", secondaryIndexToAdd);
+
+    // TODO: build index
+  }
+
+  /**
+   * Drop a secondary index by index name
+   *
+   * @param metaClient        Hoodie table meta client
+   * @param indexName         The unique secondary index name
+   * @param ignoreIfNotExists Whether ignore drop if the specific secondary index no exists
+   */
+  public void drop(HoodieTableMetaClient metaClient, String indexName, boolean ignoreIfNotExists) {
+    Option<List<HoodieSecondaryIndex>> secondaryIndexes = getSecondaryIndexes(metaClient);
+    if (!indexExists(secondaryIndexes, indexName, Option.empty(), Option.empty())) {
+      if (ignoreIfNotExists) {
+        return;
+      } else {
+        throw new HoodieSecondaryIndexException("Secondary index not exists: " + indexName);
+      }
+    }
+
+    List<HoodieSecondaryIndex> secondaryIndexesToKeep = secondaryIndexes.get().stream()
+        .filter(i -> !i.getIndexName().equals(indexName))
+        .sorted(new HoodieSecondaryIndex.HoodieIndexCompactor())
+        .collect(Collectors.toList());
+    if (CollectionUtils.nonEmpty(secondaryIndexesToKeep)) {
+      Properties updatedProps = new Properties();
+      updatedProps.put(HoodieTableConfig.SECONDARY_INDEXES_METADATA.key(),
+          SecondaryIndexUtils.toJsonString(secondaryIndexesToKeep));
+      HoodieTableConfig.update(metaClient.getFs(), new Path(metaClient.getMetaPath()), updatedProps);
+    } else {
+      HoodieTableConfig.delete(metaClient.getFs(), new Path(metaClient.getMetaPath()),
+          CollectionUtils.createSet(HoodieTableConfig.SECONDARY_INDEXES_METADATA.key()));
+    }
+
+    LOG.info("Success to delete secondary index metadata: {}", indexName);
+
+    // TODO: drop index data
+  }
+
+  /**
+   * Show secondary indexes from hoodie table
+   *
+   * @param metaClient Hoodie table meta client
+   * @return Indexes in this table
+   */
+  public Option<List<HoodieSecondaryIndex>> show(HoodieTableMetaClient metaClient) {
+    return getSecondaryIndexes(metaClient);
+  }
+
+  /**
+   * Refresh the specific secondary index
+   *
+   * @param metaClient Hoodie table meta client
+   * @param indexName  The target secondary index name
+   */
+  public void refresh(HoodieTableMetaClient metaClient, String indexName) {
+    // TODO
+  }
+
+  /**
+   * Check if the specific secondary index exists. When drop a secondary index,
+   * only check index name, but for adding a secondary index, we should also
+   * check the index type and columns when index name is different.
+   *
+   * @param secondaryIndexes Current secondary indexes in this table
+   * @param indexName        The index name of target secondary index
+   * @param indexType        The index type of target secondary index
+   * @param colNames         The column names of target secondary index
+   * @return true if secondary index exists
+   */
+  private boolean indexExists(
+      Option<List<HoodieSecondaryIndex>> secondaryIndexes,
+      String indexName,
+      Option<String> indexType,
+      Option<Set<String>> colNames) {
+    return secondaryIndexes.map(indexes ->
+        indexes.stream().anyMatch(index -> {
+          if (index.getIndexName().equals(indexName)) {
+            return true;
+          } else if (indexType.isPresent() && colNames.isPresent()) {
+            // When secondary index names are different, we should check index type
+            // and index columns to avoid repeatedly creating the same index.
+            // For example:
+            //   create index idx_name on test using lucene (name);
+            //   create index idx_name_1 on test using lucene (name);
+            return index.getIndexType().name().equalsIgnoreCase(indexType.get())
+                && CollectionUtils.diff(index.getColumns().keySet(), colNames.get()).isEmpty();
+          }
+
+          return false;
+        })).orElse(false);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/secondary/index/SecondaryIndexType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/secondary/index/SecondaryIndexType.java
@@ -17,18 +17,18 @@
  * under the License.
  */
 
-package org.apache.hudi.common.index;
+package org.apache.hudi.secondary.index;
 
 import org.apache.hudi.exception.HoodieIndexException;
 
 import java.util.Arrays;
 
-public enum HoodieIndexType {
+public enum SecondaryIndexType {
   LUCENE((byte) 1);
 
   private final byte type;
 
-  HoodieIndexType(byte type) {
+  SecondaryIndexType(byte type) {
     this.type = type;
   }
 
@@ -36,16 +36,16 @@ public enum HoodieIndexType {
     return type;
   }
 
-  public static HoodieIndexType of(byte indexType) {
-    return Arrays.stream(HoodieIndexType.values())
+  public static SecondaryIndexType of(byte indexType) {
+    return Arrays.stream(SecondaryIndexType.values())
         .filter(t -> t.type == indexType)
         .findAny()
         .orElseThrow(() ->
             new HoodieIndexException("Unknown hoodie index type:" + indexType));
   }
 
-  public static HoodieIndexType of(String indexType) {
-    return Arrays.stream(HoodieIndexType.values())
+  public static SecondaryIndexType of(String indexType) {
+    return Arrays.stream(SecondaryIndexType.values())
         .filter(t -> t.name().equals(indexType.toUpperCase()))
         .findAny()
         .orElseThrow(() ->

--- a/hudi-common/src/main/java/org/apache/hudi/secondary/index/SecondaryIndexUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/secondary/index/SecondaryIndexUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.secondary.index;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.exception.HoodieSecondaryIndexException;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+public class SecondaryIndexUtils {
+
+  /**
+   * Get secondary index metadata for this table
+   *
+   * @param metaClient HoodieTableMetaClient
+   * @return HoodieSecondaryIndex List
+   */
+  public static Option<List<HoodieSecondaryIndex>> getSecondaryIndexes(HoodieTableMetaClient metaClient) {
+    Option<String> indexesMetadata = metaClient.getTableConfig().getSecondaryIndexesMetadata();
+    return indexesMetadata.map(SecondaryIndexUtils::fromJsonString);
+  }
+
+  /**
+   * Parse secondary index str to List<HOodieSecondaryIndex>
+   *
+   * @param jsonStr Secondary indexes with json format
+   * @return List<HoodieSecondaryIndex>
+   */
+  public static List<HoodieSecondaryIndex> fromJsonString(String jsonStr) {
+    try {
+      return SecondaryIndexUtils.fromJsonString(jsonStr,
+          new TypeReference<List<HoodieSecondaryIndex>>() {
+          });
+    } catch (Exception e) {
+      throw new HoodieSecondaryIndexException("Fail to get secondary indexes", e);
+    }
+  }
+
+  public static String toJsonString(Object value) {
+    try {
+      return getObjectMapper().writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      throw new HoodieIndexException("Fail to convert object to json string", e);
+    }
+  }
+
+  public static <T> T fromJsonString(String jsonStr, TypeReference<T> type) throws Exception {
+    if (jsonStr == null || jsonStr.isEmpty()) {
+      return null;
+    }
+
+    return getObjectMapper().readValue(jsonStr, type);
+  }
+
+  public static ObjectMapper getObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    return mapper;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
@@ -31,7 +31,7 @@ case class CreateIndex(
     indexType: String,
     ignoreIfExists: Boolean,
     columns: Seq[(Attribute, Map[String, String])],
-    properties: Map[String, String],
+    options: Map[String, String],
     override val output: Seq[Attribute] = CreateIndex.getOutputAttrs) extends Command {
 
   override def children: Seq[LogicalPlan] = Seq(table)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -191,10 +191,10 @@ case class HoodieAnalysis(sparkSession: SparkSession) extends Rule[LogicalPlan]
         }
 
       // Convert to CreateIndexCommand
-      case CreateIndex(table, indexName, indexType, ignoreIfExists, columns, properties, output)
+      case CreateIndex(table, indexName, indexType, ignoreIfExists, columns, options, output)
         if table.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
         CreateIndexCommand(
-          getTableIdentifier(table), indexName, indexType, ignoreIfExists, columns, properties, output)
+          getTableIdentifier(table), indexName, indexType, ignoreIfExists, columns, options, output)
 
       // Convert to DropIndexCommand
       case DropIndex(table, indexName, ignoreIfNotExists, output)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
@@ -64,7 +64,7 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
         assertResult("idx_name")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
         assertResult("lucene")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
         assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
-        assertResult(Map("block_size" -> "1024"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].properties)
+        assertResult(Map("block_size" -> "1024"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
 
         logicalPlan = sqlParser.parsePlan(s"create index if not exists idx_price on $tableName using lucene (price options(order='desc')) options(block_size=512)")
         resolvedLogicalPlan = analyzer.execute(logicalPlan)
@@ -72,7 +72,7 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
         assertResult("idx_price")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
         assertResult("lucene")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
         assertResult(Map("order" -> "desc"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].columns.head._2)
-        assertResult(Map("block_size" -> "512"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].properties)
+        assertResult(Map("block_size" -> "512"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
 
         logicalPlan = sqlParser.parsePlan(s"drop index if exists idx_name on $tableName")
         resolvedLogicalPlan = analyzer.execute(logicalPlan)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestSecondaryIndex.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase
+
+class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+  test("Test Create/Show/Drop Secondary Index") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by(ts)
+             | location '$basePath'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+        checkAnswer(s"show indexes from default.$tableName")()
+
+        checkAnswer(s"create index idx_name on $tableName using lucene (name) options(block_size=1024)")()
+        checkAnswer(s"create index idx_price on $tableName using lucene (price options(order='desc')) options(block_size=512)")()
+
+        // Create an index with multiple columns
+        checkException(s"create index idx_id_ts on $tableName using lucene (id, ts)")("Lucene index only support single column")
+
+        // Create an index with the occupied name
+        checkException(s"create index idx_price on $tableName using lucene (price)")(
+          "Secondary index already exists: idx_price"
+        )
+
+        // Create indexes repeatedly on columns(index name is different, but the index type and involved column is same)
+        checkException(s"create index idx_price_1 on $tableName using lucene (price)")(
+          "Secondary index already exists: idx_price_1"
+        )
+
+        spark.sql(s"show indexes from $tableName").show()
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("idx_name", "name", "lucene", "", "{\"block_size\":\"1024\"}"),
+          Seq("idx_price", "price", "lucene", "{\"price\":{\"order\":\"desc\"}}", "{\"block_size\":\"512\"}")
+        )
+
+        checkAnswer(s"drop index idx_name on $tableName")()
+        checkException(s"drop index idx_name on $tableName")("Secondary index not exists: idx_name")
+
+        spark.sql(s"show indexes from $tableName").show()
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("idx_price", "price", "lucene", "{\"price\":{\"order\":\"desc\"}}", "{\"block_size\":\"512\"}")
+        )
+
+        checkAnswer(s"drop index idx_price on $tableName")()
+        checkAnswer(s"show indexes from $tableName")()
+
+        checkException(s"drop index idx_price on $tableName")("Secondary index not exists: idx_price")
+
+        checkException(s"create index idx_price_1 on $tableName using lucene (field_not_exist)")(
+          "Field not exists: field_not_exist"
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Implementing create/drop/show/refresh index command for secondary index based on related index syntax, and persisting index metadata into hoodie.properties.

## Brief change log

  - Add ``SecondaryIndexManager``, ``SecondaryIndexUtils``, ``HoodieSecondaryIndexException``, ``TestSecondaryIndex``
  - Rename ``HoodieIndex`` to ``HoodieSecondaryIndex``
  - Rename ``HoodieIndexType`` to ``SecondaryIndexType``
  - Modify ``HoodieTableConfig``, ``HoodieTableMetaClient``, ``Index``, ``IndexCommands``

## Verify this pull request

This change added tests and can be verified as follows:

  - Added TestSecondaryIndex to verify the change

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
