### PR TITLE
[HUDI-4586] Improve metadata fetching in bloom index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -133,6 +133,23 @@ public class HoodieIndexConfig extends HoodieConfig {
           + "When true, the index lookup uses bloom filters and column stats from metadata "
           + "table when available to speed up the process.");
 
+  public static final ConfigProperty<Integer> BLOOM_INDEX_METADATA_READ_PARALLELISM = ConfigProperty
+      .key("hoodie.bloom.index.metadata.read.parallelism")
+      .defaultValue(10)
+      .sinceVersion("0.13.0")
+      .withDocumentation("Only applies if index type is BLOOM and metadata table is enabled "
+          + "for index lookup (hoodie.bloom.index.use.metadata=true). "
+          + "Determines the parallelism for reading the index from metadata table.");
+
+  public static final ConfigProperty<Integer> BLOOM_INDEX_METADATA_BLOOM_FILTER_READ_BATCH_SIZE = ConfigProperty
+      .key("hoodie.bloom.index.metadata.bloom.filter.read.batch.size")
+      .defaultValue(128)
+      .sinceVersion("0.13.0")
+      .withDocumentation("Only applies if index type is BLOOM and metadata table is enabled "
+          + "for index lookup (hoodie.bloom.index.use.metadata=true). "
+          + "Determines the batch size for reading bloom filters from metadata table. "
+          + "Smaller value puts less pressure on the executor memory.");
+
   public static final ConfigProperty<String> BLOOM_INDEX_TREE_BASED_FILTER = ConfigProperty
       .key("hoodie.bloom.index.use.treebased.filter")
       .defaultValue("true")
