### PR TITLE
[HUDI-5075] Adding support to rollback residual clustering after disabling clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -310,6 +310,14 @@ public class HoodieClusteringConfig extends HoodieConfig {
           + "Please exercise caution while setting this config, especially when clustering is done very frequently. This could lead to race condition in "
           + "rare scenarios, for example, when the clustering completes after instants are fetched but before rollback completed.");
 
+  public static final ConfigProperty<String> ROLLBACK_PENDING_CLUSTERING = ConfigProperty
+      .key("hoodie.rollback.pending.clustering")
+      .defaultValue("false")
+      .sinceVersion("0.13.0")
+      .withDocumentation("After enabling clustering, if users disables clustering for any reason, and if there are any inflight clustering left in the timeline,"
+          + "it could impact the metadata table compaction which in turn will stop the progress of archival in data table. So, in such cases, users can enable "
+          + "this config to rollback any inflight clustering in timeline.");
+
   /**
    * @deprecated Use {@link #PLAN_STRATEGY_CLASS_NAME} and its methods instead
    */
@@ -573,8 +581,13 @@ public class HoodieClusteringConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withRollbackPendingClustering(Boolean rollbackPendingClustering) {
+    public Builder withRollbackPendingClusteringOnConflict(Boolean rollbackPendingClustering) {
       clusteringConfig.setValue(ROLLBACK_PENDING_CLUSTERING_ON_CONFLICT, String.valueOf(rollbackPendingClustering));
+      return this;
+    }
+
+    public Builder withRollbackPendingClustering(Boolean rollbackPendingClustering) {
+      clusteringConfig.setValue(ROLLBACK_PENDING_CLUSTERING, String.valueOf(rollbackPendingClustering));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1335,8 +1335,12 @@ public class HoodieWriteConfig extends HoodieConfig {
     return inlineClusteringEnabled() || isAsyncClusteringEnabled();
   }
 
-  public boolean isRollbackPendingClustering() {
+  public boolean isRollbackPendingClusteringOnConflict() {
     return getBoolean(HoodieClusteringConfig.ROLLBACK_PENDING_CLUSTERING_ON_CONFLICT);
+  }
+
+  public boolean isRollbackPendingClustering() {
+    return getBoolean(HoodieClusteringConfig.ROLLBACK_PENDING_CLUSTERING);
   }
 
   public int getInlineClusterMaxCommits() {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
@@ -131,7 +131,7 @@ public abstract class BaseSparkCommitActionExecutor<T extends HoodieRecordPayloa
     }
     // there are file groups pending clustering and receiving updates, so rollback the pending clustering instants
     // there could be race condition, for example, if the clustering completes after instants are fetched but before rollback completed
-    if (config.isRollbackPendingClustering()) {
+    if (config.isRollbackPendingClusteringOnConflict()) {
       Set<HoodieInstant> pendingClusteringInstantsToRollback = getAllFileGroupsInPendingClusteringPlans(table.getMetaClient()).entrySet().stream()
           .filter(e -> fileGroupsWithUpdatesAndPendingClustering.contains(e.getKey()))
           .map(Map.Entry::getValue)


### PR DESCRIPTION
### Change Logs

If a user enabled clustering and after sometime disabled it due to whatever reason, there is a chance that there is a pending clustering left in the timeline. But once clustering is disabled, this could just be lying around. but this could affect metadata table compaction whcih in turn might affect the data table archival. 
Fix: 
Introduce a new config (`hoodie.rollback.pending.clustering`) which users can enable to rollback any pending clustering. Once this is enabled and if clustering in general is disabled, hudi will rollback any pending clustering from the timeline. 


### Impact

Will help making archival progress w/ metadata enabled. 

### Risk level (write none, low medium or high below)

Medium. If not for this patch, metadata compaction will not happen and could end up in a state where table is un-usable for queries. 

### Documentation Update

A new config is added. Website will be updated during regular release process. 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
