### PR TITLE
[MINOR] Improve variable names

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -61,11 +61,11 @@ public class ReflectionUtils {
     return CLAZZ_CACHE.get(clazzName);
   }
 
-  public static <T> T loadClass(String fqcn) {
+  public static <T> T loadClass(String className) {
     try {
-      return (T) getClass(fqcn).newInstance();
+      return (T) getClass(className).newInstance();
     } catch (InstantiationException | IllegalAccessException e) {
-      throw new HoodieException("Could not load class " + fqcn, e);
+      throw new HoodieException("Could not load class " + className, e);
     }
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
@@ -39,27 +39,27 @@ public class SyncUtilHelpers {
    * Create an instance of an implementation of {@link HoodieSyncTool} that will sync all the relevant meta information
    * with an external metastore such as Hive etc. to ensure Hoodie tables can be queried or read via external systems.
    *
-   * @param metaSyncFQCN   The class that implements the sync of the metadata.
-   * @param props          property map.
-   * @param hadoopConfig   Hadoop confs.
-   * @param fs             Filesystem used.
-   * @param targetBasePath The target base path that contains the hoodie table.
-   * @param baseFileFormat The file format used by the hoodie table (defaults to PARQUET).
+   * @param syncToolClassName   Class name of the {@link HoodieSyncTool} implementation.
+   * @param props               property map.
+   * @param hadoopConfig        Hadoop confs.
+   * @param fs                  Filesystem used.
+   * @param targetBasePath      The target base path that contains the hoodie table.
+   * @param baseFileFormat      The file format used by the hoodie table (defaults to PARQUET).
    */
-  public static void runHoodieMetaSync(String metaSyncFQCN,
+  public static void runHoodieMetaSync(String syncToolClassName,
                                        TypedProperties props,
                                        Configuration hadoopConfig,
                                        FileSystem fs,
                                        String targetBasePath,
                                        String baseFileFormat) {
     try {
-      instantiateMetaSyncTool(metaSyncFQCN, props, hadoopConfig, fs, targetBasePath, baseFileFormat).syncHoodieTable();
+      instantiateMetaSyncTool(syncToolClassName, props, hadoopConfig, fs, targetBasePath, baseFileFormat).syncHoodieTable();
     } catch (Throwable e) {
-      throw new HoodieException("Could not sync using the meta sync class " + metaSyncFQCN, e);
+      throw new HoodieException("Could not sync using the meta sync class " + syncToolClassName, e);
     }
   }
 
-  static HoodieSyncTool instantiateMetaSyncTool(String metaSyncFQCN,
+  static HoodieSyncTool instantiateMetaSyncTool(String syncToolClassName,
                                                 TypedProperties props,
                                                 Configuration hadoopConfig,
                                                 FileSystem fs,
@@ -70,28 +70,28 @@ public class SyncUtilHelpers {
     properties.put(HoodieSyncConfig.META_SYNC_BASE_PATH.key(), targetBasePath);
     properties.put(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.key(), baseFileFormat);
 
-    if (ReflectionUtils.hasConstructor(metaSyncFQCN,
+    if (ReflectionUtils.hasConstructor(syncToolClassName,
         new Class<?>[] {Properties.class, Configuration.class})) {
-      return ((HoodieSyncTool) ReflectionUtils.loadClass(metaSyncFQCN,
+      return ((HoodieSyncTool) ReflectionUtils.loadClass(syncToolClassName,
           new Class<?>[] {Properties.class, Configuration.class},
           properties, hadoopConfig));
-    } else if (ReflectionUtils.hasConstructor(metaSyncFQCN,
+    } else if (ReflectionUtils.hasConstructor(syncToolClassName,
         new Class<?>[] {Properties.class})) {
-      return ((HoodieSyncTool) ReflectionUtils.loadClass(metaSyncFQCN,
+      return ((HoodieSyncTool) ReflectionUtils.loadClass(syncToolClassName,
           new Class<?>[] {Properties.class},
           properties));
-    } else if (ReflectionUtils.hasConstructor(metaSyncFQCN,
+    } else if (ReflectionUtils.hasConstructor(syncToolClassName,
         new Class<?>[] {TypedProperties.class, Configuration.class, FileSystem.class})) {
-      return ((HoodieSyncTool) ReflectionUtils.loadClass(metaSyncFQCN,
+      return ((HoodieSyncTool) ReflectionUtils.loadClass(syncToolClassName,
           new Class<?>[] {TypedProperties.class, Configuration.class, FileSystem.class},
           properties, hadoopConfig, fs));
-    } else if (ReflectionUtils.hasConstructor(metaSyncFQCN,
+    } else if (ReflectionUtils.hasConstructor(syncToolClassName,
         new Class<?>[] {Properties.class, FileSystem.class})) {
-      return ((HoodieSyncTool) ReflectionUtils.loadClass(metaSyncFQCN,
+      return ((HoodieSyncTool) ReflectionUtils.loadClass(syncToolClassName,
           new Class<?>[] {Properties.class, FileSystem.class},
           properties, fs));
     } else {
-      throw new HoodieException("Could not load meta sync class " + metaSyncFQCN
+      throw new HoodieException("Could not load meta sync class " + syncToolClassName
           + ": no valid constructor found.");
     }
   }


### PR DESCRIPTION
To align with other occurrences in the codebase, use "className" instead of FQCN.