### PR TITLE
[HUDI-5038] Increase default num_instants to fetch for incremental source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -52,7 +52,7 @@ public class HoodieIncrSource extends RowSource {
      * {@value #NUM_INSTANTS_PER_FETCH} allows the max number of instants whose changes can be incrementally fetched.
      */
     static final String NUM_INSTANTS_PER_FETCH = "hoodie.deltastreamer.source.hoodieincr.num_instants";
-    static final Integer DEFAULT_NUM_INSTANTS_PER_FETCH = 1;
+    static final Integer DEFAULT_NUM_INSTANTS_PER_FETCH = 5;
 
     /**
      * {@value #HOODIE_SRC_PARTITION_FIELDS} specifies partition fields that needs to be added to source table after

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieDeltaStreamer.java
@@ -2101,6 +2101,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     HoodieDeltaStreamer.Config downstreamCfg =
         TestHelpers.makeConfigForHudiIncrSrc(tableBasePath, downstreamTableBasePath,
             WriteOperationType.BULK_INSERT, true, null);
+    downstreamCfg.configs.add("hoodie.deltastreamer.source.hoodieincr.num_instants=1");
     new HoodieDeltaStreamer(downstreamCfg, jsc).sync();
 
     insertInTable(tableBasePath, 9, WriteOperationType.UPSERT);
@@ -2112,6 +2113,8 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       downstreamCfg.configs = new ArrayList<>();
     }
 
+    // Remove source.hoodieincr.num_instants config
+    downstreamCfg.configs.remove(downstreamCfg.configs.size() - 1);
     downstreamCfg.configs.add(DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN_FOR_NON_EXISTING_FILES().key() + "=true");
     //Adding this conf to make testing easier :)
     downstreamCfg.configs.add("hoodie.deltastreamer.source.hoodieincr.num_instants=10");


### PR DESCRIPTION
### Change Logs

By default, the default maximum number of instants to fetch in incremental source (`hoodie.deltastreamer.source.hoodieincr.num_instants`) is 1.  The checkpoint of the target Hudi table from the incremental ETL lags behind the source if the ingestion runs at a lower frequency than the source or the ingestion job stalls for some time, causing the data freshness issue.

This PR increases default num_instants to 5 so that the incremental ETL can fetch more instants to catch up with the source.

### Impact

Only in the cases mentioned above, more instants are fetched for catchup.

### Risk level 

low

### Documentation Update

N/A.  The default value is automatically updated on the Hudi website once the website is built for a new release.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
