### PR TITLE
[HUDI-4706] Fix InternalSchemaChangeApplier#applyAddChange error to add nest type

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/action/InternalSchemaChangeApplier.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/action/InternalSchemaChangeApplier.java
@@ -51,7 +51,8 @@ public class InternalSchemaChangeApplier {
       TableChange.ColumnPositionChange.ColumnPositionType positionType) {
     TableChanges.ColumnAddChange add = TableChanges.ColumnAddChange.get(latestSchema);
     String parentName = TableChangesHelper.getParentName(colName);
-    add.addColumns(parentName, colName, colType, doc);
+    String leafName = TableChangesHelper.getLeafName(colName);
+    add.addColumns(parentName, leafName, colType, doc);
     if (positionType != null) {
       switch (positionType) {
         case NO_OPERATION:

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/action/TableChangesHelper.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/action/TableChangesHelper.java
@@ -76,4 +76,9 @@ public class TableChangesHelper {
     int offset = fullColName.lastIndexOf(".");
     return offset > 0 ? fullColName.substring(0, offset) : "";
   }
+
+  public static String getLeafName(String fullColName) {
+    int offset = fullColName.lastIndexOf(".");
+    return offset > 0 ? fullColName.substring(offset + 1) : fullColName;
+  }
 }


### PR DESCRIPTION
InternalSchemaChangeApplier#applyAddChange forget to remove parent name when calling ColumnAddChange#addColumns

### Change Logs

Add removing parent name when calling ColumnAddChange#addColumns in InternalSchemaChangeApplier#applyAddChange

### Impact

Error when use InternalSchemaChangeApplier#applyAddChange to add a nest type

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
