### PR TITLE
[HUDI-4993] Make DataPlatform name and Dataset env configurable in DatahubSyncTool

### DIFF
--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -101,8 +101,8 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
     @Parameter(names = {"--emitter-supplier-class"}, description = "Pluggable class to supply a DataHub REST emitter to connect to the DataHub instance. This overwrites other emitter configs.")
     public String emitterSupplierClass;
 
-    @Parameter(names = {"--data-platform-name"}, description = "String used to represent Hudi when creating its " +
-            "corresponding DataPlatform entity within Datahub")
+    @Parameter(names = {"--data-platform-name"}, description = "String used to represent Hudi when creating its "
+            + "corresponding DataPlatform entity within Datahub")
     public String dataPlatformName;
 
     @Parameter(names = {"--dataset-env"}, description = "Which Datahub Environment to use when pushing entities")

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -30,6 +30,9 @@ import datahub.client.rest.RestEmitter;
 
 import java.util.Properties;
 
+import static org.apache.hudi.sync.datahub.config.HoodieDataHubDatasetIdentifier.DEFAULT_DATAHUB_ENV;
+import static org.apache.hudi.sync.datahub.config.HoodieDataHubDatasetIdentifier.DEFAULT_HOODIE_DATAHUB_PLATFORM_NAME;
+
 public class DataHubSyncConfig extends HoodieSyncConfig {
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_DATASET_IDENTIFIER_CLASS = ConfigProperty
@@ -51,6 +54,17 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
       .key("hoodie.meta.sync.datahub.emitter.supplier.class")
       .noDefaultValue()
       .withDocumentation("Pluggable class to supply a DataHub REST emitter to connect to the DataHub instance. This overwrites other emitter configs.");
+
+  public static final ConfigProperty<String> META_SYNC_DATAHUB_DATAPLATFORM_NAME = ConfigProperty
+          .key("hoodie.meta.sync.datahub.dataplatform.name")
+          .defaultValue(DEFAULT_HOODIE_DATAHUB_PLATFORM_NAME)
+          .withDocumentation("String used to represent Hudi when creating its corresponding DataPlatform entity "
+                  + "within Datahub");
+
+  public static final ConfigProperty<String> META_SYNC_DATAHUB_DATASET_ENV = ConfigProperty
+          .key("hoodie.meta.sync.datahub.dataset.env")
+          .defaultValue(DEFAULT_DATAHUB_ENV.name())
+          .withDocumentation("Environment to use when pushing entities to Datahub");
 
   public final HoodieDataHubDatasetIdentifier datasetIdentifier;
 
@@ -87,6 +101,13 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
     @Parameter(names = {"--emitter-supplier-class"}, description = "Pluggable class to supply a DataHub REST emitter to connect to the DataHub instance. This overwrites other emitter configs.")
     public String emitterSupplierClass;
 
+    @Parameter(names = {"--data-platform-name"}, description = "String used to represent Hudi when creating its " +
+            "corresponding DataPlatform entity within Datahub")
+    public String dataPlatformName;
+
+    @Parameter(names = {"--dataset-env"}, description = "Which Datahub Environment to use when pushing entities")
+    public String datasetEnv;
+
     public boolean isHelp() {
       return hoodieSyncConfigParams.isHelp();
     }
@@ -97,6 +118,8 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_EMITTER_SERVER.key(), emitterServer);
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_EMITTER_TOKEN.key(), emitterToken);
       props.setPropertyIfNonNull(META_SYNC_DATAHUB_EMITTER_SUPPLIER_CLASS.key(), emitterSupplierClass);
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATAPLATFORM_NAME.key(), dataPlatformName);
+      props.setPropertyIfNonNull(META_SYNC_DATAHUB_DATASET_ENV.key(), datasetEnv);
       return props;
     }
   }

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/HoodieDataHubDatasetIdentifier.java
@@ -27,6 +27,8 @@ import java.util.Properties;
 
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATAPLATFORM_NAME;
+import static org.apache.hudi.sync.datahub.config.DataHubSyncConfig.META_SYNC_DATAHUB_DATASET_ENV;
 
 /**
  * Construct and provide the default {@link DatasetUrn} to identify the Dataset on DataHub.
@@ -36,6 +38,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 public class HoodieDataHubDatasetIdentifier {
 
   public static final String DEFAULT_HOODIE_DATAHUB_PLATFORM_NAME = "hudi";
+  public static final FabricType DEFAULT_DATAHUB_ENV = FabricType.DEV;
 
   protected final Properties props;
 
@@ -44,8 +47,20 @@ public class HoodieDataHubDatasetIdentifier {
   }
 
   public DatasetUrn getDatasetUrn() {
-    DataPlatformUrn dataPlatformUrn = new DataPlatformUrn(DEFAULT_HOODIE_DATAHUB_PLATFORM_NAME);
     DataHubSyncConfig config = new DataHubSyncConfig(props);
-    return new DatasetUrn(dataPlatformUrn, String.format("%s.%s", config.getString(META_SYNC_DATABASE_NAME), config.getString(META_SYNC_TABLE_NAME)), FabricType.DEV);
+
+    return new DatasetUrn(
+            createDataPlatformUrn(config.getStringOrDefault(META_SYNC_DATAHUB_DATAPLATFORM_NAME)),
+            createDatasetName(config.getString(META_SYNC_DATABASE_NAME), config.getString(META_SYNC_TABLE_NAME)),
+            FabricType.valueOf(config.getStringOrDefault(META_SYNC_DATAHUB_DATASET_ENV))
+    );
+  }
+
+  private static DataPlatformUrn createDataPlatformUrn(String platformUrn) {
+    return new DataPlatformUrn(platformUrn);
+  }
+
+  private static String createDatasetName(String databaseName, String tableName) {
+    return String.format("%s.%s", databaseName, tableName);
   }
 }


### PR DESCRIPTION

JIRA: https://issues.apache.org/jira/browse/HUDI-4993

When pushing metadata to Datahub it is necessary to be able to customize the DataPlatform name used for the entities, and also the environment for the datasets. Currently they are hardcoded, to "hudi" and "DEV" respectively. This PR adds CLI options and hoodie configs for both, to the DatahubSyncTool.

### Impact
Adds user-facing configuration option to Datahub Sync tool. Current defaults continue.

**Risk level: low**

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed