### PR TITLE
[HUDI-4193] change protoc version so it compiles on m1 mac

### DIFF
--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.4</version>
+                <version>${protoc.version}</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>${protoc.version}</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <antlr.version>4.7</antlr.version>
     <aws.sdk.version>1.12.22</aws.sdk.version>
     <proto.version>3.17.3</proto.version>
-    <protoc.version>3.17.3</protoc.version>
+    <protoc.version>3.11.4</protoc.version>
     <dynamodb.lockclient.version>1.1.0</dynamodb.lockclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <dynamodb-local.port>8000</dynamodb-local.port>
@@ -1775,6 +1775,18 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>m1-mac</id>
+      <properties>
+        <protoc.version>3.17.3</protoc.version>
+      </properties>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
     </profile>
     <!-- Exists for backwards compatibility; profile doesn't do anything -->
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <antlr.version>4.7</antlr.version>
     <aws.sdk.version>1.12.22</aws.sdk.version>
     <proto.version>3.17.3</proto.version>
-    <protoc.version>3.11.4</protoc.version>
+    <protoc.version>3.17.3</protoc.version>
     <dynamodb.lockclient.version>1.1.0</dynamodb.lockclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <dynamodb-local.port>8000</dynamodb-local.port>


### PR DESCRIPTION
### Change Logs
Hudi was unable to build on m1 macs. Fix was to add a profile that changes the protoc version. The profile is activated by mac os + aarch64 processor.

### Impact

Able to build on m1 macs, no impact otherwise

**Risk level:  low **

### Contributor's checklist

- [ ✅] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [✅ ] Change Logs and Impact were stated clearly
- [ N/A] Adequate tests were added if applicable
- [ ✅] CI passed
