### PR TITLE
[HUDI-5251] Split GitHub actions CI by spark and flink

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -13,34 +13,25 @@ env:
   MVN_ARGS: -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn
 
 jobs:
-  build:
+  test-spark:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - scalaProfile: "scala-2.11"
             sparkProfile: "spark2.4"
-            flinkProfile: "flink1.13"
-
-          - scalaProfile: "scala-2.11"
-            sparkProfile: "spark2.4"
-            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark2.4"
-            flinkProfile: "flink1.13"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.1"
-            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.2"
-            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.3"
-            flinkProfile: "flink1.14"
 
     steps:
       - uses: actions/checkout@v2
@@ -54,38 +45,54 @@ jobs:
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn clean install -Pintegration-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
+          mvn clean install -Pintegration-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-flink,hudi-examples/hudi-examples-java,hudi-examples/hudi-examples-spark $MVN_ARGS
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-java,hudi-examples/hudi-examples-spark $MVN_ARGS
       - name: Bundle Validation
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run: |
           HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           ./packaging/bundle-validation/ci_run.sh $HUDI_VERSION
-      - name: Common Test
+      - name: UT - Common & Spark
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" '-Dtest=Test*' -pl hudi-common $MVN_ARGS
-      - name: Spark SQL Test
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-common,hudi-spark-datasource/hudi-spark $MVN_ARGS
+
+  test-flink:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - flinkProfile: "flink1.13"
+          - flinkProfile: "flink1.14"
+          - flinkProfile: "flink1.15"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Build Project
         env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
-        if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" '-Dtest=Test*' -pl hudi-spark-datasource/hudi-spark $MVN_ARGS
+          mvn clean install -Pintegration-tests -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
+      - name: Quickstart Test
+        env:
+          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+        run:
+          mvn test -Punit-tests -D"$FLINK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-flink $MVN_ARGS

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -69,7 +69,7 @@ jobs:
         run:
           mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-common,hudi-spark-datasource/hudi-spark $MVN_ARGS
 
-test-flink:
+  test-flink:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -13,25 +13,34 @@ env:
   MVN_ARGS: -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn
 
 jobs:
-  test-spark:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - scalaProfile: "scala-2.11"
             sparkProfile: "spark2.4"
+            flinkProfile: "flink1.13"
+
+          - scalaProfile: "scala-2.11"
+            sparkProfile: "spark2.4"
+            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark2.4"
+            flinkProfile: "flink1.13"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.1"
+            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.2"
+            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.3"
+            flinkProfile: "flink1.14"
 
     steps:
       - uses: actions/checkout@v2
@@ -45,54 +54,38 @@ jobs:
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
+          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn clean install -Pintegration-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS
+          mvn clean install -Pintegration-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
+          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-java,hudi-examples/hudi-examples-spark $MVN_ARGS
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-flink,hudi-examples/hudi-examples-java,hudi-examples/hudi-examples-spark $MVN_ARGS
       - name: Bundle Validation
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
+          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run: |
           HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           ./packaging/bundle-validation/ci_run.sh $HUDI_VERSION
-      - name: UT - Common & Spark
+      - name: Common Test
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
+          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-common,hudi-spark-datasource/hudi-spark $MVN_ARGS
-
-  test-flink:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - flinkProfile: "flink1.13"
-          - flinkProfile: "flink1.14"
-          - flinkProfile: "flink1.15"
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-          architecture: x64
-      - name: Build Project
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" '-Dtest=Test*' -pl hudi-common $MVN_ARGS
+      - name: Spark SQL Test
         env:
+          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+          SPARK_PROFILE: ${{ matrix.sparkProfile }}
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
+        if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run:
-          mvn clean install -Pintegration-tests -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
-      - name: Quickstart Test
-        env:
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-        run:
-          mvn test -Punit-tests -D"$FLINK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-flink $MVN_ARGS
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" '-Dtest=Test*' -pl hudi-spark-datasource/hudi-spark $MVN_ARGS

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -13,34 +13,25 @@ env:
   MVN_ARGS: -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn
 
 jobs:
