### PR TITLE
[HUDI-4796] MetricsReporter stop bug

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/ConsoleMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/ConsoleMetricsReporter.java
@@ -18,15 +18,13 @@
 
 package org.apache.hudi.metrics;
 
-import java.io.Closeable;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Hudi Console metrics reporter. Reports the metrics by printing them to the stdout on the console.
@@ -59,11 +57,6 @@ public class ConsoleMetricsReporter extends MetricsReporter {
     } else {
       LOG.error("Cannot report metrics as the consoleReporter is null.");
     }
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return consoleReporter;
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/InMemoryMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/InMemoryMetricsReporter.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.metrics;
 
-import java.io.Closeable;
-
 /**
  * Used for testing.
  */
@@ -30,11 +28,6 @@ public class InMemoryMetricsReporter extends MetricsReporter {
 
   @Override
   public void report() {}
-
-  @Override
-  public Closeable getReporter() {
-    return null;
-  }
 
   @Override
   public void stop() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/JmxMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/JmxMetricsReporter.java
@@ -26,11 +26,9 @@ import org.apache.log4j.LogManager;
 
 import javax.management.MBeanServer;
 
-import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.util.Objects;
 import java.util.stream.IntStream;
-
 
 /**
  * Implementation of Jmx reporter, which used to report jmx metric.
@@ -84,11 +82,6 @@ public class JmxMetricsReporter extends MetricsReporter {
 
   @Override
   public void report() {
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return jmxReporterServer.getReporter();
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -55,7 +55,7 @@ public class Metrics {
     Runtime.getRuntime().addShutdownHook(new Thread(Metrics::shutdown));
   }
 
-  private void reportAndCloseReporter() {
+  private void reportAndStopReporter() {
     try {
       registerHoodieCommonMetrics();
       reporter.report();
@@ -102,7 +102,7 @@ public class Metrics {
     if (!initialized) {
       return;
     }
-    instance.reportAndCloseReporter();
+    instance.reportAndStopReporter();
     initialized = false;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -27,7 +27,6 @@ import com.codahale.metrics.MetricRegistry;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import java.io.Closeable;
 import java.util.Map;
 
 /**
@@ -60,9 +59,7 @@ public class Metrics {
     try {
       registerHoodieCommonMetrics();
       reporter.report();
-      if (getReporter() != null) {
-        getReporter().close();
-      }
+      reporter.stop();
     } catch (Exception e) {
       LOG.warn("Error while closing reporter", e);
     }
@@ -134,9 +131,5 @@ public class Metrics {
 
   public MetricRegistry getRegistry() {
     return registry;
-  }
-
-  public Closeable getReporter() {
-    return reporter.getReporter();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/MetricsGraphiteReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/MetricsGraphiteReporter.java
@@ -27,7 +27,6 @@ import com.codahale.metrics.graphite.GraphiteReporter;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
@@ -76,11 +75,6 @@ public class MetricsGraphiteReporter extends MetricsReporter {
     } else {
       LOG.error("Cannot report metrics as the graphiteReporter is null.");
     }
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return graphiteReporter;
   }
 
   private GraphiteReporter createGraphiteReport() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/MetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/MetricsReporter.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.metrics;
 
-import java.io.Closeable;
-
 /**
  * Interface for implementing a Reporter.
  */
@@ -34,8 +32,6 @@ public abstract class MetricsReporter {
    * Deterministically push out metrics.
    */
   public abstract void report();
-
-  public abstract Closeable getReporter();
 
   /**
    * Stop this reporter. Should be used to stop channels, streams and release resources.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/cloudwatch/CloudWatchMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/cloudwatch/CloudWatchMetricsReporter.java
@@ -26,7 +26,6 @@ import com.codahale.metrics.MetricRegistry;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import java.io.Closeable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -70,11 +69,6 @@ public class CloudWatchMetricsReporter extends MetricsReporter {
   @Override
   public void report() {
     reporter.report();
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return reporter;
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/datadog/DatadogMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/datadog/DatadogMetricsReporter.java
@@ -28,7 +28,6 @@ import org.apache.hudi.metrics.datadog.DatadogHttpClient.ApiSite;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 
-import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -79,11 +78,6 @@ public class DatadogMetricsReporter extends MetricsReporter {
   @Override
   public void report() {
     reporter.report();
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return reporter;
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PrometheusReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PrometheusReporter.java
@@ -18,17 +18,17 @@
 
 package org.apache.hudi.metrics.prometheus;
 
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metrics.MetricsReporter;
+
 import com.codahale.metrics.MetricRegistry;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.HTTPServer;
-import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.metrics.MetricsReporter;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import java.io.Closeable;
 import java.net.InetSocketAddress;
 
 /**
@@ -63,11 +63,6 @@ public class PrometheusReporter extends MetricsReporter {
 
   @Override
   public void report() {
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return null;
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PushGatewayMetricsReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PushGatewayMetricsReporter.java
@@ -18,12 +18,12 @@
 
 package org.apache.hudi.metrics.prometheus;
 
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metrics.MetricsReporter;
 
-import java.io.Closeable;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -63,11 +63,6 @@ public class PushGatewayMetricsReporter extends MetricsReporter {
   @Override
   public void report() {
     pushGatewayReporter.report(null, null, null, null, null);
-  }
-
-  @Override
-  public Closeable getReporter() {
-    return pushGatewayReporter;
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PushGatewayReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PushGatewayReporter.java
@@ -18,23 +18,23 @@
 
 package org.apache.hudi.metrics.prometheus;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
-import com.codahale.metrics.Timer;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.PushGateway;
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PushGatewayReporter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/prometheus/PushGatewayReporter.java
@@ -18,23 +18,23 @@
 
 package org.apache.hudi.metrics.prometheus;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.Timer;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.PushGateway;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.Closeable;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,11 +85,6 @@ public class TestMetricsReporterFactory {
 
     @Override
     public void report() {}
-
-    @Override
-    public Closeable getReporter() {
-      return null;
-    }
 
     @Override
     public void stop() {}


### PR DESCRIPTION
### Change Logs

- Removes a confusing method, `getReporter()` in the abstract class MetricsReporter since we want to be calling `stop` the MetricsReporter instances to make sure they are cleaned up properly
- Updates Metrics.java to call `stop` method
- Updates implementations of MetricsReporter to no longer implement getReporter method
- Fixes import order in classes that were touched as part of this PR

### Impact

The API for the `MetricsReporter` is changing due to the removal of the `getReporter` method

**Risk level: low**

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
