### PR TITLE
[HUDI-2118] Skip checking corrupt log blocks for transactional write file systems

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
@@ -25,62 +25,65 @@ import java.util.Arrays;
  */
 public enum StorageSchemes {
   // Local filesystem
-  FILE("file", false),
+  FILE("file", false, false),
   // Hadoop File System
-  HDFS("hdfs", true),
+  HDFS("hdfs", true, false),
   // Baidu Advanced File System
-  AFS("afs", true),
+  AFS("afs", true, null),
   // Mapr File System
-  MAPRFS("maprfs", true),
+  MAPRFS("maprfs", true, null),
   // Apache Ignite FS
-  IGNITE("igfs", true),
+  IGNITE("igfs", true, null),
   // AWS S3
-  S3A("s3a", false), S3("s3", false),
+  S3A("s3a", false, true), S3("s3", false, true),
   // Google Cloud Storage
-  GCS("gs", false),
+  GCS("gs", false, true),
   // Azure WASB
-  WASB("wasb", false), WASBS("wasbs", false),
+  WASB("wasb", false, null), WASBS("wasbs", false, null),
   // Azure ADLS
-  ADL("adl", false),
+  ADL("adl", false, null),
   // Azure ADLS Gen2
-  ABFS("abfs", false), ABFSS("abfss", false),
+  ABFS("abfs", false, null), ABFSS("abfss", false, null),
   // Aliyun OSS
-  OSS("oss", false),
+  OSS("oss", false, null),
   // View FS for federated setups. If federating across cloud stores, then append support is false
-  VIEWFS("viewfs", true),
+  VIEWFS("viewfs", true, null),
   //ALLUXIO
-  ALLUXIO("alluxio", false),
+  ALLUXIO("alluxio", false, null),
   // Tencent Cloud Object Storage
-  COSN("cosn", false),
+  COSN("cosn", false, null),
   // Tencent Cloud HDFS
-  CHDFS("ofs", true),
+  CHDFS("ofs", true, null),
   // Tencent Cloud CacheFileSystem
-  GOOSEFS("gfs", false),
+  GOOSEFS("gfs", false, null),
   // Databricks file system
-  DBFS("dbfs", false),
+  DBFS("dbfs", false, null),
   // IBM Cloud Object Storage
-  COS("cos", false),
+  COS("cos", false, null),
   // Huawei Cloud Object Storage
-  OBS("obs", false),
+  OBS("obs", false, null),
   // Kingsoft Standard Storage ks3
-  KS3("ks3", false),
+  KS3("ks3", false, null),
   // JuiceFileSystem
-  JFS("jfs", true),
+  JFS("jfs", true, null),
   // Baidu Object Storage
-  BOS("bos", false),
+  BOS("bos", false, null),
   // Oracle Cloud Infrastructure Object Storage
-  OCI("oci", false),
+  OCI("oci", false, null),
   // Volcengine Object Storage
-  TOS("tos", false),
+  TOS("tos", false, null),
   // Volcengine Cloud HDFS
-  CFS("cfs", true);
+  CFS("cfs", true, null);
 
   private String scheme;
-  private boolean supportsAppend;
+  private boolean supportsAppend = false;
+  // null for uncertain if write is transactional, please update this for each FS
+  private Boolean isWriteTransactional;
 
-  StorageSchemes(String scheme, boolean supportsAppend) {
+  StorageSchemes(String scheme, boolean supportsAppend, Boolean isWriteTransactional) {
     this.scheme = scheme;
     this.supportsAppend = supportsAppend;
+    this.isWriteTransactional = isWriteTransactional;
   }
 
   public String getScheme() {
@@ -89,6 +92,10 @@ public enum StorageSchemes {
 
   public boolean supportsAppend() {
     return supportsAppend;
+  }
+
+  public boolean isWriteTransactional(){
+    return isWriteTransactional != null && isWriteTransactional;
   }
 
   public static boolean isSchemeSupported(String scheme) {
@@ -101,4 +108,22 @@ public enum StorageSchemes {
     }
     return Arrays.stream(StorageSchemes.values()).anyMatch(s -> s.supportsAppend() && s.scheme.equals(scheme));
   }
+
+  public static boolean isWriteTransactional(String scheme) {
+    if (!isSchemeSupported(scheme)) {
+      throw new IllegalArgumentException("Unsupported scheme :" + scheme);
+    }
+
+    return Arrays.stream(StorageSchemes.values()).anyMatch(s -> s.isWriteTransactional() && s.scheme.equals(scheme));
+//
+//    if (scheme == "gs"){
+//      return true;
+//    }
+
+    //    if (scheme == "file") {
+    //      return true;
+    //    }
+//    return false;
+  }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
@@ -76,7 +76,7 @@ public enum StorageSchemes {
   CFS("cfs", true, null);
 
   private String scheme;
-  private boolean supportsAppend = false;
+  private boolean supportsAppend;
   // null for uncertain if write is transactional, please update this for each FS
   private Boolean isWriteTransactional;
 
@@ -94,7 +94,7 @@ public enum StorageSchemes {
     return supportsAppend;
   }
 
-  public boolean isWriteTransactional(){
+  public boolean isWriteTransactional() {
     return isWriteTransactional != null && isWriteTransactional;
   }
 
@@ -115,15 +115,5 @@ public enum StorageSchemes {
     }
 
     return Arrays.stream(StorageSchemes.values()).anyMatch(s -> s.isWriteTransactional() && s.scheme.equals(scheme));
-//
-//    if (scheme == "gs"){
-//      return true;
-//    }
-
-    //    if (scheme == "file") {
-    //      return true;
-    //    }
-//    return false;
   }
-
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -163,17 +163,12 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       return createCorruptBlock(blockStartPos);
     }
 
-    // Block is possibly corrupted only when write is not transactional
-    // the corrupted check could take 100's msec for larger file sizes, skipping the check for fs with transactional write
-    // see https://issues.apache.org/jira/browse/HUDI-2118
-    if (!StorageSchemes.isWriteTransactional(fs.getScheme())) {
-      // We may have had a crash which could have written this block partially
-      // Skip blockSize in the stream and we should either find a sync marker (start of the next
-      // block) or EOF. If we did not find either of it, then this block is a corrupted block.
-      boolean isCorrupted = isBlockCorrupted(blockSize);
-      if (isCorrupted) {
-        return createCorruptBlock(blockStartPos);
-      }
+    // We may have had a crash which could have written this block partially
+    // Skip blockSize in the stream and we should either find a sync marker (start of the next
+    // block) or EOF. If we did not find either of it, then this block is a corrupted block.
+    boolean isCorrupted = isBlockCorrupted(blockSize);
+    if (isCorrupted) {
+      return createCorruptBlock(blockStartPos);
     }
 
     // 2. Read the version for this log format
@@ -290,45 +285,50 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
   }
 
   private boolean isBlockCorrupted(int blocksize) throws IOException {
-    long currentPos = inputStream.getPos();
-    long blockSizeFromFooter;
+    if (!StorageSchemes.isWriteTransactional(fs.getScheme())) {
+      // skip block corrupt check if writes are transactional. see https://issues.apache.org/jira/browse/HUDI-2118
+      long currentPos = inputStream.getPos();
+      long blockSizeFromFooter;
 
-    try {
-      // check if the blocksize mentioned in the footer is the same as the header;
-      // by seeking and checking the length of a long.  We do not seek `currentPos + blocksize`
-      // which can be the file size for the last block in the file, causing EOFException
-      // for some FSDataInputStream implementation
-      inputStream.seek(currentPos + blocksize - Long.BYTES);
-      // Block size in the footer includes the magic header, which the header does not include.
-      // So we have to shorten the footer block size by the size of magic hash
-      blockSizeFromFooter = inputStream.readLong() - magicBuffer.length;
-    } catch (EOFException e) {
-      LOG.info("Found corrupted block in file " + logFile + " with block size(" + blocksize + ") running past EOF");
-      // this is corrupt
-      // This seek is required because contract of seek() is different for naked DFSInputStream vs BufferedFSInputStream
-      // release-3.1.0-RC1/DFSInputStream.java#L1455
-      // release-3.1.0-RC1/BufferedFSInputStream.java#L73
-      inputStream.seek(currentPos);
-      return true;
-    }
+      try {
+        // check if the blocksize mentioned in the footer is the same as the header;
+        // by seeking and checking the length of a long.  We do not seek `currentPos + blocksize`
+        // which can be the file size for the last block in the file, causing EOFException
+        // for some FSDataInputStream implementation
+        inputStream.seek(currentPos + blocksize - Long.BYTES);
+        // Block size in the footer includes the magic header, which the header does not include.
+        // So we have to shorten the footer block size by the size of magic hash
+        blockSizeFromFooter = inputStream.readLong() - magicBuffer.length;
+      } catch (EOFException e) {
+        LOG.info("Found corrupted block in file " + logFile + " with block size(" + blocksize + ") running past EOF");
+        // this is corrupt
+        // This seek is required because contract of seek() is different for naked DFSInputStream vs BufferedFSInputStream
+        // release-3.1.0-RC1/DFSInputStream.java#L1455
+        // release-3.1.0-RC1/BufferedFSInputStream.java#L73
+        inputStream.seek(currentPos);
+        return true;
+      }
 
-    if (blocksize != blockSizeFromFooter) {
-      LOG.info("Found corrupted block in file " + logFile + ". Header block size(" + blocksize
-          + ") did not match the footer block size(" + blockSizeFromFooter + ")");
-      inputStream.seek(currentPos);
-      return true;
-    }
+      if (blocksize != blockSizeFromFooter) {
+        LOG.info("Found corrupted block in file " + logFile + ". Header block size(" + blocksize
+            + ") did not match the footer block size(" + blockSizeFromFooter + ")");
+        inputStream.seek(currentPos);
+        return true;
+      }
 
-    try {
-      readMagic();
-      // all good - either we found the sync marker or EOF. Reset position and continue
+      try {
+        readMagic();
+        // all good - either we found the sync marker or EOF. Reset position and continue
+        return false;
+      } catch (CorruptedLogFileException e) {
+        // This is a corrupted block
+        LOG.info("Found corrupted block in file " + logFile + ". No magic hash found right after footer block size entry");
+        return true;
+      } finally {
+        inputStream.seek(currentPos);
+      }
+    } else {
       return false;
-    } catch (CorruptedLogFileException e) {
-      // This is a corrupted block
-      LOG.info("Found corrupted block in file " + logFile + ". No magic hash found right after footer block size entry");
-      return true;
-    } finally {
-      inputStream.seek(currentPos);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -74,7 +74,6 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
   private static final Logger LOG = LogManager.getLogger(HoodieLogFileReader.class);
 
   private final FileSystem fs;
-  private final FileSystem fs;
   private final Configuration hadoopConf;
   private final FSDataInputStream inputStream;
   private final HoodieLogFile logFile;
@@ -173,7 +172,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       // block) or EOF. If we did not find either of it, then this block is a corrupted block.
       boolean isCorrupted = isBlockCorrupted(blockSize);
       if (isCorrupted) {
-        return createCorruptBlock();
+        return createCorruptBlock(blockStartPos);
       }
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.log;
 import org.apache.hudi.common.fs.BoundedFsDataInputStream;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.fs.SchemeAwareFSDataInputStream;
+import org.apache.hudi.common.fs.StorageSchemes;
 import org.apache.hudi.common.fs.TimedFSDataInputStream;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -72,6 +73,8 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
   private static final int BLOCK_SCAN_READ_BUFFER_SIZE = 1024 * 1024; // 1 MB
   private static final Logger LOG = LogManager.getLogger(HoodieLogFileReader.class);
 
+  private final FileSystem fs;
+  private final FileSystem fs;
   private final Configuration hadoopConf;
   private final FSDataInputStream inputStream;
   private final HoodieLogFile logFile;
@@ -107,6 +110,7 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
   public HoodieLogFileReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema, int bufferSize,
                              boolean readBlockLazily, boolean reverseReader, boolean enableRecordLookups,
                              String keyField, InternalSchema internalSchema) throws IOException {
+    this.fs = fs;
     this.hadoopConf = fs.getConf();
     // NOTE: We repackage {@code HoodieLogFile} here to make sure that the provided path
     //       is prefixed with an appropriate scheme given that we're not propagating the FS
@@ -160,12 +164,17 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       return createCorruptBlock(blockStartPos);
     }
 
-    // We may have had a crash which could have written this block partially
-    // Skip blockSize in the stream and we should either find a sync marker (start of the next
-    // block) or EOF. If we did not find either of it, then this block is a corrupted block.
-    boolean isCorrupted = isBlockCorrupted(blockSize);
-    if (isCorrupted) {
-      return createCorruptBlock(blockStartPos);
+    // Block is possibly corrupted only when write is not atomic
+    // the corrupted check could take 100's msec for larger file sizes, skipping the check for fs with atomic write
+    // see https://issues.apache.org/jira/browse/HUDI-2118
+    if (!StorageSchemes.isWriteTransactional(fs.getScheme())) {
+      // We may have had a crash which could have written this block partially
+      // Skip blockSize in the stream and we should either find a sync marker (start of the next
+      // block) or EOF. If we did not find either of it, then this block is a corrupted block.
+      boolean isCorrupted = isBlockCorrupted(blockSize);
+      if (isCorrupted) {
+        return createCorruptBlock();
+      }
     }
 
     // 2. Read the version for this log format

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -163,8 +163,8 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
       return createCorruptBlock(blockStartPos);
     }
 
-    // Block is possibly corrupted only when write is not atomic
-    // the corrupted check could take 100's msec for larger file sizes, skipping the check for fs with atomic write
+    // Block is possibly corrupted only when write is not transactional
+    // the corrupted check could take 100's msec for larger file sizes, skipping the check for fs with transactional write
     // see https://issues.apache.org/jira/browse/HUDI-2118
     if (!StorageSchemes.isWriteTransactional(fs.getScheme())) {
       // We may have had a crash which could have written this block partially

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -85,9 +85,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,6 +114,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests hoodie log format {@link HoodieLogFormat}.
@@ -912,6 +915,36 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     reader.next();
     assertFalse(reader.hasNext(), "We should have no more blocks left");
     reader.close();
+  }
+
+  @Test
+  public void testSkipCorruptedCheck() throws Exception {
+    // normal case: if the block is corrupted, we should be able to read back a corrupted block
+    Reader reader1 = createCorruptedFile("test-fileid1");
+    HoodieLogBlock block = reader1.next();
+    assertEquals(HoodieLogBlockType.CORRUPT_BLOCK, block.getBlockType(), "The read block should be a corrupt block");
+    reader1.close();
+
+    // mock case: we want to verify that isBlockCorrupted() check is skipped for transactional write fs
+    // so here created a corrupted block for a transactional write fs(which would never happen) to verify the skip logic
+    // a better way to verify it is to mock the private method isBlockCorrupted(), but it is not available in current Mockito framework
+    // and the attempt to onboard powermock with private method mocking capability has failed
+    Reader reader2 = createCorruptedFile("test-fileid2");
+    assertTrue(reader2.hasNext(), "We should have corrupted block next");
+
+    // mock the fs to be GCS to skip isBlockCorrupted() check
+    Field f1 = reader2.getClass().getDeclaredField("fs");
+    f1.setAccessible(true);
+    FileSystem spyfs = Mockito.spy(fs);
+    when(spyfs.getScheme()).thenReturn("gs");
+    f1.set(reader2, spyfs);
+
+    // except an exception for block type since the block is corrupted
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      reader2.next();
+    });
+    assertTrue(exception.getMessage().contains("Invalid block byte type found"));
+    reader2.close();
   }
 
   @Test
@@ -2647,5 +2680,44 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     List<IndexedRecord> copy = new ArrayList<>(records);
     copy.sort(Comparator.comparing(r -> ((GenericRecord) r).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString()));
     return copy;
+  }
+
+  private HoodieLogFormat.Reader createCorruptedFile(String fileId) throws Exception {
+    // block is corrupted, but check is skipped.
+    Writer writer =
+        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withFileExtension(HoodieLogFile.DELTA_EXTENSION)
+            .withFileId(fileId).overBaseCommit("100").withFs(fs).build();
+    List<IndexedRecord> records = SchemaTestUtil.generateTestRecords(0, 100);
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>();
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, "100");
+    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, getSimpleSchema().toString());
+    HoodieDataBlock dataBlock = getDataBlock(DEFAULT_DATA_BLOCK_TYPE, records, header);
+    writer.appendBlock(dataBlock);
+    writer.close();
+
+    // Append some arbit byte[] to thee end of the log (mimics a partially written commit)
+    fs = FSUtils.getFs(fs.getUri().toString(), fs.getConf());
+    FSDataOutputStream outputStream = fs.append(writer.getLogFile().getPath());
+    // create a block with
+    outputStream.write(HoodieLogFormat.MAGIC);
+    // Write out a length that does not confirm with the content
+    outputStream.writeLong(473);
+    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(10000); // an invalid block type
+
+    // Write out a length that does not confirm with the content
+    outputStream.writeLong(400);
+    // Write out incomplete content
+    outputStream.write("something-random".getBytes());
+    outputStream.flush();
+    outputStream.close();
+
+    // First round of reads - we should be able to read the first block and then EOF
+    Reader reader = HoodieLogFormat.newReader(fs, writer.getLogFile(), SchemaTestUtil.getSimpleSchema());
+
+    assertTrue(reader.hasNext(), "First block should be available");
+    reader.next();
+
+    return reader;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -925,10 +925,8 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     assertEquals(HoodieLogBlockType.CORRUPT_BLOCK, block.getBlockType(), "The read block should be a corrupt block");
     reader1.close();
 
-    // mock case: we want to verify that isBlockCorrupted() check is skipped for transactional write fs
-    // so here created a corrupted block for a transactional write fs(which would never happen) to verify the skip logic
-    // a better way to verify it is to mock the private method isBlockCorrupted(), but it is not available in current Mockito framework
-    // and the attempt to onboard powermock with private method mocking capability has failed
+    // as we can't mock a private method or directly test it, we are going this route.
+    // So adding a corrupted block which ideally should have been skipped for write transactional system. and hence when we call next() on log block reader, it will fail.
     Reader reader2 = createCorruptedFile("test-fileid2");
     assertTrue(reader2.hasNext(), "We should have corrupted block next");
 


### PR DESCRIPTION
### Change Logs

Skip checking corrupt log blocks for transactional write file systems

### Impact
- The benchmark results show corrupted block check could be 100's of msecs for larger file sizes.
- This change would boost block read of 100's of ms per block.

### Risk level (write none, low medium or high below)

low

- Only turned on S3 and GCS for this feature, those for sure supports transactional write.
- For other file systems, there's no change.

### Documentation Update
It can be considered a small feature, probably worth mentioning that for cloud storage with transactional write support, there're certain optimization around it.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
