### PR TITLE
[MINOR] Make sure all `HoodieRecord`s are appropriately serializable by Kryo

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -983,7 +983,9 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       HoodieData<HoodieRecord> rddSinglePartitionRecords = records.map(r -> {
         FileSlice slice = finalFileSlices.get(HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(r.getRecordKey(),
             fileGroupCount));
+        r.unseal();
         r.setCurrentLocation(new HoodieRecordLocation(slice.getBaseInstantTime(), slice.getFileId()));
+        r.seal();
         return r;
       });
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/commmon/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/commmon/model/HoodieSparkRecord.java
@@ -83,40 +83,58 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
   private boolean copy;
 
   /**
-   * We should use this construction method when we read internalRow from file.
-   * The record constructed by this method must be used in iter.
+   * NOTE: {@code HoodieSparkRecord} is holding the schema only in cases when it would have
+   *       to execute {@link UnsafeProjection} so that the {@link InternalRow} it's holding to
+   *       could be projected into {@link UnsafeRow} and be efficiently serialized subsequently
+   *       (by Kryo)
    */
-  public HoodieSparkRecord(InternalRow data) {
+  private final transient StructType schema;
+
+  public HoodieSparkRecord(UnsafeRow data) {
+    this(data, null);
+  }
+
+  public HoodieSparkRecord(InternalRow data, StructType schema) {
     super(null, data);
-    validateRow(data);
+
+    validateRow(data, schema);
     this.copy = false;
+    this.schema = schema;
   }
 
-  public HoodieSparkRecord(HoodieKey key, InternalRow data, boolean copy) {
+  public HoodieSparkRecord(HoodieKey key, UnsafeRow data, boolean copy) {
+    this(key, data, null, copy);
+  }
+
+  public HoodieSparkRecord(HoodieKey key, InternalRow data, StructType schema, boolean copy) {
     super(key, data);
-    validateRow(data);
+
+    validateRow(data, schema);
     this.copy = copy;
+    this.schema = schema;
   }
 
-  private HoodieSparkRecord(HoodieKey key, InternalRow data, HoodieOperation operation, boolean copy) {
+  private HoodieSparkRecord(HoodieKey key, InternalRow data, StructType schema, HoodieOperation operation, boolean copy) {
     super(key, data, operation);
-    validateRow(data);
+
+    validateRow(data, schema);
     this.copy = copy;
+    this.schema = schema;
   }
 
   @Override
   public HoodieSparkRecord newInstance() {
-    return new HoodieSparkRecord(this.key, this.data, this.operation, this.copy);
+    return new HoodieSparkRecord(this.key, this.data, this.schema, this.operation, this.copy);
   }
 
   @Override
   public HoodieSparkRecord newInstance(HoodieKey key, HoodieOperation op) {
-    return new HoodieSparkRecord(key, this.data, op, this.copy);
+    return new HoodieSparkRecord(key, this.data, this.schema, op, this.copy);
   }
 
   @Override
   public HoodieSparkRecord newInstance(HoodieKey key) {
-    return new HoodieSparkRecord(key, this.data, this.operation, this.copy);
+    return new HoodieSparkRecord(key, this.data, this.schema, this.operation, this.copy);
   }
 
   @Override
@@ -157,7 +175,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
     InternalRow mergeRow = new JoinedRow(data, (InternalRow) other.getData());
     UnsafeProjection projection =
         HoodieInternalRowUtils.getCachedUnsafeProjection(targetStructType, targetStructType);
-    return new HoodieSparkRecord(getKey(), projection.apply(mergeRow), getOperation(), copy);
+    return new HoodieSparkRecord(getKey(), projection.apply(mergeRow), targetStructType, getOperation(), copy);
   }
 
   @Override
@@ -171,7 +189,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
     // TODO add actual rewriting
     InternalRow finalRow = new HoodieInternalRow(metaFields, data, containMetaFields);
 
-    return new HoodieSparkRecord(getKey(), finalRow, getOperation(), copy);
+    return new HoodieSparkRecord(getKey(), finalRow, targetStructType, getOperation(), copy);
   }
 
   @Override
@@ -186,7 +204,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
         HoodieInternalRowUtils.rewriteRecordWithNewSchema(data, structType, newStructType, renameCols);
     HoodieInternalRow finalRow = new HoodieInternalRow(metaFields, rewrittenRow, containMetaFields);
 
-    return new HoodieSparkRecord(getKey(), finalRow, getOperation(), copy);
+    return new HoodieSparkRecord(getKey(), finalRow, newStructType, getOperation(), copy);
   }
 
   @Override
