### PR TITLE
[HUDI-5063] Enabling run time stats to be serialized with commit metadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieWriteStat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieWriteStat.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.common.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.util.JsonUtils;
 
@@ -31,7 +29,6 @@ import java.util.Map;
 /**
  * Statistics about a single Hoodie write operation.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HoodieWriteStat implements Serializable {
 
   public static final String NULL_COMMIT = "null";
@@ -163,7 +160,6 @@ public class HoodieWriteStat implements Serializable {
   private Long maxEventTime;
 
   @Nullable
-  @JsonIgnore
   private RuntimeStats runtimeStats;
 
   public HoodieWriteStat() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieCommitMetadata.java
@@ -77,8 +77,9 @@ public class TestHoodieCommitMetadata {
     String serializedCommitMetadata = commitMetadata.toJsonString();
     HoodieCommitMetadata metadata =
         HoodieCommitMetadata.fromJsonString(serializedCommitMetadata, HoodieCommitMetadata.class);
-    // Make sure timing metrics are not written to instant file
-    assertEquals(0, (long) metadata.getTotalScanTime());
+    assertTrue(commitMetadata.getTotalCreateTime() > 0);
+    assertTrue(commitMetadata.getTotalUpsertTime() > 0);
+    assertTrue(commitMetadata.getTotalScanTime() > 0);
     assertTrue(metadata.getTotalLogFilesCompacted() > 0);
   }
 


### PR DESCRIPTION
### Change Logs

Recently we landed a patch where we reduced duplicate stats from commit metadata (https://github.com/apache/hudi/pull/6646/)

But looks like runtime stats were not serialized in json and hence those are missing from commit metadata for now. Fixing those in this patch. 

### Impact

Fixed run time stats being populated in hudi commit metadata. 

### Risk level (write none, low medium or high below)

low

### Testing
Manually verified that run time stats are populated. 
commit metadata w/ the fix:
```
"partitionToWriteStats" : {
    "americas/brazil/sao_paulo" : [ {
      "fileId" : "9c16f398-2b7b-4f05-9459-00a824846313-0",
      "path" : "americas/brazil/sao_paulo/9c16f398-2b7b-4f05-9459-00a824846313-0_0-61-79_20221019123630771.parquet",
      "cdcStats" : null,
      "prevCommit" : "20221019123616086",
      "numWrites" : 3,
      "numDeletes" : 0,
      "numUpdateWrites" : 2,
      "numInserts" : 0,
      "totalWriteBytes" : 437574,
      "totalWriteErrors" : 0,
      "tempPath" : null,
      "partitionPath" : "americas/brazil/sao_paulo",
      "totalLogRecords" : 0,
      "totalLogFilesCompacted" : 0,
      "totalLogSizeCompacted" : 0,
      "totalUpdatedRecordsCompacted" : 0,
      "totalLogBlocks" : 0,
      "totalCorruptLogBlock" : 0,
      "totalRollbackBlocks" : 0,
      "fileSizeInBytes" : 437574,
      "minEventTime" : null,
      "maxEventTime" : null,
      "runtimeStats" : {
        "totalScanTime" : 0,
        "totalUpsertTime" : 256,
        "totalCreateTime" : 0
      }
    } ],
```

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
