### PR TITLE
[HUDI-4221] Optimzing getAllPartitionPaths 

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -29,11 +29,11 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieMetadataException;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -83,31 +83,35 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
       int listingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, pathsToList.size());
 
       // List all directories in parallel
-      List<Pair<Path, FileStatus[]>> dirToFileListing = engineContext.map(pathsToList, path -> {
+      List<FileStatus> dirToFileListing = engineContext.flatMap(pathsToList, path -> {
         FileSystem fileSystem = path.getFileSystem(hadoopConf.get());
-        return Pair.of(path, fileSystem.listStatus(path));
+        return Arrays.stream(fileSystem.listStatus(path));
       }, listingParallelism);
       pathsToList.clear();
 
       // if current dictionary contains PartitionMetadata, add it to result
-      // if current dictionary does not contain PartitionMetadata, add it to queue
-      dirToFileListing.forEach(p -> {
-        Option<FileStatus> partitionMetaFile = Option.fromJavaOptional(Arrays.stream(p.getRight()).parallel()
-            .filter(fileStatus -> fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX))
-            .findFirst());
-
-        if (partitionMetaFile.isPresent()) {
-          // Is a partition.
-          String partitionName = FSUtils.getRelativePartitionPath(basePath, p.getLeft());
-          partitionPaths.add(partitionName);
-        } else {
-          // Add sub-dirs to the queue
-          pathsToList.addAll(Arrays.stream(p.getRight())
-              .filter(fileStatus -> fileStatus.isDirectory() && !fileStatus.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME))
-              .map(fileStatus -> fileStatus.getPath())
-              .collect(Collectors.toList()));
+      // if current dictionary does not contain PartitionMetadata, add it to queue to be processed.
+      int fileListingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, dirToFileListing.size());
+      List<Pair<Option<String>, Option<Path>>> result = engineContext.map(dirToFileListing, fileStatus -> {
+        FileSystem fileSystem = fileStatus.getPath().getFileSystem(hadoopConf.get());
+        if (fileStatus.isDirectory()) {
+          if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, fileStatus.getPath())) {
+            return Pair.of(Option.of(FSUtils.getRelativePartitionPath(new Path(datasetBasePath), fileStatus.getPath())), Option.empty());
+          } else if (!fileStatus.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
+            return Pair.of(Option.empty(), Option.of(fileStatus.getPath()));
+          }
+        } else if (fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)) {
+          String partitionName = FSUtils.getRelativePartitionPath(new Path(datasetBasePath), fileStatus.getPath().getParent());
+          return Pair.of(Option.of(partitionName), Option.empty());
         }
-      });
+        return Pair.of(Option.empty(), Option.empty());
+      }, fileListingParallelism);
+
+      partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent()).map(entry -> entry.getKey().get())
+          .collect(Collectors.toList()));
+
+      pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
+          .collect(Collectors.toList()));
     }
     return partitionPaths;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -92,6 +92,8 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
       // if current dictionary contains PartitionMetadata, add it to result
       // if current dictionary does not contain PartitionMetadata, add it to queue to be processed.
       int fileListingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, dirToFileListing.size());
+      // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
+      // and second entry holds optionally a directory path to be processed further. 
       List<Pair<Option<String>, Option<Path>>> result = engineContext.map(dirToFileListing, fileStatus -> {
         FileSystem fileSystem = fileStatus.getPath().getFileSystem(hadoopConf.get());
         if (fileStatus.isDirectory()) {


### PR DESCRIPTION
## What is the purpose of the pull request

- We reverted the logic for getAllPartitionPaths in https://github.com/apache/hudi/pull/5829. But based on feedback, made some minor tweaks to the reverted code (leverage spark par for dir processing) and perf numbers are still holding good and infact better in some cases. 

Perf numbers from S3 listing: 

Listing a hudi table w/ 10k partitons with each partition having just 1 file. 
// Each value is avg from 10 runs. 

0.9.0: 11 to 12 secs. 
0.11.0: 120 to 140 secs.
master: 11 to 12 secs. 
this patch: 8 to 9 secs. 

Listing a hudi table w/ 40 partitions w/ each having ~ 1000 files. 

0.9.0: 900 to 1000 msec.
0.11.0: 700 to 850 ms
master: 930 to 1030 ms.
this patch: 200 to 240 ms. 

## Brief change log

- Optimizing getAllPartitionPaths 

## Verify this pull request

Already covered by existing tests.
Ran perf tests over S3. 

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
