### PR TITLE
[HUDI-4406] Support Flink compaction/clustering write error resolvement to avoid data loss

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -387,7 +387,7 @@ public class FlinkOptions extends HoodieConfig {
       .booleanType()
       .defaultValue(false)
       .withDescription("Flag to indicate whether to ignore any non exception error (e.g. writestatus error). within a checkpoint batch.\n"
-          + "By default false.  Turning this on, could hide the write status errors while the spark checkpoint moves ahead. \n"
+          + "By default false. Turning this on, could hide the write status errors while the flink checkpoint moves ahead. \n"
           + "  So, would recommend users to use this with caution.");
 
   public static final ConfigOption<String> RECORD_KEY_FIELD = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -386,9 +386,9 @@ public class FlinkOptions extends HoodieConfig {
       .key("write.ignore.failed")
       .booleanType()
       .defaultValue(false)
-      .withDescription("Flag to indicate whether to ignore any non exception error (e.g. writestatus error). within a checkpoint batch.\n"
+      .withDescription("Flag to indicate whether to ignore any non exception error (e.g. writestatus error). within a checkpoint batch. \n"
           + "By default false. Turning this on, could hide the write status errors while the flink checkpoint moves ahead. \n"
-          + "  So, would recommend users to use this with caution.");
+          + "So, would recommend users to use this with caution.");
 
   public static final ConfigOption<String> RECORD_KEY_FIELD = ConfigOptions
       .key(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key())

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -126,9 +126,9 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
         .map(ClusteringCommitEvent::getWriteStatuses)
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
-    boolean hasErrors = events.stream().anyMatch(ClusteringCommitEvent::isFailed)
-        || statuses.stream().anyMatch(WriteStatus::hasErrors);
-    if (hasErrors && !this.conf.getBoolean(FlinkOptions.IGNORE_FAILED)) {
+    boolean hasWriteErrorsNotIgnored = !this.conf.getBoolean(FlinkOptions.IGNORE_FAILED)
+        && statuses.stream().anyMatch(WriteStatus::hasErrors);
+    if (events.stream().anyMatch(ClusteringCommitEvent::isFailed) || hasWriteErrorsNotIgnored) {
       try {
         // handle failure case
         ClusteringUtil.rollbackClustering(table, writeClient, instant);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -135,9 +135,9 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
         .map(CompactionCommitEvent::getWriteStatuses)
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
-    boolean hasErrors = events.stream().anyMatch(CompactionCommitEvent::isFailed)
-        || statuses.stream().anyMatch(WriteStatus::hasErrors);
-    if (hasErrors && !this.conf.getBoolean(FlinkOptions.IGNORE_FAILED)) {
+    boolean hasWriteErrorsNotIgnored = !this.conf.getBoolean(FlinkOptions.IGNORE_FAILED)
+        && statuses.stream().anyMatch(WriteStatus::hasErrors);
+    if (events.stream().anyMatch(CompactionCommitEvent::isFailed) || hasWriteErrorsNotIgnored) {
       try {
         // handle failure case
         CompactionUtil.rollbackCompaction(table, instant);


### PR DESCRIPTION
### Change Logs

Currently CompactionCommitSink commit or rollback logics doesn't take the writestatus error under consideration (only consider null writestatus), which actually will cause data loss when compacting the delta commit log files into the new versioned data files.
eg. org.apache.hudi.io.HoodieMergeHandle#writeRecord will lead to data loss from log files due to Exceptions.
```java
  protected boolean writeRecord(HoodieRecord<T> hoodieRecord, Option<IndexedRecord> indexedRecord, boolean isDelete) {
    Option recordMetadata = hoodieRecord.getData().getMetadata();
    if (!partitionPath.equals(hoodieRecord.getPartitionPath())) {
      HoodieUpsertException failureEx = new HoodieUpsertException("mismatched partition path, record partition: "
          + hoodieRecord.getPartitionPath() + " but trying to insert into partition: " + partitionPath);
      writeStatus.markFailure(hoodieRecord, failureEx, recordMetadata);
      return false;
    }
    try {
      if (indexedRecord.isPresent() && !isDelete) {
        writeToFile(hoodieRecord.getKey(), (GenericRecord) indexedRecord.get(), preserveMetadata && useWriterSchemaForCompaction);
        recordsWritten++;
      } else {
        recordsDeleted++;
      }
      writeStatus.markSuccess(hoodieRecord, recordMetadata);
      // deflate record payload after recording success. This will help users access payload as a
      // part of marking
      // record successful.
      hoodieRecord.deflate();
      return true;
    } catch (Exception e) {
      LOG.error("Error writing record  " + hoodieRecord, e);
      writeStatus.markFailure(hoodieRecord, e, recordMetadata);
    }
    return false;
  }
```
And it's known that StreamWriteOperatorCoordinator has related commit or rollback handle process. 

So this pr will:

a)  Also add writestatus error as rollback reason for CompactionCommitSink compaction rollback to avoid data loss

b) Unify the handle procedure for write commit policy with its implementions, as described in org.apache.hudi.commit.policy.WriteCommitPolicy, which is consolidated with that of StreamWriteOperatorCoordinator.

c) All control whether data quality or ingestion stability should be in high priority through FlinkOptions#IGNORE_FAILED.
And, we suggest that FlinkOptions#IGNORE_FAILED be **false** by default to avoid data loss.

d) Optimize and fix some tiny bugs for log traces when commiting on error or rolling back.

### Impact

To help avoid compaction data loss due to caught write errors.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
