### PR TITLE
[HUDI-5196]spark sql 3.2+ query support

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieCatalystPlansUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieCatalystPlansUtils.scala
@@ -80,9 +80,20 @@ trait HoodieCatalystPlansUtils {
   def isRelationTimeTravel(plan: LogicalPlan): Boolean
 
   /**
+   * if the logical plan is a TableArgumentRelation LogicalPlan.
+   */
+  def isRelationTableArgument(plan: LogicalPlan): Boolean
+
+
+  /**
    * Get the member of the TimeTravelRelation LogicalPlan.
    */
   def getRelationTimeTravel(plan: LogicalPlan): Option[(LogicalPlan, Option[Expression], Option[String])]
+
+  /**
+   * Get the member of the TableArgumentRelation LogicalPlan.
+   */
+  def getRelationTableArgument(plan: LogicalPlan): Option[(LogicalPlan, Map[String, String])]
 
   /**
    * Create a Insert Into LogicalPlan.

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -21,10 +21,10 @@ import org.apache.hudi.DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.util.ReflectionUtils
 import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils, SparkAdapterSupport}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils, HoodieCatalogTable}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.catalog.{CatalogUtils, HoodieCatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, GenericInternalRow, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command._
@@ -134,19 +134,19 @@ case class HoodieAnalysis(sparkSession: SparkSession) extends Rule[LogicalPlan]
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan match {
       // Convert to MergeIntoHoodieTableCommand
-      case m@MergeIntoTable(target, _, _, _, _)
+      case m @ MergeIntoTable(target, _, _, _, _)
         if m.resolved && sparkAdapter.isHoodieTable(target, sparkSession) =>
-        MergeIntoHoodieTableCommand(m)
+          MergeIntoHoodieTableCommand(m)
 
       // Convert to UpdateHoodieTableCommand
-      case u@UpdateTable(table, _, _)
+      case u @ UpdateTable(table, _, _)
         if u.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
-        UpdateHoodieTableCommand(u)
+          UpdateHoodieTableCommand(u)
 
       // Convert to DeleteHoodieTableCommand
-      case d@DeleteFromTable(table, _)
+      case d @ DeleteFromTable(table, _)
         if d.resolved && sparkAdapter.isHoodieTable(table, sparkSession) =>
-        DeleteHoodieTableCommand(d)
+          DeleteHoodieTableCommand(d)
 
       // Convert to InsertIntoHoodieTableCommand
       case l if sparkAdapter.getCatalystPlanUtils.isInsertInto(l) =>
@@ -161,7 +161,7 @@ case class HoodieAnalysis(sparkSession: SparkSession) extends Rule[LogicalPlan]
       // Convert to CreateHoodieTableAsSelectCommand
       case CreateTable(table, mode, Some(query))
         if query.resolved && sparkAdapter.isHoodieTable(table) =>
-        CreateHoodieTableAsSelectCommand(table, mode, query)
+          CreateHoodieTableAsSelectCommand(table, mode, query)
 
       // Convert to CompactionHoodieTableCommand
       case CompactionTable(table, operation, options)
@@ -261,7 +261,7 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
 
   def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsUp {
     // Resolve merge into
-    case mergeInto@MergeIntoTable(target, source, mergeCondition, matchedActions, notMatchedActions)
+    case mergeInto @ MergeIntoTable(target, source, mergeCondition, matchedActions, notMatchedActions)
       if sparkAdapter.isHoodieTable(target, sparkSession) && target.resolved =>
       val resolver = sparkSession.sessionState.conf.resolver
       val resolvedSource = analyzer.execute(source)
@@ -313,7 +313,7 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
       }
 
       def resolveConditionAssignments(condition: Option[Expression],
-                                      assignments: Seq[Assignment]): (Option[Expression], Seq[Assignment]) = {
+        assignments: Seq[Assignment]): (Option[Expression], Seq[Assignment]) = {
         val resolvedCondition = condition.map(resolveExpressionFrom(resolvedSource)(_))
         val resolvedAssignments = if (isInsertOrUpdateStar(assignments)) {
           // assignments is empty means insert * or update set *
@@ -321,7 +321,7 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
           val targetOutput = target.output.filter(attr => !HoodieSqlCommonUtils.isMetaField(attr.name))
           val resolvedSourceColumnNames = resolvedSourceOutput.map(_.name)
 
-          if (targetOutput.filter(attr => resolvedSourceColumnNames.exists(resolver(_, attr.name))).equals(targetOutput)) {
+          if(targetOutput.filter(attr => resolvedSourceColumnNames.exists(resolver(_, attr.name))).equals(targetOutput)){
             //If sourceTable's columns contains all targetTable's columns,
             //We fill assign all the source fields to the target fields by column name matching.
             targetOutput.map(targetAttr => {
@@ -336,7 +336,7 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
           }
         } else {
           // For Spark3.2, InsertStarAction/UpdateStarAction's assignments will contain the meta fields.
-          val withoutMetaAttrs = assignments.filterNot { assignment =>
+          val withoutMetaAttrs = assignments.filterNot{ assignment =>
             if (assignment.key.isInstanceOf[Attribute]) {
               HoodieSqlCommonUtils.isMetaField(assignment.key.asInstanceOf[Attribute].name)
             } else {
@@ -371,9 +371,9 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
 
           // Get the map of target attribute to value of the update assignments.
           val target2Values = resolvedAssignments.map {
-            case Assignment(attr: AttributeReference, value) =>
-              attr.name -> value
-            case o => throw new IllegalArgumentException(s"Assignment key must be an attribute, current is: ${o.key}")
+              case Assignment(attr: AttributeReference, value) =>
+                attr.name -> value
+              case o => throw new IllegalArgumentException(s"Assignment key must be an attribute, current is: ${o.key}")
           }.toMap
 
           // Validate if there are incorrect target attributes.
@@ -396,7 +396,7 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
                   s" please complete all the target fields just like '...update set id = s0.id, name = s0.name ....'")
               }
               if (preCombineField.isDefined && preCombineField.get.equalsIgnoreCase(attr.name)
-                && valueOption.isEmpty) {
+                  && valueOption.isEmpty) {
                 throw new AnalysisException(s"Missing specify value for the preCombineField:" +
                   s" ${preCombineField.get} in merge-into update action. You should add" +
                   s" '... update set ${preCombineField.get} = xx....' to the when-matched clause.")
@@ -440,13 +440,13 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
       val resolvedAssignments = assignments.map(assignment => {
         val resolvedKey = resolveExpressionFrom(table)(assignment.key)
         val resolvedValue = resolveExpressionFrom(table)(assignment.value)
-        Assignment(resolvedKey, resolvedValue)
+          Assignment(resolvedKey, resolvedValue)
       })
       // Return the resolved UpdateTable
       UpdateTable(table, resolvedAssignments, resolvedCondition)
 
     // Resolve Delete Table
-    case dft@DeleteFromTable(table, condition)
+    case dft @ DeleteFromTable(table, condition)
       if sparkAdapter.isHoodieTable(table, sparkSession) && table.resolved =>
       val resolveExpression = resolveExpressionFrom(table, None)(_)
       sparkAdapter.resolveDeleteFromTable(dft, resolveExpression)
@@ -599,7 +599,7 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
     exp match {
       case Alias(_, name) if metaFields.contains(name.toLowerCase) => true
       case AttributeReference(name, _, _, _) if metaFields.contains(name.toLowerCase) => true
-      case _ => false
+      case _=> false
     }
   }
 
@@ -608,14 +608,13 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
    * 1、 Fake a a project for the expression based on the source plan
    * 2、 Resolve the fake project
    * 3、 Get the resolved expression from the faked project
-   *
-   * @param left       The left source plan for the expression.
-   * @param right      The right source plan for the expression.
+   * @param left The left source plan for the expression.
+   * @param right The right source plan for the expression.
    * @param expression The expression to resolved.
    * @return The resolved expression.
    */
   private def resolveExpressionFrom(left: LogicalPlan, right: Option[LogicalPlan] = None)
-                                   (expression: Expression): Expression = {
+                        (expression: Expression): Expression = {
     // Fake a project for the expression based on the source plan.
     val fakeProject = if (right.isDefined) {
       Project(Seq(Alias(expression, "_c0")()),
@@ -631,14 +630,8 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
       case attr: UnresolvedAttribute => attr
     }
     if (unResolvedAttrs.nonEmpty) {
-      throw new AnalysisException(s"Cannot resolve ${
-        unResolvedAttrs.mkString(",")
-      } in " +
-        s"${
-          expression.sql
-        }, the input " + s"columns is: [${
-        fakeProject.child.output.mkString(", ")
-      }]")
+      throw new AnalysisException(s"Cannot resolve ${unResolvedAttrs.mkString(",")} in " +
+        s"${expression.sql}, the input " + s"columns is: [${fakeProject.child.output.mkString(", ")}]")
     }
     // Fetch the resolved expression from the fake project.
     resolvedProject.projectList.head.asInstanceOf[Alias].child
@@ -664,25 +657,25 @@ case class HoodiePostAnalysisRule(sparkSession: SparkSession) extends Rule[Logic
       // Rewrite the AlterTableDropPartitionCommand to AlterHoodieTableDropPartitionCommand
       case AlterTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)
         if sparkAdapter.isHoodieTable(tableName, sparkSession) =>
-        AlterHoodieTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)
+          AlterHoodieTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)
       // Rewrite the AlterTableRenameCommand to AlterHoodieTableRenameCommand
       // Rewrite the AlterTableAddColumnsCommand to AlterHoodieTableAddColumnsCommand
       case AlterTableAddColumnsCommand(tableId, colsToAdd)
         if sparkAdapter.isHoodieTable(tableId, sparkSession) =>
-        AlterHoodieTableAddColumnsCommand(tableId, colsToAdd)
+          AlterHoodieTableAddColumnsCommand(tableId, colsToAdd)
       // Rewrite the AlterTableRenameCommand to AlterHoodieTableRenameCommand
       case AlterTableRenameCommand(oldName, newName, isView)
         if !isView && sparkAdapter.isHoodieTable(oldName, sparkSession) =>
-        AlterHoodieTableRenameCommand(oldName, newName, isView)
+          AlterHoodieTableRenameCommand(oldName, newName, isView)
       // Rewrite the AlterTableChangeColumnCommand to AlterHoodieTableChangeColumnCommand
       case AlterTableChangeColumnCommand(tableName, columnName, newColumn)
         if sparkAdapter.isHoodieTable(tableName, sparkSession) =>
-        AlterHoodieTableChangeColumnCommand(tableName, columnName, newColumn)
+          AlterHoodieTableChangeColumnCommand(tableName, columnName, newColumn)
       // SPARK-34238: the definition of ShowPartitionsCommand has been changed in Spark3.2.
       // Match the class type instead of call the `unapply` method.
       case s: ShowPartitionsCommand
         if sparkAdapter.isHoodieTable(s.tableName, sparkSession) =>
-        ShowHoodieTablePartitionsCommand(s.tableName, s.spec)
+          ShowHoodieTablePartitionsCommand(s.tableName, s.spec)
       // Rewrite TruncateTableCommand to TruncateHoodieTableCommand
       case TruncateTableCommand(tableName, partitionSpec)
         if sparkAdapter.isHoodieTable(tableName, sparkSession) =>

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -516,12 +516,6 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
         assert(queryArgs.contains(DataSourceReadOptions.QUERY_TYPE.key()), s"When using sql to query the hudi table, you must specify the 'hoodie.datasource.query.type' parameter")
         // Add a white list to the key to prevent users adding other parameters
         val KeyWhiteSet: HashSet[String] = HashSet(DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL
-          , DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL
-          , DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
-          , DataSourceReadOptions.INCREMENTAL_FORMAT_LATEST_STATE_VAL
-          , DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL
-          , DataSourceReadOptions.REALTIME_SKIP_MERGE_OPT_VAL
-          , DataSourceReadOptions.REALTIME_PAYLOAD_COMBINE_OPT_VAL
           , DataSourceReadOptions.INCREMENTAL_FORMAT.key()
           , DataSourceReadOptions.QUERY_TYPE.key()
           , DataSourceReadOptions.REALTIME_MERGE.key()
@@ -553,8 +547,6 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
           throw new AnalysisException(
             s"only support hudi read options,not support (${notAllowKey.toString()})")
         }
-
-
         val hoodieCatalogTable: HoodieCatalogTable = HoodieCatalogTable(sparkSession, tableIdentifier)
         val table: CatalogTable = hoodieCatalogTable.table
         val pathOption: Option[(String, String)] = table.storage.locationUri.map("path" -> CatalogUtils.URIToString(_))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -21,8 +21,9 @@ import org.apache.hudi.DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.util.ReflectionUtils
 import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils, SparkAdapterSupport}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
