### PR TITLE
[HUDI-4917] Optimized the way to get HoodieBaseFile of loadColumnRangesFromFiles of Bloom Index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieRangeInfoHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieRangeInfoHandle.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.io;
 
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -41,4 +42,11 @@ public class HoodieRangeInfoHandle<T extends HoodieRecordPayload, I, K, O> exten
       return reader.readMinMaxRecordKeys();
     }
   }
+
+  public String[] getMinMaxKeys(HoodieBaseFile baseFile) throws IOException {
+    try (HoodieFileReader reader = createNewFileReader(baseFile)) {
+      return reader.readMinMaxRecordKeys();
+    }
+  }
+
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
@@ -66,4 +66,9 @@ public abstract class HoodieReadHandle<T extends HoodieRecordPayload, I, K, O> e
     return HoodieFileReaderFactory.getFileReader(hoodieTable.getHadoopConf(),
         new Path(getLatestDataFile().getPath()));
   }
+
+  protected HoodieFileReader createNewFileReader(HoodieBaseFile hoodieBaseFile) throws IOException {
+    return HoodieFileReaderFactory.getFileReader(hoodieTable.getHadoopConf(),
+            new Path(hoodieBaseFile.getPath()));
+  }
 }


### PR DESCRIPTION
…sFromFiles of Bloom Index

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

When using Bloom Index for loadColumnRangesFromFiles in the tagLocation process, the existing method is to obtain the hoodieBaseFile by requesting the Driver side. When the amount of data is large and the parallelism is high, there is a certain network performance bottleneck, resulting in very slow tagloacation.
However, hoodieBaseFile can be obtained directly through HoodieIndexUtils.getLatestBaseFilesForAllPartitions() in loadColumnRangesFromFiles(), so it can effectively improve the performance of TagLoaction of Bloom Index.

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
