### PR TITLE
[HUDI-4762] Avoid update metastore schema if only missing column in input

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -286,7 +286,11 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
           config.getBooleanOrDefault(HIVE_SUPPORT_TIMESTAMP_TYPE));
       if (!schemaDiff.isEmpty()) {
         LOG.info("Schema difference found for " + tableName);
-        syncClient.updateTableSchema(tableName, schema);
+        if(!schemaDiff.getAddColumnTypes().isEmpty() || !schemaDiff.getUpdateColumnTypes().isEmpty()){
+          syncClient.updateTableSchema(tableName, schema);
+        }else{
+          LOG.info("Only missing columns, skipping update table schema on" + tableName);
+        }
         // Sync the table properties if the schema has changed
         if (config.getString(HIVE_TABLE_PROPERTIES) != null || config.getBoolean(HIVE_SYNC_AS_DATA_SOURCE_TABLE)) {
           syncClient.updateTableProperties(tableName, tableProperties);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -286,9 +286,9 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
           config.getBooleanOrDefault(HIVE_SUPPORT_TIMESTAMP_TYPE));
       if (!schemaDiff.isEmpty()) {
         LOG.info("Schema difference found for " + tableName);
-        if(!schemaDiff.getAddColumnTypes().isEmpty() || !schemaDiff.getUpdateColumnTypes().isEmpty()){
+        if (!schemaDiff.getAddColumnTypes().isEmpty() || !schemaDiff.getUpdateColumnTypes().isEmpty()) {
           syncClient.updateTableSchema(tableName, schema);
-        }else{
+        } else {
           LOG.info("Only missing columns, skipping update table schema on" + tableName);
         }
         // Sync the table properties if the schema has changed


### PR DESCRIPTION
### Change Logs

Currently when move a hudi table from schema1 to schema2 and then insert data with the old schema1, then schema 2 is kept for the whole table.

This is not consistent with hive metastore which get its schema updated to the old schema1. 

Then this PR avoid update the hive schema when only missing columns are in the input data.

This might only work as proposed here when reconcile = true
see https://hudi.apache.org/docs/configurations#hoodiedatasourcewritereconcileschema

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
