### PR TITLE
[HUDI-5303] Allow users to control the concurrency to submit jobs in clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -154,6 +154,15 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .sinceVersion("0.9.0")
       .withDocumentation("Config to control frequency of async clustering");
 
+  public static final ConfigProperty<Integer> CLUSTERING_MAX_THREADS = ConfigProperty
+      .key("hoodie.clustering.max.threads")
+      .defaultValue(10)
+      .sinceVersion("0.13.0")
+      .withDocumentation("Maximum number of parallelism jobs submitted in clustering operation. "
+          + "If the resource is sufficient(Like Spark engine has enough idle executors), increasing this "
+          + "value will let the clustering job run faster, while it will give additional pressure to the "
+          + "execution engines to manage more concurrent running jobs.");
+
   public static final ConfigProperty<String> PLAN_STRATEGY_SKIP_PARTITIONS_FROM_LATEST = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "daybased.skipfromlatest.partitions")
       .defaultValue("0")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -156,8 +156,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
 
   public static final ConfigProperty<Integer> CLUSTERING_MAX_THREADS = ConfigProperty
       .key("hoodie.clustering.max.threads")
-      .defaultValue(10)
-      .sinceVersion("0.13.0")
+      .defaultValue(15)
+      .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of parallelism jobs submitted in clustering operation. "
           + "If the resource is sufficient(Like Spark engine has enough idle executors), increasing this "
           + "value will let the clustering job run faster, while it will give additional pressure to the "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -154,8 +154,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .sinceVersion("0.9.0")
       .withDocumentation("Config to control frequency of async clustering");
 
-  public static final ConfigProperty<Integer> CLUSTERING_MAX_THREADS = ConfigProperty
-      .key("hoodie.clustering.max.threads")
+  public static final ConfigProperty<Integer> CLUSTERING_MAX_PARALLELISM = ConfigProperty
+      .key("hoodie.clustering.max.parallelism")
       .defaultValue(15)
       .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of parallelism jobs submitted in clustering operation. "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1634,8 +1634,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getString(HoodieClusteringConfig.PLAN_STRATEGY_CLASS_NAME);
   }
 
-  public int getClusteringMaxThreads() {
-    return getInt(HoodieClusteringConfig.CLUSTERING_MAX_THREADS);
+  public int getClusteringMaxParallelism() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_MAX_PARALLELISM);
   }
 
   public ClusteringPlanPartitionFilterMode getClusteringPlanPartitionFilterMode() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1634,6 +1634,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getString(HoodieClusteringConfig.PLAN_STRATEGY_CLASS_NAME);
   }
 
+  public int getClusteringMaxThreads() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_MAX_THREADS);
+  }
+
   public ClusteringPlanPartitionFilterMode getClusteringPlanPartitionFilterMode() {
     String mode = getString(HoodieClusteringConfig.PLAN_PARTITION_FILTER_MODE_NAME);
     return ClusteringPlanPartitionFilterMode.valueOf(mode);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -102,8 +102,6 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
 
   public MultipleSparkJobExecutionStrategy(HoodieTable table, HoodieEngineContext engineContext, HoodieWriteConfig writeConfig) {
     super(table, engineContext, writeConfig);
-    this.clusteringExecutorService = Executors.newFixedThreadPool(writeConfig.getClusteringMaxThreads(),
-        new CustomizedThreadFactory("clustering-submit-job", true));
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -105,7 +105,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
   public MultipleSparkJobExecutionStrategy(HoodieTable table, HoodieEngineContext engineContext, HoodieWriteConfig writeConfig) {
     super(table, engineContext, writeConfig);
     this.clusteringExecutorService = Executors.newFixedThreadPool(writeConfig.getClusteringMaxThreads(),
-        new CustomizedThreadFactory("clustering-submit-job-pool", true));
+        new CustomizedThreadFactory("clustering-submit-job", true));
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -109,7 +109,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     JavaSparkContext engineContext = HoodieSparkEngineContext.getSparkContext(getEngineContext());
     boolean shouldPreserveMetadata = Option.ofNullable(clusteringPlan.getPreserveHoodieMetadata()).orElse(false);
     ExecutorService clusteringExecutorService = Executors.newFixedThreadPool(
-        Math.min(clusteringPlan.getInputGroups().size(), writeConfig.getClusteringMaxThreads()),
+        Math.min(clusteringPlan.getInputGroups().size(), writeConfig.getClusteringMaxParallelism()),
         new CustomizedThreadFactory("clustering-job-group", true));
     try {
       // execute clustering for each group async and collect WriteStatus


### PR DESCRIPTION
### Change Logs

If there are sufficient resources in the clustering job, some clustering groups sometimes could still waits to be triggered, we use forkJoinPool to submit these jobs, and it's also difficult for clients to adjust this configure(`--conf spark.driver.extraJavaOptions=-Djava.util.concurrent.ForkJoinPool.common.parallelism`), and it could also affect other tasks using the forkJoinPool, so instead, we introduce a new threadPool to control the submitting job parallelism for the clustering.

### Impact

Add new configure `hoodie.clustering.max.threads` to control this behavior.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
