### PR TITLE
[HUDI-4967] Improve docs for meta sync with TimestampBasedKeyGenerator

### DIFF
--- a/website/docs/key_generation.md
+++ b/website/docs/key_generation.md
@@ -23,13 +23,14 @@ is the interface for KeyGenerator in Hudi for your reference.
 Before diving into different types of key generators, let’s go over some of the common configs required to be set for
 key generators.
 
-| Config        | Meaning/purpose|        
-| ------------- |:-------------:| 
-| ```hoodie.datasource.write.recordkey.field```     | Refers to record key field. This is a mandatory field. | 
-| ```hoodie.datasource.write.partitionpath.field```     | Refers to partition path field. This is a mandatory field. | 
-| ```hoodie.datasource.write.keygenerator.class``` | Refers to Key generator class(including full path). Could refer to any of the available ones or user defined one. This is a mandatory field. | 
-| ```hoodie.datasource.write.partitionpath.urlencode```| When set to true, partition path will be url encoded. Default value is false. |
-| ```hoodie.datasource.write.hive_style_partitioning```| When set to true, uses hive style partitioning. Partition field name will be prefixed to the value. Format: “<partition_path_field_name>=<partition_path_value>”. Default value is false.|
+| Config        |                                                                                                                                                  Meaning/purpose                                                                                                                                                   |        
+| ------------- |:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:| 
+| ```hoodie.datasource.write.recordkey.field```     |                                                                                                                               Refers to record key field. This is a mandatory field.                                                                                                                               | 
+| ```hoodie.datasource.write.partitionpath.field```     |                                                                                                                             Refers to partition path field. This is a mandatory field.                                                                                                                             | 
+| ```hoodie.datasource.write.keygenerator.class``` |                                                                                    Refers to Key generator class(including full path). Could refer to any of the available ones or user defined one. This is a mandatory field.                                                                                    | 
+| ```hoodie.datasource.write.partitionpath.urlencode```|                                                                                                                   When set to true, partition path will be url encoded. Default value is false.                                                                                                                    |
+| ```hoodie.datasource.write.hive_style_partitioning```|                                                             When set to true, uses hive style partitioning. Partition field name will be prefixed to the value. Format: “<partition_path_field_name>=<partition_path_value>”. Default value is false.                                                              |
+| ```hoodie.datasource.hive_sync.partition_value_extractor```|                 This config is used to extract and transform partition value during Hive sync. Its default is MultiPartKeysValueExtractor. If you relied on the default vaule before 0.12.2, you are required to set the config to ```org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor```                  |
 
 There are few more configs involved if you are looking for TimestampBasedKeyGenerator. Will cover those in the respective section.
 
@@ -104,12 +105,12 @@ field name.  Users are expected to set few more configs to use this KeyGenerator
 
 Configs to be set:
 
-| Config        | Meaning/purpose |       
-| ------------- | -------------|
+| Config                                                        | Meaning/purpose |       
+|---------------------------------------------------------------| -------------|
 | ```hoodie.deltastreamer.keygen.timebased.timestamp.type```    | One of the timestamp types supported(UNIX_TIMESTAMP, DATE_STRING, MIXED, EPOCHMILLISECONDS, SCALAR) |
-| ```hoodie.deltastreamer.keygen.timebased.output.dateformat```| Output date format | 
-| ```hoodie.deltastreamer.keygen.timebased.timezone```| Timezone of the data format| 
-| ```oodie.deltastreamer.keygen.timebased.input.dateformat```| Input date format |
+| ```hoodie.deltastreamer.keygen.timebased.output.dateformat``` | Output date format | 
+| ```hoodie.deltastreamer.keygen.timebased.timezone```          | Timezone of the data format| 
+| ```hoodie.deltastreamer.keygen.timebased.input.dateformat```  | Input date format |
 
 Let's go over some example values for TimestampBasedKeyGenerator.
 

--- a/website/versioned_docs/version-0.12.0/key_generation.md
+++ b/website/versioned_docs/version-0.12.0/key_generation.md
@@ -111,6 +111,8 @@ Configs to be set:
 | ```hoodie.deltastreamer.keygen.timebased.timezone```| Timezone of the data format| 
 | ```oodie.deltastreamer.keygen.timebased.input.dateformat```| Input date format |
 
+```hoodie.datasource.write.hive_style_partitioning``` must be set to true if your output date format contains ```/``` character.
+
 Let's go over some example values for TimestampBasedKeyGenerator.
 
 #### Timestamp is GMT

--- a/website/versioned_docs/version-0.12.1/key_generation.md
+++ b/website/versioned_docs/version-0.12.1/key_generation.md
@@ -111,6 +111,8 @@ Configs to be set:
 | ```hoodie.deltastreamer.keygen.timebased.timezone```| Timezone of the data format| 
 | ```oodie.deltastreamer.keygen.timebased.input.dateformat```| Input date format |
 
+```hoodie.datasource.write.hive_style_partitioning``` must be set to true if your output date format contains ```/``` character.
+
 Let's go over some example values for TimestampBasedKeyGenerator.
 
 #### Timestamp is GMT


### PR DESCRIPTION
### Change Logs

Added the config for the partition extractor to the current site. 
Added the explanation that hive_style_partitioning must be set to true if you want to have \\ in your output date format in 012.0 an 0.12.1 docs

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
