### PR TITLE
[HUDI-4952] Fixing reading from metadata table when there are no inflight commits

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1052,8 +1052,12 @@ public class HoodieTableMetadataUtil {
     HoodieTableFileSystemView fsView = fileSystemView.orElse(getFileSystemView(metaClient));
     Stream<FileSlice> fileSliceStream;
     if (mergeFileSlices) {
-      fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
-          partition, metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().get().getTimestamp());
+      if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
+        fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
+            partition, metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().get().getTimestamp());
+      } else {
+        return Collections.EMPTY_LIST;
+      }
     } else {
       fileSliceStream = fsView.getLatestFileSlices(partition);
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -305,8 +305,8 @@ object HoodieFileIndex extends Logging {
     // would be able to run SET hoodie.metadata.enable=true in the spark sql session to enable metadata listing.
     val isMetadataFilesPartitionAvailable = isFilesPartitionAvailable(metaClient) && sqlConf.getConfString(HoodieMetadataConfig.ENABLE.key(),
       HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS.toString).toBoolean
+    properties.putAll(options.filter(p => p._2 != null).asJava)
     properties.setProperty(HoodieMetadataConfig.ENABLE.key(), String.valueOf(isMetadataFilesPartitionAvailable))
-    properties.putAll(options.filter(p => p._2 != null && !p._1.equals(HoodieMetadataConfig.ENABLE.key())).asJava)
     properties
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -254,7 +254,7 @@ case class HoodieFileIndex(spark: SparkSession,
 
   override def sizeInBytes: Long = cachedFileSize
 
-  private def isDataSkippingEnabled: Boolean = HoodieFileIndex.getBooleanConfigValue(spark.sessionState.conf, options, DataSourceReadOptions.ENABLE_DATA_SKIPPING.key(),
+  private def isDataSkippingEnabled: Boolean = HoodieFileIndex.getBooleanConfigValue(options, spark.sessionState.conf, DataSourceReadOptions.ENABLE_DATA_SKIPPING.key(),
   "false")
 
   private def isMetadataTableEnabled: Boolean = metadataConfig.enabled()
@@ -271,7 +271,7 @@ case class HoodieFileIndex(spark: SparkSession,
 
 object HoodieFileIndex extends Logging {
 
-  def getBooleanConfigValue(sqlConf: SQLConf, options: Map[String, String], configKey: String, defaultValue: String) : Boolean = {
+  def getBooleanConfigValue(options: Map[String, String], sqlConf: SQLConf, configKey: String, defaultValue: String) : Boolean = {
     options.getOrElse(configKey, sqlConf.getConfString(configKey, defaultValue)).toBoolean
   }
 
@@ -308,7 +308,7 @@ object HoodieFileIndex extends Logging {
     // To support metadata listing via Spark SQL we allow users to pass the config via SQL Conf in spark session. Users
     // would be able to run SET hoodie.metadata.enable=true in the spark sql session to enable metadata listing.
     val isMetadataFilesPartitionAvailable = isFilesPartitionAvailable(metaClient) &&
-      getBooleanConfigValue(sqlConf, options, HoodieMetadataConfig.ENABLE.key(), HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS.toString)
+      getBooleanConfigValue(options, sqlConf, HoodieMetadataConfig.ENABLE.key(), HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS.toString)
     properties.putAll(options.filter(p => p._2 != null).asJava)
     properties.setProperty(HoodieMetadataConfig.ENABLE.key(), String.valueOf(isMetadataFilesPartitionAvailable))
     properties

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 import org.apache.hudi.keygen.{TimestampBasedAvroKeyGenerator, TimestampBasedKeyGenerator}
-import org.apache.hudi.metadata.HoodieMetadataPayload
+import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{And, Expression, Literal}
@@ -74,7 +74,7 @@ case class HoodieFileIndex(spark: SparkSession,
     spark = spark,
     metaClient = metaClient,
     schemaSpec = schemaSpec,
-    configProperties = getConfigProperties(spark, options),
+    configProperties = getConfigProperties(spark, options, metaClient),
     queryPaths = HoodieFileIndex.getQueryPaths(options),
     specifiedQueryInstant = options.get(DataSourceReadOptions.TIME_TRAVEL_AS_OF_INSTANT.key).map(HoodieSqlCommonUtils.formatQueryInstant),
     fileStatusCache = fileStatusCache
@@ -293,16 +293,20 @@ object HoodieFileIndex extends Logging {
     schema.fieldNames.filter { colName => refs.exists(r => resolver.apply(colName, r.name)) }
   }
 
-  def getConfigProperties(spark: SparkSession, options: Map[String, String]) = {
+  private def isFilesPartitionAvailable(metaClient: HoodieTableMetaClient): Boolean = {
+    metaClient.getTableConfig.getMetadataPartitions.contains(HoodieTableMetadataUtil.PARTITION_NAME_FILES)
+  }
+
+  def getConfigProperties(spark: SparkSession, options: Map[String, String], metaClient: HoodieTableMetaClient) = {
     val sqlConf: SQLConf = spark.sessionState.conf
     val properties = new TypedProperties()
 
     // To support metadata listing via Spark SQL we allow users to pass the config via SQL Conf in spark session. Users
     // would be able to run SET hoodie.metadata.enable=true in the spark sql session to enable metadata listing.
-    properties.setProperty(HoodieMetadataConfig.ENABLE.key(),
-      sqlConf.getConfString(HoodieMetadataConfig.ENABLE.key(),
-        HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS.toString))
-    properties.putAll(options.filter(p => p._2 != null).asJava)
+    val isMetadataFilesPartitionAvailable = isFilesPartitionAvailable(metaClient) && sqlConf.getConfString(HoodieMetadataConfig.ENABLE.key(),
+      HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS.toString).toBoolean
+    properties.setProperty(HoodieMetadataConfig.ENABLE.key(), String.valueOf(isMetadataFilesPartitionAvailable))
+    properties.putAll(options.filter(p => p._2 != null && !p._1.equals(HoodieMetadataConfig.ENABLE.key())).asJava)
     properties
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
@@ -98,7 +98,7 @@ class HoodieCDCRDD(
     metaClient.getTableConfig.cdcSupplementalLoggingMode
   )
 
-  private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty)
+  private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty, metaClient)
 
   protected val payloadProps: Properties = Option(metaClient.getTableConfig.getPreCombineField)
     .map { preCombineField =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -394,6 +394,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase {
       val props = Map[String, String](
         "path" -> basePath,
         QUERY_TYPE.key -> QUERY_TYPE_SNAPSHOT_OPT_VAL,
+        HoodieMetadataConfig.ENABLE.key -> testCase.enableMetadata.toString,
         DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> testCase.enableDataSkipping.toString,
         HoodieMetadataConfig.COLUMN_STATS_INDEX_PROCESSING_MODE_OVERRIDE.key -> testCase.columnStatsProcessingModeOverride
       ) ++ readMetadataOpts
@@ -403,7 +404,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase {
       val allFilesPartitions = fileIndex.listFiles(Seq(), Seq())
       assertEquals(10, allFilesPartitions.head.files.length)
 
-      if (testCase.enableDataSkipping && testCase.enableMetadata) {
+      if (testCase.enableDataSkipping && testCase.enableMetadata && testCase.enableColumnStats) {
         // We're selecting a single file that contains "id" == 1 row, which there should be
         // strictly 1. Given that 1 is minimal possible value, Data Skipping should be able to
         // truncate search space to just a single file

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -404,7 +404,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase {
       val allFilesPartitions = fileIndex.listFiles(Seq(), Seq())
       assertEquals(10, allFilesPartitions.head.files.length)
 
-      if (testCase.enableDataSkipping && testCase.enableMetadata && testCase.enableColumnStats) {
+      if (testCase.enableDataSkipping && testCase.enableMetadata) {
         // We're selecting a single file that contains "id" == 1 row, which there should be
         // strictly 1. Given that 1 is minimal possible value, Data Skipping should be able to
         // truncate search space to just a single file


### PR DESCRIPTION
### Change Logs

When metadata table is just getting initialized, but first commit is not yet fully complete(or lets say metadata initialization failed mid-way), reading from metadata table could fail w/ the stacktrace posted in the linked jira. Fixing the read of hudi table to fallback to FS based listing if FILES partition in metadata table if not yet ready to serve data. 
Also, if user sets "hoodie.metadata.enable" = true while querying, even if metadata table is not available, we try to fetch from metadata table. Have fixed the same in this patch as well. 

### Impact

Users should not see any failures or data loss while reading from hudi table if metadata table initialization is happening or if it fails mid-way.

**Risk level: low **

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