-import org.apache.spark.sql.catalyst.catalog.{CatalogUtils, HoodieCatalogTable}
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils, HoodieCatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, GenericInternalRow, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical._

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -512,7 +512,6 @@ case class HoodieResolveReferences(sparkSession: SparkSession) extends Rule[Logi
       val (plan: UnresolvedRelation, queryArgs) = sparkAdapter.getCatalystPlanUtils.getRelationTableArgument(rta).get
       val tableIdentifier: TableIdentifier = sparkAdapter.getCatalystPlanUtils.toTableIdentifier(plan)
       if (sparkAdapter.isHoodieTable(tableIdentifier, sparkSession) && queryArgs.nonEmpty) {
-        //
         assert(queryArgs.contains(DataSourceReadOptions.QUERY_TYPE.key()), s"When using sql to query the hudi table, you must specify the 'hoodie.datasource.query.type' parameter")
         // Add a white list to the key to prevent users adding other parameters
         val KeyWhiteSet: HashSet[String] = HashSet(DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
@@ -122,6 +122,18 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     assertResult(true)(hasException)
   }
 
+  protected def checkExceptionClass(sql: String)(clazz: Class[_ <: Throwable]): Unit = {
+    var hasException = false
+    try {
+      spark.sql(sql)
+    } catch {
+      case e: Throwable =>
+        assertResult(clazz)(e.getClass)
+        hasException = true
+    }
+    assertResult(true)(hasException)
+  }
+
   protected def checkException(sql: String)(errorMsg: String): Unit = {
     var hasException = false
     try {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestQueryTableWithArgs.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestQueryTableWithArgs.scala
@@ -346,9 +346,8 @@ class TestQueryTableWithArgs extends HoodieSparkSqlTestBase {
         )
 
         val sql = s"select id, name, price, ts from $tableName1 ['hoodie.datasource.query.type'=>'snapshot','hoodie.log.compaction.inline'=>'true']";
-        spark.sql(sql)
 
-        // checkExceptionContain()("mismatched input '[' expecting")
+        checkExceptionContain(sql)("only support hudi read options,not support (hoodie.log.compaction.inline)")
 
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestQueryTableWithArgs.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestQueryTableWithArgs.scala
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.spark.sql.execution.{ExtendedMode, SimpleMode}
+
+class TestQueryTableWithArgs extends HoodieSparkSqlTestBase {
+  test("Test query table with snapshot args") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        val tableName1 = generateTableName
+        println(HoodieSparkUtils.getSparkVersion)
+        spark.sql(
+          s"""
+             |create table $tableName1 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'cow',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName1'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName1 values(1, 'a1', 10, 1000)")
+
+        val metaClient1 = HoodieTableMetaClient.builder()
+          .setBasePath(s"${tmp.getCanonicalPath}/$tableName1")
+          .setConf(spark.sessionState.newHadoopConf())
+          .build()
+
+        val instant1 = metaClient1.getActiveTimeline.getAllCommitsTimeline
+          .lastInstant().get().getTimestamp
+
+        spark.sql(s"insert into $tableName1 values(1, 'a2', 20, 2000)")
+
+        checkAnswer(s"select id, name, price, ts from $tableName1")(
+          Seq(1, "a2", 20.0, 2000)
+        )
+
+        // time travel from instant1
+        // query plan like below
+        // == Parsed Logical Plan ==
+        // 'Project ['id, 'name, 'price, 'ts]
+        //+- 'TableArgumentRelation 'UnresolvedRelation [h0], [], false, [hoodie.datasource.query.type=snapshot, as.of.instant=$instant1]
+        val querySql =
+        s"select id, name, price, ts from $tableName1 ['hoodie.datasource.query.type'='snapshot','as.of.instant'='$instant1']"
+
+        checkAnswer(querySql)(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        checkAnswer(
+          s"select id, name, price, ts from $tableName1 TIMESTAMP AS OF '$instant1'")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+      }
+    }
+  }
+
+  test("Test query table with no query args") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        val tableName1 = generateTableName
+        println(HoodieSparkUtils.getSparkVersion)
+        spark.sql(
+          s"""
+             |create table $tableName1 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'cow',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName1'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName1 values(1, 'a1', 10, 1000)")
+
+        checkAnswer(
+          s"select id, name, price, ts from $tableName1")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        checkExceptionContain(s"select id, name, price, ts from $tableName1 []")("mismatched input '[' expecting")
+
+        val metaClient1 = HoodieTableMetaClient.builder()
+          .setBasePath(s"${tmp.getCanonicalPath}/$tableName1")
+          .setConf(spark.sessionState.newHadoopConf())
+          .build()
+
+        val instant1 = metaClient1.getActiveTimeline.getAllCommitsTimeline
+          .lastInstant().get().getTimestamp
+
+        spark.sql(s"insert into $tableName1 values(1, 'a2', 20, 2000)")
+
+        checkAnswer(s"select id, name, price, ts from $tableName1")(
+          Seq(1, "a2", 20.0, 2000)
+        )
+
+        // time travel from instant1
+        checkAnswer(
+          s"select id, name, price, ts from $tableName1 TIMESTAMP AS OF '$instant1'")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        // time travel from instant1 with empty table args
+        checkAnswer(
+          s"select id, name, price, ts from $tableName1 [] TIMESTAMP AS OF '$instant1'")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+      }
+    }
+  }
+
+  test("Test query table with query args and time travel") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        val tableName1 = generateTableName
+        println(HoodieSparkUtils.getSparkVersion)
+        spark.sql(
+          s"""
+             |create table $tableName1 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'cow',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName1'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName1 values(1, 'a1', 10, 1000)")
+
+        checkAnswer(
+          s"select id, name, price, ts from $tableName1")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        val metaClient1 = HoodieTableMetaClient.builder()
+          .setBasePath(s"${tmp.getCanonicalPath}/$tableName1")
+          .setConf(spark.sessionState.newHadoopConf())
+          .build()
+
+        val instant1 = metaClient1.getActiveTimeline.getAllCommitsTimeline
+          .lastInstant().get().getTimestamp
+
+        spark.sql(s"insert into $tableName1 values(1, 'a2', 20, 2000)")
+
+        checkAnswer(s"select id, name, price, ts from $tableName1")(
+          Seq(1, "a2", 20.0, 2000)
+        )
+
+        // time travel from instant1 with empty table args
+        checkAnswer(
+          s"select id, name, price, ts from $tableName1 [] TIMESTAMP AS OF '$instant1'")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        // time travel from instant1 with table args
+
+        val errorMsg = s"Only one table parameter ['hoodie.datasource.query.type'='snapshot','as.of.instant'='$instant1'] and snapshot query TIMESTAMPASOF'$instant1' can exist("
+
+        checkExceptionContain(
+          s"select id, name, price, ts from $tableName1 ['hoodie.datasource.query.type'='snapshot','as.of.instant'='$instant1'] TIMESTAMP AS OF '$instant1'")(errorMsg)
+      }
+    }
+  }
+
+
+  test("Test Insert Into Records with snapshot args To new Table") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        // Create Non-Partitioned table
+        val tableName1 = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName1 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'cow',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName1'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName1 values(1, 'a1', 10, 1000)")
+
+        val metaClient1 = HoodieTableMetaClient.builder()
+          .setBasePath(s"${tmp.getCanonicalPath}/$tableName1")
+          .setConf(spark.sessionState.newHadoopConf())
+          .build()
+
+        val instant1 = metaClient1.getActiveTimeline.getAllCommitsTimeline
+          .lastInstant().get().getTimestamp
+
+
+        val tableName2 = generateTableName
+        // Create a partitioned table
+        spark.sql(
+          s"""
+             |create table $tableName2 (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long,
+             |  dt string
+             |) using hudi
+             | tblproperties (primaryKey = 'id')
+             | partitioned by (dt)
+             | location '${tmp.getCanonicalPath}/$tableName2'
+       """.stripMargin)
+
+        // Insert into dynamic partition
+
+//        == Parsed Logical Plan ==
+//        'InsertIntoStatement 'UnresolvedRelation [h1], [], false, false, false
+//        +- 'Project ['id, 'name, 'price, 'ts, 2022-02-14 AS dt#43]
+//        +- 'TableArgumentRelation 'UnresolvedRelation [h0], [], false, [hoodie.datasource.query.type=snapshot, as.of.instant=20221109081017574]
+
+//        spark.sql(
+//          s"""
+//             | insert into $tableName2
+//             | select id, name, price, ts, '2022-02-14' as dt
+//             | from $tableName1 ['hoodie.datasource.query.type'='snapshot','as.of.instant'='$instant1']
+//        """.stripMargin).explain(ExtendedMode.name)
+
+
+        println("before read")
+        // Insert into static partition
+//        == Parsed Logical Plan ==
+//        'InsertIntoStatement 'UnresolvedRelation [h1], [], false, [dt=Some(2022-02-15)], false, false
+//        +- 'Project [2 AS id#88, a2 AS name#89, 'price, 'ts]
+//        +- 'UnresolvedRelation [h0], [], false
+
+        spark.sql(
+          s"""
+             | insert into $tableName2 partition (dt='2022-02-15')
+             |  select 2 as id, 'a2' as name, price, ts
+             |  from $tableName1 timestamp as of $instant1
+        """.stripMargin).explain(ExtendedMode.name)
+
+      }
+    }
+  }
+
+}

