### PR TITLE
[HUDI-3848] Fixing minor bug in listing based rollback request generation

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -242,11 +242,11 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
     return fs.listStatus(Arrays.stream(filePaths).filter(entry -> {
       try {
         return fs.exists(entry);
-      } catch (IOException e) {
+      } catch (Exception e) {
         LOG.error("Exists check failed for " + entry.toString(), e);
       }
-      // if IOException is thrown, do not ignore. lets try to add the file of interest to be deleted. we can't miss any files to be rolled back.
-      return false;
+      // if any Exception is thrown, do not ignore. let's try to add the file of interest to be deleted. we can't miss any files to be rolled back.
+      return true;
     }).toArray(Path[]::new), pathFilter);
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

- When generating files to be deleted for rollback requests, if any exception is thrown while checking fs.exists(), we were ignoring the files to be added to rollback plan. Fixing it to include any such files.

## Brief change log

- Fixing population of files in rollback requests to include any files which throws any exception while executing fs.exists(). 

## Verify this pull request

This change added tests and can be verified as follows:

- TestCopyOnWriteRollbackActionExecutor#testListBasedRollbackStrategy

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
