### PR TITLE
[HUDI-4580][DOCS] Update docs of Spark SQL create table statement

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -325,16 +325,8 @@ We can create a table on an existing hudi table(created with spark-shell or delt
 read/write to/from a pre-existing hudi table.
 
 ```sql
--- create an external hudi table based on an existing path
-
--- for non-partitioned table
-create table hudi_existing_tbl0 using hudi
-location 'file:///tmp/hudi/dataframe_hudi_nonpt_table';
-
--- for partitioned table
-create table hudi_existing_tbl1 using hudi
-partitioned by (dt, hh)
-location 'file:///tmp/hudi/dataframe_hudi_pt_table';
+create table hudi_existing_tbl using hudi
+location '/tmp/hudi/hudi_existing_table';
 ```
 
 :::tip

--- a/website/docs/table_management.md
+++ b/website/docs/table_management.md
@@ -98,12 +98,7 @@ You can create an External table using the `location` statement. If an external 
 An external table is useful if you need to read/write to/from a pre-existing hudi table.
 
 ```sql
- create table h_p1 using hudi 
- options (
-    primaryKey = 'id',
-    preCombineField = 'ts'
- )
- partitioned by (dt)
+ create table h_p1 using hudi
  location '/path/to/hudi';
 ```
 

--- a/website/versioned_docs/version-0.11.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.0/quick-start-guide.md
@@ -299,16 +299,8 @@ We can create a table on an existing hudi table(created with spark-shell or delt
 read/write to/from a pre-existing hudi table.
 
 ```sql
--- create an external hudi table based on an existing path
-
--- for non-partitioned table
-create table hudi_existing_tbl0 using hudi
-location 'file:///tmp/hudi/dataframe_hudi_nonpt_table';
-
--- for partitioned table
-create table hudi_existing_tbl1 using hudi
-partitioned by (dt, hh)
-location 'file:///tmp/hudi/dataframe_hudi_pt_table';
+create table hudi_existing_tbl using hudi
+location '/tmp/hudi/hudi_existing_table';
 ```
 
 :::tip

--- a/website/versioned_docs/version-0.11.0/table_management.md
+++ b/website/versioned_docs/version-0.11.0/table_management.md
@@ -98,12 +98,7 @@ You can create an External table using the `location` statement. If an external 
 An external table is useful if you need to read/write to/from a pre-existing hudi table.
 
 ```sql
- create table h_p1 using hudi 
- options (
-    primaryKey = 'id',
-    preCombineField = 'ts'
- )
- partitioned by (dt)
+ create table h_p1 using hudi
  location '/path/to/hudi';
 ```
 

--- a/website/versioned_docs/version-0.11.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/quick-start-guide.md
@@ -299,16 +299,8 @@ We can create a table on an existing hudi table(created with spark-shell or delt
 read/write to/from a pre-existing hudi table.
 
 ```sql
--- create an external hudi table based on an existing path
-
--- for non-partitioned table
-create table hudi_existing_tbl0 using hudi
-location 'file:///tmp/hudi/dataframe_hudi_nonpt_table';
-
--- for partitioned table
-create table hudi_existing_tbl1 using hudi
-partitioned by (dt, hh)
-location 'file:///tmp/hudi/dataframe_hudi_pt_table';
+create table hudi_existing_tbl using hudi
+location '/tmp/hudi/hudi_existing_table';
 ```
 
 :::tip

--- a/website/versioned_docs/version-0.11.1/table_management.md
+++ b/website/versioned_docs/version-0.11.1/table_management.md
@@ -98,12 +98,7 @@ You can create an External table using the `location` statement. If an external 
 An external table is useful if you need to read/write to/from a pre-existing hudi table.
 
 ```sql
- create table h_p1 using hudi 
- options (
-    primaryKey = 'id',
-    preCombineField = 'ts'
- )
- partitioned by (dt)
+ create table h_p1 using hudi
  location '/path/to/hudi';
 ```
 


### PR DESCRIPTION
### Change Logs

This PR updates the docs of Spark SQL create table statement.  Based on #4584, the create table statement for an existing Hudi table does not require `partitioned by` or `options` statement (`options (primaryKey = 'id', preCombineField = 'ts') partitioned by (dt)`), and it should be
```
create table hudi_existing_tbl using hudi
location '/tmp/hudi/hudi_existing_table';
```
### Impact

Only docs update.

**Risk level: none**
The website can be properly built and visualized locally.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
