### PR TITLE
[HUDI-4439] Fix Amazon CloudWatch reporter for metadata enabled tables

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -294,7 +294,12 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
     builder.withProperties(properties);
 
     if (writeConfig.isMetricsOn()) {
+      // Table Name is needed for metric reporters prefix
+      Properties commonProperties = new Properties();
+      commonProperties.put(HoodieWriteConfig.TBL_NAME.key(), tableName);
+
       builder.withMetricsConfig(HoodieMetricsConfig.newBuilder()
+          .fromProperties(commonProperties)
           .withReporterType(writeConfig.getMetricsReporterType().toString())
           .withExecutorMetrics(writeConfig.isExecutorMetricsEnabled())
           .on(true).build());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HUDI-4439 


## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Amazon CloudWatch reporter is broken for metadata enabled tables.

This appears to be broken since this commit: https://github.com/apache/hudi/commit/9797fdfbb27ca8f5f06875ad958b597becc27a8d. The commit makes metrics prefix configurable, changing it from the earlier way of using the table name directly. For metadata table, while publishing the metrics, this turns up as empty because the inference mechanism does not find table name in the HoodieConfig it is trying to lookup.

This breaks while publishing metrics to cloudwatch, since it cannot publish a Dimension with empty value.

## Brief change log

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.



## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
