### PR TITLE
[HUDI-4010] Improve docs on DynamoDB-based lock provider

### DIFF
--- a/website/docs/concurrency_control.md
+++ b/website/docs/concurrency_control.md
@@ -71,16 +71,26 @@ hoodie.write.lock.hivemetastore.table
 
 **`Amazon DynamoDB`** based lock provider
 
-Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters
+Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters.  You can refer to the
+[DynamoDB based Locks Configurations](https://hudi.apache.org/docs/configurations#DynamoDB-based-Locks-Configurations)
+section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
-hoodie.write.lock.dynamodb.table
-hoodie.write.lock.dynamodb.partition_key
-hoodie.write.lock.dynamodb.region
-hoodie.write.lock.dynamodb.endpoint_url
-hoodie.write.lock.dynamodb.billing_mode
+hoodie.write.lock.dynamodb.table (required)
+hoodie.write.lock.dynamodb.partition_key (optional)
+hoodie.write.lock.dynamodb.region (optional)
+hoodie.write.lock.dynamodb.endpoint_url (optional)
+hoodie.write.lock.dynamodb.billing_mode (optional)
 ```
+
+When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
+specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
+is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
+value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
+By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
+same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/docs/concurrency_control.md
+++ b/website/docs/concurrency_control.md
@@ -86,11 +86,12 @@ hoodie.write.lock.dynamodb.billing_mode (optional)
 
 When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
 specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
-don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
-is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
-value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
-By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
-same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that an attribute with
+the name `key` is present in the table.  The `key` attribute should be the partition key of the DynamoDB table. The
+config `hoodie.write.lock.dynamodb.partition_key` specifies the value to put for the `key` attribute (not the attribute
+name), which is used for the lock on the same table. By default, `hoodie.write.lock.dynamodb.partition_key` is set to
+the table name, so that multiple writers writing to the same table share the same lock. If you customize the name, make
+sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.10.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.10.0/concurrency_control.md
@@ -77,20 +77,21 @@ section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
-hoodie.write.lock.dynamodb.table
-hoodie.write.lock.dynamodb.partition_key
-hoodie.write.lock.dynamodb.region
-hoodie.write.lock.dynamodb.endpoint_url
-hoodie.write.lock.dynamodb.billing_mode
+hoodie.write.lock.dynamodb.table (required)
+hoodie.write.lock.dynamodb.partition_key (optional)
+hoodie.write.lock.dynamodb.region (optional)
+hoodie.write.lock.dynamodb.endpoint_url (optional)
+hoodie.write.lock.dynamodb.billing_mode (optional)
 ```
 
 When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
 specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
-don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
-is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
-value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
-By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
-same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that an attribute with
+the name `key` is present in the table.  The `key` attribute should be the partition key of the DynamoDB table. The
+config `hoodie.write.lock.dynamodb.partition_key` specifies the value to put for the `key` attribute (not the attribute
+name), which is used for the lock on the same table. By default, `hoodie.write.lock.dynamodb.partition_key` is set to
+the table name, so that multiple writers writing to the same table share the same lock. If you customize the name, make
+sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.10.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.10.0/concurrency_control.md
@@ -71,7 +71,9 @@ hoodie.write.lock.hivemetastore.table
 
 **`Amazon DynamoDB`** based lock provider
 
-Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters
+Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters.  You can refer to the
+[DynamoDB based Locks Configurations](https://hudi.apache.org/docs/configurations#DynamoDB-based-Locks-Configurations)
+section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
@@ -81,6 +83,14 @@ hoodie.write.lock.dynamodb.region
 hoodie.write.lock.dynamodb.endpoint_url
 hoodie.write.lock.dynamodb.billing_mode
 ```
+
+When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
+specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
+is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
+value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
+By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
+same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.10.1/concurrency_control.md
+++ b/website/versioned_docs/version-0.10.1/concurrency_control.md
@@ -70,7 +70,10 @@ hoodie.write.lock.hivemetastore.table
 `The HiveMetastore URI's are picked up from the hadoop configuration file loaded during runtime.`
 
 **`Amazon DynamoDB`** based lock provider
-Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters
+
+Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters.  You can refer to the
+[DynamoDB based Locks Configurations](https://hudi.apache.org/docs/configurations#DynamoDB-based-Locks-Configurations)
+section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
@@ -80,6 +83,14 @@ hoodie.write.lock.dynamodb.region
 hoodie.write.lock.dynamodb.endpoint_url
 hoodie.write.lock.dynamodb.billing_mode
 ```
+
+When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
+specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
+is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
+value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
+By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
+same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.10.1/concurrency_control.md
+++ b/website/versioned_docs/version-0.10.1/concurrency_control.md
@@ -77,20 +77,21 @@ section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
-hoodie.write.lock.dynamodb.table
-hoodie.write.lock.dynamodb.partition_key
-hoodie.write.lock.dynamodb.region
-hoodie.write.lock.dynamodb.endpoint_url
-hoodie.write.lock.dynamodb.billing_mode
+hoodie.write.lock.dynamodb.table (required)
+hoodie.write.lock.dynamodb.partition_key (optional)
+hoodie.write.lock.dynamodb.region (optional)
+hoodie.write.lock.dynamodb.endpoint_url (optional)
+hoodie.write.lock.dynamodb.billing_mode (optional)
 ```
 
 When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
 specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
-don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
-is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
-value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
-By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
-same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that an attribute with
+the name `key` is present in the table.  The `key` attribute should be the partition key of the DynamoDB table. The
+config `hoodie.write.lock.dynamodb.partition_key` specifies the value to put for the `key` attribute (not the attribute
+name), which is used for the lock on the same table. By default, `hoodie.write.lock.dynamodb.partition_key` is set to
+the table name, so that multiple writers writing to the same table share the same lock. If you customize the name, make
+sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.11.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.11.0/concurrency_control.md
@@ -70,7 +70,10 @@ hoodie.write.lock.hivemetastore.table
 `The HiveMetastore URI's are picked up from the hadoop configuration file loaded during runtime.`
 
 **`Amazon DynamoDB`** based lock provider
-Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters
+
+Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters.  You can refer to the
+[DynamoDB based Locks Configurations](https://hudi.apache.org/docs/configurations#DynamoDB-based-Locks-Configurations)
+section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
@@ -80,6 +83,14 @@ hoodie.write.lock.dynamodb.region
 hoodie.write.lock.dynamodb.endpoint_url
 hoodie.write.lock.dynamodb.billing_mode
 ```
+
+When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
+specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
+is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
+value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
+By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
+same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.11.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.11.0/concurrency_control.md
@@ -77,20 +77,21 @@ section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
-hoodie.write.lock.dynamodb.table
-hoodie.write.lock.dynamodb.partition_key
-hoodie.write.lock.dynamodb.region
-hoodie.write.lock.dynamodb.endpoint_url
-hoodie.write.lock.dynamodb.billing_mode
+hoodie.write.lock.dynamodb.table (required)
+hoodie.write.lock.dynamodb.partition_key (optional)
+hoodie.write.lock.dynamodb.region (optional)
+hoodie.write.lock.dynamodb.endpoint_url (optional)
+hoodie.write.lock.dynamodb.billing_mode (optional)
 ```
 
 When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
 specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
-don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
-is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
-value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
-By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
-same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that an attribute with
+the name `key` is present in the table.  The `key` attribute should be the partition key of the DynamoDB table. The
+config `hoodie.write.lock.dynamodb.partition_key` specifies the value to put for the `key` attribute (not the attribute
+name), which is used for the lock on the same table. By default, `hoodie.write.lock.dynamodb.partition_key` is set to
+the table name, so that multiple writers writing to the same table share the same lock. If you customize the name, make
+sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.11.1/concurrency_control.md
+++ b/website/versioned_docs/version-0.11.1/concurrency_control.md
@@ -70,7 +70,10 @@ hoodie.write.lock.hivemetastore.table
 `The HiveMetastore URI's are picked up from the hadoop configuration file loaded during runtime.`
 
 **`Amazon DynamoDB`** based lock provider
-Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters
+
+Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters.  You can refer to the
+[DynamoDB based Locks Configurations](https://hudi.apache.org/docs/configurations#DynamoDB-based-Locks-Configurations)
+section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
@@ -80,6 +83,14 @@ hoodie.write.lock.dynamodb.region
 hoodie.write.lock.dynamodb.endpoint_url
 hoodie.write.lock.dynamodb.billing_mode
 ```
+
+When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
+specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
+is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
+value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
+By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
+same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.11.1/concurrency_control.md
+++ b/website/versioned_docs/version-0.11.1/concurrency_control.md
@@ -77,20 +77,21 @@ section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
-hoodie.write.lock.dynamodb.table
-hoodie.write.lock.dynamodb.partition_key
-hoodie.write.lock.dynamodb.region
-hoodie.write.lock.dynamodb.endpoint_url
-hoodie.write.lock.dynamodb.billing_mode
+hoodie.write.lock.dynamodb.table (required)
+hoodie.write.lock.dynamodb.partition_key (optional)
+hoodie.write.lock.dynamodb.region (optional)
+hoodie.write.lock.dynamodb.endpoint_url (optional)
+hoodie.write.lock.dynamodb.billing_mode (optional)
 ```
 
 When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
 specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
-don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
-is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
-value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
-By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
-same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that an attribute with
+the name `key` is present in the table.  The `key` attribute should be the partition key of the DynamoDB table. The
+config `hoodie.write.lock.dynamodb.partition_key` specifies the value to put for the `key` attribute (not the attribute
+name), which is used for the lock on the same table. By default, `hoodie.write.lock.dynamodb.partition_key` is set to
+the table name, so that multiple writers writing to the same table share the same lock. If you customize the name, make
+sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.12.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.12.0/concurrency_control.md
@@ -77,20 +77,21 @@ section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
-hoodie.write.lock.dynamodb.table
-hoodie.write.lock.dynamodb.partition_key
-hoodie.write.lock.dynamodb.region
-hoodie.write.lock.dynamodb.endpoint_url
-hoodie.write.lock.dynamodb.billing_mode
+hoodie.write.lock.dynamodb.table (required)
+hoodie.write.lock.dynamodb.partition_key (optional)
+hoodie.write.lock.dynamodb.region (optional)
+hoodie.write.lock.dynamodb.endpoint_url (optional)
+hoodie.write.lock.dynamodb.billing_mode (optional)
 ```
 
 When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
 specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
-don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
-is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
-value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
-By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
-same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that an attribute with
+the name `key` is present in the table.  The `key` attribute should be the partition key of the DynamoDB table. The
+config `hoodie.write.lock.dynamodb.partition_key` specifies the value to put for the `key` attribute (not the attribute
+name), which is used for the lock on the same table. By default, `hoodie.write.lock.dynamodb.partition_key` is set to
+the table name, so that multiple writers writing to the same table share the same lock. If you customize the name, make
+sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```

--- a/website/versioned_docs/version-0.12.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.12.0/concurrency_control.md
@@ -71,7 +71,9 @@ hoodie.write.lock.hivemetastore.table
 
 **`Amazon DynamoDB`** based lock provider
 
-Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters
+Amazon DynamoDB based lock provides a simple way to support multi writing across different clusters.  You can refer to the
+[DynamoDB based Locks Configurations](https://hudi.apache.org/docs/configurations#DynamoDB-based-Locks-Configurations)
+section for the details of each related configuration knob.
 
 ```
 hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedLockProvider
@@ -81,6 +83,14 @@ hoodie.write.lock.dynamodb.region
 hoodie.write.lock.dynamodb.endpoint_url
 hoodie.write.lock.dynamodb.billing_mode
 ```
+
+When using the DynamoDB-based lock provider, the name of the DynamoDB table acting as the lock table for Hudi is
+specified by the config `hoodie.write.lock.dynamodb.table`. This DynamoDB table is automatically created by Hudi, so you
+don't have to create the table yourself. If you want to use an existing DynamoDB table, make sure that the `key` column
+is present in the table, used as the partition key.  The config `hoodie.write.lock.dynamodb.partition_key` specifies the
+value to put for the `key` column (not the partition key column name), which is used for the lock on the same table.
+By default, `hoodie.write.lock.dynamodb.partition_key` is set to the table name, so that multiple writers writing to the
+same table share the same lock. If you customize the name, make sure it's the same across multiple writers.
 
 Also, to set up the credentials for accessing AWS resources, customers can pass the following props to Hudi jobs:
 ```


### PR DESCRIPTION
### Change Logs

This PR improves docs on DynamoDB-based lock provider to avoid confusion on setting the configs.

<img width="992" alt="Screen Shot 2022-09-23 at 18 03 04" src="https://user-images.githubusercontent.com/2497195/192073638-e91c77b6-8231-4eab-8571-1c3922165895.png">

### Impact

**Risk level: none**

The website can be built and visualized with `npm start`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
