### PR TITLE
[HUDI-5206] RowColumnReader should not return null value for certain null child columns

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestSQL.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestSQL.java
@@ -62,6 +62,11 @@ public class TestSQL {
       + "(2, array['abc2', 'def2'], array[2, 2], map['abc2', 1, 'def2', 3], row(array['abc2', 'def2'], row(2, 'abc2'))),\n"
       + "(3, array['abc3', 'def3'], array[3, 3], map['abc3', 1, 'def3', 3], row(array['abc3', 'def3'], row(3, 'abc3')))";
 
+  public static final String NULL_CHILD_COLUMNS_ROW_TYPE_INSERT_T1 = "insert into t1 values\n"
+      + "(1, row(cast(null as int), 'abc1')),\n"
+      + "(2, row(2, cast(null as varchar))),\n"
+      + "(3, row(cast(null as int), cast(null as varchar)))";
+
   public static final String INSERT_DATE_PARTITION_T1 = "insert into t1 values\n"
       + "('id1','Danny',23,DATE '1970-01-01'),\n"
       + "('id2','Stephen',33,DATE '1970-01-01'),\n"

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapRowColumnVector.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapRowColumnVector.java
@@ -44,4 +44,12 @@ public class HeapRowColumnVector extends AbstractHeapVector
     columnarRowData.setRowId(i);
     return columnarRowData;
   }
+
+  @Override
+  public void reset() {
+    super.reset();
+    for (WritableColumnVector vector : vectors) {
+      vector.reset();
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/RowColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/RowColumnReader.java
@@ -41,14 +41,20 @@ public class RowColumnReader implements ColumnReader<WritableColumnVector> {
   public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
     HeapRowColumnVector rowColumnVector = (HeapRowColumnVector) vector;
     WritableColumnVector[] vectors = rowColumnVector.vectors;
+    // row vector null array
+    boolean[] isNulls = new boolean[readNumber];
     for (int i = 0; i < vectors.length; i++) {
       fieldReaders.get(i).readToVector(readNumber, vectors[i]);
 
       for (int j = 0; j < readNumber; j++) {
-        boolean isNull = (i == 0)
-            ? vectors[i].isNullAt(j)
-            : rowColumnVector.isNullAt(j) && vectors[i].isNullAt(j);
-        if (isNull) {
+        if (i == 0) {
+          isNulls[j] = vectors[i].isNullAt(j);
+        } else {
+          isNulls[j] = isNulls[j] && vectors[i].isNullAt(j);
+        }
+        if (i == vectors.length - 1 && isNulls[j]) {
+          // rowColumnVector[j] is null only when all fields[j] of rowColumnVector[j] is
+          // null
           rowColumnVector.setNullAt(j);
         }
       }

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapRowColumnVector.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapRowColumnVector.java
@@ -43,4 +43,12 @@ public class HeapRowColumnVector extends AbstractHeapVector
     columnarRowData.setRowId(i);
     return columnarRowData;
   }
+
+  @Override
+  public void reset() {
+    super.reset();
+    for (WritableColumnVector vector : vectors) {
+      vector.reset();
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/RowColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/RowColumnReader.java
@@ -41,14 +41,20 @@ public class RowColumnReader implements ColumnReader<WritableColumnVector> {
   public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
     HeapRowColumnVector rowColumnVector = (HeapRowColumnVector) vector;
     WritableColumnVector[] vectors = rowColumnVector.vectors;
+    // row vector null array
+    boolean[] isNulls = new boolean[readNumber];
     for (int i = 0; i < vectors.length; i++) {
       fieldReaders.get(i).readToVector(readNumber, vectors[i]);
 
       for (int j = 0; j < readNumber; j++) {
-        boolean isNull = (i == 0)
-            ? vectors[i].isNullAt(j)
-            : rowColumnVector.isNullAt(j) && vectors[i].isNullAt(j);
-        if (isNull) {
+        if (i == 0) {
+          isNulls[j] = vectors[i].isNullAt(j);
+        } else {
+          isNulls[j] = isNulls[j] && vectors[i].isNullAt(j);
+        }
+        if (i == vectors.length - 1 && isNulls[j]) {
+          // rowColumnVector[j] is null only when all fields[j] of rowColumnVector[j] is
+          // null
           rowColumnVector.setNullAt(j);
         }
       }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapRowColumnVector.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/HeapRowColumnVector.java
@@ -43,4 +43,12 @@ public class HeapRowColumnVector extends AbstractHeapVector
     columnarRowData.setRowId(i);
     return columnarRowData;
   }
+
+  @Override
+  public void reset() {
+    super.reset();
+    for (WritableColumnVector vector : vectors) {
+      vector.reset();
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/RowColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/RowColumnReader.java
@@ -41,14 +41,20 @@ public class RowColumnReader implements ColumnReader<WritableColumnVector> {
   public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
     HeapRowColumnVector rowColumnVector = (HeapRowColumnVector) vector;
     WritableColumnVector[] vectors = rowColumnVector.vectors;
+    // row vector null array
+    boolean[] isNulls = new boolean[readNumber];
     for (int i = 0; i < vectors.length; i++) {
       fieldReaders.get(i).readToVector(readNumber, vectors[i]);
 
       for (int j = 0; j < readNumber; j++) {
-        boolean isNull = (i == 0)
-            ? vectors[i].isNullAt(j)
-            : rowColumnVector.isNullAt(j) && vectors[i].isNullAt(j);
-        if (isNull) {
+        if (i == 0) {
+          isNulls[j] = vectors[i].isNullAt(j);
+        } else {
+          isNulls[j] = isNulls[j] && vectors[i].isNullAt(j);
+        }
+        if (i == vectors.length - 1 && isNulls[j]) {
+          // rowColumnVector[j] is null only when all fields[j] of rowColumnVector[j] is
+          // null
           rowColumnVector.setNullAt(j);
         }
       }


### PR DESCRIPTION
### Change Logs

When reading to vector of certain null child columns of row type column, `RowColumnReader` should not return null value because the value of the row type column may not be null, which results in incorrect values of row type column.

### Impact

The return value `RowColumnReader#readToVector` is correct for the row type column in the case that there are certain null child columns.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
