### PR TITLE
[HUDI-5279] move logic for deleting active instant to HoodieActiveTimeline

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -555,17 +555,18 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
     // other monitors on the timeline(such as the compaction or clustering services) would
     // mistakenly recognize the pending file as a pending operation,
     // then all kinds of weird bugs occur.
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
     if (!pendingInstants.isEmpty()) {
       context.foreach(
           pendingInstants,
-          instant -> metaClient.getActiveTimeline().deleteInstantFileIfExists(instant),
+          instant -> activeTimeline.deleteInstantFileIfExists(instant),
           Math.min(pendingInstants.size(), config.getArchiveDeleteParallelism())
       );
     }
     if (!completedInstants.isEmpty()) {
       context.foreach(
           completedInstants,
-          instant -> metaClient.getActiveTimeline().deleteInstantFileIfExists(instant),
+          instant -> activeTimeline.deleteInstantFileIfExists(instant),
           Math.min(completedInstants.size(), config.getArchiveDeleteParallelism())
       );
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -537,14 +537,15 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
   private boolean deleteArchivedInstants(List<HoodieInstant> archivedInstants, HoodieEngineContext context) throws IOException {
     LOG.info("Deleting instants " + archivedInstants);
 
-    List<HoodieInstant> pendingInstants = new ArrayList<>();
-    List<HoodieInstant> completedInstants = new ArrayList<>();
+    List<String> pendingInstantFiles = new ArrayList<>();
+    List<String> completedInstantFiles = new ArrayList<>();
 
     for (HoodieInstant instant : archivedInstants) {
+      String filePath = new Path(metaClient.getMetaPath(), instant.getFileName()).toString();
       if (instant.isCompleted()) {
-        completedInstants.add(instant);
+        completedInstantFiles.add(filePath);
       } else {
-        pendingInstants.add(instant);
+        pendingInstantFiles.add(filePath);
       }
     }
 
@@ -555,30 +556,27 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
     // other monitors on the timeline(such as the compaction or clustering services) would
     // mistakenly recognize the pending file as a pending operation,
     // then all kinds of weird bugs occur.
-    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
-    if (!pendingInstants.isEmpty()) {
-      context.foreach(
-          pendingInstants,
-          instant -> activeTimeline.deleteInstantFileIfExists(instant),
-          Math.min(pendingInstants.size(), config.getArchiveDeleteParallelism())
-      );
-    }
-    if (!completedInstants.isEmpty()) {
-      context.foreach(
-          completedInstants,
-          instant -> activeTimeline.deleteInstantFileIfExists(instant),
-          Math.min(completedInstants.size(), config.getArchiveDeleteParallelism())
-      );
-    }
+    boolean success = deleteArchivedInstantFiles(context, true, pendingInstantFiles);
+    success &= deleteArchivedInstantFiles(context, success, completedInstantFiles);
 
     // Remove older meta-data from auxiliary path too
     Option<HoodieInstant> latestCommitted = Option.fromJavaOptional(archivedInstants.stream().filter(i -> i.isCompleted() && (i.getAction().equals(HoodieTimeline.COMMIT_ACTION)
         || (i.getAction().equals(HoodieTimeline.DELTA_COMMIT_ACTION)))).max(Comparator.comparing(HoodieInstant::getTimestamp)));
     LOG.info("Latest Committed Instant=" + latestCommitted);
     if (latestCommitted.isPresent()) {
-      return deleteAllInstantsOlderOrEqualsInAuxMetaFolder(latestCommitted.get());
+      success &= deleteAllInstantsOlderOrEqualsInAuxMetaFolder(latestCommitted.get());
     }
-    return true;
+    return success;
+  }
+
+  private boolean deleteArchivedInstantFiles(HoodieEngineContext context, boolean success, List<String> files) {
+    Map<String, Boolean> resultDeleteInstantFiles = deleteFilesParallelize(metaClient, files, context, false);
+
+    for (Map.Entry<String, Boolean> result : resultDeleteInstantFiles.entrySet()) {
+      LOG.info("Archived and deleted instant file " + result.getKey() + " : " + result.getValue());
+      success &= result.getValue();
+    }
+    return success;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -266,11 +266,11 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     deleteInstantFile(instant);
   }
 
+  /**
+   * Note: This should only be used in the case that delete requested/inflight instant
+   * or empty clean instant. The completed commit instant is not allowed to delete.
+   */
   public void deleteInstantFileIfExists(HoodieInstant instant) {
-    deleteInstantFileIfExists(instant, true);
-  }
-
-  public boolean deleteInstantFileIfExists(HoodieInstant instant, boolean exceptionIfFailToDelete) {
     LOG.info("Deleting instant " + instant);
     Path commitFilePath = getInstantFileNamePath(instant.getFileName());
     try {
@@ -278,13 +278,11 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
         boolean result = metaClient.getFs().delete(commitFilePath, false);
         if (result) {
           LOG.info("Removed instant " + instant);
-        } else if (exceptionIfFailToDelete) {
+        } else {
           throw new HoodieIOException("Could not delete instant " + instant);
         }
-        return result;
       } else {
         LOG.warn("The commit " + commitFilePath + " to remove does not exist");
-        return true;
       }
     } catch (IOException e) {
       throw new HoodieIOException("Could not remove commit " + commitFilePath, e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -267,21 +267,27 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
   }
 
   public void deleteInstantFileIfExists(HoodieInstant instant) {
+    deleteInstantFileIfExists(instant, true);
+  }
+
+  public boolean deleteInstantFileIfExists(HoodieInstant instant, boolean exceptionIfFailToDelete) {
     LOG.info("Deleting instant " + instant);
-    Path inFlightCommitFilePath = getInstantFileNamePath(instant.getFileName());
+    Path commitFilePath = getInstantFileNamePath(instant.getFileName());
     try {
-      if (metaClient.getFs().exists(inFlightCommitFilePath)) {
-        boolean result = metaClient.getFs().delete(inFlightCommitFilePath, false);
+      if (metaClient.getFs().exists(commitFilePath)) {
+        boolean result = metaClient.getFs().delete(commitFilePath, false);
         if (result) {
           LOG.info("Removed instant " + instant);
-        } else {
+        } else if (exceptionIfFailToDelete) {
           throw new HoodieIOException("Could not delete instant " + instant);
         }
+        return result;
       } else {
-        LOG.warn("The commit " + inFlightCommitFilePath + " to remove does not exist");
+        LOG.warn("The commit " + commitFilePath + " to remove does not exist");
+        return true;
       }
     } catch (IOException e) {
-      throw new HoodieIOException("Could not remove inflight commit " + inFlightCommitFilePath, e);
+      throw new HoodieIOException("Could not remove commit " + commitFilePath, e);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -267,8 +267,8 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
   }
 
   /**
-   * Note: This should only be used in the case that delete requested/inflight instant
-   * or empty clean instant. The completed commit instant is not allowed to delete.
+   * Note: This method should only be used in the case that delete requested/inflight instant or empty clean instant,
+   * and completed commit instant in an archive operation.
    */
   public void deleteInstantFileIfExists(HoodieInstant instant) {
     LOG.info("Deleting instant " + instant);


### PR DESCRIPTION
### Change Logs

Currently, only the logic for deleting active instant is out of `HoodieActiveTimeline`.
I think it's better that all the operations to active instant are concentrated to `HoodieActiveTimeline`.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
