### PR TITLE
[HUDI-5128] Fix getFileSystem way in FileSystemBackedTableMetadata, DatePartitionPathSelector and BootstrapUtils not consistent issue

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapUtils.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hudi.avro.model.HoodieFileStatus;
 import org.apache.hudi.common.bootstrap.FileStatusUtils;
+import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -75,10 +76,11 @@ public class BootstrapUtils {
     }
 
     if (subDirectories.size() > 0) {
+      SerializableConfiguration serializedConf = new SerializableConfiguration(fs.getConf());
       result.addAll(context.flatMap(subDirectories, directory -> {
         PathFilter pathFilter = getFilePathFilter(baseFileExtension);
         Path path = new Path(directory);
-        FileSystem fileSystem = FSUtils.getFs(path, fs.getConf());
+        FileSystem fileSystem = FSUtils.getFs(path, serializedConf.get());
         RemoteIterator<LocatedFileStatus> itr = fileSystem.listFiles(path, true);
         List<Pair<HoodieFileStatus, Pair<Integer, String>>> res = new ArrayList<>();
         while (itr.hasNext()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.table.action.bootstrap;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -79,7 +78,7 @@ public class BootstrapUtils {
       result.addAll(context.flatMap(subDirectories, directory -> {
         PathFilter pathFilter = getFilePathFilter(baseFileExtension);
         Path path = new Path(directory);
-        FileSystem fileSystem = path.getFileSystem(new Configuration());
+        FileSystem fileSystem = FSUtils.getFs(path, fs.getConf());
         RemoteIterator<LocatedFileStatus> itr = fileSystem.listFiles(path, true);
         List<Pair<HoodieFileStatus, Pair<Integer, String>>> res = new ArrayList<>();
         while (itr.hasNext()) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -790,7 +790,7 @@ public class FSUtils {
   public static boolean deleteSubPath(String subPathStr, SerializableConfiguration conf, boolean recursive) {
     try {
       Path subPath = new Path(subPathStr);
-      FileSystem fileSystem = subPath.getFileSystem(conf.get());
+      FileSystem fileSystem = FSUtils.getFs(subPath, conf.get());
       return fileSystem.delete(subPath, recursive);
     } catch (IOException e) {
       throw new HoodieIOException(e.getMessage(), e);
@@ -824,7 +824,7 @@ public class FSUtils {
           pairOfSubPathAndConf -> {
             Path path = new Path(pairOfSubPathAndConf.getKey());
             try {
-              FileSystem fileSystem = path.getFileSystem(pairOfSubPathAndConf.getValue().get());
+              FileSystem fileSystem = FSUtils.getFs(path, pairOfSubPathAndConf.getValue().get());
               return Arrays.stream(fileSystem.listStatus(path))
                 .collect(Collectors.toList());
             } catch (IOException e) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DatePartitionPathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DatePartitionPathSelector.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.sources.helpers;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ImmutablePair;
@@ -185,7 +186,7 @@ public class DatePartitionPathSelector extends DFSPathSelector {
     for (int i = 0; i < datePartitionDepth; i++) {
       partitionPaths = context.flatMap(partitionPaths, path -> {
         Path subDir = new Path(path);
-        FileSystem fileSystem = subDir.getFileSystem(serializedConf.get());
+        FileSystem fileSystem = FSUtils.getFs(subDir, serializedConf.get());
         // skip files/dirs whose names start with (_, ., etc)
         FileStatus[] statuses = fileSystem.listStatus(subDir,
             file -> IGNORE_FILEPREFIX_LIST.stream().noneMatch(pfx -> file.getName().startsWith(pfx)));


### PR DESCRIPTION
### Change Logs
Make getFileSystem way unify to org.apache.hudi.common.fs.FSUtils#getFs(org.apache.hadoop.fs.Path, org.apache.hadoop.conf.Configuration)

### Impact
none

### Risk level (write none, low medium or high below)
none

### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
