### PR TITLE
[HUDI-5127] Call close on AsyncCleanerService in startService

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCleanerService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCleanerService.java
@@ -53,6 +53,7 @@ public class AsyncCleanerService extends HoodieAsyncTableService {
     LOG.info(String.format("Starting async clean service with instant time %s...", instantTime));
     return Pair.of(CompletableFuture.supplyAsync(() -> {
       writeClient.clean(instantTime);
+      writeClient.close();
       return true;
     }, executor), executor);
   }


### PR DESCRIPTION
### Change Logs

AsyncCleanerService hangs after running, resources should be closed in time to release resources properly like other utilities

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
