### PR TITLE
[HUDI-4311] Fix Flink lose data on some rollback scene

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -266,7 +265,7 @@ public class StreamWriteOperatorCoordinator
 
   @Override
   public void notifyCheckpointAborted(long checkpointId) {
-    if (checkpointId == this.checkpointId) {
+    if (checkpointId == this.checkpointId && !WriteMetadataEvent.BOOTSTRAP_INSTANT.equals(this.instant)) {
       executor.execute(() -> {
         this.ckpMetadata.abortInstant(this.instant);
       }, "abort instant %s", this.instant);
@@ -306,13 +305,6 @@ public class StreamWriteOperatorCoordinator
     // reset the event
     this.eventBuffer[i] = null;
     LOG.warn("Reset the event for task [" + i + "]", throwable);
-    if (Arrays.stream(this.eventBuffer).allMatch(event -> event == null)) {
-      try {
-        this.ckpMetadata.bootstrap(this.metaClient);
-      } catch (IOException e) {
-        throw new HoodieException("Bootstrap ckpMetadata exception", e);
-      }
-    }
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -266,9 +266,12 @@ public class StreamWriteOperatorCoordinator
   @Override
   public void notifyCheckpointAborted(long checkpointId) {
     if (checkpointId == this.checkpointId) {
-      executor.execute(() -> {
-        this.ckpMetadata.abortInstant(this.instant);
-      }, "abort instant %s", this.instant);
+      // write task failed we do not reuse the instant
+      if (Arrays.stream(eventBuffer).anyMatch(s -> s == null)) {
+        executor.execute(() -> {
+          this.ckpMetadata.abortInstant(this.instant);
+        }, "abort instant %s", this.instant);
+      }
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -265,6 +265,6 @@ public abstract class AbstractStreamWriteFunction<I>
    * Returns whether the pending instant is invalid to write with.
    */
   private boolean invalidInstant(String instant, boolean hasData) {
-    return instant.equals(this.currentInstant) && hasData && !this.ckpMetadata.isAborted(instant);
+    return instant.equals(this.currentInstant) && hasData && this.ckpMetadata.isAborted(instant);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -265,6 +265,6 @@ public abstract class AbstractStreamWriteFunction<I>
    * Returns whether the pending instant is invalid to write with.
    */
   private boolean invalidInstant(String instant, boolean hasData) {
-    return instant.equals(this.currentInstant) && hasData && this.ckpMetadata.isAborted(instant);
+    return instant.equals(this.currentInstant) && hasData && !this.ckpMetadata.isAborted(instant);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -152,7 +152,9 @@ public class CkpMetadata implements Serializable {
   public void abortInstant(String instant) {
     Path path = fullPath(CkpMessage.getFileName(instant, CkpMessage.State.ABORTED));
     try {
-      fs.createNewFile(path);
+      if (fs.exists(fullPath(CkpMessage.getFileName(instant, CkpMessage.State.INFLIGHT)))) {
+        fs.createNewFile(path);
+      }
     } catch (IOException e) {
       throw new HoodieException("Exception while adding checkpoint abort metadata for instant: " + instant);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -152,10 +152,7 @@ public class CkpMetadata implements Serializable {
   public void abortInstant(String instant) {
     Path path = fullPath(CkpMessage.getFileName(instant, CkpMessage.State.ABORTED));
     try {
-      // when all write task failed ckpMeta will reInit and not need abort
-      if (fs.exists(fullPath(CkpMessage.getFileName(instant, CkpMessage.State.INFLIGHT)))) {
-        fs.createNewFile(path);
-      }
+      fs.createNewFile(path);
     } catch (IOException e) {
       throw new HoodieException("Exception while adding checkpoint abort metadata for instant: " + instant);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -152,9 +152,7 @@ public class CkpMetadata implements Serializable {
   public void abortInstant(String instant) {
     Path path = fullPath(CkpMessage.getFileName(instant, CkpMessage.State.ABORTED));
     try {
-      if (fs.exists(fullPath(CkpMessage.getFileName(instant, CkpMessage.State.INFLIGHT)))) {
-        fs.createNewFile(path);
-      }
+      fs.createNewFile(path);
     } catch (IOException e) {
       throw new HoodieException("Exception while adding checkpoint abort metadata for instant: " + instant);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -89,19 +89,14 @@ public class CkpMetadata implements Serializable {
   //  WRITE METHODS
   // -------------------------------------------------------------------------
 
-  public void reInit() throws IOException {
-    fs.delete(path, true);
-    fs.mkdirs(path);
-  }
-
   /**
    * Initialize the message bus, would clean all the messages and publish the last pending instant.
    *
    * <p>This expects to be called by the driver.
    */
   public void bootstrap(HoodieTableMetaClient metaClient) throws IOException {
-    metaClient.getActiveTimeline().getCommitsTimeline().filterPendingExcludingCompaction()
-        .lastInstant().ifPresent(instant -> startInstant(instant.getTimestamp()));
+    fs.delete(path, true);
+    fs.mkdirs(path);
   }
 
   public void startInstant(String instant) {


### PR DESCRIPTION
## What is the purpose of the pull request

As https://issues.apache.org/jira/projects/HUDI/issues/HUDI-4287 mentioned

Not only in the streaming rollback but also batch write , we should bootstrap the

ckp meta after all write task is ready . And when write tasks failed or first time run

clean the ckp meta path

step to reproduce
- job start with time 1 instant1 
- task write failed trigger flink restart
- abort instant1 as instant1.abort
- start to rollback instant1
- write task bootstrap ready and load the ckpMeta with instant1.inflight and instant1.abort
- flushbucket with instant1 
- end rollback instant1 delete instant1 relate data files
- start instant2
data lose

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
