### PR TITLE
[HUDI-4759] added validations and some pyspark edits to the quick start guide

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -444,7 +444,7 @@ df.write.format("hudi").
   mode(Overwrite).
   save(basePath)
 assert(df
-  .except(spark.sql(snapshotQuery)).count == 0)
+  .except(spark.sql(snapshotQuery)).count() == 0)
 ```
 
 :::info
@@ -487,7 +487,7 @@ df.write.format("hudi").
 options(**hudi_options).
 mode("overwrite").
 save(basePath)
-assert spark.sql(snapshotQuery).exceptAll(df).count == 0
+assert spark.sql(snapshotQuery).exceptAll(df).count() == 0
 ```
 
 :::info
@@ -760,7 +760,7 @@ df.write.format("hudi").
 assert(spark
   .sql(snapshotQuery).intersect(df).count() == df.count())
 assert(spark
-  .sql(snapshotQuery).except(df).except(snapBeforeUpdate).count == 0)
+  .sql(snapshotQuery).except(df).except(snapBeforeUpdate).count() == 0)
 ```
 
 :::note

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -14,7 +14,8 @@ data both snapshot and incrementally.
 
 ## Setup
 
-Hudi works with Spark-2.4.3+ & Spark 3.x versions. You can follow instructions [here](https://spark.apache.org/downloads) for setting up Spark.
+Hudi works with Spark-2.4.3+ & Spark 3.x versions. You can follow
+instructions [here](https://spark.apache.org/downloads) for setting up Spark.
 
 **Spark 3 Support Matrix**
 
@@ -55,6 +56,7 @@ spark-shell \
   --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.2
 spark-shell \
@@ -63,6 +65,7 @@ spark-shell \
   --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.1
 spark-shell \
@@ -70,6 +73,7 @@ spark-shell \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 2.4
 spark-shell \
@@ -77,6 +81,7 @@ spark-shell \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 </TabItem>
 
 <TabItem value="python">
@@ -92,6 +97,7 @@ pyspark \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.2
 export PYSPARK_PYTHON=$(which python3)
@@ -101,6 +107,7 @@ pyspark \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.1
 export PYSPARK_PYTHON=$(which python3)
@@ -109,6 +116,7 @@ pyspark \
 --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 2.4
 export PYSPARK_PYTHON=$(which python3)
@@ -117,6 +125,7 @@ pyspark \
 --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 </TabItem>
 
 <TabItem value="sparksql">
@@ -131,6 +140,7 @@ spark-sql --packages org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.0 \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension' \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog'
 ```
+
 ```shell
 # Spark 3.2
 spark-sql --packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0 \
@@ -138,12 +148,14 @@ spark-sql --packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0 \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension' \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog'
 ```
+
 ```shell
 # Spark 3.1
 spark-sql --packages org.apache.hudi:hudi-spark3.1-bundle_2.12:0.12.0 \
 --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 2.4
 spark-sql --packages org.apache.hudi:hudi-spark2.4-bundle_2.11:0.12.0 \
@@ -178,6 +190,7 @@ values={[
 
 ```scala
 // spark-shell
+
 import org.apache.hudi.QuickstartUtils._
 import scala.collection.JavaConversions._
 import org.apache.spark.sql.SaveMode._
@@ -207,8 +220,9 @@ dataGen = sc._jvm.org.apache.hudi.QuickstartUtils.DataGenerator()
 >
 
 :::tip
-The [DataGenerator](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L51) 
-can generate sample inserts and updates based on the the sample trip schema [here](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)
+The [DataGenerator](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L51)
+can generate sample inserts and updates based on the the sample trip
+schema [here](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)
 :::
 
 ## Create Table
@@ -264,6 +278,7 @@ Spark SQL needs an explicit create table command.
 *Read more in the [table management](/docs/table_management) guide.*
 
 :::note
+
 1. Since Hudi 0.10.0, `primaryKey` is required. It aligns with Hudi DataSource writer’s and resolves behavioural
    discrepancies reported in previous versions. Non-primary-key tables are no longer supported. Any Hudi table created
    pre-0.10.0 without a `primaryKey` needs to be re-created with a `primaryKey` field with 0.10.0.
@@ -275,7 +290,7 @@ Spark SQL needs an explicit create table command.
 6. A new Hudi table created by Spark SQL will by default
    set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and
    `hoodie.datasource.write.hive_style_partitioning=true`.
-:::
+   :::
 
 **Create a Non-Partitioned Table**
 
@@ -335,7 +350,8 @@ location '/tmp/hudi/hudi_existing_table';
 ```
 
 :::tip
-You don't need to specify schema and any properties except the partitioned columns if existed. Hudi can automatically recognize the schema and configurations.
+You don't need to specify schema and any properties except the partitioned columns if existed. Hudi can automatically
+recognize the schema and configurations.
 :::
 
 **CTAS**
@@ -399,7 +415,6 @@ To set any custom hudi config(like index type, max parquet size, etc), see the  
 </Tabs
 >
 
-
 ## Insert data
 
 <Tabs
@@ -417,6 +432,7 @@ Generate some new trips, load them into a DataFrame and write the DataFrame into
 
 ```scala
 // spark-shell
+val snapshotQuery = "SELECT begin_lat, begin_lon, driver, end_lat, end_lon, fare, partitionpath, rider, ts, uuid FROM hudi_ro_table"
 val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
@@ -427,16 +443,23 @@ df.write.format("hudi").
   option(TABLE_NAME, tableName).
   mode(Overwrite).
   save(basePath)
+assert(df
+  .except(spark.sql(snapshotQuery)).count == 0)
 ```
+
 :::info
 `mode(Overwrite)` overwrites and recreates the table if it already exists.
 You can check the data generated under `/tmp/hudi_trips_cow/<region>/<country>/<city>/`. We provided a record key
-(`uuid` in [schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60)), partition field (`region/country/city`) and combine logic (`ts` in
-[schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60)) to ensure trip records are unique within each partition. For more info, refer to
+(`uuid`
+in [schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60))
+, partition field (`region/country/city`) and combine logic (`ts` in
+[schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60))
+to ensure trip records are unique within each partition. For more info, refer to
 [Modeling data stored in Hudi](https://hudi.apache.org/learn/faq/#how-do-i-model-the-data-stored-in-hudi)
 and for info on ways to ingest data into Hudi, refer to [Writing Hudi Tables](/docs/writing_data).
 Here we are using the default write operation : `upsert`. If you have a workload without updates, you can also issue
-`insert` or `bulk_insert` operations which could be faster. To know more, refer to [Write operations](/docs/write_operations)
+`insert` or `bulk_insert` operations which could be faster. To know more, refer
+to [Write operations](/docs/write_operations)
 :::
 </TabItem>
 
@@ -445,6 +468,7 @@ Generate some new trips, load them into a DataFrame and write the DataFrame into
 
 ```python
 # pyspark
+snapshotQuery = "SELECT begin_lat, begin_lon, driver, end_lat, end_lon, fare, partitionpath, rider, ts, uuid FROM hudi_ro_table"
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10))
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 
@@ -460,19 +484,25 @@ hudi_options = {
 }
 
 df.write.format("hudi").
-    options(**hudi_options).
-    mode("overwrite").
-    save(basePath)
+options(**hudi_options).
+mode("overwrite").
+save(basePath)
+assert spark.sql(snapshotQuery).exceptAll(df).count == 0
 ```
+
 :::info
 `mode(Overwrite)` overwrites and recreates the table if it already exists.
 You can check the data generated under `/tmp/hudi_trips_cow/<region>/<country>/<city>/`. We provided a record key
-(`uuid` in [schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)), partition field (`region/country/city`) and combine logic (`ts` in
-[schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)) to ensure trip records are unique within each partition. For more info, refer to
+(`uuid`
+in [schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58))
+, partition field (`region/country/city`) and combine logic (`ts` in
+[schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58))
+to ensure trip records are unique within each partition. For more info, refer to
 [Modeling data stored in Hudi](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=113709185#FAQ-HowdoImodelthedatastoredinHudi)
 and for info on ways to ingest data into Hudi, refer to [Writing Hudi Tables](/docs/writing_data).
 Here we are using the default write operation : `upsert`. If you have a workload without updates, you can also issue
-`insert` or `bulk_insert` operations which could be faster. To know more, refer to [Write operations](/docs/write_operations)
+`insert` or `bulk_insert` operations which could be faster. To know more, refer
+to [Write operations](/docs/write_operations)
 :::
 </TabItem>
 
@@ -492,8 +522,11 @@ insert into hudi_cow_pt_tbl partition(dt = '2021-12-09', hh='11') select 2, 'a2'
 ```
 
 **NOTICE**
