### PR TITLE
[HUDI-4528] Add diff tool to compare commit metadata

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieTableHeaderFields.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieTableHeaderFields.java
@@ -181,4 +181,36 @@ public class HoodieTableHeaderFields {
   public static final String HEADER_MT_REQUESTED_TIME = HEADER_MT_PREFIX + HEADER_REQUESTED_TIME;
   public static final String HEADER_MT_INFLIGHT_TIME = HEADER_MT_PREFIX + HEADER_INFLIGHT_TIME;
   public static final String HEADER_MT_COMPLETED_TIME = HEADER_MT_PREFIX + HEADER_COMPLETED_TIME;
+
+  public static TableHeader getTableHeader() {
+    return new TableHeader()
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_COMMIT_TIME)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_FILES_ADDED)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_FILES_UPDATED)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_PARTITIONS_WRITTEN)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_RECORDS_WRITTEN)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_UPDATE_RECORDS_WRITTEN)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_ERRORS);
+  }
+
+  public static TableHeader getTableHeaderWithExtraMetadata() {
+    return new TableHeader()
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_ACTION)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_INSTANT)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_PARTITION)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_FILE_ID)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_PREVIOUS_COMMIT)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_NUM_WRITES)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_NUM_INSERTS)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_NUM_DELETES)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_NUM_UPDATE_WRITES)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_ERRORS)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_LOG_BLOCKS)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_CORRUPT_LOG_BLOCKS)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_ROLLBACK_BLOCKS)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_LOG_RECORDS)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_UPDATED_RECORDS_COMPACTED)
+        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN);
+  }
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -48,8 +48,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.cli.utils.TimelineUtil.getTimeDaysAgo;
-import static org.apache.hudi.cli.utils.TimelineUtil.getTimeline;
+import static org.apache.hudi.cli.utils.CommitUtil.getTimeDaysAgo;
+import static org.apache.hudi.common.table.timeline.TimelineUtils.getTimeline;
 
 /**
  * CLI command to display commits options.

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
@@ -70,7 +70,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.cli.utils.TimelineUtil.getTimeDaysAgo;
+import static org.apache.hudi.cli.utils.CommitUtil.getTimeDaysAgo;
 
 /**
  * CLI command to display compaction related options.

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
@@ -19,6 +19,19 @@
 
 package org.apache.hudi.cli.commands;
 
+import org.apache.hudi.cli.HoodieCLI;
+import org.apache.hudi.cli.HoodiePrintHelper;
+import org.apache.hudi.cli.HoodieTableHeaderFields;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
+import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.NumericUtils;
+import org.apache.hudi.common.util.StringUtils;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.springframework.shell.core.CommandMarker;
@@ -26,6 +39,20 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.cli.utils.TimelineUtil.getTimeDaysAgo;
+
+/**
+ * Given a file id or partition value, this command line utility tracks the changes to the file group or partition across range of commits.
+ * Usage: diff file --fileId <fileId>
+ */
 @Component
 public class DiffCommand implements CommandMarker {
 
@@ -34,28 +61,136 @@ public class DiffCommand implements CommandMarker {
   @CliCommand(value = "diff file", help = "Check how file differs across range of commits")
   public String diffFile(
       @CliOption(key = {"fileId"}, help = "File ID to diff across range of commits", mandatory = true) String fileId,
-      @CliOption(key = {"includeExtraMetadata"}, help = "Include extra metadata", unspecifiedDefaultValue = "false") final boolean includeExtraMetadata,
       @CliOption(key = {"startTs"}, help = "start time for compactions, default: now - 10 days") String startTs,
       @CliOption(key = {"endTs"}, help = "end time for compactions, default: now - 1 day") String endTs,
       @CliOption(key = {"limit"}, help = "Limit compactions", unspecifiedDefaultValue = "-1") final Integer limit,
       @CliOption(key = {"sortBy"}, help = "Sorting Field", unspecifiedDefaultValue = "") final String sortByField,
       @CliOption(key = {"desc"}, help = "Ordering", unspecifiedDefaultValue = "false") final boolean descending,
-      @CliOption(key = {"headeronly"}, help = "Print Header Only", unspecifiedDefaultValue = "false") final boolean headerOnly) {
-    // TODO: implement me
-    return null;
+      @CliOption(key = {"headeronly"}, help = "Print Header Only", unspecifiedDefaultValue = "false") final boolean headerOnly,
+      @CliOption(key = {"includeArchivedTimeline"}, help = "Include archived commits as well",
+          unspecifiedDefaultValue = "false") final boolean includeArchivedTimeline) throws IOException {
+    HoodieDefaultTimeline timeline = getTimelineInRange(startTs, endTs, includeArchivedTimeline);
+    return printCommitsWithMetadataForFileId(timeline, limit, sortByField, descending, headerOnly, "", fileId);
   }
 
   @CliCommand(value = "diff partition", help = "Check how file differs across range of commits")
   public String diffPartition(
       @CliOption(key = {"partitionPath"}, help = "Relative partition path to diff across range of commits", mandatory = true) String partitionPath,
-      @CliOption(key = {"includeExtraMetadata"}, help = "Include extra metadata", unspecifiedDefaultValue = "false") final boolean includeExtraMetadata,
       @CliOption(key = {"startTs"}, help = "start time for compactions, default: now - 10 days") String startTs,
       @CliOption(key = {"endTs"}, help = "end time for compactions, default: now - 1 day") String endTs,
       @CliOption(key = {"limit"}, help = "Limit compactions", unspecifiedDefaultValue = "-1") final Integer limit,
       @CliOption(key = {"sortBy"}, help = "Sorting Field", unspecifiedDefaultValue = "") final String sortByField,
       @CliOption(key = {"desc"}, help = "Ordering", unspecifiedDefaultValue = "false") final boolean descending,
-      @CliOption(key = {"headeronly"}, help = "Print Header Only", unspecifiedDefaultValue = "false") final boolean headerOnly) {
-    // TODO: implement me
-    return null;
+      @CliOption(key = {"headeronly"}, help = "Print Header Only", unspecifiedDefaultValue = "false") final boolean headerOnly,
+      @CliOption(key = {"includeArchivedTimeline"}, help = "Include archived commits as well",
+          unspecifiedDefaultValue = "false") final boolean includeArchivedTimeline) throws IOException {
+    HoodieDefaultTimeline timeline = getTimelineInRange(startTs, endTs, includeArchivedTimeline);
+    return printCommitsWithMetadataForPartition(timeline, limit, sortByField, descending, headerOnly, "", partitionPath);
+  }
+
+  private HoodieDefaultTimeline getTimelineInRange(String startTs, String endTs, boolean includeArchivedTimeline) {
+    if (StringUtils.isNullOrEmpty(startTs)) {
+      startTs = getTimeDaysAgo(10);
+    }
+    if (StringUtils.isNullOrEmpty(endTs)) {
+      endTs = getTimeDaysAgo(1);
+    }
+    HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    if (includeArchivedTimeline) {
+      HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
+      archivedTimeline.loadInstantDetailsInMemory(startTs, endTs);
+      return archivedTimeline.findInstantsInRange(startTs, endTs).mergeTimeline(activeTimeline);
+    }
+    return activeTimeline;
+  }
+
+  private String printCommitsWithMetadataForFileId(HoodieDefaultTimeline timeline,
+                                                   final Integer limit,
+                                                   final String sortByField,
+                                                   final boolean descending,
+                                                   final boolean headerOnly,
+                                                   final String tempTableName,
+                                                   final String fileId) throws IOException {
+    final List<Comparable[]> rows = new ArrayList<>();
+
+    final List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
+        .getInstants().sorted(HoodieInstant.COMPARATOR.reversed()).collect(Collectors.toList());
+
+    for (final HoodieInstant commit : commits) {
+      if (timeline.getInstantDetails(commit).isPresent()) {
+        final HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
+            timeline.getInstantDetails(commit).get(),
+            HoodieCommitMetadata.class);
+
+        for (Map.Entry<String, List<HoodieWriteStat>> partitionWriteStat :
+            commitMetadata.getPartitionToWriteStats().entrySet()) {
+          for (HoodieWriteStat hoodieWriteStat : partitionWriteStat.getValue()) {
+            if (fileId.equals(hoodieWriteStat.getFileId())) {
+              rows.add(new Comparable[] {commit.getAction(), commit.getTimestamp(), hoodieWriteStat.getPartitionPath(),
+                  hoodieWriteStat.getFileId(), hoodieWriteStat.getPrevCommit(), hoodieWriteStat.getNumWrites(),
+                  hoodieWriteStat.getNumInserts(), hoodieWriteStat.getNumDeletes(),
+                  hoodieWriteStat.getNumUpdateWrites(), hoodieWriteStat.getTotalWriteErrors(),
+                  hoodieWriteStat.getTotalLogBlocks(), hoodieWriteStat.getTotalCorruptLogBlock(),
+                  hoodieWriteStat.getTotalRollbackBlocks(), hoodieWriteStat.getTotalLogRecords(),
+                  hoodieWriteStat.getTotalUpdatedRecordsCompacted(), hoodieWriteStat.getTotalWriteBytes()
+              });
+            }
+          }
+        }
+      }
+    }
+
+    final Map<String, Function<Object, String>> fieldNameToConverterMap = new HashMap<>();
+    fieldNameToConverterMap.put(
+        HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN,
+        entry -> NumericUtils.humanReadableByteCount((Double.parseDouble(entry.toString()))));
+
+    return HoodiePrintHelper.print(HoodieTableHeaderFields.getTableHeaderWithExtraMetadata(),
+        fieldNameToConverterMap, sortByField, descending, limit, headerOnly, rows, tempTableName);
+  }
+
+  private String printCommitsWithMetadataForPartition(HoodieDefaultTimeline timeline,
+                                                      final Integer limit, final String sortByField,
+                                                      final boolean descending,
+                                                      final boolean headerOnly,
+                                                      final String tempTableName,
+                                                      final String partition) throws IOException {
+    final List<Comparable[]> rows = new ArrayList<>();
+
+    final List<HoodieInstant> commits = timeline.getCommitsTimeline().filterCompletedInstants()
+        .getInstants().sorted(HoodieInstant.COMPARATOR.reversed()).collect(Collectors.toList());
+
+    for (final HoodieInstant commit : commits) {
+      if (timeline.getInstantDetails(commit).isPresent()) {
+        final HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
+            timeline.getInstantDetails(commit).get(),
+            HoodieCommitMetadata.class);
+
+        for (Map.Entry<String, List<HoodieWriteStat>> partitionWriteStat :
+            commitMetadata.getPartitionToWriteStats().entrySet()) {
+          for (HoodieWriteStat hoodieWriteStat : partitionWriteStat.getValue()) {
+            if (partition.equals(hoodieWriteStat.getPartitionPath())) {
+              rows.add(new Comparable[] {commit.getAction(), commit.getTimestamp(), hoodieWriteStat.getPartitionPath(),
+                  hoodieWriteStat.getFileId(), hoodieWriteStat.getPrevCommit(), hoodieWriteStat.getNumWrites(),
+                  hoodieWriteStat.getNumInserts(), hoodieWriteStat.getNumDeletes(),
+                  hoodieWriteStat.getNumUpdateWrites(), hoodieWriteStat.getTotalWriteErrors(),
+                  hoodieWriteStat.getTotalLogBlocks(), hoodieWriteStat.getTotalCorruptLogBlock(),
+                  hoodieWriteStat.getTotalRollbackBlocks(), hoodieWriteStat.getTotalLogRecords(),
+                  hoodieWriteStat.getTotalUpdatedRecordsCompacted(), hoodieWriteStat.getTotalWriteBytes()
+              });
+            }
+          }
+        }
+      }
+    }
+
+    final Map<String, Function<Object, String>> fieldNameToConverterMap = new HashMap<>();
+    fieldNameToConverterMap.put(
+        HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN,
+        entry -> NumericUtils.humanReadableByteCount((Double.parseDouble(entry.toString()))));
+
+    return HoodiePrintHelper.print(HoodieTableHeaderFields.getTableHeaderWithExtraMetadata(),
+        fieldNameToConverterMap, sortByField, descending, limit, headerOnly, rows, tempTableName);
   }
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/DiffCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.cli.commands;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiffCommand implements CommandMarker {
+
+  private static final Logger LOG = LogManager.getLogger(DiffCommand.class);
+
+  @CliCommand(value = "diff file", help = "Check how file differs across range of commits")
+  public String diffFile(
+      @CliOption(key = {"fileId"}, help = "File ID to diff across range of commits", mandatory = true) String fileId,
+      @CliOption(key = {"includeExtraMetadata"}, help = "Include extra metadata", unspecifiedDefaultValue = "false") final boolean includeExtraMetadata,
+      @CliOption(key = {"startTs"}, help = "start time for compactions, default: now - 10 days") String startTs,
+      @CliOption(key = {"endTs"}, help = "end time for compactions, default: now - 1 day") String endTs,
+      @CliOption(key = {"limit"}, help = "Limit compactions", unspecifiedDefaultValue = "-1") final Integer limit,
+      @CliOption(key = {"sortBy"}, help = "Sorting Field", unspecifiedDefaultValue = "") final String sortByField,
+      @CliOption(key = {"desc"}, help = "Ordering", unspecifiedDefaultValue = "false") final boolean descending,
+      @CliOption(key = {"headeronly"}, help = "Print Header Only", unspecifiedDefaultValue = "false") final boolean headerOnly) {
+    // TODO: implement me
+    return null;
+  }
+
+  @CliCommand(value = "diff partition", help = "Check how file differs across range of commits")
+  public String diffPartition(
+      @CliOption(key = {"partitionPath"}, help = "Relative partition path to diff across range of commits", mandatory = true) String partitionPath,
+      @CliOption(key = {"includeExtraMetadata"}, help = "Include extra metadata", unspecifiedDefaultValue = "false") final boolean includeExtraMetadata,
+      @CliOption(key = {"startTs"}, help = "start time for compactions, default: now - 10 days") String startTs,
+      @CliOption(key = {"endTs"}, help = "end time for compactions, default: now - 1 day") String endTs,
+      @CliOption(key = {"limit"}, help = "Limit compactions", unspecifiedDefaultValue = "-1") final Integer limit,
+      @CliOption(key = {"sortBy"}, help = "Sorting Field", unspecifiedDefaultValue = "") final String sortByField,
+      @CliOption(key = {"desc"}, help = "Ordering", unspecifiedDefaultValue = "false") final boolean descending,
+      @CliOption(key = {"headeronly"}, help = "Print Header Only", unspecifiedDefaultValue = "false") final boolean headerOnly) {
+    // TODO: implement me
+    return null;
+  }
+}

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieSyncValidateCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieSyncValidateCommand.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.cli.utils.TimelineUtil.countNewRecords;
+import static org.apache.hudi.cli.utils.CommitUtil.countNewRecords;
 
 /**
  * CLI command to display sync options.

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieSyncValidateCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieSyncValidateCommand.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.cli.commands;
 
 import org.apache.hudi.cli.HoodieCLI;
-import org.apache.hudi.cli.utils.CommitUtil;
 import org.apache.hudi.cli.utils.HiveUtil;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -34,6 +33,8 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.apache.hudi.cli.utils.TimelineUtil.countNewRecords;
 
 /**
  * CLI command to display sync options.
@@ -96,7 +97,7 @@ public class HoodieSyncValidateCommand implements CommandMarker {
       return "Count difference now is (count(" + target.getTableConfig().getTableName() + ") - count("
           + source.getTableConfig().getTableName() + ") == " + (targetCount - sourceCount);
     } else {
-      long newInserts = CommitUtil.countNewRecords(target,
+      long newInserts = countNewRecords(target,
           commitsToCatchup.stream().map(HoodieInstant::getTimestamp).collect(Collectors.toList()));
       return "Count difference now is (count(" + target.getTableConfig().getTableName() + ") - count("
           + source.getTableConfig().getTableName() + ") == " + (targetCount - sourceCount) + ". Catch up count is "

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/CommitUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/CommitUtil.java
@@ -21,8 +21,6 @@ package org.apache.hudi.cli.utils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
-import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
-import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 
@@ -34,7 +32,7 @@ import java.util.List;
 /**
  * Utilities related to commit operation.
  */
