### PR TITLE
[HUDI-4606]fix flink timeline marker invalid when use EmbeddedTimelineServerReuse

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkersFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkersFactory.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.marker;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.fs.StorageSchemes;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.HoodieTable;
 
@@ -46,7 +47,7 @@ public class WriteMarkersFactory {
       case DIRECT:
         return new DirectWriteMarkers(table, instantTime);
       case TIMELINE_SERVER_BASED:
-        if (!table.getConfig().isEmbeddedTimelineServerEnabled()) {
+        if (!(FileSystemViewStorageType.isRemote(table.getConfig().getViewStorageConfig().getStorageType()))) {
           Log.warn("Timeline-server-based markers are configured as the marker type "
               + "but embedded timeline server is not enabled.  Falling back to direct markers.");
           return new DirectWriteMarkers(table, instantTime);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageType.java
@@ -32,5 +32,13 @@ public enum FileSystemViewStorageType {
   REMOTE_ONLY,
   // A composite storage where file-system view calls are first delegated to Remote server ( REMOTE_ONLY )
   // In case of failures, switches subsequent calls to secondary local storage type
-  REMOTE_FIRST
+  REMOTE_FIRST;
+
+  /**
+   * Return whether FileSystemView is remote
+   * only true when FileSystemViewStorageType is {@link FileSystemViewStorageType#REMOTE_FIRST} or {@link FileSystemViewStorageType#REMOTE_ONLY}
+   */
+  public static boolean isRemote(FileSystemViewStorageType type) {
+    return type == REMOTE_ONLY || type == REMOTE_FIRST;
+  }
 }


### PR DESCRIPTION
### Change Logs

when enable EmbeddedTimelineServerReuse and disable EmbeddedTimelineServer, TimelineBasedMarkers will fall back to DirectWriteMarkers, Flink default enable EmbeddedTimelineServerReuse and disable EmbeddedTimelineServer, It cause TimelineBasedMarkers can't work

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: medium**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
