### PR TITLE
[HUDI-5056] Allow wildcards in partition paths for DELETE_PARTITIONS

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -380,7 +380,7 @@ object DataSourceWriteOptions {
   val PARTITIONS_TO_DELETE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.partitions.to.delete")
     .noDefaultValue()
-    .withDocumentation("Comma separated list of partitions to delete. Allows use of wildcard *.")
+    .withDocumentation("Comma separated list of partitions to delete. Allows use of wildcard *")
 
   val STREAMING_RETRY_CNT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.retry.count")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -380,7 +380,7 @@ object DataSourceWriteOptions {
   val PARTITIONS_TO_DELETE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.partitions.to.delete")
     .noDefaultValue()
-    .withDocumentation("Comma separated list of partitions to delete")
+    .withDocumentation("Comma separated list of partitions to delete. Allows use of wildcard *.")
 
   val STREAMING_RETRY_CNT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.retry.count")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -233,7 +233,7 @@ object HoodieSparkSqlWriter {
                       fullPartitions.append(allPartitions.filter(_.matches(regexPartition)): _*)
                 })
               }
-              fullPartitions.distinct.toList
+              java.util.Arrays.asList(fullPartitions.distinct: _*)
             } else {
               val genericRecords = registerKryoClassesAndGetGenericRecords(tblName, sparkContext, df, reconcileSchema)
               genericRecords.map(gr => keyGenerator.getKey(gr).getPartitionPath).toJavaRDD().distinct().collect()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -232,9 +232,8 @@ object HoodieSparkSqlWriter {
                       val regexPartition = "^" + partition.replace("*",".*") + "$"
                       fullPartitions.append(allPartitions.filter(_.matches(regexPartition)): _*)
                 })
-                fullPartitions.toList
               }
-
+              fullPartitions.distinct.toList
             } else {
               val genericRecords = registerKryoClassesAndGetGenericRecords(tblName, sparkContext, df, reconcileSchema)
               genericRecords.map(gr => keyGenerator.getKey(gr).getPartitionPath).toJavaRDD().distinct().collect()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -801,7 +801,7 @@ class TestHoodieSparkSqlWriter {
     var recordsToDelete = spark.emptyDataFrame
     if (usePartitionsToDeleteConfig) {
       fooTableModifier = fooTableModifier.updated(DataSourceWriteOptions.PARTITIONS_TO_DELETE.key(),
-        HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH+","+HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH)
+        HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH + "," + HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH)
     } else {
       // delete partitions contains the primary key
       recordsToDelete = df1.filter(entry => {


### PR DESCRIPTION
### Change Logs

You can now use wildcard * when listing partition paths in DELETE_PARTITIONS 

Also fixed the test testDeletePartitionsV2 because the if statement wasn't doing anything. After making it update the configs, it failed. To fix that I added the second partition path comma separated because the test expected the first 2 paths to be deleted.
### Impact

Feature that was wanted

### Risk level (write none, low medium or high below)

high
There is potential to accidentally delete a bunch of partitions so we should make sure that the logic there is correct. 

### Documentation Update

Updated config documentation which is uploaded to site?

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
