### PR TITLE
[HUDI-4336] Fix records overwritten bug with binary primary key

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.util;
 
 import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -88,7 +89,10 @@ public class StringUtils {
   }
 
   public static String objToString(@Nullable Object obj) {
-    return obj == null ? null : obj.toString();
+    if (obj == null) {
+      return null;
+    }
+    return obj instanceof ByteBuffer ? toHexString(((ByteBuffer) obj).array()) : obj.toString();
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -49,6 +50,20 @@ public class TestStringUtils {
     String str = "This is a test";
     assertEquals(str, StringUtils.nullToEmpty(str));
     assertEquals("", StringUtils.nullToEmpty(null));
+  }
+
+  @Test
+  public void testStringObjToString() {
+    assertNull(StringUtils.objToString(null));
+    assertEquals("Test String", StringUtils.objToString("Test String"));
+
+    // assert byte buffer
+    ByteBuffer byteBuffer1 = ByteBuffer.wrap("1234".getBytes());
+    ByteBuffer byteBuffer2 = ByteBuffer.wrap("5678".getBytes());
+    // assert equal because ByteBuffer has overwritten the toString to return a summary string
+    assertEquals(byteBuffer1.toString(), byteBuffer2.toString());
+    // assert not equal
+    assertNotEquals(StringUtils.objToString(byteBuffer1), StringUtils.objToString(byteBuffer2));
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the pull request

Fix the bug that records will be overwrited incorrectly, when the type of recordkey or primarykey is binary.

## Brief change log

  - Modify objToString in StringUtils, and add test cases

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
