### PR TITLE
[HUDI-4794] add an option of the log file block size

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -40,15 +40,21 @@ public class HoodieCommonConfig extends HoodieConfig {
       .key("hoodie.datasource.write.reconcile.schema")
       .defaultValue(false)
       .withDocumentation("When a new batch of write has records with old schema, but latest table schema got "
-        + "evolved, this config will upgrade the records to leverage latest table schema(default values will be "
-        + "injected to missing fields). If not, the write batch would fail.");
+          + "evolved, this config will upgrade the records to leverage latest table schema(default values will be "
+          + "injected to missing fields). If not, the write batch would fail.");
 
   public static final ConfigProperty<ExternalSpillableMap.DiskMapType> SPILLABLE_DISK_MAP_TYPE = ConfigProperty
       .key("hoodie.common.spillable.diskmap.type")
       .defaultValue(ExternalSpillableMap.DiskMapType.BITCASK)
-      .withDocumentation("When handling input data that cannot be held in memory, to merge with a file on storage, a spillable diskmap is employed.  "
-          + "By default, we use a persistent hashmap based loosely on bitcask, that offers O(1) inserts, lookups. "
-          + "Change this to `ROCKS_DB` to prefer using rocksDB, for handling the spill.");
+      .withDocumentation(
+          "When handling input data that cannot be held in memory, to merge with a file on storage, a spillable diskmap is employed.  "
+              + "By default, we use a persistent hashmap based loosely on bitcask, that offers O(1) inserts, lookups. "
+              + "Change this to `ROCKS_DB` to prefer using rocksDB, for handling the spill.");
+
+  public static final ConfigProperty<Long> LOG_FILE_BLOCK_SIZE = ConfigProperty
+      .key("hoodie.log.file.block.size")
+      .defaultValue(128 * 1024 * 1024L)
+      .withDocumentation("Log file block size");
 
   public static final ConfigProperty<Boolean> DISK_MAP_BITCASK_COMPRESSION_ENABLED = ConfigProperty
       .key("hoodie.common.diskmap.compression.enabled")
@@ -89,6 +95,11 @@ public class HoodieCommonConfig extends HoodieConfig {
 
     public Builder withSpillableDiskMapType(ExternalSpillableMap.DiskMapType diskMapType) {
       commonConfig.setValue(SPILLABLE_DISK_MAP_TYPE, diskMapType.name());
+      return this;
+    }
+
+    public Builder withLogFileBlockSize(Long logFileBlockSize) {
+      commonConfig.setValue(LOG_FILE_BLOCK_SIZE, String.valueOf(logFileBlockSize));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -69,6 +69,10 @@ public class HoodieCommonConfig extends HoodieConfig {
     return getBoolean(DISK_MAP_BITCASK_COMPRESSION_ENABLED);
   }
 
+  public Long getLogFileBlockSize() {
+    return getLong(LOG_FILE_BLOCK_SIZE);
+  }
+
   private HoodieCommonConfig() {
     super();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -230,7 +230,8 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
   }
 
   private void createNewFile() throws IOException {
-    this.output = fs.create(this.logFile.getPath(), false, bufferSize, replication, HoodieCommonConfig.LOG_FILE_BLOCK_SIZE.defaultValue(), null);
+    HoodieCommonConfig commonConfig = HoodieCommonConfig.newBuilder().build();
+    this.output = fs.create(this.logFile.getPath(), false, bufferSize, replication, commonConfig.getLogFileBlockSize(), null);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

on each hoodie log append, hdfs used will be increased with the length of the block(512M), not teh actual data length().
 Consider in a scenario,I use many writers to append concurrently to a large number of files(bucket file),but each time I append only 10 bytes.
 dfs used will be increased with the length of the block(512M),this will cause the datanode to report in-sufficient disk space on data write.
 even though it related to HDFS, We should also have the option to modify the configuration.It helps reduce the rate of increase during the du.

### Impact

The rate at which the dfsused space grows can be controlled

**Risk level: none | low | medium | high**

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
