### PR TITLE
[HUDI-4577] Adding test coverage for `DELETE FROM`, Spark Quickstart guide

### DIFF
--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
@@ -55,26 +55,33 @@ public final class HoodieSparkQuickstart {
     SparkConf sparkConf = HoodieExampleSparkUtils.defaultSparkConf("hoodie-client-example");
 
     try (JavaSparkContext jsc = new JavaSparkContext(sparkConf)) {
-      final HoodieExampleDataGenerator<HoodieAvroPayload> dataGen = new HoodieExampleDataGenerator<>();
-
-      insertData(spark, jsc, tablePath, tableName, dataGen);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      updateData(spark, jsc, tablePath, tableName, dataGen);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      incrementalQuery(spark, tablePath, tableName);
-      pointInTimeQuery(spark, tablePath, tableName);
-
-      delete(spark, tablePath, tableName);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      insertOverwriteData(spark, jsc, tablePath, tableName, dataGen);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      deleteByPartition(spark, tablePath, tableName);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
+      runQuickstart(jsc, spark, tableName, tablePath);
     }
+  }
+
+  /**
+   * Visible for testing
+   */
+  public static void runQuickstart(JavaSparkContext jsc, SparkSession spark, String tableName, String tablePath) {
+    final HoodieExampleDataGenerator<HoodieAvroPayload> dataGen = new HoodieExampleDataGenerator<>();
+
+    insertData(spark, jsc, tablePath, tableName, dataGen);
+    queryData(spark, jsc, tablePath, tableName, dataGen);
+
+    updateData(spark, jsc, tablePath, tableName, dataGen);
+    queryData(spark, jsc, tablePath, tableName, dataGen);
+
+    incrementalQuery(spark, tablePath, tableName);
+    pointInTimeQuery(spark, tablePath, tableName);
+
+    delete(spark, tablePath, tableName);
+    queryData(spark, jsc, tablePath, tableName, dataGen);
+
+    insertOverwriteData(spark, jsc, tablePath, tableName, dataGen);
+    queryData(spark, jsc, tablePath, tableName, dataGen);
+
+    deleteByPartition(spark, tablePath, tableName);
+    queryData(spark, jsc, tablePath, tableName, dataGen);
   }
 
   /**

--- a/hudi-examples/hudi-examples-spark/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieSparkQuickstart.java
+++ b/hudi-examples/hudi-examples-spark/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieSparkQuickstart.java
@@ -46,11 +46,11 @@ import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.queryDat
 import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.updateData;
 
 public class TestHoodieSparkQuickstart implements SparkProvider {
-  protected static transient HoodieSparkEngineContext context;
+  protected static HoodieSparkEngineContext context;
 
-  private static transient SparkSession spark;
-  private static transient SQLContext sqlContext;
-  private static transient JavaSparkContext jsc;
+  private static SparkSession spark;
+  private static SQLContext sqlContext;
+  private static JavaSparkContext jsc;
 
   /**
    * An indicator of the initialization status.
@@ -58,8 +58,6 @@ public class TestHoodieSparkQuickstart implements SparkProvider {
   protected boolean initialized = false;
   @TempDir
   protected java.nio.file.Path tempDir;
-
-  private static final HoodieExampleDataGenerator<HoodieAvroPayload> DATA_GEN = new HoodieExampleDataGenerator<>();
 
   @Override
   public SparkSession spark() {

--- a/hudi-examples/hudi-examples-spark/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieSparkQuickstart.java
+++ b/hudi-examples/hudi-examples-spark/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieSparkQuickstart.java
@@ -43,6 +43,7 @@ import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.insertDa
 import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.insertOverwriteData;
 import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.pointInTimeQuery;
 import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.queryData;
+import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.runQuickstart;
 import static org.apache.hudi.examples.quickstart.HoodieSparkQuickstart.updateData;
 
 public class TestHoodieSparkQuickstart implements SparkProvider {
@@ -107,25 +108,7 @@ public class TestHoodieSparkQuickstart implements SparkProvider {
     String tablePath = tablePath(tableName);
 
     try {
-      final HoodieExampleDataGenerator<HoodieAvroPayload> dataGen = new HoodieExampleDataGenerator<>();
-
-      insertData(spark, jsc, tablePath, tableName, dataGen);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      updateData(spark, jsc, tablePath, tableName, dataGen);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      incrementalQuery(spark, tablePath, tableName);
-      pointInTimeQuery(spark, tablePath, tableName);
-
-      delete(spark, tablePath, tableName);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      insertOverwriteData(spark, jsc, tablePath, tableName, dataGen);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
-
-      deleteByPartition(spark, tablePath, tableName);
-      queryData(spark, jsc, tablePath, tableName, dataGen);
+      runQuickstart(jsc, spark, tableName, tablePath);
     } finally {
       Utils.deleteRecursively(new File(tablePath));
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDeleteFromTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDeleteFromTable.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+class TestDeleteFromTable extends HoodieSparkSqlTestBase {
+
+  test("Test deleting from table") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |CREATE TABLE $tableName (
+             |  id int,
+             |  dt string,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) USING hudi
+             | tblproperties (
+             |    primaryKey = 'id',
+             |    tableType = '$tableType'
+             | )
+             | PARTITIONED BY (dt)
+             | LOCATION '${tmp.getCanonicalPath}'
+         """.stripMargin)
+
+        // NOTE: Do not write the field alias, the partition field must be placed last.
+        spark.sql(
+          s"""
+             | INSERT INTO $tableName VALUES
+             | (1, 'a1', 10, 1000, "2021-01-05"),
+             | (2, 'a2', 20, 2000, "2021-01-06"),
+             | (3, 'a3', 30, 3000, "2021-01-07")
+                """.stripMargin)
+
+        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+          Seq(1, "a1", 10.0, 1000, "2021-01-05"),
+          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+          Seq(3, "a3", 30.0, 3000, "2021-01-07")
+        )
+
+        // Delete single row
+        spark.sql(s"DELETE FROM $tableName WHERE id = 1")
+
+        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+          Seq(3, "a3", 30.0, 3000, "2021-01-07")
+        )
+
+        // Try deleting non-existent row
+        spark.sql(s"DELETE FROM $tableName WHERE id = 1")
+
+        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+          Seq(3, "a3", 30.0, 3000, "2021-01-07")
+        )
+
+        // Delete record identified by some field other than the primary-key
+        spark.sql(s"DELETE FROM $tableName WHERE name = 'a2'")
+
+        checkAnswer(s"SELECT id, name, price, ts, dt FROM $tableName")(
+          Seq(3, "a3", 30.0, 3000, "2021-01-07")
+        )
+      }
+    }
+  }
+}

--- a/hudi-utilities/src/test/resources/hive-site.xml
+++ b/hudi-utilities/src/test/resources/hive-site.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+    <property>
+        <name>hive.server2.enable.doAs</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.schema.verification</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <name>datanucleus.schema.autoCreateTables</name>
+        <value>true</value>
+    </property>
+</configuration>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contribute/how-to-contribute before opening a pull request.*

## What is the purpose of the pull request

This change aims to add/improve test coverage by picking some low-hanging fruits.

## Brief change log

 - Added "hive-site.xml" to fix DeltaStreamer tests failing locally (unable to connect to Hive)
 - Added `TestDeleteFromTable`
 - Beefed up Spark's Quickstart guide test

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.
This change added tests and can be verified as follows:

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
