### PR TITLE
[DOC] [HUDI-4968] Update old config keys

### DIFF
--- a/website/docs/flink-quick-start-guide.md
+++ b/website/docs/flink-quick-start-guide.md
@@ -310,7 +310,7 @@ WITH (
 select * from t1;
 ``` 
 
-This will give all changes that happened after the `read.streaming.start-commit` commit. The unique thing about this
+This will give all changes that happened after the `read.start-commit` commit. The unique thing about this
 feature is that it now lets you author streaming pipelines on streaming or batch data source.
 
 ### Delete Data {#deletes}

--- a/website/versioned_docs/version-0.11.0/flink-quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.0/flink-quick-start-guide.md
@@ -162,7 +162,7 @@ WITH (
 select * from t1;
 ``` 
 
-This will give all changes that happened after the `read.streaming.start-commit` commit. The unique thing about this
+This will give all changes that happened after the `read.start-commit` commit. The unique thing about this
 feature is that it now lets you author streaming pipelines on streaming or batch data source.
 
 ### Delete Data {#deletes}

--- a/website/versioned_docs/version-0.11.0/querying_data.md
+++ b/website/versioned_docs/version-0.11.0/querying_data.md
@@ -125,7 +125,7 @@ in the filter. Filters push down is not supported yet (already on the roadmap).
 
 For MERGE_ON_READ table, in order to query hudi table as a streaming, you need to add option `'read.streaming.enabled' = 'true'`,
 when querying the table, a Flink streaming pipeline starts and never ends until the user cancel the job manually.
-You can specify the start commit with option `read.streaming.start-commit` and source monitoring interval with option
+You can specify the start commit with option `read.start-commit` and source monitoring interval with option
 `read.streaming.check-interval`.
 
 ## Hive

--- a/website/versioned_docs/version-0.11.1/flink-quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/flink-quick-start-guide.md
@@ -162,7 +162,7 @@ WITH (
 select * from t1;
 ``` 
 
-This will give all changes that happened after the `read.streaming.start-commit` commit. The unique thing about this
+This will give all changes that happened after the `read.start-commit` commit. The unique thing about this
 feature is that it now lets you author streaming pipelines on streaming or batch data source.
 
 ### Delete Data {#deletes}

--- a/website/versioned_docs/version-0.11.1/querying_data.md
+++ b/website/versioned_docs/version-0.11.1/querying_data.md
@@ -125,7 +125,7 @@ in the filter. Filters push down is not supported yet (already on the roadmap).
 
 For MERGE_ON_READ table, in order to query hudi table as a streaming, you need to add option `'read.streaming.enabled' = 'true'`,
 when querying the table, a Flink streaming pipeline starts and never ends until the user cancel the job manually.
-You can specify the start commit with option `read.streaming.start-commit` and source monitoring interval with option
+You can specify the start commit with option `read.start-commit` and source monitoring interval with option
 `read.streaming.check-interval`.
 
 ## Hive

--- a/website/versioned_docs/version-0.12.0/flink-quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/flink-quick-start-guide.md
@@ -310,7 +310,7 @@ WITH (
 select * from t1;
 ``` 
 
-This will give all changes that happened after the `read.streaming.start-commit` commit. The unique thing about this
+This will give all changes that happened after the `read.start-commit` commit. The unique thing about this
 feature is that it now lets you author streaming pipelines on streaming or batch data source.
 
 ### Delete Data {#deletes}

--- a/website/versioned_docs/version-0.12.0/querying_data.md
+++ b/website/versioned_docs/version-0.12.0/querying_data.md
@@ -125,7 +125,7 @@ in the filter. Filters push down is not supported yet (already on the roadmap).
 
 For MERGE_ON_READ table, in order to query hudi table as a streaming, you need to add option `'read.streaming.enabled' = 'true'`,
 when querying the table, a Flink streaming pipeline starts and never ends until the user cancel the job manually.
-You can specify the start commit with option `read.streaming.start-commit` and source monitoring interval with option
+You can specify the start commit with option `read.start-commit` and source monitoring interval with option
 `read.streaming.check-interval`.
 
 ### Streaming Query


### PR DESCRIPTION
### Change Logs

`read.streaming.start-commit` has been updated to `read.start-commit` for versions > `0.10.0`. This commit updates lingering references to the `read.streaming.start-commit` config key to avoid confusion.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
