### PR TITLE
[HUDI-5315] The record size is dynamically estimated when the table i…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -613,6 +613,18 @@ public class HoodieWriteConfig extends HoodieConfig {
       .withDocumentation("When table is upgraded from pre 0.12 to 0.12, we check for \"default\" partition and fail if found one. "
           + "Users are expected to rewrite the data in those partitions. Enabling this config will bypass this validation");
 
+  public static final ConfigProperty<String> RECORD_SIZE_DYNAMIC_SAMPLING_MAXNUM = ConfigProperty
+          .key("hoodie.record.size.dynamic.sampling.maxnum")
+          .defaultValue(String.valueOf(100))
+          .withDocumentation("In the first time to write, if the user estimated the size of the record and the actual deviation is large, and write a huge amount of data, "
+                  + "it may cause a lot of small files. "
+                  + "This parameter is used for the first time to write data sampling, in turn to dynamically estimate the size of the record, so that more accurate.");
+
+  public static final ConfigProperty<String> RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE = ConfigProperty
+          .key("hoodie.record.size.dynamic.sampling.enable")
+          .defaultValue(String.valueOf(true))
+          .withDocumentation("Control to enable dynamic sampling record size when write in first time.");
+
   public static final ConfigProperty<String> EARLY_CONFLICT_DETECTION_STRATEGY_CLASS_NAME = ConfigProperty
       .key(CONCURRENCY_PREFIX + "early.conflict.detection.strategy")
       .noDefaultValue()
@@ -1419,6 +1431,14 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public int getCopyOnWriteRecordSizeEstimate() {
     return getInt(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE);
+  }
+
+  public int getRecordSizeDynamicSamplingMaxnum() {
+    return getInt(HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_MAXNUM);
+  }
+
+  public boolean getRecordSizeDynamicSamplingEnable() {
+    return getBoolean(HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE);
   }
 
   public boolean allowMultipleCleans() {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -332,6 +332,14 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     return kryo.readObjectOrNull(input, UnsafeRow.class);
   }
 
+  @Override
+  public long estimateSerializedDataSize() {
+    if (data instanceof UnsafeRow) {
+      return ((UnsafeRow) data).getSizeInBytes();
+    }
+    return super.estimateSerializedDataSize();
+  }
+
   private static UnsafeRow convertToUnsafeRow(InternalRow payload, StructType schema) {
     if (payload == null) {
       return null;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1203,6 +1203,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
     Properties props = new Properties();
     props.setProperty(ASYNC_CLUSTERING_ENABLE.key(), "true");
+    props.setProperty(HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE.key(), "false");
     HoodieWriteConfig config = getSmallInsertWriteConfig(100,
         TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150), true, props);
     SparkRDDWriteClient client = getHoodieWriteClient(config);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -92,6 +92,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.createCompactionCommitInMetadataTable;
 import static org.apache.hudi.config.HoodieArchivalConfig.ARCHIVE_BEYOND_SAVEPOINT;
+import static org.apache.hudi.config.HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -232,6 +233,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
             .build())
         .forTable("test-trip-table").build();
     initWriteConfigAndMetatableWriter(writeConfig, enableMetadata);
+    writeConfig.setValue(RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE, "false");
     return writeConfig;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -229,4 +229,13 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
   protected final T readRecordPayload(Kryo kryo, Input input) {
     return (T) kryo.readClassAndObject(input);
   }
+
+  @Override
+  public long estimateSerializedDataSize() {
+    if (data instanceof BaseAvroPayload) {
+      return ((BaseAvroPayload) data).recordBytes.length;
+    }
+    return super.estimateSerializedDataSize();
+  }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -25,6 +25,7 @@ import com.esotericsoftware.kryo.io.Output;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.ObjectSizeCalculator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -390,6 +391,11 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   protected static boolean hasMetaFields(Schema schema) {
     return schema.getField(HoodieRecord.RECORD_KEY_METADATA_FIELD) != null;
   }
+
+  public long estimateSerializedDataSize() {
+    return ObjectSizeCalculator.getObjectSize(this.data);
+  }
+
 
   /**
    * A special record returned by {@link HoodieRecordPayload}, which means we should just skip this record.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -600,7 +600,8 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
       RECORDKEY_FIELD.key -> "id",
       PRECOMBINE_FIELD.key -> "id",
-      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+      HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE.key() -> "false"
     ) ++ writeMetadataOpts
 
     // If there are any failures in the Data Skipping flow, test should fail

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -98,7 +98,8 @@ class TestColumnStatsIndex extends HoodieSparkClientTestBase {
       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
       RECORDKEY_FIELD.key -> "c1",
       PRECOMBINE_FIELD.key -> "c1",
-      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+      HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE.key() -> "false"
     ) ++ metadataOpts
 
     doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
@@ -194,7 +195,8 @@ class TestColumnStatsIndex extends HoodieSparkClientTestBase {
       RECORDKEY_FIELD.key -> "c1",
       PRECOMBINE_FIELD.key -> "c1",
       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
-      HoodieCommonConfig.RECONCILE_SCHEMA.key -> "true"
+      HoodieCommonConfig.RECONCILE_SCHEMA.key -> "true",
+      HoodieWriteConfig.RECORD_SIZE_DYNAMIC_SAMPLING_ENABLE.key() -> "false"
     ) ++ metadataOpts
 
     val sourceJSONTablePath = getClass.getClassLoader.getResource("index/colstats/input-table-json").toString


### PR DESCRIPTION
…s first written

### Change Logs

Although hudi has the function of dynamically estimating the size of the record, but it can only take effect if certain conditions are met, when the user commits for the first time, the default is to use [hoodie.copyonwrite.record.size.estimate = 1024], if the amount of data for the first commit is very large, and the user [hoodie.copyonwrite.record.size.estimate] parameter setting is not reasonable, it will lead to a lot of small files.

### Impact

This pr avoids  producing a lot of small files under certain circumstances

### Risk level (write none, low medium or high below)

medium

It has been verified in our production environment, you can refer to the test report in the issue
https://issues.apache.org/jira/browse/HUDI-5315

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
