### PR TITLE
[HUDI-4812] Fixing `FileIndex` impls to properly batch partitions listing

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -352,8 +352,8 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
       // Ingest newly fetched partitions into cache
       fetchedPartitionsMap.forEach((absolutePath, files) -> {
-          Path relativePath = missingPartitionPathsMap.get(absolutePath);
-          fileStatusCache.put(relativePath, files);
+        Path relativePath = missingPartitionPathsMap.get(absolutePath);
+        fileStatusCache.put(relativePath, files);
       });
 
       return combine(flatMap(cachedPartitionPaths.values()),

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -207,14 +207,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
    */
   protected Map<PartitionPath, List<FileSlice>> getAllInputFileSlices() {
     if (!areAllFileSlicesCached()) {
-      // Fetching file slices for partitions that have not been cached yet
-      List<PartitionPath> missingPartitions = getAllQueryPartitionPaths().stream()
-          .filter(p -> !cachedAllInputFileSlices.containsKey(p))
-          .collect(Collectors.toList());
-
-      // NOTE: Individual partitions are always cached in full, therefore if partition is cached
-      //       it will hold all the file-slices residing w/in the partition
-      cachedAllInputFileSlices.putAll(loadFileSlicesForPartitions(missingPartitions));
+      ensurePreloadedPartitions(getAllQueryPartitionPaths());
     }
 
     return cachedAllInputFileSlices;
@@ -223,12 +216,29 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
   /**
    * Get input file slice for the given partition. Will use cache directly if it is computed before.
    */
-  protected List<FileSlice> getInputFileSlices(PartitionPath partition) {
-    return cachedAllInputFileSlices.computeIfAbsent(partition,
-        p -> loadFileSlicesForPartitions(Collections.singletonList(p)).get(p));
+  protected Map<PartitionPath, List<FileSlice>> getInputFileSlices(PartitionPath... partitions) {
+    ensurePreloadedPartitions(Arrays.asList(partitions));
+    return Arrays.stream(partitions).collect(
+        Collectors.toMap(Function.identity(), partition -> cachedAllInputFileSlices.get(partition))
+    );
+  }
+
+  private void ensurePreloadedPartitions(List<PartitionPath> partitionPaths) {
+    // Fetching file slices for partitions that have not been cached yet
+    List<PartitionPath> missingPartitions = partitionPaths.stream()
+        .filter(p -> !cachedAllInputFileSlices.containsKey(p))
+        .collect(Collectors.toList());
+
+    // NOTE: Individual partitions are always cached in full, therefore if partition is cached
+    //       it will hold all the file-slices residing w/in the partition
+    cachedAllInputFileSlices.putAll(loadFileSlicesForPartitions(missingPartitions));
   }
 
   private Map<PartitionPath, List<FileSlice>> loadFileSlicesForPartitions(List<PartitionPath> partitions) {
+    if (partitions.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
     FileStatus[] allFiles = listPartitionPathFiles(partitions);
     HoodieTimeline activeTimeline = getActiveTimeline();
     Option<HoodieInstant> latestInstant = activeTimeline.lastInstant();
@@ -342,8 +352,8 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
       // Ingest newly fetched partitions into cache
       fetchedPartitionsMap.forEach((absolutePath, files) -> {
-        Path relativePath = missingPartitionPathsMap.get(absolutePath);
-        fileStatusCache.put(relativePath, files);
+          Path relativePath = missingPartitionPathsMap.get(absolutePath);
+          fileStatusCache.put(relativePath, files);
       });
 
       return combine(flatMap(cachedPartitionPaths.values()),
@@ -363,10 +373,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     // Reset it to null to trigger re-loading of all partition path
     this.cachedAllPartitionPaths = null;
-    List<PartitionPath> partitionPaths = getAllQueryPartitionPaths();
-
-    // Refresh the partitions & file slices
-    this.cachedAllInputFileSlices = loadFileSlicesForPartitions(partitionPaths);
+    ensurePreloadedPartitions(getAllQueryPartitionPaths());
 
     LOG.info(String.format("Refresh table %s, spent: %d ms", metaClient.getTableConfig().getTableName(), timer.endTimer()));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -353,8 +353,8 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
 
     return toStream(records)
         .map(record -> Pair.of(
-            (String) record.get(HoodieMetadataPayload.KEY_FIELD_NAME),
-            composeRecord(record, partitionName)))
+          (String) record.get(HoodieMetadataPayload.KEY_FIELD_NAME),
+          composeRecord(record, partitionName)))
         .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -167,9 +167,9 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
   def listFileSlices(partitionFilters: Seq[Expression]): Map[String, Seq[FileSlice]] = {
     // Prune the partition path by the partition filters
     val prunedPartitions = listMatchingPartitionPaths(partitionFilters)
-    prunedPartitions.map(partition => {
-      (partition.path, getInputFileSlices(partition).asScala)
-    }).toMap
+    getInputFileSlices(prunedPartitions: _*).asScala.map {
+      case (partition, fileSlices) => (partition.path, fileSlices.asScala)
+    }.toMap
   }
 
   /**


### PR DESCRIPTION
### Change Logs

While rebasing Hudi's FileIndex implementations to do lazy-listing in https://github.com/apache/hudi/pull/6680, it was  unfortunately overlooked that it was issuing point-wise lookup operations when listing actual partitions instead of doing batch operations (thanks to @psendyk for noticing and reporting this!).

### Impact

This should considerably reduce file-listing latency, especially when using MT.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
