### PR TITLE
[HUDI-4461] Fix org.apache.hudi.sink.TestWriteCopyOnWrite will failed when local hadoop env exists

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -38,6 +38,7 @@ import org.hamcrest.MatcherAssert;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -102,6 +103,23 @@ public class TestWriteBase {
         "id1,par1,id1,Danny,23,3,par1",
         "id1,par1,id1,Danny,23,4,par1",
         "id1,par1,id1,Danny,23,4,par1"));
+
+    removeHadoopConf();
+  }
+
+  private static void removeHadoopConf() {
+    Map<String, String> env = System.getenv();
+    Class<?> clazz = env.getClass();
+    Field field = null;
+    try {
+      field = clazz.getDeclaredField("m");
+      field.setAccessible(true);
+      Map<String, String> map = (Map<String, String>) field.get(env);
+      map.remove("HADOOP_CONF_DIR");
+      map.remove("HADOOP_HOME");
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalArgumentException(e);
+    }
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
Fix org.apache.hudi.sink.TestWriteCopyOnWrite will failed when local hadoop env exists

## Brief change log
Add remove HADOOP_CONF_DIR and HADOOP_HOME in TestWriteBase

## Verify this pull request
local test

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:
Manually verified the change by running a job locally

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
