### PR TITLE
[HUDI-5283] Replace deprecated method Schema.parse With Schema.Parser.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/HoodieBootstrapSchemaProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/HoodieBootstrapSchemaProvider.java
@@ -48,7 +48,7 @@ public abstract class HoodieBootstrapSchemaProvider {
   public final Schema getBootstrapSchema(HoodieEngineContext context, List<Pair<String, List<HoodieFileStatus>>> partitions) {
     if (writeConfig.getSchema() != null) {
       // Use schema specified by user if set
-      Schema userSchema = Schema.parse(writeConfig.getSchema());
+      Schema userSchema = new Schema.Parser().parse(writeConfig.getSchema());
       if (!HoodieAvroUtils.getNullSchema().equals(userSchema)) {
         return userSchema;
       }


### PR DESCRIPTION
### Change Logs
JIRA: HUDI-5283. Replace deprecated method Schema.parse With Schema.Parser.

When reading the code, I found that `HoodieBootstrapSchemaProvider#getBootstrapSchema` uses the deprecated method `Schema.parse`, which can be replaced by `Schema.Parser().parse()`,
At the same time, I searched at the moudle level, only to find that this place uses an deprecated method.

### Impact

none.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
