### PR TITLE
Update Spark SQL DDL docs with note about lack of Glue support

### DIFF
--- a/website/docs/table_management.md
+++ b/website/docs/table_management.md
@@ -183,6 +183,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;

--- a/website/versioned_docs/version-0.10.0/table_management.md
+++ b/website/versioned_docs/version-0.10.0/table_management.md
@@ -188,6 +188,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;

--- a/website/versioned_docs/version-0.10.1/table_management.md
+++ b/website/versioned_docs/version-0.10.1/table_management.md
@@ -188,6 +188,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;

--- a/website/versioned_docs/version-0.11.0/table_management.md
+++ b/website/versioned_docs/version-0.11.0/table_management.md
@@ -183,6 +183,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;

--- a/website/versioned_docs/version-0.11.1/table_management.md
+++ b/website/versioned_docs/version-0.11.1/table_management.md
@@ -183,6 +183,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;

--- a/website/versioned_docs/version-0.12.0/table_management.md
+++ b/website/versioned_docs/version-0.12.0/table_management.md
@@ -183,6 +183,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;

--- a/website/versioned_docs/version-0.12.1/table_management.md
+++ b/website/versioned_docs/version-0.12.1/table_management.md
@@ -183,6 +183,12 @@ ALTER TABLE tableIdentifier ADD COLUMNS(colAndType (,colAndType)*)
 -- Alter table column type
 ALTER TABLE tableIdentifier CHANGE COLUMN colName colName colType
 ```
+
+:::note
+`ALTER TABLE ... RENAME TO ...` is not supported when using AWS Glue Data Catalog as hive metastore as Glue itself does 
+not support table renames.
+:::
+
 ### Examples
 ```sql
 alter table h0 rename to h0_1;


### PR DESCRIPTION
### Change Logs

Add a note to Hudi docs to mention Glue Catalog does not support table renames.

### Impact

Documentation update

### Risk level (write none, low medium or high below)

NONE

### Documentation Update

Add a note to Hudi docs to mention Glue Catalog does not support table renames.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
