### PR TITLE
[HUDI-4614] fix primary key extract of delete_record when complexKeyGen configured and ChangeLogDisabled

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -73,9 +73,13 @@ public class KeyGenUtils {
    */
   public static String[] extractRecordKeys(String recordKey) {
     String[] fieldKV = recordKey.split(",");
+
     return Arrays.stream(fieldKV).map(kv -> {
       final String[] kvArray = kv.split(":");
-      if (kvArray[1].equals(NULL_RECORDKEY_PLACEHOLDER)) {
+      // a simple key
+      if (kvArray.length == 1) {
+        return kvArray[0];
+      } else if (kvArray[1].equals(NULL_RECORDKEY_PLACEHOLDER)) {
         return null;
       } else if (kvArray[1].equals(EMPTY_RECORDKEY_PLACEHOLDER)) {
         return "";

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -25,6 +25,9 @@ public class TestKeyGenUtils {
 
   @Test
   public void testExtractRecordKeys() {
+    String[] s0 = KeyGenUtils.extractRecordKeys("1");
+    Assertions.assertArrayEquals(new String[]{"1"}, s0);
+
     String[] s1 = KeyGenUtils.extractRecordKeys("id:1");
     Assertions.assertArrayEquals(new String[]{"1"}, s1);
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
+import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.table.HoodieTableSource;
 import org.apache.hudi.table.format.cow.CopyOnWriteInputFormat;
 import org.apache.hudi.table.format.mor.MergeOnReadInputFormat;
@@ -48,6 +49,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -287,6 +289,60 @@ public class TestInputFormat {
         + "-D[id3, Julian, 53, 1970-01-01T00:00:00.003, par2], "
         + "-D[id5, Sophia, 18, 1970-01-01T00:00:00.005, par3], "
         + "-D[id9, Jane, 19, 1970-01-01T00:00:00.006, par3]]";
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  void testReadWithDeletesMORWithSimpleKeyGenWithChangeLogDisabled() throws Exception {
+    Map<String, String> options = new HashMap<>();
+    options.put(FlinkOptions.CHANGELOG_ENABLED.key(), "false");
+    options.put(FlinkOptions.PARTITION_PATH_FIELD.key(), "partition");
+    options.put(FlinkOptions.KEYGEN_TYPE.key(), KeyGeneratorType.SIMPLE.name());
+    beforeEach(HoodieTableType.MERGE_ON_READ, options);
+
+    // write another commit to read again
+    TestData.writeData(TestData.DATA_SET_UPDATE_DELETE, conf);
+
+    InputFormat<RowData, ?> inputFormat = this.tableSource.getInputFormat();
+    assertThat(inputFormat, instanceOf(MergeOnReadInputFormat.class));
+    ((MergeOnReadInputFormat) inputFormat).isEmitDelete(true);
+
+    List<RowData> result = readData(inputFormat);
+
+    final String actual = TestData.rowDataToString(result);
+    final String expected = "["
+        + "+I[id1, Danny, 24, 1970-01-01T00:00:00.001, par1], "
+        + "+I[id2, Stephen, 34, 1970-01-01T00:00:00.002, par1], "
+        + "-D[id3, null, null, null, null], "
+        + "-D[id5, null, null, null, null], "
+        + "-D[id9, null, null, null, null]]";
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  void testReadWithDeletesMORWithComplexKeyGenWithChangeLogDisabled() throws Exception {
+    Map<String, String> options = new HashMap<>();
+    options.put(FlinkOptions.CHANGELOG_ENABLED.key(), "false");
+    options.put(FlinkOptions.PARTITION_PATH_FIELD.key(), "partition,name");
+    options.put(FlinkOptions.KEYGEN_TYPE.key(), KeyGeneratorType.COMPLEX.name());
+    beforeEach(HoodieTableType.MERGE_ON_READ, options);
+
+    // write another commit to read again
+    TestData.writeData(TestData.DATA_SET_UPDATE_DELETE, conf);
+
+    InputFormat<RowData, ?> inputFormat = this.tableSource.getInputFormat();
+    assertThat(inputFormat, instanceOf(MergeOnReadInputFormat.class));
+    ((MergeOnReadInputFormat) inputFormat).isEmitDelete(true);
+
+    List<RowData> result = readData(inputFormat);
+
+    final String actual = TestData.rowDataToString(result);
+    final String expected = "["
+        + "+I[id1, Danny, 24, 1970-01-01T00:00:00.001, par1], "
+        + "+I[id2, Stephen, 34, 1970-01-01T00:00:00.002, par1], "
+        + "-D[id3, null, null, null, null], "
+        + "-D[id5, null, null, null, null], "
+        + "-D[id9, null, null, null, null]]";
     assertThat(actual, is(expected));
   }
 
@@ -626,7 +682,7 @@ public class TestInputFormat {
     return new HoodieTableSource(
         TestConfigurations.TABLE_SCHEMA,
         new Path(tempFile.getAbsolutePath()),
-        Collections.singletonList("partition"),
+        Arrays.asList(conf.getString(FlinkOptions.PARTITION_PATH_FIELD).split(",")),
         "default",
         conf);
   }


### PR DESCRIPTION
### Change Logs
fix primary key extract of delete_record when complexKeyGen configured and ChangeLogDisabled
In this condition, primary key in RowData will be like "uuid:id1", not "id1";
### Impact
when complexKeyGen configured and ChangeLogDisabled, the primary key output is not correct

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
