### PR TITLE
[HUDI-4317] Remove -T option from CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ parameters:
 variables:
   BUILD_PROFILES: '-Dscala-2.11 -Dspark2 -Dflink1.14'
   PLUGIN_OPTS: '-Dcheckstyle.skip=true -Drat.skip=true -Djacoco.skip=true'
-  MVN_OPTS_INSTALL: '-T 2.5C -DskipTests $(BUILD_PROFILES) $(PLUGIN_OPTS)'
+  MVN_OPTS_INSTALL: '-DskipTests $(BUILD_PROFILES) $(PLUGIN_OPTS)'
   MVN_OPTS_TEST: '-fae $(BUILD_PROFILES) $(PLUGIN_OPTS)'
   SPARK_VERSION: '2.4.4'
   HADOOP_VERSION: '2.7'


### PR DESCRIPTION
To avoid potential CI build errors like 

```
2022-06-24T08:51:53.7477185Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run (default) on project hudi-hadoop-hive-docker: An Ant BuildException has occured: Warning: Could not find file /home/vsts/work/1/s/packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.11-0.12.0-SNAPSHOT.jar to copy.
2022-06-24T08:51:53.7479039Z [ERROR] around Ant part ...<copy file="/home/vsts/work/1/s/docker/hoodie/hadoop/hive_base/../../../../packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.11-0.12.0-SNAPSHOT.jar" tofile="target/hoodie-utilities.jar"/>... @ 7:203 in /home/vsts/work/1/s/docker/hoodie/hadoop/hive_base/target/antrun/build-main.xml
```