### PR TITLE
[HUDI-4609] Improve usability of upgrade/downgrade commands in Hudi CLI

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -138,6 +139,19 @@ public class TestUpgradeDowngradeCommand extends CLIFunctionalTestHarness {
         assertEquals(0, FileCreateUtils.getTotalMarkerFileCount(tablePath, partitionPath, "101", IOType.MERGE));
       }
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testGetHoodieTableVersionName(boolean overrideWithDefault) {
+    assertEquals(overrideWithDefault ? HoodieTableVersion.current().name() : null,
+        UpgradeOrDowngradeCommand.getHoodieTableVersionName(null, overrideWithDefault));
+    assertEquals(overrideWithDefault ? HoodieTableVersion.current().name() : "",
+        UpgradeOrDowngradeCommand.getHoodieTableVersionName("", overrideWithDefault));
+    assertEquals("FIVE",
+        UpgradeOrDowngradeCommand.getHoodieTableVersionName("FIVE", overrideWithDefault));
+    assertEquals("FIVE",
+        UpgradeOrDowngradeCommand.getHoodieTableVersionName("5", overrideWithDefault));
   }
 
   private void verifyTableVersion(HoodieTableVersion expectedVersion) throws IOException {


### PR DESCRIPTION
### Change Logs

This PR improves usability of upgrade/downgrade commands in Hudi CLI by the following:
- For the upgrade command (`upgrade table`), if `--toVersion` is not specified, the current/latest table version is used.
- Adds support for numeric table version.  If the numeric table version is provided through `--toVersion`, it is converted to the `HoodieTableVersion` enum name internally, e.g., `2` -> `TWO`.

This PR adds new tests for the conversion of the input version option to the desired version name.

### Impact

Only affecting the upgrade and downgrade commands in Hudi CLI.

**Risk level: low**
Tested the following CLI commands and they all work as expected:
- `upgrade table --sparkMaster local[2]`: `Hoodie table upgraded/downgraded to FIVE`
- `downgrade table --toVersion 2 --sparkMaster local[2]`: `Hoodie table upgraded/downgraded to TWO`
- `upgrade table --toVersion FIVE --sparkMaster local[2]`: `Hoodie table upgraded/downgraded to FIVE`
- `downgrade table --toVersion TWO --sparkMaster local[2]`: `Hoodie table upgraded/downgraded to TWO`

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
