### PR TITLE
[HUDI-4469] Flip reuse flag to true in HoodieBackedTableMetadata to improve file listing

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
@@ -18,12 +18,6 @@
 
 package org.apache.hudi.client.functional;
 
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -51,13 +45,20 @@ import org.apache.hudi.metadata.HoodieTableMetadataKeyGenerator;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.schema.MessageType;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -81,23 +82,26 @@ public class TestHoodieBackedTableMetadata extends TestHoodieMetadataBase {
 
   private static final Logger LOG = LogManager.getLogger(TestHoodieBackedTableMetadata.class);
 
-  @Test
-  public void testTableOperations() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testTableOperations(boolean reuseReaders) throws Exception {
     HoodieTableType tableType = HoodieTableType.COPY_ON_WRITE;
     init(tableType);
     doWriteInsertAndUpsert(testTable);
 
     // trigger an upsert
     doWriteOperation(testTable, "0000003");
-    verifyBaseMetadataTable();
+    verifyBaseMetadataTable(reuseReaders);
   }
 
   private void doWriteInsertAndUpsert(HoodieTestTable testTable) throws Exception {
     doWriteInsertAndUpsert(testTable, "0000001", "0000002", false);
   }
 
-  private void verifyBaseMetadataTable() throws IOException {
-    HoodieBackedTableMetadata tableMetadata = new HoodieBackedTableMetadata(context, writeConfig.getMetadataConfig(), writeConfig.getBasePath(), writeConfig.getSpillableMapBasePath(), false);
+  private void verifyBaseMetadataTable(boolean reuseMetadataReaders) throws IOException {
+    HoodieBackedTableMetadata tableMetadata = new HoodieBackedTableMetadata(
+        context, writeConfig.getMetadataConfig(), writeConfig.getBasePath(),
+        writeConfig.getSpillableMapBasePath(), reuseMetadataReaders);
     assertTrue(tableMetadata.enabled());
     List<java.nio.file.Path> fsPartitionPaths = testTable.getAllPartitionPaths();
     List<String> fsPartitions = new ArrayList<>();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
@@ -51,7 +51,7 @@ public class HoodieMetadataFileSystemView extends HoodieTableFileSystemView {
                                       HoodieMetadataConfig metadataConfig) {
     super(metaClient, visibleActiveTimeline);
     this.tableMetadata = HoodieTableMetadata.create(engineContext, metadataConfig, metaClient.getBasePath(),
-        FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue());
+        FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue(), true);
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the performance problem of repeated data file reading and log merging in the metadata table.

In `HoodieBackedTableMetadata` which provides the metadata based on the metadata table, there is a flag `reuse` to control whether to reuse base file and log readers across multiple API calls.  If enabled, the readers are reused and the merged log records are cached inside the log reader so they can be returned immediately.  If disabled, the data file reading and log merging happen again from the cold load.  The Presto Hive connector uses `FileSystemViewManager.createInMemoryFileSystemView` to create file system view, and when metadata table is enabled, the `reuse` flag is set to false, causing repeated reading and poor performance during the query planning phase.

This PR flips the `reuse` flag in the above method to make the partition listing more efficient. 

Call stack from Presto Hive connector:

```
HudiDirectoryLister constructor (Presto)
  this.fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(engineContext, metaClient, metadataConfig);
-> FileSystemViewManager.createInMemoryFileSystemViewWithTimeline (Hudi)
  new HoodieMetadataFileSystemView(engineContext, metaClient, timeline, metadataConfig)
-> HoodieMetadataFileSystemView (Hudi)
  this.tableMetadata = HoodieTableMetadata.create(engineContext, metadataConfig, metaClient.getBasePath(), (String)FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue());

HudiFileInfoIterator constructor (Presto)
  when metadata table is enabled: `this.hoodieBaseFileIterator = fileSystemView.getLatestBaseFiles(partition).iterator();`
-> AbstractTableFileSystemView (Hudi)
  getLatestBaseFiles() -> ensurePartitionLoadedCorrectly()
-> HoodieMetadataFileSystemView (Hudi)
  this.tableMetadata.getAllFilesInPartition(partitionPath);
-> BaseTableMetadata (Hudi)
  getAllFilesInPartition -> fetchAllFilesInPartition -> getRecordByKey(partitionName, MetadataPartitionType.FILES.getPartitionPath())
```

Here is the analysis of the scope of impact of the `reuse` flag flipping from `false` to `true` in `HoodieBackedTableMetadata` to avoid repeated data file reading and log merging in the metadata table:

Constructor `HoodieBackedTableMetadata(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String datasetBasePath, String spillableMapDirectory)`.  This constructor still sets the `reuse` flag to `false`, which is kept as is (no impact. We can follow up to see if this should also be flipped).
- `MetadataCommand` in `hudi-cli`: these are for Hudi metadata-related CLIs which do not affect production
- `HoodieBackedTableMetadataWriter` in `hudi-client-common`: used by `initTableMetadata()` to initialize metadata table.  Each time this is called, a new `HoodieBackedTableMetadata` instance is going to be created.
- `HoodieMergeOnReadRDD` in `hudi-spark-common`: used by `scanLog()` to directly read the metadata table with Spark datasource (`spark.read.format("hudi").load("<metadata_table_path>")`).  A new `HoodieBackedTableMetadata` instance is created each time this method is called.
- `*MetadataTable*Procedure` classes in `hudi-spark`: used for procedure SQLs to read the metadata table information, which does not affect table content.

Constructor `HoodieBackedTableMetadata(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String datasetBasePath, String spillableMapDirectory, boolean reuse)`, which assigns the `reuse` flag (no impact)
- `HoodieTableMetadata.create`: creating a new `HoodieBackedTableMetadata` instance with the `reuse` flag.
- `TestHoodieBackedTableMetadata`: for testing `HoodieBackedTableMetadata`

Static method `HoodieTableMetadata.create(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String datasetBasePath, String spillableMapPath, boolean reuse)`
- `FSUtils.getFilesInPartitions(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String basePathStr, String[] partitionPaths, String spillableMapPath)`: `reuse` flag is already set to `true` (no impact)
- `FileSystemViewManager.createViewManager(final HoodieEngineContext context, final HoodieMetadataConfig metadataConfig, final FileSystemViewStorageConfig config, final HoodieCommonConfig commonConfig, final String basePath)`: `reuse` flag is already set to `true` (no impact)
- `HoodieMetadataFileSystemView(HoodieEngineContext engineContext, HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, HoodieMetadataConfig metadataConfig)`: flips the `reuse` flag to `true` in this PR (behavior change)
- `HoodieTableMetadata.create(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig, String datasetBasePath, String spillableMapPath)`: still sets the `reuse` flag to `false` (no impact)

Constructor `HoodieMetadataFileSystemView(HoodieEngineContext engineContext, HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, HoodieMetadataConfig metadataConfig)`:
- `FileSystemViewManager.createInMemoryFileSystemViewWithTimeline`: called by `FileSystemViewManager.createInMemoryFileSystemView`, which is used in Presto Hive connector for Hudi integration.
- `ManifestFileWriter.fetchLatestBaseFilesForAllPartitions` in `hudi-sync-common`: used for listing partitions in meta sync 

## Brief change log

  - Sets `reuse` flag to `true` in `HoodieMetadataFileSystemView` to avoid repeated data file reading and log merging

## Verify this pull request

This pull request is already covered by existing tests in `TestHoodieBackedTableMetadata`.  Performance tests are done in a Presto cluster with 1 coordinator (15 cores) and 10 workers (150 cores in total).  For TPC-DS query 42 which reads partitioned tables with 1000 of partitions, before this fix, the query takes 370s with metadata table enabled in Hive connector.  After this fix, the query takes 45s (8x speedup), and based on the logging, the partition listing is much more efficient.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