--- a/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/HoodieSpark2CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/HoodieSpark2CatalystPlanUtils.scala
@@ -88,4 +88,18 @@ object HoodieSpark2CatalystPlanUtils extends HoodieCatalystPlansUtils {
         Some((c.tableName, true, false, c.cmd))
     }
   }
+
+  /**
+   * if the logical plan is a TableArgumentRelation LogicalPlan.
+   */
+  override def isRelationTableArgument(plan: LogicalPlan): Boolean = {
+    false
+  }
+
+  /**
+   * Get the member of the TableArgumentRelation LogicalPlan.
+   */
+  override def getRelationTableArgument(plan: LogicalPlan): Option[(LogicalPlan, Map[String, String])]  = {
+    throw new IllegalStateException(s"Should not call getRelationTableArgument for spark2")
+  }
 }

--- a/hudi-spark-datasource/hudi-spark3.1.x/src/main/scala/org/apache/spark/sql/HoodieSpark31CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.1.x/src/main/scala/org/apache/spark/sql/HoodieSpark31CatalystPlanUtils.scala
@@ -47,4 +47,18 @@ object HoodieSpark31CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
         Some((c.tableName, true, false, c.cmd))
     }
   }
+
+  /**
+   * if the logical plan is a TableArgumentRelation LogicalPlan.
+   */
+  override def isRelationTableArgument(plan: LogicalPlan): Boolean = {
+    false
+  }
+
+  /**
+   * Get the member of the TableArgumentRelation LogicalPlan.
+   */
+  override def getRelationTableArgument(plan: LogicalPlan): Option[(LogicalPlan, Map[String, String])]  = {
+    throw new IllegalStateException(s"Should not call getRelationTableArgument for Spark <= 3.2.x")
+  }
 }

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
@@ -709,7 +709,7 @@ identifierComment
     ;
 
 relationPrimary