-public class TimelineUtil {
+public class CommitUtil {
 
   public static long countNewRecords(HoodieTableMetaClient metaClient, List<String> commitsToCatchup) throws IOException {
     long totalNew = 0;
@@ -51,14 +49,5 @@ public class TimelineUtil {
   public static String getTimeDaysAgo(int numberOfDays) {
     Date date = Date.from(ZonedDateTime.now().minusDays(numberOfDays).toInstant());
     return HoodieActiveTimeline.formatDate(date);
-  }
-
-  public static HoodieDefaultTimeline getTimeline(HoodieTableMetaClient metaClient, boolean includeArchivedTimeline) {
-    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
-    if (includeArchivedTimeline) {
-      HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
-      return archivedTimeline.mergeTimeline(activeTimeline);
-    }
-    return activeTimeline;
   }
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/TimelineUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/TimelineUtil.java
@@ -21,6 +21,8 @@ package org.apache.hudi.cli.utils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
+import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 
@@ -32,11 +34,11 @@ import java.util.List;
 /**
  * Utilities related to commit operation.
  */
-public class CommitUtil {
+public class TimelineUtil {
 
-  public static long countNewRecords(HoodieTableMetaClient target, List<String> commitsToCatchup) throws IOException {
+  public static long countNewRecords(HoodieTableMetaClient metaClient, List<String> commitsToCatchup) throws IOException {
     long totalNew = 0;
-    HoodieTimeline timeline = target.reloadActiveTimeline().getCommitTimeline().filterCompletedInstants();
+    HoodieTimeline timeline = metaClient.reloadActiveTimeline().getCommitTimeline().filterCompletedInstants();
     for (String commit : commitsToCatchup) {
       HoodieCommitMetadata c = HoodieCommitMetadata.fromBytes(
           timeline.getInstantDetails(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, commit)).get(),
@@ -49,5 +51,14 @@ public class CommitUtil {
   public static String getTimeDaysAgo(int numberOfDays) {
     Date date = Date.from(ZonedDateTime.now().minusDays(numberOfDays).toInstant());
     return HoodieActiveTimeline.formatDate(date);
+  }
+
+  public static HoodieDefaultTimeline getTimeline(HoodieTableMetaClient metaClient, boolean includeArchivedTimeline) {
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    if (includeArchivedTimeline) {
+      HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
+      return archivedTimeline.mergeTimeline(activeTimeline);
+    }
+    return activeTimeline;
   }
 }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -170,21 +170,9 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     });
 
     final Map<String, Function<Object, String>> fieldNameToConverterMap = new HashMap<>();
-    fieldNameToConverterMap.put(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN, entry -> {
-      return NumericUtils.humanReadableByteCount((Double.valueOf(entry.toString())));
-    });
+    fieldNameToConverterMap.put(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN, entry -> NumericUtils.humanReadableByteCount((Double.parseDouble(entry.toString()))));
 
-    final TableHeader header = new TableHeader()
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_COMMIT_TIME)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_FILES_ADDED)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_FILES_UPDATED)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_PARTITIONS_WRITTEN)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_RECORDS_WRITTEN)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_UPDATE_RECORDS_WRITTEN)
-        .addTableHeaderField(HoodieTableHeaderFields.HEADER_TOTAL_ERRORS);
-
-    return HoodiePrintHelper.print(header, fieldNameToConverterMap, "", false,
+    return HoodiePrintHelper.print(HoodieTableHeaderFields.getTableHeader(), fieldNameToConverterMap, "", false,
         -1, false, rows);
   }
 
@@ -204,12 +192,67 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     assertEquals(expected, got);
   }
 
+  @Test
+  public void testShowCommitsIncludingArchivedTimeline() throws Exception {
+    Map<String, Integer[]> data = generateDataAndArchive(true);
+    data.remove("101");
+    data.remove("102");
+
+    CommandResult cr = shell().executeCommand("commits show --includeExtraMetadata true --includeArchivedTimeline true --partition 2015/03/16");
+    assertTrue(cr.isSuccess());
+
+    String expected = generateExpectDataWithExtraMetadata(1, data);
+    expected = removeNonWordAndStripSpace(expected);
+    String got = removeNonWordAndStripSpace(cr.getResult().toString());
+    assertEquals(expected, got);
+  }
+
+  private String generateExpectDataWithExtraMetadata(int records, Map<String, Integer[]> data) throws IOException {
+    List<Comparable[]> rows = new ArrayList<>();
+    data.forEach((key, value) -> {
+      for (int i = 0; i < records; i++) {
+        // there are more than 1 partitions, so need to * partitions
+        rows.add(new Comparable[] {HoodieTimeline.COMMIT_ACTION, key, "2015/03/16", HoodieTestCommitMetadataGenerator.DEFAULT_FILEID,
+            HoodieTestCommitMetadataGenerator.DEFAULT_PRE_COMMIT, key.equals("104") ? "20" : "15", "0", "0", key.equals("104") ? "10" : "15",
+            "0", HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_LOG_BLOCKS, "0", "0", HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_LOG_RECORDS,
+            "0", HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_WRITE_BYTES});
+      }
+    });
+
+    final Map<String, Function<Object, String>> fieldNameToConverterMap = new HashMap<>();
+    fieldNameToConverterMap.put(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN, entry -> NumericUtils.humanReadableByteCount((Double.parseDouble(entry.toString()))));
+
+    final TableHeader header = HoodieTableHeaderFields.getTableHeaderWithExtraMetadata();
+
+    return HoodiePrintHelper.print(header, fieldNameToConverterMap, "", false,
+        -1, false, rows);
+  }
+
   /**
    * Test case of 'commits showarchived' command.
    */
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testShowArchivedCommits(boolean enableMetadataTable) throws Exception {
+    Map<String, Integer[]> data = generateDataAndArchive(enableMetadataTable);
+
+    CommandResult cr = shell().executeCommand(String.format("commits showarchived --startTs %s --endTs %s", "100", "104"));
+    assertTrue(cr.isSuccess());
+
+    // archived 101 and 102 instant, generate expect data
+    assertEquals(2, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
+        "There should 2 instants not be archived!");
+
+    // archived 101 and 102 instants, remove 103 and 104 instant
+    data.remove("103");
+    data.remove("104");
+    String expected = generateExpectData(1, data);
+    expected = removeNonWordAndStripSpace(expected);
+    String got = removeNonWordAndStripSpace(cr.getResult().toString());
+    assertEquals(expected, got);
+  }
+
+  private Map<String, Integer[]> generateDataAndArchive(boolean enableMetadataTable) throws Exception {
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath1)
         .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
