### PR TITLE
[MINOR] fix `progress` field calculate logic in HoodieLogRecordReader

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -480,7 +480,7 @@ public abstract class AbstractHoodieLogRecordReader {
       }
     }
     // At this step the lastBlocks are consumed. We track approximate progress by number of log-files seen
-    progress = numLogFilesSeen - 1 / logFilePaths.size();
+    progress = (numLogFilesSeen - 1) / logFilePaths.size();
   }
 
   private ClosableIterator<IndexedRecord> getRecordsIterator(HoodieDataBlock dataBlock, Option<KeySpec> keySpecOpt) throws IOException {


### PR DESCRIPTION
### Change Logs
when process blocks in hoodieLogRecordReader, the `progress` field track approximate progress by number of log-files seen,
but it is calculated wrong as operator priority incorrect.

### Impact

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed