### PR TITLE
[HUDI-4212] Exclude jdk.tools from kafka-connect in dev setup

### DIFF
--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -218,6 +218,12 @@
             <groupId>${hive.groupid}</groupId>
             <artifactId>hive-metastore</artifactId>
             <version>${hive.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
 


### PR DESCRIPTION
### Change Logs

To resolve problem `Unresolved dependency: 'jdk.tools:jdk.tools:jar:1.7` when first import project.

### Impact

NA

**Risk level: none**

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
