### PR TITLE
[HUDI-4995] Relocate httpcomponents in all bundles

### DIFF
--- a/packaging/hudi-datahub-sync-bundle/pom.xml
+++ b/packaging/hudi-datahub-sync-bundle/pom.xml
@@ -88,9 +88,6 @@
                   <include>org.apache.hbase.thirdparty:hbase-shaded-netty</include>
                   <include>org.apache.hbase.thirdparty:hbase-shaded-protobuf</include>
                   <include>org.apache.htrace:htrace-core4</include>
-                  <include>org.apache.httpcomponents:fluent-hc</include>
-                  <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.apache.httpcomponents:httpclient</include>
                   <include>org.apache.httpcomponents:httpasyncclient</include>
                   <include>org.apache.httpcomponents:httpcore-nio</include>
                   <include>org.openjdk.jol:jol-core</include>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -91,9 +91,6 @@
                   <include>io.javalin:javalin</include>
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
-                  <include>org.apache.httpcomponents:httpclient</include>
-                  <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.apache.httpcomponents:fluent-hc</include>
                   <include>org.antlr:stringtemplate</include>
                   <!-- Parquet -->
                   <include>org.apache.parquet:parquet-avro</include>

--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -161,10 +161,6 @@
                   <include>org.apache.thrift:libfb303</include>
                   <include>org.apache.thrift:libthrift</include>
 
-                  <include>org.apache.httpcomponents:httpclient</include>
-                  <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.apache.httpcomponents:fluent-hc</include>
-
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                   <include>com.fasterxml.jackson.core:jackson-databind</include>
@@ -605,11 +601,6 @@
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
       <version>1.4</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
     </dependency>
 
     <dependency>

--- a/packaging/hudi-kafka-connect-bundle/pom.xml
+++ b/packaging/hudi-kafka-connect-bundle/pom.xml
@@ -101,9 +101,6 @@
                                     <include>org.eclipse.jetty:*</include>
                                     <include>org.eclipse.jetty.websocket:*</include>
                                     <include>org.rocksdb:rocksdbjni</include>
-                                    <include>org.apache.httpcomponents:httpclient</include>
-                                    <include>org.apache.httpcomponents:httpcore</include>
-                                    <include>org.apache.httpcomponents:fluent-hc</include>
 
                                     <include>io.dropwizard.metrics:metrics-core</include>
                                     <include>io.dropwizard.metrics:metrics-graphite</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -90,9 +90,6 @@
                   <include>org.eclipse.jetty.websocket:*</include>
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
-                  <include>org.apache.httpcomponents:httpclient</include>
-                  <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.apache.httpcomponents:fluent-hc</include>
                   <include>org.antlr:stringtemplate</include>
                   <include>org.apache.parquet:parquet-avro</include>
 
@@ -149,10 +146,6 @@
                 <relocation>
                   <pattern>javax.servlet.</pattern>
                   <shadedPattern>org.apache.hudi.javax.servlet.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.http.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.http.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.yammer.metrics.</pattern>

--- a/packaging/hudi-timeline-server-bundle/pom.xml
+++ b/packaging/hudi-timeline-server-bundle/pom.xml
@@ -56,12 +56,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- Httpcomponents -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
@@ -162,11 +156,8 @@
                       -->
                       <include>org.apache.hudi:hudi-common</include>
                       <include>org.apache.hudi:hudi-timeline-service</include>
-                      <include>org.apache.httpcomponents:httpclient</include>
-                      <include>org.apache.httpcomponents:httpcore</include>
                       <include>org.mortbay.jetty:jetty</include>
                       <include>org.mortbay.jetty:jetty-util</include>
-                      <include>org.apache.httpcomponents:fluent-hc</include>
                       <include>io.javalin:javalin</include>
                       <include>org.jetbrains.kotlin:kotlin-stdlib-jdk8</include>
                       <include>org.jetbrains.kotlin:kotlin-stdlib</include>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -113,9 +113,6 @@
                   <include>org.eclipse.jetty.websocket:*</include>
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
-                  <include>org.apache.httpcomponents:httpclient</include>
-                  <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.apache.httpcomponents:fluent-hc</include>
                   <include>org.antlr:stringtemplate</include>
                   <include>org.apache.parquet:parquet-avro</include>
 

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -105,9 +105,6 @@
                   <include>org.eclipse.jetty.websocket:*</include>
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
-                  <include>org.apache.httpcomponents:httpclient</include>
-                  <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.apache.httpcomponents:fluent-hc</include>
                   <include>org.antlr:stringtemplate</include>
 
                   <include>com.github.davidmoten:guava-mini</include>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,10 @@
               <include>com.esotericsoftware:kryo-shaded</include>
               <include>com.esotericsoftware:minlog</include>
               <include>org.objenesis:objenesis</include>
+              <!-- org.apache.httpcomponents -->
+              <include>org.apache.httpcomponents:httpclient</include>
+              <include>org.apache.httpcomponents:httpcore</include>
+              <include>org.apache.httpcomponents:fluent-hc</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -453,6 +457,11 @@
             <relocation>
               <pattern>org.objenesis.</pattern>
               <shadedPattern>org.apache.hudi.org.objenesis.</shadedPattern>
+            </relocation>
+            <!-- org.apache.httpcomponents -->
+            <relocation>
+              <pattern>org.apache.http.</pattern>
+              <shadedPattern>org.apache.hudi.org.apache.http.</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
### Change Logs

Relocate httpcomponents in all bundles. 

Follow up to https://github.com/apache/hudi/pull/6874

### Impact

Previously httpcomponents are included for 

- hudi-spark-bundle
- hudi-flink-bundle
- hudi-timeline-server-bundle
- hudi-utilities-bundle
- hudi-utilities-slim-bundle
- hudi-datahub-sync-bundle

This PR makes it included in all bundles, for easy alignment of these commonly used components. 

### Risk level (write none, low medium or high below)

Bundle testing and verification.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
