### PR TITLE
[HUDI-5233] Fix bug when InternalSchemaUtils.collectTypeChangedCols returns all columns

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/Type.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/Type.java
@@ -21,6 +21,7 @@ package org.apache.hudi.internal.schema;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * The type of a schema, reference avro schema.
@@ -59,6 +60,27 @@ public interface Type extends Serializable {
     @Override
     public boolean isNestedType() {
       return false;
+    }
+
+    /**
+     * We need to override equals because the check {@code intType1 == intType2} can return {@code false}.
+     * Despite the fact that most subclasses look like singleton with static field {@code INSTANCE},
+     * they can still be created by deserializer.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof PrimitiveType)) {
+        return false;
+      }
+      PrimitiveType that = (PrimitiveType) o;
+      return typeId().equals(that.typeId());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(typeId());
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/internal/schema/utils/TestInternalSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/internal/schema/utils/TestInternalSchemaUtils.java
@@ -24,6 +24,10 @@ import org.apache.hudi.internal.schema.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -74,6 +78,16 @@ public class TestInternalSchemaUtils {
     Map<String, Integer> result1 = InternalSchemaBuilder.getBuilder().buildNameToId(simpleRecord);
     Assertions.assertEquals(result1.size(), 5);
     Assertions.assertEquals(result1.get("double"), 4);
+  }
+
+  @Test
+  public void testIntTypeEqualsAfterDeserialization() throws Exception {
+    Types.IntType intType = Types.IntType.get();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    new ObjectOutputStream(baos).writeObject(intType);
+    Types.IntType deserializedIntType = (Types.IntType)
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())).readObject();
+    Assertions.assertEquals(intType, deserializedIntType);
   }
 
   public Types.RecordType getNestRecordType() {


### PR DESCRIPTION
### Change Logs

We need to override equals because the check `intType1 == intType2` can return `false`.
Despite the fact that most subclasses of `Type` look like singleton with static field `INSTANCE`, they can still be created by **deserializer**. It means that the check below always returns `true` [InternalSchemaUtils.java](https://github.com/apache/hudi/blob/6b0b03b12b5b35efd16eb976d48edba876803ca0/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/InternalSchemaUtils.java#L211-L225):
```java
if (!schema.findType(f).equals(oldSchema.findType(f))) {
```

### Impact

`InternalSchemaUtils.collectTypeChangedCols` returns only changed columns

### Risk level

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
