### PR TITLE
[HUDI-4624] Implement Closable for S3EventsSource

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
@@ -32,6 +32,8 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +43,7 @@ import java.util.List;
  * to check S3 files activity over time. The hudi table created by this source is consumed by
  * {@link S3EventsHoodieIncrSource} to apply changes to the hudi table corresponding to user data.
  */
-public class S3EventsSource extends RowSource {
+public class S3EventsSource extends RowSource implements Closeable {
 
   private final S3EventsMetaSelector pathSelector;
   private final List<Message> processedMessages = new ArrayList<>();
@@ -77,6 +79,13 @@ public class S3EventsSource extends RowSource {
           Option.of(sparkSession.read().json(eventRecords)),
           selectPathsWithLatestSqsMessage.getRight());
     }
+  }
+
+  @Override
+  public void close() throws IOException {
+    // close resource
+    this.sqs.shutdown();
+
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
@@ -85,7 +85,6 @@ public class S3EventsSource extends RowSource implements Closeable {
   public void close() throws IOException {
     // close resource
     this.sqs.shutdown();
-
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

We are not freeing resources properly in S3EventsSource. The SQS queue is now shutdown in close()

### Impact

S3EventsSource now has a close method

### Risk level (write none, low medium or high below)

low

### Documentation Update

No documentation needed

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
