### PR TITLE
[HUDI-4648] Support rename partition through CLI

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkMain.java
@@ -94,7 +94,8 @@ public class SparkMain {
   enum SparkCommand {
     BOOTSTRAP, ROLLBACK, DEDUPLICATE, ROLLBACK_TO_SAVEPOINT, SAVEPOINT, IMPORT, UPSERT, COMPACT_SCHEDULE, COMPACT_RUN, COMPACT_SCHEDULE_AND_EXECUTE,
     COMPACT_UNSCHEDULE_PLAN, COMPACT_UNSCHEDULE_FILE, COMPACT_VALIDATE, COMPACT_REPAIR, CLUSTERING_SCHEDULE,
-    CLUSTERING_RUN, CLUSTERING_SCHEDULE_AND_EXECUTE, CLEAN, DELETE_MARKER, DELETE_SAVEPOINT, UPGRADE, DOWNGRADE, REPAIR_DEPRECATED_PARTITION
+    CLUSTERING_RUN, CLUSTERING_SCHEDULE_AND_EXECUTE, CLEAN, DELETE_MARKER, DELETE_SAVEPOINT, UPGRADE, DOWNGRADE,
+    REPAIR_DEPRECATED_PARTITION, RENAME_PARTITION
   }
 
   public static void main(String[] args) throws Exception {
@@ -282,6 +283,10 @@ public class SparkMain {
           assert (args.length == 4);
           returnCode = repairDeprecatedPartition(jsc, args[3]);
           break;
+        case RENAME_PARTITION:
+          assert (args.length == 6);
+          returnCode = renamePartition(jsc, args[3], args[4], args[5]);
+          break;
         default:
           break;
       }
@@ -428,33 +433,75 @@ public class SparkMain {
 
   public static int repairDeprecatedPartition(JavaSparkContext jsc, String basePath) {
     SQLContext sqlContext = new SQLContext(jsc);
-    Dataset<Row> recordsToRewrite = sqlContext.read().option("hoodie.datasource.read.extract.partition.values.from.path","false").format("hudi").load(basePath)
-        .filter(HoodieRecord.PARTITION_PATH_METADATA_FIELD + " == '" + PartitionPathEncodeUtils.DEPRECATED_DEFAULT_PARTITION_PATH + "'")
-        .drop(HoodieRecord.RECORD_KEY_METADATA_FIELD).drop(HoodieRecord.PARTITION_PATH_METADATA_FIELD)
-        .drop(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD).drop(HoodieRecord.FILENAME_METADATA_FIELD).drop(HoodieRecord.COMMIT_TIME_METADATA_FIELD);
+    Dataset<Row> recordsToRewrite = getRecordsToRewrite(basePath, PartitionPathEncodeUtils.DEPRECATED_DEFAULT_PARTITION_PATH, sqlContext);
 
     if (!recordsToRewrite.isEmpty()) {
       recordsToRewrite.cache();
-      HoodieTableMetaClient metaClient =
-          HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
-
-      Map<String, String> propsMap = new HashMap<>();
-      metaClient.getTableConfig().getProps().forEach((k, v) -> propsMap.put(k.toString(), v.toString()));
-      propsMap.put(HoodieWriteConfig.SKIP_DEFAULT_PARTITION_VALIDATION.key(), "true");
-      propsMap.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), metaClient.getTableConfig().getRecordKeyFieldProp());
-      propsMap.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), metaClient.getTableConfig().getPartitionFieldProp());
-      propsMap.put(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key(), metaClient.getTableConfig().getKeyGeneratorClassName());
-
-      recordsToRewrite.withColumn(metaClient.getTableConfig().getPartitionFieldProp(),
-          functions.lit(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH)).write().options(propsMap)
-          .option("hoodie.datasource.write.operation","insert").format("hudi").mode("Append").save(basePath);
-
+      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
+      Map<String, String> propsMap = getPropsForRewrite(metaClient);
+      rewriteRecordsToNewPartition(basePath, PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, recordsToRewrite, metaClient, propsMap);
       // after re-writing, we can safely delete older data.
-      propsMap.put("hoodie.datasource.write.partitions.to.delete", PartitionPathEncodeUtils.DEPRECATED_DEFAULT_PARTITION_PATH);
-      recordsToRewrite.write().options(propsMap).option("hoodie.datasource.write.operation", WriteOperationType.DELETE_PARTITION.value()).format("hudi")
-          .mode("Append").save(basePath);
+      deleteOlderPartition(basePath, PartitionPathEncodeUtils.DEPRECATED_DEFAULT_PARTITION_PATH, recordsToRewrite, propsMap);
     }
     return 0;
