### PR TITLE
[HUDI-4950] Fix read log lead to oom not be catched issue

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -557,8 +557,9 @@ public class StreamerUtil {
     try {
       HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(path, hadoopConf);
       return getTableAvroSchema(metaClient, false);
-    } catch (Exception e) {
-      LOG.warn("Error while resolving the latest table schema", e);
+    } catch (Throwable throwable) {
+      LOG.warn("Error while resolving the latest table schema.", throwable);
+      // ignored
     }
     return null;
   }


### PR DESCRIPTION
### Change Logs
Make org.apache.hudi.util.StreamerUtil#getLatestTableSchema can catch oom exception caused by read log/base file to infer schema

### Impact
Use HoodieHiveCatalog to infer schema can be consistent with HoodieCatalog, which can catch oom.

**Risk level: none | low | medium | high**
none

### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
