### PR TITLE
[HUDI-4722] Added locking metrics for Hudi

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -48,7 +48,7 @@ public class LockManager implements Serializable, AutoCloseable {
   private final SerializableConfiguration hadoopConf;
   private final int maxRetries;
   private final long maxWaitTimeInMs;
-  private HoodieLockMetrics metrics;
+  private transient HoodieLockMetrics metrics;
   private volatile LockProvider lockProvider;
 
   public LockManager(HoodieWriteConfig writeConfig, FileSystem fs) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -73,7 +73,6 @@ public class LockManager implements Serializable, AutoCloseable {
           acquired = lockProvider.tryLock(writeConfig.getLockAcquireWaitTimeoutInMs(), TimeUnit.MILLISECONDS);
           if (acquired) {
             metrics.updateLockAcquiredMetric();
-            metrics.startLockHeldTimerContext();
             break;
           }
           metrics.updateLockNotAcquiredMetric();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -80,6 +80,7 @@ public class LockManager implements Serializable, AutoCloseable {
           LOG.info("Retrying to acquire lock...");
           Thread.sleep(maxWaitTimeInMs);
         } catch (HoodieLockException | InterruptedException e) {
+          metrics.updateLockNotAcquiredMetric();
           if (retryCount >= maxRetries) {
             throw new HoodieLockException("Unable to acquire lock, lock object ", e);
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.transaction.lock.metrics;
+
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metrics.Metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SlidingWindowReservoir;
+import com.codahale.metrics.Timer;
+
+import java.util.concurrent.TimeUnit;
+
+public class HoodieLockMetrics {
+
+  private final HoodieWriteConfig writeConfig;
+  private final boolean isMetricsEnabled;
+  private final int keepLastNtimes = 100;
+  private final transient HoodieTimer lockDurationTimer = HoodieTimer.create();
+  private final transient HoodieTimer lockApiRequestDurationTimer = HoodieTimer.create();
+  private transient Counter lockAttempts;
+  private transient Counter succesfulLockAttempts;
+  private transient Counter failedLockAttempts;
+  private transient Timer lockDuration;
+  private transient Timer lockApiRequestDuration;
+
+  public HoodieLockMetrics(HoodieWriteConfig writeConfig) {
+    this.isMetricsEnabled = writeConfig.isMetricsOn();
+    this.writeConfig = writeConfig;
+
+    if (writeConfig.isMetricsOn()) {
+      Metrics.init(writeConfig);
+      MetricRegistry registry = Metrics.getInstance().getRegistry();
+
+      lockAttempts = registry.counter(getMetricsName("acquire.attempts.count"));
+      succesfulLockAttempts = registry.counter(getMetricsName("acquire.success.count"));
+      failedLockAttempts = registry.counter(getMetricsName("acquire.failure.count"));
+
+      lockDuration = createTimerForMetrics(registry, "acquire.duration");
+      lockApiRequestDuration = createTimerForMetrics(registry, "request.latency");
+    }
+  }
+
+  private String getMetricsName(String metric) {
+    return writeConfig == null ? null : String.format("%s.%s.%s", writeConfig.getMetricReporterMetricsNamePrefix(), "lock", metric);
+  }
+
+  private Timer createTimerForMetrics(MetricRegistry registry, String metric) {
+    String metricName = getMetricsName(metric);
+    if (registry.getMetrics().get(metricName) == null) {
+      lockDuration = new Timer(new SlidingWindowReservoir(keepLastNtimes));
+      registry.register(metricName, lockDuration);
+      return lockDuration;
+    }
+    return (Timer) registry.getMetrics().get(metricName);
+  }
+
+  public void startLockApiTimerContext() {
+    if (isMetricsEnabled) {
+      lockApiRequestDurationTimer.startTimer();
+    }
+  }
+
+  public void updateLockAcquiredMetric() {
+    if (isMetricsEnabled) {
+      long duration = lockApiRequestDurationTimer.endTimer();
+      lockApiRequestDuration.update(duration, TimeUnit.MILLISECONDS);
+      lockAttempts.inc();
+    }
+  }
+
+  public void startLockHeldTimerContext() {
+    if (isMetricsEnabled) {
+      succesfulLockAttempts.inc();
+      lockDurationTimer.startTimer();
+    }
+  }
+
+  public void updateLockNotAcquiredMetric() {
+    if (isMetricsEnabled) {
+      long duration = lockApiRequestDurationTimer.endTimer();
+      lockApiRequestDuration.update(duration, TimeUnit.MILLISECONDS);
+      failedLockAttempts.inc();
+    }
+  }
+
+  public void updateLockHeldTimerMetrics() {
+    if (isMetricsEnabled && lockDurationTimer != null) {
+      long lockDurationInMs = lockDurationTimer.endTimer();
+      lockDuration.update(lockDurationInMs, TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
@@ -43,16 +43,16 @@ public class HoodieLockMetrics {
   private transient Timer lockApiRequestDuration;
 
   public HoodieLockMetrics(HoodieWriteConfig writeConfig) {
-    this.isMetricsEnabled = writeConfig.isMetricsOn();
+    this.isMetricsEnabled = writeConfig.isMetricsOn() && writeConfig.isLockingMetricsEnabled();
     this.writeConfig = writeConfig;
 
-    if (writeConfig.isMetricsOn() && writeConfig.isLockingMetricsEnabled()) {
+    if (isMetricsEnabled) {
       Metrics.init(writeConfig);
       MetricRegistry registry = Metrics.getInstance().getRegistry();
 
-      lockAttempts = registry.counter(getMetricsName("acquire.attempts.count"));
-      succesfulLockAttempts = registry.counter(getMetricsName("acquire.success.count"));
-      failedLockAttempts = registry.counter(getMetricsName("acquire.failure.count"));
+      lockAttempts = registry.counter(getMetricsName("acquire.attempts"));
+      succesfulLockAttempts = registry.counter(getMetricsName("acquire.success"));
+      failedLockAttempts = registry.counter(getMetricsName("acquire.failure"));
 
       lockDuration = createTimerForMetrics(registry, "acquire.duration");
       lockApiRequestDuration = createTimerForMetrics(registry, "request.latency");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
@@ -52,7 +52,6 @@ public class HoodieLockMetrics {
     this.writeConfig = writeConfig;
 
     if (isMetricsEnabled) {
-      Metrics.init(writeConfig);
       MetricRegistry registry = Metrics.getInstance().getRegistry();
 
       lockAttempts = registry.counter(getMetricsName(LOCK_ACQUIRE_ATTEMPTS_COUNTER_NAME));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
@@ -43,7 +43,7 @@ public class HoodieLockMetrics {
   private transient Timer lockApiRequestDuration;
 
   public HoodieLockMetrics(HoodieWriteConfig writeConfig) {
-    this.isMetricsEnabled = writeConfig.isMetricsOn() && writeConfig.isLockingMetricsEnabled();
+    this.isMetricsEnabled = writeConfig.isLockingMetricsEnabled();
     this.writeConfig = writeConfig;
 
     if (isMetricsEnabled) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
@@ -46,7 +46,7 @@ public class HoodieLockMetrics {
     this.isMetricsEnabled = writeConfig.isMetricsOn();
     this.writeConfig = writeConfig;
 
-    if (writeConfig.isMetricsOn()) {
+    if (writeConfig.isMetricsOn() && writeConfig.isLockingMetricsEnabled()) {
       Metrics.init(writeConfig);
       MetricRegistry registry = Metrics.getInstance().getRegistry();
 
@@ -81,8 +81,8 @@ public class HoodieLockMetrics {
 
   public void updateLockAcquiredMetric() {
     if (isMetricsEnabled) {
-      long duration = lockApiRequestDurationTimer.endTimer();
-      lockApiRequestDuration.update(duration, TimeUnit.MILLISECONDS);
+      long durationMs = lockApiRequestDurationTimer.endTimer();
+      lockApiRequestDuration.update(durationMs, TimeUnit.MILLISECONDS);
       lockAttempts.inc();
     }
   }
@@ -96,8 +96,8 @@ public class HoodieLockMetrics {
 
   public void updateLockNotAcquiredMetric() {
     if (isMetricsEnabled) {
-      long duration = lockApiRequestDurationTimer.endTimer();
-      lockApiRequestDuration.update(duration, TimeUnit.MILLISECONDS);
+      long durationMs = lockApiRequestDurationTimer.endTimer();
+      lockApiRequestDuration.update(durationMs, TimeUnit.MILLISECONDS);
       failedLockAttempts.inc();
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1745,6 +1745,10 @@ public class HoodieWriteConfig extends HoodieConfig {
         getStringOrDefault(HoodieMetricsConfig.EXECUTOR_METRICS_ENABLE, "false"));
   }
 
+  public boolean isLockingMetricsEnabled() {
+    return getBoolean(HoodieMetricsConfig.LOCK_METRICS_ENABLE);
+  }
+
   public MetricsReporterType getMetricsReporterType() {
     return MetricsReporterType.valueOf(getString(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE));
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -83,6 +83,11 @@ public class HoodieMetricsConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("");
 
+  public static final ConfigProperty<Boolean> LOCK_METRICS_ENABLE = ConfigProperty
+      .key(METRIC_PREFIX + ".lock.enable")
+      .defaultValue(false)
+      .withDocumentation("Enable metrics for locking infra. Unseful when operating in multiwriter mode");
+
   /**
    * @deprecated Use {@link #TURN_METRICS_ON} and its methods instead
    */
@@ -160,6 +165,11 @@ public class HoodieMetricsConfig extends HoodieConfig {
 
     public Builder withExecutorMetrics(boolean enable) {
       hoodieMetricsConfig.setValue(EXECUTOR_METRICS_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withLockingMetrics(boolean enable) {
+      hoodieMetricsConfig.setValue(LOCK_METRICS_ENABLE, String.valueOf(enable));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -86,7 +86,13 @@ public class HoodieMetricsConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> LOCK_METRICS_ENABLE = ConfigProperty
       .key(METRIC_PREFIX + ".lock.enable")
       .defaultValue(false)
-      .withDocumentation("Enable metrics for locking infra. Unseful when operating in multiwriter mode");
+      .withInferFunction(cfg -> {
+        if (cfg.contains(TURN_METRICS_ON)) {
+          return Option.of(cfg.getBoolean(TURN_METRICS_ON));
+        }
+        return Option.empty();
+      })
+      .withDocumentation("Enable metrics for locking infra. Useful when operating in multiwriter mode");
 
   /**
    * @deprecated Use {@link #TURN_METRICS_ON} and its methods instead

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -244,4 +244,18 @@ public class HoodieMetrics {
   public long getDurationInMs(long ctxDuration) {
     return ctxDuration / 1000000;
   }
+
+  public void emitConflictResolutionSuccessful() {
+    if (config.isMetricsOn()) {
+      LOG.info("Sending conflict resolution success metric");
+      Metrics.registerGauge(getMetricsName("resolve", "conflict.success.count"), 1);
+    }
+  }
+
+  public void emitConflictResolutionFailed() {
+    if (config.isMetricsOn()) {
+      LOG.info("Sending conflict resolution failed metric");
+      Metrics.registerGauge(getMetricsName("resolve", "conflict.failure.count"), 1);
+    }
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -141,7 +141,7 @@ public class HoodieMetrics {
   }
 
   public Timer.Context getConflictResolutionCtx() {
-    if (config.isMetricsOn() && conflictResolutionTimer == null) {
+    if (config.isLockingMetricsEnabled() && conflictResolutionTimer == null) {
       conflictResolutionTimer = createTimer(conflictResolutionTimerName);
     }
     return conflictResolutionTimer == null ? null : conflictResolutionTimer.time();
@@ -263,7 +263,7 @@ public class HoodieMetrics {
   }
 
   public void emitConflictResolutionSuccessful() {
-    if (config.isMetricsOn()) {
+    if (config.isLockingMetricsEnabled()) {
       LOG.info("Sending conflict resolution success metric");
       conflictResolutionSuccessCounter = getCounter(conflictResolutionSuccessCounter, conflictResolutionSuccessCounterName);
       conflictResolutionSuccessCounter.inc();
@@ -271,7 +271,7 @@ public class HoodieMetrics {
   }
 
   public void emitConflictResolutionFailed() {
-    if (config.isMetricsOn()) {
+    if (config.isLockingMetricsEnabled()) {
       LOG.info("Sending conflict resolution failure metric");
       conflictResolutionFailureCounter = getCounter(conflictResolutionFailureCounter, conflictResolutionFailureCounterName);
       conflictResolutionFailureCounter.inc();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -43,6 +43,7 @@ public class HoodieMetrics {
   public String finalizeTimerName = null;
   public String compactionTimerName = null;
   public String indexTimerName = null;
+  private String conflictResolutionTimerName = null;
   private HoodieWriteConfig config;
   private String tableName;
   private Timer rollbackTimer = null;
@@ -53,6 +54,7 @@ public class HoodieMetrics {
   private Timer compactionTimer = null;
   private Timer clusteringTimer = null;
   private Timer indexTimer = null;
+  private Timer conflictResolutionTimer = null;
 
   public HoodieMetrics(HoodieWriteConfig config) {
     this.config = config;
@@ -67,6 +69,7 @@ public class HoodieMetrics {
       this.finalizeTimerName = getMetricsName("timer", "finalize");
       this.compactionTimerName = getMetricsName("timer", HoodieTimeline.COMPACTION_ACTION);
       this.indexTimerName = getMetricsName("timer", "index");
+      this.conflictResolutionTimerName = getMetricsName("timer", "conflict_resolution");
     }
   }
 
@@ -128,6 +131,13 @@ public class HoodieMetrics {
       indexTimer = createTimer(indexTimerName);
     }
     return indexTimer == null ? null : indexTimer.time();
+  }
+
+  public Timer.Context getConflictResolutionCtx() {
+    if (config.isMetricsOn() && conflictResolutionTimer == null) {
+      conflictResolutionTimer = createTimer(conflictResolutionTimerName);
+    }
+    return conflictResolutionTimer == null ? null : conflictResolutionTimer.time();
   }
 
   public void updateMetricsForEmptyData(String actionType) {
@@ -231,6 +241,13 @@ public class HoodieMetrics {
     if (config.isMetricsOn()) {
       LOG.info(String.format("Sending index metrics (%s.duration, %d)", action, durationInMs));
       Metrics.registerGauge(getMetricsName("index", String.format("%s.duration", action)), durationInMs);
+    }
+  }
+
+  public void updateConflictResolutionMetrics(final String action, final long durationInMs) {
+    if (config.isMetricsOn()) {
+      LOG.info(String.format("Sending index metrics (%s.duration, %d)", action, durationInMs));
+      Metrics.registerGauge(getMetricsName("conflict_resolution", String.format("%s.duration", action)), durationInMs);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -470,7 +470,9 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
       metrics.emitConflictResolutionFailed();
       throw e;
     } finally {
-      metrics.updateConflictResolutionMetrics("pre_commit", metrics.getDurationInMs(indexTimer == null ? 0 : indexTimer.stop()));
+      if (indexTimer != null) {
+        indexTimer.stop();
+      }
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -461,7 +461,7 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
     // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
     // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
     HoodieTable table = createTable(config, hadoopConf);
-    Timer.Context indexTimer = metrics.getConflictResolutionCtx();
+    Timer.Context conflictResolutionTimer = metrics.getConflictResolutionCtx();
     try {
       TransactionUtils.resolveWriteConflictIfAny(table, this.txnManager.getCurrentTransactionOwner(),
           Option.of(metadata), config, txnManager.getLastCompletedTransactionOwner(), false, this.pendingInflightAndRequestedInstants);
@@ -470,8 +470,8 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
       metrics.emitConflictResolutionFailed();
       throw e;
     } finally {
-      if (indexTimer != null) {
-        indexTimer.stop();
+      if (conflictResolutionTimer != null) {
+        conflictResolutionTimer.stop();
       }
     }
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -41,6 +41,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieClusteringException;
+import org.apache.hudi.exception.HoodieWriteConflictException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.SparkHoodieIndexFactory;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
@@ -460,8 +461,14 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
     // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
     // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
     HoodieTable table = createTable(config, hadoopConf);
-    TransactionUtils.resolveWriteConflictIfAny(table, this.txnManager.getCurrentTransactionOwner(),
-        Option.of(metadata), config, txnManager.getLastCompletedTransactionOwner(), false, this.pendingInflightAndRequestedInstants);
+    try {
+      TransactionUtils.resolveWriteConflictIfAny(table, this.txnManager.getCurrentTransactionOwner(),
+          Option.of(metadata), config, txnManager.getLastCompletedTransactionOwner(), false, this.pendingInflightAndRequestedInstants);
+      metrics.emitConflictResolutionSuccessful();
+    } catch (HoodieWriteConflictException e) {
+      metrics.emitConflictResolutionFailed();
+      throw e;
+    }
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

Added metrics for the following for the locking infra

1. Lock request latency
2. Count of Lock success
3. Count of failed to acquire the lock
4. Duration of locks held with support for re-entrancy
5. Conflict resolution metrics. Success vs Failure
6. Conflict resolution times.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
