### PR TITLE
[HUDI-4630] Add transformer capability to individual feeds in MultiTableDeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -135,6 +135,7 @@ public class HoodieMultiTableDeltaStreamer {
       if (cfg.enableMetaSync && StringUtils.isNullOrEmpty(tableProperties.getString(HoodieSyncConfig.META_SYNC_TABLE_NAME.key(), ""))) {
         throw new HoodieException("Meta sync table field not provided!");
       }
+      populateTransformerProps(cfg, tableProperties);
       populateSchemaProviderProps(cfg, tableProperties);
       executionContext = new TableExecutionContext();
       executionContext.setProperties(tableProperties);
@@ -142,6 +143,13 @@ public class HoodieMultiTableDeltaStreamer {
       executionContext.setDatabase(database);
       executionContext.setTableName(currentTable);
       this.tableExecutionContexts.add(executionContext);
+    }
+  }
+
+  private void populateTransformerProps(HoodieDeltaStreamer.Config cfg, TypedProperties typedProperties) {
+    String transformerClassNameOverride = typedProperties.getString(Constants.TRANSFORMER_CLASS, null);
+    if (not StringUtils.isNullOrEmpty(transformerClassNameOverride)) {
+      cfg.transformerClassNames = transformerClassNameOverride;
     }
   }
 
@@ -458,6 +466,7 @@ public class HoodieMultiTableDeltaStreamer {
     private static final String DELIMITER = ".";
     private static final String UNDERSCORE = "_";
     private static final String COMMA_SEPARATOR = ",";
+    private static final String TRANSFORMER_CLASS = "hoodie.deltastreamer.transformer.class";
   }
 
   public Set<String> getSuccessTables() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -147,8 +147,8 @@ public class HoodieMultiTableDeltaStreamer {
   }
 
   private void populateTransformerProps(HoodieDeltaStreamer.Config cfg, TypedProperties typedProperties) {
-    String transformerClassNameOverride = typedProperties.getString(Constants.TRANSFORMER_CLASS, null);
-    if (not StringUtils.isNullOrEmpty(transformerClassNameOverride)) {
+    List<String> transformerClassNameOverride = Arrays.asList(typedProperties.getString(Constants.TRANSFORMER_CLASS, null).split(","));
+    if (! transformerClassNameOverride.isEmpty()) {
       cfg.transformerClassNames = transformerClassNameOverride;
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -242,10 +243,13 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
         case "dummy_table_short_trip":
           String tableLevelKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestTableLevelGenerator.class.getName(), tableLevelKeyGeneratorClass);
+          List<String> transformerClass = tableExecutionContext.getConfig().transformerClassNames;
+          assertEquals("org.apache.hudi.utilities.transform.SqlFileBasedTransformer", transformerClass.get(0));
           break;
         default:
           String defaultKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestGenerator.class.getName(), defaultKeyGeneratorClass);
+          assertNull(tableExecutionContext.getConfig().transformerClassNames);
       }
     });
   }

--- a/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
@@ -25,3 +25,4 @@ hoodie.datasource.hive_sync.table=short_trip_uber_hive_dummy_table
 hoodie.datasource.write.keygenerator.class=org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamer$TestTableLevelGenerator
 hoodie.deltastreamer.schemaprovider.registry.baseUrl=http://localhost:8081/subjects/
 hoodie.deltastreamer.schemaprovider.registry.urlSuffix=-value/versions/latest
+hoodie.deltastreamer.transformer.class=org.apache.hudi.utilities.transform.SqlFileBasedTransformer


### PR DESCRIPTION
### Change Logs

Context: https://apache-hudi.slack.com/archives/C4D716NPQ/p1660215517081789

MultiTableDeltastreamer currently supports single transformer class for all of the data being synced. And it can only be enabled or disabled as a whole. There is no support for enabling transformers for a select feed of data or to use different transformers for different feeds. This PR addresses the same.

The same feature is available in schemaprovider class through `hoodie.deltastreamer.schemaprovider.class` property in table level configs.

### Impact

The impact audience are the confined to users of MultiTableDeltaStreamer and that too if they use transformers. And since this is a new feature, things should run as-is even if this change has been incorporated.

### Risk level
low


### Contributor's checklist

- [ x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