-    : multipartIdentifier tableArgumentList ? temporalClause?
+    : multipartIdentifier temporalClause?
       sample? tableAlias                      #tableName
     | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation
@@ -1042,7 +1042,7 @@ alterColumnAction
     ;
 
 tableArgumentList
-    : '(' (tableArgument (',' tableArgument)*)? ')'
+    : '[' (tableArgument (',' tableArgument)*)? ']'
     ;
 
 tableArgument

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
@@ -709,7 +709,7 @@ identifierComment
     ;
 
 relationPrimary
-    : multipartIdentifier temporalClause?
+    : multipartIdentifier tableArgumentList? temporalClause?
       sample? tableAlias                      #tableName
     | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
@@ -709,7 +709,7 @@ identifierComment
     ;
 
 relationPrimary
-    : multipartIdentifier ('(' (tableArgument (',' tableArgument)*)? ')') ? temporalClause?
+    : multipartIdentifier tableArgumentList ? temporalClause?
       sample? tableAlias                      #tableName
     | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation
@@ -1041,10 +1041,25 @@ alterColumnAction
     | setOrDrop=(SET | DROP) NOT NULL
     ;
 
+tableArgumentList
+    : '(' (tableArgument (',' tableArgument)*)? ')'
+    ;
+
 tableArgument
