### PR TITLE
[HUDI-4435] Fix Avro field not found issue introduced by Avro 1.10.2

### DIFF
--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
@@ -44,8 +44,10 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.RealtimeFileStatus;
 import org.apache.hudi.hadoop.config.HoodieRealtimeConfig;
+import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils;
 import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
 
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.hadoop.conf.Configuration;
@@ -69,6 +71,7 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -895,6 +898,20 @@ public class TestHoodieRealtimeRecordReader {
     inputFormat.setConf(baseJobConf);
     InputSplit[] splits = inputFormat.getSplits(baseJobConf, 1);
     assertTrue(splits.length == 0);
+  }
+
+  @Test
+  public void testAvroToArrayWritable() throws IOException {
+    Schema schema = SchemaTestUtil.getEvolvedSchema();
+    GenericRecord record = SchemaTestUtil.generateAvroRecordFromJson(schema, 1, "100", "100", false);
+    ArrayWritable aWritable = (ArrayWritable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(record, schema);
+    assertEquals(schema.getFields().size(), aWritable.get().length);
+
+    // In some queries, generic records that Hudi gets are just part of the full records.
+    // Here test the case that some fields are missing in the record.
+    Schema schemaWithMetaFields = HoodieAvroUtils.addMetadataFields(schema);
+    ArrayWritable aWritable2 = (ArrayWritable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(record, schemaWithMetaFields);
+    assertEquals(schemaWithMetaFields.getFields().size(), aWritable2.get().length);
   }
 
   private File createCompactionFile(java.nio.file.Path basePath, String commitTime)


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## Issue summary 
JIRA https://issues.apache.org/jira/browse/HUDI-4435

For Avro to 1.10.2, bootstrap realtime table queries through inputformat would break w/ the following error:

```
org.apache.avro.AvroRuntimeException: Not a valid schema field: _hoodie_commit_seqno
```

This is because when converting Avro records to ArrayWritable, Hudi calls `avroToArrayWritable(Object value, Schema schema)` which would try to extract all the fields in the schema from Avro record. However, in some queries, not all the fields are required in the record, e.g. when enabling usesCustomPayload (which is enabled for bootstrap tables by default), only projection columns are loaded: https://github.com/apache/hudi/blob/release-0.10.1/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java#L145-L148. This means some fields are not provided in the record.

Before Avro 1.10, this is fine because if record.get(field.name() failed, it would just return null. However, after Avro 1.10, it would throw a realtime exception `AvroRuntimeException` and break the job. So in this patch, we would catch this runtime exception. We also want to make this flexible for both avro 1.8.2 and avro 1.10.2 which contains different api methods, for example `hasField` seems to be present in avro 1.10.2 but not older avro. 

## What is the purpose of the pull request

Contribute internal emr patche to target goal of out of box experience for 0.12 on emr 6.9.0 (for hudi-spark)


## Testing

Ran unit test in this cr 

Before applying changes to HoodieRealtimeRecordReaderUtils.java:
```
[INFO] Running org.apache.hudi.hadoop.realtime.TestHoodieRealtimeRecordReader

[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.041 s <<< FAILURE! - in org.apache.hudi.hadoop.realtime.TestHoodieRealtimeRecordReader
[ERROR] org.apache.hudi.hadoop.realtime.TestHoodieRealtimeRecordReader.testAvroToArrayWritable  Time elapsed: 0.04 s  <<< ERROR!
org.apache.avro.AvroRuntimeException: Not a valid schema field: _hoodie_commit_time
```
After applying changes to HoodieRealtimeRecordReaderUtils.java:
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.605 s - in org.apache.hudi.hadoop.realtime.TestHoodieRealtimeRecordReader
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```
* Ran internal emr integ test with bootstrapMor and inline compaction disabled  

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
