### PR TITLE
[HUDI-4716] Avoid parquet-hadoop-bundle in hudi-hadoop-mr

### DIFF
--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -68,9 +68,7 @@
                 <includes combine.children="append">
                   <include>org.apache.hudi:hudi-common</include>
                   <include>org.apache.hudi:hudi-hadoop-mr</include>
-                  <!-- Parquet -->
                   <include>org.apache.parquet:parquet-avro</include>
-                  <include>org.apache.parquet:parquet-hadoop-bundle</include>
                   <include>org.apache.avro:avro</include>
                   <include>org.apache.hbase:hbase-common</include>
                   <include>org.apache.hbase:hbase-client</include>
@@ -119,12 +117,8 @@
                   <shadedPattern>org.apache.hudi.org.apache.htrace.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.parquet.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.parquet.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>shaded.parquet.</pattern>
-                  <shadedPattern>org.apache.hudi.shaded.parquet.</shadedPattern>
+                  <pattern>org.apache.parquet.avro.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.parquet.avro.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.google.common.</pattern>
@@ -250,14 +244,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>${parquet.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-hadoop-bundle</artifactId>
-      <version>${parquet.version}</version>
+      <version>${hive.parquet.version}</version>
       <scope>compile</scope>
     </dependency>
 
@@ -265,7 +252,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
+      <version>${hive.avro.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,8 @@
     <hadoop.version>2.10.1</hadoop.version>
     <hive.groupid>org.apache.hive</hive.groupid>
     <hive.version>2.3.1</hive.version>
+    <hive.parquet.version>1.10.1</hive.parquet.version>
+    <hive.avro.version>1.8.2</hive.avro.version>
     <presto.version>0.273</presto.version>
     <trino.version>390</trino.version>
     <hive.exec.classifier>core</hive.exec.classifier>


### PR DESCRIPTION
### Change Logs

- Avoid parquet-hadoop-bundle in hudi-hadoop-mr-bundle
- Use hive2/3-compatible parquet version (1.10.x) for hadoop-mr

Previous discussion https://github.com/apache/hudi/pull/5250#discussion_r930144788

### Impact

hudi-hadoop-mr-bundle will need to work with parquet version in user-provided hive. 
- hive3 uses 1.10.0 (compatible) -> https://github.com/apache/hive/blob/4df4d75bf1e16fe0af75aad0b4179c34c07fc975/pom.xml#L191
- hive2 uses 1.8.1 (compatible) -> https://github.com/apache/hive/blob/92dd0159f440ca7863be3232f3a683a510a62b9d/pom.xml#L183

### Risk level

medium

Need to run e2e bundle testing to verify.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