-  build:
+  test-spark:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - scalaProfile: "scala-2.11"
             sparkProfile: "spark2.4"
-            flinkProfile: "flink1.13"
-
-          - scalaProfile: "scala-2.11"
-            sparkProfile: "spark2.4"
-            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark2.4"
-            flinkProfile: "flink1.13"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.1"
-            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.2"
-            flinkProfile: "flink1.14"
 
           - scalaProfile: "scala-2.12"
             sparkProfile: "spark3.3"
-            flinkProfile: "flink1.14"
 
     steps:
       - uses: actions/checkout@v2
@@ -54,38 +45,53 @@ jobs:
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn clean install -Pintegration-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
+          mvn clean install -Pintegration-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-flink,hudi-examples/hudi-examples-java,hudi-examples/hudi-examples-spark $MVN_ARGS
-      - name: Bundle Validation
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-java,hudi-examples/hudi-examples-spark $MVN_ARGS
+      - name: IT - Bundle Validation
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run: |
           HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           ./packaging/bundle-validation/ci_run.sh $HUDI_VERSION
-      - name: Common Test
+      - name: UT - Common & Spark
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
         if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" '-Dtest=Test*' -pl hudi-common $MVN_ARGS
-      - name: Spark SQL Test
+          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-common,hudi-spark-datasource/hudi-spark $MVN_ARGS
+
+test-flink:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - flinkProfile: "flink1.13"
+          - flinkProfile: "flink1.14"
+          - flinkProfile: "flink1.15"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Build Project
         env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
-        if: ${{ !endsWith(env.SPARK_PROFILE, '2.4') }} # skip test spark 2.4 as it's covered by Azure CI
         run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" '-Dtest=Test*' -pl hudi-spark-datasource/hudi-spark $MVN_ARGS
+          mvn clean install -Pintegration-tests -Dscala-2.12 -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
+      - name: Quickstart Test
+        env:
+          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+        run:
+          mvn test -Punit-tests -Dscala-2.12 -D"$FLINK_PROFILE" -DfailIfNoTests=false -pl hudi-examples/hudi-examples-flink $MVN_ARGS

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -89,7 +89,7 @@ jobs:
         env:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
         run:
-          mvn clean install -Pintegration-tests -Dscala-2.12 -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS
+          mvn clean install -Pintegration-tests -Dscala-2.12 -D"$FLINK_PROFILE" -Davro.version=1.10.0 -DskipTests=true $MVN_ARGS
       - name: Quickstart Test
         env:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,10 @@ parameters:
       - '!hudi-flink-datasource/hudi-flink1.15.x'
 
 variables:
-  BUILD_PROFILES: '-Dscala-2.11 -Dspark2.4 -Dflink1.14'
+  # NOTE: this order of build profiles is a work-around, where latter overwrites former
+  # flink profile uses an incompatible avro version as spark profile does for avro model generation
+  # this combination will become compatible (all using 1.10.x) when upgrade spark profile to 3.2 (HUDI-3088)
+  BUILD_PROFILES: '-Dflink1.14 -Dspark2.4 -Dscala-2.11'
   PLUGIN_OPTS: '-Dcheckstyle.skip=true -Drat.skip=true -Djacoco.skip=true -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn'
   MVN_OPTS_INSTALL: '-DskipTests $(BUILD_PROFILES) $(PLUGIN_OPTS)'
   MVN_OPTS_TEST: '-fae -Pwarn-log $(BUILD_PROFILES) $(PLUGIN_OPTS)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,10 +80,7 @@ parameters:
       - '!hudi-flink-datasource/hudi-flink1.15.x'
 
 variables:
