### PR TITLE
[HUDI-4764] AWS GlueSync turn partition already exist error into warning

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -138,9 +138,9 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
         BatchCreatePartitionResult result = awsGlue.batchCreatePartition(request);
         if (CollectionUtils.nonEmpty(result.getErrors())) {
-          if(result.getErrors().stream().allMatch((error) -> "AlreadyExistsException".equals(error.getErrorDetail().getErrorCode()))){
+          if (result.getErrors().stream().allMatch((error) -> "AlreadyExistsException".equals(error.getErrorDetail().getErrorCode()))) {
             LOG.warn("Partitions already exist in glue: " + result.getErrors());
-          } else{
+          }else {
             throw new HoodieGlueSyncException("Fail to add partitions to " + tableId(databaseName, tableName)
               + " with error(s): " + result.getErrors());
           }

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -140,7 +140,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         if (CollectionUtils.nonEmpty(result.getErrors())) {
           if (result.getErrors().stream().allMatch((error) -> "AlreadyExistsException".equals(error.getErrorDetail().getErrorCode()))) {
             LOG.warn("Partitions already exist in glue: " + result.getErrors());
-          }else {
+          } else {
             throw new HoodieGlueSyncException("Fail to add partitions to " + tableId(databaseName, tableName)
               + " with error(s): " + result.getErrors());
           }

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -138,8 +138,12 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
         BatchCreatePartitionResult result = awsGlue.batchCreatePartition(request);
         if (CollectionUtils.nonEmpty(result.getErrors())) {
-          throw new HoodieGlueSyncException("Fail to add partitions to " + tableId(databaseName, tableName)
+          if(result.getErrors().stream().allMatch((error) -> "AlreadyExistsException".equals(error.getErrorDetail().getErrorCode()))){
+            LOG.warn("Partitions already exist in glue: " + result.getErrors());
+          } else{
+            throw new HoodieGlueSyncException("Fail to add partitions to " + tableId(databaseName, tableName)
               + " with error(s): " + result.getErrors());
+          }
         }
         Thread.sleep(BATCH_REQUEST_SLEEP_MILLIS);
       }


### PR DESCRIPTION
### Change Logs

This avoids the sync to fail when likely concurrent sync happens or other cases 
fixes #5960 


### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
