### PR TITLE
[MINOR] Update PR template with documentation update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,15 @@ _Describe any public API or user-facing feature change or any performance impact
 
 _Choose one. If medium or high, explain what verification was done to mitigate the risks._
 
+### Documentation Update
+
+_Describe any necessary documentation update if there is any new feature, config, or user-facing change_
+
+- _The config description must be updated if new configs are added or the default value of the configs are changed_
+- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
+  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
+  changes to the website._
+
 ### Contributor's checklist
 
 - [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)


### PR DESCRIPTION
### Change Logs

As above.  The author of PRs should put up docs updates as part of their contribution.  The author should create a Jira for the docs and link them in the PR description. 

### Impact

**Risk level: none**

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
