### PR TITLE
[HUDI-5012][HUDI-4921] Batch clean delete files retry

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -513,8 +513,8 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
    * Returns the last completed commit timestamp before clean.
    */
   public String getLastCompletedCommitTimestamp() {
-    if (commitTimeline.lastInstant().isPresent()) {
-      return commitTimeline.lastInstant().get().getTimestamp();
+    if (commitTimeline.getContiguousCompletedWriteTimeline().lastInstant().isPresent()) {
+      return commitTimeline.getContiguousCompletedWriteTimeline().lastInstant().get().getTimestamp();
     } else {
       return "";
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -60,6 +60,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -230,10 +231,10 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
    * policy is useful, if you are simply interested in querying the table, and you don't want too many versions for a
    * single file (i.e run it with versionsRetained = 1)
    */
-  private Pair<Boolean, List<CleanFileInfo>> getFilesToCleanKeepingLatestVersions(String partitionPath) {
-    LOG.info("Cleaning " + partitionPath + ", retaining latest " + config.getCleanerFileVersionsRetained()
+  private Map<String, Pair<Boolean, List<CleanFileInfo>>> getFilesToCleanKeepingLatestVersions(List<String> partitionPaths) {
+    LOG.info("Cleaning " + partitionPaths + ", retaining latest " + config.getCleanerFileVersionsRetained()
         + " file versions. ");
-    List<CleanFileInfo> deletePaths = new ArrayList<>();
+    Map<String, Pair<Boolean, List<CleanFileInfo>>> map = new HashMap<>();
     // Collect all the datafiles savepointed by all the savepoints
     List<String> savepointedFiles = hoodieTable.getSavepointTimestamps().stream()
         .flatMap(this::getSavepointedDataFiles)
@@ -241,45 +242,48 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
 
     // In this scenario, we will assume that once replaced a file group automatically becomes eligible for cleaning completely
     // In other words, the file versions only apply to the active file groups.
-    deletePaths.addAll(getReplacedFilesEligibleToClean(savepointedFiles, partitionPath, Option.empty()));
-    boolean toDeletePartition = false;
-    List<HoodieFileGroup> fileGroups = fileSystemView.getAllFileGroups(partitionPath).collect(Collectors.toList());
-    for (HoodieFileGroup fileGroup : fileGroups) {
-      int keepVersions = config.getCleanerFileVersionsRetained();
-      // do not cleanup slice required for pending compaction
-      Iterator<FileSlice> fileSliceIterator =
-          fileGroup.getAllFileSlices()
-              .filter(fs -> !isFileSliceNeededForPendingMajorOrMinorCompaction(fs))
-              .iterator();
-      if (isFileGroupInPendingMajorOrMinorCompaction(fileGroup)) {
-        // We have already saved the last version of file-groups for pending compaction Id
-        keepVersions--;
-      }
-
-      while (fileSliceIterator.hasNext() && keepVersions > 0) {
-        // Skip this most recent version
-        fileSliceIterator.next();
-        keepVersions--;
-      }
-      // Delete the remaining files
-      while (fileSliceIterator.hasNext()) {
-        FileSlice nextSlice = fileSliceIterator.next();
-        Option<HoodieBaseFile> dataFile = nextSlice.getBaseFile();
-        if (dataFile.isPresent() && savepointedFiles.contains(dataFile.get().getFileName())) {
-          // do not clean up a savepoint data file
-          continue;
+    List<Pair<String, List<HoodieFileGroup>>> fileGroupsPerPartition = fileSystemView.getAllFileGroups(partitionPaths).collect(Collectors.toList());
+    for (Pair<String, List<HoodieFileGroup>> partitionFileGroupList : fileGroupsPerPartition) {
+      List<CleanFileInfo> deletePaths = new ArrayList<>(getReplacedFilesEligibleToClean(savepointedFiles, partitionFileGroupList.getLeft(), Option.empty()));
+      boolean toDeletePartition = false;
+      for (HoodieFileGroup fileGroup : partitionFileGroupList.getRight()) {
+        int keepVersions = config.getCleanerFileVersionsRetained();
+        // do not cleanup slice required for pending compaction
+        Iterator<FileSlice> fileSliceIterator =
+            fileGroup.getAllFileSlices()
+                .filter(fs -> !isFileSliceNeededForPendingMajorOrMinorCompaction(fs))
+                .iterator();
+        if (isFileGroupInPendingMajorOrMinorCompaction(fileGroup)) {
+          // We have already saved the last version of file-groups for pending compaction Id
+          keepVersions--;
         }
-        deletePaths.addAll(getCleanFileInfoForSlice(nextSlice));
+
+        while (fileSliceIterator.hasNext() && keepVersions > 0) {
+          // Skip this most recent version
+          fileSliceIterator.next();
+          keepVersions--;
+        }
+        // Delete the remaining files
+        while (fileSliceIterator.hasNext()) {
+          FileSlice nextSlice = fileSliceIterator.next();
+          Option<HoodieBaseFile> dataFile = nextSlice.getBaseFile();
+          if (dataFile.isPresent() && savepointedFiles.contains(dataFile.get().getFileName())) {
+            // do not clean up a savepoint data file
+            continue;
+          }
+          deletePaths.addAll(getCleanFileInfoForSlice(nextSlice));
+        }
       }
+      // if there are no valid file groups for the partition, mark it to be deleted
+      if (partitionFileGroupList.getValue().isEmpty()) {
+        toDeletePartition = true;
+      }
+      map.put(partitionFileGroupList.getLeft(), Pair.of(toDeletePartition, deletePaths));
     }
-    // if there are no valid file groups for the partition, mark it to be deleted
-    if (fileGroups.isEmpty()) {
-      toDeletePartition = true;
-    }
-    return Pair.of(toDeletePartition, deletePaths);
+    return map;
   }
 
-  private Pair<Boolean, List<CleanFileInfo>> getFilesToCleanKeepingLatestCommits(String partitionPath) {
+  private Map<String, Pair<Boolean, List<CleanFileInfo>>> getFilesToCleanKeepingLatestCommits(List<String> partitionPath) {
     return getFilesToCleanKeepingLatestCommits(partitionPath, config.getCleanerCommitsRetained(), HoodieCleaningPolicy.KEEP_LATEST_COMMITS);
   }
 
@@ -300,9 +304,9 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
    * @return A {@link Pair} whose left is boolean indicating whether partition itself needs to be deleted,
    *         and right is a list of {@link CleanFileInfo} about the files in the partition that needs to be deleted.
    */
-  private Pair<Boolean, List<CleanFileInfo>> getFilesToCleanKeepingLatestCommits(String partitionPath, int commitsRetained, HoodieCleaningPolicy policy) {
-    LOG.info("Cleaning " + partitionPath + ", retaining latest " + commitsRetained + " commits. ");
-    List<CleanFileInfo> deletePaths = new ArrayList<>();
+  private Map<String, Pair<Boolean, List<CleanFileInfo>>> getFilesToCleanKeepingLatestCommits(List<String> partitionPaths, int commitsRetained, HoodieCleaningPolicy policy) {
+    LOG.info("Cleaning " + partitionPaths + ", retaining latest " + commitsRetained + " commits. ");
+    Map<String, Pair<Boolean, List<CleanFileInfo>>> cleanFileInfoPerPartitionMap = new HashMap<>();
 
     // Collect all the datafiles savepointed by all the savepoints
     List<String> savepointedFiles = hoodieTable.getSavepointTimestamps().stream()
@@ -314,76 +318,79 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
     if (commitTimeline.countInstants() > commitsRetained) {
       Option<HoodieInstant> earliestCommitToRetainOption = getEarliestCommitToRetain();
       HoodieInstant earliestCommitToRetain = earliestCommitToRetainOption.get();
-      // all replaced file groups before earliestCommitToRetain are eligible to clean
-      deletePaths.addAll(getReplacedFilesEligibleToClean(savepointedFiles, partitionPath, earliestCommitToRetainOption));
       // add active files
-      List<HoodieFileGroup> fileGroups = fileSystemView.getAllFileGroups(partitionPath).collect(Collectors.toList());
-      for (HoodieFileGroup fileGroup : fileGroups) {
-        List<FileSlice> fileSliceList = fileGroup.getAllFileSlices().collect(Collectors.toList());
+      List<Pair<String, List<HoodieFileGroup>>> fileGroupsPerPartition = fileSystemView.getAllFileGroups(partitionPaths).collect(Collectors.toList());
+      for (Pair<String, List<HoodieFileGroup>> partitionFileGroupList : fileGroupsPerPartition) {
+        // all replaced file groups before earliestCommitToRetain are eligible to clean
+        List<CleanFileInfo> deletePaths = new ArrayList<>(getReplacedFilesEligibleToClean(savepointedFiles, partitionFileGroupList.getLeft(), earliestCommitToRetainOption));
+        for (HoodieFileGroup fileGroup : partitionFileGroupList.getRight()) {
+          List<FileSlice> fileSliceList = fileGroup.getAllFileSlices().collect(Collectors.toList());
 
-        if (fileSliceList.isEmpty()) {
-          continue;
-        }
-
-        String lastVersion = fileSliceList.get(0).getBaseInstantTime();
-        String lastVersionBeforeEarliestCommitToRetain =
-            getLatestVersionBeforeCommit(fileSliceList, earliestCommitToRetain);
-
-        // Ensure there are more than 1 version of the file (we only clean old files from updates)
-        // i.e always spare the last commit.
-        for (FileSlice aSlice : fileSliceList) {
-          Option<HoodieBaseFile> aFile = aSlice.getBaseFile();
-          String fileCommitTime = aSlice.getBaseInstantTime();
-          if (aFile.isPresent() && savepointedFiles.contains(aFile.get().getFileName())) {
-            // do not clean up a savepoint data file
+          if (fileSliceList.isEmpty()) {
             continue;
           }
 
-          if (policy == HoodieCleaningPolicy.KEEP_LATEST_COMMITS) {
-            // Dont delete the latest commit and also the last commit before the earliest commit we
-            // are retaining
-            // The window of commit retain == max query run time. So a query could be running which
-            // still
-            // uses this file.
-            if (fileCommitTime.equals(lastVersion) || (fileCommitTime.equals(lastVersionBeforeEarliestCommitToRetain))) {
-              // move on to the next file
-              continue;
-            }
-          } else if (policy == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS) {
-            // This block corresponds to KEEP_LATEST_BY_HOURS policy
-            // Do not delete the latest commit.
-            if (fileCommitTime.equals(lastVersion)) {
-              // move on to the next file
-              continue;
-            }
-          }
+          String lastVersion = fileSliceList.get(0).getBaseInstantTime();
+          String lastVersionBeforeEarliestCommitToRetain =
+              getLatestVersionBeforeCommit(fileSliceList, earliestCommitToRetain);
 
-          // Always keep the last commit
-          if (!isFileSliceNeededForPendingMajorOrMinorCompaction(aSlice) && HoodieTimeline
-              .compareTimestamps(earliestCommitToRetain.getTimestamp(), HoodieTimeline.GREATER_THAN, fileCommitTime)) {
-            // this is a commit, that should be cleaned.
-            aFile.ifPresent(hoodieDataFile -> {
-              deletePaths.add(new CleanFileInfo(hoodieDataFile.getPath(), false));
-              if (hoodieDataFile.getBootstrapBaseFile().isPresent() && config.shouldCleanBootstrapBaseFile()) {
-                deletePaths.add(new CleanFileInfo(hoodieDataFile.getBootstrapBaseFile().get().getPath(), true));
+          // Ensure there are more than 1 version of the file (we only clean old files from updates)
+          // i.e always spare the last commit.
+          for (FileSlice aSlice : fileSliceList) {
+            Option<HoodieBaseFile> aFile = aSlice.getBaseFile();
+            String fileCommitTime = aSlice.getBaseInstantTime();
+            if (aFile.isPresent() && savepointedFiles.contains(aFile.get().getFileName())) {
+              // do not clean up a savepoint data file
+              continue;
+            }
+
+            if (policy == HoodieCleaningPolicy.KEEP_LATEST_COMMITS) {
+              // Dont delete the latest commit and also the last commit before the earliest commit we
+              // are retaining
+              // The window of commit retain == max query run time. So a query could be running which
+              // still
+              // uses this file.
+              if (fileCommitTime.equals(lastVersion) || (fileCommitTime.equals(lastVersionBeforeEarliestCommitToRetain))) {
+                // move on to the next file
+                continue;
               }
-            });
-            if (hoodieTable.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ
-                || hoodieTable.getMetaClient().getTableConfig().isCDCEnabled()) {
-              // 1. If merge on read, then clean the log files for the commits as well;
-              // 2. If change log capture is enabled, clean the log files no matter the table type is mor or cow.
-              deletePaths.addAll(aSlice.getLogFiles().map(lf -> new CleanFileInfo(lf.getPath().toString(), false))
-                  .collect(Collectors.toList()));
+            } else if (policy == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS) {
+              // This block corresponds to KEEP_LATEST_BY_HOURS policy
+              // Do not delete the latest commit.
+              if (fileCommitTime.equals(lastVersion)) {
+                // move on to the next file
+                continue;
+              }
+            }
+
+            // Always keep the last commit
+            if (!isFileSliceNeededForPendingMajorOrMinorCompaction(aSlice) && HoodieTimeline
+                .compareTimestamps(earliestCommitToRetain.getTimestamp(), HoodieTimeline.GREATER_THAN, fileCommitTime)) {
+              // this is a commit, that should be cleaned.
+              aFile.ifPresent(hoodieDataFile -> {
+                deletePaths.add(new CleanFileInfo(hoodieDataFile.getPath(), false));
+                if (hoodieDataFile.getBootstrapBaseFile().isPresent() && config.shouldCleanBootstrapBaseFile()) {
+                  deletePaths.add(new CleanFileInfo(hoodieDataFile.getBootstrapBaseFile().get().getPath(), true));
+                }
+              });
+              if (hoodieTable.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ
+                  || hoodieTable.getMetaClient().getTableConfig().isCDCEnabled()) {
+                // 1. If merge on read, then clean the log files for the commits as well;
+                // 2. If change log capture is enabled, clean the log files no matter the table type is mor or cow.
+                deletePaths.addAll(aSlice.getLogFiles().map(lf -> new CleanFileInfo(lf.getPath().toString(), false))
+                    .collect(Collectors.toList()));
+              }
             }
           }
         }
-      }
-      // if there are no valid file groups for the partition, mark it to be deleted
-      if (fileGroups.isEmpty()) {
-        toDeletePartition = true;
+        // if there are no valid file groups for the partition, mark it to be deleted
+        if (partitionFileGroupList.getValue().isEmpty()) {
+          toDeletePartition = true;
+        }
+        cleanFileInfoPerPartitionMap.put(partitionFileGroupList.getLeft(), Pair.of(toDeletePartition, deletePaths));
       }
     }
-    return Pair.of(toDeletePartition, deletePaths);
+    return cleanFileInfoPerPartitionMap;
   }
 
   /**
@@ -391,10 +398,11 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
    * all the files with commit time earlier than 5 hours will be removed. Also the latest file for any file group is retained.
    * This policy gives much more flexibility to users for retaining data for running incremental queries as compared to
    * KEEP_LATEST_COMMITS cleaning policy. The default number of hours is 5.
+   *
    * @param partitionPath partition path to check
    * @return list of files to clean
    */
-  private Pair<Boolean, List<CleanFileInfo>> getFilesToCleanKeepingLatestHours(String partitionPath) {
+  private Map<String, Pair<Boolean, List<CleanFileInfo>>> getFilesToCleanKeepingLatestHours(List<String> partitionPath) {
     return getFilesToCleanKeepingLatestCommits(partitionPath, 0, HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS);
   }
 
@@ -460,21 +468,23 @@ public class CleanPlanner<T extends HoodieRecordPayload, I, K, O> implements Ser
   /**
    * Returns files to be cleaned for the given partitionPath based on cleaning policy.
    */
-  public Pair<Boolean, List<CleanFileInfo>> getDeletePaths(String partitionPath) {
+  public Map<String, Pair<Boolean, List<CleanFileInfo>>> getDeletePaths(List<String> partitionPaths) {
     HoodieCleaningPolicy policy = config.getCleanerPolicy();
-    Pair<Boolean, List<CleanFileInfo>> deletePaths;
+    Map<String, Pair<Boolean, List<CleanFileInfo>>> deletePaths;
     if (policy == HoodieCleaningPolicy.KEEP_LATEST_COMMITS) {
-      deletePaths = getFilesToCleanKeepingLatestCommits(partitionPath);
+      deletePaths = getFilesToCleanKeepingLatestCommits(partitionPaths);
     } else if (policy == HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS) {
-      deletePaths = getFilesToCleanKeepingLatestVersions(partitionPath);
+      deletePaths = getFilesToCleanKeepingLatestVersions(partitionPaths);
     } else if (policy == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS) {
-      deletePaths = getFilesToCleanKeepingLatestHours(partitionPath);
+      deletePaths = getFilesToCleanKeepingLatestHours(partitionPaths);
     } else {
       throw new IllegalArgumentException("Unknown cleaning policy : " + policy.name());
     }
-    LOG.info(deletePaths.getValue().size() + " patterns used to delete in partition path:" + partitionPath);
-    if (deletePaths.getKey()) {
-      LOG.info("Partition " + partitionPath + " to be deleted");
+    for (String partitionPath : deletePaths.keySet()) {
+      LOG.info(deletePaths.get(partitionPath).getRight().size() + " patterns used to delete in partition path:" + partitionPath);
+      if (deletePaths.get(partitionPath).getLeft()) {
+        LOG.info("Partition " + partitionPath + " to be deleted");
+      }
     }
     return deletePaths;
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
@@ -57,7 +57,7 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
     HoodieWriteConfig writeConfig = getConfigBuilder(true)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
-            .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(metadataEnabled).build())
+            .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(metadataEnabled).withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig);
          HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(DEFAULT_PARTITION_PATHS)) {
@@ -81,7 +81,7 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
       client.startCommitWithTime(instantTime4, HoodieActiveTimeline.REPLACE_COMMIT_ACTION);
       client.deletePartitions(Arrays.asList(DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH), instantTime4);
 
-      // 2nd write batch; 4 commits for the 4th partition; the 4th commit to trigger archiving the replace commit
+      // 2nd write batch; 4 commits for the 3rd partition; the 4th commit to trigger archiving the replace commit
       for (int i = 5; i < 9; i++) {
         String instantTime = HoodieActiveTimeline.createNewInstantTime(i * 1000);
         client.startCommitWithTime(instantTime);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -107,7 +107,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
     this.metaClient = metaClient;
     refreshTimeline(visibleActiveTimeline);
     resetFileGroupsReplaced(visibleCommitsAndCompactionTimeline);
-    this.bootstrapIndex =  BootstrapIndex.getBootstrapIndex(metaClient);
+    this.bootstrapIndex = BootstrapIndex.getBootstrapIndex(metaClient);
     // Load Pending Compaction Operations
     resetPendingCompactionOperations(CompactionUtils.getAllPendingCompactionOperations(metaClient).values().stream()
         .map(e -> Pair.of(e.getKey(), CompactionOperation.convertFromAvroRecordInstance(e.getValue()))));
@@ -121,7 +121,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   /**
    * Refresh commits timeline.
-   * 
+   *
    * @param visibleActiveTimeline Visible Active Timeline
    */
   protected void refreshTimeline(HoodieTimeline visibleActiveTimeline) {
@@ -163,13 +163,13 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
    * Build FileGroups from passed in file-status.
    */
   protected List<HoodieFileGroup> buildFileGroups(FileStatus[] statuses, HoodieTimeline timeline,
-      boolean addPendingCompactionFileSlice) {
+                                                  boolean addPendingCompactionFileSlice) {
     return buildFileGroups(convertFileStatusesToBaseFiles(statuses), convertFileStatusesToLogFiles(statuses), timeline,
         addPendingCompactionFileSlice);
   }
 
   protected List<HoodieFileGroup> buildFileGroups(Stream<HoodieBaseFile> baseFileStream,
-      Stream<HoodieLogFile> logFileStream, HoodieTimeline timeline, boolean addPendingCompactionFileSlice) {
+                                                  Stream<HoodieLogFile> logFileStream, HoodieTimeline timeline, boolean addPendingCompactionFileSlice) {
     Map<Pair<String, String>, List<HoodieBaseFile>> baseFiles =
         baseFileStream.collect(Collectors.groupingBy(baseFile -> {
           String partitionPathStr = getPartitionPathFor(baseFile);
@@ -227,7 +227,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
         // get replace instant mapping for each partition, fileId
         return replaceMetadata.getPartitionToReplaceFileIds().entrySet().stream().flatMap(entry -> entry.getValue().stream().map(e ->
-                new AbstractMap.SimpleEntry<>(new HoodieFileGroupId(entry.getKey(), e), instant)));
+            new AbstractMap.SimpleEntry<>(new HoodieFileGroupId(entry.getKey(), e), instant)));
       } catch (HoodieIOException ex) {
 
         if (ex.getIOException() instanceof FileNotFoundException) {
@@ -417,7 +417,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
    * With async compaction, it is possible to see partial/complete base-files due to inflight-compactions, Ignore those
    * base-files.
    *
-   * @param fileSlice File Slice
+   * @param fileSlice             File Slice
    * @param includeEmptyFileSlice include empty file-slice
    */
   protected Stream<FileSlice> filterBaseFileAfterPendingCompaction(FileSlice fileSlice, boolean includeEmptyFileSlice) {
@@ -557,8 +557,8 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
         return Option.empty();
       } else {
         return fetchHoodieFileGroup(partitionPath, fileId).map(fileGroup -> fileGroup.getAllBaseFiles()
-            .filter(baseFile -> HoodieTimeline.compareTimestamps(baseFile.getCommitTime(), HoodieTimeline.EQUALS,
-                instantTime)).filter(df -> !isBaseFileDueToPendingCompaction(df) && !isBaseFileDueToPendingClustering(df)).findFirst().orElse(null))
+                .filter(baseFile -> HoodieTimeline.compareTimestamps(baseFile.getCommitTime(), HoodieTimeline.EQUALS,
+                    instantTime)).filter(df -> !isBaseFileDueToPendingCompaction(df) && !isBaseFileDueToPendingClustering(df)).findFirst().orElse(null))
             .map(df -> addBootstrapBaseFileIfPresent(new HoodieFileGroupId(partitionPath, fileId), df));
       }
     } finally {
@@ -593,8 +593,8 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       return fetchAllStoredFileGroups()
           .filter(fileGroup -> !isFileGroupReplacedBeforeAny(fileGroup.getFileGroupId(), commitsToReturn))
           .map(fileGroup -> Pair.of(fileGroup.getFileGroupId(), Option.fromJavaOptional(
-          fileGroup.getAllBaseFiles().filter(baseFile -> commitsToReturn.contains(baseFile.getCommitTime())
-              && !isBaseFileDueToPendingCompaction(baseFile) && !isBaseFileDueToPendingClustering(baseFile)).findFirst()))).filter(p -> p.getValue().isPresent())
+              fileGroup.getAllBaseFiles().filter(baseFile -> commitsToReturn.contains(baseFile.getCommitTime())
+                  && !isBaseFileDueToPendingCompaction(baseFile) && !isBaseFileDueToPendingClustering(baseFile)).findFirst()))).filter(p -> p.getValue().isPresent())
           .map(p -> addBootstrapBaseFileIfPresent(p.getKey(), p.getValue().get()));
     } finally {
       readLock.unlock();
@@ -624,9 +624,9 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       String partitionPath = formatPartitionKey(partitionStr);
       ensurePartitionLoadedCorrectly(partitionPath);
       return fetchLatestFileSlices(partitionPath)
-              .filter(slice -> !isFileGroupReplaced(slice.getFileGroupId()))
-              .flatMap(slice -> this.filterBaseFileAfterPendingCompaction(slice, true))
-              .map(this::addBootstrapBaseFileIfPresent);
+          .filter(slice -> !isFileGroupReplaced(slice.getFileGroupId()))
+          .flatMap(slice -> this.filterBaseFileAfterPendingCompaction(slice, true))
+          .map(this::addBootstrapBaseFileIfPresent);
     } finally {
       readLock.unlock();
     }
@@ -681,26 +681,26 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   @Override
   public final Stream<FileSlice> getLatestFileSlicesBeforeOrOn(String partitionStr, String maxCommitTime,
-      boolean includeFileSlicesInPendingCompaction) {
+                                                               boolean includeFileSlicesInPendingCompaction) {
     try {
       readLock.lock();
       String partitionPath = formatPartitionKey(partitionStr);
       ensurePartitionLoadedCorrectly(partitionPath);
       Stream<Stream<FileSlice>> allFileSliceStream = fetchAllStoredFileGroups(partitionPath)
-              .filter(slice -> !isFileGroupReplacedBeforeOrOn(slice.getFileGroupId(), maxCommitTime))
-              .map(fg -> fg.getAllFileSlicesBeforeOn(maxCommitTime));
+          .filter(slice -> !isFileGroupReplacedBeforeOrOn(slice.getFileGroupId(), maxCommitTime))
+          .map(fg -> fg.getAllFileSlicesBeforeOn(maxCommitTime));
       if (includeFileSlicesInPendingCompaction) {
         return allFileSliceStream.map(sliceStream -> sliceStream.flatMap(slice -> this.filterBaseFileAfterPendingCompaction(slice, false)))
-                .map(sliceStream -> Option.fromJavaOptional(sliceStream.findFirst())).filter(Option::isPresent).map(Option::get)
-                .map(this::addBootstrapBaseFileIfPresent);
+            .map(sliceStream -> Option.fromJavaOptional(sliceStream.findFirst())).filter(Option::isPresent).map(Option::get)
+            .map(this::addBootstrapBaseFileIfPresent);
       } else {
         return allFileSliceStream
-                .map(sliceStream ->
-                        Option.fromJavaOptional(sliceStream
-                                .filter(slice -> !isPendingCompactionScheduledForFileId(slice.getFileGroupId()))
-                                .filter(slice -> !slice.isEmpty())
-                                .findFirst()))
-                .filter(Option::isPresent).map(Option::get).map(this::addBootstrapBaseFileIfPresent);
+            .map(sliceStream ->
+                Option.fromJavaOptional(sliceStream
+                    .filter(slice -> !isPendingCompactionScheduledForFileId(slice.getFileGroupId()))
+                    .filter(slice -> !slice.isEmpty())
+                    .findFirst()))
+            .filter(Option::isPresent).map(Option::get).map(this::addBootstrapBaseFileIfPresent);
       }
     } finally {
       readLock.unlock();
@@ -790,6 +790,15 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   @Override
   public final Stream<HoodieFileGroup> getAllFileGroups(String partitionStr) {
     return getAllFileGroupsIncludingReplaced(partitionStr).filter(fg -> !isFileGroupReplaced(fg));
+  }
+
+  @Override
+  public final Stream<Pair<String, List<HoodieFileGroup>>> getAllFileGroups(List<String> partitionPaths) {
+    List<Pair<String, List<HoodieFileGroup>>> allFileGroups = new ArrayList<>();
+    partitionPaths.forEach(partitionPath -> {
+      allFileGroups.add(Pair.of(partitionPath, getAllFileGroups(partitionPath).collect(Collectors.toList())));
+    });
+    return allFileGroups.stream();
   }
 
   private Stream<HoodieFileGroup> getAllFileGroupsIncludingReplaced(final String partitionStr) {
@@ -899,8 +908,8 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   protected abstract boolean isPendingClusteringScheduledForFileId(HoodieFileGroupId fgId);
 
   /**
-   *  Get pending clustering instant time for specified file group. Return None if file group is not in pending
-   *  clustering operation.
+   * Get pending clustering instant time for specified file group. Return None if file group is not in pending
+   * clustering operation.
    */
   protected abstract Option<HoodieInstant> getPendingClusteringInstant(final HoodieFileGroupId fileGroupId);
 
@@ -1002,7 +1011,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
    * Add a complete partition view to store.
    *
    * @param partitionPath Partition Path
-   * @param fileGroups File Groups for the partition path
+   * @param fileGroups    File Groups for the partition path
    */
   abstract void storePartitionView(String partitionPath, List<HoodieFileGroup> fileGroups);
 
@@ -1122,7 +1131,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   /**
    * Helper to merge last 2 file-slices. These 2 file-slices do not have compaction done yet.
    *
-   * @param lastSlice Latest File slice for a file-group
+   * @param lastSlice        Latest File slice for a file-group
    * @param penultimateSlice Penultimate file slice for a file-group in commit timeline order
    */
   private static FileSlice mergeCompactionPendingFileSlices(FileSlice lastSlice, FileSlice penultimateSlice) {
@@ -1187,7 +1196,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
    * Default implementation for fetching latest base-file.
    *
    * @param partitionPath Partition path
-   * @param fileId File Id
+   * @param fileId        File Id
    * @return base File if present
    */
   protected Option<HoodieBaseFile> fetchLatestBaseFile(String partitionPath, String fileId) {
@@ -1199,7 +1208,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
    * Default implementation for fetching file-slice.
    *
    * @param partitionPath Partition path
-   * @param fileId File Id
+   * @param fileId        File Id
    * @return File Slice if present
    */
   public Option<FileSlice> fetchLatestFileSlice(String partitionPath, String fileId) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/PriorityBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/PriorityBasedFileSystemView.java
@@ -205,6 +205,11 @@ public class PriorityBasedFileSystemView implements SyncableFileSystemView, Seri
   }
 
   @Override
+  public Stream<Pair<String, List<HoodieFileGroup>>> getAllFileGroups(List<String> partitionPaths) {
+    return execute(partitionPaths, preferredView::getAllFileGroups, secondaryView::getAllFileGroups);
+  }
+
+  @Override
   public Stream<HoodieFileGroup> getReplacedFileGroupsBeforeOrOn(String maxCommitTime, String partitionPath) {
     return execute(maxCommitTime, partitionPath, preferredView::getReplacedFileGroupsBeforeOrOn, secondaryView::getReplacedFileGroupsBeforeOrOn);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -51,9 +51,11 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -376,6 +378,16 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
+  }
+
+  @Override
+  public Stream<Pair<String, List<HoodieFileGroup>>> getAllFileGroups(List<String> partitionPaths) {
+    ArrayList<Pair<String, List<HoodieFileGroup>>> fileGroupPerPartitionList = new ArrayList<>();
+    for (String partitionPath : partitionPaths) {
+      Stream<HoodieFileGroup> fileGroup = getAllFileGroups(partitionPath);
+      fileGroupPerPartitionList.add(Pair.of(partitionPath, fileGroup.collect(Collectors.toList())));
+    }
+    return fileGroupPerPartitionList.stream();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/TableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/TableFileSystemView.java
@@ -109,18 +109,18 @@ public interface TableFileSystemView {
     /**
      * Stream all latest file slices in given partition with precondition that commitTime(file) before maxCommitTime.
      *
-     * @param partitionPath Partition path
-     * @param maxCommitTime Max Instant Time
+     * @param partitionPath                        Partition path
+     * @param maxCommitTime                        Max Instant Time
      * @param includeFileSlicesInPendingCompaction include file-slices that are in pending compaction
      */
     Stream<FileSlice> getLatestFileSlicesBeforeOrOn(String partitionPath, String maxCommitTime,
-        boolean includeFileSlicesInPendingCompaction);
+                                                    boolean includeFileSlicesInPendingCompaction);
 
     /**
      * Stream all "merged" file-slices before on an instant time If a file-group has a pending compaction request, the
      * file-slice before and after compaction request instant is merged and returned.
-     * 
-     * @param partitionPath Partition Path
+     *
+     * @param partitionPath  Partition Path
      * @param maxInstantTime Max Instant Time
      * @return
      */
@@ -149,10 +149,12 @@ public interface TableFileSystemView {
    */
   Stream<HoodieFileGroup> getAllFileGroups(String partitionPath);
 
+  Stream<Pair<String, List<HoodieFileGroup>>> getAllFileGroups(List<String> partitionPaths);
+
   /**
    * Return Pending Compaction Operations.
    *
-   * @return Pair<Pair<InstantTime,CompactionOperation>>
+   * @return Pair<Pair < InstantTime, CompactionOperation>>
    */
   Stream<Pair<String, CompactionOperation>> getPendingCompactionOperations();
 


### PR DESCRIPTION
### Change Logs

This patch has 2 fixes: 
1. This is a re-attempt of https://github.com/apache/hudi/pull/6580
This makes use of batch call to get fileGroup to delete during cleaning instead of 1 call per partition.
This limit the number of call to the view and should fix the perf hit in context of lot of partitions.
#fixes https://github.com/apache/hudi/issues/6373

2. Recently we added last completed commit timestamp to clean plan. But we missed to take into consideration multi-writers. So, have fixed the last completed commit to represent the last completed commit before any inflights in timeline. 

### Impact

Will improve clean planning latency for tables with large partitions. 

**Risk level:  medium**

Users reported latencies of 20 mins just for clean planning phase. This is expected to cut down the latency by a lot. 

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
