### PR TITLE
[HUDI-5004] Allow nested field as primary key and preCombineField in flink sql

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -165,6 +165,35 @@ public class TestHoodieTableFactory {
 
     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext6));
     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(sourceContext6));
+
+    // nested pk field is allowed
+    ResolvedSchema schema6 = SchemaBuilder.instance()
+        .field("f0",
+            DataTypes.ROW(DataTypes.FIELD("id", DataTypes.INT()), DataTypes.FIELD("date", DataTypes.VARCHAR(20))))
+        .field("f1", DataTypes.VARCHAR(20))
+        .field("f2", DataTypes.TIMESTAMP(3))
+        .field("ts", DataTypes.TIMESTAMP(3))
+        .build();
+    this.conf.setString(FlinkOptions.RECORD_KEY_FIELD, "f0.id");
+    this.conf.setString(FlinkOptions.PRECOMBINE_FIELD, "f2");
+    final MockContext sourceContext7 = MockContext.getInstance(this.conf, schema6, "f2");
+
+    assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext7));
+    assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(sourceContext7));
+
+    // nested precombine field is allowed
+    ResolvedSchema schema7 = SchemaBuilder.instance()
+        .field("f0", DataTypes.INT().notNull())
+        .field("f1", DataTypes.VARCHAR(20))
+        .field("f2", DataTypes.TIMESTAMP(3))
+        .field("ts", DataTypes.ROW(DataTypes.FIELD("year", DataTypes.INT()), DataTypes.FIELD("MONTH", DataTypes.INT())))
+        .build();
+    this.conf.setString(FlinkOptions.RECORD_KEY_FIELD, "f0");
+    this.conf.setString(FlinkOptions.PRECOMBINE_FIELD, "f2.year");
+    final MockContext sourceContext8 = MockContext.getInstance(this.conf, schema7, "f2");
+
+    assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext8));
+    assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(sourceContext8));
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

Added a more comprehensive validation routine for checking primary key and preCombineField to allow nested field.

Ensure that primaryKey and preCombineField definition.

**Note**: Flink's primaryKey and preCombineField validation is more strict than that of Spark's validation. Spark's validation will only check if the upper most parent exists without validating nested fields down to it's lowest level.

### Impact
No public API changed

### Risk level (write none, low medium or high below)
low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
