### PR TITLE
[HUDI-4902] Set default partitioner for SIMPLE BUCKET index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
@@ -89,8 +89,7 @@ public class HoodieLayoutConfig extends HoodieConfig {
 
         // Currently, the partitioner of the SIMPLE bucket index is supported by SparkBucketIndexPartitioner only.
         if (layoutConfig.contains(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE)
-            && layoutConfig.getString(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE).equals("SIMPLE")
-            && !layoutConfig.contains(LAYOUT_PARTITIONER_CLASS_NAME)) {
+            && layoutConfig.getString(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE).equals("SIMPLE")) {
           layoutConfig.setDefaultValue(LAYOUT_PARTITIONER_CLASS_NAME, SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME);
         }
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
@@ -48,6 +48,9 @@ public class HoodieLayoutConfig extends HoodieConfig {
       .noDefaultValue()
       .withDocumentation("Partitioner class, it is used to distribute data in a specific way.");
 
+  private static final String SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME =
+      "org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner";
+
   private HoodieLayoutConfig() {
     super();
   }
@@ -80,8 +83,16 @@ public class HoodieLayoutConfig extends HoodieConfig {
     }
 
     private void setDefault() {
-      if (layoutConfig.contains(HoodieIndexConfig.INDEX_TYPE.key()) && layoutConfig.getString(HoodieIndexConfig.INDEX_TYPE.key()).equals(HoodieIndex.IndexType.BUCKET.name())) {
+      if (layoutConfig.contains(HoodieIndexConfig.INDEX_TYPE.key())
+          && layoutConfig.getString(HoodieIndexConfig.INDEX_TYPE.key()).equals(HoodieIndex.IndexType.BUCKET.name())) {
         layoutConfig.setDefaultValue(LAYOUT_TYPE, HoodieStorageLayout.LayoutType.BUCKET.name());
+
+        // Currently, the partitioner of the SIMPLE bucket index is supported by SparkBucketIndexPartitioner only.
+        if (layoutConfig.contains(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE)
+            && layoutConfig.getString(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE).equals("SIMPLE")
+            && !layoutConfig.contains(LAYOUT_PARTITIONER_CLASS_NAME)) {
+          layoutConfig.setDefaultValue(LAYOUT_PARTITIONER_CLASS_NAME, SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME);
+        }
       }
       layoutConfig.setDefaultValue(LAYOUT_TYPE, LAYOUT_TYPE.defaultValue());
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
@@ -48,7 +48,7 @@ public class HoodieLayoutConfig extends HoodieConfig {
       .noDefaultValue()
       .withDocumentation("Partitioner class, it is used to distribute data in a specific way.");
 
-  private static final String SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME =
+  public static final String SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME =
       "org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner";
 
   private HoodieLayoutConfig() {
@@ -88,8 +88,7 @@ public class HoodieLayoutConfig extends HoodieConfig {
         layoutConfig.setDefaultValue(LAYOUT_TYPE, HoodieStorageLayout.LayoutType.BUCKET.name());
 
         // Currently, the partitioner of the SIMPLE bucket index is supported by SparkBucketIndexPartitioner only.
-        if (layoutConfig.contains(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE)
-            && layoutConfig.getString(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE).equals("SIMPLE")) {
+        if ("SIMPLE".equals(layoutConfig.getString(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE))) {
           layoutConfig.setDefaultValue(LAYOUT_PARTITIONER_CLASS_NAME, SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME);
         }
       }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -399,12 +399,20 @@ public class TestHoodieWriteConfig {
   }
 
   @Test
-  public void testSimpleBucketIndexDefaultPartitionerConfig() {
+  public void testSimpleBucketIndexPartitionerConfig() {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BUCKET)
             .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.SIMPLE).build())
         .build();
     assertEquals(HoodieLayoutConfig.SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME, writeConfig.getString(HoodieLayoutConfig.LAYOUT_PARTITIONER_CLASS_NAME));
+
+    HoodieWriteConfig overwritePartitioner = HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BUCKET)
+            .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.SIMPLE)
+            .build())
+        .withLayoutConfig(HoodieLayoutConfig.newBuilder().withLayoutPartitioner("org.apache.hudi.table.action.commit.UpsertPartitioner").build())
+        .build();
+    assertEquals("org.apache.hudi.table.action.commit.UpsertPartitioner", overwritePartitioner.getString(HoodieLayoutConfig.LAYOUT_PARTITIONER_CLASS_NAME));
   }
 
   private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -398,6 +398,15 @@ public class TestHoodieWriteConfig {
             .withClusteringExecutionStrategyClass(HoodieClusteringConfig.SPARK_SORT_AND_SIZE_EXECUTION_STRATEGY).build()));
   }
 
+  @Test
+  public void testSimpleBucketIndexDefaultPartitionerConfig() {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BUCKET)
+            .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.SIMPLE).build())
+        .build();
+    assertEquals(HoodieLayoutConfig.SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME, writeConfig.getString(HoodieLayoutConfig.LAYOUT_PARTITIONER_CLASS_NAME));
+  }
+
   private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {
     final Properties properties = new Properties();
     configs.forEach(properties::setProperty);


### PR DESCRIPTION
### Change Logs

ISSUE: https://github.com/apache/hudi/issues/6723

When we use BUCKET index in spark, the default BUCKET_INDEX_ENGINE_TYPE is SIMPLE. While only SparkBucketIndexPartitioner supports the SIMPLE bucket index.

This pr sets default partitioner for SIMPLE BUCKET index
### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
