### PR TITLE
[HUDI-1570] Added average record size in a commit to the faq's

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -632,6 +632,11 @@ Cloudera CDP stack, causing the conflict.  To get around the RuntimeException, y
 `hbase.defaults.for.version.skip` to `true` in the `hbase-site.xml` configuration file, e.g., overwriting the config
 within the Cloudera manager.
 
+### How can I find the average record size in a commit?
+The `commit showpartitons` command in [HUDI CLI](https://hudi.apache.org/docs/cli) will show both "bytes written" and 
+"records inserted." Divide the bytes written by records inserted to find the average size. Note that this answer assumes 
+metadata overhead is negligible. For a small dataset (such as 5 columns, 100 records) this will not be the case.
+
 ## Contributing to FAQ
 
 A good and usable FAQ should be community-driven and crowd source questions/thoughts across everyone.

--- a/website/versioned_docs/version-0.12.1/faq.md
+++ b/website/versioned_docs/version-0.12.1/faq.md
@@ -627,6 +627,11 @@ Cloudera CDP stack, causing the conflict.  To get around the RuntimeException, y
 `hbase.defaults.for.version.skip` to `true` in the `hbase-site.xml` configuration file, e.g., overwriting the config
 within the Cloudera manager.
 
+### How can I find the average record size in a commit?
+The `commit showpartitons` command in [HUDI CLI](https://hudi.apache.org/docs/cli) will show both "bytes written" and
+"records inserted." Divide the bytes written by records inserted to find the average size. Note that this answer assumes
+metadata overhead is negligible. For a small dataset (such as 5 columns, 100 records) this will not be the case.
+
 ## Contributing to FAQ
 
 A good and usable FAQ should be community-driven and crowd source questions/thoughts across everyone.


### PR DESCRIPTION
### Change Logs

Added explanation on how to get average record size in a commit to the website. Current version and 12.1

### Impact

This should help users and reduce the ask for the requested feature described in the issue.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

This is the documentation update

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
