### PR TITLE
[HUDI-5232] Add flushTasks config in StreamWriteFunction in hudi-flink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -319,6 +319,12 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(WriteOperationType.UPSERT.value())
       .withDescription("The write operation, that this write should do");
 
+  public static final ConfigOption<Integer> FLUSH_TASKS = ConfigOptions
+          .key("flush.tasks")
+          .intType()
+          .defaultValue(1)
+          .withDescription("Parallelism of tasks that do actual flush, default is single task in write.tasks");
+
   /**
    * Flag to indicate whether to drop duplicates before insert/upsert.
    * By default false to gain extra performance.


### PR DESCRIPTION
### Change Logs
Add flush.tasks in FlinkOptions

### Impact
none

### Risk level (write none, low medium or high below)
none

### Documentation Update
User can config flush.tasks. 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