@@ -245,21 +288,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     HoodieSparkTable table = HoodieSparkTable.create(cfg, context(), metaClient);
     HoodieTimelineArchiver archiver = new HoodieTimelineArchiver(cfg, table);
     archiver.archiveIfRequired(context());
-
-    CommandResult cr = shell().executeCommand(String.format("commits showarchived --startTs %s --endTs %s", "100", "104"));
-    assertTrue(cr.isSuccess());
-
-    // archived 101 and 102 instant, generate expect data
-    assertEquals(2, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
-        "There should 2 instants not be archived!");
-
-    // archived 101 and 102 instants, remove 103 and 104 instant
-    data.remove("103");
-    data.remove("104");
-    String expected = generateExpectData(1, data);
-    expected = removeNonWordAndStripSpace(expected);
-    String got = removeNonWordAndStripSpace(cr.getResult().toString());
-    assertEquals(expected, got);
+    return data;
   }
 
   @ParameterizedTest

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
@@ -225,7 +225,7 @@ public class TestCompactionCommand extends CLIFunctionalTestHarness {
     CommandResult cr = shell().executeCommand("compaction showarchived --instant " + instance);
 
     // generate expected
-    String expected = new CompactionCommand().printCompaction(plan, "", false, -1, false, null);
+    String expected = CompactionCommand.printCompaction(plan, "", false, -1, false, null);
 
     expected = removeNonWordAndStripSpace(expected);
     String got = removeNonWordAndStripSpace(cr.getResult().toString());

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
@@ -225,7 +225,7 @@ public class TestCompactionCommand extends CLIFunctionalTestHarness {
     CommandResult cr = shell().executeCommand("compaction showarchived --instant " + instance);
 
     // generate expected
-    String expected = new CompactionCommand().printCompaction(plan, "", false, -1, false);
+    String expected = new CompactionCommand().printCompaction(plan, "", false, -1, false, null);
 
     expected = removeNonWordAndStripSpace(expected);
     String got = removeNonWordAndStripSpace(cr.getResult().toString());

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestDiffCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestDiffCommand.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.cli.commands;
+
+import org.apache.hudi.cli.HoodieCLI;
+import org.apache.hudi.cli.HoodiePrintHelper;
+import org.apache.hudi.cli.HoodieTableHeaderFields;
+import org.apache.hudi.cli.TableHeader;
+import org.apache.hudi.cli.functional.CLIFunctionalTestHarness;
+import org.apache.hudi.cli.testutils.HoodieTestCommitMetadataGenerator;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.util.NumericUtils;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.shell.core.CommandResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test Cases for {@link DiffCommand}.
+ */
+@Tag("functional")
+public class TestDiffCommand extends CLIFunctionalTestHarness {
+
+  private String tableName;
+  private String tablePath;
+
+  @BeforeEach
+  public void init() {
+    tableName = tableName();
+    tablePath = tablePath(tableName);
+  }
+
+  @Test
+  public void testDiffFile() throws Exception {
+    // create COW table.
+    new TableCommand().createTable(
+        tablePath, tableName, HoodieTableType.COPY_ON_WRITE.name(),
+        "", TimelineLayoutVersion.VERSION_1, HoodieAvroPayload.class.getName());
+
+    Configuration conf = HoodieCLI.conf;
+
+    HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();
+    String fileId1 = UUID.randomUUID().toString();
+    String fileId2 = UUID.randomUUID().toString();
+    FileSystem fs = FSUtils.getFs(basePath(), hadoopConf());
+    HoodieTestDataGenerator.writePartitionMetadataDeprecated(fs, HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS, tablePath);
+
+    // Create four commits
+    Set<String> commits = new HashSet<>();
+    for (int i = 100; i < 104; i++) {
+      String timestamp = String.valueOf(i);
+      commits.add(timestamp);
+      // Requested Compaction
+      HoodieTestCommitMetadataGenerator.createCompactionAuxiliaryMetadata(tablePath,
+          new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, timestamp), conf);
+      // Inflight Compaction
+      HoodieTestCommitMetadataGenerator.createCompactionAuxiliaryMetadata(tablePath,
+          new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, timestamp), conf);
+
+      Map<String, String> extraCommitMetadata =
+          Collections.singletonMap(HoodieCommitMetadata.SCHEMA_KEY, HoodieTestTable.PHONY_TABLE_SCHEMA);
+      HoodieTestCommitMetadataGenerator.createCommitFileWithMetadata(tablePath, timestamp, conf, fileId1, fileId2,
+          Option.empty(), Option.empty(), extraCommitMetadata, false);
+    }
+
+    HoodieTableMetaClient.reload(metaClient);
+
+    CommandResult cr = shell().executeCommand(String.format("diff file --fileId %s", fileId1));
+    assertTrue(cr.isSuccess());
+    String expected = generateExpectDataWithExtraMetadata(commits, fileId1, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
+    expected = removeNonWordAndStripSpace(expected);
+    String got = removeNonWordAndStripSpace(cr.getResult().toString());
+    assertEquals(expected, got);
+  }
+
+  private String generateExpectDataWithExtraMetadata(Set<String> commits, String fileId, String partition) {
+    List<Comparable[]> rows = new ArrayList<>();
+    commits.stream().sorted(Comparator.reverseOrder()).forEach(commit -> rows.add(new Comparable[] {
+        HoodieTimeline.COMMIT_ACTION,
+        commit,
+        partition,
+        fileId,
+        HoodieTestCommitMetadataGenerator.DEFAULT_PRE_COMMIT,
+        HoodieTestCommitMetadataGenerator.DEFAULT_NUM_WRITES,
+        "0",
+        "0",
+        HoodieTestCommitMetadataGenerator.DEFAULT_NUM_UPDATE_WRITES,
+        "0",
+        HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_LOG_BLOCKS,
+        "0",
+        "0",
+        HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_LOG_RECORDS,
+        "0",
+        HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_WRITE_BYTES}));
+
+    final Map<String, Function<Object, String>> fieldNameToConverterMap = new HashMap<>();
+    fieldNameToConverterMap.put(HoodieTableHeaderFields.HEADER_TOTAL_BYTES_WRITTEN, entry -> NumericUtils.humanReadableByteCount((Double.parseDouble(entry.toString()))));
+
+    final TableHeader header = HoodieTableHeaderFields.getTableHeaderWithExtraMetadata();
+
+    return HoodiePrintHelper.print(header, fieldNameToConverterMap, "", false, -1, false, rows);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -44,14 +44,14 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.TableNotFoundException;
+import org.apache.hudi.hadoop.CachingPath;
+import org.apache.hudi.hadoop.SerializablePath;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.apache.hudi.hadoop.CachingPath;
-import org.apache.hudi.hadoop.SerializablePath;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -150,7 +150,8 @@ public class HoodieTableMetaClient implements Serializable {
    *
    * @deprecated
    */
-  public HoodieTableMetaClient() {}
+  public HoodieTableMetaClient() {
+  }
 
   public static HoodieTableMetaClient reload(HoodieTableMetaClient oldMetaClient) {
     return HoodieTableMetaClient.builder()

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -364,10 +364,8 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
   public HoodieDefaultTimeline getWriteTimeline() {
     // filter in-memory instants
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return new HoodieDefaultTimeline(
-        getInstants()
-            .filter(i -> readCommits.containsKey(i.getTimestamp()))
-            .filter(s -> validActions.contains(s.getAction())),
-        details);
+    return new HoodieDefaultTimeline(getInstants().filter(i ->
+            readCommits.containsKey(i.getTimestamp()))
+        .filter(s -> validActions.contains(s.getAction())), details);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -364,8 +364,10 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
   public HoodieDefaultTimeline getWriteTimeline() {
     // filter in-memory instants
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
-    return new HoodieDefaultTimeline(getInstants().filter(i ->
-        readCommits.containsKey(i.getTimestamp()))
-        .filter(s -> validActions.contains(s.getAction())), details);
+    return new HoodieDefaultTimeline(
+        getInstants()
+            .filter(i -> readCommits.containsKey(i.getTimestamp()))
+            .filter(s -> validActions.contains(s.getAction())),
+        details);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -399,4 +399,19 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   public String toString() {
     return this.getClass().getName() + ": " + instants.stream().map(Object::toString).collect(Collectors.joining(","));
   }
+
+  /**
+   * Merge this timeline with the given timeline.
+   */
+  public HoodieDefaultTimeline mergeTimeline(HoodieDefaultTimeline timeline) {
+    Stream<HoodieInstant> instantStream = Stream.concat(instants.stream(), timeline.getInstants()).sorted();
+    Function<HoodieInstant, Option<byte[]>> details = instant -> {
+      if (instants.stream().anyMatch(i -> i.equals(instant))) {
+        return this.getInstantDetails(instant);
+      } else {
+        return timeline.getInstantDetails(instant);
+      }
+    };
+    return new HoodieDefaultTimeline(instantStream, details);
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -176,4 +176,13 @@ public class TimelineUtils {
       throw new HoodieIOException("Unable to read instant information: " + instant + " for " + metaClient.getBasePath(), e);
     }
   }
+
+  public static HoodieDefaultTimeline getTimeline(HoodieTableMetaClient metaClient, boolean includeArchivedTimeline) {
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    if (includeArchivedTimeline) {
+      HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
+      return archivedTimeline.mergeTimeline(activeTimeline);
+    }
+    return activeTimeline;
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -131,7 +131,6 @@ public class TimelineUtils {
         getMetadataValue(metaClient, extraMetadataKey, instant)).orElse(Option.empty());
   }
 
-
   /**
    * Get extra metadata for specified key from latest commit/deltacommit/replacecommit instant including internal commits
    * such as clustering.


### PR DESCRIPTION
### Change Logs

- Add merge API to merge two timelines in `HoodieDefaultTimeline`. This enables merging active and archived timeline.
- Add partition level info to commits and compaction command.
- Add diff command to compare metadata.
- Add commands to list out all actions for file id through a range of commits.
- Add unit tests.

### Impact

Changes can be helpful while debugging timeline using CLI.

**Risk level: none | low | medium | high**

low

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
