### PR TITLE
[HUDI-4866] Fixes the issue that the archive operation is invalid whe…

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -439,7 +439,7 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
             } else {
               // if no savepoint present, then don't filter
               // stop at first savepoint commit
-              return !(firstSavepoint.isPresent() && compareTimestamps(firstSavepoint.get().getTimestamp(), LESSER_THAN_OR_EQUALS, s.getTimestamp()));
+              return !(firstSavepoint.isPresent() && compareTimestamps(s.getTimestamp(), LESSER_THAN_OR_EQUALS, firstSavepoint.get().getTimestamp()));
             }
           }).filter(s -> {
             // Ensure commits >= oldest pending compaction commit is retained


### PR DESCRIPTION

### Change Logs

The result of filter will be NOT. Therefore, an instant whose value is less than firstSavepoint is selected for archiving. The expected result is that an instant greater than firstSavepoint is selected for archiving.

### Impact

When a savepoint exists, the archiving condition is incorrect.

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
