### PR TITLE
[HUDI-5036] Update contribution guide based on PR validation

### DIFF
--- a/website/contribute/developer-setup.md
+++ b/website/contribute/developer-setup.md
@@ -139,7 +139,10 @@ and more importantly also try to improve the process along the way as well.
  - Sending a Pull Request
    - Format commit and the pull request title like `[HUDI-XXX] Fixes bug in Spark Datasource`, 
      where you replace `HUDI-XXX` with the appropriate JIRA issue. 
+   - Pull request titles must have either `[HUDI-XXX]` or `[MINOR]` in their title. Note the brackets and capitalization.
    - Please ensure your commit message body is descriptive of the change. Bulleted summary would be appreciated.
+   - You must follow the instructions in the template and fill out all fields to pass our compliance checks.
+   - Do not remove or modify any headings in the template.
    - Push your commit to your own fork/branch & create a pull request (PR) against the Hudi repo.
    - If you don't hear back within 3 days on the PR, please send an email to the dev @ mailing list.
    - Address code review comments & keep pushing changes to your fork/branch, which automatically updates the PR


### PR DESCRIPTION
### Change Logs

Added some bullet points to help contributors to fill out title and template correctly so that they are less likely to get stuck trying to get pr compliance to pass.

### Impact

Should help developers create pr's easier.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
