### PR TITLE
[HUDI-4142] Claim RFC-64 for table spec APIs

### DIFF
--- a/rfc/README.md
+++ b/rfc/README.md
@@ -100,3 +100,4 @@ The list of all RFCs can be found here.
 | 61 | [Snapshot view management](./rfc-61/rfc-61.md)                                                                                                                                                                       | `UNDER REVIEW` |
 | 62 | [Diagnostic Reporter](./rfc-62/rfc-62.md)                                                                                                                                                                       | `UNDER REVIEW` |
 | 63 | [Index on Function and Logical Partitioning](./rfc-63/rfc-63.md)                                                                                                                                                     | `UNDER REVIEW` |
+| 64 | [New Hudi Table Spec API for Query Integrations](./rfc-64/rfc-64.md) | `UNDER REVIEW` |


### PR DESCRIPTION
### Change Logs

This PR claims a new entry, RFC-64, for Table format APIs for query engine integrations.

### Impact

Only RFC list update.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
