### PR TITLE
[HUDI-4751] Fix owner instants for transaction manager api callers

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/InProcessLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/InProcessLockProvider.java
@@ -95,13 +95,13 @@ public class InProcessLockProvider implements LockProvider<ReentrantReadWriteLoc
     try {
       if (LOCK.isWriteLockedByCurrentThread()) {
         LOCK.writeLock().unlock();
+        LOG.info(getLogMessage(LockState.RELEASED));
       } else {
         LOG.warn("Cannot unlock because the current thread does not hold the lock.");
       }
     } catch (Exception e) {
       throw new HoodieLockException(getLogMessage(LockState.FAILED_TO_RELEASE), e);
     }
-    LOG.info(getLogMessage(LockState.RELEASED));
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
@@ -126,9 +126,9 @@ public abstract class BaseRestoreActionExecutor<T extends HoodieRecordPayload, I
 
     HoodieRestoreMetadata restoreMetadata = TimelineMetadataUtils.convertRestoreMetadata(
         instantTime, durationInMs, instantsRolledBack, instantToMetadata);
-    writeToMetadata(restoreMetadata);
-    table.getActiveTimeline().saveAsComplete(new HoodieInstant(true, HoodieTimeline.RESTORE_ACTION, instantTime),
-        TimelineMetadataUtils.serializeRestoreMetadata(restoreMetadata));
+    HoodieInstant restoreInflightInstant = new HoodieInstant(true, HoodieTimeline.RESTORE_ACTION, instantTime);
+    writeToMetadata(restoreMetadata, restoreInflightInstant);
+    table.getActiveTimeline().saveAsComplete(restoreInflightInstant, TimelineMetadataUtils.serializeRestoreMetadata(restoreMetadata));
     // get all pending rollbacks instants after restore instant time and delete them.
     // if not, rollbacks will be considered not completed and might hinder metadata table compaction.
     List<HoodieInstant> instantsToRollback = table.getActiveTimeline().getRollbackTimeline()
@@ -151,12 +151,12 @@ public abstract class BaseRestoreActionExecutor<T extends HoodieRecordPayload, I
    *
    * @param restoreMetadata instance of {@link HoodieRestoreMetadata} to be applied to metadata.
    */
-  private void writeToMetadata(HoodieRestoreMetadata restoreMetadata) {
+  private void writeToMetadata(HoodieRestoreMetadata restoreMetadata, HoodieInstant restoreInflightInstant) {
     try {
-      this.txnManager.beginTransaction(Option.empty(), Option.empty());
+      this.txnManager.beginTransaction(Option.of(restoreInflightInstant), Option.empty());
       writeTableMetadata(restoreMetadata);
     } finally {
-      this.txnManager.endTransaction(Option.empty());
+      this.txnManager.endTransaction(Option.of(restoreInflightInstant));
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -238,7 +238,7 @@ public abstract class BaseRollbackActionExecutor<T extends HoodieRecordPayload, 
     boolean enableLocking = (!skipLocking && !skipTimelinePublish);
     try {
       if (enableLocking) {
-        this.txnManager.beginTransaction(Option.empty(), Option.empty());
+        this.txnManager.beginTransaction(Option.of(inflightInstant), Option.empty());
       }
 
       // If publish the rollback to the timeline, we first write the rollback metadata
@@ -261,7 +261,7 @@ public abstract class BaseRollbackActionExecutor<T extends HoodieRecordPayload, 
       throw new HoodieIOException("Error executing rollback at instant " + instantTime, e);
     } finally {
       if (enableLocking) {
-        this.txnManager.endTransaction(Option.empty());
+        this.txnManager.endTransaction(Option.of(inflightInstant));
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
@@ -161,6 +161,48 @@ public class TestInProcessLockProvider {
   }
 
   @Test
+  public void testTryUnLockByDifferentThread() {
+    InProcessLockProvider inProcessLockProvider = new InProcessLockProvider(lockConfiguration, hadoopConfiguration);
+    final AtomicBoolean writer2Completed = new AtomicBoolean(false);
+    final AtomicBoolean writer3Completed = new AtomicBoolean(false);
+
+    // Main test thread
+    Assertions.assertTrue(inProcessLockProvider.tryLock());
+
+    // Another writer thread
+    Thread writer2 = new Thread(() -> {
+      assertDoesNotThrow(() -> {
+        inProcessLockProvider.unlock();
+      });
+    });
+    writer2.start();
+    try {
+      writer2.join();
+    } catch (InterruptedException e) {
+      //
+    }
+
+    // try acquiring by diff thread. should fail. since main thread still have acquired the lock. if previous unblock by a different thread would have succeeded, this lock
+    // acquisition would succeed.
+    Thread writer3 = new Thread(() -> {
+      Assertions.assertFalse(inProcessLockProvider.tryLock(50, TimeUnit.MILLISECONDS));
+      writer3Completed.set(true);
+    });
+    writer3.start();
+    try {
+      writer3.join();
+    } catch (InterruptedException e) {
+      //
+    }
+
+    Assertions.assertTrue(writer3Completed.get());
+    assertDoesNotThrow(() -> {
+      // unlock by main thread should succeed.
+      inProcessLockProvider.unlock();
+    });
+  }
+
+  @Test
   public void testTryLockAcquisitionBeforeTimeOutFromTwoThreads() {
     final InProcessLockProvider inProcessLockProvider = new InProcessLockProvider(lockConfiguration, hadoopConfiguration);
     final int threadCount = 3;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
@@ -163,7 +163,6 @@ public class TestInProcessLockProvider {
   @Test
   public void testTryUnLockByDifferentThread() {
     InProcessLockProvider inProcessLockProvider = new InProcessLockProvider(lockConfiguration, hadoopConfiguration);
-    final AtomicBoolean writer2Completed = new AtomicBoolean(false);
     final AtomicBoolean writer3Completed = new AtomicBoolean(false);
 
     // Main test thread


### PR DESCRIPTION
### Change Logs

There are some callers of txnManager apis which does not set the current owner instant. this patch fixes that, so that during unlock only the intended owner can actually unlock and not by anyone else. 

Added tests to InProcessLockProvider to test the unintended unlock by diff owner. already we have similar test for TransactionManager. 

### Impact

No detected bugs yet. just as precautionary measure. 

**Risk level: low **

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
