### PR TITLE
[HUDI-4807] Use base table instant for metadata table initialization

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -107,7 +107,7 @@ public class ScheduleIndexActionExecutor<T extends HoodieRecordPayload, I, K, O>
             .orElseThrow(() -> new HoodieIndexException(String.format("Could not get metadata writer to initialize filegroups for indexing for instant: %s", instantTime)));
         if (!finalPartitionsToIndex.get(0).getPartitionPath().equals(MetadataPartitionType.FILES.getPartitionPath())) {
           // initialize metadata partition only if not for FILES partition.
-          metadataWriter.initializeMetadataPartitions(table.getMetaClient(), finalPartitionsToIndex, indexInstant.getTimestamp());
+          metadataWriter.initializeMetadataPartitions(table.getMetaClient(), finalPartitionsToIndex, indexUptoInstant.get().getTimestamp());
         }
 
         // for each partitionToIndex add that time to the plan


### PR DESCRIPTION
### Change Logs

Use base table instant for metadata table initialization.

When initializing COL-STATS or BLOOM-FILTER partition in metadata table, currently we assign instant of metadata table to the records. The value will finally be overwritten in `HoodieAppendHandle` using instant from base table.

This patch fixes the behavior by assigning instant of base table at the very beginning.

### Impact

No public API change.

**Risk level: none | low | medium | high**

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