+  }
+
+  public static int renamePartition(JavaSparkContext jsc, String basePath, String oldPartition, String newPartition) {
+    SQLContext sqlContext = new SQLContext(jsc);
+    Dataset<Row> recordsToRewrite = getRecordsToRewrite(basePath, oldPartition, sqlContext);
+
+    if (!recordsToRewrite.isEmpty()) {
+      recordsToRewrite.cache();
+      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
+      Map<String, String> propsMap = getPropsForRewrite(metaClient);
+      rewriteRecordsToNewPartition(basePath, newPartition, recordsToRewrite, metaClient, propsMap);
+      // after re-writing, we can safely delete older data.
+      deleteOlderPartition(basePath, oldPartition, recordsToRewrite, propsMap);
+    }
+    return 0;
+  }
+
+  private static void deleteOlderPartition(String basePath, String oldPartition, Dataset<Row> recordsToRewrite, Map<String, String> propsMap) {
+    propsMap.put("hoodie.datasource.write.partitions.to.delete", oldPartition);
+    recordsToRewrite.write()
+        .options(propsMap)
+        .option("hoodie.datasource.write.operation", WriteOperationType.DELETE_PARTITION.value())
+        .format("hudi")
+        .mode("Append")
+        .save(basePath);
+  }
+
+  private static void rewriteRecordsToNewPartition(String basePath, String newPartition, Dataset<Row> recordsToRewrite, HoodieTableMetaClient metaClient, Map<String, String> propsMap) {
+    recordsToRewrite.withColumn(metaClient.getTableConfig().getPartitionFieldProp(), functions.lit(newPartition))
+        .write()
+        .options(propsMap)
+        .option("hoodie.datasource.write.operation", "insert")
+        .format("hudi")
+        .mode("Append")
+        .save(basePath);
+  }
+
+  private static Dataset<Row> getRecordsToRewrite(String basePath, String oldPartition, SQLContext sqlContext) {
+    return sqlContext.read()
+        .option("hoodie.datasource.read.extract.partition.values.from.path", "false")
+        .format("hudi")
+        .load(basePath)
+        .filter(HoodieRecord.PARTITION_PATH_METADATA_FIELD + " == '" + oldPartition + "'")
+        .drop(HoodieRecord.RECORD_KEY_METADATA_FIELD)
+        .drop(HoodieRecord.PARTITION_PATH_METADATA_FIELD)
+        .drop(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD)
+        .drop(HoodieRecord.FILENAME_METADATA_FIELD)
+        .drop(HoodieRecord.COMMIT_TIME_METADATA_FIELD);
+  }
+
+  private static Map<String, String> getPropsForRewrite(HoodieTableMetaClient metaClient) {
+    Map<String, String> propsMap = new HashMap<>();
+    metaClient.getTableConfig().getProps().forEach((k, v) -> propsMap.put(k.toString(), v.toString()));
+    propsMap.put(HoodieWriteConfig.SKIP_DEFAULT_PARTITION_VALIDATION.key(), "true");
+    propsMap.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), metaClient.getTableConfig().getRecordKeyFieldProp());
+    propsMap.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), metaClient.getTableConfig().getPartitionFieldProp());
+    propsMap.put(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key(), metaClient.getTableConfig().getKeyGeneratorClassName());
+    return propsMap;
   }
 
   private static int doBootstrap(JavaSparkContext jsc, String tableName, String tableType, String basePath,


### PR DESCRIPTION
### Change Logs

* Added a hudi-cli command to move from one partition to another, e.g. `rename partition --oldPatition 2022/08/29 --newPartition 2022/08/30`.
* Deletes the older partition after moving data to new partition.
* Added a unit test.

### Impact

none

**Risk level: none | low | medium | high**

low (new CLI command which is used in an offline manner)

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
