### PR TITLE
[HUDI-5162] Allow user specified start offset for streaming query

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -96,6 +96,12 @@ object DataSourceReadOptions {
     .withDocumentation("Enables use of the spark file index implementation for Hudi, "
       + "that speeds up listing of large tables.")
 
+  val START_OFFSET: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.streaming.startOffset")
+    .defaultValue("earliest")
+    .withDocumentation("Start offset to pull data from hoodie streaming source. allow earliest, latest, and " +
+      "specified start instant time")
+
   val BEGIN_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.begin.instanttime")
     .noDefaultValue()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -18,6 +18,7 @@
 package org.apache.hudi
 
 import org.apache.hadoop.fs.Path
+
 import org.apache.hudi.DataSourceReadOptions._
 import org.apache.hudi.DataSourceWriteOptions.{BOOTSTRAP_OPERATION_OPT_VAL, OPERATION}
 import org.apache.hudi.cdc.CDCRelation
@@ -28,7 +29,9 @@ import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.util.PathUtils
+
 import org.apache.log4j.LogManager
+
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.isUsingHiveCatalog
 import org.apache.spark.sql.hudi.streaming.{HoodieEarliestOffsetRangeLimit, HoodieLatestOffsetRangeLimit, HoodieSpecifiedOffsetRangeLimit, HoodieStreamSource}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieMetadataLog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieMetadataLog.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.streaming
+
+import org.apache.hudi.common.util.FileIOUtils
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.streaming.HDFSMetadataLog
+
+import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+
+/**
+ * Hoodie type metadata log that uses the specified path as the metadata storage.
+ */
+class HoodieMetadataLog(
+    sparkSession: SparkSession,
+    metadataPath: String) extends HDFSMetadataLog[HoodieSourceOffset](sparkSession, metadataPath) {
+
+  private val VERSION = 1
+
+  override def serialize(metadata: HoodieSourceOffset, out: OutputStream): Unit = {
+    val writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))
+    writer.write("v" + VERSION + "\n")
+    writer.write(metadata.json)
+    writer.flush()
+  }
+
+  /**
+   * Deserialize the init offset from the metadata file.
+   * The format in the metadata file is like this:
+   * ----------------------------------------------
+   * v1         -- The version info in the first line
+   * offsetJson -- The json string of HoodieSourceOffset in the rest of the file
+   * -----------------------------------------------
+   * @param in
+   * @return
+   */
+  override def deserialize(in: InputStream): HoodieSourceOffset = {
+    val content = FileIOUtils.readAsUTFString(in)
+    // Get version from the first line
+    val firstLineEnd = content.indexOf("\n")
+    if (firstLineEnd > 0) {
+      val version = getVersion(content.substring(0, firstLineEnd))
+      if (version > VERSION) {
+        throw new IllegalStateException(s"UnSupportVersion: max support version is: $VERSION" +
+          s" current version is: $version")
+      }
+      // Get offset from the rest line in the file
+      HoodieSourceOffset.fromJson(content.substring(firstLineEnd + 1))
+    } else {
+      throw new IllegalStateException(s"Bad metadata format, failed to find the version line.")
+    }
+  }
+
+
+  private def getVersion(versionLine: String): Int = {
+    if (versionLine.startsWith("v")) {
+      versionLine.substring(1).toInt
+    } else {
+      throw new IllegalStateException(s"Illegal version line: $versionLine " +
+        s"in the streaming metadata path")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieMetadataLog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieMetadataLog.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.hudi.streaming
 
+import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+
 import org.apache.hudi.common.util.FileIOUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.HDFSMetadataLog
-
-import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
-import java.nio.charset.StandardCharsets
 
 /**
  * Hoodie type metadata log that uses the specified path as the metadata storage.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieOffsetRangeLimit.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieOffsetRangeLimit.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.streaming
+
+/**
+ * Objects that describe the offset of the HoodieStreamSource start
+ * Available types are earliest, latest, specified commit range.
+ */
+sealed trait HoodieOffsetRangeLimit
+
+/**
+ * Represent starting from the earliest commit in the hoodie timeline
+ */
+object HoodieEarliestOffsetRangeLimit extends HoodieOffsetRangeLimit
+
+/**
+ * Represent starting from the latest commit in the hoodie timeline
+ */
+object HoodieLatestOffsetRangeLimit extends HoodieOffsetRangeLimit
+
+/**
+ * Represent starting from the specified commit in the hoodie timeline
+ */
+case class HoodieSpecifiedOffsetRangeLimit(instantTime: String) extends HoodieOffsetRangeLimit
+
+

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.hudi.streaming
 
 import java.util.Date
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.hudi.cdc.CDCRelation
 import org.apache.hudi.{AvroConversionUtils, DataSourceReadOptions, IncrementalRelation, MergeOnReadIncrementalRelation, SparkAdapterSupport}
 import org.apache.hudi.common.model.HoodieTableType

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -26,7 +26,6 @@ import org.apache.hudi.common.table.cdc.HoodieCDCUtils
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.TablePathUtils
-import org.apache.hudi.exception.HoodieException
 import org.apache.spark.sql.hudi.streaming.HoodieSourceOffset.INIT_OFFSET
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -75,8 +74,7 @@ class HoodieStreamSource(
         case HoodieEarliestOffsetRangeLimit =>
           INIT_OFFSET
         case HoodieLatestOffsetRangeLimit =>
-          getLatestOffset.getOrElse(throw new HoodieException("Cannot fetch latest offset from table, " +
-            "the table might be empty"))
+          getLatestOffset.getOrElse(INIT_OFFSET)
         case HoodieSpecifiedOffsetRangeLimit(instantTime) =>
           HoodieSourceOffset(instantTime)
       }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -100,7 +100,7 @@ class HoodieStreamSource(
   private def getLatestOffset: Option[HoodieSourceOffset] = {
     metaClient.reloadActiveTimeline()
     metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants() match {
-      case activeInstants if activeInstants.empty() =>
+      case activeInstants if !activeInstants.empty() =>
         Some(HoodieSourceOffset(activeInstants.lastInstant().get().getTimestamp))
       case _ =>
         None

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -17,26 +17,21 @@
 
 package org.apache.spark.sql.hudi.streaming
 
-import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
-import java.nio.charset.StandardCharsets
 import java.util.Date
-
 import org.apache.hadoop.fs.Path
-
 import org.apache.hudi.cdc.CDCRelation
 import org.apache.hudi.{AvroConversionUtils, DataSourceReadOptions, IncrementalRelation, MergeOnReadIncrementalRelation, SparkAdapterSupport}
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
-import org.apache.hudi.common.util.{FileIOUtils, TablePathUtils}
-import org.apache.spark.sql.hudi.streaming.HoodieStreamSource.VERSION
+import org.apache.hudi.common.util.TablePathUtils
+import org.apache.hudi.exception.HoodieException
 import org.apache.spark.sql.hudi.streaming.HoodieSourceOffset.INIT_OFFSET
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.encoders.RowEncoder
-import org.apache.spark.sql.execution.streaming.{HDFSMetadataLog, Offset, Source}
+import org.apache.spark.sql.execution.streaming.{Offset, Source}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -52,7 +47,8 @@ class HoodieStreamSource(
     sqlContext: SQLContext,
     metadataPath: String,
     schemaOption: Option[StructType],
-    parameters: Map[String, String])
+    parameters: Map[String, String],
+    offsetRangeLimit: HoodieOffsetRangeLimit)
   extends Source with Logging with Serializable with SparkAdapterSupport {
 
   @transient private val hadoopConf = sqlContext.sparkSession.sessionState.newHadoopConf()
@@ -72,57 +68,21 @@ class HoodieStreamSource(
     parameters.get(DataSourceReadOptions.QUERY_TYPE.key).contains(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL) &&
     parameters.get(DataSourceReadOptions.INCREMENTAL_FORMAT.key).contains(DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
 
-  @transient private var lastOffset: HoodieSourceOffset = _
-
   @transient private lazy val initialOffsets = {
-    val metadataLog =
-      new HDFSMetadataLog[HoodieSourceOffset](sqlContext.sparkSession, metadataPath) {
-        override def serialize(metadata: HoodieSourceOffset, out: OutputStream): Unit = {
-          val writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))
-          writer.write("v" + VERSION + "\n")
-          writer.write(metadata.json)
-          writer.flush()
-        }
-
-        /**
-          * Deserialize the init offset from the metadata file.
-          * The format in the metadata file is like this:
-          * ----------------------------------------------
-          * v1         -- The version info in the first line
-          * offsetJson -- The json string of HoodieSourceOffset in the rest of the file
-          * -----------------------------------------------
-          * @param in
-          * @return
-          */
-        override def deserialize(in: InputStream): HoodieSourceOffset = {
-          val content = FileIOUtils.readAsUTFString(in)
-          // Get version from the first line
-          val firstLineEnd = content.indexOf("\n")
-          if (firstLineEnd > 0) {
-            val version = getVersion(content.substring(0, firstLineEnd))
-            if (version > VERSION) {
-              throw new IllegalStateException(s"UnSupportVersion: max support version is: $VERSION" +
-                s" current version is: $version")
-            }
-            // Get offset from the rest line in the file
-            HoodieSourceOffset.fromJson(content.substring(firstLineEnd + 1))
-          } else {
-            throw new IllegalStateException(s"Bad metadata format, failed to find the version line.")
-          }
-        }
-      }
+    val metadataLog = new HoodieMetadataLog(sqlContext.sparkSession, metadataPath)
     metadataLog.get(0).getOrElse {
-      metadataLog.add(0, INIT_OFFSET)
-      INIT_OFFSET
-    }
-  }
-
-  private def getVersion(versionLine: String): Int = {
-    if (versionLine.startsWith("v")) {
-      versionLine.substring(1).toInt
-    } else {
-      throw new IllegalStateException(s"Illegal version line: $versionLine " +
-        s"in the streaming metadata path")
+      val offset = offsetRangeLimit match {
+        case HoodieEarliestOffsetRangeLimit =>
+          INIT_OFFSET
+        case HoodieLatestOffsetRangeLimit =>
+          getLatestOffset.getOrElse(throw new HoodieException("Cannot fetch latest offset from table, " +
+            "the table might be empty"))
+        case HoodieSpecifiedOffsetRangeLimit(instantTime) =>
+          HoodieSourceOffset(instantTime)
+      }
+      metadataLog.add(0, offset)
+      logInfo(s"The initial offset is $offset")
+      offset
     }
   }
 
@@ -137,27 +97,25 @@ class HoodieStreamSource(
     }
   }
 
+  private def getLatestOffset: Option[HoodieSourceOffset] = {
+    metaClient.reloadActiveTimeline()
+    metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants() match {
+      case activeInstants if activeInstants.empty() =>
+        Some(HoodieSourceOffset(activeInstants.lastInstant().get().getTimestamp))
+      case _ =>
+        None
+    }
+  }
+
   /**
     * Get the latest offset from the hoodie table.
     * @return
     */
   override def getOffset: Option[Offset] = {
-    metaClient.reloadActiveTimeline()
-    val activeInstants = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants
-    if (!activeInstants.empty()) {
-      val currentLatestCommitTime = activeInstants.lastInstant().get().getTimestamp
-      if (lastOffset == null || currentLatestCommitTime > lastOffset.commitTime) {
-        lastOffset = HoodieSourceOffset(currentLatestCommitTime)
-      }
-    } else { // if there are no active commits, use the init offset
-      lastOffset = initialOffsets
-    }
-    Some(lastOffset)
+    getLatestOffset
   }
 
   override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
-    initialOffsets
-
     val startOffset = start.map(HoodieSourceOffset(_))
       .getOrElse(initialOffsets)
     val endOffset = HoodieSourceOffset(end)
@@ -216,8 +174,4 @@ class HoodieStreamSource(
   override def stop(): Unit = {
 
   }
-}
-
-object HoodieStreamSource {
-  val VERSION = 1
 }


### PR DESCRIPTION
### Change Logs

Add new configure: `hoodie.datasource.streaming.startOffset` to allow users to specify start offset

### Impact

Should not affect users as it keeps the default behavior to fetch earliest offset if users don't set the configure.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
