### PR TITLE
[HUDI-4447] fix no partitioned path extractor error when sync meta

### DIFF
--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -86,7 +86,7 @@ public class HoodieSyncConfig extends HoodieConfig {
       .key("hoodie.datasource.hive_sync.partition_extractor_class")
       .defaultValue("org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor")
       .withInferFunction(cfg -> {
-        if (cfg.contains(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)) {
+        if (StringUtils.nonEmpty(cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME))) {
           int numOfPartFields = cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME).split(",").length;
           if (numOfPartFields == 1
               && cfg.contains(KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE)

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
@@ -100,6 +100,12 @@ class TestHoodieSyncConfig {
     HoodieSyncConfig config3 = new HoodieSyncConfig(new Properties(), new Configuration());
     assertEquals("org.apache.hudi.hive.NonPartitionedExtractor",
         config3.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS));
+
+    Properties props4 = new Properties();
+    props4.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
+    HoodieSyncConfig config4 = new HoodieSyncConfig(props4, new Configuration());
+    assertEquals("org.apache.hudi.hive.NonPartitionedExtractor",
+        config4.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS));
   }
 
   @Test


### PR DESCRIPTION
## *Tips*

## What is the purpose of the pull request

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
