### PR TITLE
[HUDI-5097] Fix partition reading without partition fields table config

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -186,7 +186,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     // Load all the partition path from the basePath, and filter by the query partition path.
     // TODO load files from the queryRelativePartitionPaths directly.
-    List<String> matchedPartitionPaths = getAllPartitionPathsUnchecked()
+    List<String> matchedPartitionPaths = FSUtils.getAllPartitionPaths(engineContext, metadataConfig, basePath.toString())
         .stream()
         .filter(path -> queryRelativePartitionPaths.stream().anyMatch(path::startsWith))
         .collect(Collectors.toList());
@@ -331,14 +331,6 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     }
   }
 
-  private List<String> getAllPartitionPathsUnchecked() {
-    try {
-      return isPartitionedTable() ? tableMetadata.getAllPartitionPaths() : Collections.singletonList("");
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to fetch partition paths for a table", e);
-    }
-  }
-
   private void validate(HoodieTimeline activeTimeline, Option<String> queryInstant) {
     if (shouldValidateInstant) {
       if (queryInstant.isPresent() && !activeTimeline.containsInstant(queryInstant.get())) {
@@ -364,10 +356,6 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
       }
     }
     tableMetadata = newTableMetadata;
-  }
-
-  private boolean isPartitionedTable() {
-    return partitionColumns.length > 0 || HoodieTableMetadata.isMetadataTable(basePath.toString());
   }
 
   public static final class PartitionPath {


### PR DESCRIPTION
### Change Logs

Revert to `FSUtils.getAllPartitionPaths` to load partitions properly. Details in https://github.com/apache/hudi/pull/6016#discussion_r1005459420

**Only for 0.12.2 to keep behavior consistent over patch releases**

### Impact

Affects partition reading logic for partitioned tables.

### Risk level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
