### PR TITLE
[HUDI-4325] fix spark sql procedure cause ParseException with semicolon

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4
+++ b/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4
@@ -42,7 +42,7 @@
 }
 
  singleStatement
-    : statement EOF
+    : statement ';'* EOF
     ;
 
  statement

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallCommandParser.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallCommandParser.scala
@@ -86,7 +86,7 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
   }
 
   test("Test Call Produce with semicolon") {
-    val call = parser.parsePlan("CALL system.func(c1 => 1, c2 => '2', c3 => true);").asInstanceOf[CallCommand]
+    val call = parser.parsePlan("CALL system.func(c1 => 1, c2 => '2', c3 => true)").asInstanceOf[CallCommand]
     assertResult(ImmutableList.of("system", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
 
     assertResult(3)(call.args.size)
@@ -94,6 +94,15 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
     checkArg(call, 0, "c1", 1, DataTypes.IntegerType)
     checkArg(call, 1, "c2", "2", DataTypes.StringType)
     checkArg(call, 2, "c3", true, DataTypes.BooleanType)
+
+    val call2 = parser.parsePlan("CALL system.func2(c1 => 1, c2 => '2', c3 => true);").asInstanceOf[CallCommand]
+    assertResult(ImmutableList.of("system", "func2"))(JavaConverters.seqAsJavaListConverter(call2.name).asJava)
+
+    assertResult(3)(call2.args.size)
+
+    checkArg(call2, 0, "c1", 1, DataTypes.IntegerType)
+    checkArg(call2, 1, "c2", "2", DataTypes.StringType)
+    checkArg(call2, 2, "c3", true, DataTypes.BooleanType)
   }
 
   protected def checkParseExceptionContain(sql: String)(errorMsg: String): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallCommandParser.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCallCommandParser.scala
@@ -85,6 +85,17 @@ class TestCallCommandParser extends HoodieSparkSqlTestBase {
     checkParseExceptionContain("CALL cat.system radish kebab")("mismatched input 'CALL' expecting")
   }
 
+  test("Test Call Produce with semicolon") {
+    val call = parser.parsePlan("CALL system.func(c1 => 1, c2 => '2', c3 => true);").asInstanceOf[CallCommand]
+    assertResult(ImmutableList.of("system", "func"))(JavaConverters.seqAsJavaListConverter(call.name).asJava)
+
+    assertResult(3)(call.args.size)
+
+    checkArg(call, 0, "c1", 1, DataTypes.IntegerType)
+    checkArg(call, 1, "c2", "2", DataTypes.StringType)
+    checkArg(call, 2, "c3", true, DataTypes.BooleanType)
+  }
+
   protected def checkParseExceptionContain(sql: String)(errorMsg: String): Unit = {
     var hasException = false
     try {


### PR DESCRIPTION
## What is the purpose of the pull request

fix use `spark.sql("call show_commits(table => 'delete_error_test', limit => 10);").show(false)` with ';' cause parse error

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
