### PR TITLE
[HUDI-4471] Relocate AWSDmsAvroPayload class to hudi-common

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.payload;
+package org.apache.hudi.common.model;
 
-import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/payload/TestAWSDmsAvroPayload.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/payload/TestAWSDmsAvroPayload.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.payload;
 
+import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.util.Option;
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/AWSDmsTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/AWSDmsTransformer.java
@@ -19,8 +19,8 @@
 package org.apache.hudi.utilities.transform;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.payload.AWSDmsAvroPayload;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestAWSDatabaseMigrationServiceSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestAWSDatabaseMigrationServiceSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.utilities.functional;
 
-import org.apache.hudi.payload.AWSDmsAvroPayload;
+import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.transform.AWSDmsTransformer;
 


### PR DESCRIPTION
## Issue Summary

* The payload classes from `hudi-common` get shaded inside `hudi-hadoop-mr-bundle` and are used at hive runtime . Hive realtime view is unable to reference `AWSDmsAvroPayload` as this class is bundled in `hudi-spark`.


## Aim of PR 
* This change is to relocate `AWSDmsAvroPayload` from `hudi-spark` to `hudi-common`