### PR TITLE
[HUDI-4894] Fix ClassCastException when using fixed type defining dec…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
@@ -84,7 +84,7 @@ public class MercifulJsonConverter {
   /**
    * Converts json to Avro generic record.
    *
-   * @param json Json record
+   * @param json   Json record
    * @param schema Schema
    */
   public GenericRecord convert(String json, Schema schema) {
@@ -116,7 +116,7 @@ public class MercifulJsonConverter {
   private static boolean isOptional(Schema schema) {
     return schema.getType().equals(Schema.Type.UNION) && schema.getTypes().size() == 2
         && (schema.getTypes().get(0).getType().equals(Schema.Type.NULL)
-            || schema.getTypes().get(1).getType().equals(Schema.Type.NULL));
+        || schema.getTypes().get(1).getType().equals(Schema.Type.NULL));
   }
 
   private static Object convertJsonToAvroField(Object value, String name, Schema schema) {
@@ -246,13 +246,7 @@ public class MercifulJsonConverter {
     return new JsonToAvroFieldProcessor() {
       @Override
       public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
-        // The ObjectMapper use List to represent FixedType
-        // eg: "decimal_val": [0, 0, 14, -63, -52] will convert to ArrayList<Integer>
-        List<Integer> converval = (List<Integer>) value;
-        byte[] src = new byte[converval.size()];
-        for (int i = 0; i < converval.size(); i++) {
-          src[i] = converval.get(i).byteValue();
-        }
+        byte[] src = value.toString().getBytes();
         byte[] dst = new byte[schema.getFixedSize()];
         System.arraycopy(src, 0, dst, 0, Math.min(schema.getFixedSize(), src.length));
         return Pair.of(true, new GenericData.Fixed(schema, dst));

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.avro;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link MercifulJsonConverter}.
+ */
+public class TestMercifulJsonConverter {
+
+  private static String SCHEMA_WITH_DECIMAL_FIELD = "{\"name\":\"record\",\"type\":\"record\",\"fields\":["
+      + "{\"name\":\"id\",\"type\":[\"null\",\"string\"]},"
+      + "{\"name\":\"decimal_col\",\"type\":[\"null\",{\"logicalType\":\"decimal\",\"size\":5,"
+      + "\"precision\":10,\"name\":\"fixed\",\"scale\":2,\"type\":\"fixed\"}]}]}\n";
+
+  private static String DATA_WITH_DECIMAL_FIELD = "{\"decimal_col\":35.51,\"id\":\"1\"}";
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testDecimalInFixedType() throws IOException {
+    MercifulJsonConverter converter = new MercifulJsonConverter();
+    GenericRecord record = converter.convert(DATA_WITH_DECIMAL_FIELD, new Schema.Parser().parse(SCHEMA_WITH_DECIMAL_FIELD));
+
+    double decimalValue = (double) mapper
+        .readValue(DATA_WITH_DECIMAL_FIELD, Map.class)
+        .get("decimal_col");
+
+    byte[] bytesFromFixedType = ((GenericData.Fixed) record.get("decimal_col")).bytes();
+
+    assertEquals("1", record.get("id").toString());
+    assertArrayEquals(Double.toString(decimalValue).getBytes(), bytesFromFixedType);
+
+  }
+}


### PR DESCRIPTION
when use fixed type to define decimal column, hudi will throw a ClassCastException
```
Caused by: java.lang.ClassCastException: java.lang.Double cannot be cast to java.util.List
at org.apache.hudi.avro.MercifulJsonConverter$9.convert(MercifulJsonConverter.java:254)
at org.apache.hudi.avro.MercifulJsonConverter$JsonToAvroFieldProcessor.convertToAvro(MercifulJsonConverter.java:151)
at org.apache.hudi.avro.MercifulJsonConverter.convertJsonToAvroField(MercifulJsonConverter.java:140)
at org.apache.hudi.avro.MercifulJsonConverter.convertJsonToAvro(MercifulJsonConverter.java:107)
at org.apache.hudi.avro.MercifulJsonConverter.convert(MercifulJsonConverter.java:96)
at org.apache.hudi.utilities.sources.helpers.AvroConvertor.fromJs
```

schema for decimal column
```
{
    "name": "column_name",
    "type": ["null", {
        "type": "fixed",
        "name": "fixed",
        "size": 5,
        "logicalType": "decimal",
        "precision": 10,
        "scale": 2
    }],
    "default": null
}
```

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
