### PR TITLE
[HUDI-5070] Adding lock provider to testCleaner tests since async cleaning is invoked

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -31,6 +31,7 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieSliceInfo;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.HoodieCleanStat;
 import org.apache.hudi.common.bootstrap.TestBootstrapIndex;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -72,6 +73,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.index.HoodieIndex;
@@ -519,6 +521,7 @@ public class TestCleaner extends HoodieClientTestBase {
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).withAsyncClean(isAsync).retainCommits(maxCommits).build())
         .withParallelism(1, 1).withBulkInsertParallelism(1).withFinalizeWriteParallelism(1).withDeleteParallelism(1)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())
+        .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(InProcessLockProvider.class).build())
         .build();
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
 


### PR DESCRIPTION
### Change Logs

With async cleaner, two threads are trying to instantiate metadata concurrently w/o locks and runs into issues. I could not reproduce locally though. But likely its the issue. 
Stacktrace shows that, metadata table validity fails. Only reason this could happen is, if there were two concurrent threads trying to instantiate metadata table. One of them goes ahead and creates "metadata" dir and then "metadata/.hoodie" dir and then goes ahead w/ instantiating the metadata table, while the other thread just sees that "metadata" dir exists and assumes metadata table is already instantiated and proceeds w/ commit. And so the exception. 

We do have locks for any access to metadata table including instantiation. Just that for test w/ async cleaning we did not configure any locks, it fails often due to this race condition. 


### Impact

Adding lock provider to test cleaner tests. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
