### PR TITLE
[HUDI-4570] Fix hive sync path error due to reuse of storage descript…

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -225,8 +225,9 @@ public class HMSDDLExecutor implements DDLExecutor {
         String fullPartitionPath = StorageSchemes.HDFS.getScheme().equals(partitionScheme)
             ? FSUtils.getDFSFullPartitionPath(syncConfig.getHadoopFileSystem(), partitionPath) : partitionPath.toString();
         List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partition);
-        sd.setLocation(fullPartitionPath);
-        return new Partition(partitionValues, databaseName, tableName, 0, 0, sd, null);
+        StorageDescriptor partitionSd = sd.deepCopy();
+        partitionSd.setLocation(fullPartitionPath);
+        return new Partition(partitionValues, databaseName, tableName, 0, 0, partitionSd, null);
       }).collect(Collectors.toList());
       client.alter_partitions(databaseName, tableName, partitionList, null);
     } catch (TException e) {


### PR DESCRIPTION
…ors.

### Change Logs

Fix the bug in HMSDDLExecutor. When updating more than one partition, the storage descriptor of partition is wrong.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [x] CI passed
