### PR TITLE
[HUDI-4331] Allow loading external config file from class loader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -90,11 +91,24 @@ public class DFSPropertiesConfiguration {
   }
 
   /**
-   * Load global props from hudi-defaults.conf which is under CONF_FILE_DIR_ENV_NAME.
+   * Load global props from hudi-defaults.conf which is under class loader or CONF_FILE_DIR_ENV_NAME.
    * @return Typed Properties
    */
   public static TypedProperties loadGlobalProps() {
     DFSPropertiesConfiguration conf = new DFSPropertiesConfiguration();
+
+    // First try loading the external config file from class loader
+    URL configFile = Thread.currentThread().getContextClassLoader().getResource(DEFAULT_PROPERTIES_FILE);
+    if (configFile != null) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream()))) {
+        conf.addPropsFromStream(br);
+        return conf.getProps();
+      } catch (IOException ioe) {
+        throw new HoodieIOException(
+            String.format("Failed to read %s from class loader", DEFAULT_PROPERTIES_FILE), ioe);
+      }
+    }
+    // Try loading the external config file from local file system
     Option<Path> defaultConfPath = getConfPathFromEnv();
     if (defaultConfPath.isPresent()) {
       conf.addPropsFromFile(defaultConfPath.get());


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

This PR aims to let Hudi external config support Spark cluster mode. In Spark cluster mode, the Spark driver would run on a random node within the cluster. Hudi external config file only exists in the master node and this would cause a file not found issue when the Spark driver is not running on the master node.

In this PR, when loading the external config file, it would first try to load the hudi-defaults.conf from the class loader. To add hudi-defaults.conf to the Spark class loader, similar to hive-site.xml, we can add hudi-defaults.conf through spark.yarn.dist.files option.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
