### PR TITLE
[HUDI-5124]. Fix HoodieInternalRowFileWriter#canWrite error return tag.

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriter.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public interface HoodieInternalRowFileWriter {
 
   /**
-   * @returns {@code true} if this RowFileWriter can take in more writes. else {@code false}.
+   * @return {@code true} if this RowFileWriter can take in more writes. else {@code false}.
    */
   boolean canWrite();
 


### PR DESCRIPTION
### Change Logs

When reading the code, I found that the `return` tag of the `canWrite` method of the `HoodieInternalRowFileWriter` of hudi-spark-client is inaccurate. I searched globally at the `hudi-client` module level, only this one has a problem, submit pr to fix.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