@@ -201,7 +219,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
       }
     });
 
-    return new HoodieSparkRecord(getKey(), updatableRow, getOperation(), copy);
+    return new HoodieSparkRecord(getKey(), updatableRow, structType, getOperation(), copy);
   }
 
   @Override
@@ -266,7 +284,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
       partition = data.get(HoodieMetadataField.PARTITION_PATH_METADATA_FIELD.ordinal(), StringType).toString();
     }
     HoodieKey hoodieKey = new HoodieKey(key, partition);
-    return new HoodieSparkRecord(hoodieKey, data, getOperation(), copy);
+    return new HoodieSparkRecord(hoodieKey, data, structType, getOperation(), copy);
   }
 
   @Override
@@ -367,14 +385,21 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements Kryo
 
     HoodieOperation operation = withOperationField
         ? HoodieOperation.fromName(getNullableValAsString(structType, record.data, HoodieRecord.OPERATION_METADATA_FIELD)) : null;
-    return new HoodieSparkRecord(new HoodieKey(recKey, partitionPath), record.data, operation, record.copy);
+    return new HoodieSparkRecord(new HoodieKey(recKey, partitionPath), record.data, structType, operation, record.copy);
   }
 
-  private static void validateRow(InternalRow data) {
+  private static void validateRow(InternalRow data, StructType schema) {
     // NOTE: [[HoodieSparkRecord]] is expected to hold either
     //          - Instance of [[UnsafeRow]] or
     //          - Instance of [[HoodieInternalRow]] or
     //          - Instance of [[ColumnarBatchRow]]
-    ValidationUtils.checkState(data instanceof UnsafeRow || data instanceof HoodieInternalRow || SparkAdapterSupport$.MODULE$.sparkAdapter().isColumnarBatchRow(data));
+    //
+    //       In case provided row is anything but [[UnsafeRow]], it's expected that the
+    //       corresponding schema has to be provided as well so that it could be properly
+    //       serialized (in case it would need to be)
+    boolean isValid = data instanceof UnsafeRow ||
+        schema != null && (data instanceof HoodieInternalRow || SparkAdapterSupport$.MODULE$.sparkAdapter().isColumnarBatchRow(data));
+
+    ValidationUtils.checkState(isValid);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDSpatialCurveSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDSpatialCurveSortPartitioner.java
@@ -101,7 +101,7 @@ public class RDDSpatialCurveSortPartitioner<T>
             String key = internalRow.getString(HoodieMetadataField.RECORD_KEY_METADATA_FIELD.ordinal());
             String partition = internalRow.getString(HoodieMetadataField.PARTITION_PATH_METADATA_FIELD.ordinal());
             HoodieKey hoodieKey = new HoodieKey(key, partition);
-            return (HoodieRecord) new HoodieSparkRecord(hoodieKey, internalRow, false);
+            return (HoodieRecord) new HoodieSparkRecord(hoodieKey, internalRow, structType, false);
           });
     } else {
       throw new UnsupportedOperationException(recordType.name());

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -19,6 +19,9 @@
 
 package org.apache.hudi.common.model;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
@@ -192,5 +195,18 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
     } else {
       return Option.empty();
     }
