### PR TITLE
[HUDI-4968] Update misleading read.streaming.skip_compaction/skip_clustering config

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -30,6 +30,8 @@ import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.config.HoodieClusteringConfig;
+import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hive.MultiPartKeysValueExtractor;
@@ -297,10 +299,10 @@ public class FlinkOptions extends HoodieConfig {
       .key("read.streaming.skip_compaction")
       .booleanType()
       .defaultValue(false)// default read as batch
-      .withDescription("Whether to skip compaction instants for streaming read,\n"
-          + "there are two cases that this option can be used to avoid reading duplicates:\n"
-          + "1) you are definitely sure that the consumer reads faster than any compaction instants, "
-          + "usually with delta time compaction strategy that is long enough, for e.g, one week;\n"
+      .withDescription("Whether to skip compaction instants and avoid reading compacted base files for streaming read to improve read performance.\n"
+          + "There are two cases that this option can be used to avoid reading duplicates:\n"
+          + "1) you are definitely sure that the consumer reads [faster than/completes before] any compaction instants "
+          + "when `" + HoodieCompactionConfig.PRESERVE_COMMIT_METADATA.key() + "` is set to `false`.\n"
           + "2) changelog mode is enabled, this option is a solution to keep data integrity");
 
   // this option is experimental
@@ -308,8 +310,11 @@ public class FlinkOptions extends HoodieConfig {
           .key("read.streaming.skip_clustering")
           .booleanType()
           .defaultValue(false)
-          .withDescription("Whether to skip clustering instants for streaming read,\n"
-              + "to avoid reading duplicates");
+          .withDescription("Whether to skip clustering instants to avoid reading base files of clustering operations for streaming read "
+              + "to improve read performance.\n"
+              + "This option toggled to `true` to avoid duplicates when: \n"
+              + "1) you are definitely sure that the consumer reads [faster than/completes before] any clustering instants "
+              + "when `" + HoodieClusteringConfig.PRESERVE_COMMIT_METADATA.key() + "` is set to `false`.\n");
 
   public static final String START_COMMIT_EARLIEST = "earliest";
   public static final ConfigOption<String> READ_START_COMMIT = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -302,7 +302,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Whether to skip compaction instants and avoid reading compacted base files for streaming read to improve read performance.\n"
           + "There are two cases that this option can be used to avoid reading duplicates:\n"
           + "1) you are definitely sure that the consumer reads [faster than/completes before] any compaction instants "
-          + "when `" + HoodieCompactionConfig.PRESERVE_COMMIT_METADATA.key() + "` is set to `false`.\n"
+          + "when " + HoodieCompactionConfig.PRESERVE_COMMIT_METADATA.key() + " is set to false.\n"
           + "2) changelog mode is enabled, this option is a solution to keep data integrity");
 
   // this option is experimental
@@ -312,9 +312,9 @@ public class FlinkOptions extends HoodieConfig {
           .defaultValue(false)
           .withDescription("Whether to skip clustering instants to avoid reading base files of clustering operations for streaming read "
               + "to improve read performance.\n"
-              + "This option toggled to `true` to avoid duplicates when: \n"
+              + "This option toggled to true to avoid duplicates when: \n"
               + "1) you are definitely sure that the consumer reads [faster than/completes before] any clustering instants "
-              + "when `" + HoodieClusteringConfig.PRESERVE_COMMIT_METADATA.key() + "` is set to `false`.\n");
+              + "when " + HoodieClusteringConfig.PRESERVE_COMMIT_METADATA.key() + " is set to false.\n");
 
   public static final String START_COMMIT_EARLIEST = "earliest";
   public static final ConfigOption<String> READ_START_COMMIT = ConfigOptions


### PR DESCRIPTION
### Change Logs

Update misleading `read.streaming.skip_compaction` and `read.streaming.skip_clustering`config. 

Editing the description here since the description is used to generate the doc-site's config page.

Added more concrete examples on when duplicated data might occur when reading Hudi tables using Hudi-on-Flink.

#### Compaction
If the consumer reads [faster than/completes before] any compaction instants + `hoodie.compaction.preserve.commit.metadata` is set to false (non-default value), the commit timeline will look something like this:

1. commit_0 (write to log0)
2. read_1 (read records that are written into log0)
3. compaction_2 (compact log0 `commit_instant` metadata is now changed to compaction_2, assume compaction completes before the next read)
4. read_3 (second read will read out the compacted records from log0 again as the commit instant metadata is modified to a newer instant that is larger than `issuedInstant` in `StreamReadMonitoringFunction`.

#### Clustering
If the consumer reads [faster than/completes before] any clustering instants + `hoodie.clustering.preserve.commit.metadata` is set to false (non-default value), the commit timeline will look something like this:

1. commit_0 (write to {base0, base1})
2. read_1 (read records that are written into {base0, base1})
3. clustering_2 (cluster {base0, base1} to produce {base3} `commit_instant` metadata is now changed to clustering_2, assume clustering completes before the next read)
4. read_3 (second read will read out the clustered records from {base3}, which is essentially {base0, base1} again as the commit instant metadata is modified to a newer instant that is larger than `issuedInstant` in `StreamReadMonitoringFunction`.

### Impact

No impact

### Risk level: none | low | medium | high

None

### Documentation Update
- Configuration description for `read.streaming.skip_compaction` is modified to allow for easier comprehension
- Configuration description for `read.streaming.skip_clustering` is modified to allow for easier comprehension

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
