### PR TITLE
[HUDI-4864] Fix AWSDmsAvroPayload#combineAndGetUpdateValue when using MOR snapshot query after delete operations

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/AWSDmsAvroPayload.java
@@ -49,7 +49,7 @@ public class AWSDmsAvroPayload extends OverwriteWithLatestAvroPayload {
   }
 
   public AWSDmsAvroPayload(Option<GenericRecord> record) {
-    this(record.get(), 0); // natural order
+    this(record.isPresent() ? record.get() : null, 0); // natural order
   }
 
   /**
@@ -87,7 +87,10 @@ public class AWSDmsAvroPayload extends OverwriteWithLatestAvroPayload {
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema)
       throws IOException {
-    IndexedRecord insertValue = super.getInsertValue(schema).get();
-    return handleDeleteOperation(insertValue);
+    Option<IndexedRecord> insertValue = super.getInsertValue(schema);
+    if (!insertValue.isPresent()) {
+      return Option.empty();
+    }
+    return handleDeleteOperation(insertValue.get());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestAWSDmsAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestAWSDmsAvroPayload.java
@@ -109,6 +109,27 @@ public class TestAWSDmsAvroPayload {
   }
 
   @Test
+  public void testDeleteWithEmptyPayLoad() {
+    Schema avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_STRING);
+    Properties properties = new Properties();
+
+    GenericRecord oldRecord = new GenericData.Record(avroSchema);
+    oldRecord.put("field1", 2);
+    oldRecord.put("Op", "U");
+
+    AWSDmsAvroPayload payload = new AWSDmsAvroPayload(Option.empty());
+
+    try {
+      Option<IndexedRecord> outputPayload = payload.combineAndGetUpdateValue(oldRecord, avroSchema, properties);
+      // expect nothing to be committed to table
+      assertFalse(outputPayload.isPresent());
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Unexpected exception");
+    }
+  }
+
+  @Test
   public void testPreCombineWithDelete() {
     Schema avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_STRING);
     GenericRecord deleteRecord = new GenericData.Record(avroSchema);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HUDI-4864 

Without this change encountered the following exceptions with DMS during delete operations when trying to query MOR table with snapshot. 

1.
```

Caused by: java.util.NoSuchElementException: No value present in Option
    at org.apache.hudi.common.util.Option.get(Option.java:88)
    at org.apache.hudi.common.model.AWSDmsAvroPayload.<init>(AWSDmsAvroPayload.java:52)
    ... 35 more
```
2.
```
java.util.NoSuchElementException: No value present in Option
	at org.apache.hudi.common.util.Option.get(Option.java:89)
	at org.apache.hudi.common.model.AWSDmsAvroPayload.combineAndGetUpdateValue(AWSDmsAvroPayload.java:90)
	at org.apache.hudi.common.model.AWSDmsAvroPayload.combineAndGetUpdateValue(AWSDmsAvroPayload.java:84)
	at org.apache.hudi.common.model.TestAWSDmsAvroPayload.testDeleteWithEmptyPayLoad(TestAWSDmsAvroPayload.java:123)

```

With this change these issues are gone. 
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
