### PR TITLE
[HUDI-4237] should not sync partition parameters when create non-partition table in spark

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -190,12 +190,14 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
     } else {
       val (recordName, namespace) = AvroConversionUtils.getAvroRecordNameAndNamespace(table.identifier.table)
       val schema = SchemaConverters.toAvroType(finalSchema, false, recordName, namespace)
+      val partitionColumns = if (table.partitionColumnNames.isEmpty) null else table.partitionColumnNames.mkString(",")
+
       HoodieTableMetaClient.withPropertyBuilder()
         .fromProperties(properties)
         .setDatabaseName(catalogDatabaseName)
         .setTableName(table.identifier.table)
         .setTableCreateSchema(schema.toString())
-        .setPartitionFields(table.partitionColumnNames.mkString(","))
+        .setPartitionFields(partitionColumns)
         .initTable(hadoopConf, tableLocation)
     }
   }


### PR DESCRIPTION
### issue description

Create a non-partition hudi table in Spark，it will store spark.sql.sources.schema.partCol.0 with an empty value in hiveMetastore.  This is unexpected behavior, it should not store  spark.sql.sources.schema.partCol.0 in HiveMetastore when it is a non-partition table.

Steps to reproduce the behavior:
1. Create a non-partition hudi table in Spark
```
create table hudi_mor_tbl (
id int,
name string,
price double,
ts bigint
) using hudi
tblproperties (
type = 'mor',
primaryKey = 'id',
preCombineField = 'ts'
） 
```
2. insert data one row to it.
```
insert into hudi_mor_tbl select 1, 'a1', 20, 1000; 
```
3. cat hoodie.properties in table's base path,
it include partition.fields key with an empty value
```
hoodie.table.partition.fields=
 ```
4. check spark.sql.sources.schema.partCol.0 that stored in table TABLE_PARAMS of the HiveMetaStore .
```
|50|spark.sql.sources.schema.partCol.0|
 ```
it has a value "".


### Change Logs
When init a non-partition hoodie table, should set PartitionFields as null instead of empty string "".
Then after sync table meta to hiveMetaStore, it will not store spark.sql.sources.schema.partCol.

### Impact

fix the bug when create non-partition table in spark
more detail see jira https://issues.apache.org/jira/browse/HUDI-4237
**Risk level: none | low | medium | high**

low

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
