### PR TITLE
[HUDI-5171] Ensure validateTableConfig also checks for partition path field value switch

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -159,6 +159,13 @@ object HoodieWriterUtils {
           && datasourceKeyGen != tableConfigKeyGen) {
           diffConfigs.append(s"KeyGenerator:\t$datasourceKeyGen\t$tableConfigKeyGen\n")
         }
+
+        val datasourcePartitionFields = params.getOrElse(PARTITIONPATH_FIELD.key(), null)
+        val tableConfigPartitionFields = tableConfig.getString(HoodieTableConfig.PARTITION_FIELDS)
+        if (null != datasourcePartitionFields && null != tableConfigPartitionFields
+          && datasourcePartitionFields != tableConfigPartitionFields) {
+          diffConfigs.append(s"PartitionPath:\t$datasourcePartitionFields\t$tableConfigPartitionFields\n")
+        }
       }
 
       if (diffConfigs.nonEmpty) {


### PR DESCRIPTION
### Change Logs

Partition path field is not supposed to change so now there is validation to make sure of that

### Impact

Now throws exception instead of letting user do something wrong.

### Risk level (write none, low medium or high below)

low

### Documentation Update

None needed

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
