### PR TITLE
[HUDI-4923] Fixing flaky test in TestHoodieReadClient.testReadFilterExistAfterBulkInsertPrepped

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,16 +104,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB1_MODULES),hudi-client/hudi-spark-client
-              publishJUnitResults: false
-              jdkVersionOption: '1.8'
-              mavenOptions: '-Xmx4g'
-          - task: Maven@3.205.1
-            displayName: FT common flink
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests -pl $(JOB1_MODULES)
+              options: $(MVN_OPTS_TEST) -Punit-tests -pl hudi-client/hudi-spark-client
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
@@ -121,6 +112,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_2
+        condition : false
         displayName: FT client/spark-client
         timeoutInMinutes: '150'
         steps:
@@ -145,6 +137,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_3
+        condition : false
         displayName: UT FT clients & cli & utilities & sync
         timeoutInMinutes: '150'
         steps:
@@ -178,6 +171,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_4
+        condition : false
         displayName: UT FT other modules
         timeoutInMinutes: '150'
         steps:
@@ -211,6 +205,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: IT
+        condition : false
         displayName: IT modules
         timeoutInMinutes: '150'
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,16 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests -pl hudi-client/hudi-spark-client
+              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB1_MODULES),hudi-client/hudi-spark-client
+              publishJUnitResults: false
+              jdkVersionOption: '1.8'
+              mavenOptions: '-Xmx4g'
+          - task: Maven@3.205.1
+            displayName: FT common flink
+            inputs:
+              mavenPomFile: 'pom.xml'
+              goals: 'test'
+              options: $(MVN_OPTS_TEST) -Pfunctional-tests -pl $(JOB1_MODULES)
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
@@ -112,7 +121,6 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_2
-        condition : false
         displayName: FT client/spark-client
         timeoutInMinutes: '150'
         steps:
@@ -137,7 +145,6 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_3
-        condition : false
         displayName: UT FT clients & cli & utilities & sync
         timeoutInMinutes: '150'
         steps:
@@ -171,7 +178,6 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_4
-        condition : false
         displayName: UT FT other modules
         timeoutInMinutes: '150'
         steps:
@@ -205,7 +211,6 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: IT
-        condition : false
         displayName: IT modules
         timeoutInMinutes: '150'
         steps:

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieReadClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieReadClient.java
@@ -26,7 +26,6 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.AnalysisException;
@@ -45,38 +44,20 @@ import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings("unchecked")
 /**
  * Test-cases for covering HoodieReadClient APIs
  */
+@SuppressWarnings("unchecked")
 public class TestHoodieReadClient extends HoodieClientTestBase {
 
-  private String basePathWithoutScheme = null;
-  private static final String LOCAL_FS_SCHEME = "file://";
-
-  /**
-   * Initializes basePath to use local FS.
-   */
+  @Override
   protected void initPath() {
     try {
       java.nio.file.Path basePath = tempDir.resolve("dataset");
       java.nio.file.Files.createDirectories(basePath);
-      basePathWithoutScheme = basePath.toString().contains("//") ? basePath.toString().substring(basePath.toString().indexOf("//") + 2) : basePath.toString();
-      this.basePath = LOCAL_FS_SCHEME + basePathWithoutScheme;
+      this.basePath = basePath.toUri().toString();
     } catch (IOException ioe) {
       throw new HoodieIOException(ioe.getMessage(), ioe);
-    }
-  }
-
-  /**
-   * Initializes a file system with the hadoop configuration of Spark context.
-   */
-  protected void initFileSystem() {
-    super.initFileSystem();
-    try {
-      fs.mkdirs(new Path(basePath));
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to create base path " + basePath);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieReadClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieReadClient.java
@@ -78,7 +78,6 @@ public class TestHoodieReadClient extends HoodieClientTestBase {
     } catch (IOException e) {
       throw new HoodieIOException("Failed to create base path " + basePath);
     }
-    basePath = basePathWithoutScheme;
   }
 
   /**


### PR DESCRIPTION
### Change Logs

TestHoodieReadClient was using local fs and hence defaulting to hdfs while running in azure CI. Locally I ran the test 50 times and could not reproduce the issue. To avoid hdfs related flakiness, migrating the test to use "file" scheme explicitly. 

### Impact

Will help stabilize CI runs. 

**Risk level: low **

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
