### PR TITLE
[MINOR] Following #2070, Fix BindException when running tests on shared machines.

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
@@ -103,7 +103,9 @@ public class HdfsTestService {
 
   public void stop() {
     LOG.info("HDFS Minicluster service being shut down.");
-    miniDfsCluster.shutdown();
+    if (miniDfsCluster != null) {
+      miniDfsCluster.shutdown();
+    }
     miniDfsCluster = null;
     hadoopConf = null;
   }


### PR DESCRIPTION
## What is the purpose of the pull request

This is a follow-up to #2070, retrying bind does not seem to take effect, because `miniDfsCluster` is not initialized, calling the stop method we will get a null pointer.

```
2022-06-23T18:59:25.1514164Z java.lang.NullPointerException
2022-06-23T18:59:25.1515051Z 	at org.apache.hudi.common.testutils.minicluster.HdfsTestService.stop(HdfsTestService.java:106)
2022-06-23T18:59:25.1516107Z 	at org.apache.hudi.common.testutils.minicluster.HdfsTestService.start(HdfsTestService.java:96)
2022-06-23T18:59:25.1517359Z 	at org.apache.hudi.utilities.testutils.UtilitiesTestBase.initTestServices(UtilitiesTestBase.java:118)
2022-06-23T18:59:25.1518418Z 	at org.apache.hudi.utilities.transform.TestSqlFileBasedTransformer.initClass(TestSqlFileBasedTransformer.java:52)
```

## Brief change log

  - *Added a loop when creating HDFS Cluster.*

## Verify this pull request

  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
