### PR TITLE
[HUDI-4549]  Remove avro from hudi-hive-sync-bundle and hudi-aws-bundle

### DIFF
--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -78,7 +78,6 @@
                                     <include>org.apache.hudi:hudi-hive-sync</include>
                                     <include>org.apache.hudi:hudi-aws</include>
                                     <include>org.apache.parquet:parquet-avro</include>
-                                    <include>org.apache.avro:avro</include>
                                     <include>com.amazonaws:dynamodb-lock-client</include>
                                     <include>com.amazonaws:aws-java-sdk-cloudwatch</include>
                                     <include>com.amazonaws:aws-java-sdk-dynamodb</include>
@@ -141,14 +140,6 @@
                                 <relocation>
                                     <pattern>com.amazonaws.</pattern>
                                     <shadedPattern>org.apache.hudi.com.amazonaws.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.parquet.avro.</pattern>
-                                    <shadedPattern>org.apache.hudi.org.apache.parquet.avro.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.avro.</pattern>
-                                    <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.codahale.metrics.</pattern>
@@ -284,18 +275,12 @@
             <artifactId>hudi-aws</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- Need parquet and avro to run AwsGlueCatalogSyncTool using run_sync_tool with this bundle.
-        Parquet and avro from other packages have already been shaded above-->
+
+        <!-- Parquet -->
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
             <version>${parquet.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -72,7 +72,6 @@
                   <include>org.apache.hudi:hudi-hive-sync</include>
 
                   <include>com.beust:jcommander</include>
-                  <include>org.apache.avro:avro</include>
                   <include>org.apache.hbase:hbase-common</include>
                   <include>org.apache.hbase:hbase-client</include>
                   <include>org.apache.hbase:hbase-hadoop-compat</include>
@@ -105,10 +104,6 @@
                 <relocation>
                   <pattern>com.esotericsoftware.minlog.</pattern>
                   <shadedPattern>org.apache.hudi.com.esotericsoftware.minlog.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.avro.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons.io.</pattern>
@@ -253,14 +248,6 @@
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
       <version>${parquet.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <!-- Avro -->
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
### Change Logs

- Remove Avro shading from hudi-hive-sync-bundle and hudi-aws-bundle
- We cannot shade avro in hudi-spark-bundle or hudi-utilities-bundle because we use certain SparkConf APIs that expect unshaded Avro classes. If we shade Avro in hudi-hive-sync-bundle without shading in hudi-spark or hudi-utilities bundle then it can lead to conflict (NoMethodFoundError) as mentioned in HUDI-4549.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

Tested hive sync locally and on EMR with changing the order of jars in the launch command.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
