### PR TITLE
[HUDI-5094] Remove partition fields before transform bytes to avro,if enable DROP_PARTITION_COLUMNS.

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestAWSDmsAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestAWSDmsAvroPayload.java
@@ -22,11 +22,18 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -58,6 +65,33 @@ public class TestAWSDmsAvroPayload {
       fail("Unexpected exception");
     }
 
+  }
+
+  @Test
+  public void testGetInsertValueWithoutPartitionFields() throws IOException {
+    Schema schema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)
+    ));
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "ts");
+    props.setProperty(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, "ts");
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "id");
+    props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition");
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(true));
+    Schema recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    AWSDmsAvroPayload awsDmsAvroPayload = new AWSDmsAvroPayload(recordOption);
+    assertEquals(awsDmsAvroPayload.getInsertValue(schema, props), recordOption);
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestAWSDmsAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestAWSDmsAvroPayload.java
@@ -73,7 +73,7 @@ public class TestAWSDmsAvroPayload {
         new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
         new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
         new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
-        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)
+        new Schema.Field("Op", Schema.create(Schema.Type.STRING), "", null)
     ));
     Properties props = new Properties();
     props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "ts");
@@ -84,11 +84,11 @@ public class TestAWSDmsAvroPayload {
     Schema recordSchema = Schema.createRecord(Arrays.asList(
         new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
         new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
-        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+        new Schema.Field("Op", Schema.create(Schema.Type.STRING), "", null)));
     GenericRecord record = new GenericData.Record(recordSchema);
     record.put("id", "1");
     record.put("ts", 0L);
-    record.put("_hoodie_is_deleted", false);
+    record.put("Op", "I");
     Option<GenericRecord> recordOption = Option.of(record);
     AWSDmsAvroPayload awsDmsAvroPayload = new AWSDmsAvroPayload(recordOption);
     assertEquals(awsDmsAvroPayload.getInsertValue(schema, props), recordOption);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestEventTimeAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestEventTimeAvroPayload.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests {@link EventTimeAvroPayload}.
+ */
+public class TestEventTimeAvroPayload {
+  private Schema tableSchema;
+  private Schema recordSchema;
+  private Properties props;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    tableSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)
+    ));
+    props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "ts");
+    props.setProperty(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, "ts");
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "id");
+    props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition");
+  }
+
+  /**
+   * test case:
+   * when set hoodie.datasource.write.drop.partition.columns =true,
+   * the records have been removed partition fields by {@link 'HoodieSparkSqlWriter'$write}
+   * the table schema obtained from latest commit info and always contains partition fields
+   */
+  @Test
+  public void testGetInsertValueWithoutPartitionFields() throws IOException {
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(true));
+    recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    EventTimeAvroPayload eventTimeAvroPayload = new EventTimeAvroPayload(recordOption);
+    assertEquals(eventTimeAvroPayload.getInsertValue(tableSchema, props), recordOption);
+  }
+
+  /**
+   * test case:
+   * when set hoodie.datasource.write.drop.partition.columns =false,
+   * the records contains partition fields
+   * the table schema obtained from latest commit info and always contains partition fields
+   */
+  @Test
+  public void testGetInsertValueWithPartitionFields() throws IOException {
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(false));
+    recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("partition", "001");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    EventTimeAvroPayload eventTimeAvroPayload = new EventTimeAvroPayload(recordOption);
+    assertEquals(eventTimeAvroPayload.getInsertValue(tableSchema, props), recordOption);
+  }
+
+  /**
+   * for non-partition table
+   * @param dropPartitionFields if hoodie.datasource.write.drop.partition.columns = false & true
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true,false})
+  public void testGetInsertValueWithNonPartitionTable(boolean dropPartitionFields) throws IOException {
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(dropPartitionFields));
+    props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
+    recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("partition", "001");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    EventTimeAvroPayload eventTimeAvroPayload = new EventTimeAvroPayload(recordOption);
+    assertEquals(eventTimeAvroPayload.getInsertValue(tableSchema, props), recordOption);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
@@ -17,7 +17,9 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
+/**
+ * Unit tests {@link TestHoodieRecordPayload}.
+ */
 public class TestHoodieRecordPayload {
   private Schema tableSchema;
   private Schema recordSchema;

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
@@ -51,13 +51,11 @@ public class TestHoodieRecordPayload {
         new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
         new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)
     ));
-
     props = new Properties();
     props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "ts");
     props.setProperty(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, "ts");
     props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "id");
     props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition");
