### PR TITLE
[HUDI-5159]Add support to write success file to partition when it finished in flink streaming append write

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.configuration;
 
+import org.apache.flink.configuration.description.Description;
 import org.apache.hudi.client.clustering.plan.strategy.FlinkSizeBasedClusteringPlanStrategy;
 import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
@@ -40,12 +41,15 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.text;
 import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
 import static org.apache.hudi.config.HoodieClusteringConfig.DAYBASED_LOOKBACK_PARTITIONS;
 import static org.apache.hudi.config.HoodieClusteringConfig.PARTITION_FILTER_BEGIN_PARTITION;
@@ -843,6 +847,48 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .noDefaultValue()
       .withDescription("The hive configuration directory, where the hive-site.xml lies in, the file should be put on the client machine");
+
+  public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN = ConfigOptions
+          .key("partition.time-extractor.timestamp-pattern")
+          .stringType()
+          .noDefaultValue()
+          .withDescription(
+                  "The 'default' construction way allows users to use partition"
+                          + " fields to get a legal timestamp pattern."
+                          + " Default support 'yyyy-mm-dd hh:mm:ss' from first field."
+                          + " If timestamp in partition is single field 'dt', can configure: '$dt'."
+                          + " If timestamp in partition is year, month, day, hour,"
+                          + " can configure: '$year-$month-$day $hour:00:00'."
+                          + " If timestamp in partition is dt and hour, can configure: '$dt $hour:00:00'.");
+
+  public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER =
+          key("partition.time-extractor.timestamp-formatter")
+                  .stringType()
+                  .noDefaultValue()
+                  .withDescription(
+                          Description.builder()
+                                  .text("The formatter to format timestamp from string, it can be used with 'partition.time-extractor.timestamp-pattern', "
+                                          + "creates a formatter using the specified value. "
+                                          + "Supports multiple partition fields like '$year-$month-$day $hour:00:00'.")
+                                  .list(text("The timestamp-formatter is compatible with "
+                                          + "Java's DateTimeFormatter."))
+                                  .build());
+
+
+  public static final ConfigOption<Duration> PARTITION_WRITE_SUCCESS_FILE_DELAY = ConfigOptions
+          .key("partition.write-success-file.delay")
+          .durationType()
+          .defaultValue(Duration.ofMillis(0))
+          .withDescription("The success file should be write to partition path until the delay time."
+                  + " if it is a day partition, should be '1 d',"
+                  + " if it is a hour partition, should be '1 h'");
+
+
+  public static final ConfigOption<Boolean> PARTITION_WRITE_SUCCESS_FILE_ENABLE = ConfigOptions
+          .key("partition.write-success-file.enable")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("whether enable write success file to finished partition. true for enable, false for disable");
 
   // -------------------------------------------------------------------------
   //  Utilities

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -226,4 +226,11 @@ public class OptionsResolver {
     }
     return options;
   }
+
+  /**
+   * Returns whether enable to write success file to finished partition.
+   */
+  public static boolean isPartitionSuccessFileWriteEnable(Configuration conf) {
+    return conf.get(FlinkOptions.PARTITION_WRITE_SUCCESS_FILE_ENABLE);
+  }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -83,7 +83,13 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     if (this.writerHelper == null) {
       initWriterHelper();
     }
-    this.writerHelper.write((RowData) value);
+    RowData rowValue = (RowData) value;
+    // Get partition path from the record, and emit it to next operator.
+    String partitionPath = this.writerHelper.getPartitionPath(rowValue);
+    if (partitionPath != null) {
+      out.collect(partitionPath);
+    }
+    this.writerHelper.write(rowValue);
   }
 
   /**
@@ -141,4 +147,5 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     // blocks flushing until the coordinator starts a new instant
     this.confirming = true;
   }
+
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -212,5 +212,17 @@ public class BulkInsertWriterHelper {
     writeStatus.setTotalErrorRecords(internalWriteStatus.getTotalErrorRecords());
     return writeStatus;
   }
+
+  /**
+   * Get partition path from the record.
+   * @param record
+   * @return
+   */
+  public String getPartitionPath(RowData record) {
+    if (keyGen == null) {
+      return null;
+    }
+    return keyGen.getPartitionPath(record);
+  }
 }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -18,6 +18,17 @@
 
 package org.apache.hudi.sink.utils;
 
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.util.Preconditions;
+import org.apache.hudi.adapter.PartitionTimeExtractorAdapter;
 import org.apache.hudi.common.model.ClusteringOperation;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -47,6 +58,7 @@ import org.apache.hudi.sink.compact.CompactionPlanOperator;
 import org.apache.hudi.sink.partitioner.BucketAssignFunction;
 import org.apache.hudi.sink.partitioner.BucketIndexPartitioner;
 import org.apache.hudi.sink.transform.RowDataToHoodieFunctions;
