### PR TITLE
[HUDI-4895] Object store based lock provider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ObjectStoreBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ObjectStoreBasedLockProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.transaction.lock;
+
+import org.apache.hudi.common.config.LockConfiguration;
+import org.apache.hudi.exception.HoodieIOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A ObjectStore FileSystem based lock.
+ * NOTE: This works not only for DFS with atomic create/delete operation, but also
+ * ObjectStores that has no atomic semantic guarantee.
+ */
+public class ObjectStoreBasedLockProvider extends FileSystemBasedLockProvider {
+
+  private static final Logger LOG = LogManager.getLogger(ObjectStoreBasedLockProvider.class);
+
+  private static final int RANDOM_CONTENT_LENGTH = 8192;
+
+  private byte[] randomContent;
+
+  public ObjectStoreBasedLockProvider(final LockConfiguration lockConfiguration, final Configuration conf) {
+    super(lockConfiguration, conf);
+
+    randomContent = new byte[RANDOM_CONTENT_LENGTH];
+    ThreadLocalRandom.current().nextBytes(randomContent);
+  }
+
+  @Override
+  protected void acquireLock() {
+    try (FSDataOutputStream out = fs.create(this.lockFile, false)) {
+      out.write(randomContent);
+    } catch (FileAlreadyExistsException e) {
+      throw new HoodieIOException("Failed to acquire lock since the file already exists");
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to acquire lock", e);
+    }
+
+    try (FSDataInputStream in = fs.open(this.lockFile)) {
+      byte[] buffer = new byte[RANDOM_CONTENT_LENGTH];
+      int length = in.read(buffer);
+      if (length == RANDOM_CONTENT_LENGTH && Arrays.equals(randomContent, buffer)) {
+        // lock acquired
+        return;
+      }
+      throw new HoodieIOException("Failed to acquire lock since the file content does not match");
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to acquire lock", e);
+    }
+  }
+
+  @Override
+  protected void releaseLock() {
+    try (FSDataInputStream in = fs.open(this.lockFile)) {
+      byte[] buffer = new byte[RANDOM_CONTENT_LENGTH];
+      int length = in.read(buffer);
+      if (length == RANDOM_CONTENT_LENGTH && Arrays.equals(randomContent, buffer)) {
+        super.releaseLock();
+        return;
+      }
+      throw new HoodieIOException("Failed to release lock since the file content does not match");
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to release lock", e);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestObjectStoreBasedLockProvider.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestObjectStoreBasedLockProvider.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.client.transaction.lock.ObjectStoreBasedLockProvider;
+import org.apache.hudi.common.config.LockConfiguration;
+import org.apache.hudi.common.testutils.minicluster.HdfsTestService;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieLockException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PATH_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY;
+
+public class TestObjectStoreBasedLockProvider {
+  private static HdfsTestService hdfsTestService;
+  private static MiniDFSCluster dfsCluster;
+  private static LockConfiguration lockConfiguration;
+  private static Configuration hadoopConf;
+
+  @BeforeAll
+  public static void setup() throws IOException {
+    hdfsTestService = new HdfsTestService();
+    dfsCluster = hdfsTestService.start(true);
+    hadoopConf = dfsCluster.getFileSystem().getConf();
+
+    Properties properties = new Properties();
+    properties.setProperty(FILESYSTEM_LOCK_PATH_PROP_KEY, "/tmp/");
+    properties.setProperty(FILESYSTEM_LOCK_EXPIRE_PROP_KEY, "1");
+    properties.setProperty(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY, "1000");
+    properties.setProperty(LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY, "1000");
+    properties.setProperty(LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY, "3");
+    lockConfiguration = new LockConfiguration(properties);
+  }
+
+  @AfterAll
+  public static void cleanUpAfterAll() throws IOException {
+    Path workDir = dfsCluster.getFileSystem().getWorkingDirectory();
+    FileSystem fs = workDir.getFileSystem(hdfsTestService.getHadoopConf());
+    fs.delete(new Path("/tmp"), true);
+    if (hdfsTestService != null) {
+      hdfsTestService.stop();
+      hdfsTestService = null;
+    }
+  }
+
+  @AfterEach
+  public void cleanUpAfterEach() throws IOException {
+    Path workDir = dfsCluster.getFileSystem().getWorkingDirectory();
+    FileSystem fs = workDir.getFileSystem(hdfsTestService.getHadoopConf());
+    fs.delete(new Path("/tmp/lock"), true);
+  }
+
+  @Test
+  public void testAcquireLock() {
+    ObjectStoreBasedLockProvider fileBasedLockProvider = new ObjectStoreBasedLockProvider(lockConfiguration, hadoopConf);
+    Assertions.assertTrue(fileBasedLockProvider.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    fileBasedLockProvider.unlock();
+  }
+
+  @Test
+  public void testAcquireLockWithDefaultPath() {
+    lockConfiguration.getConfig().remove(FILESYSTEM_LOCK_PATH_PROP_KEY);
+    lockConfiguration.getConfig().setProperty(HoodieWriteConfig.BASE_PATH.key(), "/tmp/");
+    ObjectStoreBasedLockProvider fileBasedLockProvider = new ObjectStoreBasedLockProvider(lockConfiguration, hadoopConf);
+    Assertions.assertTrue(fileBasedLockProvider.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    fileBasedLockProvider.unlock();
+    lockConfiguration.getConfig().setProperty(FILESYSTEM_LOCK_PATH_PROP_KEY, "/tmp/");
+  }
+
+  @Test
+  public void testUnLock() {
+    ObjectStoreBasedLockProvider fileBasedLockProvider = new ObjectStoreBasedLockProvider(lockConfiguration, hadoopConf);
+    Assertions.assertTrue(fileBasedLockProvider.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    fileBasedLockProvider.unlock();
+    Assertions.assertTrue(fileBasedLockProvider.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void testReentrantLock() {
+    ObjectStoreBasedLockProvider fileBasedLockProvider = new ObjectStoreBasedLockProvider(lockConfiguration, hadoopConf);
+    Assertions.assertTrue(fileBasedLockProvider.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    Assertions.assertFalse(fileBasedLockProvider.tryLock(lockConfiguration.getConfig()
+        .getLong(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY), TimeUnit.MILLISECONDS));
+    fileBasedLockProvider.unlock();
+  }
+
+  @Test
+  public void testUnlockWithoutLock() {
+    try {
+      ObjectStoreBasedLockProvider fileBasedLockProvider = new ObjectStoreBasedLockProvider(lockConfiguration, hadoopConf);
+      fileBasedLockProvider.unlock();
+    } catch (HoodieLockException e) {
+      Assertions.fail();
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

Currently, we have `FileSystemBasedLockProvier`, which relies on the atomic guarantee of the underlying file system. Specifically, only with filesystem's atomic rename & atomic create capability, the LockProvider can work properly.

 This PR enables Object store (e.g, AliyunOSS) as a lock provider.

### Impact

No API change.

**Risk level: none | low | medium | high**

LOW.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