-
   }
 
   @ParameterizedTest

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.table.HoodieTableConfig;

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
@@ -60,7 +60,7 @@ public class TestHoodieRecordPayload {
 
   @ParameterizedTest
   @ValueSource(booleans = true)
-  public void testGetInsertValueAfterDropPartitionFields(boolean dropPartitionFields) throws IOException {
+  public void testGetInsertValueWithoutPartitionFields(boolean dropPartitionFields) throws IOException {
     props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(dropPartitionFields));
     recordSchema = Schema.createRecord(Arrays.asList(
         new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
@@ -79,6 +79,26 @@ public class TestHoodieRecordPayload {
   @ValueSource(booleans = false)
   public void testGetInsertValueWithPartitionFields(boolean dropPartitionFields) throws IOException {
     props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(dropPartitionFields));
+    recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("partition", "001");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    HoodieAvroPayload hoodieAvroPayload = new HoodieAvroPayload(recordOption);
+    assertEquals(hoodieAvroPayload.getInsertValue(tableSchema, props), recordOption);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true,false})
+  public void testGetInsertValueWithNonPartitionTable(boolean dropPartitionFields) throws IOException {
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(dropPartitionFields));
+    props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
     recordSchema = Schema.createRecord(Arrays.asList(
         new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
         new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieRecordPayload.java
@@ -1,0 +1,78 @@
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class TestHoodieRecordPayload {
+  private Schema tableSchema;
+  private Schema recordSchema;
+  private Properties props;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    tableSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)
+    ));
+
+    props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "ts");
+    props.setProperty(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, "ts");
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "id");
+    props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition");
+
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = true)
+  public void testGetInsertValueAfterDropPartitionFields(boolean dropPartitionFields) throws IOException {
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(dropPartitionFields));
+    recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    HoodieAvroPayload hoodieAvroPayload = new HoodieAvroPayload(recordOption);
+    assertEquals(hoodieAvroPayload.getInsertValue(tableSchema, props), recordOption);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = false)
+  public void testGetInsertValueWithPartitionFields(boolean dropPartitionFields) throws IOException {
+    props.setProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key(), String.valueOf(dropPartitionFields));
+    recordSchema = Schema.createRecord(Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("partition", Schema.create(Schema.Type.STRING), "", null),
+        new Schema.Field("ts", Schema.create(Schema.Type.LONG), "", null),
+        new Schema.Field("_hoodie_is_deleted", Schema.create(Schema.Type.BOOLEAN), "", false)));
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("id", "1");
+    record.put("partition", "001");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+    Option<GenericRecord> recordOption = Option.of(record);
+    HoodieAvroPayload hoodieAvroPayload = new HoodieAvroPayload(recordOption);
+    assertEquals(hoodieAvroPayload.getInsertValue(tableSchema, props), recordOption);
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.hudi.command.payload
 
-import java.util
-
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord, IndexedRecord}
@@ -27,7 +25,7 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro
 import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodiePayloadProps, HoodieRecord}
-import org.apache.hudi.common.util.{CollectionUtils, ValidationUtils, Option => HOption}
+import org.apache.hudi.common.util.{ValidationUtils, Option => HOption}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.io.HoodieWriteHandle
 import org.apache.hudi.sql.IExpressionEvaluator
@@ -36,11 +34,8 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.hudi.SerDeUtils
 import org.apache.spark.sql.hudi.command.payload.ExpressionPayload.{getEvaluator, getMergedSchema, setWriteSchema}
 import org.apache.spark.sql.types.{StructField, StructType}
-import java.util.{Base64, Properties, Set}
+import java.util.{Base64, Properties}
 import java.util.function.Function
-
-import org.apache.hudi.common.table.HoodieTableConfig
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -179,15 +174,7 @@ class ExpressionPayload(record: GenericRecord,
   }
 
   override def getInsertValue(schema: Schema, properties: Properties): HOption[IndexedRecord] = {
-    var incomingRecord:GenericRecord = null
-    val dropPartCol = properties.getProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key).asInstanceOf[Boolean]
-    if (dropPartCol) {
-      val partitionFields = properties.getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key).split(",")
-      val removeFields = partitionFields.toSet.asJava
-      val schemaNoPartitionFields: Schema = HoodieAvroUtils.removeFields(schema, removeFields)
-       incomingRecord = bytesToAvro(recordBytes, schemaNoPartitionFields)
-    }
-    else incomingRecord = bytesToAvro(recordBytes, schema)
+    val incomingRecord = bytesToAvro(recordBytes, schema)
     if (isDeleteRecord(incomingRecord)) {
       HOption.empty[IndexedRecord]()
     } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -34,9 +34,9 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.hudi.SerDeUtils
 import org.apache.spark.sql.hudi.command.payload.ExpressionPayload.{getEvaluator, getMergedSchema, setWriteSchema}
 import org.apache.spark.sql.types.{StructField, StructType}
+
 import java.util.{Base64, Properties}
 import java.util.function.Function
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -180,10 +180,10 @@ class ExpressionPayload(record: GenericRecord,
 
   override def getInsertValue(schema: Schema, properties: Properties): HOption[IndexedRecord] = {
     var incomingRecord:GenericRecord = null
-    val dropPartCol: Boolean = (properties.getProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key)).asInstanceOf[Boolean]
+    val dropPartCol = properties.getProperty(HoodieTableConfig.DROP_PARTITION_COLUMNS.key).asInstanceOf[Boolean]
     if (dropPartCol) {
-      val partitionFields: Array[String] = properties.getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key).split(",")
-      val removeFields: util.Set[String] = CollectionUtils.createSet(partitionFields)
+      val partitionFields = properties.getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key).split(",")
+      val removeFields = partitionFields.toSet.asJava
       val schemaNoPartitionFields: Schema = HoodieAvroUtils.removeFields(schema, removeFields)
        incomingRecord = bytesToAvro(recordBytes, schemaNoPartitionFields)
     }


### PR DESCRIPTION
### Change Logs

when enable DROP_PARTITION_COLUMNS, spark streaming failed after first compaction.
The compaction action changed schema which in the write config, Hoodie Record Payload can't transform bytes to avro with changed schema, we need to remove partition fields before transform bytes to Avro.

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
