### PR TITLE
[HUDI-4523] Sequential submitting of flink jobs leads to java.net.ConnectException

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -91,7 +91,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
     if (timelineServer.isPresent() && shouldStopTimelineServer) {
       // Stop only if owner
       LOG.info("Stopping Timeline service !!");
-      timelineServer.get().stop();
+      EmbeddedTimelineServerHelper.stopEmbeddedTimelineService(timelineServer.get());
     }
 
     timelineServer = Option.empty();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineServerHelper.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 public class EmbeddedTimelineServerHelper {
 
   private static final Logger LOG = LogManager.getLogger(EmbeddedTimelineService.class);
+
   private static final Map<String, EmbeddedTimelineService> PATH_TO_SERVER = new HashMap<>();
   private static final Map<EmbeddedTimelineService, Integer> SERVER_TO_COUNTER = new IdentityHashMap<>();
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -124,10 +124,8 @@ public class EmbeddedTimelineService {
     return viewManager;
   }
 
-  public boolean canReuseFor(String basePath) {
-    return this.server != null
-        && this.viewManager != null
-        && this.basePath.equals(basePath);
+  public boolean canReuse() {
+    return this.server != null && this.viewManager != null;
   }
 
   public void stop() {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
@@ -451,7 +451,8 @@ public class ITTestDataStreamWrite extends TestLogger {
   @Test
   @Timeout(180)
   public void testConcurrentSink() throws Exception {
-    TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+    TableEnvironment tEnv = TableEnvironment.create(settings);
     tEnv.executeSql("create table t1 (uuid int) with (" + prepareOptions() + ")");
     TableResult r1 = tEnv.executeSql("insert into t1 values (0)");
     waitForFirstCommit();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -901,7 +901,7 @@ public class DeltaSync implements Serializable {
 
     LOG.info("Shutting down embedded timeline server");
     if (embeddedTimelineService.isPresent()) {
-      embeddedTimelineService.get().stop();
+      EmbeddedTimelineServerHelper.stopEmbeddedTimelineService(embeddedTimelineService.get());
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request
This PR fixes `java.net.ConnectException` when two flink jobs are submitted with `metadata.enabled: true`
```java
tEnv.executeSql("insert into t1 values (0)").await();
tEnv.executeSql("insert into t1 values (1), (2)").await();
```
```
Caused by: org.apache.http.conn.HttpHostConnectException: Connect to 192.168.0.5:58517 [/192.168.0.5] failed: Connection refused (Connection refused)
  at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:151)
...
Caused by: java.net.ConnectException: Connection refused (Connection refused)
  at java.net.PlainSocketImpl.socketConnect(Native Method)
``` 

## Brief change log
  - Add `Map<String, EmbeddedTimelineService> PATH_TO_SERVER` to support multiple base paths
  - Handle concurrent `timelineService.start`/`timelineService.stop` in `EmbeddedTimelineServerHelper`
  - Add new synchronized method `EmbeddedTimelineServerHelper.stopEmbeddedTimelineService` to handle
```java
thread1: c1 = new HoodieFlinkWriteClient()
thread1: c1.stop() || thread2: c2 = new HoodieFlinkWriteClient()
thread2: c2.use()
thread2: c2.stop()
```
  - Add `Map<EmbeddedTimelineService, Integer> SERVER_TO_COUNTER` to `EmbeddedTimelineServerHelper` to handle
```java
thread1: c1 = new HoodieFlinkWriteClient()
thread2: c2 = new HoodieFlinkWriteClient()
thread1: c1.stop() || thread2: c2.use()
thread2: c2.stop()
```
  - Replace usage of `EmbeddedTimelineService.stop` with new synchronized method  `EmbeddedTimelineServerHelper.stopEmbeddedTimelineService` in `BaseHoodieClient`, `DeltaSync`

## Verify this pull request

This change added tests and can be verified as follows:
  - Added integration test `ITTestDataStreamWrite.testConcurrentSink`

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
