### PR TITLE
[HUDI-4456] Close FileSystem in SparkClientFunctionalTestHarness 

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -214,9 +214,10 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
   }
 
   @AfterEach
-  public void closeFilesystem() throws IOException {
+  public void closeFileSystem() throws IOException {
     if (fileSystem != null) {
       fileSystem.close();
+      fileSystem = null;
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -67,6 +67,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -96,6 +97,7 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
   private static transient JavaSparkContext jsc;
   private static transient HoodieSparkEngineContext context;
   private static transient TimelineService timelineService;
+  private FileSystem fileSystem;
 
   /**
    * An indicator of the initialization status.
@@ -128,7 +130,10 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
   }
 
   public FileSystem fs() {
-    return FSUtils.getFs(basePath(), hadoopConf());
+    if (fileSystem == null) {
+      fileSystem = FSUtils.getFs(basePath(), hadoopConf());
+    }
+    return fileSystem;
   }
 
   @Override
@@ -205,6 +210,13 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
     }
     if (timelineService != null) {
       timelineService.close();
+    }
+  }
+
+  @AfterEach
+  public void closeFilesystem() throws IOException {
+    if (fileSystem != null) {
+      fileSystem.close();
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.10.1</parquet.version>
-    <junit.jupiter.version>5.7.2</junit.jupiter.version>
-    <junit.vintage.version>5.7.2</junit.vintage.version>
+    <junit.jupiter.version>5.8.2</junit.jupiter.version>
+    <junit.vintage.version>5.8.2</junit.vintage.version>
     <junit.platform.version>1.7.2</junit.platform.version>
     <mockito.jupiter.version>3.3.3</mockito.jupiter.version>
     <log4j.test.version>2.17.2</log4j.test.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.10.1</parquet.version>
-    <junit.jupiter.version>5.8.2</junit.jupiter.version>
-    <junit.vintage.version>5.8.2</junit.vintage.version>
+    <junit.jupiter.version>5.7.2</junit.jupiter.version>
+    <junit.vintage.version>5.7.2</junit.vintage.version>
     <junit.platform.version>1.7.2</junit.platform.version>
     <mockito.jupiter.version>3.3.3</mockito.jupiter.version>
     <log4j.test.version>2.17.2</log4j.test.version>


### PR DESCRIPTION
## What is the purpose of the pull request

We occasionally see failures in CI due to the junit `TempDir` not being cleaned up. Other people have seen similar errors due to some references to the files in that dir not being closed properly. This PR updates the `SparkClientFunctionalTestHarness` to provide a single `FileSystem` instance per test and close it after the test completes.

## Brief change log
  - update `getFs()` method in `SparkClientFunctionalTestHarness` to return a single instance
  - close `FileSystem` instance at end of tests with `@AfterEach` method in the test harness

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
