### PR TITLE
[HUDI-5280] Fix taskmanager concurrent registry

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/metrics/TestHoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/metrics/TestHoodieLockMetrics.java
@@ -1,0 +1,65 @@
+package org.apache.hudi.config.metrics;
+
+import org.apache.hudi.client.transaction.lock.metrics.HoodieLockMetrics;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
+import org.apache.hudi.common.util.CustomizedThreadFactory;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieStorageConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.metrics.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+
+public class TestHoodieLockMetrics {
+
+    @TempDir
+    public java.nio.file.Path tempDir;
+    protected String basePath = null;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        java.nio.file.Path basePath = tempDir.resolve("dataset");
+        java.nio.file.Files.createDirectories(basePath);
+        this.basePath = basePath.toString();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testTaskManagerConcurrentRegisterMetrics(){
+        ExecutorService threadPoolExecutor = Executors.newFixedThreadPool(10, new CustomizedThreadFactory("hudi-metrics-"));
+
+        threadPoolExecutor.submit( () -> {
+            HoodieWriteConfig writeConfig = getConfigBuilder(false).build();
+            return new HoodieLockMetrics(writeConfig);
+        });
+    }
+    protected HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit) {
+
+        return HoodieWriteConfig.newBuilder().withPath(basePath)
+                .withSchema(TRIP_EXAMPLE_SCHEMA)
+                .withParallelism(2, 2)
+                .withAutoCommit(autoCommit)
+                .withMetadataConfig(HoodieMetadataConfig.newBuilder().withAssumeDatePartitioning(true).build())
+                .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024 * 1024)
+                        .withInlineCompaction(false).withMaxNumDeltaCommitsBeforeCompaction(1).build())
+                .withStorageConfig(HoodieStorageConfig.newBuilder()
+                        .hfileMaxFileSize(1024 * 1024 * 1024).parquetMaxFileSize(1024 * 1024 * 1024).orcMaxFileSize(1024 * 1024 * 1024).build())
+                .forTable("test-trip-table")
+                .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
+                .withEmbeddedTimelineServerEnabled(true).withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+                        .withStorageType(FileSystemViewStorageType.EMBEDDED_KV_STORE).build());
+    }
+}


### PR DESCRIPTION
### Change Logs

When running the MOR task on flink, we found that the taskmanager log repeatedly loaded related metrics, so we thought that the task thread did not isolate it during concurrent access, causing this error to occur in the next Task thread access. After the repair, the problem disappeared
### Impact

![error](https://user-images.githubusercontent.com/20021404/205759054-5286bbf9-72c1-469c-bb43-7901799b287a.png)


### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