+  }
+
+  @Override
+  protected final void writeRecordPayload(T payload, Kryo kryo, Output output) {
+    // NOTE: Since [[orderingVal]] is polymorphic we have to write out its class
+    //       to be able to properly deserialize it
+    kryo.writeClassAndObject(output, payload);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected final T readRecordPayload(Kryo kryo, Input input) {
+    return (T) kryo.readClassAndObject(input);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -18,6 +18,11 @@
 
 package org.apache.hudi.common.model;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -27,13 +32,13 @@ import java.util.Objects;
  * - recordKey : a recordKey that acts as primary key for a record.
  * - partitionPath : the partition path of a record.
  */
-public class HoodieKey implements Serializable {
+public class HoodieKey implements Serializable, KryoSerializable {
 
   private String recordKey;
   private String partitionPath;
 
-  public HoodieKey() {
-  }
+  // Required for serializer
+  public HoodieKey() {}
 
   public HoodieKey(String recordKey, String partitionPath) {
     this.recordKey = recordKey;
@@ -80,5 +85,17 @@ public class HoodieKey implements Serializable {
     sb.append(" partitionPath=").append(partitionPath);
     sb.append('}');
     return sb.toString();
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output) {
+    output.writeString(recordKey);
+    output.writeString(partitionPath);
+  }
+
+  @Override
+  public void read(Kryo kryo, Input input) {
+    this.recordKey = input.readString();
+    this.partitionPath = input.readString();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * - recordKey : a recordKey that acts as primary key for a record.
  * - partitionPath : the partition path of a record.
  */
-public class HoodieKey implements Serializable, KryoSerializable {
+public final class HoodieKey implements Serializable, KryoSerializable {
 
   private String recordKey;
   private String partitionPath;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -287,12 +287,16 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     }
   }
 
-  protected abstract void writeRecordPayload(T recordPayload, Kryo kryo, Output output);
+  protected abstract void writeRecordPayload(T payload, Kryo kryo, Output output);
 
   protected abstract T readRecordPayload(Kryo kryo, Input input);
 
+  /**
+   * NOTE: This method is declared final to make sure there's no polymorphism and therefore
+   *       JIT compiler could perform more aggressive optimizations
+   */
   @Override
-  public void write(Kryo kryo, Output output) {
+  public final void write(Kryo kryo, Output output) {
     Serializer recLocSerializer = kryo.getSerializer(HoodieRecordLocation.class);
 
     kryo.writeObjectOrNull(output, key, HoodieKey.class);
@@ -304,8 +308,12 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     writeRecordPayload(data, kryo, output);
   }
 
+  /**
+   * NOTE: This method is declared final to make sure there's no polymorphism and therefore
+   *       JIT compiler could perform more aggressive optimizations
+   */
   @Override
-  public void read(Kryo kryo, Input input) {
+  public final void read(Kryo kryo, Input input) {
     Serializer recLocSerializer = kryo.getSerializer(HoodieRecordLocation.class);
 
     this.key = kryo.readObjectOrNull(input, HoodieKey.class);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.common.model;
 
-import java.util.Collections;
-
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.Serializer;
@@ -27,7 +25,6 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -35,11 +32,12 @@ import org.apache.hudi.keygen.BaseKeyGenerator;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
@@ -18,18 +18,21 @@
 
 package org.apache.hudi.common.model;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import java.util.Objects;
 
 /**
  * Similar with {@link org.apache.hudi.common.model.HoodieRecordLocation} but with partition path.
  */
-public class HoodieRecordGlobalLocation extends HoodieRecordLocation {
+public final class HoodieRecordGlobalLocation extends HoodieRecordLocation {
   private static final long serialVersionUID = 1L;
 
   private String partitionPath;
 
-  public HoodieRecordGlobalLocation() {
-  }
+  public HoodieRecordGlobalLocation() {}
 
   public HoodieRecordGlobalLocation(String partitionPath, String instantTime, String fileId) {
     super(instantTime, fileId);
@@ -92,6 +95,20 @@ public class HoodieRecordGlobalLocation extends HoodieRecordLocation {
    */
   public HoodieRecordGlobalLocation copy(String partitionPath) {
     return new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId);
+  }
+
+  @Override
+  public final void write(Kryo kryo, Output output) {
+    super.write(kryo, output);
+
+    kryo.writeObjectOrNull(output, partitionPath, String.class);
+  }
+
+  @Override
+  public void read(Kryo kryo, Input input) {
+    super.read(kryo, input);
+
+    this.partitionPath = kryo.readObject(input, String.class);
   }
 }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
@@ -18,13 +18,18 @@
 
 package org.apache.hudi.common.model;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Location of a HoodieRecord within the partition it belongs to. Ultimately, this points to an actual file on disk
  */
-public class HoodieRecordLocation implements Serializable {
+public class HoodieRecordLocation implements Serializable, KryoSerializable {
 
   protected String instantTime;
   protected String fileId;
@@ -77,5 +82,17 @@ public class HoodieRecordLocation implements Serializable {
 
   public void setFileId(String fileId) {
     this.fileId = fileId;
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output) {
+    output.writeString(instantTime);
+    output.writeString(fileId);
+  }
+
+  @Override
+  public void read(Kryo kryo, Input input) {
+    this.instantTime = input.readString();
+    this.fileId = input.readString();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
@@ -184,8 +184,11 @@ public class BucketAssignFunction<K, I, O extends HoodieRecord<?>>
           // then update the index state using location with new partition path.
           HoodieRecord<?> deleteRecord = new HoodieAvroRecord<>(new HoodieKey(recordKey, oldLoc.getPartitionPath()),
               payloadCreation.createDeletePayload((BaseAvroPayload) record.getData()));
+
+          deleteRecord.unseal();
           deleteRecord.setCurrentLocation(oldLoc.toLocal("U"));
           deleteRecord.seal();
+
           out.collect((O) deleteRecord);
         }
         location = getNewRecordLocation(partitionPath);
@@ -200,7 +203,11 @@ public class BucketAssignFunction<K, I, O extends HoodieRecord<?>>
     if (isChangingRecords) {
       updateIndexState(partitionPath, location);
     }
+
+    record.unseal();
     record.setCurrentLocation(location);
+    record.seal();
+
     out.collect((O) record);
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -877,7 +877,7 @@ object HoodieSparkSqlWriter {
             val partitionPath = sparkKeyGenerator.getPartitionPath(internalRow, structType)
             val key = new HoodieKey(recordKey.toString, partitionPath.toString)
 
-            new HoodieSparkRecord(key, processedRow, false)
+            new HoodieSparkRecord(key, processedRow, structType, false)
           }
         }.toJavaRDD().asInstanceOf[JavaRDD[HoodieRecord[_]]]
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/LogFileIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/LogFileIterator.scala
@@ -238,7 +238,7 @@ class RecordMergingFileIterator(split: HoodieMergeOnReadFileSplit,
     //       on the record from the Delta Log
     recordMerger.getRecordType match {
       case HoodieRecordType.SPARK =>
-        val curRecord = new HoodieSparkRecord(curRow)
+        val curRecord = new HoodieSparkRecord(curRow, baseFileReader.schema)
         val result = recordMerger.merge(curRecord, baseFileReaderAvroSchema, newRecord, logFileReaderAvroSchema, payloadProps)
         toScalaOption(result)
           .map(r => {

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
@@ -96,7 +96,7 @@ public abstract class SparkFullBootstrapDataProviderBase extends FullRecordBoots
           String recordKey = sparkKeyGenerator.getRecordKey(internalRow, structType).toString();
           String partitionPath = sparkKeyGenerator.getPartitionPath(internalRow, structType).toString();
           HoodieKey key = new HoodieKey(recordKey, partitionPath);
-          return new HoodieSparkRecord(key, internalRow, false);
+          return new HoodieSparkRecord(key, internalRow, structType, false);
         });
       } else {
         throw new UnsupportedOperationException(recordType.name());

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieSparkRecord.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieSparkRecord.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model
+
+import org.apache.hudi.HoodieInternalRowUtils
+import org.apache.hudi.client.model.HoodieInternalRow
+import org.apache.hudi.commmon.model.HoodieSparkRecord
+import org.apache.hudi.common.model.TestHoodieSparkRecord.{cloneUsingKryo, toUnsafeRow}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.catalyst.expressions.objects.SerializerSupport
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.addMetaFields
+import org.apache.spark.sql.types.{Decimal, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.nio.ByteBuffer
+import java.sql.{Date, Timestamp}
+import java.time.{Instant, LocalDate}
+
+class TestHoodieSparkRecord {
+
+  private val rowSchema = StructType.fromDDL("a INT, b STRING, c DATE, d TIMESTAMP, e STRUCT<a: DECIMAL(3, 2)>")
+
+  @Test
+  def testSerialization(): Unit = {
+    def routine(row: InternalRow, schema: StructType, serializedSize: Int): Unit = {
+      val record = row match {
+        case ur: UnsafeRow => new HoodieSparkRecord(ur)
+        case _ => new HoodieSparkRecord(row, schema)
+      }
+
+      // Step 1: Serialize/de- original [[HoodieSparkRecord]]
+      val (cloned, originalBytes) = cloneUsingKryo(record)
+
+      assertEquals(serializedSize, originalBytes.length)
+      // NOTE: That in case when original row isn't an instance of [[UnsafeRow]]
+      //       it would be
+      //         - Projected into [[UnsafeRow]] (prior to serialization by Kryo)
+      //         - Re-constructed as [[UnsafeRow]]
+      row match {
+        case _: UnsafeRow => assertEquals(record, cloned)
+        case _ =>
+          val convertedRecord = new HoodieSparkRecord(toUnsafeRow(row, schema))
+          assertEquals(convertedRecord, cloned)
+      }
+
+      // Step 2: Serialize the already cloned record, and assert that ser/de loop is lossless
+      val (_, clonedBytes) = cloneUsingKryo(cloned)
+      assertEquals(ByteBuffer.wrap(originalBytes), ByteBuffer.wrap(clonedBytes))
+    }
+
+    val row = Row(1, "test", Date.valueOf(LocalDate.of(2022, 10, 1)),
+      Timestamp.from(Instant.parse("2022-10-01T23:59:59.00Z")), Row(Decimal.apply(123, 3, 2)))
+
+    val unsafeRow: UnsafeRow = toUnsafeRow(row, rowSchema)
+    val hoodieInternalRow = new HoodieInternalRow(new Array[UTF8String](5), unsafeRow, false)
+
+    Seq(
+      (unsafeRow, rowSchema, 135),
+      (hoodieInternalRow, addMetaFields(rowSchema), 175)
+    ) foreach { case (row, schema, expectedSize) => routine(row, schema, expectedSize) }
+  }
+}
+
+object TestHoodieSparkRecord {
+
+  private def cloneUsingKryo(r: HoodieSparkRecord): (HoodieSparkRecord, Array[Byte]) = {
+    val serializer = SerializerSupport.newSerializer(true)
+
+    val buf = serializer.serialize(r)
+    val cloned: HoodieSparkRecord = serializer.deserialize(buf)
+
+    val bytes = new Array[Byte](buf.remaining())
+    buf.get(bytes)
+
+    (cloned, bytes)
+  }
+
+  private def toUnsafeRow(row: InternalRow, schema: StructType): UnsafeRow = {
+    val project = HoodieInternalRowUtils.getCachedUnsafeProjection(schema, schema)
+    project(row)
+  }
+
+  private def toUnsafeRow(row: Row, schema: StructType): UnsafeRow = {
+    val encoder = RowEncoder(schema).resolveAndBind()
+    val internalRow = encoder.toRow(row)
+    internalRow.asInstanceOf[UnsafeRow]
+  }
+
+}


### PR DESCRIPTION
### Change Logs

This PR adjusts the way new and existing `HoodieRecord`s implementations are being serialized by Kryo t/h explicit implementation of `KryoSerializable` interfaces for 

 - `HodieRecord` (and inheritors)
 - `HoodieKey`
 - `HoodieRecordLocation`

Additionally, `HoodieSparkRecord` serialization is streamlined to always project the `Row` into `UnsafeRow` before serialization to avoid penalty of serializing whole object tree.

### Impact

No impact

### Risk level (write none, low medium or high below)

Risk: medium

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
