### PR TITLE
[HUDI-5201] add totalRecordsDeleted metric

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -168,6 +168,7 @@ public class HoodieMetrics {
     Metrics.registerGauge(getMetricsName(actionType, "totalRecordsWritten"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalUpdateRecordsWritten"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalInsertRecordsWritten"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalRecordsDeleted"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalBytesWritten"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalScanTime"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalCreateTime"), 0);
@@ -175,7 +176,6 @@ public class HoodieMetrics {
     Metrics.registerGauge(getMetricsName(actionType, "totalCompactedRecordsUpdated"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesCompacted"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesSize"), 0);
-    Metrics.registerGauge(getMetricsName(actionType, "totalRecordsDeleted"), 0);
   }
 
   public void updateCommitMetrics(long commitEpochTimeInMs, long durationInMs, HoodieCommitMetadata metadata,
@@ -188,6 +188,7 @@ public class HoodieMetrics {
       long totalRecordsWritten = metadata.fetchTotalRecordsWritten();
       long totalUpdateRecordsWritten = metadata.fetchTotalUpdateRecordsWritten();
       long totalInsertRecordsWritten = metadata.fetchTotalInsertRecordsWritten();
+      long totalRecordsDeleted = metadata.getTotalRecordsDeleted();
       long totalBytesWritten = metadata.fetchTotalBytesWritten();
       long totalTimeTakenByScanner = metadata.getTotalScanTime();
       long totalTimeTakenForInsert = metadata.getTotalCreateTime();
@@ -195,7 +196,6 @@ public class HoodieMetrics {
       long totalCompactedRecordsUpdated = metadata.getTotalCompactedRecordsUpdated();
       long totalLogFilesCompacted = metadata.getTotalLogFilesCompacted();
       long totalLogFilesSize = metadata.getTotalLogFilesSize();
-      long totalRecordsDeleted = metadata.getTotalRecordsDeleted();
       Metrics.registerGauge(getMetricsName(actionType, "totalPartitionsWritten"), totalPartitionsWritten);
       Metrics.registerGauge(getMetricsName(actionType, "totalFilesInsert"), totalFilesInsert);
       Metrics.registerGauge(getMetricsName(actionType, "totalFilesUpdate"), totalFilesUpdate);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -175,6 +175,7 @@ public class HoodieMetrics {
     Metrics.registerGauge(getMetricsName(actionType, "totalCompactedRecordsUpdated"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesCompacted"), 0);
     Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesSize"), 0);
+    Metrics.registerGauge(getMetricsName(actionType, "totalRecordsDeleted"), 0);
   }
 
   public void updateCommitMetrics(long commitEpochTimeInMs, long durationInMs, HoodieCommitMetadata metadata,
@@ -194,6 +195,7 @@ public class HoodieMetrics {
       long totalCompactedRecordsUpdated = metadata.getTotalCompactedRecordsUpdated();
       long totalLogFilesCompacted = metadata.getTotalLogFilesCompacted();
       long totalLogFilesSize = metadata.getTotalLogFilesSize();
+      long totalRecordsDeleted = metadata.getTotalRecordsDeleted();
       Metrics.registerGauge(getMetricsName(actionType, "totalPartitionsWritten"), totalPartitionsWritten);
       Metrics.registerGauge(getMetricsName(actionType, "totalFilesInsert"), totalFilesInsert);
       Metrics.registerGauge(getMetricsName(actionType, "totalFilesUpdate"), totalFilesUpdate);
@@ -207,6 +209,7 @@ public class HoodieMetrics {
       Metrics.registerGauge(getMetricsName(actionType, "totalCompactedRecordsUpdated"), totalCompactedRecordsUpdated);
       Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesCompacted"), totalLogFilesCompacted);
       Metrics.registerGauge(getMetricsName(actionType, "totalLogFilesSize"), totalLogFilesSize);
+      Metrics.registerGauge(getMetricsName(actionType, "totalRecordsDeleted"), totalRecordsDeleted);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
@@ -137,8 +137,9 @@ public class TestHoodieMetrics {
       when(metadata.getTotalCompactedRecordsUpdated()).thenReturn(randomValue + 11);
       when(metadata.getTotalLogFilesCompacted()).thenReturn(randomValue + 12);
       when(metadata.getTotalLogFilesSize()).thenReturn(randomValue + 13);
+      when(metadata.getTotalRecordsDeleted()).thenReturn(randomValue + 14);
       when(metadata.getMinAndMaxEventTime()).thenReturn(Pair.of(Option.empty(), Option.empty()));
-      metrics.updateCommitMetrics(randomValue + 14, commitTimer.stop(), metadata, action);
+      metrics.updateCommitMetrics(randomValue + 15, commitTimer.stop(), metadata, action);
 
       String metricname = metrics.getMetricsName(action, "duration");
       long duration = (Long)Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue();
@@ -158,7 +159,7 @@ public class TestHoodieMetrics {
       metricname = metrics.getMetricsName(action, "totalBytesWritten");
       assertEquals((long)Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), metadata.fetchTotalBytesWritten());
       metricname = metrics.getMetricsName(action, "commitTime");
-      assertEquals((long)Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), randomValue + 14);
+      assertEquals((long)Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), randomValue + 15);
       metricname = metrics.getMetricsName(action, "totalScanTime");
       assertEquals(Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), metadata.getTotalScanTime());
       metricname = metrics.getMetricsName(action, "totalCreateTime");
@@ -171,6 +172,8 @@ public class TestHoodieMetrics {
       assertEquals(Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), metadata.getTotalLogFilesCompacted());
       metricname = metrics.getMetricsName(action, "totalLogFilesSize");
       assertEquals(Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), metadata.getTotalLogFilesSize());
+      metricname = metrics.getMetricsName(action, "totalRecordsDeleted");
+      assertEquals(Metrics.getInstance().getRegistry().getGauges().get(metricname).getValue(), metadata.getTotalRecordsDeleted());
     });
   }
 }


### PR DESCRIPTION
### Change Logs

Add missing `totalRecordsDeleted` metric.

### Impact

A new metric will be logged to the different reporters.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
