### PR TITLE
[HUDI-4434] Disable EmrFS file metadata caching and EMR Spark's data prefetcher feature

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -56,6 +56,9 @@ class DefaultSource extends RelationProvider
       // Enable "passPartitionByAsOptions" to support "write.partitionBy(...)"
       spark.conf.set("spark.sql.legacy.sources.write.passPartitionByAsOptions", "true")
     }
+    // Revisit EMR Spark and EMRFS incompatibilities, for now disable
+    spark.conf.set("spark.sql.dataPrefetch.enabled", "false")
+    spark.sparkContext.hadoopConfiguration.set("fs.s3.metadata.cache.expiration.seconds", "0")
   }
 
   private val log = LogManager.getLogger(classOf[DefaultSource])


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
JIRA https://issues.apache.org/jira/browse/HUDI-4434

Contribute internal EMR patches to target goal of out of box experience for 0.12 on EMR 6.9.0 (for hudi-spark), for now disabling these two properties. 


## Issue Summary for dataPrefetch disabled

Read optimized queries on Hudi 0.11 are failing with EMR spark with partition schema mismatch error, the root caused comes from the data prefetcher feature implemented by EMR Spark team. To target goal of out of box experience for hudi 0.12 on emr 6.9.0, the safest bet is to disable the data prefetcher functionality for Hudi.

This issue has been introduced since 0.11, because with this release Hudi has introduced its own `FileFormat` implementation wrapped within `HadoopFsRelation` for performing read optimized queries. In that logic has been introduced to handle scenarios where partition values are read directly from data file instead of being derived from path as was the case earlier. However, this is not correctly handled in EMR Spark's case because Hudi's File Format implementation has not overridden the data prefetcher api and it still goes to the default implementation.

 We will look at a fix to make this work, but it will require a much larger change within Hudi or Spark. We will either have to modify Hudi's file format implementation to override data prefetcher API as well and have custom logic for partition schema handling, or we have to update EMR Spark's implementation to handle this better. So for now, its best to disable this feature for Hudi.

## Testing for dataPrefetch disabled
Performed manual testing on latest emr spark to confirm that after disabling, read optimized queries work fine.
```
spark-sql> select * from hudi_basic_test_cow41992;
...
20220513222434502    20220513222434502_0_2    1    one    689d1788-9496-42c0-997c-29a23dbf4678-0_0-7-8_20220513222434502.parquet    1    2015-01-01T23:37:44.343090Z    event_a    8087121    one
20220513222434502    20220513222434502_0_3    3    one    689d1788-9496-42c0-997c-29a23dbf4678-0_0-7-8_20220513222434502.parquet    3    2015-01-01T18:47:44.343090Z    event_c    423424    one
20220513222434502    20220513222434502_0_4    4    one    689d1788-9496-42c0-997c-29a23dbf4678-0_0-7-8_20220513222434502.parquet    4    2015-01-01T19:57:44.343090Z    event_d    52352    one
20220513222434502    20220513222434502_0_5    5    one    689d1788-9496-42c0-997c-29a23dbf4678-0_0-7-8_20220513222434502.parquet    5    2015-01-01T20:31:44.343090Z    event_e    1111    one
20220513222434502    20220513222434502_1_1    2    two    8a1ebcb8-53ca-462d-b9b0-67c00c5579bc-0_1-7-9_20220513222434502.parquet    2    2015-01-02T22:20:44.343090Z    event_b    312131    two
Time taken: 1.341 seconds, Fetched 5 row(s)
spark-sql> show tables;
```

## Issue Summary for S3 metadata cache disable

similar JIRA https://github.com/apache/hudi/issues/5553 

EmrFS has a cache that is enabled by default, where is maintains File Metadata (FileStaus info) for 60 seconds:

It appears that there is a bug with this caching mechanism, and it has surfaced up with Hudi 0.11.0 release more prominently, specially with the checksum information being saved to hoodie.properties which increases the likely hood of file length being changed upon update.

EMR Hudi's DML test in is failing in the select query that is run immediately after the alter table rename. The root cause is that with alter table rename, the drive modifies the hoodie.properties file with the new table name and checksum. 

However, select query is run immediately after, and the existing executor has hoodie.properties file metadata still cached in its EmrFS instance (there is one instance per executor) from a previous query run. Thus, it uses the previous length of the file in the InputStream, even though the file length has changed.

This needs a fix in EmrFS, and we will work with internal AWS team.

## Testing for emrfs caching disabled
The DML integration tests are passing after this change:

Also, ran the test several times manually on the cluster to confirm there is no flakiness.




## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
