### PR TITLE
[HUDI-5289] Fix writeStatus RDD recalculated in cluster

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -469,7 +469,7 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
   }
 
   private void validateClusteringCommit(HoodieWriteMetadata<JavaRDD<WriteStatus>> clusteringMetadata, String clusteringCommitTime, HoodieTable table) {
-    if (clusteringMetadata.getWriteStatuses().isEmpty()) {
+    if (!clusteringMetadata.getWriteStats().isPresent() || clusteringMetadata.getWriteStats().get().isEmpty()) {
       HoodieClusteringPlan clusteringPlan = ClusteringUtils.getClusteringPlan(
               table.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(clusteringCommitTime))
           .map(Pair::getRight).orElseThrow(() -> new HoodieClusteringException(

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -469,7 +469,7 @@ public class SparkRDDWriteClient<T extends HoodieRecordPayload> extends
   }
 
   private void validateClusteringCommit(HoodieWriteMetadata<JavaRDD<WriteStatus>> clusteringMetadata, String clusteringCommitTime, HoodieTable table) {
-    if (!clusteringMetadata.getWriteStats().isPresent() || clusteringMetadata.getWriteStats().get().isEmpty()) {
+    if (clusteringMetadata.getWriteStatuses().isEmpty()) {
       HoodieClusteringPlan clusteringPlan = ClusteringUtils.getClusteringPlan(
               table.getMetaClient(), HoodieTimeline.getReplaceCommitRequestedInstant(clusteringCommitTime))
           .map(Pair::getRight).orElseThrow(() -> new HoodieClusteringException(

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -70,6 +70,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.sources.BaseRelation;
+import org.apache.spark.storage.StorageLevel;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -122,6 +123,8 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
         .stream();
     JavaRDD<WriteStatus>[] writeStatuses = convertStreamToArray(writeStatusesStream.map(HoodieJavaRDD::getJavaRDD));
     JavaRDD<WriteStatus> writeStatusRDD = engineContext.union(writeStatuses);
+    // Persist writeStatus, since it may be reused
+    writeStatusRDD.persist(StorageLevel.MEMORY_AND_DISK());
 
     HoodieWriteMetadata<HoodieData<WriteStatus>> writeMetadata = new HoodieWriteMetadata<>();
     writeMetadata.setWriteStatuses(HoodieJavaRDD.of(writeStatusRDD));


### PR DESCRIPTION
### Change Logs

fix https://issues.apache.org/jira/projects/HUDI/issues/HUDI-5289

There is a [patch](https://github.com/apache/hudi/pull/6561) similar to this problem, but after this patch is added, the problem still exists.

### Impact

Could improve the clustering performance.

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
