### PR TITLE
[HUDI-4982] Upgrade Bundle Testing

### DIFF
--- a/packaging/bundle-validation/Dockerfile-base
+++ b/packaging/bundle-validation/Dockerfile-base
@@ -27,6 +27,8 @@ ARG HIVE_VERSION=3.1.3
 ARG DERBY_VERSION=10.14.1.0
 ARG SPARK_VERSION=3.1.3
 ARG SPARK_HADOOP_VERSION=2.7
+ARG SPARK_PROFILE=spark3.1
+ARG SCALA_VERSION=2.12
 
 RUN wget https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz -P "$WORKDIR" \
     && tar -xf $WORKDIR/hadoop-$HADOOP_VERSION.tar.gz -C $WORKDIR/ \
@@ -47,3 +49,44 @@ RUN wget https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK
     && tar -xf $WORKDIR/spark-$SPARK_VERSION-bin-hadoop$SPARK_HADOOP_VERSION.tgz -C $WORKDIR/ \
     && rm $WORKDIR/spark-$SPARK_VERSION-bin-hadoop$SPARK_HADOOP_VERSION.tgz
 ENV SPARK_HOME=$WORKDIR/spark-$SPARK_VERSION-bin-hadoop$SPARK_HADOOP_VERSION
+
+
+# Utilities bundles
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-bundle_$SCALA_VERSION/0.11.0/hudi-utilities-bundle_$SCALA_VERSION-0.11.0.jar -P "$WORKDIR" 
+ENV UTILITIES_BUNDLE_0_11_0=$WORKDIR/hudi-utilities-bundle_$SCALA_VERSION-0.11.0.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-bundle_$SCALA_VERSION/0.11.1/hudi-utilities-bundle_$SCALA_VERSION-0.11.1.jar -P "$WORKDIR" 
+ENV UTILITIES_BUNDLE_0_11_1=$WORKDIR/hudi-utilities-bundle_$SCALA_VERSION-0.11.1.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-bundle_$SCALA_VERSION/0.12.0/hudi-utilities-bundle_$SCALA_VERSION-0.12.0.jar -P "$WORKDIR" 
+ENV UTILITIES_BUNDLE_0_12_0=$WORKDIR/hudi-utilities-bundle_$SCALA_VERSION-0.12.0.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-bundle_$SCALA_VERSION/0.12.1/hudi-utilities-bundle_$SCALA_VERSION-0.12.1.jar -P "$WORKDIR" 
+ENV UTILITIES_BUNDLE_0_12_1=$WORKDIR/hudi-utilities-bundle_$SCALA_VERSION-0.12.1.jar
+
+
+# Utilities slim bundles
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-slim-bundle_$SCALA_VERSION/0.11.0/hudi-utilities-slim-bundle_$SCALA_VERSION-0.11.0.jar -P "$WORKDIR" 
+ENV UTILITIES_SLIM_BUNDLE_0_11_0=$WORKDIR/hudi-utilities-slim-bundle_$SCALA_VERSION-0.11.0.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-slim-bundle_$SCALA_VERSION/0.11.1/hudi-utilities-slim-bundle_$SCALA_VERSION-0.11.1.jar -P "$WORKDIR" 
+ENV UTILITIES_SLIM_BUNDLE_0_11_1=$WORKDIR/hudi-utilities-slim-bundle_$SCALA_VERSION-0.11.1.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-slim-bundle_$SCALA_VERSION/0.12.0/hudi-utilities-slim-bundle_$SCALA_VERSION-0.12.0.jar -P "$WORKDIR" 
+ENV UTILITIES_SLIM_BUNDLE_0_12_0=$WORKDIR/hudi-utilities-slim-bundle_$SCALA_VERSION-0.12.0.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-utilities-slim-bundle_$SCALA_VERSION/0.12.1/hudi-utilities-slim-bundle_$SCALA_VERSION-0.12.1.jar -P "$WORKDIR" 
+ENV UTILITIES_SLIM_BUNDLE_0_12_1=$WORKDIR/hudi-utilities-slim-bundle_$SCALA_VERSION-0.12.1.jar
+
+# Spark bundles
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION/0.11.0/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.11.0.jar -P "$WORKDIR"
+ENV SPARK_BUNDLE_0_11_0=$WORKDIR/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.11.0.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION/0.11.1/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.11.1.jar -P "$WORKDIR"
+ENV SPARK_BUNDLE_0_11_1=$WORKDIR/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.11.1.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION/0.12.0/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.12.0.jar -P "$WORKDIR"
+ENV SPARK_BUNDLE_0_12_0=$WORKDIR/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.12.0.jar
+
+RUN wget https://repo1.maven.org/maven2/org/apache/hudi/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION/0.12.1/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.12.1.jar -P "$WORKDIR"
+ENV SPARK_BUNDLE_0_12_1=$WORKDIR/hudi-$SPARK_PROFILE-bundle_$SCALA_VERSION-0.12.1.jar

--- a/packaging/bundle-validation/ci_run.sh
+++ b/packaging/bundle-validation/ci_run.sh
@@ -84,6 +84,8 @@ docker build \
 --build-arg SPARK_VERSION=$SPARK_VERSION \
 --build-arg SPARK_HADOOP_VERSION=$SPARK_HADOOP_VERSION \
 --build-arg IMAGE_TAG=$IMAGE_TAG \
+--build-arg SPARK_PROFILE=$SPARK_PROFILE \
+--build-arg SCALA_VERSION=${SCALA_PROFILE#'scala-'} \
 -t hudi-ci-bundle-validation:$IMAGE_TAG \
 .
 


### PR DESCRIPTION
### Change Logs

Bundle tests are improved to add bundle upgrade testing. 

- Base Docker file is updated to download the older bundle versions
- test_utilities_bundle now has a helper because we delete the output folder at the start, but with upgrading, we want to run the testing twice, and don't want to delete the output folder at the start of the second test

### Impact

better bundle testing

### Risk level (write none, low medium or high below)

low

### Documentation Update

no documentation needed

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
