### PR TITLE
[HUDI-4282] Repair IOException in CHDFS when check block corrupted in HoodieLogFileReader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/BoundedFsDataInputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/BoundedFsDataInputStream.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+package org.apache.hudi.common.fs;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class BoundedFsDataInputStream extends FSDataInputStream {
+  private FileSystem fs;
+  private Path file;
+  private long fileLen = -1L;
+
+  public BoundedFsDataInputStream(FileSystem fs, Path file, InputStream in) {
+    super(in);
+    this.fs = fs;
+    this.file = file;
+  }
+
+  @Override
+  public boolean markSupported() {
+    return false;
+  }
+
+  /* Return the file length */
+  private long getFileLength() throws IOException {
+    if (fileLen == -1L) {
+      fileLen = fs.getContentSummary(file).getLength();
+    }
+    return fileLen;
+  }
+
+  @Override
+  public synchronized void seek(long pos) throws IOException {
+    if (pos < 0 || pos > getFileLength()) {
+      throw new EOFException("Try to seek pos[" + pos + "] , but fileSize is " + getFileLength());
+    }
+    super.seek(pos);
+  }
+
+  @Override
+  public synchronized long skip(long n) throws IOException {
+    long curPos = getPos();
+    long fileLength = getFileLength();
+    if (n + curPos > fileLength) {
+      n = fileLength - curPos;
+    }
+    return super.skip(n);
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -653,6 +653,14 @@ public class FSUtils {
     return fs.getScheme().equals(StorageSchemes.GCS.getScheme());
   }
 
+  /**
+   * Chdfs will throw {@code IOException} instead of {@code EOFException}. It will cause error in isBlockCorrupted().
+   * Wrapped by {@code BoundedFsDataInputStream}, to check whether the desired offset is out of the file size in advance.
+   */
+  public static boolean isCHDSFileSystem(FileSystem fs) {
+    return StorageSchemes.CHDFS.getScheme().equals(fs.getScheme());
+  }
+
   public static Configuration registerFileSystem(Path file, Configuration conf) {
     Configuration returnConf = new Configuration(conf);
     String scheme = FSUtils.getFs(file.toString(), conf).getScheme();

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -657,7 +657,7 @@ public class FSUtils {
    * Chdfs will throw {@code IOException} instead of {@code EOFException}. It will cause error in isBlockCorrupted().
    * Wrapped by {@code BoundedFsDataInputStream}, to check whether the desired offset is out of the file size in advance.
    */
-  public static boolean isCHDSFileSystem(FileSystem fs) {
+  public static boolean isCHDFileSystem(FileSystem fs) {
     return StorageSchemes.CHDFS.getScheme().equals(fs.getScheme());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hbase.util.Bytes;
-
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -479,7 +478,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       return new SchemeAwareFSDataInputStream(getFSDataInputStreamForGCS(fsDataInputStream, logFile, bufferSize), true);
     }
 
-    if (FSUtils.isCHDSFileSystem(fs)) {
+    if (FSUtils.isCHDFileSystem(fs)) {
       return new BoundedFsDataInputStream(fs, logFile.getPath(), fsDataInputStream);
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.log;
 
+import org.apache.hudi.common.fs.BoundedFsDataInputStream;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.fs.SchemeAwareFSDataInputStream;
 import org.apache.hudi.common.fs.TimedFSDataInputStream;
@@ -476,6 +477,10 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     if (FSUtils.isGCSFileSystem(fs)) {
       // in GCS FS, we might need to interceptor seek offsets as we might get EOF exception
       return new SchemeAwareFSDataInputStream(getFSDataInputStreamForGCS(fsDataInputStream, logFile, bufferSize), true);
+    }
+
+    if (FSUtils.isCHDSFileSystem(fs)) {
+      return new BoundedFsDataInputStream(fs, logFile.getPath(), fsDataInputStream);
     }
 
     if (fsDataInputStream.getWrappedStream() instanceof FSInputStream) {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Problem: Not all dfs throw EOFException, when seek index out of the length of file, such as chdfs. So it is not suitable to use EOFException to check whether "currentPos + blocksize - Long.BYTES" is out of the file length.

Solution: When throw IOException，read file length to check whether to the end.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
