### PR TITLE
[HUDI-4509] filter out files not exist

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -91,6 +91,7 @@ class MergeOnReadIncrementalRelation(sqlContext: SQLContext,
       val commitsMetadata = includedCommits.map(getCommitMetadata(_, timeline)).asJava
 
       val modifiedFiles = listAffectedFilesForCommits(conf, new Path(metaClient.getBasePath), commitsMetadata)
+        .filter(file => metaClient.getFs.exists(file.getPath))
       val fsView = new HoodieTableFileSystemView(metaClient, timeline, modifiedFiles)
 
       val modifiedPartitions = getWritePartitionPaths(commitsMetadata)


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

When I read hudi table with spark readStream, FileNotFoundException happens after a while. This happens when a compaction happens and completes quickly while reading, deleting the file that was being read. Details I described at jira ticket.

The code I read hudi
```
    val df: DataFrame = spark.readStream.format("org.apache.hudi")
      .load("hdfs://10.19.29.148:8020/tmp/hudi/ss_bucket")
    df.writeStream
      .format("console")
      .trigger(Trigger.ProcessingTime("5 seconds"))
      .option("checkpointLocation", "/tmp/hoodie/checkpoint_xicm")
      .start()
      .awaitTermination()
```

It seems that there is no mechanism to ensure no compaction while doing incremental read. 

Because of the checkpoint the job can't succeed even after a restart. 
This pr filter files not exist to make stream read successful after a spark retry.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
