### PR TITLE
[HUDI-4458] Add a converter cache for flink ColumnStatsIndices

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsIndices.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsIndices.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -161,6 +162,7 @@ public class ColumnStatsIndices {
         .filter(indexedColumns::contains)
         .collect(Collectors.toCollection(TreeSet::new));
 
+    final Map<LogicalType, AvroToRowDataConverters.AvroToRowDataConverter> converters = new ConcurrentHashMap<>();
     Map<StringData, List<RowData>> fileNameToRows = colStats.stream().parallel()
         .filter(row -> sortedTargetColumns.contains(row.getString(ORD_COL_NAME).toString()))
         .map(row -> {
@@ -172,7 +174,7 @@ public class ColumnStatsIndices {
           } else {
             String colName = row.getString(ORD_COL_NAME).toString();
             LogicalType colType = tableFieldTypeMap.get(colName);
-            return unpackMinMaxVal(row, colType);
+            return unpackMinMaxVal(row, colType, converters);
           }
         }).collect(Collectors.groupingBy(rowData -> rowData.getString(ORD_FILE_NAME)));
 
@@ -222,7 +224,8 @@ public class ColumnStatsIndices {
 
   private static RowData unpackMinMaxVal(
       RowData row,
-      LogicalType colType) {
+      LogicalType colType,
+      Map<LogicalType, AvroToRowDataConverters.AvroToRowDataConverter> converters) {
 
     RowData minValueStruct = row.getRow(ORD_MIN_VAL, 1);
     RowData maxValueStruct = row.getRow(ORD_MAX_VAL, 1);
@@ -230,8 +233,8 @@ public class ColumnStatsIndices {
     checkState(minValueStruct != null && maxValueStruct != null,
         "Invalid Column Stats record: either both min/max have to be null, or both have to be non-null");
 
-    Object minValue = tryUnpackNonNullVal(minValueStruct, colType);
-    Object maxValue = tryUnpackNonNullVal(maxValueStruct, colType);
+    Object minValue = tryUnpackNonNullVal(minValueStruct, colType, converters);
+    Object maxValue = tryUnpackNonNullVal(maxValueStruct, colType, converters);
 
     // the column schema:
     // |- file_name: string
@@ -252,18 +255,24 @@ public class ColumnStatsIndices {
     return unpackedRow;
   }
 
-  private static Object tryUnpackNonNullVal(RowData rowData, LogicalType colType) {
+  private static Object tryUnpackNonNullVal(
+      RowData rowData,
+      LogicalType colType,
+      Map<LogicalType, AvroToRowDataConverters.AvroToRowDataConverter> converters) {
     for (int i = 0; i < rowData.getArity(); i++) {
       // row data converted from avro is definitely generic.
       Object nested = ((GenericRowData) rowData).getField(i);
       if (nested != null) {
-        return doUnpack(nested, colType);
+        return doUnpack(nested, colType, converters);
       }
     }
     return null;
   }
 
-  private static Object doUnpack(Object rawVal, LogicalType logicalType) {
+  private static Object doUnpack(
+      Object rawVal,
+      LogicalType logicalType,
+      Map<LogicalType, AvroToRowDataConverters.AvroToRowDataConverter> converters) {
     // fix time unit
     switch (logicalType.getTypeRoot()) {
       case TIME_WITHOUT_TIME_ZONE:
@@ -287,7 +296,8 @@ public class ColumnStatsIndices {
       default:
         // no operation
     }
-    AvroToRowDataConverters.AvroToRowDataConverter converter = AvroToRowDataConverters.createConverter(logicalType);
+    AvroToRowDataConverters.AvroToRowDataConverter converter =
+        converters.computeIfAbsent(logicalType, k -> AvroToRowDataConverters.createConverter(logicalType));
     return converter.convert(rawVal);
   }
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
