### PR TITLE
[HUDI-5271] fix issue inconsistent reader and writer schema in HoodieAvroDataBlock

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -165,7 +165,7 @@ class MergeOnReadSnapshotRelation(sqlContext: SQLContext,
           StructType(requiredDataSchema.structTypeSchema.fields
             .filterNot(f => superfluousColumnNames.contains(f.name)))
 
-        HoodieTableSchema(prunedStructSchema, convertToAvroSchema(prunedStructSchema).toString)
+        HoodieTableSchema(prunedStructSchema, convertToAvroSchema(prunedStructSchema, tableConfig.getTableName).toString)
       }
 
       val requiredSchemaReaderSkipMerging = createBaseFileReader(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMorTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMorTable.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+class TestMorTable extends HoodieSparkSqlTestBase {
+  test("Test Insert Into MOR table") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      // Create a partitioned table
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  dt string,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  test_decimal_col decimal(25, 4)
+           |) using hudi
+           |options
+           |(
+           |    type = 'mor'
+           |    ,primaryKey = 'id'
+           |    ,hoodie.index.type = 'INMEMORY'
+           |)
+           | tblproperties (primaryKey = 'id')
+           | partitioned by (dt)
+           | location '${tmp.getCanonicalPath}'
+           | """.stripMargin)
+
+      // Note: Do not write the field alias, the partition field must be placed last.
+      spark.sql(
+        s"""
+           | insert into $tableName values
+           | (1, 'a1', 10, 1000, 1.0, "2021-01-05"),
+           | (2, 'a2', 20, 2000, 2.0, "2021-01-06"),
+           | (3, 'a3', 30, 3000, 3.0, "2021-01-07")
+          """.stripMargin)
+
+      spark.sql(
+        s"""
+           | insert into $tableName values
+           | (1, 'a1', 10, null, 1.0, "2021-01-05"),
+           | (4, 'a2', 20, 2000, null, "2021-01-06")
+          """.stripMargin)
+
+      checkAnswer(s"select id, name, price, ts, cast(test_decimal_col AS string), dt from $tableName")(
+        Seq(1, "a1", 10.0, null, "1.0000", "2021-01-05"),
+        Seq(2, "a2", 20.0, 2000, "2.0000", "2021-01-06"),
+        Seq(3, "a3", 30.0, 3000, "3.0000", "2021-01-07"),
+        Seq(4, "a2", 20.0, 2000, null, "2021-01-06")
+      )
+    }
+  }
+}


### PR DESCRIPTION
Trouble shooting detail in this issue and fix: https://github.com/apache/hudi/issues/7284

### Change Logs

* Add a new parameter in method `HoodieBaseRelation#convertToAvroSchema` for generating a aualified name according to the table name for Avro schema
* Use the new API `AvroConversionUtils#convertStructTypeToAvroSchema` in `HoodieBaseRelation#convertToAvroSchema` for struct schema to avro schema converting
* Add a new test case `TestMorTable` for verifying the issue is fixed

### Impact

No public API changed.

### Risk level (write none, low medium or high below)

low

### Documentation Update

No doc or configuration changed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
