### PR TITLE
[HUDI-4532] Return 'Seq.empty' instead of 'Seq(Row.empty)' if there is no clean_metadata

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
@@ -76,7 +76,7 @@ class RunCleanProcedure extends BaseProcedure with ProcedureBuilder with Logging
     val client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, props)
     val hoodieCleanMeta = client.clean(cleanInstantTime, scheduleInLine, skipLocking)
 
-    if (hoodieCleanMeta == null) Seq(Row.empty)
+    if (hoodieCleanMeta == null) Seq.empty
     else Seq(Row(hoodieCleanMeta.getStartCleanTime,
       hoodieCleanMeta.getTimeTakenInMillis,
       hoodieCleanMeta.getTotalFilesDeleted,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
@@ -55,6 +55,10 @@ class TestCleanProcedure extends HoodieSparkSqlTestBase {
       assertResult(1)(result1.length)
       assertResult(2)(result1(0)(2))
 
+      val result2 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
+        .collect()
+      assertResult(0)(result2.length)
+
       checkAnswer(s"select id, name, price, ts from $tableName order by id") (
         Seq(1, "a1", 13, 1000)
       )


### PR DESCRIPTION
[HUDI-4532] Return 'Seq.empty' instead of 'Seq(Row.empty)' if there is no clean_metadata

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
