### PR TITLE
[HUDI-4875] Fix NoSuchTableException when dropping temporary view after applied HoodieSparkSessionExtension in Spark 3.2

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -581,9 +581,9 @@ case class HoodiePostAnalysisRule(sparkSession: SparkSession) extends Rule[Logic
         if sparkAdapter.isHoodieTable(table) =>
         CreateHoodieTableCommand(table, ignoreIfExists)
       // Rewrite the DropTableCommand to DropHoodieTableCommand
-      case DropTableCommand(tableName, ifExists, isView, purge)
+      case DropTableCommand(tableName, ifExists, false, purge)
         if sparkAdapter.isHoodieTable(tableName, sparkSession) =>
-        DropHoodieTableCommand(tableName, ifExists, isView, purge)
+        DropHoodieTableCommand(tableName, ifExists, false, purge)
       // Rewrite the AlterTableDropPartitionCommand to AlterHoodieTableDropPartitionCommand
       case AlterTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)
         if sparkAdapter.isHoodieTable(tableName, sparkSession) =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
@@ -314,7 +314,6 @@ class TestDropTable extends HoodieSparkSqlTestBase {
     }
   }
 
-
   test("Drop an MANAGED table which path is lost.") {
     val tableName = generateTableName
     spark.sql(
@@ -339,6 +338,30 @@ class TestDropTable extends HoodieSparkSqlTestBase {
     filesystem.delete(tablePath, true)
     spark.sql(s"drop table ${tableName}")
     checkAnswer("show tables")()
+  }
+
+  test("Drop local temporary view should not fail") {
+    val viewName = generateTableName
+    spark.sql(
+      s"""
+         |create temporary view $viewName as
+         | select 1
+         |""".stripMargin)
+
+    spark.sql(s"drop view $viewName")
+    checkAnswer(s"show views like '$viewName'")()
+  }
+
+  test("Drop global temporary view should not fail") {
+    val viewName = generateTableName
+    spark.sql(
+      s"""
+         |create global temporary view $viewName as
+         | select 1
+         |""".stripMargin)
+
+    spark.sql(s"drop view global_temp.$viewName")
+    checkAnswer(s"show views in global_temp like '$viewName'")()
   }
 
   private def alterSerdeProperties(sessionCatalog: SessionCatalog, tableIdt: TableIdentifier,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
@@ -349,7 +349,6 @@ class TestDropTable extends HoodieSparkSqlTestBase {
          |""".stripMargin)
 
     spark.sql(s"drop view $viewName")
-    checkAnswer(s"show views like '$viewName'")()
   }
 
   test("Drop global temporary view should not fail") {
@@ -361,7 +360,6 @@ class TestDropTable extends HoodieSparkSqlTestBase {
          |""".stripMargin)
 
     spark.sql(s"drop view global_temp.$viewName")
-    checkAnswer(s"show views in global_temp like '$viewName'")()
   }
 
   private def alterSerdeProperties(sessionCatalog: SessionCatalog, tableIdt: TableIdentifier,


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HUDI-4875

Without this change encountered the following exception when `DROP VIEW test_view` after `CREATE TEMP VIEW test_view AS SELECT 1`, while HoodieSparkSessionExtension is enabled in Spark 3.2, :

```
org.apache.spark.sql.catalyst.analysis.NoSuchTableException: Table or view 'test_view' not found in database 'default'
  at org.apache.spark.sql.catalyst.catalog.SessionCatalog.requireTableExists(SessionCatalog.scala:225)
  at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTableRawMetadata(SessionCatalog.scala:516)
  at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTableMetadata(SessionCatalog.scala:502)
  at org.apache.spark.sql.hudi.SparkAdapter.isHoodieTable(SparkAdapter.scala:160)
  at org.apache.spark.sql.hudi.SparkAdapter.isHoodieTable$(SparkAdapter.scala:159)
  at org.apache.spark.sql.adapter.BaseSpark3Adapter.isHoodieTable(BaseSpark3Adapter.scala:45)
  at org.apache.spark.sql.hudi.analysis.HoodiePostAnalysisRule.apply(HoodieAnalysis.scala:539)
  at org.apache.spark.sql.hudi.analysis.HoodiePostAnalysisRule.apply(HoodieAnalysis.scala:530)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$2(RuleExecutor.scala:211)
  at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
  at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
  at scala.collection.immutable.List.foldLeft(List.scala:91)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1(RuleExecutor.scala:208)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1$adapted(RuleExecutor.scala:200)
  at scala.collection.immutable.List.foreach(List.scala:431)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.execute(RuleExecutor.scala:200)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.org$apache$spark$sql$catalyst$analysis$Analyzer$$executeSameContext(Analyzer.scala:222)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.$anonfun$execute$1(Analyzer.scala:218)
  at org.apache.spark.sql.catalyst.analysis.AnalysisContext$.withNewAnalysisContext(Analyzer.scala:167)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.execute(Analyzer.scala:218)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.execute(Analyzer.scala:182)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$executeAndTrack$1(RuleExecutor.scala:179)
  at org.apache.spark.sql.catalyst.QueryPlanningTracker$.withTracker(QueryPlanningTracker.scala:88)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.executeAndTrack(RuleExecutor.scala:179)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.$anonfun$executeAndCheck$1(Analyzer.scala:203)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.markInAnalyzer(AnalysisHelper.scala:330)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.executeAndCheck(Analyzer.scala:202)
  at org.apache.spark.sql.execution.QueryExecution.$anonfun$analyzed$1(QueryExecution.scala:75)
  at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
  at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:183)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:788)
  at org.apache.spark.sql.execution.QueryExecution.executePhase(QueryExecution.scala:183)
  at org.apache.spark.sql.execution.QueryExecution.analyzed$lzycompute(QueryExecution.scala:75)
  at org.apache.spark.sql.execution.QueryExecution.analyzed(QueryExecution.scala:73)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:629)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:788)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:620)
  ... 51 elided 
```

### Change Logs

1. Add test cases for dropping temporary views
2. Skip dropping views in HoodiePostAnalysisRule

### Impact

Low 

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
