### PR TITLE
[HUDI-4296]Fix the bug that TestHoodieSparkSqlWriter.testSchemaEvolut…

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/BaseFileOnlyRelation.scala
@@ -166,7 +166,9 @@ class BaseFileOnlyRelation(sqlContext: SQLContext,
       DataSource.apply(
         sparkSession = sparkSession,
         paths = extraReadPaths,
-        userSpecifiedSchema = userSchema,
+        // Here we should specify the schema to the latest commit schema since
+        // the table schema evolution.
+        userSpecifiedSchema = userSchema.orElse(Some(tableStructSchema)),
         className = formatClassName,
         // Since we're reading the table as just collection of files we have to make sure
         // we only read the latest version of every Hudi's file-group, which might be compacted, clustered, etc.
@@ -175,8 +177,7 @@ class BaseFileOnlyRelation(sqlContext: SQLContext,
         // We rely on [[HoodieROTablePathFilter]], to do proper filtering to assure that
         options = optParams ++ Map(
           "mapreduce.input.pathFilter.class" -> classOf[HoodieROTablePathFilter].getName
-        ),
-        partitionColumns = partitionColumns
+        )
       )
         .resolveRelation()
         .asInstanceOf[HadoopFsRelation]


### PR DESCRIPTION
…ionForTableType is flaky

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fix TestHoodieSparkSqlWriter.testSchemaEvolutionForTableType failed random
the reason for it is that:
1）when we use glob path to read hudi table (like spark.read.format("hudi").load("/tmp/tableName///*")). spark will infer parquet schema auto,
2）when evolution happen, hoodie table may exist different schema parquet files, spark choose a parquet file randomly to infer schema
3）once spark choose a old parquet file，an old schema will be used which is wrong.

Therefore we should specify the schema to the latest commit schema since the table schema evolution.
*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
