### PR TITLE
[HUDI-4516] fix Task not serializable error when run HoodieCleaner after one failure

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/DefaultSizeEstimator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/DefaultSizeEstimator.java
@@ -18,12 +18,14 @@
 
 package org.apache.hudi.common.util;
 
+import java.io.Serializable;
+
 /**
  * Default implementation of size-estimator that uses Twitter's ObjectSizeCalculator.
  * 
  * @param <T>
  */
-public class DefaultSizeEstimator<T> implements SizeEstimator<T> {
+public class DefaultSizeEstimator<T> implements SizeEstimator<T>, Serializable {
 
   @Override
   public long sizeEstimate(T t) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordSizeEstimator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordSizeEstimator.java
@@ -26,12 +26,14 @@ import org.apache.avro.Schema;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import java.io.Serializable;
+
 /**
  * Size Estimator for Hoodie record payload.
  * 
  * @param <T>
  */
-public class HoodieRecordSizeEstimator<T extends HoodieRecordPayload> implements SizeEstimator<HoodieRecord<T>> {
+public class HoodieRecordSizeEstimator<T extends HoodieRecordPayload> implements SizeEstimator<HoodieRecord<T>>, Serializable {
 
   private static final Logger LOG = LogManager.getLogger(HoodieRecordSizeEstimator.class);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -52,7 +52,7 @@ import java.util.stream.Stream;
  * map may occupy more memory than is available, resulting in OOM. However, if the spill threshold is too low, we spill
  * frequently and incur unnecessary disk writes.
  */
-public class ExternalSpillableMap<T extends Serializable, R extends Serializable> implements Map<T, R> {
+public class ExternalSpillableMap<T extends Serializable, R extends Serializable> implements Map<T, R>, Serializable {
 
   // Find the actual estimated payload size after inserting N records
   private static final int NUMBER_OF_RECORDS_TO_ESTIMATE_PAYLOAD_SIZE = 100;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBBasedMap.java
@@ -29,12 +29,12 @@ import java.util.Set;
 /**
  * A map's implementation based on RocksDB.
  */
-public final class RocksDBBasedMap<K extends Serializable, R extends Serializable> implements Map<K, R> {
+public final class RocksDBBasedMap<K extends Serializable, R extends Serializable> implements Map<K, R>, Serializable {
 
   private static final String COL_FAMILY_NAME = "map_handle";
 
   private final String rocksDbStoragePath;
-  private RocksDBDAO rocksDBDAO;
+  private transient RocksDBDAO rocksDBDAO;
   private final String columnFamilyName;
 
   public RocksDBBasedMap(String rocksDbStoragePath) {


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request
Let's say HoodieCleaner failed for any reason, if we rerun it, will throw the following exception. need to implement Serializable interface in ExternalSpillableMap.  there should be no side effects of adding Serializable interface
> 2/08/01 10:43:08 ERROR HoodieCleaner: Fail to run cleaning for hdfs://xx/user/xxxx/
org.apache.spark.SparkException: Task not serializable
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:416)
	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:406)
	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:162)
	at org.apache.spark.SparkContext.clean(SparkContext.scala:2467)
	at org.apache.spark.rdd.RDD.$anonfun$map$1(RDD.scala:422)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
	at org.apache.spark.rdd.RDD.withScope(RDD.scala:414)
	at org.apache.spark.rdd.RDD.map(RDD.scala:421)
	at org.apache.spark.api.java.JavaRDDLike.map(JavaRDDLike.scala:93)
	at org.apache.spark.api.java.JavaRDDLike.map$(JavaRDDLike.scala:92)
	at org.apache.spark.api.java.AbstractJavaRDDLike.map(JavaRDDLike.scala:45)
	at org.apache.hudi.client.common.HoodieSparkEngineContext.map(HoodieSparkEngineContext.java:103)
	at org.apache.hudi.table.action.clean.CleanPlanActionExecutor.requestClean(CleanPlanActionExecutor.java:113)
	at org.apache.hudi.table.action.clean.CleanPlanActionExecutor.requestClean(CleanPlanActionExecutor.java:141)
	at org.apache.hudi.table.action.clean.CleanPlanActionExecutor.execute(CleanPlanActionExecutor.java:166)
	at org.apache.hudi.table.HoodieSparkCopyOnWriteTable.scheduleCleaning(HoodieSparkCopyOnWriteTable.java:204)
	at org.apache.hudi.client.BaseHoodieWriteClient.scheduleTableServiceInternal(BaseHoodieWriteClient.java:1352)
	at org.apache.hudi.client.BaseHoodieWriteClient.clean(BaseHoodieWriteClient.java:863)
	at org.apache.hudi.client.BaseHoodieWriteClient.clean(BaseHoodieWriteClient.java:836)
	at org.apache.hudi.client.BaseHoodieWriteClient.clean(BaseHoodieWriteClient.java:890)
	at org.apache.hudi.client.BaseHoodieWriteClient.clean(BaseHoodieWriteClient.java:880)
	at org.apache.hudi.utilities.HoodieCleaner.run(HoodieCleaner.java:69)
	at org.apache.hudi.utilities.HoodieCleaner.main(HoodieCleaner.java:110)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:743)
Caused by: java.io.NotSerializableException: org.apache.hudi.common.util.collection.ExternalSpillableMap
Serialization stack:
	- object not serializable (class: org.apache.hudi.common.util.collection.ExternalSpillableMap, value: org.apache.hudi.common.util.collection.ExternalSpillableMap@564f5b8f)
	- writeObject data (class: org.apache.hudi.common.table.view.HoodieTableFileSystemView)
	- object (class org.apache.hudi.common.table.view.SpillableMapBasedFileSystemView, org.apache.hudi.common.table.view.SpillableMapBasedFileSystemView@1bebb4c9)
	- field (class: org.apache.hudi.table.action.clean.CleanPlanner, name: fileSystemView, type: interface org.apache.hudi.common.table.view.SyncableFileSystemView)
	- object (class org.apache.hudi.table.action.clean.CleanPlanner, org.apache.hudi.table.action.clean.CleanPlanner@347dc85b)
	- element of array (index: 0)
	- array (class [Ljava.lang.Object;, size 1)
	- field (class: java.lang.invoke.SerializedLambda, name: capturedArgs, type: class [Ljava.lang.Object;)
	- object (class java.lang.invoke.SerializedLambda, SerializedLambda[capturingClass=class org.apache.hudi.table.action.clean.CleanPlanActionExecutor, functionalInterfaceMethod=org/apache/hudi/common/function/SerializableFunction.apply:(Ljava/lang/Object;)Ljava/lang/Object;, implementation=invokeStatic org/apache/hudi/table/action/clean/CleanPlanActionExecutor.lambda$requestClean$e73901b4$1:(Lorg/apache/hudi/table/action/clean/CleanPlanner;Ljava/lang/String;)Lorg/apache/hudi/common/util/collection/Pair;, instantiatedMethodType=(Ljava/lang/String;)Lorg/apache/hudi/common/util/collection/Pair;, numCaptured=1])
	- writeReplace data (class: java.lang.invoke.SerializedLambda)
	- object (class org.apache.hudi.table.action.clean.CleanPlanActionExecutor$$Lambda$1860/1603900739, org.apache.hudi.table.action.clean.CleanPlanActionExecutor$$Lambda$1860/1603900739@68c1ef97)
	- element of array (index: 0)
	- array (class [Ljava.lang.Object;, size 1)
	- field (class: java.lang.invoke.SerializedLambda, name: capturedArgs, type: class [Ljava.lang.Object;)
	- object (class java.lang.invoke.SerializedLambda, SerializedLambda[capturingClass=class org.apache.hudi.client.common.HoodieSparkEngineContext, functionalInterfaceMethod=org/apache/spark/api/java/function/Function.call:(Ljava/lang/Object;)Ljava/lang/Object;, implementation=invokeInterface org/apache/hudi/common/function/SerializableFunction.apply:(Ljava/lang/Object;)Ljava/lang/Object;, instantiatedMethodType=(Ljava/lang/Object;)Ljava/lang/Object;, numCaptured=1])
	- writeReplace data (class: java.lang.invoke.SerializedLambda)
	- object (class org.apache.hudi.client.common.HoodieSparkEngineContext$$Lambda$1207/398430635, org.apache.hudi.client.common.HoodieSparkEngineContext$$Lambda$1207/398430635@4ab46aba)
	- element of array (index: 0)
	- array (class [Ljava.lang.Object;, size 1)
	- field (class: java.lang.invoke.SerializedLambda, name: capturedArgs, type: class [Ljava.lang.Object;)
	- object (class java.lang.invoke.SerializedLambda, SerializedLambda[capturingClass=class org.apache.spark.api.java.JavaPairRDD$, functionalInterfaceMethod=scala/Function1.apply:(Ljava/lang/Object;)Ljava/lang/Object;, implementation=invokeStatic org/apache/spark/api/java/JavaPairRDD$.$anonfun$toScalaFunction$1:(Lorg/apache/spark/api/java/function/Function;Ljava/lang/Object;)Ljava/lang/Object;, instantiatedMethodType=(Ljava/lang/Object;)Ljava/lang/Object;, numCaptured=1])
	- writeReplace data (class: java.lang.invoke.SerializedLambda)
	- object (class org.apache.spark.api.java.JavaPairRDD$$$Lambda$1208/2104349, org.apache.spark.api.java.JavaPairRDD$$$Lambda$1208/2104349@5de52b56)
	at org.apache.spark.serializer.SerializationDebugger$.improveException(SerializationDebugger.scala:41)
	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:47)
	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:101)
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:413)
	... 28 more

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
