### PR TITLE
[HUDI-5203] Handle null fields in debezium avro payloads

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -58,18 +59,20 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
     super(record);
   }
 
-  private Long extractLSN(IndexedRecord record) {
-    GenericRecord genericRecord = (GenericRecord) record;
-    return (Long) genericRecord.get(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+  private Option<Long> extractLSN(IndexedRecord record) {
+    Object value = ((GenericRecord) record).get(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    return Option.ofNullable(value != null ? (Long) value : null);
   }
 
   @Override
   protected boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException {
-    Long currentSourceLSN = extractLSN(currentRecord);
-    Long insertSourceLSN = extractLSN(insertRecord);
-
+    Long insertSourceLSN = extractLSN(insertRecord)
+        .orElseThrow(() ->
+            new HoodieDebeziumAvroPayloadException(String.format("%s cannot be null in insert record: %s",
+                DebeziumConstants.FLATTENED_LSN_COL_NAME, insertRecord)));
+    Option<Long> currentSourceLSNOpt = extractLSN(currentRecord);
     // Pick the current value in storage only if its LSN is latest compared to the LSN of the insert value
-    return insertSourceLSN < currentSourceLSN;
+    return currentSourceLSNOpt.isPresent() && insertSourceLSN < currentSourceLSNOpt.get();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieDebeziumAvroPayloadException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieDebeziumAvroPayloadException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.exception;
+
+import java.io.IOException;
+
+public class HoodieDebeziumAvroPayloadException extends IOException {
+
+  public HoodieDebeziumAvroPayloadException(String msg) {
+    super(msg);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -27,11 +28,15 @@ import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestMySqlDebeziumAvroPayload {
 
@@ -43,8 +48,10 @@ public class TestMySqlDebeziumAvroPayload {
   void setUp() {
     this.avroSchema = Schema.createRecord(Arrays.asList(
         new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
-        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME, Schema.create(Schema.Type.STRING), "", null),
-        new Schema.Field(DebeziumConstants.ADDED_SEQ_COL_NAME, Schema.create(Schema.Type.STRING), "", null)
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(DebeziumConstants.ADDED_SEQ_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null)
     ));
   }
 
@@ -102,10 +109,31 @@ public class TestMySqlDebeziumAvroPayload {
     validateRecord(mergedRecord, 2, Operation.UPDATE, "00001.111");
   }
 
-  private GenericRecord createRecord(int primaryKeyValue, Operation op, String seqValue) {
+  @Test
+  public void testMergeWithBootstrappedExistingRecords() throws IOException {
+    GenericRecord incomingRecord = createRecord(3, Operation.UPDATE, "00002.111");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incomingRecord, "00002.111");
+
+    GenericRecord existingRecord = createRecord(3, null, null);
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
+    validateRecord(mergedRecord, 3, Operation.UPDATE, "00002.111");
+  }
+
+  @Test
+  public void testInvalidIncomingRecord() {
+    GenericRecord incomingRecord = createRecord(4, null, null);
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incomingRecord, "00002.111");
+
+    GenericRecord existingRecord = createRecord(4, Operation.INSERT, "00001.111");
+    assertThrows(HoodieDebeziumAvroPayloadException.class,
+        () -> payload.combineAndGetUpdateValue(existingRecord, avroSchema),
+        "should have thrown because event seq value of the incoming record is null");
+  }
+
+  private GenericRecord createRecord(int primaryKeyValue, @Nullable Operation op, @Nullable String seqValue) {
     GenericRecord record = new GenericData.Record(avroSchema);
     record.put(KEY_FIELD_NAME, primaryKeyValue);
-    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, op.op);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
     record.put(DebeziumConstants.ADDED_SEQ_COL_NAME, seqValue);
     return record;
   }
@@ -126,6 +154,11 @@ public class TestMySqlDebeziumAvroPayload {
 
     Operation(String op) {
       this.op = op;
+    }
+
+    @Override
+    public String toString() {
+      return op;
     }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -29,14 +30,18 @@ import org.apache.avro.util.Utf8;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestPostgresDebeziumAvroPayload {
 
@@ -47,8 +52,10 @@ public class TestPostgresDebeziumAvroPayload {
   void setUp() {
     this.avroSchema = Schema.createRecord(Arrays.asList(
         new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
-        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME, Schema.create(Schema.Type.STRING), "", null),
-        new Schema.Field(DebeziumConstants.FLATTENED_LSN_COL_NAME, Schema.create(Schema.Type.LONG), "", null)
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(DebeziumConstants.FLATTENED_LSN_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
     ));
   }
 
@@ -107,6 +114,27 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   @Test
+  public void testMergeWithBootstrappedExistingRecords() throws IOException {
+    GenericRecord incomingRecord = createRecord(3, Operation.UPDATE, 100L);
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(incomingRecord, 100L);
+
+    GenericRecord existingRecord = createRecord(3, null, null);
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
+    validateRecord(mergedRecord, 3, Operation.UPDATE, 100L);
+  }
+
+  @Test
+  public void testInvalidIncomingRecord() {
+    GenericRecord incomingRecord = createRecord(4, null, null);
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(incomingRecord, 100L);
+
+    GenericRecord existingRecord = createRecord(4, Operation.INSERT, 99L);
+    assertThrows(HoodieDebeziumAvroPayloadException.class,
+        () -> payload.combineAndGetUpdateValue(existingRecord, avroSchema),
+        "should have thrown because LSN value of the incoming record is null");
+  }
+
+  @Test
   public void testMergeWithToastedValues() throws IOException {
     Schema avroSchema = SchemaBuilder.builder()
         .record("test_schema")
@@ -152,10 +180,10 @@ public class TestPostgresDebeziumAvroPayload {
     assertEquals("valid byte value", new String(((ByteBuffer) outputRecord.get("byte_null_col_2")).array(), StandardCharsets.UTF_8));
   }
 
-  private GenericRecord createRecord(int primaryKeyValue, Operation op, long lsnValue) {
+  private GenericRecord createRecord(int primaryKeyValue, @Nullable Operation op, @Nullable Long lsnValue) {
     GenericRecord record = new GenericData.Record(avroSchema);
     record.put(KEY_FIELD_NAME, primaryKeyValue);
-    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, op.op);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
     record.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, lsnValue);
     return record;
   }
@@ -176,6 +204,11 @@ public class TestPostgresDebeziumAvroPayload {
 
     Operation(String op) {
       this.op = op;
+    }
+
+    @Override
+    public String toString() {
+      return op;
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Handle cases where event seq (mysql) or LSN (postgres) is null for debezium avro payload. This could happen when datasets were first bootstrapped via jdbc source, which would leave debezium fields null

### Impact

NA

### Risk level

Low

### Documentation Update

NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
