### PR TITLE
[HUDI-4571] Fix partition extractor infer function when partition field mismatch

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/replication/TestHiveSyncGlobalCommitTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/replication/TestHiveSyncGlobalCommitTool.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.hive.replication;
 
+import org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor;
 import org.apache.hudi.hive.testutils.HiveTestCluster;
 
 import org.apache.hadoop.fs.Path;
@@ -41,6 +42,7 @@ import static org.apache.hudi.hive.replication.HiveSyncGlobalCommitParams.REMOTE
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_ASSUME_DATE_PARTITION;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,6 +77,7 @@ public class TestHiveSyncGlobalCommitTool {
     params.loadedProps.setProperty(META_SYNC_ASSUME_DATE_PARTITION.key(), "true");
     params.loadedProps.setProperty(HIVE_USE_PRE_APACHE_INPUT_FORMAT.key(), "false");
     params.loadedProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "datestr");
+    params.loadedProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());
     return params;
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -23,8 +23,10 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.sync.common.util.ConfigUtils;
 
 import com.beust.jcommander.Parameter;
@@ -44,9 +46,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE;
 import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
 import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY;
-import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING;
-import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME;
 
 /**
  * Configs needed to sync data into external meta stores, catalogs, etc.
@@ -88,16 +88,16 @@ public class HoodieSyncConfig extends HoodieConfig {
   public static final ConfigProperty<String> META_SYNC_PARTITION_FIELDS = ConfigProperty
       .key("hoodie.datasource.hive_sync.partition_fields")
       .defaultValue("")
-      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(PARTITION_FIELDS))
-          .or(() -> Option.ofNullable(cfg.getString(PARTITIONPATH_FIELD_NAME))))
+      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HoodieTableConfig.PARTITION_FIELDS))
+          .or(() -> Option.ofNullable(cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME))))
       .withDocumentation("Field in the table to use for determining hive partition columns.");
 
   public static final ConfigProperty<String> META_SYNC_PARTITION_EXTRACTOR_CLASS = ConfigProperty
       .key("hoodie.datasource.hive_sync.partition_extractor_class")
       .defaultValue("org.apache.hudi.hive.MultiPartKeysValueExtractor")
       .withInferFunction(cfg -> {
-        Option<String> partitionFieldsOpt = Option.ofNullable(cfg.getString(PARTITION_FIELDS))
-            .or(() -> Option.ofNullable(cfg.getString(PARTITIONPATH_FIELD_NAME)));
+        Option<String> partitionFieldsOpt = Option.ofNullable(cfg.getString(HoodieTableConfig.PARTITION_FIELDS))
+            .or(() -> Option.ofNullable(cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)));
         if (!partitionFieldsOpt.isPresent()) {
           return Option.empty();
         }


### PR DESCRIPTION
### Change Logs

- Infer `META_SYNC_PARTITION_FIELDS` and `META_SYNC_PARTITION_EXTRACTOR_CLASS` from `hoodie.table.partition.fields` first; if not set, then from `hoodie.datasource.write.partitionpath.field`

### Impact

Without this fix, in the scenario mentioned above, the partition extractor would be set as `NonPartitionedExtractor` even though hoodie.properties has a partition field.

**Risk level: high**

Added a test to cover the scenario in `TestHoodieSyncConfig`. Also, manually verified spark-sql as follows:
```
spark-sql> create table hudi_cow_pt_tbl (
         >   id bigint,
         >   name string,
         >   ts bigint,
         >   dt string,
         >   hh string
         > ) using hudi
         > tblproperties (
         >   type = 'cow',
         >   primaryKey = 'id',
         >   preCombineField = 'ts'
         >  )
         > partitioned by (dt, hh)
         > location '/tmp/hudi/hudi_cow_pt_tbl';
spark-sql> insert into hudi_cow_pt_tbl partition (dt, hh)
         > select 1 as id, 'a1' as name, 1000 as ts, '2021-12-09' as dt, '10' as hh;
...
...
22/08/08 23:15:04 INFO BaseHoodieTableFileIndex: Refresh table hudi_cow_pt_tbl, spent: 389 ms
Time taken: 18.07 seconds
22/08/08 23:15:04 INFO SparkSQLCLIDriver: Time taken: 18.07 seconds
```

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
