### PR TITLE
[HUDI-4335] Bug fixes in AWSGlueCatalogSyncClient post schema evolution.

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -412,7 +412,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     List<Column> cols = new ArrayList<>();
     for (String key : mapSchema.keySet()) {
       // In Glue, the full schema should exclude the partition keys
-      if (!syncConfig.partitionFields.contains(key)) {
+      if (!config.getSplitStrings(META_SYNC_PARTITION_FIELDS).contains(key)) {
         String keyType = getPartitionKeyType(mapSchema, key);
         Column column = new Column().withName(key).withType(keyType.toLowerCase()).withComment("");
         cols.add(column);

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -64,9 +64,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.aws.utils.S3Utils.s3aToS3;
-import static org.apache.hudi.common.util.MapUtils.nonEmpty;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
+import static org.apache.hudi.common.util.MapUtils.isNullOrEmpty;
 import static org.apache.hudi.hive.util.HiveSchemaUtil.getPartitionKeyType;
 import static org.apache.hudi.hive.util.HiveSchemaUtil.parquetSchemaToMapSchema;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
@@ -193,7 +193,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
    */
   @Override
   public void updateTableProperties(String tableName, Map<String, String> tableProperties) {
-    if (nonEmpty(tableProperties)) {
+    if (isNullOrEmpty(tableProperties)) {
       return;
     }
     try {
@@ -210,10 +210,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     try {
       Table table = getTable(awsGlue, databaseName, tableName);
       Map<String, String> newSchemaMap = parquetSchemaToMapSchema(newSchema, config.getBoolean(HIVE_SUPPORT_TIMESTAMP_TYPE), false);
-      List<Column> newColumns = newSchemaMap.keySet().stream().map(key -> {
-        String keyType = getPartitionKeyType(newSchemaMap, key);
-        return new Column().withName(key).withType(keyType.toLowerCase()).withComment("");
-      }).collect(Collectors.toList());
+      List<Column> newColumns = getColumnsFromSchema(newSchemaMap);
       StorageDescriptor sd = table.getStorageDescriptor();
       sd.setColumns(newColumns);
 
@@ -258,15 +255,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     try {
       Map<String, String> mapSchema = parquetSchemaToMapSchema(storageSchema, config.getBoolean(HIVE_SUPPORT_TIMESTAMP_TYPE), false);
 
-      List<Column> schemaWithoutPartitionKeys = new ArrayList<>();
-      for (String key : mapSchema.keySet()) {
-        String keyType = getPartitionKeyType(mapSchema, key);
-        Column column = new Column().withName(key).withType(keyType.toLowerCase()).withComment("");
-        // In Glue, the full schema should exclude the partition keys
-        if (!config.getSplitStrings(META_SYNC_PARTITION_FIELDS).contains(key)) {
-          schemaWithoutPartitionKeys.add(column);
-        }
-      }
+      List<Column> schemaWithoutPartitionKeys = getColumnsFromSchema(mapSchema);
 
       // now create the schema partition
       List<Column> schemaPartitionKeys = config.getSplitStrings(META_SYNC_PARTITION_FIELDS).stream().map(partitionKey -> {
@@ -417,6 +406,19 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   @Override
   public void deleteLastReplicatedTimeStamp(String tableName) {
     throw new UnsupportedOperationException("Not supported: `deleteLastReplicatedTimeStamp`");
+  }
+
+  private List<Column> getColumnsFromSchema(Map<String, String> mapSchema) {
+    List<Column> cols = new ArrayList<>();
+    for (String key : mapSchema.keySet()) {
+      // In Glue, the full schema should exclude the partition keys
+      if (!syncConfig.partitionFields.contains(key)) {
+        String keyType = getPartitionKeyType(mapSchema, key);
+        Column column = new Column().withName(key).withType(keyType.toLowerCase()).withComment("");
+        cols.add(column);
+      }
+    }
+    return cols;
   }
 
   private enum TableType {

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -197,7 +197,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
       return;
     }
     try {
-      updateTableParameters(awsGlue, databaseName, tableName, tableProperties, true);
+      updateTableParameters(awsGlue, databaseName, tableName, tableProperties, false);
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update properties for table " + tableId(databaseName, tableName), e);
     }


### PR DESCRIPTION
## What is the purpose of the pull request
Aims to resolve the following bugs in AWS Glue Meta Sync post schema evolution.

### Bugs
* CreateTable filters out the partition column but updating the table doesn't filter the schema which leads to having duplicate columns and incompatible metadata in Glue.
* Table properties not getting updated when the schema changes because of the incorrect `nonEmpty` predicate.
* Update table parameters function overrides the `EXTERNAL` and `last_commit_time_sync` causing to reload all the partitions.

## Brief change log
* Separates `getColumnsFromSchema` logic into a method that provides common functionality to get the columns in a consistent manner for both creating and updating tables (Excluding partition columns).
* Replaces `nonEmpty(tableProperties)` with `isNullOrEmpty(tableProperties)` to make sure tableProperties are updated during schema updates unless if it is null or empty.
* `updateTableProperties` now doesn't replace table parameters to ensure that `EXTERNAL` and `last_commit_time_sync` properties are not lost during schema updates.

## Verify this pull request
  - *Manually verified the change by running the sync job for creation / updation of tables.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
