### PR TITLE
[HUDI-4823]Add read_optimize spark_session config to use in spark-sql

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -73,6 +73,14 @@ class DefaultSource extends RelationProvider
                               schema: StructType): BaseRelation = {
     val path = optParams.get("path")
     val readPathsStr = optParams.get(DataSourceReadOptions.READ_PATHS.key)
+    val sessionQueryType = sqlContext.sparkSession.conf.get(QUERY_TYPE.key, "")
+    val modifiedOptParams = (if (sessionQueryType != "") {
+      Map(
+        QUERY_TYPE.key -> sessionQueryType
+      )
+    } else {
+      Map()
+    }) ++ optParams
 
     if (path.isEmpty && readPathsStr.isEmpty) {
       throw new HoodieException(s"'path' or '$READ_PATHS' or both must be specified.")
@@ -96,7 +104,7 @@ class DefaultSource extends RelationProvider
       )
     } else {
       Map()
-    }) ++ DataSourceOptionsHelper.parametersWithReadDefaults(optParams)
+    }) ++ DataSourceOptionsHelper.parametersWithReadDefaults(modifiedOptParams)
 
     // Get the table base path
     val tablePath = if (globPaths.nonEmpty) {


### PR DESCRIPTION
### Change Logs

When create a table not using hive catalog in spark, we can not easily do read_optimized query in sqark-sql(using global hudi config file is inconvenient),so I add the read_optimize spark_session config to use in spark-sql
Reference `hoodie.schema.on.read.enable` spark_session config 
https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala#648

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
