### PR TITLE
[HUDI-4617] Fix delete_record's preCombine logic when changelog disabled

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -50,10 +50,6 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
 
   @Override
   public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue) {
-    if (oldValue.recordBytes.length == 0) {
-      // use natural order for delete record
-      return this;
-    }
     if (oldValue.orderingVal.compareTo(orderingVal) > 0) {
       // pick the payload with greatest ordering value
       return oldValue;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -815,7 +815,7 @@ public class TestData {
     return row;
   }
 
-  private static BinaryRowData deleteRow(Object... fields) {
+  public static BinaryRowData deleteRow(Object... fields) {
     BinaryRowData rowData = insertRow(fields);
     rowData.setRowKind(RowKind.DELETE);
     return rowData;


### PR DESCRIPTION
### Change Logs

when changelog disabled, we first emit  "+I[id1, Danny, 24, 1970-01-01T00:00:00.003, par1]", then emit  "-D[id1, Danny, 30, 1970-01-01T00:00:00.001, par1]", the former +I will be selected comparing preCombine field in `processNextDeletedRecord`
 https://github.com/apache/hudi/blob/master/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java#L178 when read.

But when we first emit  "-D[id1, Danny, 24, 1970-01-01T00:00:00.003, par1]", then emit  "+I[id1, Danny, 30, 1970-01-01T00:00:00.001, par1]", the latter +I will always be selected irrespective of preCombine field in `processNextRecord`  https://github.com/apache/hudi/blob/master/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java#L53 when read.

The semantic is inconsistent when the emit order changes. Also it is not aligned to preCombine logic when changelog enabled.

### Impact
 medium 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
