### PR TITLE
[HUDI-5003] Fix the type of InLineFileSystem`startOffset to long

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFSUtils.java
@@ -95,11 +95,11 @@ public class InLineFSUtils {
    * input: "inlinefs://file1/s3a/?start_offset=20&length=40".
    * output: 20
    */
-  public static int startOffset(Path inlineFSPath) {
+  public static long startOffset(Path inlineFSPath) {
     assertInlineFSPath(inlineFSPath);
 
     String[] slices = inlineFSPath.toString().split("[?&=]");
-    return Integer.parseInt(slices[slices.length - 3]);
+    return Long.parseLong(slices[slices.length - 3]);
   }
 
   /**
@@ -108,11 +108,11 @@ public class InLineFSUtils {
    * input: "inlinefs:/file1/s3a/?start_offset=20&length=40".
    * output: 40
    */
-  public static int length(Path inlinePath) {
+  public static long length(Path inlinePath) {
     assertInlineFSPath(inlinePath);
 
     String[] slices = inlinePath.toString().split("[?&=]");
-    return Integer.parseInt(slices[slices.length - 1]);
+    return Long.parseLong(slices[slices.length - 1]);
   }
 
   private static void assertInlineFSPath(Path inlinePath) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFsDataInputStream.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/inline/InLineFsDataInputStream.java
@@ -33,11 +33,11 @@ import java.util.EnumSet;
  */
 public class InLineFsDataInputStream extends FSDataInputStream {
 
-  private final int startOffset;
+  private final long startOffset;
   private final FSDataInputStream outerStream;
-  private final int length;
+  private final long length;
 
-  public InLineFsDataInputStream(int startOffset, FSDataInputStream outerStream, int length) throws IOException {
+  public InLineFsDataInputStream(long startOffset, FSDataInputStream outerStream, long length) throws IOException {
     super(outerStream.getWrappedStream());
     this.startOffset = startOffset;
     this.outerStream = outerStream;

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/InLineFSUtilsTest.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/inline/InLineFSUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.fs.inline;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.testutils.FileSystemTestUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests {@link InLineFileSystem}.
+ */
+public class InLineFSUtilsTest {
+
+  private static Stream<Arguments> configParams() {
+    Long[] data = new Long[] {
+        0L,
+        1000L,
+        (long) Integer.MAX_VALUE + 1,
+        Long.MAX_VALUE
+    };
+    return Stream.of(data).map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("configParams")
+  void startOffset(long startOffset) {
+    Path inlinePath =  FileSystemTestUtils.getPhantomFile(FileSystemTestUtils.getRandomOuterFSPath(), startOffset, 0L);
+    assertEquals(startOffset, InLineFSUtils.startOffset(inlinePath));
+  }
+
+  @ParameterizedTest
+  @MethodSource("configParams")
+  void length(long inlineLength) {
+    Path inlinePath =  FileSystemTestUtils.getPhantomFile(FileSystemTestUtils.getRandomOuterFSPath(), 0L, inlineLength);
+    assertEquals(inlineLength, InLineFSUtils.length(inlinePath));
+  }
+}


### PR DESCRIPTION
### Change Logs

InLineFileSystem will throw NumberFormatException, cause the type of startOffset is int and out of bounds.
The exception detail see [HUDI-5003](https://issues.apache.org/jira/browse/HUDI-5003)

### Impact

N/A

**Risk level: low**

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
