### PR TITLE
[MINOR] Reuse empty InternalSchema instance

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/InternalSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/InternalSchema.java
@@ -38,6 +38,8 @@ import java.util.stream.Collectors;
  */
 public class InternalSchema implements Serializable {
 
+  private static final InternalSchema EMPTY_SCHEMA = new InternalSchema(-1L, RecordType.get());
+
   private static final long DEFAULT_VERSION_ID = 0;
 
   private final RecordType record;
@@ -50,7 +52,7 @@ public class InternalSchema implements Serializable {
   private transient Map<Integer, String> idToName = null;
 
   public static InternalSchema getEmptyInternalSchema() {
-    return new InternalSchema(-1L, RecordType.get());
+    return EMPTY_SCHEMA;
   }
 
   public boolean isEmptySchema() {


### PR DESCRIPTION
### Change Logs

When schema evolution is disabled each instance of HoodieAvroDataBlock calls `getEmptyInternalSchema()` which triggers creation of ArrayList and InternalSchema. We can easily avoid unnecessary object creation by reusing empty schema.

### Impact

Avoid unnecessary creation of empty InternalSchema

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
