### PR TITLE
[HUDI-4517] If no marker type file, fallback to timeline based marker

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
@@ -21,12 +21,13 @@ package org.apache.hudi.table.marker;
 
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.marker.MarkerType;
-import org.apache.hudi.common.util.MarkerUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.HoodieTable;
 
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,10 +37,19 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.marker.MarkerType.DIRECT;
+import static org.apache.hudi.common.table.marker.MarkerType.TIMELINE_SERVER_BASED;
+import static org.apache.hudi.common.util.MarkerUtils.MARKER_TYPE_FILENAME;
+import static org.apache.hudi.common.util.MarkerUtils.readMarkerType;
+import static org.apache.hudi.common.util.MarkerUtils.readTimelineServerBasedMarkersFromFileSystem;
+
 /**
  * A utility class for marker-based rollback.
  */
 public class MarkerBasedRollbackUtils {
+
+  private static final Logger LOG = LogManager.getLogger(MarkerBasedRollbackUtils.class);
+
   /**
    * Gets all marker paths.
    *
@@ -54,31 +64,35 @@ public class MarkerBasedRollbackUtils {
                                                String instant, int parallelism) throws IOException {
     String markerDir = table.getMetaClient().getMarkerFolderPath(instant);
     FileSystem fileSystem = table.getMetaClient().getFs();
-    Option<MarkerType> markerTypeOption = MarkerUtils.readMarkerType(fileSystem, markerDir);
+    Option<MarkerType> markerTypeOption = readMarkerType(fileSystem, markerDir);
 
     // If there is no marker type file "MARKERS.type", first assume "DIRECT" markers are used.
     // If not, then fallback to "TIMELINE_SERVER_BASED" markers.
     if (!markerTypeOption.isPresent()) {
-      WriteMarkers writeMarkers = WriteMarkersFactory.get(MarkerType.DIRECT, table, instant);
+      WriteMarkers writeMarkers = WriteMarkersFactory.get(DIRECT, table, instant);
       try {
         return new ArrayList<>(writeMarkers.allMarkerFilePaths());
-      } catch (Exception e) {
-        writeMarkers = WriteMarkersFactory.get(MarkerType.TIMELINE_SERVER_BASED, table, instant);
-        return new ArrayList<>(writeMarkers.allMarkerFilePaths());
+      } catch (IOException | IllegalArgumentException e) {
+        LOG.warn(String.format("%s not present and %s marker failed with error: %s. So, falling back to %s marker",
+            MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
+        return getTimelineServerBasedMarkers(context, parallelism, markerDir, fileSystem);
       }
     }
 
     switch (markerTypeOption.get()) {
       case TIMELINE_SERVER_BASED:
         // Reads all markers written by the timeline server
-        Map<String, Set<String>> markersMap =
-            MarkerUtils.readTimelineServerBasedMarkersFromFileSystem(
-                markerDir, fileSystem, context, parallelism);
-        return markersMap.values().stream().flatMap(Collection::stream)
-            .collect(Collectors.toCollection(ArrayList::new));
+        return getTimelineServerBasedMarkers(context, parallelism, markerDir, fileSystem);
       default:
         throw new HoodieException(
             "The marker type \"" + markerTypeOption.get().name() + "\" is not supported.");
     }
+  }
+
+  private static List<String> getTimelineServerBasedMarkers(HoodieEngineContext context, int parallelism, String markerDir, FileSystem fileSystem) {
+    Map<String, Set<String>> markersMap = readTimelineServerBasedMarkersFromFileSystem(markerDir, fileSystem, context, parallelism);
+    return markersMap.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
@@ -64,7 +64,8 @@ public class MarkerUtils {
    * @return marker file name
    */
   public static String stripMarkerFolderPrefix(String fullMarkerPath, String basePath, String instantTime) {
-    ValidationUtils.checkArgument(fullMarkerPath.contains(HoodieTableMetaClient.MARKER_EXTN));
+    ValidationUtils.checkArgument(fullMarkerPath.contains(HoodieTableMetaClient.MARKER_EXTN),
+        String.format("Using DIRECT markers but marker path does not contain extension: %s", HoodieTableMetaClient.MARKER_EXTN));
     String markerRootPath = Path.getPathWithoutSchemeAndAuthority(
         new Path(String.format("%s/%s/%s", basePath, HoodieTableMetaClient.TEMPFOLDER_NAME, instantTime))).toString();
     return stripMarkerFolderPrefix(fullMarkerPath, markerRootPath);

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerDirState.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerDirState.java
@@ -273,7 +273,7 @@ public class MarkerDirState implements Serializable {
   private void writeMarkerTypeToFile() {
     Path dirPath = new Path(markerDirPath);
     try {
-      if (!fileSystem.exists(dirPath)) {
+      if (!fileSystem.exists(dirPath) || !MarkerUtils.doesMarkerTypeFileExist(fileSystem, markerDirPath)) {
         // There is no existing marker directory, create a new directory and write marker type
         fileSystem.mkdirs(dirPath);
         MarkerUtils.writeMarkerTypeToFile(MarkerType.TIMELINE_SERVER_BASED, fileSystem, markerDirPath);


### PR DESCRIPTION
## What is the purpose of the pull request

If `MARKERS.type` file is not present, the logic assumes that the direct markers are stored, which causes the read failure in certain cases even where timeline server based marker is enabled. This PR handles the failure by falling back to timeline based marker in such cases.

See #5591 for more details.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
