### PR TITLE
[HUDI-5053] Create clean complete commit when there is none to clean in order to leverage incremental cleaning

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -86,7 +86,7 @@ public class CleanPlanActionExecutor<T extends HoodieRecordPayload, I, K, O> ext
     if (strategy == CleaningTriggerStrategy.NUM_COMMITS) {
       int numberOfCommits = getCommitsSinceLastCleaning();
       int maxInlineCommitsForNextClean = config.getCleaningMaxCommits();
-      return numberOfCommits >= maxInlineCommitsForNextClean;
+      return numberOfCommits > maxInlineCommitsForNextClean;
     } else {
       throw new HoodieException("Unsupported cleaning trigger strategy: " + config.getCleaningTriggerStrategy());
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -38,6 +38,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.BaseActionExecutor;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -146,22 +147,17 @@ public class CleanPlanActionExecutor<T extends HoodieRecordPayload, I, K, O> ext
    */
   protected Option<HoodieCleanerPlan> requestClean(String startCleanTime) {
     final HoodieCleanerPlan cleanerPlan = requestClean(context);
-    if ((cleanerPlan.getFilePathsToBeDeletedPerPartition() != null)
-        && !cleanerPlan.getFilePathsToBeDeletedPerPartition().isEmpty()
-        && cleanerPlan.getFilePathsToBeDeletedPerPartition().values().stream().mapToInt(List::size).sum() > 0) {
-      // Only create cleaner plan which does some work
-      final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, startCleanTime);
-      // Save to both aux and timeline folder
-      try {
-        table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
-        LOG.info("Requesting Cleaning with instant time " + cleanInstant);
-      } catch (IOException e) {
-        LOG.error("Got exception when saving cleaner requested file", e);
-        throw new HoodieIOException(e.getMessage(), e);
-      }
-      return Option.of(cleanerPlan);
+    // Always create a cleaner plan to save a checkpoint of the checked partitions, to avoid re-checking them in the next clean if the incremental cleaner mode is enabled
+    final HoodieInstant cleanInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, startCleanTime);
+    // Save to both aux and timeline folder
+    try {
+      table.getActiveTimeline().saveToCleanRequested(cleanInstant, TimelineMetadataUtils.serializeCleanerPlan(cleanerPlan));
+      LOG.info("Requesting Cleaning with instant time " + cleanInstant);
+    } catch (IOException e) {
+      LOG.error("Got exception when saving cleaner requested file", e);
+      throw new HoodieIOException(e.getMessage(), e);
     }
-    return Option.empty();
+    return Option.of(cleanerPlan);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -776,31 +776,33 @@ public class TestCleaner extends HoodieClientTestBase {
       HoodieTestTable.of(metaClient).addCommit(commitTime);
     }
 
-    List<HoodieCleanStat> cleanStats = runCleaner(config);
+    int currentInstant = startInstant;
+
+    List<HoodieCleanStat> cleanStats = runCleaner(config, currentInstant++, false);
     HoodieActiveTimeline timeline = metaClient.reloadActiveTimeline();
 
     assertEquals(0, cleanStats.size(), "Must not clean any files");
+    assertEquals(2, timeline.getTimelineOfActions(
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().countInstants());
     assertEquals(1, timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().countInstants());
-    assertEquals(0, timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflights().countInstants());
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflights().countInstants());
     assertEquals(--cleanCount, timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().countInstants());
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().countInstants());
     assertTrue(timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().containsInstant(makeNewCommitTime(--instantClean, "%09d")));
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().containsInstant(makeNewCommitTime(--instantClean, "%09d")));
 
-    cleanStats = runCleaner(config);
+    cleanStats = runCleaner(config, currentInstant, false);
     timeline = metaClient.reloadActiveTimeline();
 
     assertEquals(0, cleanStats.size(), "Must not clean any files");
