### PR TITLE
[HUDI-5252] ClusteringCommitSink supports to rollback clustering

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -36,7 +36,7 @@ import org.apache.hudi.exception.HoodieClusteringException;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
-import org.apache.hudi.util.CompactionUtil;
+import org.apache.hudi.util.ClusteringUtil;
 import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
@@ -122,7 +122,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
     if (events.stream().anyMatch(ClusteringCommitEvent::isFailed)) {
       try {
         // handle failure case
-        CompactionUtil.rollbackCompaction(table, instant);
+        ClusteringUtil.rollbackClustering(table, writeClient, instant);
       } finally {
         // remove commitBuffer to avoid obsolete metadata commit
         reset(instant);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestClusteringUtil.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utils;
+
+import org.apache.hudi.avro.model.HoodieClusteringGroup;
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.avro.model.HoodieClusteringStrategy;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.client.HoodieFlinkWriteClient;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.util.ClusteringUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.table.HoodieFlinkTable;
+import org.apache.hudi.util.ClusteringUtil;
+import org.apache.hudi.util.FlinkTables;
+import org.apache.hudi.util.FlinkWriteClients;
+import org.apache.hudi.util.StreamerUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.apache.flink.configuration.Configuration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link ClusteringUtil}.
+ */
+public class TestClusteringUtil {
+
+  private HoodieFlinkTable<?> table;
+  private HoodieTableMetaClient metaClient;
+  private HoodieFlinkWriteClient<?> writeClient;
+  private Configuration conf;
+
+  @TempDir
+  File tempFile;
+
+  void beforeEach() throws IOException {
+    beforeEach(Collections.emptyMap());
+  }
+
+  void beforeEach(Map<String, String> options) throws IOException {
+    this.conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.setString(FlinkOptions.OPERATION, WriteOperationType.INSERT.value());
+    options.forEach((k, v) -> conf.setString(k, v));
+
+    StreamerUtil.initTableIfNotExists(conf);
+
+    this.table = FlinkTables.createTable(conf);
+    this.metaClient = table.getMetaClient();
+    this.writeClient = FlinkWriteClients.createWriteClient(conf);
+  }
+
+  @Test
+  void rollbackClustering() throws Exception {
+    beforeEach();
+    List<String> oriInstants = IntStream.range(0, 3)
+        .mapToObj(i -> generateClusteringPlan()).collect(Collectors.toList());
+    List<HoodieInstant> instants = ClusteringUtils.getPendingClusteringInstantTimes(table.getMetaClient())
+        .stream().filter(instant -> instant.getState() == HoodieInstant.State.INFLIGHT)
+        .collect(Collectors.toList());
+    assertThat("all the instants should be in pending state", instants.size(), is(3));
+    ClusteringUtil.rollbackClustering(table, writeClient);
+    boolean allRolledBack = ClusteringUtils.getPendingClusteringInstantTimes(table.getMetaClient())
+        .stream().allMatch(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
+    assertTrue(allRolledBack, "all the instants should be rolled back");
+    List<String> actualInstants = ClusteringUtils.getPendingClusteringInstantTimes(table.getMetaClient())
+        .stream().map(HoodieInstant::getTimestamp).collect(Collectors.toList());
+    assertThat(actualInstants, is(oriInstants));
+  }
+
+  /**
+   * Generates a clustering plan on the timeline and returns its instant time.
+   */
+  private String generateClusteringPlan() {
+    HoodieClusteringGroup group = new HoodieClusteringGroup();
+    HoodieClusteringPlan plan = new HoodieClusteringPlan(Collections.singletonList(group),
+        HoodieClusteringStrategy.newBuilder().build(), Collections.emptyMap(), 1, false);
+    HoodieRequestedReplaceMetadata metadata = new HoodieRequestedReplaceMetadata(WriteOperationType.CLUSTER.name(),
+        plan, Collections.emptyMap(), 1);
+    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+    HoodieInstant clusteringInstant =
+        new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime);
+    try {
+      metaClient.getActiveTimeline().saveToPendingReplaceCommit(clusteringInstant,
+          TimelineMetadataUtils.serializeRequestedReplaceMetadata(metadata));
+      table.getActiveTimeline().transitionReplaceRequestedToInflight(clusteringInstant, Option.empty());
+    } catch (IOException ioe) {
+      throw new HoodieIOException("Exception scheduling clustering", ioe);
+    }
+    metaClient.reloadActiveTimeline();
+    return instantTime;
+  }
+}


### PR DESCRIPTION
### Change Logs

When commit buffer has failed `ClusteringCommitEvent`, the `ClusteringCommitSink` invokes the `CompactionUtil#rollbackCompaction` to rollback clustering. `ClusteringCommitSink` should call `ClusteringUtil#rollbackClustering` to rollback clustering. 

### Impact

Correct the way of rollback clustering to handle failure case in the `ClusteringCommitSink`.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
