### PR TITLE
[HUDI-4426] The implementation of Clean is inconsistent with CLEANER_COMMITS_RETAINED

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -401,12 +401,12 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
   }
 
   /**
-   * Gets the latest version < instantTime. This version file could still be used by queries.
+   * Gets the latest version <= instantTime. This version file could still be used by queries.
    */
   private String getLatestVersionBeforeCommit(List<FileSlice> fileSliceList, HoodieInstant instantTime) {
     for (FileSlice file : fileSliceList) {
       String fileCommitTime = file.getBaseInstantTime();
-      if (HoodieTimeline.compareTimestamps(instantTime.getTimestamp(), HoodieTimeline.GREATER_THAN, fileCommitTime)) {
+      if (HoodieTimeline.compareTimestamps(fileCommitTime, HoodieTimeline.LESSER_THAN_OR_EQUALS, instantTime.getTimestamp())) {
         // fileList is sorted on the reverse, so the first commit we find <= instantTime is the
         // one we want
         return fileCommitTime;

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
@@ -52,8 +52,9 @@ class TestCleanProcedure extends HoodieSparkSqlTestBase {
         .collect()
         .map(row => Seq(row.getString(0), row.getLong(1), row.getInt(2), row.getString(3), row.getString(4), row.getInt(5)))
 
+
       assertResult(1)(result1.length)
-      assertResult(2)(result1(0)(2))
+      assertResult(3)(result1(0)(2))
 
       checkAnswer(s"select id, name, price, ts from $tableName order by id") (
         Seq(1, "a1", 13, 1000)


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Described in https://issues.apache.org/jira/browse/HUDI-4426,

The clean behavior is inconsistent with CLEANER_COMMITS_RETAINED, it's not a big problem, but I think it's better to be precise



## Brief change log

Fix logic error in getLatestVersionBeforeCommit

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
