### PR TITLE
[MINOR] Only log stdout output for non-zero exit from commands in IT

### DIFF
--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestBase.java
@@ -236,7 +236,9 @@ public abstract class ITTestBase {
     int exitCode = dockerClient.inspectExecCmd(createCmdResponse.getId()).exec().getExitCode();
     LOG.info("Exit code for command : " + exitCode);
 
-    LOG.error("\n\n ###### Stdout #######\n" + callback.getStdout().toString());
+    if (exitCode != 0) {
+      LOG.error("\n\n ###### Stdout #######\n" + callback.getStdout().toString());
+    }
     LOG.error("\n\n ###### Stderr #######\n" + callback.getStderr().toString());
 
     if (checkIfSucceed) {


### PR DESCRIPTION
## What is the purpose of the pull request

This PR restores the logging behavior in IT where stdout output is only logged for non-zero exit from commands in IT.

## Brief change log

  - Adjusts the logging behavior in `ITTestBase`

## Verify this pull request

Only logging changes.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
