### PR TITLE
[HUDI-5286] UnsupportedOperationException throws when enabling filesy…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieRetryWrapperFileSystem.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieRetryWrapperFileSystem.java
@@ -258,4 +258,9 @@ public class HoodieRetryWrapperFileSystem extends FileSystem {
   public Configuration getConf() {
     return fileSystem.getConf();
   }
+
+  @Override
+  public String getScheme() {
+    return fileSystem.getScheme();
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -77,6 +78,14 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     List<String> folders =
             Arrays.asList("2016/04/15", ".hoodie/.temp/2/2016/04/15");
     folders.forEach(f -> assertThrows(RuntimeException.class, () -> metaClient.getFs().mkdirs(new Path(new Path(basePath), f))));
+  }
+
+  @Test
+  public void testGetSchema() {
+    FakeRemoteFileSystem fakeFs = new FakeRemoteFileSystem(FSUtils.getFs(metaClient.getMetaPath(), metaClient.getHadoopConf()), 100);
+    FileSystem fileSystem = new HoodieRetryWrapperFileSystem(fakeFs, maxRetryIntervalMs, maxRetryNumbers, initialRetryIntervalMs, "");
+    HoodieWrapperFileSystem fs = new HoodieWrapperFileSystem(fileSystem, new NoOpConsistencyGuard());
+    assertDoesNotThrow(fs::getScheme, "Method #getSchema does not implement correctly");
   }
 
   /**
@@ -204,6 +213,11 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     @Override
     public Configuration getConf() {
       return fs.getConf();
+    }
+
+    @Override
+    public String getScheme() {
+      return fs.getScheme();
     }
   }
 }


### PR DESCRIPTION
…stem retry

### Change Logs

FileSystem#getScheme is a method that must be overridden.

### Impact

Fix the UnsupportedOperationException on object storage.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
