### PR TITLE
[HUDI-4309] Spark3.2 custom parser should not throw exception

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
@@ -238,4 +238,15 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
       }
     }
   }
+
+  test("Test Unsupported syntax can be parsed") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      checkAnswer("select 1 distribute by 1")(Seq(1))
+      withTempDir { dir =>
+        val path = dir.toURI.getPath
+        spark.sql(s"insert overwrite local directory '$path' using parquet select 1")
+        spark.sql(s"insert overwrite local directory '$path' stored as orc select 1")
+      }
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
@@ -245,7 +245,8 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
       withTempDir { dir =>
         val path = dir.toURI.getPath
         spark.sql(s"insert overwrite local directory '$path' using parquet select 1")
-        spark.sql(s"insert overwrite local directory '$path' stored as orc select 1")
+        // Requires enable hive support, so didn't test it
+        // spark.sql(s"insert overwrite local directory '$path' stored as orc select 1")
       }
     }
   }


### PR DESCRIPTION
## What is the purpose of the pull request

In `HoodieSpark3_2ExtendedSqlAstBuilder`, there are three places where the syntax is not supported, which causes sql to report an error in the parse stage.

```
visitInsertOverwriteDir
visitInsertOverwriteHiveDir
withRepartitionByExpression
```

We can avoid exceptions, so we can also use `delegate.parsePlan`.

## Brief change log

  - *Spark3.2 custom parser should not throw exception*

## Verify this pull request

  - *add UT.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
