### PR TITLE
[HUDI-5153] Fix the write token name resolution of cdc log file

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -77,9 +77,10 @@ import static org.apache.hudi.hadoop.CachingPath.getPathWithoutSchemeAndAuthorit
 public class FSUtils {
 
   private static final Logger LOG = LogManager.getLogger(FSUtils.class);
-  // Log files are of this pattern - .b5068208-e1a4-11e6-bf01-fe55135034f3_20170101134598.log.1
+  // Log files are of this pattern - .b5068208-e1a4-11e6-bf01-fe55135034f3_20170101134598.log.1_1-0-1
+  // Archive log files are of this pattern - .commits_.archive.1_1-0-1
   private static final Pattern LOG_FILE_PATTERN =
-      Pattern.compile("\\.(.*)_(.*)\\.(.*)\\.([0-9]*)(_(([0-9]*)-([0-9]*)-([0-9]*)(-cdc)?))?");
+      Pattern.compile("\\.(.+)_(.*)\\.(.+)\\.(\\d+)(_((\\d+)-(\\d+)-(\\d+))(-cdc)?)?");
   private static final String LOG_FILE_PREFIX = ".";
   private static final int MAX_ATTEMPTS_RECOVER_LEASE = 10;
   private static final long MIN_CLEAN_TO_KEEP = 10;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
@@ -141,6 +141,8 @@ public interface HoodieLogFormat {
     private Path parentPath;
     // Log File Write Token
     private String logWriteToken;
+    // optional file suffix
+    private String suffix;
     // Rollover Log file write token
     private String rolloverLogWriteToken;
 
@@ -161,6 +163,11 @@ public interface HoodieLogFormat {
 
     public WriterBuilder withLogWriteToken(String logWriteToken) {
       this.logWriteToken = logWriteToken;
+      return this;
+    }
+
+    public WriterBuilder withSuffix(String suffix) {
+      this.suffix = suffix;
       return this;
     }
 
@@ -248,6 +255,14 @@ public interface HoodieLogFormat {
         logVersion += 1;
         fileLen = 0L;
         logWriteToken = rolloverLogWriteToken;
+      }
+
+      if (suffix != null) {
+        // A little hacky to simplify the file name concatenation:
+        // patch the write token with an optional suffix
+        // instead of adding a new extension
+        logWriteToken = logWriteToken + suffix;
+        rolloverLogWriteToken = rolloverLogWriteToken + suffix;
       }
 
       Path logPath = new Path(parentPath,

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.cdc.HoodieCDCUtils;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -248,6 +249,42 @@ public class TestFSUtils extends HoodieCommonTestHarness {
     assertEquals(1, FSUtils.getTaskPartitionIdFromLogPath(rlPath));
     assertEquals(0, FSUtils.getStageIdFromLogPath(rlPath));
     assertEquals(1, FSUtils.getTaskAttemptIdFromLogPath(rlPath));
+  }
+
+  @Test
+  public void testCdcLogFileName() {
+    String partitionPath = "2022/11/04/";
+    String fileName = UUID.randomUUID().toString();
+    String logFile = FSUtils.makeLogFileName(fileName, ".log", "100", 2, "1-0-1") + HoodieCDCUtils.CDC_LOGFILE_SUFFIX;
+    Path path = new Path(new Path(partitionPath), logFile);
+
+    assertTrue(FSUtils.isLogFile(path));
+    assertEquals("log", FSUtils.getFileExtensionFromLog(path));
+    assertEquals(fileName, FSUtils.getFileIdFromLogPath(path));
+    assertEquals("100", FSUtils.getBaseCommitTimeFromLogPath(path));
+    assertEquals(1, FSUtils.getTaskPartitionIdFromLogPath(path));
+    assertEquals("1-0-1", FSUtils.getWriteTokenFromLogPath(path));
+    assertEquals(0, FSUtils.getStageIdFromLogPath(path));
+    assertEquals(1, FSUtils.getTaskAttemptIdFromLogPath(path));
+    assertEquals(2, FSUtils.getFileVersionFromLog(path));
+  }
+
+  @Test
+  public void testArchiveLogFileName() {
+    String partitionPath = "2022/11/04/";
+    String fileName = "commits";
+    String logFile = FSUtils.makeLogFileName(fileName, ".archive", "", 2, "1-0-1");
+    Path path = new Path(new Path(partitionPath), logFile);
+
+    assertFalse(FSUtils.isLogFile(path));
+    assertEquals("archive", FSUtils.getFileExtensionFromLog(path));
+    assertEquals(fileName, FSUtils.getFileIdFromLogPath(path));
+    assertEquals("", FSUtils.getBaseCommitTimeFromLogPath(path));
+    assertEquals(1, FSUtils.getTaskPartitionIdFromLogPath(path));
+    assertEquals("1-0-1", FSUtils.getWriteTokenFromLogPath(path));
+    assertEquals(0, FSUtils.getStageIdFromLogPath(path));
+    assertEquals(1, FSUtils.getTaskAttemptIdFromLogPath(path));
+    assertEquals(2, FSUtils.getFileVersionFromLog(path));
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Fix the write token resolution, it should not include the `-cdc` suffix.

### Impact

No impact.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
