### PR TITLE
[HUDI-4669] Incorrect protoc executable in kafka-connect fails build …

### DIFF
--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -67,6 +67,9 @@
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
                 <version>3.11.4</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:3.21.1</protocArtifact>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -192,8 +192,8 @@
     <zk-curator.version>2.7.1</zk-curator.version>
     <antlr.version>4.7</antlr.version>
     <aws.sdk.version>1.12.22</aws.sdk.version>
-    <proto.version>3.17.3</proto.version>
-    <protoc.version>3.11.4</protoc.version>
+    <proto.version>3.21.1</proto.version>
+    <protoc.version>3.21.1</protoc.version>
     <dynamodb.lockclient.version>1.1.0</dynamodb.lockclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <dynamodb-local.port>8000</dynamodb-local.port>


### PR DESCRIPTION
…on Mac M1

### Change Logs

Protoc 3..11.1 executable fails on Apple Mac M1 (works fine on Intel hardware), this fix upgrades both protoc and protobuf to 3.21.1

### Impact

this impact the hudi-kafka-connect module - which was failing to build on Arm64 processors

**Risk level: none | low | medium | high**

Medium

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
