### PR TITLE
[MINOR] Typo fix for kryo in flink-bundle

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -130,7 +130,7 @@
                   <include>javax.servlet:javax.servlet-api</include>
 
                   <!-- Used for HUDI write handle -->
-                  <inclide>com.esotericsoftware:kryo-shaded</inclide>
+                  <include>com.esotericsoftware:kryo-shaded</include>
 
                   <include>org.apache.flink:${flink.hadoop.compatibility.artifactId}</include>
                   <include>org.apache.flink:flink-json</include>


### PR DESCRIPTION
### Change Logs

There's a typo for the `Kryo-shaded` item in flink-bundle's pom file which causes the lib not to be packaged into the bundle file. Not sure if we should include it or just remove it.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: high**

The Kryo lib causes a lot of issues when we integrate hudi with Flink. This change could potentially introduce some dependency conflict to the existing jobs.

