### PR TITLE
[DOCS] add FAQ on how to reduce table versions created in metastore by hudi

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -643,6 +643,11 @@ This will occur when capital letters are used in the table name. Metastores such
 to lowercase. While we allow capitalization on Hudi tables, if you would like to use a metastore you may be required to
 use all lowercase letters. More details on how this issue presents can be found [here](https://github.com/apache/hudi/issues/6832).
 
+### How can I reduce table versions created by Hudi in AWS Glue Data Catalog/ metastore?
+With each commit, Hudi creates a new table version in the metastore. This can be reduced by setting the option 
+[hoodie.datasource.meta_sync.condition.sync](https://hudi.apache.org/docs/configurations#hoodiedatasourcemeta_syncconditionsync) to true.
+This will ensure that hive sync is triggered on schema or partitions changes.
+
 ## Contributing to FAQ
 
 A good and usable FAQ should be community-driven and crowd source questions/thoughts across everyone.

--- a/website/versioned_docs/version-0.12.1/faq.md
+++ b/website/versioned_docs/version-0.12.1/faq.md
@@ -638,6 +638,11 @@ This will occur when capital letters are used in the table name. Metastores such
 to lowercase. While we allow capitalization on Hudi tables, if you would like to use a metastore you may be required to
 use all lowercase letters. More details on how this issue presents can be found [here](https://github.com/apache/hudi/issues/6832).
 
+### How can I reduce table versions created by Hudi in AWS Glue Data Catalog/ metastore?
+With each commit, Hudi creates a new table version in the metastore. This can be reduced by setting the option 
+[hoodie.datasource.meta_sync.condition.sync](https://hudi.apache.org/docs/configurations#hoodiedatasourcemeta_syncconditionsync) to true.
+This will ensure that hive sync is triggered on schema or partitions changes.
+
 ## Contributing to FAQ
 
 A good and usable FAQ should be community-driven and crowd source questions/thoughts across everyone.


### PR DESCRIPTION
### Change Logs

Add faq about how to reduce rable versions created by hudi in metastore, esp aws glue data catalog.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

Added new FAQ entry: How can I reduce table versions created by Hudi in AWS Glue Data Catalog/ metastore?

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
