### PR TITLE
[HUDI-4340] fix not parsable text DateTimeParseException in HoodieInstantTimeGenerator.parseDateFromInstantTime

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -74,14 +74,55 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
       REQUESTED_REPLACE_COMMIT_EXTENSION, INFLIGHT_REPLACE_COMMIT_EXTENSION, REPLACE_COMMIT_EXTENSION,
       REQUESTED_INDEX_COMMIT_EXTENSION, INFLIGHT_INDEX_COMMIT_EXTENSION, INDEX_COMMIT_EXTENSION,
       REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION, INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION, SAVE_SCHEMA_ACTION_EXTENSION));
+
+  private static final Set<String> NOT_PARSABLE_TIMESTAMPS = new HashSet<String>(3) {{
+      add(HoodieTimeline.INIT_INSTANT_TS);
+      add(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS);
+      add(HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS);
+    }};
+
   private static final Logger LOG = LogManager.getLogger(HoodieActiveTimeline.class);
   protected HoodieTableMetaClient metaClient;
 
   /**
    * Parse the timestamp of an Instant and return a {@code Date}.
+   * Throw ParseException if timestamp is not valid format as
+   *  {@link org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator#SECS_INSTANT_TIMESTAMP_FORMAT}.
+   *
+   * @param timestamp a timestamp String which follow pattern as
+   *  {@link org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator#SECS_INSTANT_TIMESTAMP_FORMAT}.
+   * @return Date of instant timestamp
    */
   public static Date parseDateFromInstantTime(String timestamp) throws ParseException {
     return HoodieInstantTimeGenerator.parseDateFromInstantTime(timestamp);
+  }
+
+  /**
+   * The same parsing method as above, but this method will mute ParseException.
+   * If the given timestamp is invalid, returns {@code Option.empty}.
+   * Or a corresponding Date value if these timestamp strings are provided
+   *  {@link org.apache.hudi.common.table.timeline.HoodieTimeline#INIT_INSTANT_TS},
+   *  {@link org.apache.hudi.common.table.timeline.HoodieTimeline#METADATA_BOOTSTRAP_INSTANT_TS},
+   *  {@link org.apache.hudi.common.table.timeline.HoodieTimeline#FULL_BOOTSTRAP_INSTANT_TS}.
+   * This method is useful when parsing timestamp for metrics
+   *
+   * @param timestamp a timestamp String which follow pattern as
+   *  {@link org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator#SECS_INSTANT_TIMESTAMP_FORMAT}.
+   * @return {@code Option<Date>} of instant timestamp, {@code Option.empty} if invalid timestamp
+   */
+  public static Option<Date> parseDateFromInstantTimeSafely(String timestamp) {
+    Option<Date> parsedDate;
+    try {
+      parsedDate = Option.of(HoodieInstantTimeGenerator.parseDateFromInstantTime(timestamp));
+    } catch (ParseException e) {
+      if (NOT_PARSABLE_TIMESTAMPS.contains(timestamp)) {
+        parsedDate = Option.of(new Date(Integer.parseInt(timestamp)));
+      } else {
+        LOG.warn("Failed to parse timestamp " + timestamp + ": " + e.getMessage());
+        parsedDate = Option.empty();
+      }
+    }
+    return parsedDate;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -50,7 +50,6 @@ public class HoodieInstantTimeGenerator {
 
   // The last Instant timestamp generated
   private static AtomicReference<String> lastInstantTime = new AtomicReference<>(String.valueOf(Integer.MIN_VALUE));
-  private static final String ALL_ZERO_TIMESTAMP = "00000000000000";
 
   // The default number of milliseconds that we add if they are not present
   // We prefer the max timestamp as it mimics the current behavior with second granularity
@@ -96,11 +95,7 @@ public class HoodieInstantTimeGenerator {
       LocalDateTime dt = LocalDateTime.parse(timestampInMillis, MILLIS_INSTANT_TIME_FORMATTER);
       return Date.from(dt.atZone(ZoneId.systemDefault()).toInstant());
     } catch (DateTimeParseException e) {
-      // Special handling for all zero timestamp which is not parsable by DateTimeFormatter
-      if (timestamp.equals(ALL_ZERO_TIMESTAMP)) {
-        return new Date(0);
-      }
-      throw e;
+      throw new ParseException(e.getMessage(), e.getErrorIndex());
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -567,9 +567,6 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
       lastInstantTime = newInstantTime;
     }
 
-    // All zero timestamp can be parsed
-    HoodieActiveTimeline.parseDateFromInstantTime("00000000000000");
-
     // Multiple thread test
     final int numChecks = 100000;
     final int numThreads = 100;
@@ -629,6 +626,26 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
             - HoodieActiveTimeline.parseDateFromInstantTime(secondGranularityInstant).getTime() / 1000,
         "Expected the difference between later instant and previous instant to be 10 seconds"
     );
+  }
+
+  @Test
+  public void testInvalidInstantDateParsing() throws ParseException {
+    // Test all invalid timestamp in HoodieTimeline, shouldn't throw any error and should return a correct value
+    assertEquals(Long.parseLong(HoodieTimeline.INIT_INSTANT_TS),
+        HoodieActiveTimeline.parseDateFromInstantTimeSafely(HoodieTimeline.INIT_INSTANT_TS).get().getTime());
+    assertEquals(Long.parseLong(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS),
+        HoodieActiveTimeline.parseDateFromInstantTimeSafely(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS).get().getTime());
+    assertEquals(Long.parseLong(HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS),
+        HoodieActiveTimeline.parseDateFromInstantTimeSafely(HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS).get().getTime());
+
+    // Test metadata table compaction instant date parsing with INIT_INSTANT_TS, should return Option.empty
+    assertEquals(Option.empty(),
+        HoodieActiveTimeline.parseDateFromInstantTimeSafely(HoodieTimeline.INIT_INSTANT_TS + "001"));
+
+    // Test a valid instant timestamp, should equal the same result as HoodieActiveTimeline.parseDateFromInstantTime
+    String testInstant = "20210101120101";
+    assertEquals(HoodieActiveTimeline.parseDateFromInstantTime(testInstant).getTime(),
+        HoodieActiveTimeline.parseDateFromInstantTimeSafely(testInstant).get().getTime());
   }
 
   /**


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Fix HUDI-4340: DeltaStreamer bootstrap failed when metrics on caused by DateTimeParseException: Text '00000000000001999' could not be parsed

HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS is a invalid value, "00000000000001", which can not be parsed by DateTimeFormatter with format SECS_INSTANT_TIMESTAMP_FORMAT = "yyyyMMddHHmmss" in method HoodieInstantTimeGenerator.parseDateFromInstantTime.

Error log in DeltaStreamer

```log
Exception in thread "main" java.time.format.DateTimeParseException: Text '00000000000001999' could not be parsed: Invalid value for YearOfEra (valid values 1 - 999999999/1000000000): 0
	at java.time.format.DateTimeFormatter.createError(DateTimeFormatter.java:1920)
	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1855)
	at java.time.LocalDateTime.parse(LocalDateTime.java:492)
	at org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.parseDateFromInstantTime(HoodieInstantTimeGenerator.java:96)
	at org.apache.hudi.common.table.timeline.HoodieActiveTimeline.parseDateFromInstantTime(HoodieActiveTimeline.java:84)
	at org.apache.hudi.client.BaseHoodieWriteClient.emitCommitMetrics(BaseHoodieWriteClient.java:307)
	at org.apache.hudi.client.SparkRDDWriteClient.postWrite(SparkRDDWriteClient.java:288)
	at org.apache.hudi.client.SparkRDDWriteClient.upsertPreppedRecords(SparkRDDWriteClient.java:171)
	at org.apache.hudi.metadata.SparkHoodieBackedTableMetadataWriter.commit(SparkHoodieBackedTableMetadataWriter.java:166)
	at org.apache.hudi.metadata.HoodieBackedTableMetadataWriter.processAndCommit(HoodieBackedTableMetadataWriter.java:803)
	at org.apache.hudi.metadata.HoodieBackedTableMetadataWriter.update(HoodieBackedTableMetadataWriter.java:870)
	at org.apache.hudi.table.action.BaseActionExecutor.lambda$writeTableMetadata$0(BaseActionExecutor.java:60)
	at org.apache.hudi.common.util.Option.ifPresent(Option.java:97)
	at org.apache.hudi.table.action.BaseActionExecutor.writeTableMetadata(BaseActionExecutor.java:60)
	at org.apache.hudi.table.action.bootstrap.SparkBootstrapCommitActionExecutor.commit(SparkBootstrapCommitActionExecutor.java:238)
	at org.apache.hudi.table.action.bootstrap.SparkBootstrapCommitActionExecutor.commit(SparkBootstrapCommitActionExecutor.java:211)
	at org.apache.hudi.table.action.commit.BaseCommitActionExecutor.autoCommit(BaseCommitActionExecutor.java:191)
	at org.apache.hudi.table.action.commit.BaseCommitActionExecutor.commitOnAutoCommit(BaseCommitActionExecutor.java:175)
	at org.apache.hudi.table.action.bootstrap.SparkBootstrapCommitActionExecutor.updateIndexAndCommitIfNeeded(SparkBootstrapCommitActionExecutor.java:174)
	at org.apache.hudi.table.action.bootstrap.SparkBootstrapCommitActionExecutor.metadataBootstrap(SparkBootstrapCommitActionExecutor.java:161)
	at org.apache.hudi.table.action.bootstrap.SparkBootstrapCommitActionExecutor.execute(SparkBootstrapCommitActionExecutor.java:124)
	at org.apache.hudi.table.HoodieSparkCopyOnWriteTable.bootstrap(HoodieSparkCopyOnWriteTable.java:193)
	at org.apache.hudi.client.SparkRDDWriteClient.bootstrap(SparkRDDWriteClient.java:146)
	at org.apache.hudi.utilities.deltastreamer.BootstrapExecutor.execute(BootstrapExecutor.java:151)
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.sync(HoodieDeltaStreamer.java:183)
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.main(HoodieDeltaStreamer.java:556)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:845)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:161)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:184)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:86)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:920)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:929)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: java.time.DateTimeException: Invalid value for YearOfEra (valid values 1 - 999999999/1000000000): 0
	at java.time.temporal.ValueRange.checkValidValue(ValueRange.java:311)
	at java.time.temporal.ChronoField.checkValidValue(ChronoField.java:703)
	at java.time.chrono.IsoChronology.resolveYearOfEra(IsoChronology.java:512)
	at java.time.chrono.IsoChronology.resolveYearOfEra(IsoChronology.java:123)
	at java.time.chrono.AbstractChronology.resolveDate(AbstractChronology.java:463)
	at java.time.chrono.IsoChronology.resolveDate(IsoChronology.java:492)
	at java.time.chrono.IsoChronology.resolveDate(IsoChronology.java:123)
	at java.time.format.Parsed.resolveDateFields(Parsed.java:351)
	at java.time.format.Parsed.resolveFields(Parsed.java:257)
	at java.time.format.Parsed.resolve(Parsed.java:244)
	at java.time.format.DateTimeParseContext.toResolved(DateTimeParseContext.java:331)
	at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1955)
	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1851)
	... 36 more
```

## Brief change log

  - Add a new method `HoodieActiveTimeline.parseDateFromInstantTimeSafely` for parsing timestamp when output metrics
  - Add a test method `testInvalidInstantDateParsing` in `TestHoodieActiveTimeline` for `HoodieActiveTimeline.parseDateFromInstantTimeSafely`
  - Replace `HoodieActiveTimeline.parseDateFromInstantTime` with `parseDateFromInstantTimeSafely` in `SparkRDDWriteClient` and `BaseHoodieWriteClient` when output metrics

## Verify this pull request

This pull request is already covered by existing tests, such as *ITTestHoodieDemo.testParquetDemo*.

Minor change, and can be verified manually in method `ITTestHoodieDemo.testParquetDemo`

  - Enable metrics in test method `ITTestHoodieDemo.testParquetDemo`
  - The old code will fail in method `ingestFirstBatchAndHiveSync()` when DeltaStreamer do the bootstrap when execute `bootstrapCmds` at ` executeCommandStringsInDocker(ADHOC_1_CONTAINER, bootstrapCmds);`
  - The fixed code will pass in the test method `ITTestHoodieDemo.testParquetDemo` when metrics on
  - And there is a test method for verifying `TestHoodieActiveTimeline.testInvalidInstantDateParsing`

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR (no need)
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.(no need)
