### PR TITLE
[MINOR] Remove redundant space in PR compliance check

### DIFF
--- a/scripts/pr_compliance.py
+++ b/scripts/pr_compliance.py
@@ -396,7 +396,7 @@ def make_default_validator(body, debug=False):
         "### Impact",
         {"_Describe any public API or user-facing feature change or any performance impact._"})
     risklevel = RiskLevelData("RISKLEVEL",
-        "### Risk level ",
+        "### Risk level",
         {"_If medium or high, explain what verification was done to mitigate the risks._"})
     checklist = ParseSectionData("CHECKLIST",
         "### Contributor's checklist",


### PR DESCRIPTION
### Change Logs

This PR fixes the PR compliance check to remove trailing space for section `### Risk level`.  Without this fix, if the PR description has the section header `### Risk level` (no trailing space) instead of `### Risk level ` (with trailing space), the PR compliance check fails. 

### Impact

Fix the bug so PR compliance check can succeed.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
