### PR TITLE
[HUDI-4365] Fixing URL-encoding in Bulk Insert row-writing path

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1065,6 +1065,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBooleanOrDefault(KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE);
   }
 
+  public boolean shouldURLEncodePartitionPath() {
+    return getBooleanOrDefault(KeyGeneratorOptions.URL_ENCODE_PARTITIONING);
+  }
+
   public int getMarkersTimelineServerBasedBatchNumThreads() {
     return getInt(MARKERS_TIMELINE_SERVER_BASED_BATCH_NUM_THREADS);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -146,16 +146,25 @@ public class KeyGenUtils {
   public static String getPartitionPath(GenericRecord record, String partitionPathField,
       boolean hiveStylePartitioning, boolean encodePartitionPath, boolean consistentLogicalTimestampEnabled) {
     String partitionPath = HoodieAvroUtils.getNestedFieldValAsString(record, partitionPathField, true, consistentLogicalTimestampEnabled);
-    if (partitionPath == null || partitionPath.isEmpty()) {
-      partitionPath = HUDI_DEFAULT_PARTITION_PATH;
+    return handlePartitionPathDecoration(partitionPathField, partitionPath, encodePartitionPath, hiveStylePartitioning);
+  }
+
+  public static String handlePartitionPathDecoration(String partitionPathField,
+                                                      String partitionPathValue,
+                                                      boolean encodePartitionPath,
+                                                      boolean hiveStylePartitioning) {
+    String decoratedPartitionPath = partitionPathValue;
+    if (StringUtils.isNullOrEmpty(decoratedPartitionPath)) {
+      decoratedPartitionPath = HUDI_DEFAULT_PARTITION_PATH;
     }
     if (encodePartitionPath) {
-      partitionPath = PartitionPathEncodeUtils.escapePathName(partitionPath);
+      decoratedPartitionPath = PartitionPathEncodeUtils.escapePathName(decoratedPartitionPath);
     }
     if (hiveStylePartitioning) {
-      partitionPath = partitionPathField + "=" + partitionPath;
+      decoratedPartitionPath = partitionPathField + "=" + decoratedPartitionPath;
     }
-    return partitionPath;
+
+    return decoratedPartitionPath;
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -165,8 +165,10 @@ object HoodieSparkUtils extends SparkAdapterSupport {
       } else {
         val readerAvroSchema = new Schema.Parser().parse(readerAvroSchemaStr)
         val transform: GenericRecord => GenericRecord =
-          if (sameSchema) identity
-          else {
+          if (sameSchema) {
+            identity
+          } else {
+            // NOTE: Avro schema parsing is performed outside of the transforming lambda
             HoodieAvroUtils.rewriteRecordDeep(_, readerAvroSchema)
           }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileSystemTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileSystemTestUtils.java
@@ -44,7 +44,7 @@ public class FileSystemTestUtils {
   public static final String FORWARD_SLASH = "/";
   public static final String FILE_SCHEME = "file";
   public static final String COLON = ":";
-  public static final Random RANDOM = new Random();
+  public static final Random RANDOM = new Random(0xDEED);
 
   public static Path getRandomOuterInMemPath() {
     String randomFileName = UUID.randomUUID().toString();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/BulkInsertDataInternalWriterHelper.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/BulkInsertDataInternalWriterHelper.java
@@ -23,12 +23,12 @@ import org.apache.hudi.client.HoodieInternalWriteStatus;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.PartitionPathEncodeUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.storage.row.HoodieRowCreateHandle;
 import org.apache.hudi.io.storage.row.HoodieRowCreateHandleWithoutMetaFields;
 import org.apache.hudi.keygen.BuiltinKeyGenerator;
+import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.keygen.NonpartitionedKeyGenerator;
 import org.apache.hudi.keygen.SimpleKeyGenerator;
 import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory;
@@ -125,18 +125,17 @@ public class BulkInsertDataInternalWriterHelper {
       if (populateMetaFields) { // usual path where meta fields are pre populated in prep step.
         partitionPath = String.valueOf(record.getUTF8String(HoodieRecord.PARTITION_PATH_META_FIELD_POS));
       } else { // if meta columns are disabled.
-        // TODO(HUDI-3993) remove duplication
+        // TODO(HUDI-3993) remove duplication, unify with HoodieDatasetBulkInsertHelper
         if (!keyGeneratorOpt.isPresent()) { // NoPartitionerKeyGen
           partitionPath = "";
         } else if (simpleKeyGen) { // SimpleKeyGen
           Object partitionPathValue = record.get(simplePartitionFieldIndex, simplePartitionFieldDataType);
-          partitionPath = partitionPathValue != null ? partitionPathValue.toString() : PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
-          if (writeConfig.shouldURLEncodePartitionPath()) {
-            partitionPath = PartitionPathEncodeUtils.escapePathName(partitionPath);
-          }
-          if (writeConfig.isHiveStylePartitioningEnabled()) {
-            partitionPath = (keyGeneratorOpt.get()).getPartitionPathFields().get(0) + "=" + partitionPath;
-          }
+          String partitionPathField = keyGeneratorOpt.get().getPartitionPathFields().get(0);
+          boolean shouldURLEncodePartitionPath = writeConfig.shouldURLEncodePartitionPath();
+          boolean hiveStylePartitioningEnabled = writeConfig.isHiveStylePartitioningEnabled();
+
+          partitionPath = KeyGenUtils.handlePartitionPathDecoration(partitionPathField,
+              partitionPathValue == null ? null : partitionPathValue.toString(), shouldURLEncodePartitionPath, hiveStylePartitioningEnabled);
         } else {
           // only BuiltIn key generators are supported if meta fields are disabled.
           partitionPath = keyGeneratorOpt.get().getPartitionPath(record, structType);

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/internal/HoodieBulkInsertInternalWriterTestBase.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/internal/HoodieBulkInsertInternalWriterTestBase.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class HoodieBulkInsertInternalWriterTestBase extends HoodieClientTestHarness {
 
-  protected static final Random RANDOM = new Random();
+  protected static final Random RANDOM = new Random(0xDEED);
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/hudi-spark-datasource/hudi-spark2/src/test/java/org/apache/hudi/internal/TestHoodieBulkInsertDataInternalWriter.java
+++ b/hudi-spark-datasource/hudi-spark2/src/test/java/org/apache/hudi/internal/TestHoodieBulkInsertDataInternalWriter.java
@@ -109,7 +109,7 @@ public class TestHoodieBulkInsertDataInternalWriter extends
   }
 
   @Test
-  public void testDataInternalWriterHiveStylePartitioning() throws Exception {
+  public void testDataInternalWriterPartitioningHandling() throws Exception {
     boolean sorted = true;
     boolean populateMetaFields = false;
     // init config and table


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Currently when doing bulk-insert using partition paths with slashes in it's being laid out incorrectly missing URL-encoding for the partition path, even though it's set to true.

This fix is purely a duct-tape until it's properly addressed by HUDI-3993

## Brief change log

See above

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
