### PR TITLE
[HUDI-5269] Enhancing spark-sql write tests for some of the core user flows

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -44,7 +44,6 @@ import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -818,7 +817,6 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   public List<HoodieRecord> generateUniqueUpdatesNestedExample(String instantTime, Integer n) {
     return generateUniqueUpdatesStream(instantTime, n, TRIP_NESTED_EXAMPLE_SCHEMA).collect(Collectors.toList());
   }
-
 
   public List<HoodieRecord> generateUniqueUpdatesAsPerSchema(String instantTime, Integer n, String schemaStr) {
     return generateUniqueUpdatesStream(instantTime, n, schemaStr).collect(Collectors.toList());

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -353,7 +353,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   /**
    * Populate rec with values for EXTRA_TYPE_SCHEMA
    */
-  private void generateExtraValues(GenericRecord rec) {
+  private void generateExtraSchemaValues(GenericRecord rec) {
     rec.put("distance_in_meters", rand.nextInt());
     rec.put("seconds_since_epoch", rand.nextLong());
     rec.put("weight", rand.nextFloat());
@@ -374,7 +374,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   /**
    * Populate rec with values for MAP_TYPE_SCHEMA
    */
-  private void generateMapValues(GenericRecord rec) {
+  private void generateMapTypeValues(GenericRecord rec) {
     rec.put("city_to_state", Collections.singletonMap("LA", "CA"));
   }
 
@@ -424,8 +424,8 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     if (isFlattened) {
       generateFareFlattenedValues(rec);
     } else {
-      generateExtraValues(rec);
-      generateMapValues(rec);
+      generateExtraSchemaValues(rec);
+      generateMapTypeValues(rec);
       generateFareNestedValues(rec);
       generateTipNestedValues(rec);
     }
@@ -564,7 +564,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   }
 
   /**
-   * Generates new inserts with nested schema, uniformly across the partition paths above.
+   * Generates new inserts for TRIP_EXAMPLE_SCHEMA with nested schema, uniformly across the partition paths above.
    * It also updates the list of existing keys.
    */
   public List<HoodieRecord> generateInserts(String instantTime, Integer n) {
@@ -574,52 +574,6 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   public List<HoodieRecord> generateInsertsNestedExample(String instantTime, Integer n) {
     return generateInsertsStream(instantTime, n, false, TRIP_NESTED_EXAMPLE_SCHEMA).collect(Collectors.toList());
   }
-
-  public List<Map<String,Object>> convertInsertsToMapNestedExample(List<HoodieRecord> recs) throws IOException {
-    List<Map<String,Object>> maps = new ArrayList<>();
-    for (HoodieRecord rec : recs) {
-      maps.add(getNestedExampleValues(rec));
-    }
-    return maps;
-  }
-
-  public Map<String,Object> getNestedExampleValues(HoodieRecord rec) throws IOException {
-    Map<String,Object> values = new HashMap<>();
-    RawTripTestPayload payload  = (RawTripTestPayload) rec.getData();
-    IndexedRecord irec = payload.getInsertValue(NESTED_AVRO_SCHEMA).get();
-    IndexedRecord fare = (IndexedRecord) irec.get(9);
-    values.put("timestamp", irec.get(0));
-    values.put("_row_key", irec.get(1));
-    values.put("rider", irec.get(3));
-    values.put("driver", irec.get(4));
-    values.put("begin_lat", irec.get(5));
-    values.put("begin_lon", irec.get(6));
-    values.put("end_lat", irec.get(7));
-    values.put("end_lon", irec.get(8));
-    values.put("fare.amount", fare.get(0));
-    values.put("fare.currency", fare.get(1));
-    values.put("_hoodie_is_deleted", irec.get(10));
-    values.put("partition_path", irec.get(2));
-    return values;
-  }
-
-  public String getNestedExampleSQLString(Map<String,Object> rec) {
-    return "( "
-        + rec.get("timestamp").toString() + ", " //timestamp
-        + "'" + rec.get("_row_key").toString() + "', " //_row_key
-        + "'" + rec.get("rider").toString()  + "', " //rider
-        + "'" + rec.get("driver").toString()  + "', " //driver
-        + "double(" + rec.get("begin_lat").toString()  + "), " //begin_lat
-        + "double(" + rec.get("begin_lon").toString()  + "), " //begin_lon
-        + "double(" + rec.get("end_lat").toString()  + "), " //end_lat
-        + "double(" + rec.get("end_lon").toString()  + "), " //end_lon
-        + "struct( "
-        + "double(" + rec.get("fare.amount").toString()  + "), " //amount
-        + "'" + rec.get("fare.currency").toString()  + "' ), " //currency
-        + rec.get("_hoodie_is_deleted").toString()  + ", " //_hoodie_is_deleted
-        + "\"" + rec.get("partition_path").toString()  + "\" )";
-  }
-
 
   /**
    * Generates new inserts, uniformly across the partition paths above.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSql.scala
@@ -36,216 +36,162 @@ import scala.collection.JavaConversions._
 
 
 class TestSparkSql extends HoodieSparkSqlTestBase {
+  val colsToCompare = "timestamp, _row_key, partition_path, rider, driver, begin_lat, begin_lon, end_lat, end_lon, fare.amount, fare.currency, _hoodie_is_deleted"
+
   //params for core flow tests
   val params: List[String] = List(
-        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM"
+        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM"
       )
 
   //extracts the params and runs each core flow test
   forAll (params) { (paramStr: String) =>
     test(s"Core flow with params: $paramStr") {
       val splits = paramStr.split('|')
-      withTempDir { tmp =>
-        testCoreFlows(tmp,
+      withTempDir { basePath =>
+        testCoreFlows(basePath,
           tableType = splits(0),
           isMetadataEnabledOnWrite = splits(1).toBoolean,
           isMetadataEnabledOnRead = splits(2).toBoolean,
           keyGenClass = splits(3),
-          recordKeys = splits(4),
-          indexType = splits(5))
+          indexType = splits(4))
       }
     }
   }
 
-  def testCoreFlows(tmp: File, tableType: String, isMetadataEnabledOnWrite: Boolean, isMetadataEnabledOnRead: Boolean, keyGenClass: String, recordKeys: String, indexType: String): Unit = {
+  def testCoreFlows(basePath: File, tableType: String, isMetadataEnabledOnWrite: Boolean, isMetadataEnabledOnRead: Boolean, keyGenClass: String, indexType: String): Unit = {
+    //Create table and set up for testing
     val tableName = generateTableName
-    val basePath = tmp.getCanonicalPath + "/" + tableName
-    val writeOptions = getWriteOptions(tableName, tableType, isMetadataEnabledOnWrite, keyGenClass,
-      recordKeys, indexType)
-    val partitionedBy = if (!keyGenClass.equals("org.apache.hudi.keygen.NonpartitionedKeyGenerator")) {
-      "partitioned by (partition_path)"
-    } else {
-      ""
-    }
-    spark.sql(
-      s"""
-         | create table $tableName (
-         |  timestamp long,
-         |  _row_key string,
-         |  rider string,
-         |  driver string,
-         |  begin_lat double,
-         |  begin_lon double,
-         |  end_lat double,
-         |  end_lon double,
-         |  fare STRUCT<
-         |    amount: double,
-         |    currency: string >,
-         |  _hoodie_is_deleted boolean,
-         |  partition_path string
-         |) using hudi
-         | $partitionedBy
-         | $writeOptions
-         | location '$basePath'
-         |
-  """.stripMargin)
-    val cols = Seq("timestamp", "_row_key", "partition_path", "rider", "driver", "begin_lat", "begin_lon", "end_lat", "end_lon", "fare.amount", "fare.currency", "_hoodie_is_deleted")
-    val colsToSelect = getColsToSelect(cols)
-    val fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
-
-    //Insert Operation
+    val tableBasePath = basePath.getCanonicalPath + "/" + tableName
+    val writeOptions = getWriteOptions(tableName, tableType, isMetadataEnabledOnWrite, keyGenClass, indexType)
+    createTable(tableName, keyGenClass, writeOptions, tableBasePath)
+    val fs = FSUtils.getFs(tableBasePath, spark.sparkContext.hadoopConfiguration)
     val dataGen = new HoodieTestDataGenerator(HoodieTestDataGenerator.TRIP_NESTED_EXAMPLE_SCHEMA, 0xDEED)
-    val (inputDf0, _, values0) = generateInserts(dataGen, "000", 100)
-    insertInto(tableName, values0, "bulk_insert", isMetadataEnabledOnWrite, keyGenClass)
-    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
 
-    //Snapshot query
-    val snapshotDf1 = doRead(tableName, isMetadataEnabledOnRead)
+    //Bulk insert first set of records
+    val inputDf0 = generateInserts(dataGen, "000", 100)
+    inputDf0.cache()
+    insertInto(tableName, inputDf0, "bulk_insert", isMetadataEnabledOnWrite, keyGenClass)
+    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, tableBasePath, "000"))
+    //Verify bulk insert works correctly
+    val snapshotDf1 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
     snapshotDf1.cache()
     assertEquals(100, snapshotDf1.count())
+    compareEntireInputDfWithHudiDf(inputDf0, snapshotDf1)
 
-    val (updateDf, _, values1) = generateUniqueUpdates(dataGen, "001", 50)
-    insertInto(tableName, values1, "upsert", isMetadataEnabledOnWrite, keyGenClass)
-
-    val commitInstantTime2 = HoodieDataSourceHelpers.latestCommit(fs, basePath)
-
-    val snapshotDf2 = doRead(tableName, isMetadataEnabledOnRead)
+    //Test updated records
+    val updateDf = generateUniqueUpdates(dataGen, "001", 50)
+    insertInto(tableName, updateDf, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+    val commitInstantTime2 = HoodieDataSourceHelpers.latestCommit(fs, tableBasePath)
+    val snapshotDf2 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
     snapshotDf2.cache()
     assertEquals(100, snapshotDf2.count())
+    compareUpdateDfWithHudiDf(updateDf, snapshotDf2, snapshotDf1)
 
-    compareUpdateDfWithHudiDf(updateDf, snapshotDf2, snapshotDf1, colsToSelect)
-
-    val (inputDf2, _, values2) = generateUniqueUpdates(dataGen, "002", 60)
+    val inputDf2 = generateUniqueUpdates(dataGen, "002", 60)
     val uniqueKeyCnt2 = inputDf2.select("_row_key").distinct().count()
-    insertInto(tableName, values2, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+    insertInto(tableName, inputDf2, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+    val commitInstantTime3 = HoodieDataSourceHelpers.latestCommit(fs, tableBasePath)
+    assertEquals(3, HoodieDataSourceHelpers.listCommitsSince(fs, tableBasePath, "000").size())
 
-    val commitInstantTime3 = HoodieDataSourceHelpers.latestCommit(fs, basePath)
-    assertEquals(3, HoodieDataSourceHelpers.listCommitsSince(fs, basePath, "000").size())
-
-    // Snapshot Query
-    val snapshotDf3 = doRead(tableName, isMetadataEnabledOnRead)
+    val snapshotDf3 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
     snapshotDf3.cache()
     assertEquals(100, snapshotDf3.count())
-
-    compareUpdateDfWithHudiDf(inputDf2, snapshotDf3, snapshotDf3, colsToSelect)
+    compareUpdateDfWithHudiDf(inputDf2, snapshotDf3, snapshotDf3)
 
     // Read Incremental Query, need to use spark-ds because functionality does not exist for spark sql
     // we have 2 commits, try pulling the first commit (which is not the latest)
-    val firstCommit = HoodieDataSourceHelpers.listCommitsSince(fs, basePath, "000").get(0)
+    //HUDI-5266
+    val firstCommit = HoodieDataSourceHelpers.listCommitsSince(fs, tableBasePath, "000").get(0)
     val hoodieIncViewDf1 = spark.read.format("org.apache.hudi")
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key, "000")
       .option(DataSourceReadOptions.END_INSTANTTIME.key, firstCommit)
-      .load(basePath)
+      .load(tableBasePath)
     //val hoodieIncViewDf1 = doIncRead(tableName, isMetadataEnabledOnRead, "000", firstCommit)
     assertEquals(100, hoodieIncViewDf1.count()) // 100 initial inserts must be pulled
     var countsPerCommit = hoodieIncViewDf1.groupBy("_hoodie_commit_time").count().collect()
     assertEquals(1, countsPerCommit.length)
     assertEquals(firstCommit, countsPerCommit(0).get(0).toString)
 
-    val (inputDf3, _, values3) = generateUniqueUpdates(dataGen, "003", 80)
-    val uniqueKeyCnt3 = inputDf3.select("_row_key").distinct().count()
-    insertInto(tableName, values3, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+    val inputDf3 = generateUniqueUpdates(dataGen, "003", 80)
+    insertInto(tableName, inputDf3, "upsert", isMetadataEnabledOnWrite, keyGenClass)
 
     //another incremental query with commit2 and commit3
+    //HUDI-5266
     val hoodieIncViewDf2 = spark.read.format("org.apache.hudi")
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key, commitInstantTime2)
       .option(DataSourceReadOptions.END_INSTANTTIME.key(), commitInstantTime3)
-      .load(basePath)
-    //val hoodieIncViewDf2 = doIncRead(tableName, isMetadataEnabledOnRead, commitInstantTime2, commitInstantTime3)
-
+      .load(tableBasePath)
 
     assertEquals(uniqueKeyCnt2, hoodieIncViewDf2.count()) // 60 records must be pulled
     countsPerCommit = hoodieIncViewDf2.groupBy("_hoodie_commit_time").count().collect()
     assertEquals(1, countsPerCommit.length)
     assertEquals(commitInstantTime3, countsPerCommit(0).get(0).toString)
 
-    // time travel query.
+
     val timeTravelDf = if (HoodieSparkUtils.gteqSpark3_2_1) {
       spark.sql(s"select * from $tableName timestamp as of '$commitInstantTime2'")
     } else {
+      //HUDI-5265
       spark.read.format("org.apache.hudi")
         .option("as.of.instant", commitInstantTime2)
-        .load(basePath)
+        .load(tableBasePath)
     }
-    //val timeTravelDf = doTimeTravel(tableName, isMetadataEnabledOnRead, commitInstantTime2)
     assertEquals(100, timeTravelDf.count())
-    compareEntireInputDfWithHudiDf(snapshotDf2, timeTravelDf, colsToSelect)
+    compareEntireInputDfWithHudiDf(snapshotDf2, timeTravelDf)
 
     if (tableType.equals("MERGE_ON_READ")) {
-      doMORReadOptimizedQuery(inputDf0, colsToSelect, isMetadataEnabledOnRead, tableName, basePath)
+      val readOptDf = doMORReadOptimizedQuery(isMetadataEnabledOnRead, tableBasePath)
+      compareEntireInputDfWithHudiDf(inputDf0, readOptDf)
 
-      val snapshotDf4 = doRead(tableName, isMetadataEnabledOnRead)
+      val snapshotDf4 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
       snapshotDf4.cache()
 
       // trigger compaction and try out Read optimized query.
-      val (inputDf4, _, values4) = generateUniqueUpdates(dataGen, "004", 40)
-      val uniqueKeyCnt4 = inputDf4.select("_row_key").distinct().count()
-      doInlineCompact(tableName, values4, "upsert", isMetadataEnabledOnWrite, "3", keyGenClass)
-
-      val snapshotDf5 = doRead(tableName, isMetadataEnabledOnRead)
+      val inputDf4 = generateUniqueUpdates(dataGen, "004", 40)
+      doInlineCompact(tableName, inputDf4, "upsert", isMetadataEnabledOnWrite, "3", keyGenClass)
+      val snapshotDf5 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
       snapshotDf5.cache()
+      compareUpdateDfWithHudiDf(inputDf4, snapshotDf5, snapshotDf4)
 
-      compareUpdateDfWithHudiDf(inputDf4, snapshotDf5, snapshotDf4, colsToSelect)
       // compaction is expected to have completed. both RO and RT are expected to return same results.
-      compareROAndRT(colsToSelect, isMetadataEnabledOnRead, tableName)
+      compareROAndRT(isMetadataEnabledOnRead, tableName, tableBasePath)
     }
   }
 
-  def doRead(tableName: String, isMetadataEnabledOnRead: Boolean): sql.DataFrame = {
+  def doSnapshotRead(tableName: String, isMetadataEnabledOnRead: Boolean): sql.DataFrame = {
     spark.sql("set hoodie.datasource.query.type=\"snapshot\"")
     spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
     spark.sql(s"select * from $tableName")
   }
 
-  def doIncRead(tableName: String, isMetadataEnabledOnRead: Boolean, beginInstantTime: String, endInstantTime: String): sql.DataFrame = {
-    spark.sql("set hoodie.datasource.query.type=\"incremental\"")
-    spark.sql(s"set hoodie.datasource.read.begin.instanttime='$beginInstantTime'")
-    spark.sql(s"set hoodie.datasource.read.end.instanttime='$endInstantTime''")
-    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
-    spark.sql(s"select * from $tableName")
-  }
-
-  def doTimeTravel(tableName: String, isMetadataEnabledOnRead: Boolean, asOf: String): sql.DataFrame = {
-    spark.sql("set hoodie.datasource.query.type=\"snapshot\"")
-    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
-    if (HoodieSparkUtils.gteqSpark3_2_1) {
-      spark.sql(s"select * from $tableName timestamp as of '$asOf'")
-    } else {
-      spark.sql(s"set as.of.instant='$asOf'")
-      val asOfDf = spark.sql(s"select * from $tableName")
-      spark.sql(s"set as.of.instant=''")
-      asOfDf
-    }
-  }
-
-  def doInlineCompact(tableName: String, values: String, writeOp: String, isMetadataEnabledOnWrite: Boolean, numDeltaCommits: String, keyGenClass: String): Unit = {
+  def doInlineCompact(tableName: String, recDf: sql.DataFrame, writeOp: String, isMetadataEnabledOnWrite: Boolean, numDeltaCommits: String, keyGenClass: String): Unit = {
     spark.sql("set hoodie.compact.inline=true")
     spark.sql(s"set hoodie.compact.inline.max.delta.commits=$numDeltaCommits")
-    insertInto(tableName, values, writeOp, isMetadataEnabledOnWrite, keyGenClass)
+    insertInto(tableName, recDf, writeOp, isMetadataEnabledOnWrite, keyGenClass)
     spark.sql("set hoodie.compact.inline=false")
   }
 
   def getWriteOptions(tableName: String, tableType: String, isMetadataEnabledOnWrite: Boolean,
-                      keyGenClass: String, recordKeys: String, indexType: String): String = {
+                      keyGenClass: String, indexType: String): String = {
     val typeString = if (tableType.equals("COPY_ON_WRITE")) {
       "cow"
     } else if (tableType.equals("MERGE_ON_READ")) {
@@ -255,9 +201,9 @@ class TestSparkSql extends HoodieSparkSqlTestBase {
     }
 
     s"""
-       |options (
+       |tblproperties (
        |  type = '$typeString',
-       |  primaryKey = '$recordKeys',
+       |  primaryKey = '_row_key',
        |  preCombineField = 'timestamp',
        |  hoodie.bulkinsert.shuffle.parallelism = 4,
        |  hoodie.database.name = "databaseName",
@@ -271,189 +217,46 @@ class TestSparkSql extends HoodieSparkSqlTestBase {
        | )""".stripMargin
   }
 
-
-  def getColsToSelect(cols: Seq[String]): String = {
-    var colsToSelect = cols.get(0)
-    for (i <- 1 until cols.size) {
-      colsToSelect += ", " + cols.get(i)
-    }
-    colsToSelect
-  }
-
-  def insertInto(tableName: String, values: String, writeOp: String, isMetadataEnabledOnWrite: Boolean, keyGenClass: String): Unit = {
-    if (writeOp.equals("upsert")||writeOp.equals("insert")) {
-      spark.sql("set hoodie.sql.insert.mode=upsert")
-    } else if (writeOp.equals("bulk_insert")) {
-      spark.sql("set hoodie.sql.insert.mode=non-strict")
-    }
-    spark.sql(s"set hoodie.datasource.write.operation=$writeOp")
+  def insertInto(tableName: String, inputDf: sql.DataFrame, writeOp: String, isMetadataEnabledOnWrite: Boolean, keyGenClass: String): Unit = {
+    inputDf.select("timestamp", "_row_key", "rider", "driver", "begin_lat", "begin_lon", "end_lat", "end_lon", "fare",
+      "_hoodie_is_deleted", "partition_path").createOrReplaceTempView("insert_temp_table")
     spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnWrite)}")
     spark.sql(s"set hoodie.datasource.write.keygenerator.class=$keyGenClass")
-    spark.sql(
-      s"""
-         | insert into $tableName values
-         | $values
-         |""".stripMargin
-    )
-  }
-
-  def getDataSeq(cols: Seq[String], m: Map[String, Any]): Seq[Any] = {
-    cols.map(col => m.getOrElse(col, ""))
-  }
-
-  def rowsToSeq(cols: Seq[String], rows: List[Map[String, Any]]): Seq[Seq[Any]] = {
-    rows.map(data => getDataSeq(cols, data))
-  }
-
-  def fixJavaListMap(m: java.util.List[java.util.Map[String, AnyRef]]): List[Map[String, Any]] = {
-    m.map(i => i.toMap).toList
-  }
-
-  def recConvert(dataGen: HoodieTestDataGenerator, recs: java.util.List[HoodieRecord[_]]): (sql.DataFrame, List[Map[String, Any]], String) = {
-    val recDf = spark.read.json(spark.sparkContext.parallelize(recordsToStrings(recs), 2))
-    val inserts = dataGen.convertInsertsToMapNestedExample(recs)
-    var tableValues = dataGen.getNestedExampleSQLString(inserts.get(0))
-    for (i <- 1 until inserts.size()) {
-      tableValues += "," + dataGen.getNestedExampleSQLString(inserts.get(i))
-    }
-    (recDf, fixJavaListMap(inserts), tableValues)
-  }
-
-  def generateInserts(dataGen: HoodieTestDataGenerator, instantTime: String, n: Int): (sql.DataFrame, List[Map[String, Any]], String) = {
-    recConvert(dataGen, dataGen.generateInsertsNestedExample(instantTime, n))
-  }
-
-  def generateUniqueUpdates(dataGen: HoodieTestDataGenerator, instantTime: String, n: Int): (sql.DataFrame, List[Map[String, Any]], String) = {
-    recConvert(dataGen, dataGen.generateUniqueUpdatesNestedExample(instantTime, n))
-  }
-
-  def compareUpdateDfWithHudiDf(inputDf: Dataset[Row], hudiDf: Dataset[Row], beforeDf: Dataset[Row], colsToCompare: String): Unit = {
-    val hudiWithoutMeta = hudiDf.drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
-    hudiWithoutMeta.registerTempTable("hudiTbl")
-    inputDf.registerTempTable("inputTbl")
-    beforeDf.registerTempTable("beforeTbl")
-    val hudiDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl")
-    val inputDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from inputTbl")
-    val beforeDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from beforeTbl")
-
-    assertEquals(hudiDfToCompare.intersect(inputDfToCompare).count, inputDfToCompare.count)
-    assertEquals(hudiDfToCompare.except(inputDfToCompare).except(beforeDfToCompare).count, 0)
-  }
-
-  def compareEntireInputDfWithHudiDf(inputDf: Dataset[Row], hudiDf: Dataset[Row], colsToCompare: String): Unit = {
-    val hudiWithoutMeta = hudiDf.drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
-    hudiWithoutMeta.registerTempTable("hudiTbl")
-    inputDf.registerTempTable("inputTbl")
-    val hudiDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl")
-    val inputDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from inputTbl")
-
-    assertEquals(hudiDfToCompare.intersect(inputDfToCompare).count, inputDfToCompare.count)
-    assertEquals(hudiDfToCompare.except(inputDfToCompare).count, 0)
-  }
-
-  def doMORReadOptimizedQuery(inputDf: Dataset[Row], colsToSelect: String, isMetadataEnabledOnRead: Boolean, tableName: String, basePath: String): Unit = {
-    // read optimized query.
-    // spark.sql("set hoodie.datasource.query.type=\"read_optimized\"")
-    // spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
-    // val readOptDf = spark.sql(s"select * from $tableName")
-
-    val readOptDf = spark.read.format("org.apache.hudi")
-      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
-      .option(HoodieMetadataConfig.ENABLE.key(), isMetadataEnabledOnRead)
-      .load(basePath)
-
-    compareEntireInputDfWithHudiDf(inputDf, readOptDf, colsToSelect)
-  }
-
-  def compareROAndRT(colsToCompare: String, isMetadataEnabledOnRead: Boolean, tableName: String): Unit = {
-    spark.sql("set hoodie.datasource.query.type=\"read_optimized\"")
-    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
-    val roDf = spark.sql(s"select * from $tableName")
-    val rtDf = doRead(tableName, isMetadataEnabledOnRead)
-
-
-    val hudiWithoutMeta1 = roDf
-      .drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
-    val hudiWithoutMeta2 = rtDf
-      .drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
-    hudiWithoutMeta1.registerTempTable("hudiTbl1")
-    hudiWithoutMeta2.registerTempTable("hudiTbl2")
-
-    val hudiDf1ToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl1")
-    val hudiDf2ToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl2")
-
-    assertEquals(hudiDf1ToCompare.intersect(hudiDf2ToCompare).count, hudiDf1ToCompare.count)
-    assertEquals(hudiDf1ToCompare.except(hudiDf2ToCompare).count, 0)
-  }
-
-  //params for immutable user flow
-  val paramsForImmutable: List[String] = List(
-    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
-    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
-    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
-    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM"
-  )
-
-  //extracts the params and runs each immutable user flow test
-  forAll(paramsForImmutable) { (paramStr: String) =>
-    test(s"Immutable user flow with params: $paramStr") {
-      val splits = paramStr.split('|')
-      withTempDir { tmp =>
-        testImmutableUserFlowFlow(tmp,
-          tableType = splits(0),
-          operation = splits(1),
-          isMetadataEnabledOnWrite = splits(2).toBoolean,
-          isMetadataEnabledOnRead = splits(3).toBoolean,
-          keyGenClass = splits(4),
-          recordKeys = splits(5),
-          indexType = splits(6))
-      }
+    if (writeOp.equals("upsert")) {
+      spark.sql(s"set hoodie.datasource.write.operation=$writeOp")
+      spark.sql("set hoodie.sql.bulk.insert.enable=false")
+      spark.sql("set hoodie.sql.insert.mode=upsert")
+      spark.sql(
+        s"""
+           | merge into $tableName as target
+           | using insert_temp_table as source
+           | on target._row_key = source._row_key and
+           | target.partition_path = source.partition_path
+           | when matched then update set *
+           | when not matched then insert *
+           | """.stripMargin)
+    } else if (writeOp.equals("bulk_insert")) {
+      //If HUDI-5257 is resolved, write operation should be bulk_insert, and this function can be more compact due to
+      //less repeated code
+      spark.sql("set hoodie.datasource.write.operation=insert")
+      spark.sql("set hoodie.sql.bulk.insert.enable=true")
+      spark.sql("set hoodie.sql.insert.mode=non-strict")
+      spark.sql(s"insert into $tableName select * from insert_temp_table")
+    } else if (writeOp.equals("insert")) {
+      spark.sql(s"set hoodie.datasource.write.operation=$writeOp")
+      spark.sql("set hoodie.sql.bulk.insert.enable=false")
+      spark.sql("set hoodie.sql.insert.mode=non-strict")
+      spark.sql(s"insert into $tableName select * from insert_temp_table")
     }
   }
-
-  def testImmutableUserFlowFlow(tmp: File, tableType: String, operation: String, isMetadataEnabledOnWrite: Boolean,
-                                isMetadataEnabledOnRead: Boolean, keyGenClass: String, recordKeys: String, indexType: String): Unit = {
-    val tableName = generateTableName
-    val basePath = tmp.getCanonicalPath + "/" + tableName
-    val writeOptions = getWriteOptions(tableName, tableType, isMetadataEnabledOnWrite, keyGenClass,
-      recordKeys, indexType)
+  def createTable(tableName: String, keyGenClass: String, writeOptions: String, tableBasePath: String): Unit = {
+    //If you have partitioned by (partition_path) with nonpartitioned keygen, the partition_path will be empty in the table
     val partitionedBy = if (!keyGenClass.equals("org.apache.hudi.keygen.NonpartitionedKeyGenerator")) {
       "partitioned by (partition_path)"
     } else {
       ""
     }
+
     spark.sql(
       s"""
          | create table $tableName (
@@ -473,46 +276,167 @@ class TestSparkSql extends HoodieSparkSqlTestBase {
          |) using hudi
          | $partitionedBy
          | $writeOptions
-         | location '$basePath'
+         | location '$tableBasePath'
          |
     """.stripMargin)
-    val cols = Seq("timestamp", "_row_key", "partition_path", "rider", "driver", "begin_lat", "begin_lon", "end_lat", "end_lon", "fare.amount", "fare.currency", "_hoodie_is_deleted")
-    val colsToSelect = getColsToSelect(cols)
-    val fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
+  }
+
+  def generateInserts(dataGen: HoodieTestDataGenerator, instantTime: String, n: Int): sql.DataFrame = {
+    val recs = dataGen.generateInsertsNestedExample(instantTime, n)
+    spark.read.json(spark.sparkContext.parallelize(recordsToStrings(recs), 2))
+  }
+
+  def generateUniqueUpdates(dataGen: HoodieTestDataGenerator, instantTime: String, n: Int): sql.DataFrame = {
+    val recs = dataGen.generateUniqueUpdatesNestedExample(instantTime, n)
+    spark.read.json(spark.sparkContext.parallelize(recordsToStrings(recs), 2))
+  }
+
+  def compareUpdateDfWithHudiDf(inputDf: Dataset[Row], hudiDf: Dataset[Row], beforeDf: Dataset[Row]): Unit = {
+    dropMetadata(hudiDf).createOrReplaceTempView("hudiTbl")
+    inputDf.createOrReplaceTempView("inputTbl")
+    beforeDf.createOrReplaceTempView("beforeTbl")
+    val hudiDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl")
+    val inputDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from inputTbl")
+    val beforeDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from beforeTbl")
+
+    assertEquals(hudiDfToCompare.intersect(inputDfToCompare).count, inputDfToCompare.count)
+    assertEquals(hudiDfToCompare.except(inputDfToCompare).except(beforeDfToCompare).count, 0)
+  }
+
+  def compareEntireInputDfWithHudiDf(inputDf: Dataset[Row], hudiDf: Dataset[Row]): Unit = {
+    dropMetadata(hudiDf).createOrReplaceTempView("hudiTbl")
+    inputDf.createOrReplaceTempView("inputTbl")
+    val hudiDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl")
+    val inputDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from inputTbl")
+
+    assertEquals(hudiDfToCompare.intersect(inputDfToCompare).count, inputDfToCompare.count)
+    assertEquals(hudiDfToCompare.except(inputDfToCompare).count, 0)
+  }
+
+  def doMORReadOptimizedQuery(isMetadataEnabledOnRead: Boolean, basePath: String): sql.DataFrame = {
+    
+    spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
+      .option(HoodieMetadataConfig.ENABLE.key(), isMetadataEnabledOnRead)
+      .load(basePath)
+  }
+
+  def compareROAndRT(isMetadataEnabledOnRead: Boolean, tableName: String, basePath: String): Unit = {
+    val roDf = doMORReadOptimizedQuery(isMetadataEnabledOnRead, basePath)
+    val rtDf = doSnapshotRead(tableName, isMetadataEnabledOnRead)
+    dropMetadata(roDf).createOrReplaceTempView("hudiTbl1")
+    dropMetadata(rtDf).createOrReplaceTempView("hudiTbl2")
+
+    val hudiDf1ToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl1")
+    val hudiDf2ToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl2")
+
+    assertEquals(hudiDf1ToCompare.intersect(hudiDf2ToCompare).count, hudiDf1ToCompare.count)
+    assertEquals(hudiDf1ToCompare.except(hudiDf2ToCompare).count, 0)
+  }
+
+  def dropMetadata(inputDf: sql.DataFrame): sql.DataFrame = {
+    inputDf.drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD,
+      HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD,
+      HoodieRecord.FILENAME_METADATA_FIELD)
+  }
+
+  //params for immutable user flow
+  val paramsForImmutable: List[String] = List(
+    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|BLOOM",
+    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|SIMPLE",
+    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|GLOBAL_BLOOM"
+  )
+
+  //extracts the params and runs each immutable user flow test
+  forAll(paramsForImmutable) { (paramStr: String) =>
+    test(s"Immutable user flow with params: $paramStr") {
+      val splits = paramStr.split('|')
+      withTempDir { basePath =>
+        testImmutableUserFlow(basePath,
+          tableType = splits(0),
+          operation = splits(1),
+          isMetadataEnabledOnWrite = splits(2).toBoolean,
+          isMetadataEnabledOnRead = splits(3).toBoolean,
+          keyGenClass = splits(4),
+          indexType = splits(5))
+      }
+    }
+  }
+
+  def testImmutableUserFlow(basePath: File, tableType: String, operation: String, isMetadataEnabledOnWrite: Boolean,
+                                isMetadataEnabledOnRead: Boolean, keyGenClass: String, indexType: String): Unit = {
+    val tableName = generateTableName
+    val tableBasePath = basePath.getCanonicalPath + "/" + tableName
+    val writeOptions = getWriteOptions(tableName, tableType, isMetadataEnabledOnWrite, keyGenClass, indexType)
+    createTable(tableName, keyGenClass, writeOptions, tableBasePath)
+    val fs = FSUtils.getFs(tableBasePath, spark.sparkContext.hadoopConfiguration)
 
     //Insert Operation
     val dataGen = new HoodieTestDataGenerator(HoodieTestDataGenerator.TRIP_NESTED_EXAMPLE_SCHEMA, 0xDEED)
-    val (inputDf0, _, values0) = generateInserts(dataGen, "000", 100)
-    spark.sql("set hoodie.sql.insert.mode=non-strict")
-    insertInto(tableName, values0, "bulk_insert", isMetadataEnabledOnWrite, keyGenClass)
+    val inputDf0 = generateInserts(dataGen, "000", 100)
+    insertInto(tableName, inputDf0, "bulk_insert", isMetadataEnabledOnWrite, keyGenClass)
 
-    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
+    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, tableBasePath, "000"))
 
     //Snapshot query
-    val snapshotDf1 = doRead(tableName, isMetadataEnabledOnRead)
+    val snapshotDf1 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
     snapshotDf1.cache()
     assertEquals(100, snapshotDf1.count())
+    compareEntireInputDfWithHudiDf(inputDf0, snapshotDf1)
 
-    val (inputDf1, _, values1) = generateInserts(dataGen, "001", 50)
-    insertInto(tableName, values1, operation, isMetadataEnabledOnWrite, keyGenClass)
+    val inputDf1 = generateInserts(dataGen, "001", 50)
+    insertInto(tableName, inputDf1, operation, isMetadataEnabledOnWrite, keyGenClass)
 
-    val snapshotDf2 = doRead(tableName, isMetadataEnabledOnRead)
+    val snapshotDf2 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
     snapshotDf2.cache()
     assertEquals(150, snapshotDf2.count())
 
-    compareEntireInputDfWithHudiDf(inputDf1.union(inputDf0), snapshotDf2, colsToSelect)
+    compareEntireInputDfWithHudiDf(inputDf1.union(inputDf0), snapshotDf2)
 
-    val (inputDf2, _, values2) = generateInserts(dataGen, "002", 60)
+    val inputDf2 = generateInserts(dataGen, "002", 60)
     inputDf2.cache()
-    insertInto(tableName, values2, operation, isMetadataEnabledOnWrite, keyGenClass)
+    insertInto(tableName, inputDf2, operation, isMetadataEnabledOnWrite, keyGenClass)
 
-    assertEquals(3, HoodieDataSourceHelpers.listCommitsSince(fs, basePath, "000").size())
+    assertEquals(3, HoodieDataSourceHelpers.listCommitsSince(fs, tableBasePath, "000").size())
 
     // Snapshot Query
-    val snapshotDf3 = doRead(tableName, isMetadataEnabledOnRead)
+    val snapshotDf3 = doSnapshotRead(tableName, isMetadataEnabledOnRead)
     snapshotDf3.cache()
     assertEquals(210, snapshotDf3.count())
-    compareEntireInputDfWithHudiDf(inputDf1.union(inputDf0).union(inputDf2), snapshotDf3, colsToSelect)
+    compareEntireInputDfWithHudiDf(inputDf1.union(inputDf0).union(inputDf2), snapshotDf3)
   }
 
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSql.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSql.scala
@@ -1,0 +1,518 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.{DataSourceReadOptions, HoodieDataSourceHelpers, HoodieSparkUtils}
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+import org.apache.spark.sql
+import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+import org.scalatest.Inspectors.forAll
+
+import java.io.File
+import scala.collection.JavaConversions._
+
+
+class TestSparkSql extends HoodieSparkSqlTestBase {
+  //params for core flow tests
+  val params: List[String] = List(
+        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+        "COPY_ON_WRITE|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+        "COPY_ON_WRITE|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+        "COPY_ON_WRITE|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+        "MERGE_ON_READ|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+        "MERGE_ON_READ|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+        "MERGE_ON_READ|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM"
+      )
+
+  //extracts the params and runs each core flow test
+  forAll (params) { (paramStr: String) =>
+    test(s"Core flow with params: $paramStr") {
+      val splits = paramStr.split('|')
+      withTempDir { tmp =>
+        testCoreFlows(tmp,
+          tableType = splits(0),
+          isMetadataEnabledOnWrite = splits(1).toBoolean,
+          isMetadataEnabledOnRead = splits(2).toBoolean,
+          keyGenClass = splits(3),
+          recordKeys = splits(4),
+          indexType = splits(5))
+      }
+    }
+  }
+
+  def testCoreFlows(tmp: File, tableType: String, isMetadataEnabledOnWrite: Boolean, isMetadataEnabledOnRead: Boolean, keyGenClass: String, recordKeys: String, indexType: String): Unit = {
+    val tableName = generateTableName
+    val basePath = tmp.getCanonicalPath + "/" + tableName
+    val writeOptions = getWriteOptions(tableName, tableType, isMetadataEnabledOnWrite, keyGenClass,
+      recordKeys, indexType)
+    val partitionedBy = if (!keyGenClass.equals("org.apache.hudi.keygen.NonpartitionedKeyGenerator")) {
+      "partitioned by (partition_path)"
+    } else {
+      ""
+    }
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  timestamp long,
+         |  _row_key string,
+         |  rider string,
+         |  driver string,
+         |  begin_lat double,
+         |  begin_lon double,
+         |  end_lat double,
+         |  end_lon double,
+         |  fare STRUCT<
+         |    amount: double,
+         |    currency: string >,
+         |  _hoodie_is_deleted boolean,
+         |  partition_path string
+         |) using hudi
+         | $partitionedBy
+         | $writeOptions
+         | location '$basePath'
+         |
+  """.stripMargin)
+    val cols = Seq("timestamp", "_row_key", "partition_path", "rider", "driver", "begin_lat", "begin_lon", "end_lat", "end_lon", "fare.amount", "fare.currency", "_hoodie_is_deleted")
+    val colsToSelect = getColsToSelect(cols)
+    val fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
+
+    //Insert Operation
+    val dataGen = new HoodieTestDataGenerator(HoodieTestDataGenerator.TRIP_NESTED_EXAMPLE_SCHEMA, 0xDEED)
+    val (inputDf0, _, values0) = generateInserts(dataGen, "000", 100)
+    insertInto(tableName, values0, "bulk_insert", isMetadataEnabledOnWrite, keyGenClass)
+    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
+
+    //Snapshot query
+    val snapshotDf1 = doRead(tableName, isMetadataEnabledOnRead)
+    snapshotDf1.cache()
+    assertEquals(100, snapshotDf1.count())
+
+    val (updateDf, _, values1) = generateUniqueUpdates(dataGen, "001", 50)
+    insertInto(tableName, values1, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+
+    val commitInstantTime2 = HoodieDataSourceHelpers.latestCommit(fs, basePath)
+
+    val snapshotDf2 = doRead(tableName, isMetadataEnabledOnRead)
+    snapshotDf2.cache()
+    assertEquals(100, snapshotDf2.count())
+
+    compareUpdateDfWithHudiDf(updateDf, snapshotDf2, snapshotDf1, colsToSelect)
+
+    val (inputDf2, _, values2) = generateUniqueUpdates(dataGen, "002", 60)
+    val uniqueKeyCnt2 = inputDf2.select("_row_key").distinct().count()
+    insertInto(tableName, values2, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+
+    val commitInstantTime3 = HoodieDataSourceHelpers.latestCommit(fs, basePath)
+    assertEquals(3, HoodieDataSourceHelpers.listCommitsSince(fs, basePath, "000").size())
+
+    // Snapshot Query
+    val snapshotDf3 = doRead(tableName, isMetadataEnabledOnRead)
+    snapshotDf3.cache()
+    assertEquals(100, snapshotDf3.count())
+
+    compareUpdateDfWithHudiDf(inputDf2, snapshotDf3, snapshotDf3, colsToSelect)
+
+    // Read Incremental Query, need to use spark-ds because functionality does not exist for spark sql
+    // we have 2 commits, try pulling the first commit (which is not the latest)
+    val firstCommit = HoodieDataSourceHelpers.listCommitsSince(fs, basePath, "000").get(0)
+    val hoodieIncViewDf1 = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+      .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key, "000")
+      .option(DataSourceReadOptions.END_INSTANTTIME.key, firstCommit)
+      .load(basePath)
+    //val hoodieIncViewDf1 = doIncRead(tableName, isMetadataEnabledOnRead, "000", firstCommit)
+    assertEquals(100, hoodieIncViewDf1.count()) // 100 initial inserts must be pulled
+    var countsPerCommit = hoodieIncViewDf1.groupBy("_hoodie_commit_time").count().collect()
+    assertEquals(1, countsPerCommit.length)
+    assertEquals(firstCommit, countsPerCommit(0).get(0).toString)
+
+    val (inputDf3, _, values3) = generateUniqueUpdates(dataGen, "003", 80)
+    val uniqueKeyCnt3 = inputDf3.select("_row_key").distinct().count()
+    insertInto(tableName, values3, "upsert", isMetadataEnabledOnWrite, keyGenClass)
+
+    //another incremental query with commit2 and commit3
+    val hoodieIncViewDf2 = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+      .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key, commitInstantTime2)
+      .option(DataSourceReadOptions.END_INSTANTTIME.key(), commitInstantTime3)
+      .load(basePath)
+    //val hoodieIncViewDf2 = doIncRead(tableName, isMetadataEnabledOnRead, commitInstantTime2, commitInstantTime3)
+
+
+    assertEquals(uniqueKeyCnt2, hoodieIncViewDf2.count()) // 60 records must be pulled
+    countsPerCommit = hoodieIncViewDf2.groupBy("_hoodie_commit_time").count().collect()
+    assertEquals(1, countsPerCommit.length)
+    assertEquals(commitInstantTime3, countsPerCommit(0).get(0).toString)
+
+    // time travel query.
+    val timeTravelDf = if (HoodieSparkUtils.gteqSpark3_2_1) {
+      spark.sql(s"select * from $tableName timestamp as of '$commitInstantTime2'")
+    } else {
+      spark.read.format("org.apache.hudi")
+        .option("as.of.instant", commitInstantTime2)
+        .load(basePath)
+    }
+    //val timeTravelDf = doTimeTravel(tableName, isMetadataEnabledOnRead, commitInstantTime2)
+    assertEquals(100, timeTravelDf.count())
+    compareEntireInputDfWithHudiDf(snapshotDf2, timeTravelDf, colsToSelect)
+
+    if (tableType.equals("MERGE_ON_READ")) {
+      doMORReadOptimizedQuery(inputDf0, colsToSelect, isMetadataEnabledOnRead, tableName, basePath)
+
+      val snapshotDf4 = doRead(tableName, isMetadataEnabledOnRead)
+      snapshotDf4.cache()
+
+      // trigger compaction and try out Read optimized query.
+      val (inputDf4, _, values4) = generateUniqueUpdates(dataGen, "004", 40)
+      val uniqueKeyCnt4 = inputDf4.select("_row_key").distinct().count()
+      doInlineCompact(tableName, values4, "upsert", isMetadataEnabledOnWrite, "3", keyGenClass)
+
+      val snapshotDf5 = doRead(tableName, isMetadataEnabledOnRead)
+      snapshotDf5.cache()
+
+      compareUpdateDfWithHudiDf(inputDf4, snapshotDf5, snapshotDf4, colsToSelect)
+      // compaction is expected to have completed. both RO and RT are expected to return same results.
+      compareROAndRT(colsToSelect, isMetadataEnabledOnRead, tableName)
+    }
+  }
+
+  def doRead(tableName: String, isMetadataEnabledOnRead: Boolean): sql.DataFrame = {
+    spark.sql("set hoodie.datasource.query.type=\"snapshot\"")
+    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
+    spark.sql(s"select * from $tableName")
+  }
+
+  def doIncRead(tableName: String, isMetadataEnabledOnRead: Boolean, beginInstantTime: String, endInstantTime: String): sql.DataFrame = {
+    spark.sql("set hoodie.datasource.query.type=\"incremental\"")
+    spark.sql(s"set hoodie.datasource.read.begin.instanttime='$beginInstantTime'")
+    spark.sql(s"set hoodie.datasource.read.end.instanttime='$endInstantTime''")
+    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
+    spark.sql(s"select * from $tableName")
+  }
+
+  def doTimeTravel(tableName: String, isMetadataEnabledOnRead: Boolean, asOf: String): sql.DataFrame = {
+    spark.sql("set hoodie.datasource.query.type=\"snapshot\"")
+    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
+    if (HoodieSparkUtils.gteqSpark3_2_1) {
+      spark.sql(s"select * from $tableName timestamp as of '$asOf'")
+    } else {
+      spark.sql(s"set as.of.instant='$asOf'")
+      val asOfDf = spark.sql(s"select * from $tableName")
+      spark.sql(s"set as.of.instant=''")
+      asOfDf
+    }
+  }
+
+  def doInlineCompact(tableName: String, values: String, writeOp: String, isMetadataEnabledOnWrite: Boolean, numDeltaCommits: String, keyGenClass: String): Unit = {
+    spark.sql("set hoodie.compact.inline=true")
+    spark.sql(s"set hoodie.compact.inline.max.delta.commits=$numDeltaCommits")
+    insertInto(tableName, values, writeOp, isMetadataEnabledOnWrite, keyGenClass)
+    spark.sql("set hoodie.compact.inline=false")
+  }
+
+  def getWriteOptions(tableName: String, tableType: String, isMetadataEnabledOnWrite: Boolean,
+                      keyGenClass: String, recordKeys: String, indexType: String): String = {
+    val typeString = if (tableType.equals("COPY_ON_WRITE")) {
+      "cow"
+    } else if (tableType.equals("MERGE_ON_READ")) {
+      "mor"
+    } else {
+      tableType
+    }
+
+    s"""
+       |options (
+       |  type = '$typeString',
+       |  primaryKey = '$recordKeys',
+       |  preCombineField = 'timestamp',
+       |  hoodie.bulkinsert.shuffle.parallelism = 4,
+       |  hoodie.database.name = "databaseName",
+       |  hoodie.table.keygenerator.class = '$keyGenClass',
+       |  hoodie.delete.shuffle.parallelism = 2,
+       |  hoodie.index.type = "$indexType",
+       |  hoodie.insert.shuffle.parallelism = 4,
+       |  hoodie.metadata.enable = ${String.valueOf(isMetadataEnabledOnWrite)},
+       |  hoodie.table.name = "$tableName",
+       |  hoodie.upsert.shuffle.parallelism = 4
+       | )""".stripMargin
+  }
+
+
+  def getColsToSelect(cols: Seq[String]): String = {
+    var colsToSelect = cols.get(0)
+    for (i <- 1 until cols.size) {
+      colsToSelect += ", " + cols.get(i)
+    }
+    colsToSelect
+  }
+
+  def insertInto(tableName: String, values: String, writeOp: String, isMetadataEnabledOnWrite: Boolean, keyGenClass: String): Unit = {
+    if (writeOp.equals("upsert")||writeOp.equals("insert")) {
+      spark.sql("set hoodie.sql.insert.mode=upsert")
+    } else if (writeOp.equals("bulk_insert")) {
+      spark.sql("set hoodie.sql.insert.mode=non-strict")
+    }
+    spark.sql(s"set hoodie.datasource.write.operation=$writeOp")
+    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnWrite)}")
+    spark.sql(s"set hoodie.datasource.write.keygenerator.class=$keyGenClass")
+    spark.sql(
+      s"""
+         | insert into $tableName values
+         | $values
+         |""".stripMargin
+    )
+  }
+
+  def getDataSeq(cols: Seq[String], m: Map[String, Any]): Seq[Any] = {
+    cols.map(col => m.getOrElse(col, ""))
+  }
+
+  def rowsToSeq(cols: Seq[String], rows: List[Map[String, Any]]): Seq[Seq[Any]] = {
+    rows.map(data => getDataSeq(cols, data))
+  }
+
+  def fixJavaListMap(m: java.util.List[java.util.Map[String, AnyRef]]): List[Map[String, Any]] = {
+    m.map(i => i.toMap).toList
+  }
+
+  def recConvert(dataGen: HoodieTestDataGenerator, recs: java.util.List[HoodieRecord[_]]): (sql.DataFrame, List[Map[String, Any]], String) = {
+    val recDf = spark.read.json(spark.sparkContext.parallelize(recordsToStrings(recs), 2))
+    val inserts = dataGen.convertInsertsToMapNestedExample(recs)
+    var tableValues = dataGen.getNestedExampleSQLString(inserts.get(0))
+    for (i <- 1 until inserts.size()) {
+      tableValues += "," + dataGen.getNestedExampleSQLString(inserts.get(i))
+    }
+    (recDf, fixJavaListMap(inserts), tableValues)
+  }
+
+  def generateInserts(dataGen: HoodieTestDataGenerator, instantTime: String, n: Int): (sql.DataFrame, List[Map[String, Any]], String) = {
+    recConvert(dataGen, dataGen.generateInsertsNestedExample(instantTime, n))
+  }
+
+  def generateUniqueUpdates(dataGen: HoodieTestDataGenerator, instantTime: String, n: Int): (sql.DataFrame, List[Map[String, Any]], String) = {
+    recConvert(dataGen, dataGen.generateUniqueUpdatesNestedExample(instantTime, n))
+  }
+
+  def compareUpdateDfWithHudiDf(inputDf: Dataset[Row], hudiDf: Dataset[Row], beforeDf: Dataset[Row], colsToCompare: String): Unit = {
+    val hudiWithoutMeta = hudiDf.drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
+    hudiWithoutMeta.registerTempTable("hudiTbl")
+    inputDf.registerTempTable("inputTbl")
+    beforeDf.registerTempTable("beforeTbl")
+    val hudiDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl")
+    val inputDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from inputTbl")
+    val beforeDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from beforeTbl")
+
+    assertEquals(hudiDfToCompare.intersect(inputDfToCompare).count, inputDfToCompare.count)
+    assertEquals(hudiDfToCompare.except(inputDfToCompare).except(beforeDfToCompare).count, 0)
+  }
+
+  def compareEntireInputDfWithHudiDf(inputDf: Dataset[Row], hudiDf: Dataset[Row], colsToCompare: String): Unit = {
+    val hudiWithoutMeta = hudiDf.drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
+    hudiWithoutMeta.registerTempTable("hudiTbl")
+    inputDf.registerTempTable("inputTbl")
+    val hudiDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl")
+    val inputDfToCompare = spark.sqlContext.sql("select " + colsToCompare + " from inputTbl")
+
+    assertEquals(hudiDfToCompare.intersect(inputDfToCompare).count, inputDfToCompare.count)
+    assertEquals(hudiDfToCompare.except(inputDfToCompare).count, 0)
+  }
+
+  def doMORReadOptimizedQuery(inputDf: Dataset[Row], colsToSelect: String, isMetadataEnabledOnRead: Boolean, tableName: String, basePath: String): Unit = {
+    // read optimized query.
+    // spark.sql("set hoodie.datasource.query.type=\"read_optimized\"")
+    // spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
+    // val readOptDf = spark.sql(s"select * from $tableName")
+
+    val readOptDf = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
+      .option(HoodieMetadataConfig.ENABLE.key(), isMetadataEnabledOnRead)
+      .load(basePath)
+
+    compareEntireInputDfWithHudiDf(inputDf, readOptDf, colsToSelect)
+  }
+
+  def compareROAndRT(colsToCompare: String, isMetadataEnabledOnRead: Boolean, tableName: String): Unit = {
+    spark.sql("set hoodie.datasource.query.type=\"read_optimized\"")
+    spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
+    val roDf = spark.sql(s"select * from $tableName")
+    val rtDf = doRead(tableName, isMetadataEnabledOnRead)
+
+
+    val hudiWithoutMeta1 = roDf
+      .drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
+    val hudiWithoutMeta2 = rtDf
+      .drop(HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
+    hudiWithoutMeta1.registerTempTable("hudiTbl1")
+    hudiWithoutMeta2.registerTempTable("hudiTbl2")
+
+    val hudiDf1ToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl1")
+    val hudiDf2ToCompare = spark.sqlContext.sql("select " + colsToCompare + " from hudiTbl2")
+
+    assertEquals(hudiDf1ToCompare.intersect(hudiDf2ToCompare).count, hudiDf1ToCompare.count)
+    assertEquals(hudiDf1ToCompare.except(hudiDf2ToCompare).count, 0)
+  }
+
+  //params for immutable user flow
+  val paramsForImmutable: List[String] = List(
+    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "COPY_ON_WRITE|insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "MERGE_ON_READ|insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "MERGE_ON_READ|insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "MERGE_ON_READ|insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "COPY_ON_WRITE|bulk_insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "COPY_ON_WRITE|bulk_insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|BLOOM",
+    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.SimpleKeyGenerator|_row_key|SIMPLE",
+    "MERGE_ON_READ|bulk_insert|false|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM",
+    "MERGE_ON_READ|bulk_insert|true|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|_row_key|GLOBAL_BLOOM"
+  )
+
+  //extracts the params and runs each immutable user flow test
+  forAll(paramsForImmutable) { (paramStr: String) =>
+    test(s"Immutable user flow with params: $paramStr") {
+      val splits = paramStr.split('|')
+      withTempDir { tmp =>
+        testImmutableUserFlowFlow(tmp,
+          tableType = splits(0),
+          operation = splits(1),
+          isMetadataEnabledOnWrite = splits(2).toBoolean,
+          isMetadataEnabledOnRead = splits(3).toBoolean,
+          keyGenClass = splits(4),
+          recordKeys = splits(5),
+          indexType = splits(6))
+      }
+    }
+  }
+
+  def testImmutableUserFlowFlow(tmp: File, tableType: String, operation: String, isMetadataEnabledOnWrite: Boolean,
+                                isMetadataEnabledOnRead: Boolean, keyGenClass: String, recordKeys: String, indexType: String): Unit = {
+    val tableName = generateTableName
+    val basePath = tmp.getCanonicalPath + "/" + tableName
+    val writeOptions = getWriteOptions(tableName, tableType, isMetadataEnabledOnWrite, keyGenClass,
+      recordKeys, indexType)
+    val partitionedBy = if (!keyGenClass.equals("org.apache.hudi.keygen.NonpartitionedKeyGenerator")) {
+      "partitioned by (partition_path)"
+    } else {
+      ""
+    }
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  timestamp long,
+         |  _row_key string,
+         |  rider string,
+         |  driver string,
+         |  begin_lat double,
+         |  begin_lon double,
+         |  end_lat double,
+         |  end_lon double,
+         |  fare STRUCT<
+         |    amount: double,
+         |    currency: string >,
+         |  _hoodie_is_deleted boolean,
+         |  partition_path string
+         |) using hudi
+         | $partitionedBy
+         | $writeOptions
+         | location '$basePath'
+         |
+    """.stripMargin)
+    val cols = Seq("timestamp", "_row_key", "partition_path", "rider", "driver", "begin_lat", "begin_lon", "end_lat", "end_lon", "fare.amount", "fare.currency", "_hoodie_is_deleted")
+    val colsToSelect = getColsToSelect(cols)
+    val fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
+
+    //Insert Operation
+    val dataGen = new HoodieTestDataGenerator(HoodieTestDataGenerator.TRIP_NESTED_EXAMPLE_SCHEMA, 0xDEED)
+    val (inputDf0, _, values0) = generateInserts(dataGen, "000", 100)
+    spark.sql("set hoodie.sql.insert.mode=non-strict")
+    insertInto(tableName, values0, "bulk_insert", isMetadataEnabledOnWrite, keyGenClass)
+
+    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
+
+    //Snapshot query
+    val snapshotDf1 = doRead(tableName, isMetadataEnabledOnRead)
+    snapshotDf1.cache()
+    assertEquals(100, snapshotDf1.count())
+
+    val (inputDf1, _, values1) = generateInserts(dataGen, "001", 50)
+    insertInto(tableName, values1, operation, isMetadataEnabledOnWrite, keyGenClass)
+
+    val snapshotDf2 = doRead(tableName, isMetadataEnabledOnRead)
+    snapshotDf2.cache()
+    assertEquals(150, snapshotDf2.count())
+
+    compareEntireInputDfWithHudiDf(inputDf1.union(inputDf0), snapshotDf2, colsToSelect)
+
+    val (inputDf2, _, values2) = generateInserts(dataGen, "002", 60)
+    inputDf2.cache()
+    insertInto(tableName, values2, operation, isMetadataEnabledOnWrite, keyGenClass)
+
+    assertEquals(3, HoodieDataSourceHelpers.listCommitsSince(fs, basePath, "000").size())
+
+    // Snapshot Query
+    val snapshotDf3 = doRead(tableName, isMetadataEnabledOnRead)
+    snapshotDf3.cache()
+    assertEquals(210, snapshotDf3.count())
+    compareEntireInputDfWithHudiDf(inputDf1.union(inputDf0).union(inputDf2), snapshotDf3, colsToSelect)
+  }
+
+}


### PR DESCRIPTION
### Change Logs

We realized we don't have good test coverage for some of the core user flows w/ spark data source writes. So, enhancing the tests to cover the scenarios.

Tests coverage added w/ spark-data source writes:
```
COW and MOR * (w/ and w/o metadata)
    Partitioned(BLOOM, SIMPLE, GLOBAL_BLOOM), non-partitioned(GLOBAL_BLOOM).
        Immutable data. pure bulk_insert row writing. 
        Immutable w/ file sizing. pure inserts. 
        initial bulk ingest, followed by updates.
```
This pr is modeled after https://github.com/apache/hudi/pull/7179
This uses a different sql schema that only has regular and struct fields because the the schema in the test above was too complicated to create in sql
### Impact

Will help catch any bugs around core user flows upfront.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
