### PR TITLE
[MINOR] Adding tags to assist in filtering tests from maven command line

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/FlakyTestTag.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/FlakyTestTag.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.scalatest.Tag
+
+object FlakyTestTag extends Tag("org.apache.hudi.FlakyTestTag")

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,7 @@
           <artifactId>scalatest-maven-plugin</artifactId>
           <version>1.0</version>
           <configuration>
+            <!--tagsToInclude>org.apache.hudi.FlakyTestTag</tagsToInclude-->
             <skipTests>${skipUTs}</skipTests>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
@@ -1841,6 +1842,48 @@
                 </goals>
                 <configuration>
                   <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>flaky-tests</id>
+      <properties>
+        <skipUTs>true</skipUTs>
+        <skipFTs>true</skipFTs>
+        <skipITs>true</skipITs>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <configuration combine.self="append">
+              <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
+              <groups>FlakyTests</groups>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>post-unit-tests</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
### Change Logs

Adding support to filter tests based on tags. We can now filter both java and scala tests from maven command line. 

Eg for java: Add 
```
@Tag("FlakyTests")
```
to any java tests. and then run command as below. 
```
mvn  -Pflaky-tests  -Dcheckstyle.skip -DfailIfNoTests=false  -Drat.ignoreErrors=true test -pl hudi-spark-datasource/hudi-spark/
```

For scala tests, some more manual step is required. 
We need to include scala test tags to the test of interest. for eg, Lets say we want to run just 
"TestInsertTable.Test Insert Into with values"

```
diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
index c6eccac2bc..b7fb562725 100644
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -25,12 +25,13 @@ import org.apache.hudi.exception.HoodieDuplicateKeyException
 import org.apache.hudi.keygen.ComplexKeyGenerator
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.internal.SQLConf
+import org.scalatest.Tag
 
 import java.io.File
 
 class TestInsertTable extends HoodieSparkSqlTestBase {
 
-  test("Test Insert Into with values") {
+  test("Test Insert Into with values", Tag("org.apache.hudi.FlakyTestTag")) {
     withTempDir { tmp =>
       val tableName = generateTableName
       // Create a partitioned table
```

And then we need to uncomment "tagsToInclude" in root pom
```
<tagsToInclude>org.apache.hudi.FlakyTestTag</tagsToInclude>
```

Depending on whether you are running unit tests or functional tests, add "flaky test" group to corresponding one (this will ensure we ignore all java tests while executing "test" goal. 

For instance incase of unit tests, 
```
iff --git a/pom.xml b/pom.xml
index bf751b5d0b..50ee937bbe 100644
--- a/pom.xml
+++ b/pom.xml
@@ -1683,6 +1683,7 @@
               <skip>${skipUTs}</skip>
               <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
               <excludedGroups>functional</excludedGroups>
+              <groups>FlakyTests</groups>
               <excludes>
                 <exclude>**/*FunctionalTestSuite.java</exclude>
                 <exclude>**/IT*.java</exclude>
```

After this, we can run just 1 scala test from command line. 
```
mvn  -Punit-tests  -Dcheckstyle.skip -DfailIfNoTests=false  -Drat.ignoreErrors=true test -pl hudi-spark-datasource/hudi-spark/
```


### Impact

Assist Developers to run specific test from command line using maven. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

Will put up an update to our website to add this info to dev set up page. 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
