### PR TITLE
[HUDI-5065] Call close on SparkRDDWriteClient in HoodieCleaner

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
@@ -65,9 +65,9 @@ public class HoodieCleaner {
 
   public void run() {
     HoodieWriteConfig hoodieCfg = getHoodieClientConfig();
-    SparkRDDWriteClient client = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), hoodieCfg);
-    client.clean();
-    client.close();
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), hoodieCfg)) {
+      client.clean();
+    }
   }
 
   private HoodieWriteConfig getHoodieClientConfig() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
@@ -67,6 +67,7 @@ public class HoodieCleaner {
     HoodieWriteConfig hoodieCfg = getHoodieClientConfig();
     SparkRDDWriteClient client = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), hoodieCfg);
     client.clean();
+    client.close();
   }
 
   private HoodieWriteConfig getHoodieClientConfig() {


### PR DESCRIPTION
### Change Logs

HoodieCleaner was hanging after running and users needed to ctrl-c to finish. Now it will correctly free resources like the other utilities

### Impact

Better for users 
### Risk level (write none, low medium or high below)

low

### Documentation Update

none required

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
