### PR TITLE
[HUDI-4966] Add a partition extractor to handle partition values with slashes

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SinglePartPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SinglePartPartitionValueExtractor.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hudi.sync.common.model.PartitionValueExtractor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Extractor for a partition path from a single column.
+ * <p>
+ * This implementation extracts the partition value from the partition path as a single part
+ * even if the relative partition path contains slashes, e.g., the `TimestampBasedKeyGenerator`
+ * transforms the timestamp column into the partition path in the format of "yyyyMM/dd/HH".
+ * The slash (`/`) is replaced with dash (`-`), e.g., `202210/01/20` -> `202210-01-20`.
+ */
+public class SinglePartPartitionValueExtractor implements PartitionValueExtractor {
+  @Override
+  public List<String> extractPartitionValuesInPath(String partitionPath) {
+    return Collections.singletonList(partitionPath.replace('/', '-'));
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
@@ -18,8 +18,12 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.hudi.sync.common.model.PartitionValueExtractor;
+
 import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,5 +49,13 @@ public class TestPartitionValueExtractor {
     assertThrows(
         IllegalArgumentException.class,
         () -> hiveStylePartition.extractPartitionValuesInPath("2021/04/02"));
+  }
+
+  @Test
+  public void testSinglePartPartition() {
+    PartitionValueExtractor extractor = new SinglePartPartitionValueExtractor();
+    assertEquals(
+        Collections.singletonList("202210-01-20"),
+        extractor.extractPartitionValuesInPath("202210/01/20"));
   }
 }

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -104,10 +104,13 @@ public class HoodieSyncConfig extends HoodieConfig {
         String partitionFields = partitionFieldsOpt.get();
         if (StringUtils.nonEmpty(partitionFields)) {
           int numOfPartFields = partitionFields.split(",").length;
-          if (numOfPartFields == 1
-              && cfg.contains(HIVE_STYLE_PARTITIONING_ENABLE)
-              && cfg.getString(HIVE_STYLE_PARTITIONING_ENABLE).equals("true")) {
-            return Option.of("org.apache.hudi.hive.HiveStylePartitionValueExtractor");
+          if (numOfPartFields == 1) {
+            if (cfg.contains(HIVE_STYLE_PARTITIONING_ENABLE)
+                && cfg.getString(HIVE_STYLE_PARTITIONING_ENABLE).equals("true")) {
+              return Option.of("org.apache.hudi.hive.HiveStylePartitionValueExtractor");
+            } else {
+              return Option.of("org.apache.hudi.hive.SinglePartPartitionValueExtractor");
+            }
           } else {
             return Option.of("org.apache.hudi.hive.MultiPartKeysValueExtractor");
           }

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
@@ -104,7 +104,7 @@ class TestHoodieSyncConfig {
   }
 
   @Test
-  void testInferPartitonExtractorClass() {
+  void testInferPartitionExtractorClass() {
     Properties props0 = new Properties();
     HoodieSyncConfig config0 = new HoodieSyncConfig(props0, new Configuration());
     assertEquals("org.apache.hudi.hive.MultiPartKeysValueExtractor",
@@ -140,6 +140,13 @@ class TestHoodieSyncConfig {
     HoodieSyncConfig config4 = new HoodieSyncConfig(props4, new Configuration());
     assertEquals("org.apache.hudi.hive.HiveStylePartitionValueExtractor",
         config4.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS));
+
+    Properties props5 = new Properties();
+    props5.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), "foo");
+    props5.setProperty(HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE.key(), "false");
+    HoodieSyncConfig config5 = new HoodieSyncConfig(props5, new Configuration());
+    assertEquals("org.apache.hudi.hive.SinglePartPartitionValueExtractor",
+        config5.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS));
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

This PR fixes the issue reported in #6281.

For Deltastreamer, when using `TimestampBasedKeyGenerator` with the customized output dateformat (`hoodie.deltastreamer.keygen.timebased.output.dateformat`) of partition path containing slashes, e.g., "yyyy/MM/dd", and hive-style partitioning disabled (by default), the meta sync fails.  Relevant key generator configs are:

```
--hoodie-conf hoodie.datasource.write.partitionpath.field=createdDate
--hoodie-conf hoodie.datasource.write.keygenerator.class=org.apache.hudi.keygen.TimestampBasedKeyGenerator
--hoodie-conf hoodie.deltastreamer.keygen.timebased.timezone=GMT
--hoodie-conf hoodie.deltastreamer.keygen.timebased.output.dateformat=yyyy/MM/dd
--hoodie-conf hoodie.deltastreamer.keygen.timebased.timestamp.type=EPOCHMILLISECONDS 
```
Hive Sync exception:
```
Caused by: org.apache.hudi.hive.HoodieHiveSyncException: Failed to sync partitions for table test_table
...
Caused by: org.apache.hudi.hive.HoodieHiveSyncException: default.test_table add partition failed
...
Caused by: MetaException(message:Invalid partition key & values; keys [createddate, ], values [2022, 10, 02, ])
    at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$add_partitions_req_result$add_partitions_req_resultStandardScheme.read(ThriftHiveMetastore.java)
...
```
Glue Sync exception:
```
Exception in thread "main" org.apache.hudi.exception.HoodieException: Could not sync using the meta sync class org.apache.hudi.aws.sync.AwsGlueCatalogSyncTool
...
Caused by: org.apache.hudi.aws.sync.HoodieGlueSyncException: Fail to add partitions to default.test_table
	at org.apache.hudi.aws.sync.AWSGlueCatalogSyncClient.addPartitionsToTable(AWSGlueCatalogSyncClient.java:147)
...
Caused by: org.apache.hudi.com.amazonaws.services.glue.model.InvalidInputException: The number of partition keys do not match the number of partition values (Service: AWSGlue; Status Code: 400; Error Code: InvalidInputException; Request ID: <>; Proxy: null)
	at org.apache.hudi.com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1819)
...
```

The exception is thrown because the partition values for meta sync are not properly extracted.  In the current logic, "hoodie.datasource.hive_sync.partition_extractor_class" determines the partition extractor to use and in such a case, the `MultiPartKeysValueExtractor` is inferred to be used.  The root cause is that this extractor splits the parts by slashes, i.e., `2022/10/02` -> `[2022, 10, 02]`, instead of treating it as a single value, as there is only one partition column.  In general, if user specifies the output dateformat to contain slashes, that fails the extraction.

This PR fixes the problem by introducing a new partition extractor, `SinglePartPartitionValueExtractor`, so that we treat the partition value as a whole when there is only a single partition column, instead of relying on `MultiPartKeysValueExtractor`.  The slash (`/`) is replaced by dash (`-`), as slashes are encoded by default, making it inconvenient for querying.

### Impact

**Risk level: low**

The fix is tested locally with Hive sync and on EMR with Glue Sync.  Before this fix, the meta sync fails.  After the fix, the meta sync succeeds.  The correct partitions can be shown: beeline (with `show partitions test_table;`) in Hive and Glue web UI for Glue Data Catalog.

### Documentation Update

We need to improve the docs for meta sync with `TimestampBasedKeyGenerator`.  Docs update is tracked in HUDI-4967.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
