### PR TITLE
[HUDI-4572] fix 'Not a valid schema field: ts' error in HoodieFlinkCompactor, if …

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
@@ -173,6 +173,8 @@ public class HoodieFlinkCompactor {
       // set table schema
       CompactionUtil.setAvroSchema(conf, metaClient);
 
+      CompactionUtil.setPreCombineField(conf, metaClient);
+
       // infer changelog mode
       CompactionUtil.inferChangelogMode(conf, metaClient);
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
@@ -120,6 +120,20 @@ public class CompactionUtil {
   }
 
   /**
+   * Sets up the preCombine field into the given configuration {@code conf}
+   * through reading from the hoodie table metadata.
+   *
+   * This value is non-null as compaction can only be performed on MOR tables.
+   * Of which, MOR tables will have non-null precombine fields.
+   *
+   * @param conf The configuration
+   */
+  public static void setPreCombineField(Configuration conf, HoodieTableMetaClient metaClient) {
+    String preCombineField = metaClient.getTableConfig().getPreCombineField();
+    conf.setString(FlinkOptions.PRECOMBINE_FIELD, preCombineField);
+  }
+
+  /**
    * Infers the changelog mode based on the data file schema(including metadata fields).
    *
    * <p>We can improve the code if the changelog mode is set up as table config.


### PR DESCRIPTION
…precombine field is not ts

### Change Logs

if table's pre-combine field is not 'ts', should pass it into the compactor then let some payload class get right `hoodie.payload.ordering.field`
### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
