### PR TITLE
[HUDI-4763] Allow hoodie read client to choose index

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
@@ -93,6 +93,18 @@ public class HoodieReadClient<T extends HoodieRecordPayload<T>> implements Seria
   }
 
   /**
+   * @param context
+   * @param basePath
+   * @param sqlContext
+   * @param indexType
+   */
+  public HoodieReadClient( HoodieSparkEngineContext context, String basePath, SQLContext sqlContext, HoodieIndex.IndexType indexType) {
+    this(context, HoodieWriteConfig.newBuilder() .withPath(basePath)
+                       .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(indexType).build()).build());
+    this.sqlContextOpt = Option.of(sqlContext);
+  }
+
+  /**
    * @param clientConfig instance of HoodieWriteConfig
    */
   public HoodieReadClient(HoodieSparkEngineContext context, HoodieWriteConfig clientConfig) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
@@ -98,8 +98,8 @@ public class HoodieReadClient<T extends HoodieRecordPayload<T>> implements Seria
    * @param sqlContext
    * @param indexType
    */
-  public HoodieReadClient( HoodieSparkEngineContext context, String basePath, SQLContext sqlContext, HoodieIndex.IndexType indexType) {
-    this(context, HoodieWriteConfig.newBuilder() .withPath(basePath)
+  public HoodieReadClient(HoodieSparkEngineContext context, String basePath, SQLContext sqlContext, HoodieIndex.IndexType indexType) {
+    this(context, HoodieWriteConfig.newBuilder().withPath(basePath)
                        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(indexType).build()).build());
     this.sqlContextOpt = Option.of(sqlContext);
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/HoodieReadClient.java
@@ -93,10 +93,12 @@ public class HoodieReadClient<T extends HoodieRecordPayload<T>> implements Seria
   }
 
   /**
-   * @param context
-   * @param basePath
-   * @param sqlContext
-   * @param indexType
+   * Initializes the {@link HoodieReadClient} with engine context, base path, SQL context and index type.
+   *
+   * @param context    Hudi Spark engine context
+   * @param basePath   Base path of the table
+   * @param sqlContext {@link SQLContext} instance
+   * @param indexType  Hudi index type
    */
   public HoodieReadClient(HoodieSparkEngineContext context, String basePath, SQLContext sqlContext, HoodieIndex.IndexType indexType) {
     this(context, HoodieWriteConfig.newBuilder().withPath(basePath)


### PR DESCRIPTION
### Change Logs

Currently the hudi read client use BLOOM and this cannot be overwriten. This allows to use GLOBAL_BLOOM
and provides fast lookup on the primary key (without partition keys)

```
    HudiReadClient client =
        new HudiReadClient(context, path, spark.sqlContext(), GLOBAL_BLOOM);
   client.readROView(keyRdd, 200);

```

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