+import org.apache.hudi.sync.common.model.PartitionValueExtractor;
 import org.apache.hudi.table.format.FilePathUtils;
 
 import org.apache.flink.api.common.functions.Partitioner;
@@ -62,9 +74,20 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -450,4 +473,159 @@ public class Pipelines {
     private static final long serialVersionUID = 1L;
     public static DummySink INSTANCE = new DummySink();
   }
+
+  public static DataStreamSink<Object> successFileSink(DataStream<Object> dataStream, Configuration conf) {
+    return dataStream.addSink(new PartitionSuccessFileWriteSink(conf))
+            .setParallelism(1)
+            .name("success_file_sink");
+  }
+
+  /**
+   * Sink that write a success file to partition path when it write finished.
+   **/
+  public static class PartitionSuccessFileWriteSink extends RichSinkFunction<Object> implements CheckpointedFunction, CheckpointListener {
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(PartitionSuccessFileWriteSink.class);
+    // Success file name.
+    private static final String SUCCESS_FILE_NAME = "_SUCCESS";
+    // The name of active partitions state.
+    private static final String ACTIVE_PARTITION_STATE_NAME = "active-partition-state";
+    // The name of finished partition state.
+    private static final String FINISHED_PARTITION_STATE_NAME = "finished-partition-state";
+    // The global configuration of flink job.
+    private Configuration conf;
+    // The configured file system handle.
+    private FileSystem fileSystem;
+    // The extractor for partition time.
+    private PartitionTimeExtractorAdapter partitionTimeExtractor;
+    // The extractor for extract partition value from partition path.
+    private PartitionValueExtractor partitionValueExtractor;
+    // The table base path.
+    private String tablePath;
+    // The partition keys.
+    private List<String> partitionKeys;
+    // The partitions on writing currently.
+    private Set<String> activePartitions;
+    // The partitions write finished.
+    private Set<String> finishedPartitions;
+    // The operator state to store active partitions.
+    private ListState<String> activePartitionsState;
+    // The operator state to store finished partitions.
+    private ListState<String> finishedPartitionsState;
+    // The configured time delay to write success file.
+    private Duration partitionSuccessFileDelay;
+    // The checkpoint lock
+    private Object checkpointLock;
+
+    PartitionSuccessFileWriteSink(Configuration conf) {
+      this.conf = conf;
+    }
+
+    @Override
+    public void open(Configuration config) throws Exception {
+      activePartitions = new TreeSet<>();
+      finishedPartitions = new TreeSet<>();
+      tablePath = conf.get(FlinkOptions.PATH);
+      fileSystem = FileSystem.get(URI.create(tablePath));
+      checkpointLock = new Object();
+      String[] partitionFields = conf.get(FlinkOptions.PARTITION_PATH_FIELD).split(",");
+      partitionKeys = Arrays.asList(partitionFields);
+      partitionSuccessFileDelay = conf.get(FlinkOptions.PARTITION_WRITE_SUCCESS_FILE_DELAY);
+      String partitionValueExtractorClzName = conf.get(FlinkOptions.HIVE_SYNC_PARTITION_EXTRACTOR_CLASS_NAME);
+      String partitionTimestampExtractPattern = conf.get(FlinkOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN);
+      String partitionTimestampFormatPattern = conf.get(FlinkOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER);
+      try {
+        Class<?> partitionValueExtractorClz = Class.forName(partitionValueExtractorClzName);
+        partitionValueExtractor = (PartitionValueExtractor) partitionValueExtractorClz.newInstance();
+      } catch (ClassNotFoundException e) {
+        LOG.error("class not found for: {}", partitionValueExtractorClzName, e);
+        throw e;
+      }
+      partitionTimeExtractor = new PartitionTimeExtractorAdapter(partitionTimestampExtractPattern, partitionTimestampFormatPattern);
+    }
+
+    // Extract the partition time value from partition path, and convert them to timestamp.
+    private Long convertTimestampByPartitionPath(String partitionPath) {
+      List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partitionPath);
+      LocalDateTime localDateTime = partitionTimeExtractor.extract(partitionKeys, partitionValues);
+      return PartitionTimeExtractorAdapter.toMills(localDateTime);
+    }
+
+    @Override
+    public void invoke(Object value, SinkFunction.Context context) throws Exception {
+      String partition = (String) value;
+      activePartitions.add(partition);
+      long watermark = context.currentWatermark();
+      Iterator<String> it = activePartitions.iterator();
+      while (it.hasNext()) {
+        String partitionPath = it.next();
+        // Convert the partition path to timestamp if the table is partitioned by time field, like day, hour
+        Long partitionTimestamp = convertTimestampByPartitionPath(partitionPath);
+        // If the watermark is greater than the partition timestamp plus the delay time, it represents the
+        // minimum timestamp in the streaming data is beyond the partition max timestamp, so add the partition
+        // path to the finished partitions set and remove it from active partitions set.
+        if (partitionTimestamp + partitionSuccessFileDelay.toMillis() < watermark) {
+          synchronized (checkpointLock) {
+            finishedPartitions.add(partitionPath);
+            it.remove();
+          }
+        }
+      }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
+      synchronized (checkpointLock) {
+        // Save the partition path of active & finished partition path to state.
+        Preconditions.checkNotNull(activePartitions);
+        Preconditions.checkNotNull(finishedPartitions);
+        activePartitionsState.update(new ArrayList<>(activePartitions));
+        finishedPartitionsState.update(new ArrayList<>(finishedPartitions));
+      }
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+      ListStateDescriptor<String> activePartitionStateDesc =
+              new ListStateDescriptor<>(ACTIVE_PARTITION_STATE_NAME, String.class);
+      activePartitionsState = context.getOperatorStateStore().getListState(activePartitionStateDesc);
+      ListStateDescriptor<String> finishedPartitionStateDesc =
+              new ListStateDescriptor<>(FINISHED_PARTITION_STATE_NAME, String.class);
+      finishedPartitionsState = context.getOperatorStateStore().getListState(finishedPartitionStateDesc);
+      if (context.isRestored()) {
+        activePartitions = new TreeSet<>();
+        finishedPartitions = new TreeSet<>();
+        for (String p : activePartitionsState.get()) {
+          activePartitions.add(p);
+        }
+        for (String p : finishedPartitionsState.get()) {
+          finishedPartitions.add(p);
+        }
+      } else {
+        activePartitions = new TreeSet<>();
+        finishedPartitions = new TreeSet<>();
+      }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long l) throws Exception {
+      Iterator<String> it = finishedPartitions.iterator();
+      //Iterate the finished partitions set, and write success file to the path of partition.
+      synchronized (checkpointLock) {
+        while (it.hasNext()) {
+          String partitionPath = it.next();
+          partitionPath = tablePath + "/" + partitionPath;
+          fileSystem.create(new Path(partitionPath, SUCCESS_FILE_NAME), FileSystem.WriteMode.OVERWRITE).close();
+          LOG.info("Write success file to partition {}", partitionPath);
+          it.remove();
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      LOG.info("close partition success file write sink.");
+    }
+  }
+
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSink.java
@@ -84,7 +84,13 @@ public class HoodieTableSink implements DynamicTableSink, SupportsPartitioning, 
         if (OptionsResolver.needsAsyncClustering(conf)) {
           return Pipelines.cluster(conf, rowType, pipeline);
         } else {
-          return Pipelines.dummySink(pipeline);
+          // If the partition success file sink enabled, add a success file sink as next operator,
+          // else add a dummy sink.
+          if (OptionsResolver.isPartitionSuccessFileWriteEnable(conf)) {
+            return Pipelines.successFileSink(pipeline, conf);
+          } else {
+            return Pipelines.dummySink(pipeline);
+          }
         }
       }
 

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/adapter/PartitionTimeExtractorAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/adapter/PartitionTimeExtractorAdapter.java
@@ -1,0 +1,15 @@
+package org.apache.hudi.adapter;
+
+import com.google.inject.internal.util.$Nullable;
+import org.apache.flink.table.filesystem.DefaultPartTimeExtractor;
+
+import javax.annotation.Nullable;
+
+/**
+ * Bridge class for flink partition time extractor {@code PartitionTimeExtractor}.
+ */
+public class PartitionTimeExtractorAdapter extends DefaultPartTimeExtractor {
+  public PartitionTimeExtractorAdapter(@Nullable String extractPattern, @$Nullable String formatPattern) {
+    super(extractPattern);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/adapter/PartitionTimeExtractorAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/adapter/PartitionTimeExtractorAdapter.java
@@ -1,0 +1,15 @@
+package org.apache.hudi.adapter;
+
+import com.google.inject.internal.util.$Nullable;
+import org.apache.flink.table.filesystem.DefaultPartTimeExtractor;
+
+import javax.annotation.Nullable;
+
+/**
+ * Bridge class for flink partition time extractor {@code PartitionTimeExtractor}.
+ */
+public class PartitionTimeExtractorAdapter extends DefaultPartTimeExtractor {
+  public PartitionTimeExtractorAdapter(@Nullable String extractPattern, @$Nullable String formatPattern) {
+    super(extractPattern);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.15.x/pom.xml
+++ b/hudi-flink-datasource/hudi-flink1.15.x/pom.xml
@@ -114,6 +114,12 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-files</artifactId>
+            <version>${flink1.15.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/adapter/PartitionTimeExtractorAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/adapter/PartitionTimeExtractorAdapter.java
@@ -1,0 +1,15 @@
+package org.apache.hudi.adapter;
+
+import org.apache.flink.connector.file.table.DefaultPartTimeExtractor;
+
+import javax.annotation.Nullable;
+
+/**
+ * Bridge class for flink partition time extractor {@code PartitionTimeExtractor}.
+ */
+public class PartitionTimeExtractorAdapter extends DefaultPartTimeExtractor {
+  public PartitionTimeExtractorAdapter(@Nullable String extractorPattern, @Nullable String formatterPattern) {
+    super(extractorPattern, formatterPattern);
+  }
+
+}


### PR DESCRIPTION
…eaming append write

### Change Logs
Add support for write success file to a finished partition in flink streaming append write:
1. add a PartitionSuccessFileWriteSink class which aimed at to write succe file to partition;
2. add  flink options
 `partition.write-success-file.enable` to switch whether enable this feature in flink job；
 `partition.write-success-file.delay` the delay of write success file;
 `partition.time-extractor.timestamp-formatter`  timestamp format used to extract timestamp from partition path;
``
3.  change `HoodieTableSink` class, support to extract partition path from streaming record, and emit to extract.
4. 

### Impact
Used in flink sql job consume from mq and write into hudi, if you want to use this feature, set the options as below in hudi sink table ddl
```
create table test_out(
id  bigint,
data string,
  `day` string,
  `hour` string
) partitioned by (`day`, `hour`)
with (
 'connector' = 'hudi',
 'partition.time-extractor.timestamp-pattern' = '$day $hour:00:00',
 'partition.write-success-file.delay' = '1h',   -- if the table partitioned by hour, set the delay 1h; if the table partitioned by day, set the delay 1day;
 'partition.write-success-file.enable' = 'true',
 'table.type' = 'COPY_ON_WRITE',
 'write.operation' = 'insert',
 'write.tasks' = '5',
 'write.insert.cluster' = 'false',
 'metadata.enabled' = 'true',
 'path' = 'hdfs://testcluster/user/test/hudi/test_out14',
);
```

### Risk level (write none, low medium or high below)

LOW

### Documentation Update

