### PR TITLE
[HUDI-4795] Fix KryoException when bulk insert into a not bucket index hudi table

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -144,7 +144,7 @@ public class Pipelines {
         // sort by partition keys
         dataStream = dataStream
             .transform("partition_key_sorter",
-                TypeInformation.of(RowData.class),
+                InternalTypeInfo.of(rowType),
                 sortOperatorGen.createSortOperator())
             .setParallelism(conf.getInteger(FlinkOptions.WRITE_TASKS));
         ExecNodeUtil.setManagedMemoryWeight(dataStream.getTransformation(),


### PR DESCRIPTION
Fix KryoException when bulk insert into a not bucket index hudi table

### Change Logs

Provide InternalTypeInfo instead of TypeInformation of RowData to transform method when adding SortOperator to flink pipeline. Because SortOperator now use kryo to serialize BinaryRowData object that it pass to flink collector which will cause KryoException see [https://github.com/apache/hudi/issues/6540](url).
Use InternalTypeInfo will switch to a flink serializer to avoid KryoException.

### Impact

no public API or user-facing feature change


