### PR TITLE
[HUDI-4975] Fix datahub bundle dependency

### DIFF
--- a/packaging/hudi-datahub-sync-bundle/pom.xml
+++ b/packaging/hudi-datahub-sync-bundle/pom.xml
@@ -69,10 +69,8 @@
               <artifactSet>
                 <includes combine.children="append">
                   <include>org.apache.hudi:hudi-common</include>
-                  <include>org.apache.hudi:hudi-hadoop-mr</include>
                   <include>org.apache.hudi:hudi-sync-common</include>
                   <include>org.apache.hudi:hudi-datahub-sync</include>
-                  <include>org.apache.parquet:parquet-avro</include>
 
                   <include>io.acryl:datahub-client</include>
                   <include>com.beust:jcommander</include>
@@ -231,7 +229,7 @@
 
     <dependency>
       <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-hadoop-mr-bundle</artifactId>
+      <artifactId>hudi-sync-common</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -245,16 +243,14 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Avro -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
### Change Logs

- Make parquet-avro and avro scope provided in datahub bundle
- Remove unneeded dependencies

### Impact

**Risk level: low**

[Official guide](https://hudi.apache.org/docs/syncing_datahub) shows running datahub sync bundle with utilities-bundle (deltastreamer) or utilities-slim+spark-bundle, which will provide parquet-avro that matches running spark's parquet version. Running datahub-sync bundle as a standalone sync tool requires hadoop and parquet dependencies (no official support/guide yet).

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
