### PR TITLE
[HUDI-4777] Fix flink gen bucket index of mor table not consistent wi…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -578,12 +578,12 @@ public class HoodieFlinkWriteClient<T extends HoodieRecordPayload> extends
 
     final boolean isDelta = table.getMetaClient().getTableType().equals(HoodieTableType.MERGE_ON_READ);
     final HoodieWriteHandle<?, ?, ?, ?> writeHandle;
-    if (isDelta) {
-      writeHandle = new FlinkAppendHandle<>(config, instantTime, table, partitionPath, fileID, recordItr,
-          table.getTaskContextSupplier());
-    } else if (loc.getInstantTime().equals("I")) {
+    if (loc.getInstantTime().equals("I")) {
       writeHandle = new FlinkCreateHandle<>(config, instantTime, table, partitionPath,
-          fileID, table.getTaskContextSupplier());
+              fileID, table.getTaskContextSupplier());
+    } else if (isDelta) {
+      writeHandle = new FlinkAppendHandle<>(config, instantTime, table, partitionPath, fileID, recordItr,
+              table.getTaskContextSupplier());
     } else {
       writeHandle = insertClustering
           ? new FlinkConcatHandle<>(config, instantTime, table, recordItr, partitionPath,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkMergeOnReadTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkMergeOnReadTable.java
@@ -66,10 +66,7 @@ public class HoodieFlinkMergeOnReadTable<T extends HoodieRecordPayload>
       HoodieWriteHandle<?, ?, ?, ?> writeHandle,
       String instantTime,
       List<HoodieRecord<T>> hoodieRecords) {
-    ValidationUtils.checkArgument(writeHandle instanceof FlinkAppendHandle,
-        "MOR write handle should always be a FlinkAppendHandle");
-    FlinkAppendHandle<?, ?, ?, ?> appendHandle = (FlinkAppendHandle<?, ?, ?, ?>) writeHandle;
-    return new FlinkUpsertDeltaCommitActionExecutor<>(context, appendHandle, config, this, instantTime, hoodieRecords).execute();
+    return new FlinkUpsertDeltaCommitActionExecutor<>(context, writeHandle, config, this, instantTime, hoodieRecords).execute();
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertDeltaCommitActionExecutor.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.FlinkAppendHandle;
+import org.apache.hudi.io.HoodieWriteHandle;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.commit.FlinkWriteHelper;
@@ -35,7 +35,7 @@ public class FlinkUpsertDeltaCommitActionExecutor<T extends HoodieRecordPayload<
   private final List<HoodieRecord<T>> inputRecords;
 
   public FlinkUpsertDeltaCommitActionExecutor(HoodieEngineContext context,
-                                              FlinkAppendHandle<?, ?, ?, ?> writeHandle,
+                                              HoodieWriteHandle<?, ?, ?, ?> writeHandle,
                                               HoodieWriteConfig config,
                                               HoodieTable table,
                                               String instantTime,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertPreppedDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertPreppedDeltaCommitActionExecutor.java
@@ -24,7 +24,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.FlinkAppendHandle;
+import org.apache.hudi.io.HoodieWriteHandle;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 
@@ -36,7 +36,7 @@ public class FlinkUpsertPreppedDeltaCommitActionExecutor<T extends HoodieRecordP
   private final List<HoodieRecord<T>> preppedRecords;
 
   public FlinkUpsertPreppedDeltaCommitActionExecutor(HoodieEngineContext context,
-                                                     FlinkAppendHandle<?, ?, ?, ?> writeHandle,
+                                                     HoodieWriteHandle<?, ?, ?, ?> writeHandle,
                                                      HoodieWriteConfig config,
                                                      HoodieTable table,
                                                      String instantTime,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -326,8 +326,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
    * Sets up the write options from the table definition.
    */
   private static void setupWriteOptions(Configuration conf) {
-    if (FlinkOptions.isDefaultValueDefined(conf, FlinkOptions.OPERATION)
-        && OptionsResolver.isCowTable(conf)) {
+    if (FlinkOptions.isDefaultValueDefined(conf, FlinkOptions.OPERATION)) {
       conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
     }
   }


### PR DESCRIPTION
### Change Logs
Make hudi-flink of mor table also will gen CreateHandle with base bucket not exist.
Open deduplicate function for mor table.

### Impact
The duplicate issue is from hudi-flink mor table, which first append log, but not compact right now, so the bucket num is not in base file;
When spark use loadPartitionBucketIdFileIdMapping of org.apache.hudi.index.bucket.HoodieSimpleBucketIndex, it will not find the bucket num which written by hudi-flink, so it will generate a new one which not consistent with hudi-flink.
After this change, when hudi-flink write mor table use bucket index, it will firstly consider to write base parquet file after deduplicate, if base file exists, it will change to write log file, follow spark way seems more stable for mor table.

**Risk level: none | low | medium | high**
None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
