### PR TITLE
[HUDI-5016] Flink clustering does not reserve commit metadata

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/AbstractHoodieRowData.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/AbstractHoodieRowData.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.model;
+
+import org.apache.hudi.common.model.HoodieOperation;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.RowKind;
+
+/**
+ * RowData implementation for Hoodie Row. It wraps an {@link RowData} and keeps meta columns locally. But the {@link RowData}
+ * does include the meta columns as well just that {@link AbstractHoodieRowData} will intercept queries for meta columns and serve from its
+ * copy rather than fetching from {@link RowData}.
+ */
+public abstract class AbstractHoodieRowData implements RowData {
+  private final String[] metaColumns;
+  protected final RowData row;
+  protected final int metaColumnsNum;
+
+  public AbstractHoodieRowData(String commitTime,
+                               String commitSeqNumber,
+                               String recordKey,
+                               String partitionPath,
+                               String fileName,
+                               RowData row,
+                               boolean withOperation) {
+    this.metaColumnsNum = withOperation ? 6 : 5;
+    this.metaColumns = new String[metaColumnsNum];
+    metaColumns[0] = commitTime;
+    metaColumns[1] = commitSeqNumber;
+    metaColumns[2] = recordKey;
+    metaColumns[3] = partitionPath;
+    metaColumns[4] = fileName;
+    if (withOperation) {
+      metaColumns[5] = HoodieOperation.fromValue(row.getRowKind().toByteValue()).getName();
+    }
+    this.row = row;
+  }
+
+  @Override
+  public RowKind getRowKind() {
+    return row.getRowKind();
+  }
+
+  @Override
+  public void setRowKind(RowKind kind) {
+    this.row.setRowKind(kind);
+  }
+
+  @Override
+  public boolean isNullAt(int ordinal) {
+    if (ordinal < metaColumnsNum) {
+      return null == getMetaColumnVal(ordinal);
+    }
+    return row.isNullAt(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public boolean getBoolean(int ordinal) {
+    return row.getBoolean(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public byte getByte(int ordinal) {
+    return row.getByte(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public short getShort(int ordinal) {
+    return row.getShort(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public int getInt(int ordinal) {
+    return row.getInt(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public long getLong(int ordinal) {
+    return row.getLong(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public float getFloat(int ordinal) {
+    return row.getFloat(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public double getDouble(int ordinal) {
+    return row.getDouble(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public DecimalData getDecimal(int ordinal, int precision, int scale) {
+    return row.getDecimal(rebaseOrdinal(ordinal), precision, scale);
+  }
+
+  @Override
+  public TimestampData getTimestamp(int ordinal, int precision) {
+    return row.getTimestamp(rebaseOrdinal(ordinal), precision);
+  }
+
+  @Override
+  public <T> RawValueData<T> getRawValue(int ordinal) {
+    return row.getRawValue(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public StringData getString(int ordinal) {
+    if (ordinal < metaColumnsNum) {
+      return StringData.fromString(getMetaColumnVal(ordinal));
+    }
+    return row.getString(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public byte[] getBinary(int ordinal) {
+    return row.getBinary(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public RowData getRow(int ordinal, int numFields) {
+    return row.getRow(rebaseOrdinal(ordinal), numFields);
+  }
+
+  @Override
+  public ArrayData getArray(int ordinal) {
+    return row.getArray(rebaseOrdinal(ordinal));
+  }
+
+  @Override
+  public MapData getMap(int ordinal) {
+    return row.getMap(rebaseOrdinal(ordinal));
+  }
+
+  private String getMetaColumnVal(int ordinal) {
+    return this.metaColumns[ordinal];
+  }
+
+  protected abstract int rebaseOrdinal(int ordinal);
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieRowDataCreation.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieRowDataCreation.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.model;
+
+import org.apache.flink.table.data.RowData;
+
+/**
+ * The factory clazz for hoodie row data.
+ */
+public abstract class HoodieRowDataCreation {
+  /**
+   * Creates a {@link AbstractHoodieRowData} instance based on the given configuration.
+   */
+  public static AbstractHoodieRowData create(
+      String commitTime,
+      String commitSeqNumber,
+      String recordKey,
+      String partitionPath,
+      String fileName,
+      RowData row,
+      boolean withOperation,
+      boolean withMetaFields) {
+    return withMetaFields
+        ? new HoodieRowDataWithMetaFields(commitTime, commitSeqNumber, recordKey, partitionPath, fileName, row, withOperation)
+        : new HoodieRowData(commitTime, commitSeqNumber, recordKey, partitionPath, fileName, row, withOperation);
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieRowDataWithMetaFields.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieRowDataWithMetaFields.java
@@ -22,31 +22,30 @@ import org.apache.flink.table.data.RowData;
 
 /**
  * RowData implementation for Hoodie Row. It wraps an {@link RowData} and keeps meta columns locally. But the {@link RowData}
- * does include the meta columns as well just that {@link HoodieRowData} will intercept queries for meta columns and serve from its
+ * does include the meta columns as well just that {@link HoodieRowDataWithMetaFields} will intercept queries for meta columns and serve from its
  * copy rather than fetching from {@link RowData}.
  *
- * <p>The wrapped {@link RowData} does not contain hoodie metadata fields.
+ * <p>The wrapped {@link RowData} contains hoodie metadata fields.
  */
-public class HoodieRowData extends AbstractHoodieRowData {
+public class HoodieRowDataWithMetaFields extends AbstractHoodieRowData {
 
-  public HoodieRowData(String commitTime,
-                       String commitSeqNumber,
-                       String recordKey,
-                       String partitionPath,
-                       String fileName,
-                       RowData row,
-                       boolean withOperation) {
+  public HoodieRowDataWithMetaFields(String commitTime,
+                                     String commitSeqNumber,
+                                     String recordKey,
+                                     String partitionPath,
+                                     String fileName,
+                                     RowData row,
+                                     boolean withOperation) {
     super(commitTime, commitSeqNumber, recordKey, partitionPath, fileName, row, withOperation);
   }
 
   @Override
   public int getArity() {
-    return metaColumnsNum + row.getArity();
+    return row.getArity();
   }
 
   protected int rebaseOrdinal(int ordinal) {
-    // NOTE: In cases when source row does not contain meta fields, we will have to
-    //       rebase ordinal onto its indexes
-    return ordinal - metaColumnsNum;
+    // NOTE: The source row contains the same number of meta fields of current row
+    return ordinal;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -81,7 +81,7 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
         close();
       }
       HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, fileId,
-          instantTime, taskPartitionId, taskId, taskEpochId, rowType);
+          instantTime, taskPartitionId, taskId, taskEpochId, rowType, preserveHoodieMetadata);
       handles.put(fileId, rowCreateHandle);
     }
     return handles.get(fileId);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bulk;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.table.HoodieFlinkTable;
+import org.apache.hudi.util.FlinkTables;
+import org.apache.hudi.util.StreamerUtil;
+import org.apache.hudi.utils.TestConfigurations;
+import org.apache.hudi.utils.TestData;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test cases for {@link BulkInsertWriterHelper}.
+ */
+public class TestBulkInsertWriteHelper {
+  protected Configuration conf;
+
+  @TempDir
+  File tempFile;
+
+  @BeforeEach
+  public void before() throws IOException {
+    conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    StreamerUtil.initTableIfNotExists(conf);
+  }
+
+  @Test
+  void testWrite() throws Exception {
+    HoodieFlinkTable<?> table = FlinkTables.createTable(conf);
+    String instant = HoodieActiveTimeline.createNewInstantTime();
+    RowType rowType = TestConfigurations.ROW_TYPE;
+    BulkInsertWriterHelper writerHelper = new BulkInsertWriterHelper(conf, table, table.getConfig(), instant,
+        1, 1, 0, rowType, false);
+    for (RowData row: TestData.DATA_SET_INSERT) {
+      writerHelper.write(row);
+    }
+    List<WriteStatus> writeStatusList = writerHelper.getWriteStatuses(1);
+    assertWriteStatus(writeStatusList);
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("par1", "[id1,par1,id1,Danny,23,1,par1, id2,par1,id2,Stephen,33,2,par1]");
+    expected.put("par2", "[id3,par2,id3,Julian,53,3,par2, id4,par2,id4,Fabian,31,4,par2]");
+    expected.put("par3", "[id5,par3,id5,Sophia,18,5,par3, id6,par3,id6,Emma,20,6,par3]");
+    expected.put("par4", "[id7,par4,id7,Bob,44,7,par4, id8,par4,id8,Han,56,8,par4]");
+
+    TestData.checkWrittenData(tempFile, expected);
+
+    // set up preserveHoodieMetadata as true and check again
+    RowType rowType2 = BulkInsertWriterHelper.addMetadataFields(rowType, false);
+    BulkInsertWriterHelper writerHelper2 = new BulkInsertWriterHelper(conf, table, table.getConfig(), instant,
+        1, 1, 0, rowType2, true);
+    for (RowData row: rowsWithMetadata(instant, TestData.DATA_SET_INSERT)) {
+      writerHelper.write(row);
+    }
+    List<WriteStatus> writeStatusList2 = writerHelper.getWriteStatuses(1);
+    assertWriteStatus(writeStatusList2);
+
+    String expectRows = "[" + instant + ", " + instant + "]";
+    Map<String, String> expected2 = new HashMap<>();
+    expected2.put("par1", expectRows);
+    expected2.put("par2", expectRows);
+    expected2.put("par3", expectRows);
+    expected2.put("par4", expectRows);
+
+    TestData.checkWrittenData(tempFile, expected2, 4, TestBulkInsertWriteHelper::filterCommitTime);
+  }
+
+  private void assertWriteStatus(List<WriteStatus> writeStatusList) {
+    String partitions = writeStatusList.stream()
+        .map(writeStatus -> StringUtils.nullToEmpty(writeStatus.getStat().getPartitionPath()))
+        .sorted()
+        .collect(Collectors.joining(","));
+    assertThat(partitions, is("par1,par2,par3,par4"));
+    List<String> files = writeStatusList.stream()
+        .map(writeStatus -> writeStatus.getStat().getPath())
+        .collect(Collectors.toList());
+    assertThat(files.size(), is(4));
+  }
+
+  private static List<RowData> rowsWithMetadata(String instantTime, List<RowData> rows) {
+    List<RowData> rowsWithMetadata = new ArrayList<>();
+    int seqNum = 0;
+    for (RowData row : rows) {
+      GenericRowData rebuilt = new GenericRowData(row.getArity() + 5);
+      rebuilt.setField(0, StringData.fromString(instantTime));
+      rebuilt.setField(1, seqNum++);
+      rebuilt.setField(2, row.getString(0));
+      rebuilt.setField(3, row.getString(4));
+      rebuilt.setField(4, StringData.fromString("f" + seqNum));
+    }
+    return rowsWithMetadata;
+  }
+
+  private static String filterCommitTime(GenericRecord genericRecord) {
+    return genericRecord.get("_hoodie_commit_time").toString();
+  }
+}


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

After this change, the clustering would keep the original commit time by default .

**Risk level: none | low | medium | high**

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
