### PR TITLE
[HUDI-4739] Wrong value returned when key's length equals 1

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -73,21 +73,16 @@ public class KeyGenUtils {
    */
   public static String[] extractRecordKeys(String recordKey) {
     String[] fieldKV = recordKey.split(",");
-    if (fieldKV.length == 1) {
-      return fieldKV;
-    } else {
-      // a complex key
-      return Arrays.stream(fieldKV).map(kv -> {
-        final String[] kvArray = kv.split(":");
-        if (kvArray[1].equals(NULL_RECORDKEY_PLACEHOLDER)) {
-          return null;
-        } else if (kvArray[1].equals(EMPTY_RECORDKEY_PLACEHOLDER)) {
-          return "";
-        } else {
-          return kvArray[1];
-        }
-      }).toArray(String[]::new);
-    }
+    return Arrays.stream(fieldKV).map(kv -> {
+      final String[] kvArray = kv.split(":");
+      if (kvArray[1].equals(NULL_RECORDKEY_PLACEHOLDER)) {
+        return null;
+      } else if (kvArray[1].equals(EMPTY_RECORDKEY_PLACEHOLDER)) {
+        return "";
+      } else {
+        return kvArray[1];
+      }
+    }).toArray(String[]::new);
   }
 
   public static String getRecordKey(GenericRecord record, List<String> recordKeyFields, boolean consistentLogicalTimestampEnabled) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/TestKeyGenUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.keygen;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestKeyGenUtils {
+
+  @Test
+  public void testExtractRecordKeys() {
+    String[] s1 = KeyGenUtils.extractRecordKeys("id:1");
+    Assertions.assertArrayEquals(new String[]{"1"}, s1);
+
+    String[] s2 = KeyGenUtils.extractRecordKeys("id:1,id:2");
+    Assertions.assertArrayEquals(new String[]{"1", "2"}, s2);
+
+    String[] s3 = KeyGenUtils.extractRecordKeys("id:1,id2:__null__,id3:__empty__");
+    Assertions.assertArrayEquals(new String[]{"1", null, ""}, s3);
+  }
+}


### PR DESCRIPTION
### Change Logs

Delete the judgment on length.
Because this function needs to return the value corresponding to the key in the recordKey. However, when the length is equal to 1, the entire recordKey is returned.

### Impact

When there is only one primary key, the cdc data read by the user contains the delete type rowdata.

**Risk level: none | low | medium | high**

low

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
