### PR TITLE
[HUDI-4438] Fix flaky TestCopyOnWriteActionExecutor#testPartitionMetafileFormat

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -532,7 +532,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase {
     writeClient.startCommitWithTime(instantTime);
 
     // Insert new records
-    final JavaRDD<HoodieRecord> inputRecords = generateTestRecordsForBulkInsert(jsc, 10);
+    final JavaRDD<HoodieRecord> inputRecords = generateTestRecordsForBulkInsert(jsc, 50);
     writeClient.bulkInsert(inputRecords, instantTime);
 
     // Partition metafile should be created


### PR DESCRIPTION
### Change Logs

Fixed flaky TestCopyOnWriteActionExecutor#testPartitionMetafileFormat. When generating data, test wasn't generating data to all partitions. during validation we validate that partition meta file exists for one of the 3 partitions that HoodieTestDataGenerator generates. 

### Impact

will fix CI stability

**Risk level: low**


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
