### PR TITLE
[HUDI-4518] Free lock if allocated but not acquired

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
@@ -149,6 +149,7 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
     try {
       if (lock != null) {
         hiveClient.unlock(lock.getLockid());
+        lock = null;
       }
       Hive.closeCurrent();
     } catch (Exception e) {
@@ -197,6 +198,7 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
       // it is better to release WAITING lock, otherwise hive lock will hang forever
       if (this.lock != null && this.lock.getState() != LockState.ACQUIRED) {
         hiveClient.unlock(this.lock.getLockid());
+        lock = null;
       }
     }
   }


### PR DESCRIPTION
## What is the purpose of the pull request

Fixes the issue observed in #5702 .
Essentially, if lock is not null but its state has not yet transitioned to ACQUIRED, retry fails because the lock is no de-allocated. This PR fixes that.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