-   : identifier '=' constant    #namedArgument
+   : key=tableArgumentKey '=' value=tableArgumentValue
    ;
 
+tableArgumentKey
+    : identifier ('.' identifier)*
+    | STRING
+    ;
+
+tableArgumentValue
+    : INTEGER_VALUE
+    | DECIMAL_VALUE
+    | booleanValue
+    | STRING
+    ;
 // When `SQL_standard_keyword_behavior=true`, there are 2 kinds of keywords in Spark SQL.
 // - Reserved keywords:
 //     Keywords that are reserved and can't be used as identifiers for table, view, column,

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
@@ -1046,7 +1046,7 @@ tableArgumentList
     ;
 
 tableArgument
-   : key=tableArgumentKey '=' value=tableArgumentValue
+   : key=tableArgumentKey '=>' value=tableArgumentValue
    ;
 
 tableArgumentKey
@@ -1889,7 +1889,6 @@ IDENTIFIER
 BACKQUOTED_IDENTIFIER
     : '`' ( ~'`' | '``' )* '`'
     ;
-
 
 fragment DECIMAL_DIGITS
     : DIGIT+ '.' DIGIT*

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/antlr4/imports/SqlBase.g4
@@ -709,7 +709,7 @@ identifierComment
     ;
 
 relationPrimary
-    : multipartIdentifier temporalClause?
+    : multipartIdentifier ('(' (tableArgument (',' tableArgument)*)? ')') ? temporalClause?
       sample? tableAlias                      #tableName
     | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation
@@ -1040,6 +1040,10 @@ alterColumnAction
     | colPosition
     | setOrDrop=(SET | DROP) NOT NULL
     ;
+
+tableArgument
+   : identifier '=' constant    #namedArgument
+   ;
 
 // When `SQL_standard_keyword_behavior=true`, there are 2 kinds of keywords in Spark SQL.
 // - Reserved keywords:
@@ -1870,6 +1874,7 @@ IDENTIFIER
 BACKQUOTED_IDENTIFIER
     : '`' ( ~'`' | '``' )* '`'
     ;
+
 
 fragment DECIMAL_DIGITS
     : DIGIT+ '.' DIGIT*

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/HoodieSpark32CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/HoodieSpark32CatalystPlanUtils.scala
@@ -20,11 +20,11 @@ package org.apache.spark.sql
 
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
-
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Expression, ProjectionOverSchema}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TimeTravelRelation}
 import org.apache.spark.sql.execution.command.RepairTableCommand
+import org.apache.spark.sql.hudi.logical.TableArgumentRelation
 import org.apache.spark.sql.types.StructType
 
 object HoodieSpark32CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
