### PR TITLE
[HUDI-4632] Map Flink artifact ids correctly as per scala dependence

### DIFF
--- a/hudi-examples/hudi-examples-flink/pom.xml
+++ b/hudi-examples/hudi-examples-flink/pom.xml
@@ -335,13 +335,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-json</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-csv</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -132,15 +132,15 @@
     <hudi.flink.module>hudi-flink1.13.x</hudi.flink.module>
     <flink.bundle.version>1.13</flink.bundle.version>
     <flink.format.parquet.version>1.12.2</flink.format.parquet.version>
-    <flink.runtime.artifactId>flink-runtime</flink.runtime.artifactId>
-    <flink.table.runtime.artifactId>flink-table-runtime_${scala.binary.version}</flink.table.runtime.artifactId>
-    <flink.table.planner.artifactId>flink-table-planner_${scala.binary.version}</flink.table.planner.artifactId>
-    <flink.parquet.artifactId>flink-parquet</flink.parquet.artifactId>
-    <flink.statebackend.rocksdb.artifactId>flink-statebackend-rocksdb</flink.statebackend.rocksdb.artifactId>
-    <flink.test.utils.artifactId>flink-test-utils</flink.test.utils.artifactId>
-    <flink.streaming.java.artifactId>flink-streaming-java</flink.streaming.java.artifactId>
-    <flink.clients.artifactId>flink-clients</flink.clients.artifactId>
-    <flink.connector.kafka.artifactId>flink-connector-kafka</flink.connector.kafka.artifactId>
+    <flink.runtime.artifactId>flink-runtime_${scala.binary.version}</flink.runtime.artifactId>
+    <flink.table.runtime.artifactId>flink-table-runtime-blink_${scala.binary.version}</flink.table.runtime.artifactId>
+    <flink.table.planner.artifactId>flink-table-planner-blink_${scala.binary.version}</flink.table.planner.artifactId>
+    <flink.parquet.artifactId>flink-parquet_${scala.binary.version}</flink.parquet.artifactId>
+    <flink.statebackend.rocksdb.artifactId>flink-statebackend-rocksdb_${scala.binary.version}</flink.statebackend.rocksdb.artifactId>
+    <flink.test.utils.artifactId>flink-test-utils_${scala.binary.version}</flink.test.utils.artifactId>
+    <flink.streaming.java.artifactId>flink-streaming-java_${scala.binary.version}</flink.streaming.java.artifactId>
+    <flink.clients.artifactId>flink-clients_${scala.binary.version}</flink.clients.artifactId>
+    <flink.connector.kafka.artifactId>flink-connector-kafka_${scala.binary.version}</flink.connector.kafka.artifactId>
     <flink.hadoop.compatibility.artifactId>flink-hadoop-compatibility_${scala.binary.version}</flink.hadoop.compatibility.artifactId>
     <spark31.version>3.1.3</spark31.version>
     <spark32.version>3.2.1</spark32.version>
@@ -1823,7 +1823,9 @@
       <id>flink1.15</id>
       <properties>
         <flink.version>${flink1.15.version}</flink.version>
+        <flink.runtime.artifactId>flink-runtime</flink.runtime.artifactId>
         <flink.table.runtime.artifactId>flink-table-runtime</flink.table.runtime.artifactId>
+        <flink.table.planner.artifactId>flink-table-planner_2.12</flink.table.planner.artifactId>
         <flink.parquet.artifactId>flink-parquet</flink.parquet.artifactId>
         <flink.statebackend.rocksdb.artifactId>flink-statebackend-rocksdb</flink.statebackend.rocksdb.artifactId>
         <flink.test.utils.artifactId>flink-test-utils</flink.test.utils.artifactId>
@@ -1845,7 +1847,9 @@
       <id>flink1.14</id>
       <properties>
         <flink.version>${flink1.14.version}</flink.version>
+        <flink.runtime.artifactId>flink-runtime</flink.runtime.artifactId>
         <flink.table.runtime.artifactId>flink-table-runtime_${scala.binary.version}</flink.table.runtime.artifactId>
+        <flink.table.planner.artifactId>flink-table-planner_${scala.binary.version}</flink.table.planner.artifactId>
         <flink.parquet.artifactId>flink-parquet_${scala.binary.version}</flink.parquet.artifactId>
         <flink.statebackend.rocksdb.artifactId>flink-statebackend-rocksdb_${scala.binary.version}</flink.statebackend.rocksdb.artifactId>
         <flink.test.utils.artifactId>flink-test-utils_${scala.binary.version}</flink.test.utils.artifactId>


### PR DESCRIPTION
### Change Logs

Fixes the issue reported in #6422 
Since the default flink profile is still scala version dependent, so the default artifact ids should be named correctly.
Tested all 3 flink profiles.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
