### PR TITLE
[HUDI-4356] Fix the error when sync hive in CTAS

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala
@@ -76,6 +76,7 @@ case class CreateHoodieTableAsSelectCommand(
       table.storage.compressed,
       table.storage.properties.--(needFilterProps))
     val newTable = table.copy(
+      identifier = tableIdentWithDB,
       storage = newStorage,
       schema = reOrderedQuery.schema,
       properties = table.properties.--(needFilterProps)


### PR DESCRIPTION
the error due to the wrong configuration `hoodie.datasource.hive_sync.database`
Example:
## partitionTable

### CTAS
```sql
use hudi;
create table test_hudi_table using hudi
 partitioned by(dt)
 options(
    primaryKey = 'id',
    preCombineField = 'ts',
    type = 'cow'
 )
 AS
 select 1 as id, 'a1' as name, 10 as price, 1000 as ts,'2022-07-03' as dt;
```
### result
two tables is created by sync hive;`EXTERNAL default.test_hudi_table` and `hudi.test_hudi_table`,And added a partition in `default.test_hudi_table` but the`hudi.test_hudi_table`  didn't,So it is empty when querying the table `hudi.test_hudi_table`

## noPartitionTable
```sql
use hudi;
 create table test_hudi_table_2 using hudi
 options(
    primaryKey = 'id',
    preCombineField = 'ts',
    type = 'cow'
 )
 AS
 select 1 as id, 'a1' as name, 10 as price, 1000 as ts,'2022-07-03' as dt;
```
two tables is created by sync hive;`EXTERNAL default.test_hudi_table_2 ` and `hudi.test_hudi_table_2 `,Both tables can be queried normally, but we should only synchronize one table

## What is the purpose of the pull request

Fix the error when sync hive in CTAS

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
