### PR TITLE
fix(sec): upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <joda.version>2.9.9</joda.version>
     <hadoop.version>2.10.1</hadoop.version>
     <hive.groupid>org.apache.hive</hive.groupid>
-    <hive.version>2.3.1</hive.version>
+    <hive.version>3.1.3</hive.version>
     <presto.version>0.273</presto.version>
     <trino.version>390</trino.version>
     <hive.exec.classifier>core</hive.exec.classifier>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 2.3.1
- [CVE-2018-11777](https://www.oscs1024.com/hd/CVE-2018-11777)


### What did I do？
Upgrade org.apache.hive:hive-exec from 2.3.1 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS