### PR TITLE
[HUDI-5071] Upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -286,7 +286,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>12.0.1</version>
+      <version>30.0-jre</version>
       <scope>${presto.bundle.bootstrap.scope}</scope>
     </dependency>
 

--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -274,7 +274,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>12.0.1</version>
+      <version>30.0-jre</version>
       <scope>${trino.bundle.bootstrap.scope}</scope>
     </dependency>
 


### PR DESCRIPTION
### Change Logs

There is 1 security vulnerability found in com.google.guava:guava 12.0.1
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237). This PR upgrades com.google.guava:guava from 12.0.1 to 30.0-jre for vulnerability fix

### Impact

Fix guava security vulnerability.
### Risk level (write none, low medium or high below)

medium

### Documentation Update
N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed

