### PR TITLE
[HUDI-4742] Fix AWS Glue partition's location is wrong when updatePartition

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -162,7 +162,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         StorageDescriptor partitionSd = sd.clone();
         String fullPartitionPath = FSUtils.getPartitionPath(getBasePath(), partition).toString();
         List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partition);
-        sd.setLocation(fullPartitionPath);
+        partitionSd.setLocation(fullPartitionPath);
         PartitionInput partitionInput = new PartitionInput().withValues(partitionValues).withStorageDescriptor(partitionSd);
         return new BatchUpdatePartitionRequestEntry().withPartitionInput(partitionInput).withPartitionValueList(partitionValues);
       }).collect(Collectors.toList());


### PR DESCRIPTION
### Change Logs

AWSGlueCatalogSyncClient udpatePartitionsToTable() function
https://issues.apache.org/jira/browse/HUDI-4742

### Impact

If the location is wrong, then the table could not be queried almost, it's a serious bug, when synced to AWS glue

**Risk level: none | low | medium | high**

low

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
