### PR TITLE
[HUDI-4643] MergeInto syntax WHEN MATCHED is optional but must be set

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -153,7 +153,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     if (mergeInto.matchedActions.nonEmpty) { // Do the upsert
       executeUpsert(sourceDF, parameters)
     } else { // If there is no match actions in the statement, execute insert operation only.
-      executeInsertOnly(sourceDF, parameters)
+      val targetDF = Dataset.ofRows(sparkSession, mergeInto.targetTable)
+      val primaryKeys = hoodieCatalogTable.tableConfig.getRecordKeyFieldProp.split(",")
+      // Only records that are not included in the target table can be inserted
+      val insertSourceDF = sourceDF.join(targetDF, primaryKeys,"leftanti")
+      executeInsertOnly(insertSourceDF, parameters)
     }
     sparkSession.catalog.refreshTable(targetTableIdentify.unquotedString)
     Seq.empty[Row]

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
@@ -258,7 +258,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
            | )
        """.stripMargin)
 
-      // Insert data to source table
+      // Insert data
       spark.sql(s"insert into $tableName select 1, 'a1', 1, 10, '2021-03-21'")
       checkAnswer(s"select id, name, price, ts, dt from $tableName")(
         Seq(1, "a1", 1.0, 10, "2021-03-21")
@@ -540,6 +540,98 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
       )
       checkAnswer(s"select id, name, price, ts, dt from $tableName")(
         Seq(1, "a1", 111.0, 1111, "2021-05-05")
+      )
+    }
+  }
+
+  test("Test only insert when source table contains history") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      // Create table
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  dt string
+           |) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           |  primaryKey ='id',
+           |  preCombineField = 'ts'
+           | )
+       """.stripMargin)
+      // Insert data
+      spark.sql(s"insert into $tableName select 1, 'a1', 1, 10, '2022-08-18'")
+      checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+        Seq(1, "a1", 1.0, 10, "2022-08-18")
+      )
+
+      // Insert data which not matched insert-condition.
+      spark.sql(
+        s"""
+           | merge into $tableName as t0
+           | using (
+           |  select 1 as id, 'a1' as name, 11 as price, 110 as ts, '2022-08-19' as dt union all
+           |  select 2 as id, 'a2' as name, 10 as price, 100 as ts, '2022-08-18' as dt
+           | ) as s0
+           | on t0.id = s0.id
+           | when not matched then insert *
+         """.stripMargin
+      )
+
+      checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+        Seq(1, "a1", 1.0, 10, "2022-08-18"),
+        Seq(2, "a2", 10.0, 100, "2022-08-18")
+      )
+    }
+  }
+
+  test("Test only insert when source table contains history and target table has multiple keys") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      // Create table with multiple keys
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id1 int,
+           |  id2 int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  dt string
+           |) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           |  primaryKey ='id1,id2',
+           |  preCombineField = 'ts'
+           | )
+       """.stripMargin)
+      spark.sql("set hoodie.merge.allow.duplicate.on.inserts = true")
+      // Insert data
+      spark.sql(s"insert into $tableName select 1, 1, 'a1', 1, 10, '2022-08-18'")
+      checkAnswer(s"select id1, id2, name, price, ts, dt from $tableName")(
+        Seq(1, 1, "a1", 1.0, 10, "2022-08-18")
+      )
+
+      // Insert data which not matched insert-condition.
+      spark.sql(
+        s"""
+           | merge into $tableName as t0
+           | using (
+           |  select 1 as id1, 1 as id2, 'a1' as name, 11 as price, 110 as ts, '2022-08-19' as dt union all
+           |  select 1 as id1, 2 as id2, 'a2' as name, 10 as price, 100 as ts, '2022-08-18' as dt
+           | ) as s0
+           | on t0.id1 = s0.id1
+           | when not matched then insert *
+         """.stripMargin
+      )
+
+      checkAnswer(s"select id1, id2, name, price, ts, dt from $tableName")(
+        Seq(1, 1, "a1", 1.0, 10, "2022-08-18"),
+        Seq(1, 2, "a2", 10.0, 100, "2022-08-18")
       )
     }
   }


### PR DESCRIPTION
```sql
spark.sql(
s"""
|create table $tableName (
| id int,
| name string,
| price double,
| ts long,
| dt string
|) using hudi
| location '${tmp.getCanonicalPath}/$tableName'
| tblproperties (
| primaryKey ='id',
| preCombineField = 'ts'
| )
""".stripMargin)
// Insert data
spark.sql(s"insert into $tableName select 1, 'a1', 1, 10, '2022-08-18'")
spark.sql(
s"""
| merge into $tableName as t0
| using (
| select 1 as id, 'a1' as name, 11 as price, 110 as ts, '2022-08-19' as dt union all
| select 2 as id, 'a2' as name, 10 as price, 100 as ts, '2022-08-18' as dt
| ) as s0
| on t0.id = s0.id
| when not matched then insert *
""".stripMargin
)
```

```
11493 [Executor task launch worker for task 65] ERROR org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor  - Error upserting bucketType UPDATE for partition :0
org.apache.hudi.exception.HoodieException: org.apache.hudi.exception.HoodieException: java.util.concurrent.ExecutionException: java.lang.AssertionError: assertion failed: hoodie.payload.update.condition.assignments have not set
    at org.apache.hudi.table.action.commit.HoodieMergeHelper.runMerge(HoodieMergeHelper.java:149)
    at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpdateInternal(BaseSparkCommitActionExecutor.java:358)
    at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpdate(BaseSparkCommitActionExecutor.java:349)
    at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpsertPartition(BaseSparkCommitActionExecutor.java:322)
    at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleInsertPartition(BaseSparkCommitActionExecutor.java:335)
    at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.lambda$mapPartitionsAsRDD$a3ab3c4$1(BaseSparkCommitActionExecutor.java:246)
```

if  set hoodie.merge.allow.duplicate.on.inserts = true，The result is one more record than expected：
```java
[1,a1,1.0,10,2022-08-18], [1,a1,11.0,110,2022-08-19], [2,a2,10.0,100,2022-08-18]
```
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
