### PR TITLE
[HUDI-4401] Skip HBase version check

### DIFF
--- a/hudi-common/src/main/resources/hbase-site.xml
+++ b/hudi-common/src/main/resources/hbase-site.xml
@@ -37,6 +37,13 @@ HBaseConfiguration::addHbaseResources().  To get around this issue,
 since HBase loads "hbase-site.xml" after "hbase-default.xml", we
 provide hbase-site.xml from the bundle so that HBaseConfiguration
 can pick it up and ensure the right defaults.
+
+The HBase version check is skipped (setting "hbase.defaults.for.version.skip"
+to true instead of false as default) to avoid any inconvenience caused
+by the RuntimeException due to version mismatch if multiple versions
+of HBase library are present in the class path.  In such a case, the
+user needs to make sure there is no config conflict between different
+versions.
 -->
 
 <!--
@@ -1427,7 +1434,7 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>hbase.defaults.for.version.skip</name>
-    <value>false</value>
+    <value>true</value>
     <description>Set to true to skip the 'hbase.defaults.for.version' check.
       Setting this to true can be useful in contexts other than
       the other side of a maven generation; i.e. running in an


### PR DESCRIPTION
## What is the purpose of the pull request

This PR changes the `hbase.defaults.for.version.skip` config to true instead of false as default in `hbase-site.xml` under `hudi-common/src/main/resources` to skip the HBase version check to avoid any inconvenience caused by the `RuntimeException` due to version mismatch if multiple versions of HBase library are present in the class path.

## Brief change log

- Changes the `hbase.defaults.for.version.skip` config to true and adds notes in `hbase-site.xml` under `hudi-common/src/main/resources`

## Verify this pull request

This pull request is already covered by existing tests.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