-- By default,  if `preCombineKey `  is provided,  `insert into` use `upsert` as the type of write operation, otherwise use `insert`.
-- We support to use `bulk_insert` as the type of write operation, just need to set two configs: `hoodie.sql.bulk.insert.enable` and `hoodie.sql.insert.mode`. Example as follow: 
+
+- By default, if `preCombineKey `  is provided,  `insert into` use `upsert` as the type of write operation, otherwise
+  use `insert`.
+- We support to use `bulk_insert` as the type of write operation, just need to set two
+  configs: `hoodie.sql.bulk.insert.enable` and `hoodie.sql.insert.mode`. Example as follow:
 
 ```sql
 -- upsert mode for preCombineField-provided table
@@ -517,17 +550,17 @@ select id, name, price, ts from hudi_mor_tbl;
 >
 
 
-Checkout https://hudi.apache.org/blog/2021/02/13/hudi-key-generators for various key generator options, like Timestamp based,
+Checkout https://hudi.apache.org/blog/2021/02/13/hudi-key-generators for various key generator options, like Timestamp
+based,
 complex, custom, NonPartitioned Key gen, etc.
-
 
 :::tip
 With [externalized config file](/docs/next/configurations#externalized-config-file),
-instead of directly passing configuration settings to every Hudi job, 
+instead of directly passing configuration settings to every Hudi job,
 you can also centrally set them in a configuration file `hudi-default.conf`.
 :::
 
-## Query data 
+## Query data
 
 Load the data files into a DataFrame.
 
@@ -553,28 +586,32 @@ tripsSnapshotDF.createOrReplaceTempView("hudi_trips_snapshot")
 spark.sql("select fare, begin_lon, begin_lat, ts from  hudi_trips_snapshot where fare > 20.0").show()
 spark.sql("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_trips_snapshot").show()
 ```
+
 </TabItem>
 <TabItem value="python">
 
 ```python
 # pyspark
-tripsSnapshotDF = spark. \
-  read. \
-  format("hudi"). \
-  load(basePath)
+tripsSnapshotDF = spark.
+read.
+format("hudi").
+load(basePath)
 # load(basePath) use "/partitionKey=partitionValue" folder structure for Spark auto partition discovery
 
 tripsSnapshotDF.createOrReplaceTempView("hudi_trips_snapshot")
 
 spark.sql("select fare, begin_lon, begin_lat, ts from  hudi_trips_snapshot where fare > 20.0").show()
-spark.sql("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_trips_snapshot").show()
+spark.sql(
+    "select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_trips_snapshot").show()
 ```
+
 </TabItem>
 <TabItem value="sparksql">
 
 ```sql
  select fare, begin_lon, begin_lat, ts from  hudi_trips_snapshot where fare > 20.0
 ```
+
 </TabItem>
 
 </Tabs
@@ -586,7 +623,8 @@ which supports partition pruning and metatable for query. This will help improve
 It also supports non-global query path which means users can query the table by the base path without
 specifing the "*" in the query path. This feature has enabled by default for the non-global query path.
 For the global query path, hudi uses the old query path.
