### PR TITLE
[MINOR]add integrity check of merged parquet file for HoodieMergeHandle.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -66,6 +66,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
+
 @SuppressWarnings("Duplicates")
 /**
  * Handle to merge incoming records to those in storage.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -66,8 +66,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
-
 @SuppressWarnings("Duplicates")
 /**
  * Handle to merge incoming records to those in storage.
@@ -453,10 +451,11 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload, I, K, O> extends H
       return;
     }
 
-    // Verify the integrity of the parquet file
+    // Fast verify the integrity of the parquet file.
+    // only check the readable of parquet metadata.
     final String extension = FSUtils.getFileExtension(newFilePath.toString());
     if (PARQUET.getFileExtension().equals(extension )) {
-      ParquetUtils.checkReadableOfParquet(hoodieTable.getHadoopConf(), newFilePath);
+      new ParquetUtils().readMetadata(hoodieTable.getHadoopConf(), newFilePath);
     }
 
     long oldNumWrites = 0;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -456,7 +456,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload, I, K, O> extends H
     // Fast verify the integrity of the parquet file.
     // only check the readable of parquet metadata.
     final String extension = FSUtils.getFileExtension(newFilePath.toString());
-    if (PARQUET.getFileExtension().equals(extension )) {
+    if (PARQUET.getFileExtension().equals(extension)) {
       new ParquetUtils().readMetadata(hoodieTable.getHadoopConf(), newFilePath);
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.util.DefaultSizeEstimator;
 import org.apache.hudi.common.util.HoodieRecordSizeEstimator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -64,6 +65,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
 
 @SuppressWarnings("Duplicates")
 /**
@@ -448,6 +451,12 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload, I, K, O> extends H
   public void performMergeDataValidationCheck(WriteStatus writeStatus) {
     if (!config.isMergeDataValidationCheckEnabled()) {
       return;
+    }
+
+    // Verify the integrity of the parquet file
+    final String extension = FSUtils.getFileExtension(newFilePath.toString());
+    if (PARQUET.getFileExtension().equals(extension )) {
+      ParquetUtils.checkReadableOfParquet(hoodieTable.getHadoopConf(), newFilePath);
     }
 
     long oldNumWrites = 0;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -35,7 +34,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.parquet.HadoopReadOptions;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.avro.AvroSchemaConverter;
@@ -43,8 +41,6 @@ import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.apache.parquet.hadoop.util.HadoopInputFile;
-import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.DecimalMetadata;
 import org.apache.parquet.schema.MessageType;
@@ -57,7 +53,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -493,31 +488,6 @@ public class ParquetUtils extends BaseFileUtils {
     @Override
     public HoodieKey next() {
       return this.func.apply(this.nestedItr.next());
-    }
-  }
-
-  /**
-   * Check readable of parquet files.
-   *
-   *
-   * @param configuration   configuration to build fs object
-   * @param checkPath        The parquet file path.
-   */
-  public static void checkReadableOfParquet(Configuration configuration, Path checkPath) {
-    try {
-      List<InputFile> inputFiles = Collections.singletonList((InputFile) HadoopInputFile.fromPath(checkPath, configuration));
-      // check footer
-      new ParquetUtils().readMetadata(configuration, checkPath);
-      // check row group and page
-      ParquetFileReader parquetFileReader = new ParquetFileReader(inputFiles.get(0), HadoopReadOptions.builder(configuration, checkPath).build());
-      while (true) {
-        if (parquetFileReader.readNextFilteredRowGroup() == null) {
-          break;
-        }
-      }
-    } catch (Exception e) {
-      LOG.error(String.format("failed to verify the correctness of current parquet file: %s, this parquet is corrupted", checkPath));
-      throw new HoodieException(e);
     }
   }
 }


### PR DESCRIPTION
### Change Logs

add integrity check of merged parquet file for HoodieMergeHandle.

In the current production environment, due to the instability of the cluster, it is very easy for hudi to write the corrupt parquet file, which makes the entire table unavailable,
eg：
Caused by: java.io.IOException: can not read class org.apache.parquet.format.PageHeader: Required field 

'uncompressed_page_size' was not found in serialized data! Struct: org.apache.parquet.format.PageHeader$PageHeaderStandardScheme@183284b
	at org.apache.parquet.format.Util.read(Util.java:365)
	at org.apache.parquet.format.Util.readPageHeader(Util.java:132)
	at org.apache.parquet.hadoop.ParquetFileReader$Chunk.readPageHeader(ParquetFileReader.java:1382)


After the hudi completes the parquet writing, add a simple parquet file integrity check to ensure that no corrupt files will enter the hudi table


### Impact

**Risk level: low**

### Documentation Update

N/A
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
