### PR TITLE
[HUDI-5031] Fix MERGE INTO creates empty partition files when source table has partitions but target table does not

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/execution/CopyOnWriteInsertHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/execution/CopyOnWriteInsertHandler.java
@@ -82,7 +82,7 @@ public class CopyOnWriteInsertHandler<T>
     String partitionPath = record.getPartitionPath();
     // just skip the ignored record，do not make partitions on fs
     try {
-      if (record.shouldIgnore(genResult.schema, genResult.props)) {
+      if (record.shouldIgnore(genResult.schema, config.getProps())) {
         numSkippedRecords++;
         return;
       }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/SparkLazyInsertIterable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/SparkLazyInsertIterable.java
@@ -34,8 +34,6 @@ import org.apache.hudi.util.ExecutorFactory;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
-
 public class SparkLazyInsertIterable<T> extends HoodieLazyInsertIterable<T> {
 
   private final boolean useWriterSchema;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/SparkLazyInsertIterable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/SparkLazyInsertIterable.java
@@ -78,7 +78,6 @@ public class SparkLazyInsertIterable<T> extends HoodieLazyInsertIterable<T> {
           getTransformer(schema, hoodieConfig), hoodieTable.getPreExecuteRunnable());
 
       final List<WriteStatus> result = bufferedIteratorExecutor.execute();
-      checkState(result != null && !result.isEmpty());
       return result;
     } catch (Exception e) {
       throw new HoodieException(e);


### PR DESCRIPTION
…rce table has partitions and the target table does not

### Change Logs

Hudi merge into creates empty partition files when the source table has partitions and the target table does not

### Impact

No impact for users, this is a internal code refactoring.

### Risk level (write none, low medium or high below)

medium，see ut for detail

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