-Refer to [Table types and queries](/docs/concepts#table-types--queries) for more info on all table types and query types supported.
+Refer to [Table types and queries](/docs/concepts#table-types--queries) for more info on all table types and query types
+supported.
 :::
 
 ### Time Travel Query
@@ -627,22 +665,24 @@ spark.read.
 <TabItem value="python">
 
 ```python
-#pyspark
-spark.read. \
-  format("hudi"). \
-  option("as.of.instant", "20210728141108"). \
-  load(basePath)
+# pyspark
+spark.read.
+format("hudi").
+option("as.of.instant", "20210728141108").
+load(basePath)
 
-spark.read. \
-  format("hudi"). \
-  option("as.of.instant", "2021-07-28 14: 11: 08"). \
-  load(basePath)
+spark.read.
+format("hudi").
+option("as.of.instant", "2021-07-28 14: 11: 08").
+load(basePath)
 
-// It is equal to "as.of.instant = 2021-07-28 00:00:00"
-spark.read. \
-  format("hudi"). \
-  option("as.of.instant", "2021-07-28"). \
-  load(basePath)
+// It is equal
+to
+"as.of.instant = 2021-07-28 00:00:00"
+spark.read.
+format("hudi").
+option("as.of.instant", "2021-07-28").
+load(basePath)
 ```
 
 </TabItem>
@@ -689,7 +729,8 @@ select * from hudi_cow_pt_tbl timestamp as of '2022-03-08' where id = 1;
 
 ## Update data
 
-This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a DataFrame 
+This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a
+DataFrame
 and write DataFrame into the hudi table.
 
 <Tabs
@@ -705,6 +746,7 @@ values={[
 
 ```scala
 // spark-shell
+val snapBeforeUpdate = spark.sql(snapshotQuery)
 val updates = convertToStringList(dataGen.generateUpdates(10))
 val df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
 df.write.format("hudi").
@@ -715,11 +757,19 @@ df.write.format("hudi").
   option(TABLE_NAME, tableName).
   mode(Append).
   save(basePath)
+assert(spark
+  .sql(snapshotQuery).intersect(df).count() == df.count())
+assert(spark
+  .sql(snapshotQuery).except(df).except(snapBeforeUpdate).count == 0)
 ```
+
 :::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table
+for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a
+new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the
+same `_hoodie_record_key`s in previous commit.
 :::
 </TabItem>
 <TabItem value="sparksql">
@@ -729,10 +779,13 @@ Spark SQL supports two kinds of DML to update hudi table: Merge-Into and Update.
 ### Update
 
 **Syntax**
+
 ```sql
 UPDATE tableIdentifier SET column = EXPRESSION(,column = EXPRESSION) [ WHERE boolExpression]
 ```
+
 **Case**
+
 ```sql
 update hudi_mor_tbl set price = price * 2, ts = 1111 where id = 1;
 
@@ -741,6 +794,7 @@ update hudi_cow_pt_tbl set name = 'a1_1', ts = 1001 where id = 1;
 -- update using non-PK field
 update hudi_cow_pt_tbl set ts = 1001 where name = 'a1';
 ```
+
 :::note
 `Update` operation requires `preCombineField` specified.
 :::
@@ -766,7 +820,9 @@ ON <merge_condition>
   INSERT *  |
   INSERT (column1 [, column2 ...]) VALUES (value1 [, value2 ...])
 ```
+
 **Example**
+
 ```sql
 -- source table using hudi for testing merging into non-partitioned table
 create table merge_source (id int, name string, price double, ts bigint) using hudi
@@ -803,17 +859,24 @@ when not matched then
 
 ```python
 # pyspark
+snapshotBeforeUpdate = spark.sql(snapshotQuery)
 updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
 df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
-df.write.format("hudi"). \
-  options(**hudi_options). \
-  mode("append"). \
-  save(basePath)
+df.write.format("hudi").
+options(**hudi_options).
+mode("append").
+save(basePath)
+assert spark.sql(snapshotQuery).intersect(df).count() == df.count()
+assert spark.sql(snapshotQuery).exceptAll(snapshotBeforeUpdate).exceptAll(df).count() == 0
 ```
+
 :::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table
+for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a
+new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the
+same `_hoodie_record_key`s in previous commit.
 :::
 
 </TabItem>
@@ -821,12 +884,12 @@ denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `d
 </Tabs
 >
 
-
 ## Incremental query
 
-Hudi also provides capability to obtain a stream of records that changed since given commit timestamp. 
-This can be achieved using Hudi's incremental querying and providing a begin time from which changes need to be streamed. 
-We do not need to specify endTime, if we want all changes after the given commit (as is the common case). 
+Hudi also provides capability to obtain a stream of records that changed since given commit timestamp.
+This can be achieved using Hudi's incremental querying and providing a begin time from which changes need to be
+streamed.
+We do not need to specify endTime, if we want all changes after the given commit (as is the common case).
 
 <Tabs
 defaultValue="scala"
@@ -866,27 +929,30 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hu
 ```python
 # pyspark
 # reload data
-spark. \
-  read. \
-  format("hudi"). \
-  load(basePath). \
-  createOrReplaceTempView("hudi_trips_snapshot")
+spark.
+read.
+format("hudi").
+load(basePath).
+createOrReplaceTempView("hudi_trips_snapshot")
 
-commits = list(map(lambda row: row[0], spark.sql("select distinct(_hoodie_commit_time) as commitTime from  hudi_trips_snapshot order by commitTime").limit(50).collect()))
-beginTime = commits[len(commits) - 2] # commit time we are interested in
+commits = list(map(lambda row: row[0], spark.sql(
+    "select distinct(_hoodie_commit_time) as commitTime from  hudi_trips_snapshot order by commitTime").limit(
+    50).collect()))
+beginTime = commits[len(commits) - 2]  # commit time we are interested in
 
 # incrementally query data
 incremental_read_options = {
-  'hoodie.datasource.query.type': 'incremental',
-  'hoodie.datasource.read.begin.instanttime': beginTime,
+    'hoodie.datasource.query.type': 'incremental',
+    'hoodie.datasource.read.begin.instanttime': beginTime,
 }
 
-tripsIncrementalDF = spark.read.format("hudi"). \
-  options(**incremental_read_options). \
-  load(basePath)
+tripsIncrementalDF = spark.read.format("hudi").
+options(**incremental_read_options).
+load(basePath)
 tripsIncrementalDF.createOrReplaceTempView("hudi_trips_incremental")
 
-spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hudi_trips_incremental where fare > 20.0").show()
+spark.sql(
+    "select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hudi_trips_incremental where fare > 20.0").show()
 ```
 
 </TabItem>
@@ -895,14 +961,15 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hu
 >
 
 :::info
-This will give all changes that happened after the beginTime commit with the filter of fare > 20.0. The unique thing about this
+This will give all changes that happened after the beginTime commit with the filter of fare > 20.0. The unique thing
+about this
 feature is that it now lets you author streaming pipelines on batch data.
 :::
 
 ## Point in time query
 
-Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 
-specific commit time and beginTime to "000" (denoting earliest possible commit time). 
+Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a
+specific commit time and beginTime to "000" (denoting earliest possible commit time).
 
 <Tabs
 defaultValue="scala"
@@ -934,22 +1001,23 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hud
 
 ```python
 # pyspark
-beginTime = "000" # Represents all commits > this time.
+beginTime = "000"  # Represents all commits > this time.
 endTime = commits[len(commits) - 2]
 
 # query point in time data
 point_in_time_read_options = {
-  'hoodie.datasource.query.type': 'incremental',
-  'hoodie.datasource.read.end.instanttime': endTime,
-  'hoodie.datasource.read.begin.instanttime': beginTime
+    'hoodie.datasource.query.type': 'incremental',
+    'hoodie.datasource.read.end.instanttime': endTime,
+    'hoodie.datasource.read.begin.instanttime': beginTime
 }
 
-tripsPointInTimeDF = spark.read.format("hudi"). \
-  options(**point_in_time_read_options). \
-  load(basePath)
+tripsPointInTimeDF = spark.read.format("hudi").
+options(**point_in_time_read_options).
+load(basePath)
 
 tripsPointInTimeDF.createOrReplaceTempView("hudi_trips_point_in_time")
-spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hudi_trips_point_in_time where fare > 20.0").show()
+spark.sql(
+    "select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hudi_trips_point_in_time where fare > 20.0").show()
 ```
 
 </TabItem>
@@ -959,9 +1027,10 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hud
 
 ## Delete data {#deletes}
 
-Apache Hudi supports two types of deletes: (1) **Soft Deletes**: retaining the record key and just nulling out the values
+Apache Hudi supports two types of deletes: (1) **Soft Deletes**: retaining the record key and just nulling out the
+values
 for all the other fields (records with nulls in soft deletes are always persisted in storage and never removed);
-(2) **Hard Deletes**: physically removing any trace of the record from the table.  See the
+(2) **Hard Deletes**: physically removing any trace of the record from the table. See the
 [deletion section](/docs/writing_data#deletes) of the writing data page for more details.
 
 ### Soft Deletes
@@ -1022,6 +1091,7 @@ spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 // This should return (total - 2) count as two records are updated with nulls
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is not null").count()
 ```
+
 :::note
 Notice that the save mode is `Append`.
 :::
@@ -1033,9 +1103,9 @@ Notice that the save mode is `Append`.
 from pyspark.sql.functions import lit
 from functools import reduce
 
-spark.read.format("hudi"). \
-  load(basePath). \
-  createOrReplaceTempView("hudi_trips_snapshot")
+spark.read.format("hudi").
+load(basePath).
+createOrReplaceTempView("hudi_trips_snapshot")
 # fetch total records count
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is not null").count()
@@ -1043,42 +1113,43 @@ spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is no
 soft_delete_ds = spark.sql("select * from hudi_trips_snapshot").limit(2)
 
 # prepare the soft deletes by ensuring the appropriate fields are nullified
-meta_columns = ["_hoodie_commit_time", "_hoodie_commit_seqno", "_hoodie_record_key", \
-  "_hoodie_partition_path", "_hoodie_file_name"]
+meta_columns = ["_hoodie_commit_time", "_hoodie_commit_seqno", "_hoodie_record_key",
+                "_hoodie_partition_path", "_hoodie_file_name"]
 excluded_columns = meta_columns + ["ts", "uuid", "partitionpath"]
-nullify_columns = list(filter(lambda field: field[0] not in excluded_columns, \
-  list(map(lambda field: (field.name, field.dataType), softDeleteDs.schema.fields))))
+nullify_columns = list(filter(lambda field: field[0] not in excluded_columns,
+                              list(map(lambda field: (field.name, field.dataType), soft_delete_ds.schema.fields))))
 
 hudi_soft_delete_options = {
-  'hoodie.table.name': tableName,
-  'hoodie.datasource.write.recordkey.field': 'uuid',
-  'hoodie.datasource.write.partitionpath.field': 'partitionpath',
-  'hoodie.datasource.write.table.name': tableName,
-  'hoodie.datasource.write.operation': 'upsert',
-  'hoodie.datasource.write.precombine.field': 'ts',
-  'hoodie.upsert.shuffle.parallelism': 2, 
-  'hoodie.insert.shuffle.parallelism': 2
+    'hoodie.table.name': tableName,
+    'hoodie.datasource.write.recordkey.field': 'uuid',
+    'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+    'hoodie.datasource.write.table.name': tableName,
+    'hoodie.datasource.write.operation': 'upsert',
+    'hoodie.datasource.write.precombine.field': 'ts',
+    'hoodie.upsert.shuffle.parallelism': 2,
+    'hoodie.insert.shuffle.parallelism': 2
 }
 
-soft_delete_df = reduce(lambda df,col: df.withColumn(col[0], lit(None).cast(col[1])), \
-  nullify_columns, reduce(lambda df,col: df.drop(col[0]), meta_columns, soft_delete_ds))
+soft_delete_df = reduce(lambda df, col: df.withColumn(col[0], lit(None).cast(col[1])),
+                        nullify_columns, reduce(lambda df, col: df.drop(col[0]), meta_columns, soft_delete_ds))
 
 # simply upsert the table after setting these fields to null
-soft_delete_df.write.format("hudi"). \
-  options(**hudi_soft_delete_options). \
-  mode("append"). \
-  save(basePath)
+soft_delete_df.write.format("hudi").
+options(**hudi_soft_delete_options).
+mode("append").
+save(basePath)
 
 # reload data
-spark.read.format("hudi"). \
-  load(basePath). \
-  createOrReplaceTempView("hudi_trips_snapshot")
+spark.read.format("hudi").
+load(basePath).
+createOrReplaceTempView("hudi_trips_snapshot")
 
 # This should return the same total count as before
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 # This should return (total - 2) count as two records are updated with nulls
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is not null").count()
 ```
+
 :::note
 Notice that the save mode is `Append`.
 :::
@@ -1086,7 +1157,6 @@ Notice that the save mode is `Append`.
 
 </Tabs
 >
-
 
 ### Hard Deletes
 
@@ -1105,6 +1175,7 @@ Delete records for the HoodieKeys passed in.<br/>
 ```scala
 // spark-shell
 // fetch total records count
+val snapshotBeforeDelete = spark.sql(snapshotQuery)
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 // fetch two records to be deleted
 val ds = spark.sql("select uuid, partitionpath from hudi_trips_snapshot").limit(2)
@@ -1115,7 +1186,7 @@ val hardDeleteDf = spark.read.json(spark.sparkContext.parallelize(deletes, 2))
 
 hardDeleteDf.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY,"delete").
+  option(OPERATION_OPT_KEY, "delete").
   option(PRECOMBINE_FIELD_OPT_KEY, "ts").
   option(RECORDKEY_FIELD_OPT_KEY, "uuid").
   option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
@@ -1132,7 +1203,12 @@ val roAfterDeleteViewDF = spark.
 roAfterDeleteViewDF.registerTempTable("hudi_trips_snapshot")
 // fetch should return (total - 2) records
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
+assert(spark
+  .sql("select uuid, partitionpath, ts from hudi_trips_snapshot").intersect(hardDeleteDf).count() == 0)
+assert(snapshotBeforeDelete
+  .except(spark.sql("select uuid, partitionpath, ts from hudi_trips_snapshot")).except(snapshotBeforeDelete).count() == 0)
 ```
+
 :::note
 Only `Append` mode is supported for delete operation.
 :::
@@ -1140,10 +1216,13 @@ Only `Append` mode is supported for delete operation.
 <TabItem value="sparksql">
 
 **Syntax**
+
 ```sql
 DELETE FROM tableIdentifier [ WHERE BOOL_EXPRESSION]
 ```
+
 **Example**
+
 ```sql
 delete from hudi_cow_nonpcf_tbl where uuid = 1;
 
@@ -1159,6 +1238,7 @@ Delete records for the HoodieKeys passed in.<br/>
 
 ```python
 # pyspark
+snapshotBeforeDelete = spark.sql(snapshotQuery)
 # fetch total records count
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 # fetch two records to be deleted
@@ -1166,33 +1246,37 @@ ds = spark.sql("select uuid, partitionpath from hudi_trips_snapshot").limit(2)
 
 # issue deletes
 hudi_hard_delete_options = {
-  'hoodie.table.name': tableName,
-  'hoodie.datasource.write.recordkey.field': 'uuid',
-  'hoodie.datasource.write.partitionpath.field': 'partitionpath',
-  'hoodie.datasource.write.table.name': tableName,
-  'hoodie.datasource.write.operation': 'delete',
-  'hoodie.datasource.write.precombine.field': 'ts',
-  'hoodie.upsert.shuffle.parallelism': 2, 
-  'hoodie.insert.shuffle.parallelism': 2
+    'hoodie.table.name': tableName,
+    'hoodie.datasource.write.recordkey.field': 'uuid',
+    'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+    'hoodie.datasource.write.table.name': tableName,
+    'hoodie.datasource.write.operation': 'delete',
+    'hoodie.datasource.write.precombine.field': 'ts',
+    'hoodie.upsert.shuffle.parallelism': 2,
+    'hoodie.insert.shuffle.parallelism': 2
 }
 
 from pyspark.sql.functions import lit
+
 deletes = list(map(lambda row: (row[0], row[1]), ds.collect()))
 hard_delete_df = spark.sparkContext.parallelize(deletes).toDF(['uuid', 'partitionpath']).withColumn('ts', lit(0.0))
-hard_delete_df.write.format("hudi"). \
-  options(**hudi_hard_delete_options). \
-  mode("append"). \
-  save(basePath)
+hard_delete_df.write.format("hudi").
+options(**hudi_hard_delete_options).
+mode("append").
+save(basePath)
 
 # run the same read query as above.
-roAfterDeleteViewDF = spark. \
-  read. \
-  format("hudi"). \
-  load(basePath) 
-roAfterDeleteViewDF.registerTempTable("hudi_trips_snapshot")
+roAfterDeleteViewDF = spark.
+read.
+format("hudi").
+load(basePath)
+roAfterDeleteViewDF.createOrReplaceTempView("hudi_trips_snapshot")
 # fetch should return (total - 2) records
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
+assert spark.sql("select uuid, partitionpath, ts from hudi_trips_snapshot").intersect(hard_delete_df).count() == 0
+assert snapshotBeforeDelete.excptAll(spark.sql("select uuid, partitionpath, ts from hudi_trips_snapshot")).count() == 0
 ```
+
 :::note
 Only `Append` mode is supported for delete operation.
 :::
@@ -1223,17 +1307,18 @@ values={[
 spark.
   read.format("hudi").
   load(basePath).
-  select("uuid","partitionpath").
-  sort("partitionpath","uuid").
+  select("uuid", "partitionpath").
+  sort("partitionpath", "uuid").
   show(100, false)
 
+val snapshotBeforeOverwrite = spark.sql(snapshotQuery)
 val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.
   read.json(spark.sparkContext.parallelize(inserts, 2)).
   filter("partitionpath = 'americas/united_states/san_francisco'")
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION.key(),"insert_overwrite").
+  option(OPERATION.key(), "insert_overwrite").
   option(PRECOMBINE_FIELD.key(), "ts").
   option(RECORDKEY_FIELD.key(), "uuid").
   option(PARTITIONPATH_FIELD.key(), "partitionpath").
@@ -1245,15 +1330,60 @@ df.write.format("hudi").
 spark.
   read.format("hudi").
   load(basePath).
-  select("uuid","partitionpath").
-  sort("partitionpath","uuid").
+  select("uuid", "partitionpath").
+  sort("partitionpath", "uuid").
   show(100, false)
+
+val withoutSanFran = snapshotBeforeOverwrite.filter("partitionpath != 'americas/united_states/san_francisco'")
+val expectedDf = withoutSanFran.union(df)
+assert(spark
+  .sql(snapshotQuery).except(expectedDf).count() == 0)
 ```
+
+</TabItem>
+
+<TabItem value="python">
+Delete records for the HoodieKeys passed in.<br/>
+
+```python
+snapshotBeforeOverwrite = spark.sql(snapshotQuery)
+self.spark.read.format("hudi")
+.load(self.basePath)
+.select(["uuid", "partitionpath"])
+.sort(["partitionpath", "uuid"])
+.show(n=100, truncate=False)
+
+inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10))
+df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
+.filter("partitionpath = 'americas/united_states/san_francisco'")
+
+hudi_insert_overwrite_options = {
+    'hoodie.table.name': self.tableName,
+    'hoodie.datasource.write.recordkey.field': 'uuid',
+    'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+    'hoodie.datasource.write.table.name': self.tableName,
+    'hoodie.datasource.write.operation': 'insert_overwrite',
+    'hoodie.datasource.write.precombine.field': 'ts',
+    'hoodie.upsert.shuffle.parallelism': 2,
+    'hoodie.insert.shuffle.parallelism': 2
+}
+df.write.format("hudi").options(**hudi_insert_overwrite_options).mode("append").save(basePath)
+spark.read.format("hudi")
+.load(basePath).select(["uuid", "partitionpath"]).sort(["partitionpath", "uuid"]).show(n=100, truncate=False)
+
+withoutSanFran = snapshotBeforeOverwrite.filter("partitionpath != 'americas/united_states/san_francisco'")
+expectedDf = withoutSanFran.union(df)
+assert spark
+.sql(snapshotQuery).exceptAll(expectedDf).count() == 0
+
+```
+
 </TabItem>
 
 <TabItem value="sparksql">
 
-`insert overwrite` a partitioned table use the `INSERT_OVERWRITE` type of write operation, while a non-partitioned table to `INSERT_OVERWRITE_TABLE`.
+`insert overwrite` a partitioned table use the `INSERT_OVERWRITE` type of write operation, while a non-partitioned table
+to `INSERT_OVERWRITE_TABLE`.
 
 ```sql
 -- insert overwrite non-partitioned table
@@ -1266,6 +1396,7 @@ insert overwrite table hudi_cow_pt_tbl select 10, 'a10', 1100, '2021-12-09', '10
 -- insert overwrite partitioned table with static partition
 insert overwrite hudi_cow_pt_tbl partition(dt = '2021-12-09', hh='12') select 13, 'a13', 1100;
 ```
+
 </TabItem>
 
 </Tabs
@@ -1282,6 +1413,7 @@ For more detailed examples, please prefer to [schema evolution](schema_evolution
 :::
 
 **Syntax**
+
 ```sql
 -- Alter table name
 ALTER TABLE oldTableName RENAME TO newTableName
@@ -1295,7 +1427,9 @@ ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 -- Alter table properties
 ALTER TABLE tableIdentifier SET TBLPROPERTIES (key = 'value')
 ```
+
 **Examples**
+
 ```sql
 --rename to:
 ALTER TABLE hudi_cow_nonpcf_tbl RENAME TO hudi_cow_nonpcf_tbl2;
@@ -1321,7 +1455,9 @@ ALTER TABLE tableIdentifier DROP PARTITION ( partition_col_name = partition_col_
 -- Show Partitions
 SHOW PARTITIONS tableIdentifier
 ```
+
 **Examples**
+
 ```sql
 --show partition:
 show partitions hudi_cow_pt_tbl;
@@ -1329,14 +1465,17 @@ show partitions hudi_cow_pt_tbl;
 --drop partition：
 alter table hudi_cow_pt_tbl drop partition (dt='2021-12-09', hh='10');
 ```
+
 :::note
-Currently,  the result of `show partitions` is based on the filesystem table path. It's not precise when delete the whole partition data or drop certain partition directly.
+Currently, the result of `show partitions` is based on the filesystem table path. It's not precise when delete the whole
+partition data or drop certain partition directly.
 
 :::
 
 ### Procedures
 
 **Syntax**
+
 ```sql
 --Call procedure by positional arguments
 CALL system.procedure_name(arg_1, arg_2, ... arg_n)
@@ -1344,25 +1483,31 @@ CALL system.procedure_name(arg_1, arg_2, ... arg_n)
 --Call procedure by named arguments
 CALL system.procedure_name(arg_name_2 => arg_2, arg_name_1 => arg_1, ... arg_name_n => arg_n)
 ```
+
 **Examples**
+
 ```sql
 --show commit's info
 call show_commits(table => 'test_hudi_table', limit => 10);
 ```
 
-Call command has already support some commit procedures and table optimization procedures, 
+Call command has already support some commit procedures and table optimization procedures,
 more details please refer to [procedures](procedures).
 
 ## Where to go from here?
 
-You can also do the quickstart by [building hudi yourself](https://github.com/apache/hudi#building-apache-hudi-from-source), 
-and using `--jars <path to hudi_code>/packaging/hudi-spark-bundle/target/hudi-spark3.2-bundle_2.1?-*.*.*-SNAPSHOT.jar` in the spark-shell command above
-instead of `--packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0`. Hudi also supports scala 2.12. Refer [build with scala 2.12](https://github.com/apache/hudi#build-with-different-spark-versions)
+You can also do the quickstart
+by [building hudi yourself](https://github.com/apache/hudi#building-apache-hudi-from-source),
+and using `--jars <path to hudi_code>/packaging/hudi-spark-bundle/target/hudi-spark3.2-bundle_2.1?-*.*.*-SNAPSHOT.jar`
+in the spark-shell command above
+instead of `--packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0`. Hudi also supports scala 2.12.
+Refer [build with scala 2.12](https://github.com/apache/hudi#build-with-different-spark-versions)
 for more info.
 
-Also, we used Spark here to show case the capabilities of Hudi. However, Hudi can support multiple table types/query types and 
-Hudi tables can be queried from query engines like Hive, Spark, Presto and much more. We have put together a 
-[demo video](https://www.youtube.com/watch?v=VhNgUsxdrD0) that show cases all of this on a docker based setup with all 
-dependent systems running locally. We recommend you replicate the same setup and run the demo yourself, by following 
-steps [here](/docs/docker_demo) to get a taste for it. Also, if you are looking for ways to migrate your existing data 
+Also, we used Spark here to show case the capabilities of Hudi. However, Hudi can support multiple table types/query
+types and
+Hudi tables can be queried from query engines like Hive, Spark, Presto and much more. We have put together a
+[demo video](https://www.youtube.com/watch?v=VhNgUsxdrD0) that show cases all of this on a docker based setup with all
+dependent systems running locally. We recommend you replicate the same setup and run the demo yourself, by following
+steps [here](/docs/docker_demo) to get a taste for it. Also, if you are looking for ways to migrate your existing data
 to Hudi, refer to [migration guide](/docs/migration_guide).

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -14,7 +14,8 @@ data both snapshot and incrementally.
 
 ## Setup
 
-Hudi works with Spark-2.4.3+ & Spark 3.x versions. You can follow instructions [here](https://spark.apache.org/downloads) for setting up Spark.
+Hudi works with Spark-2.4.3+ & Spark 3.x versions. You can follow
+instructions [here](https://spark.apache.org/downloads) for setting up Spark.
 
 **Spark 3 Support Matrix**
 
@@ -55,6 +56,7 @@ spark-shell \
   --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.2
 spark-shell \
@@ -63,6 +65,7 @@ spark-shell \
   --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.1
 spark-shell \
@@ -70,6 +73,7 @@ spark-shell \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 2.4
 spark-shell \
@@ -77,6 +81,7 @@ spark-shell \
   --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
   --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 </TabItem>
 
 <TabItem value="python">
@@ -92,6 +97,7 @@ pyspark \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.2
 export PYSPARK_PYTHON=$(which python3)
@@ -101,6 +107,7 @@ pyspark \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 3.1
 export PYSPARK_PYTHON=$(which python3)
@@ -109,6 +116,7 @@ pyspark \
 --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 2.4
 export PYSPARK_PYTHON=$(which python3)
@@ -117,6 +125,7 @@ pyspark \
 --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 </TabItem>
 
 <TabItem value="sparksql">
@@ -131,6 +140,7 @@ spark-sql --packages org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.0 \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension' \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog'
 ```
+
 ```shell
 # Spark 3.2
 spark-sql --packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0 \
@@ -138,12 +148,14 @@ spark-sql --packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0 \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension' \
 --conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog'
 ```
+
 ```shell
 # Spark 3.1
 spark-sql --packages org.apache.hudi:hudi-spark3.1-bundle_2.12:0.12.0 \
 --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer' \
 --conf 'spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension'
 ```
+
 ```shell
 # Spark 2.4
 spark-sql --packages org.apache.hudi:hudi-spark2.4-bundle_2.11:0.12.0 \
@@ -178,6 +190,7 @@ values={[
 
 ```scala
 // spark-shell
+
 import org.apache.hudi.QuickstartUtils._
 import scala.collection.JavaConversions._
 import org.apache.spark.sql.SaveMode._
@@ -207,8 +220,9 @@ dataGen = sc._jvm.org.apache.hudi.QuickstartUtils.DataGenerator()
 >
 
 :::tip
-The [DataGenerator](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L51) 
-can generate sample inserts and updates based on the the sample trip schema [here](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)
+The [DataGenerator](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L51)
+can generate sample inserts and updates based on the the sample trip
+schema [here](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)
 :::
 
 ## Create Table
@@ -264,6 +278,7 @@ Spark SQL needs an explicit create table command.
 *Read more in the [table management](/docs/table_management) guide.*
 
 :::note
+
 1. Since Hudi 0.10.0, `primaryKey` is required. It aligns with Hudi DataSource writer’s and resolves behavioural
    discrepancies reported in previous versions. Non-primary-key tables are no longer supported. Any Hudi table created
    pre-0.10.0 without a `primaryKey` needs to be re-created with a `primaryKey` field with 0.10.0.
@@ -275,7 +290,7 @@ Spark SQL needs an explicit create table command.
 6. A new Hudi table created by Spark SQL will by default
    set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and
    `hoodie.datasource.write.hive_style_partitioning=true`.
-:::
+   :::
 
 **Create a Non-Partitioned Table**
 
@@ -335,7 +350,8 @@ location '/tmp/hudi/hudi_existing_table';
 ```
 
 :::tip
-You don't need to specify schema and any properties except the partitioned columns if existed. Hudi can automatically recognize the schema and configurations.
+You don't need to specify schema and any properties except the partitioned columns if existed. Hudi can automatically
+recognize the schema and configurations.
 :::
 
 **CTAS**
@@ -399,7 +415,6 @@ To set any custom hudi config(like index type, max parquet size, etc), see the  
 </Tabs
 >
 
-
 ## Insert data
 
 <Tabs
@@ -417,6 +432,7 @@ Generate some new trips, load them into a DataFrame and write the DataFrame into
 
 ```scala
 // spark-shell
+val snapshotQuery = "SELECT begin_lat, begin_lon, driver, end_lat, end_lon, fare, partitionpath, rider, ts, uuid FROM hudi_ro_table"
 val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 df.write.format("hudi").
@@ -427,16 +443,23 @@ df.write.format("hudi").
   option(TABLE_NAME, tableName).
   mode(Overwrite).
   save(basePath)
+assert(df
+  .except(spark.sql(snapshotQuery)).count == 0)
 ```
+
 :::info
 `mode(Overwrite)` overwrites and recreates the table if it already exists.
 You can check the data generated under `/tmp/hudi_trips_cow/<region>/<country>/<city>/`. We provided a record key
-(`uuid` in [schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60)), partition field (`region/country/city`) and combine logic (`ts` in
-[schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60)) to ensure trip records are unique within each partition. For more info, refer to
+(`uuid`
+in [schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60))
+, partition field (`region/country/city`) and combine logic (`ts` in
+[schema](https://github.com/apache/hudi/blob/2e6e302efec2fa848ded4f88a95540ad2adb7798/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L60))
+to ensure trip records are unique within each partition. For more info, refer to
 [Modeling data stored in Hudi](https://hudi.apache.org/learn/faq/#how-do-i-model-the-data-stored-in-hudi)
 and for info on ways to ingest data into Hudi, refer to [Writing Hudi Tables](/docs/writing_data).
 Here we are using the default write operation : `upsert`. If you have a workload without updates, you can also issue
-`insert` or `bulk_insert` operations which could be faster. To know more, refer to [Write operations](/docs/write_operations)
+`insert` or `bulk_insert` operations which could be faster. To know more, refer
+to [Write operations](/docs/write_operations)
 :::
 </TabItem>
 
@@ -445,6 +468,7 @@ Generate some new trips, load them into a DataFrame and write the DataFrame into
 
 ```python
 # pyspark
+snapshotQuery = "SELECT begin_lat, begin_lon, driver, end_lat, end_lon, fare, partitionpath, rider, ts, uuid FROM hudi_ro_table"
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10))
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
 
@@ -460,19 +484,25 @@ hudi_options = {
 }
 
 df.write.format("hudi").
-    options(**hudi_options).
-    mode("overwrite").
-    save(basePath)
+options(**hudi_options).
+mode("overwrite").
+save(basePath)
+assert spark.sql(snapshotQuery).exceptAll(df).count() == 0
 ```
+
 :::info
 `mode(Overwrite)` overwrites and recreates the table if it already exists.
 You can check the data generated under `/tmp/hudi_trips_cow/<region>/<country>/<city>/`. We provided a record key
-(`uuid` in [schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)), partition field (`region/country/city`) and combine logic (`ts` in
-[schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58)) to ensure trip records are unique within each partition. For more info, refer to
+(`uuid`
+in [schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58))
+, partition field (`region/country/city`) and combine logic (`ts` in
+[schema](https://github.com/apache/hudi/blob/master/hudi-spark/src/main/java/org/apache/hudi/QuickstartUtils.java#L58))
+to ensure trip records are unique within each partition. For more info, refer to
 [Modeling data stored in Hudi](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=113709185#FAQ-HowdoImodelthedatastoredinHudi)
 and for info on ways to ingest data into Hudi, refer to [Writing Hudi Tables](/docs/writing_data).
 Here we are using the default write operation : `upsert`. If you have a workload without updates, you can also issue
-`insert` or `bulk_insert` operations which could be faster. To know more, refer to [Write operations](/docs/write_operations)
+`insert` or `bulk_insert` operations which could be faster. To know more, refer
+to [Write operations](/docs/write_operations)
 :::
 </TabItem>
 
@@ -492,8 +522,11 @@ insert into hudi_cow_pt_tbl partition(dt = '2021-12-09', hh='11') select 2, 'a2'
 ```
 
 **NOTICE**
-- By default,  if `preCombineKey `  is provided,  `insert into` use `upsert` as the type of write operation, otherwise use `insert`.
-- We support to use `bulk_insert` as the type of write operation, just need to set two configs: `hoodie.sql.bulk.insert.enable` and `hoodie.sql.insert.mode`. Example as follow: 
+
+- By default, if `preCombineKey `  is provided,  `insert into` use `upsert` as the type of write operation, otherwise
+  use `insert`.
+- We support to use `bulk_insert` as the type of write operation, just need to set two
+  configs: `hoodie.sql.bulk.insert.enable` and `hoodie.sql.insert.mode`. Example as follow:
 
 ```sql
 -- upsert mode for preCombineField-provided table
@@ -517,17 +550,17 @@ select id, name, price, ts from hudi_mor_tbl;
 >
 
 
-Checkout https://hudi.apache.org/blog/2021/02/13/hudi-key-generators for various key generator options, like Timestamp based,
+Checkout https://hudi.apache.org/blog/2021/02/13/hudi-key-generators for various key generator options, like Timestamp
+based,
 complex, custom, NonPartitioned Key gen, etc.
-
 
 :::tip
 With [externalized config file](/docs/next/configurations#externalized-config-file),
-instead of directly passing configuration settings to every Hudi job, 
+instead of directly passing configuration settings to every Hudi job,
 you can also centrally set them in a configuration file `hudi-default.conf`.
 :::
 
-## Query data 
+## Query data
 
 Load the data files into a DataFrame.
 
@@ -553,28 +586,32 @@ tripsSnapshotDF.createOrReplaceTempView("hudi_trips_snapshot")
 spark.sql("select fare, begin_lon, begin_lat, ts from  hudi_trips_snapshot where fare > 20.0").show()
 spark.sql("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_trips_snapshot").show()
 ```
+
 </TabItem>
 <TabItem value="python">
 
 ```python
 # pyspark
-tripsSnapshotDF = spark. \
-  read. \
-  format("hudi"). \
-  load(basePath)
+tripsSnapshotDF = spark.
+read.
+format("hudi").
+load(basePath)
 # load(basePath) use "/partitionKey=partitionValue" folder structure for Spark auto partition discovery
 
 tripsSnapshotDF.createOrReplaceTempView("hudi_trips_snapshot")
 
 spark.sql("select fare, begin_lon, begin_lat, ts from  hudi_trips_snapshot where fare > 20.0").show()
-spark.sql("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_trips_snapshot").show()
+spark.sql(
+    "select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_trips_snapshot").show()
 ```
+
 </TabItem>
 <TabItem value="sparksql">
 
 ```sql
  select fare, begin_lon, begin_lat, ts from  hudi_trips_snapshot where fare > 20.0
 ```
+
 </TabItem>
 
 </Tabs
@@ -586,7 +623,8 @@ which supports partition pruning and metatable for query. This will help improve
 It also supports non-global query path which means users can query the table by the base path without
 specifing the "*" in the query path. This feature has enabled by default for the non-global query path.
 For the global query path, hudi uses the old query path.
-Refer to [Table types and queries](/docs/concepts#table-types--queries) for more info on all table types and query types supported.
+Refer to [Table types and queries](/docs/concepts#table-types--queries) for more info on all table types and query types
+supported.
 :::
 
 ### Time Travel Query
@@ -627,22 +665,24 @@ spark.read.
 <TabItem value="python">
 
 ```python
-#pyspark
-spark.read. \
-  format("hudi"). \
-  option("as.of.instant", "20210728141108"). \
-  load(basePath)
+# pyspark
+spark.read.
+format("hudi").
+option("as.of.instant", "20210728141108").
+load(basePath)
 
-spark.read. \
-  format("hudi"). \
-  option("as.of.instant", "2021-07-28 14: 11: 08"). \
-  load(basePath)
+spark.read.
+format("hudi").
+option("as.of.instant", "2021-07-28 14: 11: 08").
+load(basePath)
 
-// It is equal to "as.of.instant = 2021-07-28 00:00:00"
-spark.read. \
-  format("hudi"). \
-  option("as.of.instant", "2021-07-28"). \
-  load(basePath)
+// It is equal
+to
+"as.of.instant = 2021-07-28 00:00:00"
+spark.read.
+format("hudi").
+option("as.of.instant", "2021-07-28").
+load(basePath)
 ```
 
 </TabItem>
@@ -689,7 +729,8 @@ select * from hudi_cow_pt_tbl timestamp as of '2022-03-08' where id = 1;
 
 ## Update data
 
-This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a DataFrame 
+This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a
+DataFrame
 and write DataFrame into the hudi table.
 
 <Tabs
@@ -705,6 +746,7 @@ values={[
 
 ```scala
 // spark-shell
+val snapBeforeUpdate = spark.sql(snapshotQuery)
 val updates = convertToStringList(dataGen.generateUpdates(10))
 val df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
 df.write.format("hudi").
@@ -715,11 +757,19 @@ df.write.format("hudi").
   option(TABLE_NAME, tableName).
   mode(Append).
   save(basePath)
+assert(spark
+  .sql(snapshotQuery).intersect(df).count() == df.count())
+assert(spark
+  .sql(snapshotQuery).except(df).except(snapBeforeUpdate).count() == 0)
 ```
+
 :::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table
+for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a
+new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the
+same `_hoodie_record_key`s in previous commit.
 :::
 </TabItem>
 <TabItem value="sparksql">
@@ -729,10 +779,13 @@ Spark SQL supports two kinds of DML to update hudi table: Merge-Into and Update.
 ### Update
 
 **Syntax**
+
 ```sql
 UPDATE tableIdentifier SET column = EXPRESSION(,column = EXPRESSION) [ WHERE boolExpression]
 ```
+
 **Case**
+
 ```sql
 update hudi_mor_tbl set price = price * 2, ts = 1111 where id = 1;
 
@@ -741,6 +794,7 @@ update hudi_cow_pt_tbl set name = 'a1_1', ts = 1001 where id = 1;
 -- update using non-PK field
 update hudi_cow_pt_tbl set ts = 1001 where name = 'a1';
 ```
+
 :::note
 `Update` operation requires `preCombineField` specified.
 :::
@@ -766,7 +820,9 @@ ON <merge_condition>
   INSERT *  |
   INSERT (column1 [, column2 ...]) VALUES (value1 [, value2 ...])
 ```
+
 **Example**
+
 ```sql
 -- source table using hudi for testing merging into non-partitioned table
 create table merge_source (id int, name string, price double, ts bigint) using hudi
@@ -803,17 +859,24 @@ when not matched then
 
 ```python
 # pyspark
+snapshotBeforeUpdate = spark.sql(snapshotQuery)
 updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
 df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
-df.write.format("hudi"). \
-  options(**hudi_options). \
-  mode("append"). \
-  save(basePath)
+df.write.format("hudi").
+options(**hudi_options).
+mode("append").
+save(basePath)
+assert spark.sql(snapshotQuery).intersect(df).count() == df.count()
+assert spark.sql(snapshotQuery).exceptAll(snapshotBeforeUpdate).exceptAll(df).count() == 0
 ```
+
 :::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table
+for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a
+new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the
+same `_hoodie_record_key`s in previous commit.
 :::
 
 </TabItem>
@@ -821,12 +884,12 @@ denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `d
 </Tabs
 >
 
-
 ## Incremental query
 
-Hudi also provides capability to obtain a stream of records that changed since given commit timestamp. 
-This can be achieved using Hudi's incremental querying and providing a begin time from which changes need to be streamed. 
-We do not need to specify endTime, if we want all changes after the given commit (as is the common case). 
+Hudi also provides capability to obtain a stream of records that changed since given commit timestamp.
+This can be achieved using Hudi's incremental querying and providing a begin time from which changes need to be
+streamed.
+We do not need to specify endTime, if we want all changes after the given commit (as is the common case).
 
 <Tabs
 defaultValue="scala"
@@ -866,27 +929,30 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hu
 ```python
 # pyspark
 # reload data
-spark. \
-  read. \
-  format("hudi"). \
-  load(basePath). \
-  createOrReplaceTempView("hudi_trips_snapshot")
+spark.
+read.
+format("hudi").
+load(basePath).
+createOrReplaceTempView("hudi_trips_snapshot")
 
-commits = list(map(lambda row: row[0], spark.sql("select distinct(_hoodie_commit_time) as commitTime from  hudi_trips_snapshot order by commitTime").limit(50).collect()))
-beginTime = commits[len(commits) - 2] # commit time we are interested in
+commits = list(map(lambda row: row[0], spark.sql(
+    "select distinct(_hoodie_commit_time) as commitTime from  hudi_trips_snapshot order by commitTime").limit(
+    50).collect()))
+beginTime = commits[len(commits) - 2]  # commit time we are interested in
 
 # incrementally query data
 incremental_read_options = {
-  'hoodie.datasource.query.type': 'incremental',
-  'hoodie.datasource.read.begin.instanttime': beginTime,
+    'hoodie.datasource.query.type': 'incremental',
+    'hoodie.datasource.read.begin.instanttime': beginTime,
 }
 
-tripsIncrementalDF = spark.read.format("hudi"). \
-  options(**incremental_read_options). \
-  load(basePath)
+tripsIncrementalDF = spark.read.format("hudi").
+options(**incremental_read_options).
+load(basePath)
 tripsIncrementalDF.createOrReplaceTempView("hudi_trips_incremental")
 
-spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hudi_trips_incremental where fare > 20.0").show()
+spark.sql(
+    "select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hudi_trips_incremental where fare > 20.0").show()
 ```
 
 </TabItem>
@@ -895,14 +961,15 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from  hu
 >
 
 :::info
-This will give all changes that happened after the beginTime commit with the filter of fare > 20.0. The unique thing about this
+This will give all changes that happened after the beginTime commit with the filter of fare > 20.0. The unique thing
+about this
 feature is that it now lets you author streaming pipelines on batch data.
 :::
 
 ## Point in time query
 
-Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 
-specific commit time and beginTime to "000" (denoting earliest possible commit time). 
+Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a
+specific commit time and beginTime to "000" (denoting earliest possible commit time).
 
 <Tabs
 defaultValue="scala"
@@ -934,22 +1001,23 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hud
 
 ```python
 # pyspark
-beginTime = "000" # Represents all commits > this time.
+beginTime = "000"  # Represents all commits > this time.
 endTime = commits[len(commits) - 2]
 
 # query point in time data
 point_in_time_read_options = {
-  'hoodie.datasource.query.type': 'incremental',
-  'hoodie.datasource.read.end.instanttime': endTime,
-  'hoodie.datasource.read.begin.instanttime': beginTime
+    'hoodie.datasource.query.type': 'incremental',
+    'hoodie.datasource.read.end.instanttime': endTime,
+    'hoodie.datasource.read.begin.instanttime': beginTime
 }
 
-tripsPointInTimeDF = spark.read.format("hudi"). \
-  options(**point_in_time_read_options). \
-  load(basePath)
+tripsPointInTimeDF = spark.read.format("hudi").
+options(**point_in_time_read_options).
+load(basePath)
 
 tripsPointInTimeDF.createOrReplaceTempView("hudi_trips_point_in_time")
-spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hudi_trips_point_in_time where fare > 20.0").show()
+spark.sql(
+    "select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hudi_trips_point_in_time where fare > 20.0").show()
 ```
 
 </TabItem>
@@ -959,9 +1027,10 @@ spark.sql("select `_hoodie_commit_time`, fare, begin_lon, begin_lat, ts from hud
 
 ## Delete data {#deletes}
 
-Apache Hudi supports two types of deletes: (1) **Soft Deletes**: retaining the record key and just nulling out the values
+Apache Hudi supports two types of deletes: (1) **Soft Deletes**: retaining the record key and just nulling out the
+values
 for all the other fields (records with nulls in soft deletes are always persisted in storage and never removed);
-(2) **Hard Deletes**: physically removing any trace of the record from the table.  See the
+(2) **Hard Deletes**: physically removing any trace of the record from the table. See the
 [deletion section](/docs/writing_data#deletes) of the writing data page for more details.
 
 ### Soft Deletes
@@ -1022,6 +1091,7 @@ spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 // This should return (total - 2) count as two records are updated with nulls
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is not null").count()
 ```
+
 :::note
 Notice that the save mode is `Append`.
 :::
@@ -1033,9 +1103,9 @@ Notice that the save mode is `Append`.
 from pyspark.sql.functions import lit
 from functools import reduce
 
-spark.read.format("hudi"). \
-  load(basePath). \
-  createOrReplaceTempView("hudi_trips_snapshot")
+spark.read.format("hudi").
+load(basePath).
+createOrReplaceTempView("hudi_trips_snapshot")
 # fetch total records count
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is not null").count()
@@ -1043,42 +1113,43 @@ spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is no
 soft_delete_ds = spark.sql("select * from hudi_trips_snapshot").limit(2)
 
 # prepare the soft deletes by ensuring the appropriate fields are nullified
-meta_columns = ["_hoodie_commit_time", "_hoodie_commit_seqno", "_hoodie_record_key", \
-  "_hoodie_partition_path", "_hoodie_file_name"]
+meta_columns = ["_hoodie_commit_time", "_hoodie_commit_seqno", "_hoodie_record_key",
+                "_hoodie_partition_path", "_hoodie_file_name"]
 excluded_columns = meta_columns + ["ts", "uuid", "partitionpath"]
-nullify_columns = list(filter(lambda field: field[0] not in excluded_columns, \
-  list(map(lambda field: (field.name, field.dataType), softDeleteDs.schema.fields))))
+nullify_columns = list(filter(lambda field: field[0] not in excluded_columns,
+                              list(map(lambda field: (field.name, field.dataType), softDeleteDs.schema.fields))))
 
 hudi_soft_delete_options = {
-  'hoodie.table.name': tableName,
-  'hoodie.datasource.write.recordkey.field': 'uuid',
-  'hoodie.datasource.write.partitionpath.field': 'partitionpath',
-  'hoodie.datasource.write.table.name': tableName,
-  'hoodie.datasource.write.operation': 'upsert',
-  'hoodie.datasource.write.precombine.field': 'ts',
-  'hoodie.upsert.shuffle.parallelism': 2, 
-  'hoodie.insert.shuffle.parallelism': 2
+    'hoodie.table.name': tableName,
+    'hoodie.datasource.write.recordkey.field': 'uuid',
+    'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+    'hoodie.datasource.write.table.name': tableName,
+    'hoodie.datasource.write.operation': 'upsert',
+    'hoodie.datasource.write.precombine.field': 'ts',
+    'hoodie.upsert.shuffle.parallelism': 2,
+    'hoodie.insert.shuffle.parallelism': 2
 }
 
-soft_delete_df = reduce(lambda df,col: df.withColumn(col[0], lit(None).cast(col[1])), \
-  nullify_columns, reduce(lambda df,col: df.drop(col[0]), meta_columns, soft_delete_ds))
+soft_delete_df = reduce(lambda df, col: df.withColumn(col[0], lit(None).cast(col[1])),
+                        nullify_columns, reduce(lambda df, col: df.drop(col[0]), meta_columns, soft_delete_ds))
 
 # simply upsert the table after setting these fields to null
-soft_delete_df.write.format("hudi"). \
-  options(**hudi_soft_delete_options). \
-  mode("append"). \
-  save(basePath)
+soft_delete_df.write.format("hudi").
+options(**hudi_soft_delete_options).
+mode("append").
+save(basePath)
 
 # reload data
-spark.read.format("hudi"). \
-  load(basePath). \
-  createOrReplaceTempView("hudi_trips_snapshot")
+spark.read.format("hudi").
+load(basePath).
+createOrReplaceTempView("hudi_trips_snapshot")
 
 # This should return the same total count as before
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 # This should return (total - 2) count as two records are updated with nulls
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot where rider is not null").count()
 ```
+
 :::note
 Notice that the save mode is `Append`.
 :::
@@ -1086,7 +1157,6 @@ Notice that the save mode is `Append`.
 
 </Tabs
 >
-
 
 ### Hard Deletes
 
@@ -1104,6 +1174,7 @@ Delete records for the HoodieKeys passed in.<br/>
 
 ```scala
 // spark-shell
+val snapshotBeforeDelete = spark.sql(snapshotQuery)
 // fetch total records count
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 // fetch two records to be deleted
@@ -1115,7 +1186,7 @@ val hardDeleteDf = spark.read.json(spark.sparkContext.parallelize(deletes, 2))
 
 hardDeleteDf.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION_OPT_KEY,"delete").
+  option(OPERATION_OPT_KEY, "delete").
   option(PRECOMBINE_FIELD_OPT_KEY, "ts").
   option(RECORDKEY_FIELD_OPT_KEY, "uuid").
   option(PARTITIONPATH_FIELD_OPT_KEY, "partitionpath").
@@ -1132,7 +1203,12 @@ val roAfterDeleteViewDF = spark.
 roAfterDeleteViewDF.registerTempTable("hudi_trips_snapshot")
 // fetch should return (total - 2) records
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
+assert(spark
+  .sql("select uuid, partitionpath, ts from hudi_trips_snapshot").intersect(hardDeleteDf).count() == 0)
+assert(snapshotBeforeDelete
+  .except(spark.sql("select uuid, partitionpath, ts from hudi_trips_snapshot")).except(snapshotBeforeDelete).count() == 0)
 ```
+
 :::note
 Only `Append` mode is supported for delete operation.
 :::
@@ -1140,10 +1216,13 @@ Only `Append` mode is supported for delete operation.
 <TabItem value="sparksql">
 
 **Syntax**
+
 ```sql
 DELETE FROM tableIdentifier [ WHERE BOOL_EXPRESSION]
 ```
+
 **Example**
+
 ```sql
 delete from hudi_cow_nonpcf_tbl where uuid = 1;
 
@@ -1159,6 +1238,7 @@ Delete records for the HoodieKeys passed in.<br/>
 
 ```python
 # pyspark
+snapshotBeforeDelete = spark.sql(snapshotQuery)
 # fetch total records count
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
 # fetch two records to be deleted
@@ -1166,33 +1246,37 @@ ds = spark.sql("select uuid, partitionpath from hudi_trips_snapshot").limit(2)
 
 # issue deletes
 hudi_hard_delete_options = {
-  'hoodie.table.name': tableName,
-  'hoodie.datasource.write.recordkey.field': 'uuid',
-  'hoodie.datasource.write.partitionpath.field': 'partitionpath',
-  'hoodie.datasource.write.table.name': tableName,
-  'hoodie.datasource.write.operation': 'delete',
-  'hoodie.datasource.write.precombine.field': 'ts',
-  'hoodie.upsert.shuffle.parallelism': 2, 
-  'hoodie.insert.shuffle.parallelism': 2
+    'hoodie.table.name': tableName,
+    'hoodie.datasource.write.recordkey.field': 'uuid',
+    'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+    'hoodie.datasource.write.table.name': tableName,
+    'hoodie.datasource.write.operation': 'delete',
+    'hoodie.datasource.write.precombine.field': 'ts',
+    'hoodie.upsert.shuffle.parallelism': 2,
+    'hoodie.insert.shuffle.parallelism': 2
 }
 
 from pyspark.sql.functions import lit
+
 deletes = list(map(lambda row: (row[0], row[1]), ds.collect()))
 hard_delete_df = spark.sparkContext.parallelize(deletes).toDF(['uuid', 'partitionpath']).withColumn('ts', lit(0.0))
-hard_delete_df.write.format("hudi"). \
-  options(**hudi_hard_delete_options). \
-  mode("append"). \
-  save(basePath)
+hard_delete_df.write.format("hudi").
+options(**hudi_hard_delete_options).
+mode("append").
+save(basePath)
 
 # run the same read query as above.
-roAfterDeleteViewDF = spark. \
-  read. \
-  format("hudi"). \
-  load(basePath) 
+roAfterDeleteViewDF = spark.
+read.
+format("hudi").
+load(basePath)
 roAfterDeleteViewDF.registerTempTable("hudi_trips_snapshot")
 # fetch should return (total - 2) records
 spark.sql("select uuid, partitionpath from hudi_trips_snapshot").count()
+assert spark.sql("select uuid, partitionpath, ts from hudi_trips_snapshot").intersect(hard_delete_df).count() == 0
+assert snapshotBeforeDelete.excptAll(spark.sql("select uuid, partitionpath, ts from hudi_trips_snapshot")).count() == 0
 ```
+
 :::note
 Only `Append` mode is supported for delete operation.
 :::
@@ -1223,17 +1307,18 @@ values={[
 spark.
   read.format("hudi").
   load(basePath).
-  select("uuid","partitionpath").
-  sort("partitionpath","uuid").
+  select("uuid", "partitionpath").
+  sort("partitionpath", "uuid").
   show(100, false)
 
+val snapshotBeforeOverwrite = spark.sql(snapshotQuery)
 val inserts = convertToStringList(dataGen.generateInserts(10))
 val df = spark.
   read.json(spark.sparkContext.parallelize(inserts, 2)).
   filter("partitionpath = 'americas/united_states/san_francisco'")
 df.write.format("hudi").
   options(getQuickstartWriteConfigs).
-  option(OPERATION.key(),"insert_overwrite").
+  option(OPERATION.key(), "insert_overwrite").
   option(PRECOMBINE_FIELD.key(), "ts").
   option(RECORDKEY_FIELD.key(), "uuid").
   option(PARTITIONPATH_FIELD.key(), "partitionpath").
@@ -1245,15 +1330,57 @@ df.write.format("hudi").
 spark.
   read.format("hudi").
   load(basePath).
-  select("uuid","partitionpath").
-  sort("partitionpath","uuid").
+  select("uuid", "partitionpath").
+  sort("partitionpath", "uuid").
   show(100, false)
+
+val withoutSanFran = snapshotBeforeOverwrite.filter("partitionpath != 'americas/united_states/san_francisco'")
+val expectedDf = withoutSanFran.union(df)
+assert(spark
+  .sql(snapshotQuery).except(expectedDf).count() == 0)
 ```
+
+</TabItem>
+</TabItem>
+
+<TabItem value="python">
+Delete records for the HoodieKeys passed in.<br/>
+
+```python
+snapshotBeforeOverwrite = spark.sql(snapshotQuery)
+self.spark.read.format("hudi")
+.load(self.basePath)
+.select(["uuid", "partitionpath"])
+.sort(["partitionpath", "uuid"])
+.show(n=100, truncate=False)
+inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10))
+df = spark.read.json(spark.sparkContext.parallelize(inserts, 2))
+.filter("partitionpath = 'americas/united_states/san_francisco'")
+hudi_insert_overwrite_options = {
+    'hoodie.table.name': self.tableName,
+    'hoodie.datasource.write.recordkey.field': 'uuid',
+    'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+    'hoodie.datasource.write.table.name': self.tableName,
+    'hoodie.datasource.write.operation': 'insert_overwrite',
+    'hoodie.datasource.write.precombine.field': 'ts',
+    'hoodie.upsert.shuffle.parallelism': 2,
+    'hoodie.insert.shuffle.parallelism': 2
+}
+df.write.format("hudi").options(**hudi_insert_overwrite_options).mode("append").save(basePath)
+spark.read.format("hudi")
+.load(basePath).select(["uuid", "partitionpath"]).sort(["partitionpath", "uuid"]).show(n=100, truncate=False)
+withoutSanFran = snapshotBeforeOverwrite.filter("partitionpath != 'americas/united_states/san_francisco'")
+expectedDf = withoutSanFran.union(df)
+assert spark
+.sql(snapshotQuery).exceptAll(expectedDf).count() == 0
+```
+
 </TabItem>
 
 <TabItem value="sparksql">
 
-`insert overwrite` a partitioned table use the `INSERT_OVERWRITE` type of write operation, while a non-partitioned table to `INSERT_OVERWRITE_TABLE`.
+`insert overwrite` a partitioned table use the `INSERT_OVERWRITE` type of write operation, while a non-partitioned table
+to `INSERT_OVERWRITE_TABLE`.
 
 ```sql
 -- insert overwrite non-partitioned table
@@ -1266,6 +1393,7 @@ insert overwrite table hudi_cow_pt_tbl select 10, 'a10', 1100, '2021-12-09', '10
 -- insert overwrite partitioned table with static partition
 insert overwrite hudi_cow_pt_tbl partition(dt = '2021-12-09', hh='12') select 13, 'a13', 1100;
 ```
+
 </TabItem>
 
 </Tabs
@@ -1282,6 +1410,7 @@ For more detailed examples, please prefer to [schema evolution](schema_evolution
 :::
 
 **Syntax**
+
 ```sql
 -- Alter table name
 ALTER TABLE oldTableName RENAME TO newTableName
@@ -1295,7 +1424,9 @@ ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 -- Alter table properties
 ALTER TABLE tableIdentifier SET TBLPROPERTIES (key = 'value')
 ```
+
 **Examples**
+
 ```sql
 --rename to:
 ALTER TABLE hudi_cow_nonpcf_tbl RENAME TO hudi_cow_nonpcf_tbl2;
@@ -1321,7 +1452,9 @@ ALTER TABLE tableIdentifier DROP PARTITION ( partition_col_name = partition_col_
 -- Show Partitions
 SHOW PARTITIONS tableIdentifier
 ```
+
 **Examples**
+
 ```sql
 --show partition:
 show partitions hudi_cow_pt_tbl;
@@ -1329,14 +1462,17 @@ show partitions hudi_cow_pt_tbl;
 --drop partition：
 alter table hudi_cow_pt_tbl drop partition (dt='2021-12-09', hh='10');
 ```
+
 :::note
-Currently,  the result of `show partitions` is based on the filesystem table path. It's not precise when delete the whole partition data or drop certain partition directly.
+Currently, the result of `show partitions` is based on the filesystem table path. It's not precise when delete the whole
+partition data or drop certain partition directly.
 
 :::
 
 ### Procedures
 
 **Syntax**
+
 ```sql
 --Call procedure by positional arguments
 CALL system.procedure_name(arg_1, arg_2, ... arg_n)
@@ -1344,25 +1480,31 @@ CALL system.procedure_name(arg_1, arg_2, ... arg_n)
 --Call procedure by named arguments
 CALL system.procedure_name(arg_name_2 => arg_2, arg_name_1 => arg_1, ... arg_name_n => arg_n)
 ```
+
 **Examples**
+
 ```sql
 --show commit's info
 call show_commits(table => 'test_hudi_table', limit => 10);
 ```
 
-Call command has already support some commit procedures and table optimization procedures, 
+Call command has already support some commit procedures and table optimization procedures,
 more details please refer to [procedures](procedures).
 
 ## Where to go from here?
 
-You can also do the quickstart by [building hudi yourself](https://github.com/apache/hudi#building-apache-hudi-from-source), 
-and using `--jars <path to hudi_code>/packaging/hudi-spark-bundle/target/hudi-spark3.2-bundle_2.1?-*.*.*-SNAPSHOT.jar` in the spark-shell command above
-instead of `--packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0`. Hudi also supports scala 2.12. Refer [build with scala 2.12](https://github.com/apache/hudi#build-with-different-spark-versions)
+You can also do the quickstart
+by [building hudi yourself](https://github.com/apache/hudi#building-apache-hudi-from-source),
+and using `--jars <path to hudi_code>/packaging/hudi-spark-bundle/target/hudi-spark3.2-bundle_2.1?-*.*.*-SNAPSHOT.jar`
+in the spark-shell command above
+instead of `--packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.12.0`. Hudi also supports scala 2.12.
+Refer [build with scala 2.12](https://github.com/apache/hudi#build-with-different-spark-versions)
 for more info.
 
-Also, we used Spark here to show case the capabilities of Hudi. However, Hudi can support multiple table types/query types and 
-Hudi tables can be queried from query engines like Hive, Spark, Presto and much more. We have put together a 
-[demo video](https://www.youtube.com/watch?v=VhNgUsxdrD0) that show cases all of this on a docker based setup with all 
-dependent systems running locally. We recommend you replicate the same setup and run the demo yourself, by following 
-steps [here](/docs/docker_demo) to get a taste for it. Also, if you are looking for ways to migrate your existing data 
+Also, we used Spark here to show case the capabilities of Hudi. However, Hudi can support multiple table types/query
+types and
+Hudi tables can be queried from query engines like Hive, Spark, Presto and much more. We have put together a
+[demo video](https://www.youtube.com/watch?v=VhNgUsxdrD0) that show cases all of this on a docker based setup with all
+dependent systems running locally. We recommend you replicate the same setup and run the demo yourself, by following
+steps [here](/docs/docker_demo) to get a taste for it. Also, if you are looking for ways to migrate your existing data
 to Hudi, refer to [migration guide](/docs/migration_guide).


### PR DESCRIPTION
### Change Logs

Added pyspark and scala validations to the quickstart. Added pyspark insert overwrite example. Fixed some errors with the existing pyspark examples

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none **

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
