### PR TITLE
[HUDI-5332] HiveSyncTool can avoid initializing all permanent custom functions of Hive

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -49,6 +49,7 @@ import org.apache.log4j.Logger;
 import org.apache.parquet.schema.MessageType;
 import org.apache.thrift.TException;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -83,7 +84,7 @@ public class HMSDDLExecutor implements DDLExecutor {
     IMetaStoreClient tempMetaStoreClient;
     try {
       tempMetaStoreClient = ((Hive) Hive.class.getMethod("getWithoutRegisterFns", HiveConf.class).invoke(null, hiveConf)).getMSC();
-    } catch (Exception ex) {
+    } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
       tempMetaStoreClient = Hive.get(hiveConf).getMSC();
     }
     this.client = tempMetaStoreClient;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -38,6 +38,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,7 +65,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     IMetaStoreClient tempMetaStoreClient;
     try {
       tempMetaStoreClient = ((Hive) Hive.class.getMethod("getWithoutRegisterFns", HiveConf.class).invoke(null, hiveConf)).getMSC();
-    } catch (Exception ex) {
+    } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
       tempMetaStoreClient = Hive.get(hiveConf).getMSC();
     }
     this.metaStoreClient = tempMetaStoreClient;


### PR DESCRIPTION
### Change Logs

HiveSyncTool can avoid initializing all permanent custom functions of Hive

### Impact

Improve the execution speed of synchronization tools and reduce the load of HMS

### Risk level (write none, low medium or high below)



### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
