### PR TITLE
[MINOR] Handling null event time

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.util.DateTimeUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -99,9 +100,11 @@ public class WriteStatus implements Serializable {
     if (optionalRecordMetadata.isPresent()) {
       String eventTimeVal = optionalRecordMetadata.get().getOrDefault(METADATA_EVENT_TIME_KEY, null);
       try {
-        long eventTime = DateTimeUtils.parseDateTime(eventTimeVal).toEpochMilli();
-        stat.setMinEventTime(eventTime);
-        stat.setMaxEventTime(eventTime);
+        if (!StringUtils.isNullOrEmpty(eventTimeVal)) {
+          long eventTime = DateTimeUtils.parseDateTime(eventTimeVal).toEpochMilli();
+          stat.setMinEventTime(eventTime);
+          stat.setMaxEventTime(eventTime);
+        }
       } catch (DateTimeException | IllegalArgumentException e) {
         LOG.debug(String.format("Fail to parse event time value: %s", eventTimeVal), e);
       }


### PR DESCRIPTION
### Change Logs

Seeing noisy debug logs (`Fail to parse event time value`) with tests. Fixing null event time handling. 

```
109986 [consumer-thread-1] DEBUG org.apache.hudi.client.WriteStatus [] - Fail to parse event time value: null
java.lang.IllegalArgumentException: Input String cannot be null.
	at org.apache.hudi.common.util.ValidationUtils.checkArgument(ValidationUtils.java:40) ~[classes/:?]
	at org.apache.hudi.common.util.DateTimeUtils.parseDateTime(DateTimeUtils.java:77) ~[classes/:?]
	at org.apache.hudi.client.WriteStatus.markSuccess(WriteStatus.java:102) ~[classes/:?]
	at org.apache.hudi.testutils.MetadataMergeWriteStatus.markSuccess(MetadataMergeWriteStatus.java:68) ~[test-classes/:?]
	at org.apache.hudi.io.HoodieCreateHandle.write(HoodieCreateHandle.java:159) ~[classes/:?]
	at org.apache.hudi.io.HoodieWriteHandle.write(HoodieWriteHandle.java:225) ~[classes/:?]
	at org.apache.hudi.execution.CopyOnWriteInsertHandler.consumeOneRecord(CopyOnWriteInsertHandler.java:96) ~[classes/:?]
	at org.apache.hudi.execution.CopyOnWriteInsertHandler.consumeOneRecord(CopyOnWriteInsertHandler.java:40) ~[classes/:?]
	at org.apache.hudi.common.util.queue.BoundedInMemoryQueueConsumer.consume(BoundedInMemoryQueueConsumer.java:37) ~[classes/:?]
	at org.apache.hudi.common.util.queue.BoundedInMemoryExecutor.lambda$null$2(BoundedInMemoryExecutor.java:135) ~[classes/:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_192]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_192]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_192]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_192]
```

### Impact

No impact. Minor fix.

**Risk level: none**


### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