@@ -537,6 +554,16 @@ public class HoodieIndexConfig extends HoodieConfig {
 
     public Builder bloomIndexUseMetadata(boolean useMetadata) {
       hoodieIndexConfig.setValue(BLOOM_INDEX_USE_METADATA, String.valueOf(useMetadata));
+      return this;
+    }
+
+    public Builder bloomIndexMetadataReadParallelism(int parallelism) {
+      hoodieIndexConfig.setValue(BLOOM_INDEX_METADATA_READ_PARALLELISM, String.valueOf(parallelism));
+      return this;
+    }
+
+    public Builder bloomIndexMetadataBloomFilterReadBatchSize(int batchSize) {
+      hoodieIndexConfig.setValue(BLOOM_INDEX_METADATA_BLOOM_FILTER_READ_BATCH_SIZE, String.valueOf(batchSize));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1580,6 +1580,14 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBooleanOrDefault(HoodieIndexConfig.BLOOM_INDEX_USE_METADATA);
   }
 
+  public int getBloomIndexMetadataReadParallelism() {
+    return getIntOrDefault(HoodieIndexConfig.BLOOM_INDEX_METADATA_READ_PARALLELISM);
+  }
+
+  public int getBloomIndexMetadataBloomFilterReadBatchSize() {
+    return getIntOrDefault(HoodieIndexConfig.BLOOM_INDEX_METADATA_BLOOM_FILTER_READ_BATCH_SIZE);
+  }
+
   public boolean useBloomIndexTreebasedFilter() {
     return getBoolean(HoodieIndexConfig.BLOOM_INDEX_TREE_BASED_FILTER);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/BaseHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/BaseHoodieBloomIndexHelper.java
@@ -29,7 +29,6 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,7 +42,7 @@ public abstract class BaseHoodieBloomIndexHelper implements Serializable {
    * @param context                 {@link HoodieEngineContext} instance to use.
    * @param hoodieTable             {@link HoodieTable} instance to use.
    * @param partitionRecordKeyPairs Pairs of partition path and record key.
-   * @param fileComparisonPairs     Pairs of filename and record key based on file comparisons.
+   * @param fileComparisonPairs     Pairs of (file ID, filename) pair and record key based on file comparisons.
    * @param partitionToFileInfo     Partition path to {@link BloomIndexFileInfo} map.
    * @param recordsPerPartition     Number of records per partition in a map.
    * @return {@link HoodiePairData} of {@link HoodieKey} and {@link HoodieRecordLocation} pairs.
@@ -51,7 +50,7 @@ public abstract class BaseHoodieBloomIndexHelper implements Serializable {
   public abstract HoodiePairData<HoodieKey, HoodieRecordLocation> findMatchingFilesForRecordKeys(
       HoodieWriteConfig config, HoodieEngineContext context, HoodieTable hoodieTable,
       HoodiePairData<String, String> partitionRecordKeyPairs,
-      HoodieData<Pair<String, HoodieKey>> fileComparisonPairs,
-      Map<String, List<BloomIndexFileInfo>> partitionToFileInfo,
+      HoodieData<Pair<Pair<String, String>, HoodieKey>> fileComparisonPairs,
+      Map<String, Map<String, BloomIndexFileInfo>> partitionToFileInfo,
       Map<String, Long> recordsPerPartition);
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/BloomIndexFileInfo.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/BloomIndexFileInfo.java
@@ -27,25 +27,30 @@ import java.util.Objects;
 public class BloomIndexFileInfo implements Serializable {
 
   private final String fileId;
-
+  private final String filename;
   private final String minRecordKey;
-
   private final String maxRecordKey;
 
-  public BloomIndexFileInfo(String fileId, String minRecordKey, String maxRecordKey) {
+  public BloomIndexFileInfo(String fileId, String filename, String minRecordKey, String maxRecordKey) {
     this.fileId = fileId;
+    this.filename = filename;
     this.minRecordKey = minRecordKey;
     this.maxRecordKey = maxRecordKey;
   }
 
-  public BloomIndexFileInfo(String fileId) {
+  public BloomIndexFileInfo(String fileId, String filename) {
     this.fileId = fileId;
+    this.filename = filename;
     this.minRecordKey = null;
     this.maxRecordKey = null;
   }
 
   public String getFileId() {
     return fileId;
+  }
+
+  public String getFilename() {
+    return filename;
   }
 
   public String getMinRecordKey() {
@@ -78,20 +83,23 @@ public class BloomIndexFileInfo implements Serializable {
     }
 
     BloomIndexFileInfo that = (BloomIndexFileInfo) o;
-    return Objects.equals(that.fileId, fileId) && Objects.equals(that.minRecordKey, minRecordKey)
+    return Objects.equals(that.fileId, fileId)
+        && Objects.equals(that.filename, filename)
+        && Objects.equals(that.minRecordKey, minRecordKey)
         && Objects.equals(that.maxRecordKey, maxRecordKey);
 
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(fileId, minRecordKey, maxRecordKey);
+    return Objects.hash(fileId, filename, minRecordKey, maxRecordKey);
   }
 
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("BloomIndexFileInfo {");
     sb.append(" fileId=").append(fileId);
+    sb.append(" filename=").append(filename);
     sb.append(" minRecordKey=").append(minRecordKey);
     sb.append(" maxRecordKey=").append(maxRecordKey);
     sb.append('}');

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieGlobalBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieGlobalBloomIndex.java
@@ -74,8 +74,8 @@ public class HoodieGlobalBloomIndex extends HoodieBloomIndex {
    */
 
   @Override
-  HoodieData<Pair<String, HoodieKey>> explodeRecordsWithFileComparisons(
-      final Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo,
+  HoodieData<Pair<Pair<String, String>, HoodieKey>> explodeRecordsWithFileComparisons(
+      final Map<String, Map<String, BloomIndexFileInfo>> partitionToFileIndexInfo,
       HoodiePairData<String, String> partitionRecordKeyPairs) {
 
     IndexFileFilter indexFileFilter =
@@ -87,7 +87,7 @@ public class HoodieGlobalBloomIndex extends HoodieBloomIndex {
       String partitionPath = partitionRecordKeyPair.getLeft();
 
       return indexFileFilter.getMatchingFilesAndPartition(partitionPath, recordKey).stream()
-          .map(partitionFileIdPair -> (Pair<String, HoodieKey>) new ImmutablePair<>(partitionFileIdPair.getRight(),
+          .map(partitionFileIdPair -> (Pair<Pair<String, String>, HoodieKey>) new ImmutablePair<>(partitionFileIdPair.getRight(),
               new HoodieKey(recordKey, partitionFileIdPair.getLeft())))
           .collect(Collectors.toList());
     }).flatMap(List::iterator);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/IndexFileFilter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/IndexFileFilter.java
@@ -33,9 +33,9 @@ public interface IndexFileFilter extends Serializable {
    *
    * @param partitionPath the partition path of interest
    * @param recordKey     the record key to be looked up
-   * @return the {@link Set} of matching <Partition path, file name> pairs where the record could potentially be
+   * @return the {@link Set} of matching <Partition path, <file ID, file name>> pairs where the record could potentially be
    * present.
    */
-  Set<Pair<String, String>> getMatchingFilesAndPartition(String partitionPath, String recordKey);
+  Set<Pair<String, Pair<String, String>>> getMatchingFilesAndPartition(String partitionPath, String recordKey);
 
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedGlobalIndexFileFilter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedGlobalIndexFileFilter.java
@@ -21,7 +21,6 @@ package org.apache.hudi.index.bloom;
 import org.apache.hudi.common.util.collection.Pair;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,18 +31,19 @@ class ListBasedGlobalIndexFileFilter extends ListBasedIndexFileFilter {
    *
    * @param partitionToFileIndexInfo Map of partition to List of {@link BloomIndexFileInfo}
    */
-  ListBasedGlobalIndexFileFilter(Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo) {
+  ListBasedGlobalIndexFileFilter(Map<String, Map<String, BloomIndexFileInfo>> partitionToFileIndexInfo) {
     super(partitionToFileIndexInfo);
   }
 
   @Override
-  public Set<Pair<String, String>> getMatchingFilesAndPartition(String partitionPath, String recordKey) {
-    Set<Pair<String, String>> toReturn = new HashSet<>();
-    partitionToFileIndexInfo.forEach((partition, bloomIndexFileInfoList) -> bloomIndexFileInfoList.forEach(file -> {
-      if (shouldCompareWithFile(file, recordKey)) {
-        toReturn.add(Pair.of(partition, file.getFileId()));
-      }
-    }));
+  public Set<Pair<String, Pair<String, String>>> getMatchingFilesAndPartition(String partitionPath, String recordKey) {
+    Set<Pair<String, Pair<String, String>>> toReturn = new HashSet<>();
+    partitionToFileIndexInfo.forEach((partition, bloomIndexFileInfoListMap) ->
+        bloomIndexFileInfoListMap.values().forEach(fileInfo -> {
+          if (shouldCompareWithFile(fileInfo, recordKey)) {
+            toReturn.add(Pair.of(partition, Pair.of(fileInfo.getFileId(), fileInfo.getFilename())));
+          }
+        }));
     return toReturn;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedHoodieBloomIndexHelper.java
@@ -56,10 +56,11 @@ public class ListBasedHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper 
   public HoodiePairData<HoodieKey, HoodieRecordLocation> findMatchingFilesForRecordKeys(
       HoodieWriteConfig config, HoodieEngineContext context, HoodieTable hoodieTable,
       HoodiePairData<String, String> partitionRecordKeyPairs,
-      HoodieData<Pair<String, HoodieKey>> fileComparisonPairs,
-      Map<String, List<BloomIndexFileInfo>> partitionToFileInfo, Map<String, Long> recordsPerPartition) {
+      HoodieData<Pair<Pair<String, String>, HoodieKey>> fileComparisonPairs,
+      Map<String, Map<String, BloomIndexFileInfo>> partitionToFileInfo, Map<String, Long> recordsPerPartition) {
     List<Pair<String, HoodieKey>> fileComparisonPairList =
         fileComparisonPairs.collectAsList().stream()
+            .map(e -> Pair.of(e.getLeft().getLeft(), e.getRight()))
             .sorted(Comparator.comparing(Pair::getLeft)).collect(toList());
 
     List<HoodieKeyLookupResult> keyLookupResults = new ArrayList<>();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedIndexFileFilter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedIndexFileFilter.java
@@ -21,7 +21,6 @@ package org.apache.hudi.index.bloom;
 import org.apache.hudi.common.util.collection.Pair;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,26 +30,26 @@ import java.util.Set;
  */
 class ListBasedIndexFileFilter implements IndexFileFilter {
 
-  final Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo;
+  final Map<String, Map<String, BloomIndexFileInfo>> partitionToFileIndexInfo;
 
   /**
    * Instantiates {@link ListBasedIndexFileFilter}.
    *
    * @param partitionToFileIndexInfo Map of partition to List of {@link BloomIndexFileInfo}
    */
-  ListBasedIndexFileFilter(final Map<String, List<BloomIndexFileInfo>> partitionToFileIndexInfo) {
+  ListBasedIndexFileFilter(final Map<String, Map<String, BloomIndexFileInfo>> partitionToFileIndexInfo) {
     this.partitionToFileIndexInfo = partitionToFileIndexInfo;
   }
 
   @Override
-  public Set<Pair<String, String>> getMatchingFilesAndPartition(String partitionPath, String recordKey) {
-    List<BloomIndexFileInfo> indexInfos = partitionToFileIndexInfo.get(partitionPath);
-    Set<Pair<String, String>> toReturn = new HashSet<>();
+  public Set<Pair<String, Pair<String, String>>> getMatchingFilesAndPartition(String partitionPath, String recordKey) {
+    Map<String, BloomIndexFileInfo> indexInfos = partitionToFileIndexInfo.get(partitionPath);
+    Set<Pair<String, Pair<String, String>>> toReturn = new HashSet<>();
     if (indexInfos != null) { // could be null, if there are no files in a given partition yet.
       // for each candidate file in partition, that needs to be compared.
-      for (BloomIndexFileInfo indexInfo : indexInfos) {
+      for (BloomIndexFileInfo indexInfo : indexInfos.values()) {
         if (shouldCompareWithFile(indexInfo, recordKey)) {
-          toReturn.add(Pair.of(partitionPath, indexInfo.getFileId()));
+          toReturn.add(Pair.of(partitionPath, Pair.of(indexInfo.getFileId(), indexInfo.getFilename())));
         }
       }
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/BloomIndexTestUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/BloomIndexTestUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.testutils;
+
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.index.bloom.BloomIndexFileInfo;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BloomIndexTestUtils {
+  public static Map<String, BloomIndexFileInfo> convertBloomIndexFileInfoListToMap(
+      List<BloomIndexFileInfo> infoList) {
+    return infoList.stream().collect(Collectors.toMap(BloomIndexFileInfo::getFileId, Function.identity()));
+  }
+
+  public static Map<String, BloomIndexFileInfo> convertBloomIndexFileInfoPairListToMap(
+      List<Pair<String, BloomIndexFileInfo>> filesList) {
+    Map<String, BloomIndexFileInfo> filesMap = new HashMap<>();
+    for (Pair<String, BloomIndexFileInfo> t : filesList) {
+      filesMap.put(t.getKey() + "/" + t.getValue().getFileId(), t.getValue());
+    }
+    return filesMap;
+  }
+
+  public static void assertBloomInfoEquals(
+      List<Pair<String, BloomIndexFileInfo>> expected, List<Pair<String, BloomIndexFileInfo>> actual) {
+    assertEquals(expected.size(), actual.size());
+    Map<String, BloomIndexFileInfo> expectedMap = convertBloomIndexFileInfoPairListToMap(expected);
+    Map<String, BloomIndexFileInfo> actualMap = convertBloomIndexFileInfoPairListToMap(actual);
+
+    for (String key : expectedMap.keySet()) {
+      assertTrue(actualMap.containsKey(key));
+      BloomIndexFileInfo expectedInfo = expectedMap.get(key);
+      BloomIndexFileInfo actualInfo = actualMap.get(key);
+      assertEquals(expectedInfo.getFileId(), actualInfo.getFileId());
+      assertEquals(expectedInfo.getMinRecordKey(), actualInfo.getMinRecordKey());
+      assertEquals(expectedInfo.getMaxRecordKey(), actualInfo.getMaxRecordKey());
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomIndexCheckFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomIndexCheckFunction.java
@@ -18,31 +18,33 @@
 
 package org.apache.hudi.index.bloom;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.client.utils.LazyIterableIterator;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieKey;
-import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.index.HoodieIndexUtils;
 import org.apache.hudi.io.HoodieKeyLookupResult;
 import org.apache.hudi.table.HoodieTable;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.function.Function2;
-import scala.Tuple2;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+
+import scala.Tuple2;
 
 /**
  * Spark Function2 implementation for checking bloom filters for the
@@ -53,26 +55,30 @@ import java.util.concurrent.atomic.AtomicInteger;
  * keys are checked against them.
  */
 public class HoodieMetadataBloomIndexCheckFunction implements
-    Function2<Integer, Iterator<Tuple2<String, HoodieKey>>, Iterator<List<HoodieKeyLookupResult>>> {
+    Function2<Integer, Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>, Iterator<List<HoodieKeyLookupResult>>> {
 
   private static final Logger LOG = LogManager.getLogger(HoodieMetadataBloomIndexCheckFunction.class);
 
-  // Assuming each file bloom filter takes up 512K, sizing the max file count
-  // per batch so that the total fetched bloom filters would not cross 128 MB.
-  private static final long BLOOM_FILTER_CHECK_MAX_FILE_COUNT_PER_BATCH = 256;
   private final HoodieTable hoodieTable;
+  private final String basePath;
+  private final int batchSize;
 
-  public HoodieMetadataBloomIndexCheckFunction(HoodieTable hoodieTable) {
+  public HoodieMetadataBloomIndexCheckFunction(HoodieTable hoodieTable, String basePath, int batchSize) {
     this.hoodieTable = hoodieTable;
+    this.basePath = basePath;
+    this.batchSize = batchSize;
   }
 
   @Override
-  public Iterator<List<HoodieKeyLookupResult>> call(Integer integer, Iterator<Tuple2<String, HoodieKey>> tuple2Iterator) throws Exception {
+  public Iterator<List<HoodieKeyLookupResult>> call(Integer integer, Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tuple2Iterator) throws Exception {
     return new BloomIndexLazyKeyCheckIterator(tuple2Iterator);
   }
 
-  private class BloomIndexLazyKeyCheckIterator extends LazyIterableIterator<Tuple2<String, HoodieKey>, List<HoodieKeyLookupResult>> {
-    public BloomIndexLazyKeyCheckIterator(Iterator<Tuple2<String, HoodieKey>> tuple2Iterator) {
+  private class BloomIndexLazyKeyCheckIterator extends LazyIterableIterator<Tuple2<Tuple2<String, String>, HoodieKey>, List<HoodieKeyLookupResult>> {
+
+    private final Set<String> processedFileIdSet = new HashSet<>();
+
+    public BloomIndexLazyKeyCheckIterator(Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tuple2Iterator) {
       super(tuple2Iterator);
     }
 
@@ -83,37 +89,64 @@ public class HoodieMetadataBloomIndexCheckFunction implements
     @Override
     protected List<HoodieKeyLookupResult> computeNext() {
       // Partition path and file name pair to list of keys
-      final Map<Pair<String, String>, List<HoodieKey>> fileToKeysMap = new HashMap<>();
-      final Map<String, HoodieBaseFile> fileIDBaseFileMap = new HashMap<>();
+      final Map<Pair<String, String>, List<HoodieKey>> batchFileToKeysMap = new HashMap<>();
       final List<HoodieKeyLookupResult> resultList = new ArrayList<>();
+      String lastFileId = null;
 
-      while (inputItr.hasNext()) {
-        Tuple2<String, HoodieKey> entry = inputItr.next();
-        final String partitionPath = entry._2.getPartitionPath();
-        final String fileId = entry._1;
-        if (!fileIDBaseFileMap.containsKey(fileId)) {
-          Option<HoodieBaseFile> baseFile = hoodieTable.getBaseFileOnlyView().getLatestBaseFile(partitionPath, fileId);
-          if (!baseFile.isPresent()) {
-            throw new HoodieIndexException("Failed to find the base file for partition: " + partitionPath
-                + ", fileId: " + fileId);
+      try {
+        // Here we batch process the lookup of bloom filters in metadata table
+        // assuming the partition path and file name pairs are already sorted by the corresponding key
+        while (inputItr.hasNext()) {
+          Tuple2<Tuple2<String, String>, HoodieKey> entry = inputItr.next();
+          final String partitionPath = entry._2.getPartitionPath();
+          final String fileId = entry._1._1();
+          final String filename = entry._1._2();
+
+          if (lastFileId == null || !lastFileId.equals(fileId)) {
+            if (processedFileIdSet.contains(fileId)) {
+              LOG.warn(String.format("Fetching the bloom filter for file ID %s again.  "
+                  + " The input pairs of file ID and record key are not sorted.", fileId));
+            }
+            lastFileId = fileId;
+            processedFileIdSet.add(fileId);
           }
-          fileIDBaseFileMap.put(fileId, baseFile.get());
-        }
-        fileToKeysMap.computeIfAbsent(Pair.of(partitionPath, fileIDBaseFileMap.get(fileId).getFileName()),
-            k -> new ArrayList<>()).add(entry._2);
-        if (fileToKeysMap.size() > BLOOM_FILTER_CHECK_MAX_FILE_COUNT_PER_BATCH) {
-          break;
-        }
-      }
-      if (fileToKeysMap.isEmpty()) {
-        return Collections.emptyList();
-      }
 
-      List<Pair<String, String>> partitionNameFileNameList = new ArrayList<>(fileToKeysMap.keySet());
+          batchFileToKeysMap.computeIfAbsent(Pair.of(partitionPath, filename), k -> new ArrayList<>()).add(entry._2);
+
+          if (batchFileToKeysMap.size() == batchSize) {
+            resultList.addAll(lookupKeysInBloomFilters(batchFileToKeysMap));
+            batchFileToKeysMap.clear();
+          }
+        }
+
+        if (batchFileToKeysMap.size() > 0) {
+          resultList.addAll(lookupKeysInBloomFilters(batchFileToKeysMap));
+          batchFileToKeysMap.clear();
+        }
+
+        return resultList;
+      } catch (Throwable e) {
+        if (e instanceof HoodieException) {
+          throw e;
+        }
+        throw new HoodieIndexException("Error checking bloom filter using metadata table.", e);
+      }
+    }
+
+    @Override
+    protected void end() {
+    }
+
+    private List<HoodieKeyLookupResult> lookupKeysInBloomFilters(
+        Map<Pair<String, String>, List<HoodieKey>> fileToKeysMap) {
+      List<HoodieKeyLookupResult> resultList = new ArrayList<>();
+      List<Pair<String, String>> partitionPathFileNameList = new ArrayList<>(fileToKeysMap.keySet());
+      HoodieTimer timer = HoodieTimer.start();
       Map<Pair<String, String>, BloomFilter> fileToBloomFilterMap =
-          hoodieTable.getMetadataTable().getBloomFilters(partitionNameFileNameList);
+          hoodieTable.getMetadataTable().getBloomFilters(partitionPathFileNameList);
+      LOG.error(String.format("Took %d ms to look up %s bloom filters",
+          timer.endTimer(), partitionPathFileNameList.size()));
 
-      final AtomicInteger totalKeys = new AtomicInteger(0);
       fileToKeysMap.forEach((partitionPathFileNamePair, hoodieKeyList) -> {
         final String partitionPath = partitionPathFileNamePair.getLeft();
         final String fileName = partitionPathFileNamePair.getRight();
@@ -127,28 +160,24 @@ public class HoodieMetadataBloomIndexCheckFunction implements
 
         List<String> candidateRecordKeys = new ArrayList<>();
         hoodieKeyList.forEach(hoodieKey -> {
-          totalKeys.incrementAndGet();
           if (fileBloomFilter.mightContain(hoodieKey.getRecordKey())) {
             candidateRecordKeys.add(hoodieKey.getRecordKey());
           }
         });
 
-        final HoodieBaseFile dataFile = fileIDBaseFileMap.get(fileId);
         List<String> matchingKeys =
-            HoodieIndexUtils.filterKeysFromFile(new Path(dataFile.getPath()), candidateRecordKeys,
+            HoodieIndexUtils.filterKeysFromFile(
+                new CachingPath(FSUtils.getPartitionPath(basePath, partitionPath), fileName),
+                candidateRecordKeys,
                 hoodieTable.getHadoopConf());
         LOG.debug(
             String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
                 hoodieKeyList.size(), candidateRecordKeys.size(),
                 candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
 
-        resultList.add(new HoodieKeyLookupResult(fileId, partitionPath, dataFile.getCommitTime(), matchingKeys));
+        resultList.add(new HoodieKeyLookupResult(fileId, partitionPath, FSUtils.getCommitTime(fileName), matchingKeys));
       });
       return resultList;
-    }
-
-    @Override
-    protected void end() {
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1853,6 +1853,7 @@
       <activation>
         <property>
           <name>flink1.14</name>
+          <value>!disabled</value>
         </property>
       </activation>
     </profile>


### PR DESCRIPTION
### Change Logs

When enabling column stats and bloom filter reading from metadata table for Bloom index (`hoodie.bloom.index.use.metadata=true`), frequent S3 timeouts like below happen and cause the write job to retry a lot or fail:
```
Caused by: org.apache.hudi.exception.HoodieIOException: IOException when reading logblock from log file HoodieLogFile{pathStr='s3a://<>/.hoodie/metadata/column_stats/.col-stats-0000_00000000000000.log.4_5-116-20141', fileLen=-1}
	at org.apache.hudi.common.table.log.HoodieLogFileReader.next(HoodieLogFileReader.java:389)
	at org.apache.hudi.common.table.log.HoodieLogFormatReader.next(HoodieLogFormatReader.java:123)
	at org.apache.hudi.common.table.log.AbstractHoodieLogRecordReader.scanInternal(AbstractHoodieLogRecordReader.java:229)
	... 38 more
Caused by: org.apache.hadoop.fs.s3a.AWSClientIOException: re-open s3a://<>/.hoodie/metadata/column_stats/.col-stats-0000_00000000000000.log.4_5-116-20141 at 475916 on s3a://<>/.hoodie/metadata/column_stats/.col-stats-0000_00000000000000.log.4_5-116-20141: com.amazonaws.SdkClientException: Unable to execute HTTP request: The target server failed to respond: Unable to execute HTTP request: The target server failed to respond
	at org.apache.hadoop.fs.s3a.S3AUtils.translateException(S3AUtils.java:208)
	at org.apache.hadoop.fs.s3a.Invoker.once(Invoker.java:117)
	at org.apache.hadoop.fs.s3a.S3AInputStream.reopen(S3AInputStream.java:226)
	at org.apache.hadoop.fs.s3a.S3AInputStream.lambda$lazySeek$1(S3AInputStream.java:392)
	at org.apache.hadoop.fs.s3a.Invoker.lambda$maybeRetry$3(Invoker.java:228)
	at org.apache.hadoop.fs.s3a.Invoker.once(Invoker.java:115)
	at org.apache.hadoop.fs.s3a.Invoker.maybeRetry(Invoker.java:354)
	at org.apache.hadoop.fs.s3a.Invoker.maybeRetry(Invoker.java:226)
	at org.apache.hadoop.fs.s3a.Invoker.maybeRetry(Invoker.java:270)
	at org.apache.hadoop.fs.s3a.S3AInputStream.lazySeek(S3AInputStream.java:384)
	at org.apache.hadoop.fs.s3a.S3AInputStream.read(S3AInputStream.java:418)
	at java.io.FilterInputStream.read(FilterInputStream.java:83)
	at java.io.DataInputStream.readInt(DataInputStream.java:387)
	at org.apache.hudi.common.table.log.block.HoodieLogBlock.getLogMetadata(HoodieLogBlock.java:228)
	at org.apache.hudi.common.table.log.HoodieLogFileReader.readBlock(HoodieLogFileReader.java:193)
	at org.apache.hudi.common.table.log.HoodieLogFileReader.next(HoodieLogFileReader.java:387)
	... 40 more
```
Relevant Spark stages are (1) fetching column stats from the metadata table (Stage 86 below) (2) fetching bloom filters from metadata table and do record key lookup (Stage 141 below)
<img width="1758" alt="Screen Shot 2022-08-22 at 12 52 05" src="https://user-images.githubusercontent.com/2497195/186024756-0516e507-cd47-499a-883a-bdc53215c538.png">
<img width="1734" alt="Screen Shot 2022-08-22 at 14 22 14" src="https://user-images.githubusercontent.com/2497195/186024763-f8793c04-1e88-4f17-84b2-feebdf4ae803.png">

The root cause is that, the parallelism to fetch column stats and bloom filters is too high, causing too much concurrency reading metadata table from each executor, where HFiles and log files are scanned.

To address this problem, this PR adjusts the Bloom Index DAG to limit the parallelism to fetch column stats and bloom filters from the metadata table.  Specifically, 
- Adds a new write config `hoodie.bloom.index.metadata.read.parallelism` (default `10`) to control the parallelism for reading the index from metadata table.  This affects the fetching of both column stats and bloom filters.
  - Limits the parallelism of column stats fetching inside `HoodieBloomIndex::loadColumnRangesFromMetaIndex()`
  - Limits the parallelism of bloom filter fetching inside `SparkHoodieBloomIndexHelper::findMatchingFilesForRecordKeys()`
- Rewrites `HoodieMetadataBloomIndexCheckFunction` to support batch processing of bloom filter fetching
  - Adds a new write config `hoodie.bloom.index.metadata.bloom.filter.read.batch.size` (default `128`) to determine the batch size for reading bloom filters from metadata table.  Smaller value puts less pressure on the executor memory.
- Before the lookup of <file ID, and record key> pairs, sorts the list of pairs based on the bloom filter key entry in the metadata table, instead of file ID alone (which does not provide value).  In this way, bloom filter keys are nicely laid out in sequential lookup.
  - To support this, we need to have the file name (required for generating the hash key) stored alongside the file ID, by adding a new member in `BloomIndexFileInfo`.  To support efficient lookup of file name based on the file ID, the data structure of a few intermediate results are changed.

### Impact

**Risk level: high**
The changes are tested and benchmarked through upserts to Hudi tables on S3, using both 1GB and 100GB batches.

Below shows the Spark stages of fetching column stats and bloom filters after the fix.  Timeouts are no longer present.  The index fetching is much faster (column stats: 1min+ -> 7s, 2min+ -> 1min).
<img width="1894" alt="Screen Shot 2022-08-22 at 14 24 03" src="https://user-images.githubusercontent.com/2497195/186026942-d90c2f31-9054-4228-82c9-dda6d1f80484.png">
<img width="1890" alt="Screen Shot 2022-08-22 at 14 24 25" src="https://user-images.githubusercontent.com/2497195/186026894-4e8ad4d1-62ff-4cb2-8ba5-02d8963c0246.png">

Based on the benchmarking, when enabling metadata table reading for column stats and bloom filters in Bloom index, the overall upsert latency is reduced by 1-3 min (10%+) after the fix.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
