### PR TITLE
[HUDI-4808] Fix HoodieSimpleBucketIndex not consider bucket num in lo…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
@@ -68,6 +69,26 @@ public class HoodieIndexUtils {
       return hoodieTable.getBaseFileOnlyView()
           .getLatestBaseFilesBeforeOrOn(partition, latestCommitTime.get().getTimestamp())
           .collect(toList());
+    }
+    return Collections.emptyList();
+  }
+
+  /**
+   * Fetches Pair of partition path and {@link FileSlice}s for interested partitions.
+   *
+   * @param partition   Partition of interest
+   * @param hoodieTable Instance of {@link HoodieTable} of interest
+   * @return the list of {@link FileSlice}
+   */
+  public static List<FileSlice> getLatestFileSlicesForPartition(
+          final String partition,
+          final HoodieTable hoodieTable) {
+    Option<HoodieInstant> latestCommitTime = hoodieTable.getMetaClient().getCommitsTimeline()
+            .filterCompletedInstants().lastInstant();
+    if (latestCommitTime.isPresent()) {
+      return hoodieTable.getHoodieView()
+              .getLatestFileSlicesBeforeOrOn(partition, latestCommitTime.get().getTimestamp(), true)
+              .collect(toList());
     }
     return Collections.emptyList();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieSimpleBucketIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieSimpleBucketIndex.java
@@ -18,16 +18,13 @@
 
 package org.apache.hudi.index.bucket;
 
-import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieKey;
-import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.index.HoodieIndexUtils;
 import org.apache.hudi.table.HoodieTable;
-
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -56,17 +53,8 @@ public class HoodieSimpleBucketIndex extends HoodieBucketIndex {
     HoodieIndexUtils
         .getLatestFileSlicesForPartition(partition, hoodieTable)
         .forEach(fileSlice -> {
-          String fileId;
-          String commitTime;
-          if (fileSlice.getBaseFile().isPresent()) {
-            HoodieBaseFile file = fileSlice.getBaseFile().get();
-            fileId = file.getFileId();
-            commitTime = file.getCommitTime();
-          } else {
-            HoodieLogFile logFile = fileSlice.getLatestLogFile().get();
-            fileId = logFile.getFileId();
-            commitTime = logFile.getBaseCommitTime();
-          }
+          String fileId = fileSlice.getFileId();
+          String commitTime = fileSlice.getBaseInstantTime();
 
           int bucketId = BucketIdentifier.bucketIdFromFileId(fileId);
           if (!bucketIdToFileIdMapping.containsKey(bucketId)) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -45,9 +44,9 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieStorageConfig;
 import org.apache.hudi.io.storage.HoodieAvroParquetWriter;
-import org.apache.hudi.io.storage.HoodieParquetConfig;
 import org.apache.hudi.io.storage.HoodieOrcConfig;
 import org.apache.hudi.io.storage.HoodieOrcWriter;
+import org.apache.hudi.io.storage.HoodieParquetConfig;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -152,27 +151,21 @@ public class HoodieWriteableTestTable extends HoodieMetadataTestTable {
     return baseFilePath;
   }
 
-  public Map<String, List<HoodieLogFile>> withLogAppends(List<HoodieRecord> records) throws Exception {
+  public Map<String, List<HoodieLogFile>> withAppends(String partition, String fileId, List<HoodieRecord> records) throws Exception {
     Map<String, List<HoodieLogFile>> partitionToLogfilesMap = new HashMap<>();
-    for (List<HoodieRecord> groupedRecords : records.stream()
-        .collect(Collectors.groupingBy(HoodieRecord::getCurrentLocation)).values()) {
-      final Pair<String, HoodieLogFile> appendedLogFile = appendRecordsToLogFile(groupedRecords);
-      partitionToLogfilesMap.computeIfAbsent(
-          appendedLogFile.getKey(), k -> new ArrayList<>()).add(appendedLogFile.getValue());
-    }
+    final Pair<String, HoodieLogFile> appendedLogFile = appendRecordsToLogFile(partition, fileId, records);
+    partitionToLogfilesMap.computeIfAbsent(appendedLogFile.getKey(), k -> new ArrayList<>()).add(appendedLogFile.getValue());
     return partitionToLogfilesMap;
   }
 
-  private Pair<String, HoodieLogFile> appendRecordsToLogFile(List<HoodieRecord> groupedRecords) throws Exception {
-    String partitionPath = groupedRecords.get(0).getPartitionPath();
-    HoodieRecordLocation location = groupedRecords.get(0).getCurrentLocation();
+  private Pair<String, HoodieLogFile> appendRecordsToLogFile(String partitionPath, String fileId, List<HoodieRecord> records) throws Exception {
     try (HoodieLogFormat.Writer logWriter = HoodieLogFormat.newWriterBuilder().onParentPath(new Path(basePath, partitionPath))
-        .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(location.getFileId())
-        .overBaseCommit(location.getInstantTime()).withFs(fs).build()) {
+        .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(fileId)
+        .overBaseCommit(currentInstantTime).withFs(fs).build()) {
       Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
-      header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, location.getInstantTime());
+      header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, currentInstantTime);
       header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
-      logWriter.appendBlock(new HoodieAvroDataBlock(groupedRecords.stream().map(r -> {
+      logWriter.appendBlock(new HoodieAvroDataBlock(records.stream().map(r -> {
         try {
           GenericRecord val = (GenericRecord) ((HoodieRecordPayload) r.getData()).getInsertValue(schema).get();
           HoodieAvroUtils.addHoodieKeyToRecord(val, r.getRecordKey(), r.getPartitionPath(), "");

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
@@ -151,7 +151,7 @@ public class HoodieWriteableTestTable extends HoodieMetadataTestTable {
     return baseFilePath;
   }
 
-  public Map<String, List<HoodieLogFile>> withAppends(String partition, String fileId, List<HoodieRecord> records) throws Exception {
+  public Map<String, List<HoodieLogFile>> withLogAppends(String partition, String fileId, List<HoodieRecord> records) throws Exception {
     Map<String, List<HoodieLogFile>> partitionToLogfilesMap = new HashMap<>();
     final Pair<String, HoodieLogFile> appendedLogFile = appendRecordsToLogFile(partition, fileId, records);
     partitionToLogfilesMap.computeIfAbsent(appendedLogFile.getKey(), k -> new ArrayList<>()).add(appendedLogFile.getValue());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bucket/TestHoodieSimpleBucketIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bucket/TestHoodieSimpleBucketIndex.java
@@ -128,9 +128,9 @@ public class TestHoodieSimpleBucketIndex extends HoodieClientTestHarness {
       testTable.addCommit("002").withInserts("2016/01/31", getRecordFileId(record2), record2);
       testTable.addCommit("003").withInserts("2016/01/31", getRecordFileId(record3), record3);
     } else {
-      testTable.addCommit("001").withAppends("2016/01/31", getRecordFileId(record1), record1);
-      testTable.addCommit("002").withAppends("2016/01/31", getRecordFileId(record2), record2);
-      testTable.addCommit("003").withAppends("2016/01/31", getRecordFileId(record3), record3);
+      testTable.addCommit("001").withLogAppends("2016/01/31", getRecordFileId(record1), record1);
+      testTable.addCommit("002").withLogAppends("2016/01/31", getRecordFileId(record2), record2);
+      testTable.addCommit("003").withLogAppends("2016/01/31", getRecordFileId(record3), record3);
     }
 
     taggedRecordRDD = bucketIndex.tagLocation(HoodieJavaRDD.of(recordRDD), context,

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkWriteableTestTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkWriteableTestTable.java
@@ -119,12 +119,12 @@ public class HoodieSparkWriteableTestTable extends HoodieWriteableTestTable {
     return super.withInserts(partition, fileId, records, new SparkTaskContextSupplier());
   }
 
-  public HoodieSparkWriteableTestTable withAppends(String partition, String fileId, HoodieRecord... records) throws Exception {
-    withAppends(partition, fileId, Arrays.asList(records));
+  public HoodieSparkWriteableTestTable withLogAppends(String partition, String fileId, HoodieRecord... records) throws Exception {
+    withLogAppends(partition, fileId, Arrays.asList(records));
     return this;
   }
 
-  public Map<String, List<HoodieLogFile>> withAppends(String partition, String fileId, List<HoodieRecord> records) throws Exception {
-    return super.withAppends(partition, fileId, records);
+  public Map<String, List<HoodieLogFile>> withLogAppends(String partition, String fileId, List<HoodieRecord> records) throws Exception {
+    return super.withLogAppends(partition, fileId, records);
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkWriteableTestTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkWriteableTestTable.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.SparkTaskContextSupplier;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
@@ -36,6 +37,7 @@ import org.apache.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class HoodieSparkWriteableTestTable extends HoodieWriteableTestTable {
@@ -115,5 +117,14 @@ public class HoodieSparkWriteableTestTable extends HoodieWriteableTestTable {
 
   public Path withInserts(String partition, String fileId, List<HoodieRecord> records) throws Exception {
     return super.withInserts(partition, fileId, records, new SparkTaskContextSupplier());
+  }
+
+  public HoodieSparkWriteableTestTable withAppends(String partition, String fileId, HoodieRecord... records) throws Exception {
+    withAppends(partition, fileId, Arrays.asList(records));
+    return this;
+  }
+
+  public Map<String, List<HoodieLogFile>> withAppends(String partition, String fileId, List<HoodieRecord> records) throws Exception {
+    return super.withAppends(partition, fileId, records);
   }
 }


### PR DESCRIPTION
### Change Logs
Make HoodieSimpleBucketIndex also load bucket index from log file

### Impact
Spark will read bucket index correctly where the log file is written by flink to mor table. 

**Risk level: none | low | medium | high**
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
