### PR TITLE
added two options to manage partition field names and types during th…

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -138,6 +138,18 @@ object DataSourceReadOptions {
         " read from the data file (in Hudi partition columns are persisted by default)." +
         " This config is a fallback allowing to preserve existing behavior, and should not be used otherwise.")
 
+  val PARTITION_FIELD_IS_STRING: ConfigProperty[Boolean] =
+    ConfigProperty.key("hoodie.datasource.read.partition.field.is.string")
+      .defaultValue(false)
+      .sinceVersion("0.12.0")
+      .withDocumentation("When set to true, the partition field type will always be string")
+
+  val PARTITION_FIELD_NAMES: ConfigProperty[String] =
+    ConfigProperty.key("hoodie.datasource.read.partition.field.names")
+      .noDefaultValue()
+      .sinceVersion("0.12.0")
+      .withDocumentation("The partition field name how it will appear in the selected data")
+
   val INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN_FOR_NON_EXISTING_FILES: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.incr.fallback.fulltablescan.enable")
     .defaultValue("false")


### PR DESCRIPTION
## What is the purpose of the pull request

This is a PoC to demonstrate a possible way of defining a partition field name during the hudi table read operation. This is in response to https://issues.apache.org/jira/browse/HUDI-4430

## Brief change log
Added two options:
1. Force struct string type for the partition field
2. User custom partition field names for the partition fields.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
