### PR TITLE
[HUDI-5186] Parallelism does not take effect when hoodie.combine.before.upsert/insert false

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseWriteHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseWriteHelper.java
@@ -70,7 +70,7 @@ public abstract class BaseWriteHelper<T extends HoodieRecordPayload, I, K, O, R>
 
   public I combineOnCondition(
       boolean condition, I records, int parallelism, HoodieTable<T, I, K, O> table) {
-    return condition ? deduplicateRecords(records, table, parallelism) : records;
+    return condition ? deduplicateRecords(records, table, parallelism) : repartitionRecords(records, parallelism);
   }
 
   /**
@@ -87,4 +87,8 @@ public abstract class BaseWriteHelper<T extends HoodieRecordPayload, I, K, O, R>
 
   public abstract I deduplicateRecords(
       I records, HoodieIndex<?, ?> index, int parallelism, String schema);
+
+  public I repartitionRecords(I records, int parallelism) {
+    return records;
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieWriteHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieWriteHelper.java
@@ -73,4 +73,9 @@ public class HoodieWriteHelper<T extends HoodieRecordPayload, R> extends BaseWri
     }, reduceParallelism).map(Pair::getRight);
   }
 
+  @Override
+  public HoodieData<HoodieRecord<T>> repartitionRecords(HoodieData<HoodieRecord<T>> records, int parallelism) {
+    return records.repartition(parallelism);
+  }
+
 }


### PR DESCRIPTION
### Change Logs

Parallelism does not take effect when `hoodie.combine.before.upsert/insert` false
It may cause data skew without shuffle based on our PRD experience.

```
hoodie.upsert.shuffle.parallelism

Parallelism to use for upsert operation on the table. Upserts can shuffle data to perform index lookups, file sizing, bin packing records optimallyinto file groups.
Default Value: 200 (Optional)
Config Param: UPSERT_PARALLELISM_VALUE

hoodie.insert.shuffle.parallelism

Parallelism for inserting records into the table. Inserts can shuffle data before writing to tune file sizes and optimize the storage layout.
Default Value: 200 (Optional)
Config Param: INSERT_PARALLELISM_VALUE
```

### Impact
scene 1: users set upsert with `hoodie.combine.before.upsert` false (default true)

scene 2: users set insert with `hoodie.combine.before.insert` false (default false)

Both scenes will have an extra shuffle action which change partition numbers to `Parallelism`.

### Risk level (write none, low medium or high below)

low or medium ?

### Documentation Update

no

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
