### PR TITLE
[HUDI-4071] Match ROLLBACK_USING_MARKERS_ENABLE in sql as datasource

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/BaseProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/BaseProcedure.scala
@@ -50,7 +50,6 @@ abstract class BaseProcedure extends Procedure {
     HoodieWriteConfig.newBuilder
       .withPath(basePath)
       .withIndexConfig(HoodieIndexConfig.newBuilder.withIndexType(IndexType.BLOOM).build)
-      .withRollbackUsingMarkers(false)
       .build
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToInstantTimeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToInstantTimeProcedure.scala
@@ -21,6 +21,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion
 import org.apache.hudi.common.util.Option
+import org.apache.hudi.config.HoodieWriteConfig.ROLLBACK_USING_MARKERS_ENABLE
 import org.apache.hudi.exception.HoodieException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -51,6 +52,7 @@ class RollbackToInstantTimeProcedure extends BaseProcedure with ProcedureBuilder
     val hoodieCatalogTable = HoodieCatalogTable(sparkSession, new TableIdentifier(table))
     val basePath = hoodieCatalogTable.tableLocation
     val client = createHoodieClient(jsc, basePath)
+    client.getConfig.setValue(ROLLBACK_USING_MARKERS_ENABLE, "false")
     val config = getWriteConfig(basePath)
     val metaClient = HoodieTableMetaClient.builder
       .setConf(jsc.hadoopConfiguration)


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

Based on [#6197](https://github.com/apache/hudi/pull/6197), Set `RollbackToInstantTimeProcedure`'s `ROLLBACK_USING_MARKERS_ENABLE` to `false` to pass ut.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
