### PR TITLE
[HUDI-5074] Warn if table for metastore sync has capitals in it

### DIFF
--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
@@ -73,7 +73,7 @@ public class SyncUtilHelpers {
     properties.put(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.key(), baseFileFormat);
     String tableName = properties.getString(HoodieSyncConfig.META_SYNC_TABLE_NAME.key());
     if (!tableName.equals(tableName.toLowerCase())) {
-      LOG.warn("Table name \"" + tableName + "\" contains capital letters. Your metastore may auto convert this to lowercase and cause table not found errors.");
+      LOG.warn("Table name \"" + tableName + "\" contains capital letters. Your metastore may automatically convert this to lower case and can cause table not found errors during subsequent syncs.");
     }
 
     if (ReflectionUtils.hasConstructor(syncToolClassName,

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
@@ -55,7 +55,6 @@ public class SyncUtilHelpers {
                                        String targetBasePath,
                                        String baseFileFormat) {
     try {
-      LOG.warn("VEXLER HERE58");
       instantiateMetaSyncTool(syncToolClassName, props, hadoopConfig, fs, targetBasePath, baseFileFormat).syncHoodieTable();
     } catch (Throwable e) {
       throw new HoodieException("Could not sync using the meta sync class " + syncToolClassName, e);
@@ -73,8 +72,6 @@ public class SyncUtilHelpers {
     properties.put(HoodieSyncConfig.META_SYNC_BASE_PATH.key(), targetBasePath);
     properties.put(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.key(), baseFileFormat);
     String tableName = properties.getString(HoodieSyncConfig.META_SYNC_TABLE_NAME.key());
-    LOG.warn("VEXLER HERE75");
-    LOG.warn(("VEXLER TABLE NAME IS: " + tableName));
     if (!tableName.equals(tableName.toLowerCase())) {
       LOG.warn("Table name \"" + tableName + "\" contains capital letters. Your metastore may auto convert this to lowercase and cause table not found errors.");
     }

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
@@ -27,6 +27,8 @@ import org.apache.hudi.sync.common.HoodieSyncTool;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
 import java.util.Properties;
 
@@ -34,7 +36,7 @@ import java.util.Properties;
  * Helper class for syncing Hudi commit data with external metastores.
  */
 public class SyncUtilHelpers {
-
+  private static final Logger LOG = LogManager.getLogger(SyncUtilHelpers.class);
   /**
    * Create an instance of an implementation of {@link HoodieSyncTool} that will sync all the relevant meta information
    * with an external metastore such as Hive etc. to ensure Hoodie tables can be queried or read via external systems.
@@ -53,6 +55,7 @@ public class SyncUtilHelpers {
                                        String targetBasePath,
                                        String baseFileFormat) {
     try {
+      LOG.warn("VEXLER HERE58");
       instantiateMetaSyncTool(syncToolClassName, props, hadoopConfig, fs, targetBasePath, baseFileFormat).syncHoodieTable();
     } catch (Throwable e) {
       throw new HoodieException("Could not sync using the meta sync class " + syncToolClassName, e);
@@ -69,6 +72,12 @@ public class SyncUtilHelpers {
     properties.putAll(props);
     properties.put(HoodieSyncConfig.META_SYNC_BASE_PATH.key(), targetBasePath);
     properties.put(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.key(), baseFileFormat);
+    String tableName = properties.getString(HoodieSyncConfig.META_SYNC_TABLE_NAME.key());
+    LOG.warn("VEXLER HERE75");
+    LOG.warn(("VEXLER TABLE NAME IS: " + tableName));
+    if (!tableName.equals(tableName.toLowerCase())) {
+      LOG.warn("Table name \"" + tableName + "\" contains capital letters. Your metastore may auto convert this to lowercase and cause table not found errors.");
+    }
 
     if (ReflectionUtils.hasConstructor(syncToolClassName,
         new Class<?>[] {Properties.class, Configuration.class})) {


### PR DESCRIPTION
### Change Logs
If you try to sync to the metastore with a table with capital letters, you will see the warning:
`Table name "[TABLE_NAME]" contains capital letters. Your metastore may auto convert this to lowercase and cause table not found errors.`

To test this I ran TestHoodieDeltaStreamer.testForceEmptyMetaSync and verified that the warning didn't show up. Then I changed the table name to include a capital letter and ran it again. The warning showed up. 

### Impact

This should help users if they encounter this issue in the future

### Risk level (write none, low medium or high below)

low

### Documentation Update

Documentation in PR 7078

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
