### PR TITLE
[HUDI-4955] Use same retain count to archive clean and rollback instant

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -72,7 +72,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -386,15 +385,8 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
   private Stream<HoodieInstant> getCleanInstantsToArchive() {
     HoodieTimeline cleanAndRollbackTimeline = table.getActiveTimeline()
         .getTimelineOfActions(CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION, HoodieTimeline.ROLLBACK_ACTION)).filterCompletedInstants();
-    return cleanAndRollbackTimeline.getInstants()
-        .collect(Collectors.groupingBy(HoodieInstant::getAction)).values().stream()
-        .map(hoodieInstants -> {
-          if (hoodieInstants.size() > this.maxInstantsToKeep) {
-            return hoodieInstants.subList(0, hoodieInstants.size() - this.minInstantsToKeep);
-          } else {
-            return new ArrayList<HoodieInstant>();
-          }
-        }).flatMap(Collection::stream);
+    List<HoodieInstant> cleanAdnRollbackInstants = cleanAndRollbackTimeline.getInstants().collect(Collectors.toList());
+    return cleanAdnRollbackInstants.subList(0, cleanAdnRollbackInstants.size() - this.minInstantsToKeep).stream();
   }
 
   private Stream<HoodieInstant> getCommitInstantsToArchive() {


### PR DESCRIPTION
### Change Logs

Currently archive clean and rollback time line will keep retain instant seperate . Will result left

long time ago rollback instants

## RealInstant
![企业微信截图_1664529795792](https://user-images.githubusercontent.com/3350718/193240387-5cbbe56c-cb6a-416d-8253-9381767fd6b9.png)

## To archive instants
![企业微信截图_16645300022473](https://user-images.githubusercontent.com/3350718/193240456-3feec253-c791-4095-ba19-8b55d2bf326d.png)




### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