@@ -66,6 +66,25 @@ object HoodieSpark32CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
     plan match {
       case rtc: RepairTableCommand =>
         Some((rtc.tableName, rtc.enableAddPartitions, rtc.enableDropPartitions, rtc.cmd))
+      case _ =>
+        None
+    }
+  }
+
+  /**
+   * if the logical plan is a TableArgumentRelation LogicalPlan.
+   */
+  override def isRelationTableArgument(plan: LogicalPlan): Boolean = {
+    plan.isInstanceOf[TableArgumentRelation]
+  }
+
+  /**
+   * Get the member of the TableArgumentRelation LogicalPlan.
+   */
+  override def getRelationTableArgument(plan: LogicalPlan): Option[(LogicalPlan, Map[String, String])] = {
+    plan match {
+      case tableArg: TableArgumentRelation =>
+        Some((tableArg.table, tableArg.args))
       case _ =>
         None
     }

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
@@ -80,27 +80,25 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   override def visitTableName(ctx: TableNameContext): LogicalPlan = withOrigin(ctx) {
     val tableId = visitMultipartIdentifier(ctx.multipartIdentifier())
     val relation = UnresolvedRelation(tableId)
+    val tableArgumentList = ctx.tableArgumentList()
+    val temporalClause = ctx.temporalClause()
 
-//    val tableArgumentList = ctx.tableArgumentList()
-//    val temporalClause = ctx.temporalClause()
-//    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0 && temporalClause != null) {
-//      throw new ParseException(
-//        s"Only one table parameter ${tableArgumentList.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
-//    }
-//    println(s"visitTableName table:${relation.tableName}  txt:${ctx.getText}")
-//
-//    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
-//      println(s"visitTableName table:${relation.tableName}  args:${tableArgumentList.tableArgument().get(0).getText}")
-//    }
-//    val table = if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
-//      mayApplyAliasPlan(
-//        ctx.tableAlias, relation.optionalMap(ctx.tableArgumentList())(withTableArgument))
-//    } else {
-//      mayApplyAliasPlan(
-//        ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
-//    }
-    val table =  mayApplyAliasPlan(
-          ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
+    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0 && temporalClause != null) {
+      throw new ParseException(
+        s"Only one table parameter ${tableArgumentList.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
+    }
+    println(s"visitTableName table:${relation.tableName}  txt:${ctx.getText}")
+
+    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
+      println(s"visitTableName table:${relation.tableName}  args:${tableArgumentList.tableArgument().get(0).getText}")
+    }
+    val table = if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
+      mayApplyAliasPlan(
+        ctx.tableAlias, relation.optionalMap(ctx.tableArgumentList())(withTableArgument))
+    } else {
+      mayApplyAliasPlan(
+        ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
+    }
     table.optionalMap(ctx.sample)(withSample)
   }
 

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
@@ -87,11 +87,6 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       throw new ParseException(
         s"Only one table parameter ${tableArgumentList.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
     }
-    println(s"visitTableName table:${relation.tableName}  txt:${ctx.getText}")
-
-    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
-      println(s"visitTableName table:${relation.tableName}  args:${tableArgumentList.tableArgument().get(0).getText}")
-    }
     val table = if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
       mayApplyAliasPlan(
         ctx.tableAlias, relation.optionalMap(ctx.tableArgumentList())(withTableArgument))
@@ -158,9 +153,6 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   // ============== The following code is fork from org.apache.spark.sql.catalyst.parser.AstBuilder
   override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {
-    println(s"visitSingleStatement : ${ctx.statement.getClass} ${ctx.statement().toStringTree}")
-    println(s"visitSingleStatement : ${ctx.statement.children.get(0).getClass} ${ctx.statement.children.get(0).getText}")
-
     visit(ctx.statement).asInstanceOf[LogicalPlan]
   }
 
@@ -391,7 +383,6 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val cols = Option(ctx.identifierList()).map(visitIdentifierList).getOrElse(Nil)
     val partitionKeys = Option(ctx.partitionSpec).map(visitPartitionSpec).getOrElse(Map.empty)
 
-    println(s"visitInsertIntoTable dt:$partitionKeys table:${ctx.multipartIdentifier().getText}")
     if (ctx.EXISTS != null) {
       operationNotAllowed("INSERT INTO ... IF NOT EXISTS", ctx)
     }

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
@@ -125,7 +125,7 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       key -> value
     })
     checkDuplicateKeys(argMap, ctx)
