### PR TITLE
[HUDI-4946] fix merge into with no preCombineField has dup row by onl…

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable2.scala
@@ -673,7 +673,7 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
     }
   }
 
-  test("Test Merge into with String cast to Double") {
+  test ("Test Merge into with String cast to Double") {
     withTempDir { tmp =>
       val tableName = generateTableName
       // Create a cow partitioned table.
@@ -748,6 +748,138 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
       checkAnswer(s"select id,name,ts from $tableName")(
         Seq(1, "a2", 1000)
       )
+    }
+  }
+
+  test("Test only insert for source table in dup key with preCombineField") {
+    Seq("cow", "mor").foreach {
+      tableType => {
+        withTempDir { tmp =>
+          val tableName = generateTableName
+          // Create a cow partitioned table with preCombineField
+          spark.sql(
+            s"""
+               | create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  ts long,
+               |  dt string
+               | ) using hudi
+               | tblproperties (
+               |  type = '$tableType',
+               |  primaryKey = 'id',
+               |  preCombineField = 'ts'
+               | )
+               | partitioned by(dt)
+               | location '${tmp.getCanonicalPath}'
+         """.stripMargin)
+          // Insert data without match condition
+          spark.sql(
+            s"""
+               | merge into $tableName as t0
+               | using (
+               |  select 1 as id, 'a1' as name, 10.1 as price, 1000 as ts, '2021-03-21' as dt
+               |  union all
+               |  select 1 as id, 'a2' as name, 10.2 as price, 1002 as ts, '2021-03-21' as dt
+               | ) as s0
+               | on t0.id = s0.id
+               | when not matched then insert *
+         """.stripMargin
+          )
+          checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+            Seq(1, "a2", 10.2, 1002, "2021-03-21")
+          )
+
+          // Insert data with match condition
+          spark.sql(
+            s"""
+               | merge into $tableName as t0
+               | using (
+               |  select 1 as id, 'a1_new' as name, 10.1 as price, 1003 as ts, '2021-03-21' as dt
+               |  union all
+               |  select 3 as id, 'a3' as name, 10.3 as price, 1003 as ts, '2021-03-21' as dt
+               |  union all
+               |  select 3 as id, 'a3' as name, 10.3 as price, 1003 as ts, '2021-03-21' as dt
+               | ) as s0
+               | on t0.id = s0.id
+               | when matched then update set *
+               | when not matched then insert *
+         """.stripMargin
+          )
+          checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+            Seq(1, "a1_new", 10.1, 1003, "2021-03-21"),
+            Seq(3, "a3", 10.3, 1003, "2021-03-21")
+          )
+        }
+      }
+    }
+  }
+
+  test("Test only insert for source table in dup key without preCombineField") {
+    Seq("cow", "mor").foreach {
+      tableType => {
+        withTempDir { tmp =>
+          val tableName = generateTableName
+          spark.sql(
+            s"""
+               | create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  ts long,
+               |  dt string
+               | ) using hudi
+               | tblproperties (
+               |  type = '$tableType',
+               |  primaryKey = 'id'
+               | )
+               | partitioned by(dt)
+               | location '${tmp.getCanonicalPath}'
+         """.stripMargin)
+          // append records to small file is use update bucket, set this conf use concat handler
+          spark.sql("set hoodie.merge.allow.duplicate.on.inserts = true")
+
+          // Insert data without matched condition
+          spark.sql(
+            s"""
+               | merge into $tableName as t0
+               | using (
+               |  select 1 as id, 'a1' as name, 10.1 as price, 1000 as ts, '2021-03-21' as dt
+               |  union all
+               |  select 1 as id, 'a2' as name, 10.2 as price, 1002 as ts, '2021-03-21' as dt
+               | ) as s0
+               | on t0.id = s0.id
+               | when not matched then insert *
+         """.stripMargin
+          )
+          checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+            Seq(1, "a1", 10.1, 1000, "2021-03-21"),
+            Seq(1, "a2", 10.2, 1002, "2021-03-21")
+          )
+
+          // Insert data with matched condition
+          spark.sql(
+            s"""
+               | merge into $tableName as t0
+               | using (
+               |  select 3 as id, 'a3' as name, 10.3 as price, 1003 as ts, '2021-03-21' as dt
+               |  union all
+               |  select 1 as id, 'a2' as name, 10.2 as price, 1002 as ts, '2021-03-21' as dt
+               | ) as s0
+               | on t0.id = s0.id
+               | when matched then update set *
+               | when not matched then insert *
+         """.stripMargin
+          )
+          checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+            Seq(1, "a1", 10.1, 1000, "2021-03-21"),
+            Seq(1, "a2", 10.2, 1002, "2021-03-21"),
+            Seq(3, "a3", 10.3, 1003, "2021-03-21"),
+            Seq(1, "a2", 10.2, 1002, "2021-03-21")
+          )
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Change Logs

merge into only_insert's operation  is consistent with has match action, if table has precombineField, op is upsert otherwise is insert

### Impact

spark merge into sql

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
