### PR TITLE
[HUDI-4628] hudi-flink support GLOBAL_BLOOM，GLOBAL_SIMPLE，BUCKET inde…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/index/FlinkHoodieIndexFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/index/FlinkHoodieIndexFactory.java
@@ -25,7 +25,10 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.index.bloom.HoodieBloomIndex;
+import org.apache.hudi.index.bloom.HoodieGlobalBloomIndex;
 import org.apache.hudi.index.bloom.ListBasedHoodieBloomIndexHelper;
+import org.apache.hudi.index.bucket.HoodieSimpleBucketIndex;
+import org.apache.hudi.index.simple.HoodieGlobalSimpleIndex;
 import org.apache.hudi.index.simple.HoodieSimpleIndex;
 import org.apache.hudi.index.state.FlinkInMemoryStateIndex;
 
@@ -49,8 +52,14 @@ public final class FlinkHoodieIndexFactory {
         return new FlinkInMemoryStateIndex(context, config);
       case BLOOM:
         return new HoodieBloomIndex(config, ListBasedHoodieBloomIndexHelper.getInstance());
+      case GLOBAL_BLOOM:
+        return new HoodieGlobalBloomIndex(config, ListBasedHoodieBloomIndexHelper.getInstance());
       case SIMPLE:
         return new HoodieSimpleIndex(config, Option.empty());
+      case GLOBAL_SIMPLE:
+        return new HoodieGlobalSimpleIndex(config, Option.empty());
+      case BUCKET:
+        return new HoodieSimpleBucketIndex(config);
       default:
         throw new HoodieIndexException("Unsupported index type " + config.getIndexType());
     }


### PR DESCRIPTION
Change Logs
Index type support in org.apache.hudi.index.FlinkHoodieIndexFactory

Impact
Describe any public API or user-facing feature change or any performance impact.

Risk level: none

Contributor's checklist
 Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
 Change Logs and Impact were stated clearly
 Adequate tests were added if applicable
 CI passed