-  # NOTE: this order of build profiles is a work-around, where latter overwrites former
-  # flink profile uses an incompatible avro version as spark profile does for avro model generation
-  # this combination will become compatible (all using 1.10.x) when upgrade spark profile to 3.2 (HUDI-3088)
-  BUILD_PROFILES: '-Dflink1.14 -Dspark2.4 -Dscala-2.11'
+  BUILD_PROFILES: '-Dscala-2.11 -Dspark2.4 -Dflink1.14'
   PLUGIN_OPTS: '-Dcheckstyle.skip=true -Drat.skip=true -Djacoco.skip=true -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn'
   MVN_OPTS_INSTALL: '-DskipTests $(BUILD_PROFILES) $(PLUGIN_OPTS)'
   MVN_OPTS_TEST: '-fae -Pwarn-log $(BUILD_PROFILES) $(PLUGIN_OPTS)'

--- a/hudi-examples/hudi-examples-flink/pom.xml
+++ b/hudi-examples/hudi-examples-flink/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
+            <version>${flink.avro.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/hudi-examples/hudi-examples-flink/pom.xml
+++ b/hudi-examples/hudi-examples-flink/pom.xml
@@ -204,8 +204,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <!-- Override the version to be same with Flink avro -->
-            <version>1.10.0</version>
+            <version>${avro.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/hudi-flink-datasource/hudi-flink/pom.xml
+++ b/hudi-flink-datasource/hudi-flink/pom.xml
@@ -230,8 +230,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <!-- Override the version to be same with Flink avro -->
-            <version>1.10.0</version>
+            <version>${avro.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/hudi-flink-datasource/hudi-flink/pom.xml
+++ b/hudi-flink-datasource/hudi-flink/pom.xml
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
+            <version>${flink.avro.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -496,8 +496,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <!-- Override the version to be same with Flink avro -->
-      <version>1.10.0</version>
+      <version>${avro.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -496,7 +496,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
+      <version>${flink.avro.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2238,6 +2238,7 @@
     <profile>
       <id>flink1.15</id>
       <properties>
+        <scala-2.12>true</scala-2.12>
         <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
       </properties>
@@ -2250,6 +2251,7 @@
     <profile>
       <id>flink1.14</id>
       <properties>
+        <scala-2.12>true</scala-2.12>
         <flink.version>${flink1.14.version}</flink.version>
         <hudi.flink.module>hudi-flink1.14.x</hudi.flink.module>
         <flink.bundle.version>1.14</flink.bundle.version>
@@ -2274,6 +2276,7 @@
     <profile>
       <id>flink1.13</id>
       <properties>
+        <scala-2.12>true</scala-2.12>
         <flink.version>${flink1.13.version}</flink.version>
         <hudi.flink.module>hudi-flink1.13.x</hudi.flink.module>
         <flink.bundle.version>1.13</flink.bundle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2240,7 +2240,6 @@
     <profile>
       <id>flink1.15</id>
       <properties>
-        <scala-2.12>true</scala-2.12>
         <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
       </properties>
@@ -2253,7 +2252,6 @@
     <profile>
       <id>flink1.14</id>
       <properties>
-        <scala-2.12>true</scala-2.12>
         <flink.version>${flink1.14.version}</flink.version>
         <hudi.flink.module>hudi-flink1.14.x</hudi.flink.module>
         <flink.bundle.version>1.14</flink.bundle.version>
@@ -2278,7 +2276,6 @@
     <profile>
       <id>flink1.13</id>
       <properties>
-        <scala-2.12>true</scala-2.12>
         <flink.version>${flink1.13.version}</flink.version>
         <hudi.flink.module>hudi-flink1.13.x</hudi.flink.module>
         <flink.bundle.version>1.13</flink.bundle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2025,6 +2025,7 @@
       </modules>
       <properties>
         <skip.hudi-spark3.unit.tests>true</skip.hudi-spark3.unit.tests>
+        <avro.version>1.8.2</avro.version>
       </properties>
       <activation>
         <activeByDefault>true</activeByDefault>
@@ -2045,6 +2046,7 @@
       <properties>
         <sparkbundle.version>2.4</sparkbundle.version>
         <skip.hudi-spark3.unit.tests>true</skip.hudi-spark3.unit.tests>
+        <avro.version>1.8.2</avro.version>
       </properties>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -2240,7 +2240,6 @@
     <profile>
       <id>flink1.15</id>
       <properties>
-        <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
       </properties>
       <activation>
@@ -2255,7 +2254,6 @@
         <flink.version>${flink1.14.version}</flink.version>
         <hudi.flink.module>hudi-flink1.14.x</hudi.flink.module>
         <flink.bundle.version>1.14</flink.bundle.version>
-        <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
         <flink.table.runtime.artifactId>flink-table-runtime_${scala.binary.version}</flink.table.runtime.artifactId>
         <flink.table.planner.artifactId>flink-table-planner_${scala.binary.version}</flink.table.planner.artifactId>
@@ -2279,7 +2277,6 @@
         <flink.version>${flink1.13.version}</flink.version>
         <hudi.flink.module>hudi-flink1.13.x</hudi.flink.module>
         <flink.bundle.version>1.13</flink.bundle.version>
-        <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
         <flink.runtime.artifactId>flink-runtime_${scala.binary.version}</flink.runtime.artifactId>
         <flink.table.runtime.artifactId>flink-table-runtime-blink_${scala.binary.version}</flink.table.runtime.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2238,6 +2238,7 @@
     <profile>
       <id>flink1.15</id>
       <properties>
+        <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
       </properties>
       <activation>
@@ -2252,6 +2253,7 @@
         <flink.version>${flink1.14.version}</flink.version>
         <hudi.flink.module>hudi-flink1.14.x</hudi.flink.module>
         <flink.bundle.version>1.14</flink.bundle.version>
+        <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
         <flink.table.runtime.artifactId>flink-table-runtime_${scala.binary.version}</flink.table.runtime.artifactId>
         <flink.table.planner.artifactId>flink-table-planner_${scala.binary.version}</flink.table.planner.artifactId>
@@ -2275,6 +2277,7 @@
         <flink.version>${flink1.13.version}</flink.version>
         <hudi.flink.module>hudi-flink1.13.x</hudi.flink.module>
         <flink.bundle.version>1.13</flink.bundle.version>
+        <avro.version>1.10.0</avro.version>
         <orc.flink.version>1.5.6</orc.flink.version>
         <flink.runtime.artifactId>flink-runtime_${scala.binary.version}</flink.runtime.artifactId>
         <flink.table.runtime.artifactId>flink-table-runtime-blink_${scala.binary.version}</flink.table.runtime.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,8 @@
     <flink.version>${flink1.15.version}</flink.version>
     <hudi.flink.module>hudi-flink1.15.x</hudi.flink.module>
     <flink.bundle.version>1.15</flink.bundle.version>
+    <!-- This is fixed to match with version from flink-avro -->
+    <flink.avro.version>1.10.0</flink.avro.version>
     <flink.format.parquet.version>1.12.2</flink.format.parquet.version>
     <flink.runtime.artifactId>flink-runtime</flink.runtime.artifactId>
     <flink.table.runtime.artifactId>flink-table-runtime</flink.table.runtime.artifactId>


### PR DESCRIPTION
### Change Logs

flink bundle use 1.10.0 avro version, but hudi common modes were generated during build process controlled by `avro.version` property, which is not overwritten in flink profiles. This would resulted in generated models being incompatible with included avro lib in flink-bundle. 

This change separate out spark and flink build process in GH actions CI so that spark and flink profiles do not interfere each other. For example, spark 3.3 profile uses avro 1.11  which should not be used for flink bundle.

#### Related issues

- https://github.com/apache/hudi/issues/7259 
- https://github.com/apache/hudi/issues/7047


#### Follow up 

We need to make sure release artifacts not to be impacted by the profile settings.

- https://github.com/apache/hudi/pull/7419/


### Impact

Build process for flink bundles has to be separated out from other bundles. Dev and release processes should be updated accordingly.

### Risk level

low

### Documentation Update

- [ ] build instructions to be updated
- [ ] release process to be updated


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