-    assertEquals(1, timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().countInstants());
-    assertEquals(0, timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflights().countInstants());
+    assertEquals(3, timeline.getTimelineOfActions(
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().countInstants());
+    assertEquals(2, timeline.getTimelineOfActions(
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflights().countInstants());
     assertEquals(--cleanCount, timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().countInstants());
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().countInstants());
     assertTrue(timeline.getTimelineOfActions(
-            CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().containsInstant(makeNewCommitTime(--instantClean, "%09d")));
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterInflightsAndRequested().containsInstant(makeNewCommitTime(--instantClean, "%09d")));
   }
   
   @Test

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -811,7 +811,66 @@ public class TestCleaner extends HoodieClientTestBase {
     assertTrue(timeline.getTimelineOfActions(
         CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().containsInstant(makeNewCommitTime(41, "%09d")));
   }
-  
+
+  @Test
+  public void testCleanIncrementalModeWhenNoDeleteFiles() throws Exception {
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
+            .retainCommits(1)
+            .retainFileVersions(1)
+            .withIncrementalCleaningMode(true).build())
+        .build();
+
+    HoodieTableMetadataWriter metadataWriter = SparkHoodieBackedTableMetadataWriter.create(hadoopConf, config, context);
+    HoodieTestTable testTable = HoodieMetadataTestTable.of(metaClient, metadataWriter);
+    // make 4 commits, each with 1 file in a different partition
+    String file1P1C1 = UUID.randomUUID().toString();
+    String file2P2C2 = UUID.randomUUID().toString();
+    String file3P3C3 = UUID.randomUUID().toString();
+    String file4P3C4 = UUID.randomUUID().toString();
+    String p1 = "2020/01/01";
+    String p2 = "2020/01/02";
+    String p3 = "2020/01/03";
+    String p4 = "2020/01/04";
+    String c1 = makeNewCommitTime(1, "%014d");
+    String c2 = makeNewCommitTime(2, "%014d");
+    String c3 = makeNewCommitTime(4, "%014d");
+    String c4 = makeNewCommitTime(5, "%014d");
+
+    testTable.addCommit(c1).withBaseFilesInPartition(p1, file1P1C1);
+    List<HoodieCleanStat> cleanStats = runCleaner(config, 2, true);
+    // no need to clean: cleanStats should be empty and no clean commit
+    assertEquals(0, cleanStats.size());
+    assertEquals(0, metaClient.getActiveTimeline().reload().getCleanerTimeline().countInstants());
+
+    testTable.addCommit(c2).withBaseFilesInPartition(p2, file2P2C2);
+    cleanStats = runCleaner(config, 3, true);
+    // nothing to clean: cleanStats should be empty but a clean commit should be created
+    assertEquals(0, cleanStats.size());
+    assertEquals(1, metaClient.getActiveTimeline().reload().getCleanerTimeline().countInstants());
+    assertTrue(metaClient.getActiveTimeline().reload().getTimelineOfActions(
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().containsInstant(makeNewCommitTime(3, "%014d")));
+
+
+    testTable.addCommit(c3).withBaseFilesInPartition(p3, file3P3C3);
+    cleanStats = runCleaner(config, 5, true);
+    // no need to clean: cleanStats should be empty and no clean commit
+    assertEquals(0, cleanStats.size());
+    assertEquals(1, metaClient.getActiveTimeline().reload().getCleanerTimeline().countInstants());
+    assertFalse(metaClient.getActiveTimeline().reload().getTimelineOfActions(
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().containsInstant(makeNewCommitTime(5, "%014d")));
+
+    testTable.addCommit(c4).withBaseFilesInPartition(p4, file4P3C4);
+    cleanStats = runCleaner(config, 6, true);
+    // nothing to clean: cleanStats should be empty but a clean commit should be created, and the last clean should be used to list the files to clean without errors
+    assertEquals(0, cleanStats.size());
+    assertEquals(2, metaClient.getActiveTimeline().reload().getCleanerTimeline().countInstants());
+    assertTrue(metaClient.getActiveTimeline().reload().getTimelineOfActions(
+        CollectionUtils.createSet(HoodieTimeline.CLEAN_ACTION)).filterCompletedInstants().containsInstant(makeNewCommitTime(6, "%014d")));
+  }
+
   @Test
   public void testCleanWithReplaceCommits() throws Exception {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -268,20 +268,20 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
 
   public void deleteInstantFileIfExists(HoodieInstant instant) {
     LOG.info("Deleting instant " + instant);
-    Path inFlightCommitFilePath = getInstantFileNamePath(instant.getFileName());
+    Path inFlightOrRequestCommitFilePath = getInstantFileNamePath(instant.getFileName());
     try {
-      if (metaClient.getFs().exists(inFlightCommitFilePath)) {
-        boolean result = metaClient.getFs().delete(inFlightCommitFilePath, false);
+      if (metaClient.getFs().exists(inFlightOrRequestCommitFilePath)) {
+        boolean result = metaClient.getFs().delete(inFlightOrRequestCommitFilePath, false);
         if (result) {
           LOG.info("Removed instant " + instant);
         } else {
           throw new HoodieIOException("Could not delete instant " + instant);
         }
       } else {
-        LOG.warn("The commit " + inFlightCommitFilePath + " to remove does not exist");
+        LOG.warn("The commit " + inFlightOrRequestCommitFilePath + " to remove does not exist");
       }
     } catch (IOException e) {
-      throw new HoodieIOException("Could not remove inflight commit " + inFlightCommitFilePath, e);
+      throw new HoodieIOException("Could not remove inflight commit " + inFlightOrRequestCommitFilePath, e);
     }
   }
 


### PR DESCRIPTION
### Change Logs

When the clean planner lists the files in the partitions and it doesn't find any file to delete, the clean operation is skipped without any commit, then in the next clean, if the incremental cleaning mode is enabled, the clean planner doesn't find any information about the checked commits, and it will recheck all the files a second time. This PR creates a clean commit contains the `earliestCommitToRetain` regardless the deleted files list, in this case the clean planner will check only the partitions that have been changed since the `earliestCommitToRetain` in the last clean commit.

### Impact

A new clean commit will be added to the timeline even if there was not a real clean operation. For the benefits, a big performance improvement (and cost reduction of S3 listing) in cleaning operation for table where old partitions are seldom changed.

### Risk level (write none, low medium or high below)

low:
The risk level is low because these changes affects only the clean plans without files to delete, and I kept the checks on the empty commit files to avoid Avro empty file exception, and I improved the method which clean this empty files. If for some reason we have an empty Avro file, a brute force will be performed to prepare the clean plan.
I will test these changes on our project within the week to make sure everything is fine

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
