### PR TITLE
[DOCS] sql-client.execution.result-mode = tableau

### DIFF
--- a/website/docs/flink-quick-start-guide.md
+++ b/website/docs/flink-quick-start-guide.md
@@ -82,7 +82,7 @@ Creates a Flink Hudi table first and insert data into the Hudi table using SQL `
 
 ```sql
 -- sets up the result mode to tableau to show the results directly in the CLI
-set execution.result-mode=tableau;
+set sql-client.execution.result-mode = tableau;
 
 CREATE TABLE t1(
   uuid VARCHAR(20) PRIMARY KEY NOT ENFORCED,


### PR DESCRIPTION
use 'SET execution.result-mode=tableau;' at flink 1.12 or before
u can see it at https://nightlies.apache.org/flink/flink-docs-release-1.12/dev/table/sqlClient.html
after flink 1.13 , use 'SET sql-client.execution.result-mode = tableau'
u can see it at https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/dev/table/sqlclient/
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
