### PR TITLE
[HUDI-4962] Move cloud dependencies to cloud modules

### DIFF
--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -130,12 +130,20 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
-      <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-glue -->
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-glue</artifactId>
-        <version>${aws.sdk.version}</version>
-      </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-glue -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-glue</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sqs -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/hudi-gcp/pom.xml
+++ b/hudi-gcp/pom.xml
@@ -68,6 +68,18 @@ See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google
     </dependency>
 
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsub</artifactId>
+      <version>${google.cloud.pubsub.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud.bigdataoss</groupId>
+      <artifactId>gcs-connector</artifactId>
+      <version>${gcs.connector.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
     </dependency>

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -126,6 +126,19 @@
       </exclusions>
     </dependency>
 
+    <!-- Hoodie - cloud providers -->
+
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-aws</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-gcp</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- Hoodie - Other -->
 
     <!-- NOTE: This dependency is kept around even though it's not necessary, due to the fact
@@ -436,31 +449,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- AWS Services -->
-    <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sqs -->
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
-
-    <!-- start: GCS Incremental Ingestion -->
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-pubsub</artifactId>
-      <version>${google.cloud.pubsub.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud.bigdataoss</groupId>
-      <artifactId>gcs-connector</artifactId>
-      <version>${gcs.connector.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- end: GCS Incremental Ingestion -->
-    
     <!-- Hive - Test -->
     <dependency>
       <groupId>${hive.groupid}</groupId>


### PR DESCRIPTION
### Change Logs

Move aws & gcp dependencies to the cloud modules respectively.

### Impact

**Risk level: low**

Affecting dev modules; No bundle dependencies change.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
