### PR TITLE
[HUDI-5022] made better error messages for pr compliance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,9 @@ _Describe context and summary for this change. Highlight if any code was copied.
 
 _Describe any public API or user-facing feature change or any performance impact._
 
-**Risk level: none | low | medium | high**
+### Risk level (write none, low medium or high below)
 
-_Choose one. If medium or high, explain what verification was done to mitigate the risks._
+_If medium or high, explain what verification was done to mitigate the risks._
 
 ### Documentation Update
 

--- a/.github/workflows/pr_compliance.yml
+++ b/.github/workflows/pr_compliance.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - name: run script
-        run: python3 scripts/pr_compliance.py > test.log || { echo "::error::pr_compliance.py $(cat test.log)" && exit 1; }
+        run: python3 scripts/pr_compliance.py 
 
 
 


### PR DESCRIPTION
### Change Logs

Created better error messages so that users can figure out how they filled out the pr incorrectly
Changed risk level section in the template because it was confusing to some users.
Now risk level is written below the section header. Validation for this does not check for "(write none, low medium or high below)" because I think some users might delete that.

### Impact

This should allow users to be able to fix their incorrectly filled out pr without help from me

### Risk level (write none, low medium or high below)

low

Overall execution path should not be changed at all, so I don't expect the script to fail. Error messages could possibly suggest incorrect issue with the pr but I have pretty thorough tests so I think it should be accurate.

### Documentation Update
N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
