### PR TITLE
[HUDI-5276][WIP] Exclude unnecessary partiton paths return

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -49,6 +49,7 @@ import org.apache.hudi.common.util.ClosableIterator;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SpillableMapUtils;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -152,7 +152,8 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
   @Override
   public List<String> getPartitionPathsWithPrefixes(List<String> prefixes) throws IOException {
     return getAllPartitionPaths().stream()
-        .filter(p -> prefixes.stream().anyMatch(p::startsWith))
+        .filter(p -> prefixes.stream().anyMatch(queryPaths ->
+            p.startsWith(queryPaths + "/") || queryPaths.equals(p) || (StringUtils.isNullOrEmpty(queryPaths) && p.startsWith(queryPaths))))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request
fix https://github.com/apache/hudi/issues/7298


Fix query partition path add  invalid input path.  In function getPartitionPathsWithPrefixes will fetch list of all partitions path that whose relative partition paths match the given prefixes. It caused a unexpected path add and throw exception in hive.  Like this:

Table has partition 2 partitions:
year=2022/month=08/day=30
year=2022back/month=08/day=31

When query "year=2022",  we only want get the path 2022 not the 2022back. 
Expect paths  _[year=2022/month=08/day=30]_.  
actual paths [year=2022/month=08/day=30,  year=2022back/month=08/day=30]