### PR TITLE
[HUDI-4334] close SparkRDDWriteClient after usage in Create/Delete/RollbackSavepointsProcedure

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointsProcedure.scala
@@ -68,6 +68,8 @@ class CreateSavepointsProcedure extends BaseProcedure with ProcedureBuilder with
     } catch {
       case _: HoodieSavepointException =>
         logWarning(s"Failed: Could not create savepoint $commitTime.")
+    } finally {
+      client.close()
     }
 
     Seq(Row(result))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointsProcedure.scala
@@ -67,6 +67,8 @@ class DeleteSavepointsProcedure extends BaseProcedure with ProcedureBuilder with
     } catch {
       case _: HoodieSavepointException =>
         logWarning(s"Failed: Could not delete savepoint $instantTime.")
+    } finally {
+      client.close()
     }
 
     Seq(Row(result))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackSavepointsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackSavepointsProcedure.scala
@@ -67,6 +67,8 @@ class RollbackSavepointsProcedure extends BaseProcedure with ProcedureBuilder wi
     } catch {
       case _: HoodieSavepointException =>
         logWarning(s"The commit $instantTime failed to roll back.")
+    } finally {
+      client.close()
     }
 
     Seq(Row(result))


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fix HUDI-4334: close SparkRDDWriteClient after usage in Create/Delete/RollbackSavepointsProcedure

## Brief change log

  - Close SparkRDDWriteClient in finally after try-catch in Create/Delete/RollbackSavepointsProcedure

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
