### PR TITLE
[HUDI-4615] Return checkpoint as null for empty data from events queue. 

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
@@ -153,6 +153,8 @@ public class S3EventsMetaSelector extends CloudObjectsSelector {
       for (Map<String, Object> eventRecord : eventRecords) {
         filteredEventRecords.add(new ObjectMapper().writeValueAsString(eventRecord).replace("%3D", "="));
       }
+      // Return the old checkpoint if no messages to consume from queue.
+      String newCheckpoint = newCheckpointTime == 0 ? lastCheckpointStr.orElse(null) : String.valueOf(newCheckpointTime);
       return new ImmutablePair<>(filteredEventRecords, String.valueOf(newCheckpointTime));
     } catch (JSONException | IOException e) {
       throw new HoodieException("Unable to read from SQS: ", e);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
@@ -154,8 +154,8 @@ public class S3EventsMetaSelector extends CloudObjectsSelector {
         filteredEventRecords.add(new ObjectMapper().writeValueAsString(eventRecord).replace("%3D", "="));
       }
       // Return the old checkpoint if no messages to consume from queue.
-      String newCheckpoint = newCheckpointTime == 0 ? lastCheckpointStr.orElse(null) : String.valueOf(newCheckpointTime);
-      return new ImmutablePair<>(filteredEventRecords, String.valueOf(newCheckpointTime));
+      String newCheckpoint = newCheckpointTime == 0L ? lastCheckpointStr.orElse(null) : String.valueOf(newCheckpointTime);
+      return new ImmutablePair<>(filteredEventRecords, newCheckpoint);
     } catch (JSONException | IOException e) {
       throw new HoodieException("Unable to read from SQS: ", e);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
@@ -154,7 +154,7 @@ public class S3EventsMetaSelector extends CloudObjectsSelector {
         filteredEventRecords.add(new ObjectMapper().writeValueAsString(eventRecord).replace("%3D", "="));
       }
       // Return the old checkpoint if no messages to consume from queue.
-      String newCheckpoint = newCheckpointTime == 0L ? lastCheckpointStr.orElse(null) : String.valueOf(newCheckpointTime);
+      String newCheckpoint = newCheckpointTime == 0 ? lastCheckpointStr.orElse(null) : String.valueOf(newCheckpointTime);
       return new ImmutablePair<>(filteredEventRecords, newCheckpoint);
     } catch (JSONException | IOException e) {
       throw new HoodieException("Unable to read from SQS: ", e);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestS3EventsMetaSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestS3EventsMetaSelector.java
@@ -27,11 +27,14 @@ import org.apache.hudi.testutils.HoodieClientTestHarness;
 import org.apache.hudi.utilities.testutils.CloudObjectTestUtils;
 
 import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
 import com.amazonaws.services.sqs.model.Message;
 import org.apache.hadoop.fs.Path;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -43,9 +46,12 @@ import java.util.List;
 
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.Config.S3_SOURCE_QUEUE_REGION;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.Config.S3_SOURCE_QUEUE_URL;
+import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.SQS_ATTR_APPROX_MESSAGES;
 import static org.apache.hudi.utilities.sources.helpers.TestCloudObjectsSelector.REGION_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 public class TestS3EventsMetaSelector extends HoodieClientTestHarness {
 
@@ -104,12 +110,15 @@ public class TestS3EventsMetaSelector extends HoodieClientTestHarness {
     assertEquals("1627376736755", eventFromQueue.getRight());
   }
 
-  @ParameterizedTest
-  @ValueSource(classes = {S3EventsMetaSelector.class})
-  public void testEventsFromQueueNoMessages(Class<?> clazz) {
-    S3EventsMetaSelector selector = (S3EventsMetaSelector) ReflectionUtils.loadClass(clazz.getName(), props);
-    List<Message> processed = new ArrayList<>();
+  @Test
+  public void testEventsFromQueueNoMessages() {
+    S3EventsMetaSelector selector = new S3EventsMetaSelector(props);
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(
+            new GetQueueAttributesResult()
+                .addAttributesEntry(SQS_ATTR_APPROX_MESSAGES, "0"));
 
+    List<Message> processed = new ArrayList<>();
     Pair<List<String>, String> eventFromQueue =
         selector.getNextEventsFromQueue(sqs, Option.empty(), processed);
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestS3EventsMetaSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestS3EventsMetaSelector.java
@@ -45,6 +45,7 @@ import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.Con
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.Config.S3_SOURCE_QUEUE_URL;
 import static org.apache.hudi.utilities.sources.helpers.TestCloudObjectsSelector.REGION_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestS3EventsMetaSelector extends HoodieClientTestHarness {
 
@@ -101,5 +102,19 @@ public class TestS3EventsMetaSelector extends HoodieClientTestHarness {
             .getJSONObject("object")
             .getString("key"));
     assertEquals("1627376736755", eventFromQueue.getRight());
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {S3EventsMetaSelector.class})
+  public void testEventsFromQueueNoMessages(Class<?> clazz) {
+    S3EventsMetaSelector selector = (S3EventsMetaSelector) ReflectionUtils.loadClass(clazz.getName(), props);
+    List<Message> processed = new ArrayList<>();
+
+    Pair<List<String>, String> eventFromQueue =
+        selector.getNextEventsFromQueue(sqs, Option.empty(), processed);
+
+    assertEquals(0, eventFromQueue.getLeft().size());
+    assertEquals(0, processed.size());
+    assertNull(eventFromQueue.getRight());
   }
 }


### PR DESCRIPTION
### Change Logs

When we start a new deltastreamer with S3EventsSource, checkpoint is Option.empty(). After consumption from source, if there is no data, the source returns "val=0" as the checkpoint. So, deltastreamer assumes checkpoint has changed and makes an empty commit. This needs fixing. 

https://github.com/apache/hudi/blob/0d0a4152cfd362185066519ae926ac4513c7a152/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java#L151


### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**
 low

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
