### PR TITLE
[HUDI-4998] Inference of META_SYNC_PARTITION_EXTRACTOR_CLASS does not work with META_SYNC_PARTITION_FIELDS

### DIFF
--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -96,8 +96,7 @@ public class HoodieSyncConfig extends HoodieConfig {
       .key("hoodie.datasource.hive_sync.partition_extractor_class")
       .defaultValue("org.apache.hudi.hive.MultiPartKeysValueExtractor")
       .withInferFunction(cfg -> {
-        Option<String> partitionFieldsOpt = Option.ofNullable(cfg.getString(HoodieTableConfig.PARTITION_FIELDS))
-            .or(() -> Option.ofNullable(cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)));
+        Option<String> partitionFieldsOpt = Option.ofNullable(cfg.getString(META_SYNC_PARTITION_FIELDS));
         if (!partitionFieldsOpt.isPresent()) {
           return Option.empty();
         }

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
@@ -107,7 +107,7 @@ class TestHoodieSyncConfig {
   void testInferPartitionExtractorClass() {
     Properties props0 = new Properties();
     HoodieSyncConfig config0 = new HoodieSyncConfig(props0, new Configuration());
-    assertEquals("org.apache.hudi.hive.MultiPartKeysValueExtractor",
+    assertEquals("org.apache.hudi.hive.NonPartitionedExtractor",
         config0.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS),
         String.format("should get default value due to absence of both %s and %s",
             HoodieTableConfig.PARTITION_FIELDS.key(), KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()));

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
@@ -107,7 +107,7 @@ class TestHoodieSyncConfig {
   void testInferPartitionExtractorClass() {
     Properties props0 = new Properties();
     HoodieSyncConfig config0 = new HoodieSyncConfig(props0, new Configuration());
-    assertEquals("org.apache.hudi.hive.NonPartitionedExtractor",
+    assertEquals("org.apache.hudi.hive.MultiPartKeysValueExtractor",
         config0.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS),
         String.format("should get default value due to absence of both %s and %s",
             HoodieTableConfig.PARTITION_FIELDS.key(), KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()));


### PR DESCRIPTION
### Change Logs

We infer META_SYNC_PARTITION_EXTRACTOR_CLASS from partition fields, and get partition fields from HoodieTableConfig.PARTITION_FIELDS or KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME. When we run hive sync the value of --partitioned-by is passed to META_SYNC_PARTITION_FIELDS,  the infrence can't get the partition fields and the job will use unmatched partition extractor class.

### Impact

change the default value of META_SYNC_PARTITION_EXTRACTOR_CLASS.

### Risk level (write none, low medium or high below)
low

_Choose one. If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
