### PR TITLE
[HUDI-5037] Upgrade org.apache.thrift:libthrift to 0.14.0

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -734,7 +734,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>0.9.3</version>
+      <version>0.14.0</version>
     </dependency>
 
     <!-- zookeeper -->


### PR DESCRIPTION
### Change Logs

Upgrade org.apache.thrift:libthrift from 0.9.3 to 0.14.0 for vulnerability fix

There are 1 security vulnerabilities found in org.apache.thrift:libthrift 0.9.3
- [CVE-2018-1320](https://www.oscs1024.com/hd/CVE-2018-1320)

### Impact

Only updating integ-test-bundle.

**Risk level: low**

Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

What happened？
There are 1 security vulnerabilities found in org.apache.thrift:libthrift 0.9.3
- [CVE-2018-1320](https://www.oscs1024.com/hd/CVE-2018-1320)

What did I do？
Upgrade org.apache.thrift:libthrift from 0.9.3 to 0.14.0 for vulnerability fix

What did you expect to happen？
Ideally, no insecure libs should be used.

How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed