### PR TITLE
[HUDI-4720] Fix HoodieInternalRow return wrong num of fields when sou…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/model/HoodieInternalRow.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/model/HoodieInternalRow.java
@@ -94,7 +94,11 @@ public class HoodieInternalRow extends InternalRow {
 
   @Override
   public int numFields() {
-    return sourceRow.numFields();
+    if (sourceContainsMetaFields) {
+      return sourceRow.numFields();
+    } else {
+      return sourceRow.numFields() + metaFields.length;
+    }
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/model/TestHoodieInternalRow.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/model/TestHoodieInternalRow.java
@@ -113,6 +113,28 @@ public class TestHoodieInternalRow {
   }
 
   @Test
+  public void testNumFields() {
+    Object[] values = getRandomValue(true);
+    InternalRow row = new GenericInternalRow(values);
+    HoodieInternalRow hoodieInternalRow1 = new HoodieInternalRow(UTF8String.fromString("commitTime"),
+        UTF8String.fromString("commitSeqNo"),
+        UTF8String.fromString("recordKey"),
+        UTF8String.fromString("partitionPath"),
+        UTF8String.fromString("fileName"),
+        row,
+        true);
+    HoodieInternalRow hoodieInternalRow2 = new HoodieInternalRow(UTF8String.fromString("commitTime"),
+        UTF8String.fromString("commitSeqNo"),
+        UTF8String.fromString("recordKey"),
+        UTF8String.fromString("partitionPath"),
+        UTF8String.fromString("fileName"),
+        row,
+        false);
+    assertEquals(row.numFields(), hoodieInternalRow1.numFields());
+    assertEquals(row.numFields() + 5, hoodieInternalRow2.numFields());
+  }
+
+  @Test
   public void testIsNullCheck() {
 
     for (int i = 0; i < 16; i++) {


### PR DESCRIPTION
HoodieInternalRow return wrong num of fields when source not contains meta fields

### Change Logs

When source row in HoodieInternalRow not contains meta fields, HoodieInternalRow#numFields will return size of source row. We expect it return size of source row + num of meta fields

### Impact

None. There is no code to use HoodieInternalRow that not contains meta fields. But it is a potential bug.

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
