### PR TITLE
[HUDI-4970] Update kafka-connect readme and refactor HoodieConfig#create

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestUpgradeDowngradeCommand.java
@@ -164,9 +164,9 @@ public class TestUpgradeDowngradeCommand extends CLIFunctionalTestHarness {
     Path propertyFile = new Path(metaClient.getMetaPath() + "/" + HoodieTableConfig.HOODIE_PROPERTIES_FILE);
     // Load the properties and verify
     FSDataInputStream fsDataInputStream = metaClient.getFs().open(propertyFile);
-    HoodieConfig hoodieConfig = HoodieConfig.create(fsDataInputStream);
+    HoodieConfig config = new HoodieConfig();
+    config.getProps().load(fsDataInputStream);
     fsDataInputStream.close();
-    assertEquals(Integer.toString(expectedVersion.versionCode()), hoodieConfig
-        .getString(HoodieTableConfig.VERSION));
+    assertEquals(Integer.toString(expectedVersion.versionCode()), config.getString(HoodieTableConfig.VERSION));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -770,9 +770,9 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     Path propertyFile = new Path(metaClient.getMetaPath() + "/" + HoodieTableConfig.HOODIE_PROPERTIES_FILE);
     // Load the properties and verify
     FSDataInputStream fsDataInputStream = metaClient.getFs().open(propertyFile);
-    HoodieConfig hoodieConfig = HoodieConfig.create(fsDataInputStream);
+    HoodieConfig config = new HoodieConfig();
+    config.getProps().load(fsDataInputStream);
     fsDataInputStream.close();
-    assertEquals(Integer.toString(expectedVersion.versionCode()), hoodieConfig
-        .getString(HoodieTableConfig.VERSION));
+    assertEquals(Integer.toString(expectedVersion.versionCode()), config.getString(HoodieTableConfig.VERSION));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -18,15 +18,14 @@
 
 package org.apache.hudi.common.config;
 
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -41,12 +40,6 @@ public class HoodieConfig implements Serializable {
   private static final Logger LOG = LogManager.getLogger(HoodieConfig.class);
 
   protected static final String CONFIG_VALUES_DELIMITER = ",";
-
-  public static HoodieConfig create(FSDataInputStream inputStream) throws IOException {
-    HoodieConfig config = new HoodieConfig();
-    config.props.load(inputStream);
-    return config;
-  }
 
   protected TypedProperties props;
 

--- a/hudi-kafka-connect/README.md
+++ b/hudi-kafka-connect/README.md
@@ -36,10 +36,10 @@ After installing these dependencies, follow steps based on your requirement.
 
 ### 1 - Starting the environment
 
-For runtime dependencies, we encourage using the confluent HDFS connector jars. We have tested our setup with
-version `10.1.0`. Either use confluent-hub to install the connector or download it
-from [here](https://tinyurl.com/yb472f79). You can install the confluent-hub command-line tool by downloading Confluent
-Platform from [here](https://tinyurl.com/s2jjby53).
+For runtime dependencies, we encourage using the confluent HDFS connector jars. We have tested our setup with version `10.1.0` 
+(essentially, `hadoop-common` dependency version 2.10.1 is required which comes as part of confluent HDFS connector). 
+Either use confluent-hub to install the connector or download it from [here](https://tinyurl.com/yb472f79). 
+You can install the confluent-hub command-line tool by downloading Confluent Platform from [here](https://tinyurl.com/s2jjby53).
 
 Copy the entire folder to the classpath that will be used by the Hudi Kafka Connector.
 
@@ -145,6 +145,9 @@ successful running of the workers.
 cd $KAFKA_HOME
 ./bin/connect-distributed.sh $HUDI_DIR/hudi-kafka-connect/demo/connect-distributed.properties
 ```
+Ensure that the `plugin.path` property points to the location where all connect plugins are installed.
+For this doc, it is `/usr/local/share/kafka/plugins`. If your plugins are installed at a different location,
+then please change the above property in `$HUDI_DIR/hudi-kafka-connect/demo/connect-distributed.properties`.
 
 ### 6 - To add the Hudi Sink to the Connector (delete it if you want to re-configure)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
@@ -87,10 +87,11 @@ class TestUpgradeOrDowngradeProcedure extends HoodieSparkProcedureTestBase {
     val propertyFile = new Path(metaClient.getMetaPath + "/" + HoodieTableConfig.HOODIE_PROPERTIES_FILE)
     // Load the properties and verify
     val fsDataInputStream = metaClient.getFs.open(propertyFile)
-    val hoodieConfig = HoodieConfig.create(fsDataInputStream)
+    val config = new HoodieConfig
+    config.getProps.load(fsDataInputStream)
     fsDataInputStream.close()
     assertResult(Integer.toString(versionCode)) {
-      hoodieConfig.getString(HoodieTableConfig.VERSION)
+      config.getString(HoodieTableConfig.VERSION)
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Update Kafka-connect setup with some details. Also, remove `HoodieConfig#create`, which is being used only in tests an unnecessarily class loader has to load `org.apache.hadoop.fs.FSDataInputStream`.

### Impact

Refactoring does not have any impact in this case.

**Risk level: none**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
