### PR TITLE
[HUDI-4608] Fix upgrade command in Hudi CLI

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -515,8 +515,10 @@ public class SparkMain {
             .setLoadActiveTimelineOnLoad(false).setConsistencyGuardConfig(config.getConsistencyGuardConfig())
             .setLayoutVersion(Option.of(new TimelineLayoutVersion(config.getTimelineLayoutVersion())))
             .setFileSystemRetryConfig(config.getFileSystemRetryConfig()).build();
+    HoodieWriteConfig updatedConfig = HoodieWriteConfig.newBuilder().withProps(config.getProps())
+        .forTable(metaClient.getTableConfig().getTableName()).build();
     try {
-      new UpgradeDowngrade(metaClient, config, new HoodieSparkEngineContext(jsc), SparkUpgradeDowngradeHelper.getInstance())
+      new UpgradeDowngrade(metaClient, updatedConfig, new HoodieSparkEngineContext(jsc), SparkUpgradeDowngradeHelper.getInstance())
           .run(HoodieTableVersion.valueOf(toVersion), null);
       LOG.info(String.format("Table at \"%s\" upgraded / downgraded to version \"%s\".", basePath, toVersion));
       return 0;


### PR DESCRIPTION
### Change Logs

This PR fixes the table upgrade from version THREE to FOUR using Hudi CLI.  Before this fix, the following exception is thrown.  This is due to the missing `hoodie.table.name` property in the write config passed in.

```
22/08/11 15:35:39 INFO UpgradeDowngrade: Attempting to move table from version THREE to FIVE
22/08/11 15:35:39 WARN SparkMain: Failed: Could not upgrade/downgrade table at "/<>/test_table" to version "FIVE".
java.lang.IllegalArgumentException: hoodie.table.name property needs to be specified
    at org.apache.hudi.common.table.HoodieTableConfig.generateChecksum(HoodieTableConfig.java:437)
    at org.apache.hudi.table.upgrade.ThreeToFourUpgradeHandler.upgrade(ThreeToFourUpgradeHandler.java:43)
    at org.apache.hudi.table.upgrade.UpgradeDowngrade.upgrade(UpgradeDowngrade.java:147)
    at org.apache.hudi.table.upgrade.UpgradeDowngrade.run(UpgradeDowngrade.java:118)
    at org.apache.hudi.cli.commands.SparkMain.upgradeOrDowngradeTable(SparkMain.java:520)
    at org.apache.hudi.cli.commands.SparkMain.main(SparkMain.java:271)
```

Code changes:
- Adds the logic in CLI class `SparkMain` to add the `hoodie.table.name` property to the write config passed to the `UpgradeDowngrade`.
- Adds unit tests to cover all supported upgrade and downgrade cases.

### Impact

Only affecting the upgrade and downgrade commands in Hudi CLI.

**Risk level: low**
- Before this change, the newly added tests for upgrading the table from TWO to FIVE fails.  After this change, all tests pass.
- Runs hudi-cli on a local table.  Both upgrade and downgrade commands work.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
