### PR TITLE
[HUDI-4721] Revert "[HUDI-3669] Add a remote request retry mechanism for 'RemoteHoodietablefiles… (#5884)"

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -117,11 +117,6 @@ public class EmbeddedTimelineService {
         .withRemoteServerHost(hostAddr)
         .withRemoteServerPort(serverPort)
         .withRemoteTimelineClientTimeoutSecs(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientTimeoutSecs())
-        .withRemoteTimelineClientRetry(writeConfig.getClientSpecifiedViewStorageConfig().isRemoteTimelineClientRetryEnabled())
-        .withRemoteTimelineClientMaxRetryNumbers(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientMaxRetryNumbers())
-        .withRemoteTimelineInitialRetryIntervalMs(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineInitialRetryIntervalMs())
-        .withRemoteTimelineClientMaxRetryIntervalMs(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientMaxRetryIntervalMs())
-        .withRemoteTimelineClientRetryExceptions(writeConfig.getClientSpecifiedViewStorageConfig().getRemoteTimelineClientRetryExceptions())
         .build();
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
@@ -214,7 +214,8 @@ public class FileSystemViewManager {
     LOG.info("Creating remote view for basePath " + metaClient.getBasePath() + ". Server="
         + viewConf.getRemoteViewServerHost() + ":" + viewConf.getRemoteViewServerPort() + ", Timeout="
         + viewConf.getRemoteTimelineClientTimeoutSecs());
-    return new RemoteHoodieTableFileSystemView(metaClient, viewConf);
+    return new RemoteHoodieTableFileSystemView(viewConf.getRemoteViewServerHost(), viewConf.getRemoteViewServerPort(),
+        metaClient, viewConf.getRemoteTimelineClientTimeoutSecs());
   }
 
   public static FileSystemViewManager createViewManager(final HoodieEngineContext context,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -110,37 +110,6 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
       .defaultValue(5 * 60) // 5 min
       .withDocumentation("Timeout in seconds, to wait for API requests against a remote file system view. e.g timeline server.");
 
-  public static final ConfigProperty<String> REMOTE_RETRY_ENABLE = ConfigProperty
-          .key("hoodie.filesystem.view.remote.retry.enable")
-          .defaultValue("false")
-          .sinceVersion("0.12.0")
-          .withDocumentation("Whether to enable API request retry for remote file system view.");
-
-  public static final ConfigProperty<Integer> REMOTE_MAX_RETRY_NUMBERS = ConfigProperty
-      .key("hoodie.filesystem.view.remote.retry.max_numbers")
-      .defaultValue(3) // 3 times
-      .sinceVersion("0.12.0")
-      .withDocumentation("Maximum number of retry for API requests against a remote file system view. e.g timeline server.");
-
-  public static final ConfigProperty<Long> REMOTE_INITIAL_RETRY_INTERVAL_MS = ConfigProperty
-      .key("hoodie.filesystem.view.remote.retry.initial_interval_ms")
-      .defaultValue(100L)
-      .sinceVersion("0.12.0")
-      .withDocumentation("Amount of time (in ms) to wait, before retry to do operations on storage.");
-
-  public static final ConfigProperty<Long> REMOTE_MAX_RETRY_INTERVAL_MS = ConfigProperty
-      .key("hoodie.filesystem.view.remote.retry.max_interval_ms")
-      .defaultValue(2000L)
-      .sinceVersion("0.12.0")
-      .withDocumentation("Maximum amount of time (in ms), to wait for next retry.");
-
-  public static final ConfigProperty<String> RETRY_EXCEPTIONS = ConfigProperty
-          .key("hoodie.filesystem.view.remote.retry.exceptions")
-          .defaultValue("")
-          .sinceVersion("0.12.0")
-          .withDocumentation("The class name of the Exception that needs to be re-tryed, separated by commas. "
-                  + "Default is empty which means retry all the IOException and RuntimeException from Remote Request.");
-
   public static final ConfigProperty<String> REMOTE_BACKUP_VIEW_ENABLE = ConfigProperty
       .key("hoodie.filesystem.remote.backup.view.enable")
       .defaultValue("true") // Need to be disabled only for tests.
@@ -173,26 +142,6 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
   public Integer getRemoteTimelineClientTimeoutSecs() {
     return getInt(REMOTE_TIMEOUT_SECS);
-  }
-
-  public boolean isRemoteTimelineClientRetryEnabled() {
-    return getBoolean(REMOTE_RETRY_ENABLE);
-  }
-
-  public Integer getRemoteTimelineClientMaxRetryNumbers() {
-    return getInt(REMOTE_MAX_RETRY_NUMBERS);
-  }
-
-  public Long getRemoteTimelineInitialRetryIntervalMs() {
-    return getLong(REMOTE_INITIAL_RETRY_INTERVAL_MS);
-  }
-
-  public Long getRemoteTimelineClientMaxRetryIntervalMs() {
-    return getLong(REMOTE_MAX_RETRY_INTERVAL_MS);
-  }
-
-  public String getRemoteTimelineClientRetryExceptions() {
-    return getString(RETRY_EXCEPTIONS);
   }
 
   public long getMaxMemoryForFileGroupMap() {
@@ -293,31 +242,6 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
 
     public Builder withRemoteTimelineClientTimeoutSecs(Integer timelineClientTimeoutSecs) {
       fileSystemViewStorageConfig.setValue(REMOTE_TIMEOUT_SECS, timelineClientTimeoutSecs.toString());
-      return this;
-    }
-
-    public Builder withRemoteTimelineClientRetry(boolean enableRetry) {
-      fileSystemViewStorageConfig.setValue(REMOTE_RETRY_ENABLE, Boolean.toString(enableRetry));
-      return this;
-    }
-
-    public Builder withRemoteTimelineClientMaxRetryNumbers(Integer maxRetryNumbers) {
-      fileSystemViewStorageConfig.setValue(REMOTE_MAX_RETRY_NUMBERS, maxRetryNumbers.toString());
-      return this;
-    }
-
-    public Builder withRemoteTimelineInitialRetryIntervalMs(Long initialRetryIntervalMs) {
-      fileSystemViewStorageConfig.setValue(REMOTE_INITIAL_RETRY_INTERVAL_MS, initialRetryIntervalMs.toString());
-      return this;
-    }
-
-    public Builder withRemoteTimelineClientMaxRetryIntervalMs(Long maxRetryIntervalMs) {
-      fileSystemViewStorageConfig.setValue(REMOTE_MAX_RETRY_INTERVAL_MS, maxRetryIntervalMs.toString());
-      return this;
-    }
-
-    public Builder withRemoteTimelineClientRetryExceptions(String retryExceptions) {
-      fileSystemViewStorageConfig.setValue(RETRY_EXCEPTIONS, retryExceptions);
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -39,7 +39,6 @@ import org.apache.hudi.common.table.timeline.dto.FileSliceDTO;
 import org.apache.hudi.common.table.timeline.dto.InstantDTO;
 import org.apache.hudi.common.table.timeline.dto.TimelineDTO;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.RetryHelper;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -133,35 +132,22 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
   private boolean closed = false;
 
-  private RetryHelper<Response> retryHelper;
-
-  private final HttpRequestCheckedFunction urlCheckedFunc;
-
   private enum RequestMethod {
     GET, POST
   }
 
   public RemoteHoodieTableFileSystemView(String server, int port, HoodieTableMetaClient metaClient) {
-    this(metaClient, FileSystemViewStorageConfig.newBuilder().withRemoteServerHost(server).withRemoteServerPort(port).build());
+    this(server, port, metaClient, 300);
   }
 
-  public RemoteHoodieTableFileSystemView(HoodieTableMetaClient metaClient, FileSystemViewStorageConfig viewConf) {
+  public RemoteHoodieTableFileSystemView(String server, int port, HoodieTableMetaClient metaClient, int timeoutSecs) {
     this.basePath = metaClient.getBasePath();
+    this.serverHost = server;
+    this.serverPort = port;
     this.mapper = new ObjectMapper();
     this.metaClient = metaClient;
     this.timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
-    this.serverHost = viewConf.getRemoteViewServerHost();
-    this.serverPort = viewConf.getRemoteViewServerPort();
-    this.timeoutSecs = viewConf.getRemoteTimelineClientTimeoutSecs();
-    this.urlCheckedFunc = new HttpRequestCheckedFunction(this.timeoutSecs * 1000);
-    if (viewConf.isRemoteTimelineClientRetryEnabled()) {
-      retryHelper =  new RetryHelper(
-              viewConf.getRemoteTimelineClientMaxRetryIntervalMs(),
-              viewConf.getRemoteTimelineClientMaxRetryNumbers(),
-              viewConf.getRemoteTimelineInitialRetryIntervalMs(),
-              viewConf.getRemoteTimelineClientRetryExceptions(),
-              "Sending request");
-    }
+    this.timeoutSecs = timeoutSecs;
   }
 
   private <T> T executeRequest(String requestPath, Map<String, String> queryParameters, TypeReference reference,
@@ -179,9 +165,17 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
 
     String url = builder.toString();
     LOG.info("Sending request : (" + url + ")");
-    // Reset url and method, to avoid repeatedly instantiating objects.
-    urlCheckedFunc.setUrlAndMethod(url, method);
-    Response response =  retryHelper != null ? retryHelper.tryWith(urlCheckedFunc).start() : urlCheckedFunc.get();
+    Response response;
+    int timeout = this.timeoutSecs * 1000; // msec
+    switch (method) {
+      case GET:
+        response = Request.Get(url).connectTimeout(timeout).socketTimeout(timeout).execute();
+        break;
+      case POST:
+      default:
+        response = Request.Post(url).connectTimeout(timeout).socketTimeout(timeout).execute();
+        break;
+    }
     String content = response.returnContent().asString();
     return (T) mapper.readValue(content, reference);
   }
@@ -499,35 +493,6 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
       return Option.fromJavaOptional(dataFiles.stream().map(BaseFileDTO::toHoodieBaseFile).findFirst());
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
-    }
-  }
-
-  /**
-   * For remote HTTP requests, to avoid repeatedly instantiating objects.
-   */
-  private class HttpRequestCheckedFunction implements RetryHelper.CheckedFunction<Response> {
-    private String url;
-    private RequestMethod method;
-    private final int timeoutMs;
-
-    public void setUrlAndMethod(String url, RequestMethod method) {
-      this.method = method;
-      this.url = url;
-    }
-    
-    public HttpRequestCheckedFunction(int timeoutMs) {
-      this.timeoutMs = timeoutMs;
-    }
-
-    @Override
-    public Response get() throws IOException {
-      switch (method) {
-        case GET:
-          return Request.Get(url).connectTimeout(timeoutMs).socketTimeout(timeoutMs).execute();
-        case POST:
-        default:
-          return Request.Post(url).connectTimeout(timeoutMs).socketTimeout(timeoutMs).execute();
-      }
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -429,11 +429,6 @@ public class StreamerUtil {
         .withRemoteServerHost(viewStorageConfig.getRemoteViewServerHost())
         .withRemoteServerPort(viewStorageConfig.getRemoteViewServerPort())
         .withRemoteTimelineClientTimeoutSecs(viewStorageConfig.getRemoteTimelineClientTimeoutSecs())
-        .withRemoteTimelineClientRetry(viewStorageConfig.isRemoteTimelineClientRetryEnabled())
-        .withRemoteTimelineClientMaxRetryNumbers(viewStorageConfig.getRemoteTimelineClientMaxRetryNumbers())
-        .withRemoteTimelineInitialRetryIntervalMs(viewStorageConfig.getRemoteTimelineInitialRetryIntervalMs())
-        .withRemoteTimelineClientMaxRetryIntervalMs(viewStorageConfig.getRemoteTimelineClientMaxRetryIntervalMs())
-        .withRemoteTimelineClientRetryExceptions(viewStorageConfig.getRemoteTimelineClientRetryExceptions())
         .build();
     ViewStorageProperties.createProperties(conf.getString(FlinkOptions.PATH), rebuilt, conf);
     return writeClient;

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -28,14 +28,12 @@ import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.table.view.TestHoodieTableFileSystemView;
-import org.apache.hudi.exception.HoodieRemoteException;
 import org.apache.hudi.timeline.service.TimelineService;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.junit.jupiter.api.Test;
 
 /**
  * Bring up a remote Timeline Server and run all test-cases of TestHoodieTableFileSystemView against it.
@@ -65,32 +63,5 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
     LOG.info("Connecting to Timeline Server :" + server.getServerPort());
     view = new RemoteHoodieTableFileSystemView("localhost", server.getServerPort(), metaClient);
     return view;
-  }
-
-  @Test
-  public void testRemoteHoodieTableFileSystemViewWithRetry() {
-    // Service is available.
-    view.getLatestBaseFiles();
-    // Shut down the service.
-    server.close();
-    try {
-      // Immediately fails and throws a connection refused exception.
-      view.getLatestBaseFiles();
-    } catch (HoodieRemoteException e) {
-      assert e.getMessage().contains("Connection refused (Connection refused)");
-    }
-    // Enable API request retry for remote file system view.
-    view =  new RemoteHoodieTableFileSystemView(metaClient, FileSystemViewStorageConfig
-            .newBuilder()
-            .withRemoteServerHost("localhost")
-            .withRemoteServerPort(server.getServerPort())
-            .withRemoteTimelineClientRetry(true)
-            .withRemoteTimelineClientMaxRetryNumbers(4)
-            .build());
-    try {
-      view.getLatestBaseFiles();
-    } catch (HoodieRemoteException e) {
-      assert e.getMessage().equalsIgnoreCase("Still failed to Sending request after retried 4 times.");
-    }
   }
 }


### PR DESCRIPTION
This reverts commit 660177bce1cd82975d7c25715497e0d2fbb2a95e.

### Change Logs

Some [thread safety issues](https://github.com/apache/hudi/pull/5884/files#r955363946) are deducted w/ this feature added. Reverting it for now. I will let the author put up a new patch w/ proper fix. 

### Impact

Could result in wrong data being served. Should not be an issue w/ SparkEngineContext. But java and flink could be impacted since in Spark, remoteFSView requests are triggered by executors. 

**Risk level: high**

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
