### PR TITLE
[HUDI-5147] Flink data skipping doesn't work when HepPlanner calls copy()…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
@@ -80,12 +80,6 @@ public class FileIndex {
     return new FileIndex(path, conf, rowType);
   }
 
-  public static FileIndex instance(Path path, Configuration conf, RowType rowType, List<ResolvedExpression> filters) {
-    FileIndex fileIndex = instance(path, conf, rowType);
-    fileIndex.setFilters(filters);
-    return fileIndex;
-  }
-
   /**
    * Returns the partition path key and values as a list of map, each map item in the list
    * is a mapping of the partition key name to its actual partition value. For example, say

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
@@ -80,6 +80,12 @@ public class FileIndex {
     return new FileIndex(path, conf, rowType);
   }
 
+  public static FileIndex instance(Path path, Configuration conf, RowType rowType, List<ResolvedExpression> filters) {
+    FileIndex fileIndex = instance(path, conf, rowType);
+    fileIndex.setFilters(filters);
+    return fileIndex;
+  }
+
   /**
    * Returns the partition path key and values as a list of map, each map item in the list
    * is a mapping of the partition key name to its actual partition value. For example, say
@@ -297,5 +303,10 @@ public class FileIndex {
     properties.put(HoodieMetadataConfig.ENABLE.key(), conf.getBoolean(FlinkOptions.METADATA_ENABLED));
 
     return HoodieMetadataConfig.newBuilder().fromProperties(properties).build();
+  }
+
+  @VisibleForTesting
+  public List<ResolvedExpression> getFilters() {
+    return filters;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -164,7 +164,7 @@ public class HoodieTableSource implements
     this.filters = filters == null ? Collections.emptyList() : filters;
     this.hadoopConf = HadoopConfigurations.getHadoopConf(conf);
     this.metaClient = StreamerUtil.metaClientForReader(conf, hadoopConf);
-    this.fileIndex = FileIndex.instance(this.path, this.conf, this.tableRowType);
+    this.fileIndex = FileIndex.instance(this.path, this.conf, this.tableRowType, this.filters);
     this.maxCompactionMemoryInBytes = StreamerUtil.getMaxCompactionMemoryInBytes(conf);
   }
 
@@ -542,5 +542,10 @@ public class HoodieTableSource implements
       return new FileStatus[0];
     }
     return fileIndex.getFilesInPartitions();
+  }
+
+  @VisibleForTesting
+  FileIndex getFileIndex() {
+    return fileIndex;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -127,7 +127,6 @@ public class HoodieTableSource implements
 
   private int[] requiredPos;
   private long limit;
-  private List<ResolvedExpression> filters;
 
   private List<Map<String, String>> requiredPartitions;
 
@@ -146,25 +145,26 @@ public class HoodieTableSource implements
       List<String> partitionKeys,
       String defaultPartName,
       Configuration conf,
+      @Nullable FileIndex fileIndex,
       @Nullable List<Map<String, String>> requiredPartitions,
       @Nullable int[] requiredPos,
-      @Nullable Long limit,
-      @Nullable List<ResolvedExpression> filters) {
+      @Nullable Long limit) {
     this.schema = schema;
     this.tableRowType = (RowType) schema.toPhysicalRowDataType().notNull().getLogicalType();
     this.path = path;
     this.partitionKeys = partitionKeys;
     this.defaultPartName = defaultPartName;
     this.conf = conf;
+    this.fileIndex = fileIndex == null
+        ? FileIndex.instance(this.path, this.conf, this.tableRowType)
+        : fileIndex;
     this.requiredPartitions = requiredPartitions;
     this.requiredPos = requiredPos == null
         ? IntStream.range(0, this.tableRowType.getFieldCount()).toArray()
         : requiredPos;
     this.limit = limit == null ? NO_LIMIT_CONSTANT : limit;
-    this.filters = filters == null ? Collections.emptyList() : filters;
     this.hadoopConf = HadoopConfigurations.getHadoopConf(conf);
     this.metaClient = StreamerUtil.metaClientForReader(conf, hadoopConf);
-    this.fileIndex = FileIndex.instance(this.path, this.conf, this.tableRowType, this.filters);
     this.maxCompactionMemoryInBytes = StreamerUtil.getMaxCompactionMemoryInBytes(conf);
   }
 
@@ -215,7 +215,7 @@ public class HoodieTableSource implements
   @Override
   public DynamicTableSource copy() {
     return new HoodieTableSource(schema, path, partitionKeys, defaultPartName,
-        conf, requiredPartitions, requiredPos, limit, filters);
+        conf, fileIndex, requiredPartitions, requiredPos, limit);
   }
 
   @Override
@@ -225,8 +225,10 @@ public class HoodieTableSource implements
 
   @Override
   public Result applyFilters(List<ResolvedExpression> filters) {
-    this.filters = filters.stream().filter(ExpressionUtils::isSimpleCallExpression).collect(Collectors.toList());
-    this.fileIndex.setFilters(this.filters);
+    List<ResolvedExpression> callExpressionFilters = filters.stream()
+        .filter(ExpressionUtils::isSimpleCallExpression)
+        .collect(Collectors.toList());
+    this.fileIndex.setFilters(callExpressionFilters);
     // refuse all the filters now
     return SupportsFilterPushDown.Result.of(Collections.emptyList(), new ArrayList<>(filters));
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
@@ -28,6 +28,9 @@ import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
@@ -40,6 +43,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -47,6 +51,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -115,16 +120,7 @@ public class TestHoodieTableSource {
 
   @Test
   void testGetTableAvroSchema() {
-    final String path = tempFile.getAbsolutePath();
-    conf = TestConfigurations.getDefaultConf(path);
-    conf.setBoolean(FlinkOptions.READ_AS_STREAMING, true);
-
-    HoodieTableSource tableSource = new HoodieTableSource(
-        TestConfigurations.TABLE_SCHEMA,
-        new Path(tempFile.getPath()),
-        Arrays.asList(conf.getString(FlinkOptions.PARTITION_PATH_FIELD).split(",")),
-        "default-par",
-        conf);
+    HoodieTableSource tableSource = getEmptyStreamingSource();
     assertNull(tableSource.getMetaClient(), "Streaming source with empty table path is allowed");
     final String schemaFields = tableSource.getTableAvroSchema().getFields().stream()
         .map(Schema.Field::name)
@@ -136,5 +132,32 @@ public class TestHoodieTableSource {
         + "_hoodie_file_name,"
         + "uuid,name,age,ts,partition";
     assertThat(schemaFields, is(expected));
+  }
+
+  @Test
+  void testDataSkippingFilterShouldBeNotNullWhenTableSourceIsCopied() {
+    HoodieTableSource tableSource = getEmptyStreamingSource();
+    ResolvedExpression mockExpression = CallExpression.anonymous(
+        BuiltInFunctionDefinitions.IN,
+        Collections.emptyList(),
+        TestConfigurations.ROW_DATA_TYPE);
+    List<ResolvedExpression> expectedFilters = Collections.singletonList(mockExpression);
+    tableSource.applyFilters(expectedFilters);
+    HoodieTableSource copiedSource = (HoodieTableSource) tableSource.copy();
+    List<ResolvedExpression> actualFilters = copiedSource.getFileIndex().getFilters();
+    assertEquals(expectedFilters, actualFilters);
+  }
+
+  private HoodieTableSource getEmptyStreamingSource() {
+    final String path = tempFile.getAbsolutePath();
+    conf = TestConfigurations.getDefaultConf(path);
+    conf.setBoolean(FlinkOptions.READ_AS_STREAMING, true);
+
+    return new HoodieTableSource(
+        TestConfigurations.TABLE_SCHEMA,
+        new Path(tempFile.getPath()),
+        Arrays.asList(conf.getString(FlinkOptions.PARTITION_PATH_FIELD).split(",")),
+        "default-par",
+        conf);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
@@ -137,7 +137,7 @@ public class TestHoodieTableSource {
   @Test
   void testDataSkippingFilterShouldBeNotNullWhenTableSourceIsCopied() {
     HoodieTableSource tableSource = getEmptyStreamingSource();
-    ResolvedExpression mockExpression = CallExpression.anonymous(
+    ResolvedExpression mockExpression = new CallExpression(
         BuiltInFunctionDefinitions.IN,
         Collections.emptyList(),
         TestConfigurations.ROW_DATA_TYPE);


### PR DESCRIPTION
… on HoodieTableSource

### Change Logs

When `HepPlanner` applies `PushFilterIntoSourceScanRuleBase` it copies `HoodieTableSource` which leads to the loss of `List<ResolvedExpression> filters` in `FileIndex`.

This PR adds `filters` to `FileIndex` when `HoodieTableSource` is copied.

### Impact

Flink data skipping feature works fine now

### Risk level low

Low because `read.data.skipping.enabled` is false by default

### Documentation Update

No need

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
