### PR TITLE
[HUDI-4825] Remove redundant fields in serialized commit metadata in JSON

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.common.util;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -29,7 +28,14 @@ public class JsonUtils {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   static {
     MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-    MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    // We need to exclude custom getters, setters and creators which can use member fields
+    // to derive new fields, so that they are not included in the serialization
+    MAPPER.setVisibility(
+        MAPPER.getSerializationConfig().getDefaultVisibilityChecker()
+            .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+            .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+            .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+            .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
   }
 
   public static ObjectMapper getObjectMapper() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.util;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -30,12 +31,11 @@ public class JsonUtils {
     MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     // We need to exclude custom getters, setters and creators which can use member fields
     // to derive new fields, so that they are not included in the serialization
-    MAPPER.setVisibility(
-        MAPPER.getSerializationConfig().getDefaultVisibilityChecker()
-            .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
-            .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
-            .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
-            .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+    MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    MAPPER.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+    MAPPER.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+    MAPPER.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+    MAPPER.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NONE);
   }
 
   public static ObjectMapper getObjectMapper() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
@@ -19,15 +19,14 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.JsonUtils;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,12 +46,9 @@ public class TestHoodieCommitMetadata {
       HoodieCommitMetadata commitMetadata, List<String> expectedFieldNameList)
       throws IOException {
     String serializedCommitMetadata = commitMetadata.toJsonString();
-    Iterator<String> fieldNameIterator = JsonUtils.getObjectMapper()
-        .readTree(serializedCommitMetadata).fieldNames();
-    List<String> actualFieldNameList = new ArrayList<>();
-    while (fieldNameIterator.hasNext()) {
-      actualFieldNameList.add(fieldNameIterator.next());
-    }
+    List<String> actualFieldNameList = CollectionUtils.toStream(
+            JsonUtils.getObjectMapper().readTree(serializedCommitMetadata).fieldNames())
+        .collect(Collectors.toList());
     assertEquals(
         expectedFieldNameList.stream().sorted().collect(Collectors.toList()),
         actualFieldNameList.stream().sorted().collect(Collectors.toList())

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieReplaceCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieReplaceCommitMetadata.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hudi.common.model.TestHoodieCommitMetadata.verifyMetadataFieldNames;
+
+public class TestHoodieReplaceCommitMetadata {
+
+  private static final List<String> EXPECTED_FIELD_NAMES = Arrays.asList(
+      "partitionToWriteStats", "partitionToReplaceFileIds", "compacted", "extraMetadata", "operationType");
+
+  @Test
+  public void verifyFieldNamesInReplaceCommitMetadata() throws IOException {
+    List<HoodieWriteStat> fakeHoodieWriteStats = HoodieTestUtils.generateFakeHoodieWriteStat(10);
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    fakeHoodieWriteStats.forEach(stat -> {
+      commitMetadata.addWriteStat(stat.getPartitionPath(), stat);
+      commitMetadata.addReplaceFileId(stat.getPartitionPath(), stat.getFileId());
+    });
+    verifyMetadataFieldNames(commitMetadata, EXPECTED_FIELD_NAMES);
+  }
+}


### PR DESCRIPTION
### Change Logs

This PR fixes the serialization of commit metadata to remove redundant fields in serialized commit metadata in JSON.

The commit metadata in JSON (*.commit, *.deltacommit) written to the Hudi timeline under `.hoodie/` contains redundant fields that can be trimmed.  As shown below, the same set of write stats is written to both "partitionToWriteStats" and "writeStats", doubling the size and increasing the serde overhead.  Other fields like "totalRecordsDeleted", "writePartitionPaths", "fileIdAndRelativePaths", etc., can be removed as well as they are derived from "partitionToWriteStats" and not directly used by HoodieCommitMetadata class.

The root cause of the problem is that, when serializing the `HoodieCommitMetadata` and `HoodieReplaceCommitMetadata` class instance to JSON string, the getters are also included, which introduce necessary fields.  The fix is to exclude getters, setters and creators in the serialization config.  After the fix, the fields are consistent with Avro schema definition, i.e., `HoodieCommitMetadata.avsc` and `HoodieReplaceCommitMetadata.avsc`.

Two more unit tests are added to verify the field names in the serialized JSON.

Sample commit metadata before this change:
```
{
  "partitionToWriteStats" : {
    "2022/1/31" : [ {
      "fileId" : "0cb6ac8a-ee31-4f00-a359-ba6ebfb80463-0",
      "path" : "2022/1/31/0cb6ac8a-ee31-4f00-a359-ba6ebfb80463-0_0-9-38_20220410134618909.parquet",
      "prevCommit" : "20220410134320333",
      "numWrites" : 250175,
      "numDeletes" : 0,
      "numUpdateWrites" : 0,
      "numInserts" : 50035,
      "totalWriteBytes" : 90720802,
      "totalWriteErrors" : 0,
      "tempPath" : null,
      "partitionPath" : "2022/1/31",
      "totalLogRecords" : 0,
      "totalLogFilesCompacted" : 0,
      "totalLogSizeCompacted" : 0,
      "totalUpdatedRecordsCompacted" : 0,
      "totalLogBlocks" : 0,
      "totalCorruptLogBlock" : 0,
      "totalRollbackBlocks" : 0,
      "fileSizeInBytes" : 90720802,
      "minEventTime" : null,
      "maxEventTime" : null
    } ],
    ...
  },
  "compacted" : false,
  "extraMetadata" : {
    "schema" : "{\"type\":\"record\",\"name\":\"hoodie_source\",\"namespace\":\"hoodie.source\",\"fields\":[{\"name\":\"key\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"partition\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"textField\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"decimalField\",\"type\":[\"null\",\"float\"],\"default\":null},{\"name\":\"longField\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"arrayField\",\"type\":[\"null\",{\"type\":\"array\",\"items\":[\"int\",\"null\"]}],\"default\":null},{\"name\":\"mapField\",\"type\":[\"null\",{\"type\":\"map\",\"values\":[\"int\",\"null\"]}],\"default\":null},{\"name\":\"round\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
    "deltastreamer.checkpoint.key" : "17"
  },
  "operationType" : "INSERT",
  "writeStats" : [ {
    "fileId" : "0cb6ac8a-ee31-4f00-a359-ba6ebfb80463-0",
    "path" : "2022/1/31/0cb6ac8a-ee31-4f00-a359-ba6ebfb80463-0_0-9-38_20220410134618909.parquet",
    "prevCommit" : "20220410134320333",
    "numWrites" : 250175,
    "numDeletes" : 0,
    "numUpdateWrites" : 0,
    "numInserts" : 50035,
    "totalWriteBytes" : 90720802,
    "totalWriteErrors" : 0,
    "tempPath" : null,
    "partitionPath" : "2022/1/31",
    "totalLogRecords" : 0,
    "totalLogFilesCompacted" : 0,
    "totalLogSizeCompacted" : 0,
    "totalUpdatedRecordsCompacted" : 0,
    "totalLogBlocks" : 0,
    "totalCorruptLogBlock" : 0,
    "totalRollbackBlocks" : 0,
    "fileSizeInBytes" : 90720802,
    "minEventTime" : null,
    "maxEventTime" : null
  }, 
  ... 
  ],
  "totalRecordsDeleted" : 0,
  "totalLogFilesSize" : 0,
  "totalScanTime" : 0,
  "totalCreateTime" : 0,
  "totalUpsertTime" : 309120,
  "minAndMaxEventTime" : {
    "Optional.empty" : {
      "val" : null,
      "present" : false
    }
  },
  "writePartitionPaths" : [ "2022/1/31", "2022/1/30", "2022/1/28", "2022/1/27", "2022/2/2", "2022/1/29", "2022/1/24", "2022/2/1", "2022/1/26", "2022/1/25" ],
  "fileIdAndRelativePaths" : {
    "3e31414c-fb4c-4ce9-aa27-a43640d94430-0" : "2022/1/25/3e31414c-fb4c-4ce9-aa27-a43640d94430-0_9-9-47_20220410134618909.parquet",
    ...
  },
  "totalLogRecordsCompacted" : 0,
  "totalLogFilesCompacted" : 0,
  "totalCompactedRecordsUpdated" : 0
} 
```
Sample commit metadata after this change:
```
{
  "partitionToWriteStats" : {
    "2022/1/31" : [ {
      "fileId" : "0cb6ac8a-ee31-4f00-a359-ba6ebfb80463-0",
      "path" : "2022/1/31/0cb6ac8a-ee31-4f00-a359-ba6ebfb80463-0_0-9-38_20220410134618909.parquet",
      "prevCommit" : "20220410134320333",
      "numWrites" : 250175,
      "numDeletes" : 0,
      "numUpdateWrites" : 0,
      "numInserts" : 50035,
      "totalWriteBytes" : 90720802,
      "totalWriteErrors" : 0,
      "tempPath" : null,
      "partitionPath" : "2022/1/31",
      "totalLogRecords" : 0,
      "totalLogFilesCompacted" : 0,
      "totalLogSizeCompacted" : 0,
      "totalUpdatedRecordsCompacted" : 0,
      "totalLogBlocks" : 0,
      "totalCorruptLogBlock" : 0,
      "totalRollbackBlocks" : 0,
      "fileSizeInBytes" : 90720802,
      "minEventTime" : null,
      "maxEventTime" : null
    } ],
    ...
  },
  "compacted" : false,
  "extraMetadata" : {
    "schema" : "{\"type\":\"record\",\"name\":\"hoodie_source\",\"namespace\":\"hoodie.source\",\"fields\":[{\"name\":\"key\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"partition\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"ts\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"textField\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"decimalField\",\"type\":[\"null\",\"float\"],\"default\":null},{\"name\":\"longField\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"arrayField\",\"type\":[\"null\",{\"type\":\"array\",\"items\":[\"int\",\"null\"]}],\"default\":null},{\"name\":\"mapField\",\"type\":[\"null\",{\"type\":\"map\",\"values\":[\"int\",\"null\"]}],\"default\":null},{\"name\":\"round\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
    "deltastreamer.checkpoint.key" : "17"
  },
  "operationType" : "INSERT"
} 
```
### Impact

**Risk level: low**

This trims the fields in commit metadata.  The existing APIs fetching the commit information still work.

This PR is tested on both COW and MOR tables with Deltastreamer.  The changes are both backward and forward compatible, i.e., (1) Spark and utilities bundles after this PR can load time and commit metadata with redundant fields generated before this PR, (2) Spark and utilities bundles before this PR can load time and commit metadata without redundant fields generated after this PR.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
