### PR TITLE
[HUDI-4921] Fixing last completed commit with clean scheduling

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -509,8 +509,8 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
    * Returns the last completed commit timestamp before clean.
    */
   public String getLastCompletedCommitTimestamp() {
-    if (commitTimeline.lastInstant().isPresent()) {
-      return commitTimeline.lastInstant().get().getTimestamp();
+    if (commitTimeline.getContiguousCompletedWriteTimeline().lastInstant().isPresent()) {
+      return commitTimeline.getContiguousCompletedWriteTimeline().lastInstant().get().getTimestamp();
     } else {
       return "";
     }


### PR DESCRIPTION
### Change Logs

While clean planning, we set last completed commit from the timeline. We just fetch the last completed commit, but it has to refer to last completed w/o any inflights in between. Fixing the same in this patch. 
This will impact only multi-writer scenarios. 

### Impact

_Describe any public API or user-facing feature change or any performance impact._

**Risk level: low **

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
