### PR TITLE
[HUDI-4995] Fix dependency conflicts bundle with several http clients

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -151,6 +151,10 @@
                   <shadedPattern>org.apache.hudi.javax.servlet.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.http.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.http.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.yammer.metrics.</pattern>
                   <shadedPattern>org.apache.hudi.com.yammer.metrics.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
we are not enabled to use hudi bundle due to conflicts with elasticsearch client on the httpClient version.

This fixes the issue