### PR TITLE
[HUDI-5244] Fix bugs in schema evolution client with lost operation field and not found schema

### DIFF
--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestSchemaEvolutionClient.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestSchemaEvolutionClient.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.testutils.RawTripTestPayload;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.internal.schema.Types;
+import org.apache.hudi.testutils.HoodieJavaClientTestBase;
+
+import org.apache.avro.Schema;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for schema evolution client api.
+ */
+public class TestSchemaEvolutionClient extends HoodieJavaClientTestBase {
+
+  private static final Schema SCHEMA = getSchemaFromResource(TestSchemaEvolutionClient.class, "/exampleSchema.avsc");
+
+  @BeforeEach
+  public void setUpClient() throws IOException {
+    HoodieJavaWriteClient<RawTripTestPayload> writeClient = getWriteClient();
+    this.writeClient = writeClient;
+    prepareTable(writeClient);
+  }
+
+  @AfterEach
+  public void closeClient() {
+    if (writeClient != null) {
+      writeClient.close();
+    }
+  }
+
+  @Test
+  public void testUpdateColumnType() {
+    writeClient.updateColumnType("number", Types.LongType.get());
+    assertEquals(Types.LongType.get(), getFieldByName("number").type());
+  }
+
+  private HoodieJavaWriteClient<RawTripTestPayload> getWriteClient() {
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+        .withEngineType(EngineType.JAVA)
+        .withPath(basePath)
+        .withSchema(SCHEMA.toString())
+        .build();
+    return new HoodieJavaWriteClient<>(context, config);
+  }
+
+  private void prepareTable(HoodieJavaWriteClient<RawTripTestPayload> writeClient) throws IOException {
+    String commitTime = "1";
+    writeClient.startCommitWithTime(commitTime);
+    //language=JSON
+    String jsonRow = "{\"_row_key\": \"1\", \"time\": \"2000-01-01T00:00:00.000Z\", \"number\": 1}";
+    RawTripTestPayload payload = new RawTripTestPayload(jsonRow);
+    HoodieAvroRecord<RawTripTestPayload> record = new HoodieAvroRecord<>(
+        new HoodieKey(payload.getRowKey(), payload.getPartitionPath()), payload);
+    writeClient.insert(Collections.singletonList(record), commitTime);
+  }
+
+  private Types.Field getFieldByName(String fieldName) {
+    return new TableSchemaResolver(metaClient)
+        .getTableInternalSchemaFromCommitMetadata()
+        .get()
+        .findField(fieldName);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -184,6 +184,10 @@ public class HoodieAvroUtils {
     return createHoodieWriteSchema(new Schema.Parser().parse(originalSchema));
   }
 
+  public static Schema createHoodieWriteSchema(String originalSchema, boolean withOperationField) {
+    return addMetadataFields(new Schema.Parser().parse(originalSchema), withOperationField);
+  }
+
   /**
    * Adds the Hoodie metadata fields to the given schema.
    *


### PR DESCRIPTION
### Change Logs

This PR fixes 2 issues in schema evolution client api:

1. Lost operation field in avro schema
2. Not found schema for table
```
org.apache.hudi.exception.HoodieException: cannot find schema for current table: /tmp/hudi
	at org.apache.hudi.client.BaseHoodieWriteClient.getInternalSchemaAndMetaClient(BaseHoodieWriteClient.java:1767)
	at org.apache.hudi.client.BaseHoodieWriteClient.addColumn(BaseHoodieWriteClient.java:1673)
	at org.apache.hudi.sink.TestWriteCopyOnWrite.test(TestWriteCopyOnWrite.java:454)
```
Introduced new test `TestSchemaEvolutionClient`for schema evolution client api.

Flink schema evolution https://github.com/apache/hudi/pull/5830 requires these fixes

### Impact

Fixed lost operation field in avro schema and not found schema for table

### Risk level

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
