### PR TITLE
[HUDI-4994] Adding undo of soft-delete to upsert code flow

### DIFF
--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DatahubResponseLogger.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DatahubResponseLogger.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.sync.datahub;
+
+import datahub.client.Callback;
+import datahub.client.MetadataWriteResponse;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+/**
+ * Handle responses to requests to Datahub Metastore. Just logs them.
+ */
+public class DatahubResponseLogger implements Callback {
+  private static final Logger LOG = LogManager.getLogger(DatahubResponseLogger.class);
+
+  @Override
+  public void onCompletion(MetadataWriteResponse response) {
+    LOG.info("Completed Datahub RestEmitter request. " +
+            "Status: " + (response.isSuccess() ? " succeeded" : " failed"));
+    if (!response.isSuccess()) {
+      LOG.error("Request failed. " + response);
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Response details: " + response);
+    }
+  }
+
+  @Override
+  public void onFailure(Throwable e) {
+    LOG.error("Error during Datahub RestEmitter request", e);
+  }
+
+}


### PR DESCRIPTION
### Change Logs
JIRA: https://issues.apache.org/jira/browse/HUDI-4994

Datahub has a notion of soft-deletes, which means the entity might still exist in the database after soft-delete. When DatahubSyncTool updates a property of a table, it can be assumed that users also want to change the soft-delete status of the entity. Or else the entity won't get reflected in the Datahub UI. 

This PR adds this undo of soft-delete, via setting status="removed:false" into the metadata object. This will have no impact on new entities, or hard-deleted entities (which will have nothing inside Datahub anyway)

Ref: See sections on Soft Delete and Hard Delete in the Datahub docs: https://datahubproject.io/docs/how/delete-metadata/#soft-delete-the-default.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: none | low | medium | high**

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
