### PR TITLE
[HUDI-4343] Update maven build command for docker demo setup

### DIFF
--- a/website/docs/docker_demo.md
+++ b/website/docs/docker_demo.md
@@ -44,7 +44,7 @@ Also, this has not been tested on some environments like Docker on Windows.
 The first step is to build hudi. **Note** This step builds hudi on default supported scala version - 2.11.
 ```java
 cd <HUDI_WORKSPACE>
-mvn package -DskipTests
+mvn clean package -Pintegration-tests -DskipTests
 ```
 
 ### Bringing up Demo Cluster

--- a/website/versioned_docs/version-0.11.0/docker_demo.md
+++ b/website/versioned_docs/version-0.11.0/docker_demo.md
@@ -44,7 +44,7 @@ Also, this has not been tested on some environments like Docker on Windows.
 The first step is to build hudi. **Note** This step builds hudi on default supported scala version - 2.11.
 ```java
 cd <HUDI_WORKSPACE>
-mvn package -DskipTests
+mvn clean package -Pintegration-tests -DskipTests
 ```
 
 ### Bringing up Demo Cluster

--- a/website/versioned_docs/version-0.11.1/docker_demo.md
+++ b/website/versioned_docs/version-0.11.1/docker_demo.md
@@ -44,7 +44,7 @@ Also, this has not been tested on some environments like Docker on Windows.
 The first step is to build hudi. **Note** This step builds hudi on default supported scala version - 2.11.
 ```java
 cd <HUDI_WORKSPACE>
-mvn package -DskipTests
+mvn clean package -Pintegration-tests -DskipTests
 ```
 
 ### Bringing up Demo Cluster


### PR DESCRIPTION
## What is the purpose of the pull request

This PR updates the maven build command for docker demo setup, by adding the `-Pintegration-tests` argument.  Without that, the Hudi jars are missing when building the docker images and running the demo.

## Brief change log

  - Updates the docker demo page of the current, 0.11.1, and 0.11.0 versions.

## Verify this pull request

The website can be built and visualized properly, by running `npm start` locally.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