-    TableArgumentRelation(plan, argMap)
+    TableArgumentRelation(plan, argMap.toMap)
   }
 
 

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
@@ -79,6 +79,18 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   override def visitTableName(ctx: TableNameContext): LogicalPlan = withOrigin(ctx) {
     val tableId = visitMultipartIdentifier(ctx.multipartIdentifier())
     val relation = UnresolvedRelation(tableId)
+
+    val tableArgument = ctx.tableArgument()
+    val temporalClause = ctx.temporalClause()
+    if (tableArgument != null && temporalClause != null) {
+      throw new ParseException(
+        s"Only one table parameter ${tableArgument.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
+    }
+    if (tableArgument != null) {
+
+    }
+
+
     val table = mayApplyAliasPlan(
       ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
     table.optionalMap(ctx.sample)(withSample)

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
@@ -81,19 +81,26 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val tableId = visitMultipartIdentifier(ctx.multipartIdentifier())
     val relation = UnresolvedRelation(tableId)
 
-    val tableArgumentList = ctx.tableArgumentList()
-    val temporalClause = ctx.temporalClause()
-    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0 && temporalClause != null) {
-      throw new ParseException(
-        s"Only one table parameter ${tableArgumentList.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
-    }
-    val table = if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
-      mayApplyAliasPlan(
-        ctx.tableAlias, relation.optionalMap(ctx.tableArgumentList())(withTableArgument))
-    } else {
-      mayApplyAliasPlan(
-        ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
-    }
+//    val tableArgumentList = ctx.tableArgumentList()
+//    val temporalClause = ctx.temporalClause()
+//    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0 && temporalClause != null) {
+//      throw new ParseException(
+//        s"Only one table parameter ${tableArgumentList.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
+//    }
+//    println(s"visitTableName table:${relation.tableName}  txt:${ctx.getText}")
+//
+//    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
+//      println(s"visitTableName table:${relation.tableName}  args:${tableArgumentList.tableArgument().get(0).getText}")
+//    }
+//    val table = if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
+//      mayApplyAliasPlan(
+//        ctx.tableAlias, relation.optionalMap(ctx.tableArgumentList())(withTableArgument))
+//    } else {
+//      mayApplyAliasPlan(
+//        ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
+//    }
+    val table =  mayApplyAliasPlan(
+          ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
     table.optionalMap(ctx.sample)(withSample)
   }
 
@@ -153,6 +160,9 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   // ============== The following code is fork from org.apache.spark.sql.catalyst.parser.AstBuilder
   override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {
+    println(s"visitSingleStatement : ${ctx.statement.getClass} ${ctx.statement().toStringTree}")
+    println(s"visitSingleStatement : ${ctx.statement.children.get(0).getClass} ${ctx.statement.children.get(0).getText}")
+
     visit(ctx.statement).asInstanceOf[LogicalPlan]
   }
 
@@ -383,6 +393,7 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val cols = Option(ctx.identifierList()).map(visitIdentifierList).getOrElse(Nil)
     val partitionKeys = Option(ctx.partitionSpec).map(visitPartitionSpec).getOrElse(Map.empty)
 
+    println(s"visitInsertIntoTable dt:$partitionKeys table:${ctx.multipartIdentifier().getText}")
     if (ctx.EXISTS != null) {
       operationNotAllowed("INSERT INTO ... IF NOT EXISTS", ctx)
     }

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlAstBuilder.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform, Expression => V2Expression}
+import org.apache.spark.sql.hudi.logical.TableArgumentRelation
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -80,21 +81,53 @@ class HoodieSpark3_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val tableId = visitMultipartIdentifier(ctx.multipartIdentifier())
     val relation = UnresolvedRelation(tableId)
 
-    val tableArgument = ctx.tableArgument()
+    val tableArgumentList = ctx.tableArgumentList()
     val temporalClause = ctx.temporalClause()
-    if (tableArgument != null && temporalClause != null) {
+    if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0 && temporalClause != null) {
       throw new ParseException(
-        s"Only one table parameter ${tableArgument.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
+        s"Only one table parameter ${tableArgumentList.getText} and snapshot query ${temporalClause.getText} can exist", ctx)
     }
-    if (tableArgument != null) {
-
+    val table = if (tableArgumentList != null && tableArgumentList.tableArgument().size() > 0) {
+      mayApplyAliasPlan(
+        ctx.tableAlias, relation.optionalMap(ctx.tableArgumentList())(withTableArgument))
+    } else {
+      mayApplyAliasPlan(
+        ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
     }
-
-
-    val table = mayApplyAliasPlan(
-      ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
     table.optionalMap(ctx.sample)(withSample)
   }
+
+  override def visitTableArgumentKey(key: TableArgumentKeyContext): String = {
+    if (key.STRING != null) {
+      string(key.STRING)
+    } else {
+      key.getText
+    }
+  }
+
+  override def visitTableArgumentValue(value: TableArgumentValueContext): String = {
+    if (value == null) {
+      null
+    } else if (value.STRING != null) {
+      string(value.STRING)
+    } else if (value.booleanValue != null) {
+      value.getText.toLowerCase(Locale.ROOT)
+    } else {
+      value.getText
+    }
+  }
+
+  private def withTableArgument(ctx: TableArgumentListContext, plan: LogicalPlan) = withOrigin(ctx) {
+    val args = ctx.tableArgument()
+    val argMap = args.asScala.map(arg => {
+      val key = visitTableArgumentKey(arg.key)
+      val value = visitTableArgumentValue(arg.value)
+      key -> value
+    })
+    checkDuplicateKeys(argMap, ctx)
+    TableArgumentRelation(plan, argMap)
+  }
+
 
   private def withTimeTravel(
                               ctx: TemporalClauseContext, plan: LogicalPlan): LogicalPlan = withOrigin(ctx) {

--- a/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_2ExtendedSqlParser.scala
@@ -46,8 +46,7 @@ class HoodieSpark3_2ExtendedSqlParser(session: SparkSession, delegate: ParserInt
     val substitutionSql = substitutor.substitute(sqlText)
     if (isHoodieCommand(substitutionSql)) {
       parse(substitutionSql) { parser =>
-        val res: AnyRef = builder.visit(parser.singleStatement())
-        res match {
+        builder.visit(parser.singleStatement()) match {
           case plan: LogicalPlan => plan
           case _ => delegate.parsePlan(sqlText)
         }
@@ -124,7 +123,6 @@ class HoodieSpark3_2ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("system_version as of") ||
       normalized.contains("version as of") ||
       normalized.contains("hoodie.datasource.query.type")
-
   }
 }
 
@@ -133,17 +131,11 @@ class HoodieSpark3_2ExtendedSqlParser(session: SparkSession, delegate: ParserInt
  */
 class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
   override def consume(): Unit = wrapped.consume
-
   override def getSourceName(): String = wrapped.getSourceName
-
   override def index(): Int = wrapped.index
-
   override def mark(): Int = wrapped.mark
-
   override def release(marker: Int): Unit = wrapped.release(marker)
-
   override def seek(where: Int): Unit = wrapped.seek(where)
-
   override def size(): Int = wrapped.size
 
   override def getText(interval: Interval): String = {
@@ -158,7 +150,6 @@ class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
       ""
     }
   }
-
   // scalastyle:off
   override def LA(i: Int): Int = {
     // scalastyle:on

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/logical/TableArgumentRelation.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/logical/TableArgumentRelation.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.hudi.logical
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.{ Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 
 case class TableArgumentRelation(
-                               table: LogicalPlan,
-                               args: Seq[String]) extends Command {
+                                  table: LogicalPlan,
+                                  args: Map[String, String]) extends Command {
   override def children: Seq[LogicalPlan] = Seq.empty
 
   override def output: Seq[Attribute] = Nil

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/logical/TableArgumentRelation.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/logical/TableArgumentRelation.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{ Command, LogicalPlan}
+
+case class TableArgumentRelation(
+                               table: LogicalPlan,
+                               args: Seq[String]) extends Command {
+  override def children: Seq[LogicalPlan] = Seq.empty
+
+  override def output: Seq[Attribute] = Nil
+
+  override lazy val resolved: Boolean = false
+
+  def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = this
+}

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/antlr4/imports/SqlBase.g4
@@ -1041,11 +1041,11 @@ alterColumnAction
     | setOrDrop=(SET | DROP) NOT NULL
     ;
 tableArgumentList
-    : '(' (tableArgument (',' tableArgument)*)? ')'
+    : '[' (tableArgument (',' tableArgument)*)? ']'
     ;
 
 tableArgument
-   : key=tableArgumentKey '=' value=tableArgumentValue
+   : key=tableArgumentKey '=>' value=tableArgumentValue
    ;
 
 tableArgumentKey

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/antlr4/imports/SqlBase.g4
@@ -709,7 +709,7 @@ identifierComment
     ;
 
 relationPrimary
-    : multipartIdentifier temporalClause?
+    : multipartIdentifier tableArgumentList? temporalClause?
       sample? tableAlias                      #tableName
     | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation
@@ -1039,6 +1039,25 @@ alterColumnAction
     | commentSpec
     | colPosition
     | setOrDrop=(SET | DROP) NOT NULL
+    ;
+tableArgumentList
+    : '(' (tableArgument (',' tableArgument)*)? ')'
+    ;
+
+tableArgument
+   : key=tableArgumentKey '=' value=tableArgumentValue
+   ;
+
+tableArgumentKey
+    : identifier ('.' identifier)*
+    | STRING
+    ;
+
+tableArgumentValue
+    : INTEGER_VALUE
+    | DECIMAL_VALUE
+    | booleanValue
+    | STRING
     ;
 
 // When `SQL_standard_keyword_behavior=true`, there are 2 kinds of keywords in Spark SQL.

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/HoodieSpark33CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/HoodieSpark33CatalystPlanUtils.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Expression, ProjectionOverSchema}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TimeTravelRelation}
 import org.apache.spark.sql.execution.command.RepairTableCommand
+import org.apache.spark.sql.hudi.logical.TableArgumentRelation
 import org.apache.spark.sql.types.StructType
 
 object HoodieSpark33CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
@@ -50,6 +51,25 @@ object HoodieSpark33CatalystPlanUtils extends HoodieSpark3CatalystPlanUtils {
     plan match {
       case rtc: RepairTableCommand =>
         Some((rtc.tableName, rtc.enableAddPartitions, rtc.enableDropPartitions, rtc.cmd))
+      case _ =>
+        None
+    }
+  }
+
+  /**
+   * if the logical plan is a TableArgumentRelation LogicalPlan.
+   */
+  override def isRelationTableArgument(plan: LogicalPlan): Boolean = {
+    plan.isInstanceOf[TableArgumentRelation]
+  }
+
+  /**
+   * Get the member of the TableArgumentRelation LogicalPlan.
+   */
+  override def getRelationTableArgument(plan: LogicalPlan): Option[(LogicalPlan, Map[String, String])] = {
+    plan match {
+      case tableArg: TableArgumentRelation =>
+        Some((tableArg.table, tableArg.args))
       case _ =>
         None
     }

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlParser.scala
@@ -125,7 +125,8 @@ class HoodieSpark3_3ExtendedSqlParser(session: SparkSession, delegate: ParserInt
     normalized.contains("system_time as of") ||
       normalized.contains("timestamp as of") ||
       normalized.contains("system_version as of") ||
-      normalized.contains("version as of")
+      normalized.contains("version as of") ||
+      normalized.contains("hoodie.datasource.query.type")
   }
 }
 


### PR DESCRIPTION
### Change Logs

For spark with version greater than 3.2+, the query of hudi table using spark sql supports reading parameter configuration.

on this pr,when can query hudi table

```sql
// query snapshot table
select id, name, price, ts from $tableName1 ['hoodie.datasource.query.type'=>'snapshot','as.of.instant'=>'$instant1'] 
// query incremental table
select id, name, price, ts from $tableName1
   |[
   |'hoodie.datasource.query.type'=>'incremental',
   |'hoodie.datasource.read.begin.instanttime'=>'$instant1',
   |'hoodie.datasource.read.end.instanttime'=>'$instant2'
   |]
// query read_optimized table
select id, name, price, ts from $tableName1 ['hoodie.datasource.query.type'=>'read_optimized']
```

### Impact

spark sql query.

### Risk level (write none, low medium or high below)

low 
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_



### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
