### PR TITLE
[HUDI-5100][flink]Support writing tasks independently in the flink batch mode

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -406,8 +406,11 @@ public class StreamWriteOperatorCoordinator
   }
 
   private void handleBootstrapEvent(WriteMetadataEvent event) {
+    boolean hasAnyEvent = Arrays.stream(this.eventBuffer).anyMatch(evt -> evt != null);
     this.eventBuffer[event.getTaskID()] = event;
-    if (Arrays.stream(eventBuffer).allMatch(evt -> evt != null && evt.isBootstrap())) {
+    if (Arrays.stream(eventBuffer).allMatch(evt -> evt != null && evt.isBootstrap())
+        || !hasAnyEvent
+    ) {
       // start to initialize the instant.
       initInstant(event.getInstantTime());
     }
@@ -483,6 +486,7 @@ public class StreamWriteOperatorCoordinator
    * @return true if the write statuses are committed successfully.
    */
   private boolean commitInstant(String instant, long checkpointId) {
+    this.ckpMetadata.startCommitInstant(instant);
     if (Arrays.stream(eventBuffer).allMatch(Objects::isNull)) {
       // The last checkpoint finished successfully.
       return false;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -26,6 +26,7 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.event.CommitAckEvent;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
+import org.apache.hudi.sink.meta.CkpMessage;
 import org.apache.hudi.sink.meta.CkpMetadata;
 import org.apache.hudi.sink.utils.TimeWait;
 import org.apache.hudi.util.StreamerUtil;
@@ -160,6 +161,9 @@ public abstract class AbstractStreamWriteFunction<I>
 
   @Override
   public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
+    if (this.currentInstant != null) {
+      this.ckpMetadata.startCommitInstant(this.currentInstant);
+    }
     if (inputEnded) {
       return;
     }
@@ -279,6 +283,7 @@ public abstract class AbstractStreamWriteFunction<I>
    * Returns whether the pending instant is invalid to write with.
    */
   private boolean invalidInstant(String instant, boolean hasData) {
-    return instant.equals(this.currentInstant) && hasData;
+    List<CkpMessage> messages = this.ckpMetadata.getMessages();
+    return messages.get(messages.size() - 1).getState().equals(CkpMessage.State.START_COMPLETE);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMessage.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMessage.java
@@ -102,6 +102,8 @@ public class CkpMessage implements Serializable, Comparable<CkpMessage> {
     // An instant can be aborted then be reused again, so it has lower priority
     // than COMPLETED
     ABORTED,
+    // Committing instant
+    START_COMPLETE,
     // Committed instant
     COMPLETED
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -137,6 +137,20 @@ public class CkpMetadata implements Serializable {
    *
    * @param instant The committed instant
    */
+  public void startCommitInstant(String instant) {
+    Path path = fullPath(CkpMessage.getFileName(instant, CkpMessage.State.START_COMPLETE));
+    try {
+      fs.createNewFile(path);
+    } catch (IOException e) {
+      throw new HoodieException("Exception while adding checkpoint commit metadata for instant: " + instant, e);
+    }
+  }
+
+  /**
+   * Add a checkpoint commit message.
+   *
+   * @param instant The committed instant
+   */
   public void commitInstant(String instant) {
     Path path = fullPath(CkpMessage.getFileName(instant, CkpMessage.State.COMPLETED));
     try {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -133,9 +133,9 @@ public class CkpMetadata implements Serializable {
   }
 
   /**
-   * Add a checkpoint commit message.
+   * start a checkpoint commit message.
    *
-   * @param instant The committed instant
+   * @param instant The start commit instant
    */
   public void startCommitInstant(String instant) {
     Path path = fullPath(CkpMessage.getFileName(instant, CkpMessage.State.START_COMPLETE));


### PR DESCRIPTION
…tch mode

### Change Logs

Support writing tasks independently in the flink batch mode, jira:https://issues.apache.org/jira/browse/HUDI-5100

### Impact

Support writing tasks independently in the flink batch mode,

### Risk level (write none, low medium or high below)

medium

### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
