### PR TITLE
fix(sec): upgrade com.beust:jcommander to 1.75

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -941,7 +941,7 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.72</version>
+        <version>1.75</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.beust:jcommander 1.72
- [MPS-2022-12225](https://www.oscs1024.com/hd/MPS-2022-12225)


### What did I do？
Upgrade com.beust:jcommander from 1.72 to 1.75 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS