### PR TITLE
[HUDI-4914] Managed memory weight should be set when sort clustering is enabled

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/ITTestDataStreamWrite.java
@@ -158,10 +158,22 @@ public class ITTestDataStreamWrite extends TestLogger {
 
   @Test
   public void testWriteCopyOnWriteWithClustering() throws Exception {
+    testWriteCopyOnWriteWithClustering(false);
+  }
+
+  @Test
+  public void testWriteCopyOnWriteWithSortClustering() throws Exception {
+    testWriteCopyOnWriteWithClustering(true);
+  }
+
+  private void testWriteCopyOnWriteWithClustering(boolean sortClusteringEnabled) throws Exception {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     conf.setBoolean(FlinkOptions.CLUSTERING_SCHEDULE_ENABLED, true);
     conf.setInteger(FlinkOptions.CLUSTERING_DELTA_COMMITS, 1);
     conf.setString(FlinkOptions.OPERATION, "insert");
+    if (sortClusteringEnabled) {
+      conf.setString(FlinkOptions.CLUSTERING_SORT_COLUMNS, "uuid");
+    }
 
     testWriteToHoodieWithCluster(conf, "cow_write_with_cluster", 1, EXPECTED);
   }


### PR DESCRIPTION
### Change Logs

Managed memory weight should be set when sort clustering is enabled, otherwise the fraction of memory to allocate is 0 that throws the following exception when initialzing the sorter.

- Sets the managed memory weight when sort clustering is enabled in Pipelines#cluster()
- Initializes the `BinaryExternalSorter` in `ClusteringOperator#doClustering()`.

### Impact

When sort clustering is enabled, the `ClusteringOperator` could initialize the `BinaryExternalSorter`.

**Risk level: none | low | medium | high**

high.

- Introduces the `testWriteCopyOnWriteWithSortClustering` in `ITTestDataStreamWrite` to verify whether the sort clustering could work normally.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
