### PR TITLE
[MINOR] Fix locale specific NumberFormatException in testutils …

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -68,6 +68,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -363,7 +364,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     rec.put("current_date", (int) LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toLocalDate().toEpochDay());
     rec.put("current_ts", randomMillis);
 
-    BigDecimal bigDecimal = new BigDecimal(String.format("%5f", rand.nextFloat()));
+    BigDecimal bigDecimal = new BigDecimal(String.format(Locale.ENGLISH, "%5f", rand.nextFloat()));
     Schema decimalSchema = AVRO_SCHEMA.getField("height").schema();
     Conversions.DecimalConversion decimalConversions = new Conversions.DecimalConversion();
     GenericFixed genericFixed = decimalConversions.toFixed(bigDecimal, decimalSchema, LogicalTypes.decimal(10, 6));


### PR DESCRIPTION
…HoodieTestDataGenerator

### Change Logs

String.format is locale specific. Example:
```java
if (Locale.getDefault() == ENGLISH) {
  assert String.format("%5f", 0.1f) == "0.100000"
}
if (Locale.getDefault() == GERMAN) {
  assert String.format("%5f", 0.1f) == "0,100000"
}
```

So default GERMAN locale leads to failure of `new BigDecimal("0,100000")` with exception `NumberFormatException`.
It is not convenient to develop when we have locale specific tests.

### Impact

Fix `NumberFormatException` when default locale consists of comma as decimal separator
```
java.lang.NumberFormatException
	at java.math.BigDecimal.<init>(BigDecimal.java:501)
	at java.math.BigDecimal.<init>(BigDecimal.java:387)
	at java.math.BigDecimal.<init>(BigDecimal.java:813)
	at org.apache.hudi.common.testutils.HoodieTestDataGenerator.generateGenericRecord(HoodieTestDataGenerator.java:330)
	at org.apache.hudi.functional.TestBootstrap.lambda$generateTestRawTripDataset$14(TestBootstrap.java:576)
	at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(Streams.java:110)
	at java.util.stream.IntPipeline$Head.forEach(IntPipeline.java:581)
	at org.apache.hudi.functional.TestBootstrap.generateTestRawTripDataset(TestBootstrap.java:574)
	at org.apache.hudi.functional.TestBootstrap.generateNewDataSetAndReturnSchema(TestBootstrap.java:165)
	at org.apache.hudi.functional.TestBootstrap.testBootstrapCommon(TestBootstrap.java:242)
	at org.apache.hudi.functional.TestBootstrap.testMetadataBootstrapNonpartitionedCOW(TestBootstrap.java:182)
```

### Risk level

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
