### PR TITLE
[HUDI-5165][WIP] Adding sorting option during insert/upsert

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -320,6 +320,20 @@ public class HoodieWriteConfig extends HoodieConfig {
           + "lowest and best effort file sizing. "
           + "NONE: No sorting. Fastest and matches `spark.write.parquet()` in terms of number of files, overheads");
 
+  public static final ConfigProperty<String> WRITE_SORT_MODE = ConfigProperty
+      .key("hoodie.write.sort.mode")
+      .defaultValue(BulkInsertSortMode.NONE.toString())
+      .withDocumentation("Sorting modes to use for sorting records for insert and upserts. Available values are - "
+          + "GLOBAL_SORT: this ensures best file sizes, with lowest memory overhead at cost of sorting. "
+          + "PARTITION_SORT: Strikes a balance by only sorting within a partition, still keeping the memory overhead of writing "
+          + "lowest and best effort file sizing. "
+          + "NONE: No sorting. Fastest and matches `spark.write.parquet()` in terms of number of files, overheads");
+
+  public static final ConfigProperty<String> WRITE_SORT_COLS = ConfigProperty
+      .key("hoodie.write.sort.cols")
+      .noDefaultValue()
+      .withDocumentation("Columns to sort by when write.sort.mode is set to any other mode other than NONE.");
+
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_SERVER_ENABLE = ConfigProperty
       .key("hoodie.embed.timeline.server")
       .defaultValue("true")
@@ -1128,6 +1142,15 @@ public class HoodieWriteConfig extends HoodieConfig {
   public BulkInsertSortMode getBulkInsertSortMode() {
     String sortMode = getStringOrDefault(BULK_INSERT_SORT_MODE);
     return BulkInsertSortMode.valueOf(sortMode.toUpperCase());
+  }
+
+  public BulkInsertSortMode getWriteSortMode() {
+    String sortMode = getStringOrDefault(WRITE_SORT_MODE);
+    return BulkInsertSortMode.valueOf(sortMode.toUpperCase());
+  }
+
+  public String getWriteSortCols() {
+    return getString(WRITE_SORT_COLS);
   }
 
   public boolean isMergeDataValidationCheckEnabled() {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -212,7 +212,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
         default:
           throw new UnsupportedOperationException(String.format("Layout optimization strategy '%s' is not supported", layoutOptStrategy));
       }
-    }).orElse(isRowPartitioner ? BulkInsertInternalPartitionerWithRowsFactory.get(getWriteConfig().getBulkInsertSortMode()) :
+    }).orElse(isRowPartitioner ? BulkInsertInternalPartitionerWithRowsFactory.get(getWriteConfig().getBulkInsertSortMode(), getWriteConfig().getWriteSortCols()) :
         BulkInsertInternalPartitionerFactory.get(getWriteConfig().getBulkInsertSortMode()));
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerWithRowsFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerWithRowsFactory.java
@@ -29,12 +29,12 @@ import org.apache.spark.sql.Row;
  */
 public abstract class BulkInsertInternalPartitionerWithRowsFactory {
 
-  public static BulkInsertPartitioner<Dataset<Row>> get(BulkInsertSortMode sortMode) {
+  public static BulkInsertPartitioner<Dataset<Row>> get(BulkInsertSortMode sortMode, String colstoSort) {
     switch (sortMode) {
       case NONE:
         return new NonSortPartitionerWithRows();
       case GLOBAL_SORT:
-        return new GlobalSortPartitionerWithRows();
+        return new GlobalSortPartitionerWithRows(colstoSort);
       case PARTITION_SORT:
         return new PartitionSortPartitionerWithRows();
       default:

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -35,7 +35,7 @@ import org.apache.hudi.common.util.{CommitUtils, StringUtils}
 import org.apache.hudi.config.HoodieBootstrapConfig.{BASE_PATH, INDEX_CLASS_NAME, KEYGEN_CLASS_NAME}
 import org.apache.hudi.config.{HoodieInternalConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieException
-import org.apache.hudi.execution.bulkinsert.{BulkInsertInternalPartitionerWithRowsFactory, NonSortPartitionerWithRows}
+import org.apache.hudi.execution.bulkinsert.{BulkInsertInternalPartitionerWithRowsFactory, BulkInsertSortMode, NonSortPartitionerWithRows}
 import org.apache.hudi.hive.{HiveSyncConfigHolder, HiveSyncTool}
 import org.apache.hudi.index.SparkHoodieIndexFactory
 import org.apache.hudi.internal.DataSourceInternalWriterHelper
@@ -282,8 +282,17 @@ object HoodieSparkSqlWriter {
             sparkContext.getConf.registerAvroSchemas(writerSchema)
             log.info(s"Registered avro schema : ${writerSchema.toString(true)}")
 
+            // sort if required.
+            var orderedDf = df;
+            if (!parameters.getOrElse(HoodieWriteConfig.WRITE_SORT_MODE.key(), HoodieWriteConfig.WRITE_SORT_MODE.defaultValue()).toString.equalsIgnoreCase(BulkInsertSortMode.NONE.name())) {
+              log.warn("Sorting incoming records ")
+              val sortMode = parameters.get(HoodieWriteConfig.WRITE_SORT_MODE.key()).get;
+              // todo: determine the shuffle parallelism based on write operation type.
+              val shuffleParallelism = parameters.getOrElse(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key(), HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.defaultValue()).toInt
+              orderedDf = BulkInsertInternalPartitionerWithRowsFactory.get(BulkInsertSortMode.valueOf(sortMode), parameters.getOrElse(HoodieWriteConfig.WRITE_SORT_COLS.key(), null)).repartitionRecords(df, shuffleParallelism);
+            }
             // Convert to RDD[HoodieRecord]
-            val genericRecords: RDD[GenericRecord] = HoodieSparkUtils.createRdd(df, structName, nameSpace, reconcileSchema,
+            val genericRecords: RDD[GenericRecord] = HoodieSparkUtils.createRdd(orderedDf, structName, nameSpace, reconcileSchema,
               org.apache.hudi.common.util.Option.of(writerSchema))
             val shouldCombine = parameters(INSERT_DROP_DUPS.key()).toBoolean ||
               operation.equals(WriteOperationType.UPSERT) ||
@@ -564,7 +573,7 @@ object HoodieSparkSqlWriter {
         userDefinedBulkInsertPartitionerOpt.get
       }
       else {
-        BulkInsertInternalPartitionerWithRowsFactory.get(writeConfig.getBulkInsertSortMode)
+        BulkInsertInternalPartitionerWithRowsFactory.get(writeConfig.getBulkInsertSortMode, writeConfig.getWriteSortCols)
       }
     } else {
       // Sort modes are not yet supported when meta fields are disabled


### PR DESCRIPTION
### Change Logs

Sometimes users prefer to sort the incoming records based on some columns with insert/upsert. As of now, sorting is supported only w/ bulk_insert. This patch adds the support with insert and upsert operation as well. 

Typical use-case:
Classic problem of event time vs query predicates. in case of uber's trip data, dataset will be partitioned on datestr, but most of the queries might be based on city_id. So, instead of relying on clustering to sort after the fact, this patch adds support to sort before ingesting only. 

### Impact

Users will now be able to optionally sort records based on columns of their choice while ingesting records with insert or upsert. 
Configs of interest:
hoodie.write.sort.mode: possible values NONE, GLOBAL_SORT and PARTITIONER_SORT
hoodie.write.sort.cols: comma separated list of columns to sort. 

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
