### PR TITLE
[HUDI-5237] Support for HoodieUnMergedLogRecordScanner with InternalSchema

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -817,6 +817,8 @@ public abstract class AbstractHoodieLogRecordReader {
 
     public abstract Builder withReaderSchema(Schema schema);
 
+    public abstract Builder withInternalSchema(InternalSchema internalSchema);
+
     public abstract Builder withLatestInstantTime(String latestInstantTime);
 
     public abstract Builder withReadBlocksLazily(boolean readBlocksLazily);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -308,8 +308,9 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
       return this;
     }
 
+    @Override
     public Builder withInternalSchema(InternalSchema internalSchema) {
-      this.internalSchema = internalSchema == null ? InternalSchema.getEmptyInternalSchema() : internalSchema;
+      this.internalSchema = internalSchema;
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -40,9 +40,10 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
 
   private HoodieUnMergedLogRecordScanner(FileSystem fs, String basePath, List<String> logFilePaths, Schema readerSchema,
                                          String latestInstantTime, boolean readBlocksLazily, boolean reverseReader, int bufferSize,
-                                         LogRecordScannerCallback callback, Option<InstantRange> instantRange, boolean useScanV2) {
+                                         LogRecordScannerCallback callback, Option<InstantRange> instantRange, InternalSchema internalSchema,
+                                         boolean useScanV2) {
     super(fs, basePath, logFilePaths, readerSchema, latestInstantTime, readBlocksLazily, reverseReader, bufferSize, instantRange,
-        false, true, Option.empty(), InternalSchema.getEmptyInternalSchema(), useScanV2);
+        false, true, Option.empty(), internalSchema, useScanV2);
     this.callback = callback;
   }
 
@@ -81,6 +82,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
     private String basePath;
     private List<String> logFilePaths;
     private Schema readerSchema;
+    private InternalSchema internalSchema;
     private String latestInstantTime;
     private boolean readBlocksLazily;
     private boolean reverseReader;
@@ -109,6 +111,12 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
 
     public Builder withReaderSchema(Schema schema) {
       this.readerSchema = schema;
+      return this;
+    }
+
+    @Override
+    public Builder withInternalSchema(InternalSchema internalSchema) {
+      this.internalSchema = internalSchema;
       return this;
     }
 
@@ -151,7 +159,8 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
     @Override
     public HoodieUnMergedLogRecordScanner build() {
       return new HoodieUnMergedLogRecordScanner(fs, basePath, logFilePaths, readerSchema,
-          latestInstantTime, readBlocksLazily, reverseReader, bufferSize, callback, instantRange, useScanV2);
+          latestInstantTime, readBlocksLazily, reverseReader, bufferSize, callback, instantRange,
+          internalSchema, useScanV2);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMergedLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMergedLogRecordReader.java
@@ -169,6 +169,11 @@ public class HoodieMetadataMergedLogRecordReader extends HoodieMergedLogRecordSc
     }
 
     @Override
+    public Builder withInternalSchema(InternalSchema internalSchema) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Builder withLatestInstantTime(String latestInstantTime) {
       this.latestInstantTime = latestInstantTime;
       return this;


### PR DESCRIPTION
### Change Logs

Currently, only `HoodieMergedLogRecordScanner` has support of InternalSchema.
Implementing schema evolution in flink https://github.com/apache/hudi/pull/5830 is required supporting for `HoodieUnMergedLogRecordScanner` with InternalSchema as well.

### Impact

Support for HoodieUnMergedLogRecordScanner with InternalSchema.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
