### PR TITLE
[HUDI-4961] Support optional table synchronization to hive.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieSyncTableStrategy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieSyncTableStrategy.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+/**
+ * Hoodie table synchronization strategy.
+ */
+public enum HoodieSyncTableStrategy {
+  RO, RT, ALL
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
+import org.apache.hudi.common.model.HoodieSyncTableStrategy;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -851,6 +852,12 @@ public class FlinkOptions extends HoodieConfig {
       .stringType()
       .noDefaultValue()
       .withDescription("The hive configuration directory, where the hive-site.xml lies in, the file should be put on the client machine");
+
+  public static final ConfigOption<String> HIVE_SYNC_TABLE_STRATEGY = ConfigOptions
+          .key("hive_sync.table.strategy")
+          .stringType()
+          .defaultValue(HoodieSyncTableStrategy.ALL.name())
+          .withDescription("Hive table synchronization strategy. Available option: RO, RT, ALL.");
 
   // -------------------------------------------------------------------------
   //  Utilities

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -40,6 +40,7 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_MODE;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_SERDE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
@@ -117,6 +118,7 @@ public class HiveSyncContext {
     props.setPropertyIfNonNull(META_SYNC_DECODE_PARTITION.key(), String.valueOf(conf.getBoolean(FlinkOptions.URL_ENCODE_PARTITIONING)));
     props.setPropertyIfNonNull(HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE.key(), String.valueOf(conf.getBoolean(FlinkOptions.HIVE_SYNC_SKIP_RO_SUFFIX)));
     props.setPropertyIfNonNull(META_SYNC_ASSUME_DATE_PARTITION.key(), String.valueOf(conf.getBoolean(FlinkOptions.HIVE_SYNC_ASSUME_DATE_PARTITION)));
+    props.setPropertyIfNonNull(HIVE_SYNC_TABLE_STRATEGY.key(), String.valueOf(conf.getString(FlinkOptions.HIVE_SYNC_TABLE_STRATEGY)));
     return props;
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.hive;
 
 import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.model.HoodieSyncTableStrategy;
 
 public class HiveSyncConfigHolder {
   /*
@@ -130,4 +131,9 @@ public class HiveSyncConfigHolder {
       .key("hoodie.datasource.hive_sync.sync_comment")
       .defaultValue("false")
       .withDocumentation("Whether to sync the table column comments while syncing the table.");
+
+  public static final ConfigProperty<String> HIVE_SYNC_TABLE_STRATEGY = ConfigProperty
+          .key("hoodie.datasource.hive_sync.table.strategy")
+          .defaultValue(HoodieSyncTableStrategy.ALL.name())
+          .withDocumentation("Hive table synchronization strategy. Available option: ONLY_RO, ONLY_RT, ALL.");
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive;
 
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieSyncTableStrategy;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
@@ -53,6 +54,7 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SKIP_RO_SUFFIX_FOR_
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_AS_DATA_SOURCE_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_COMMENT;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_PROPERTIES;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_TABLE_SERDE_PROPERTIES;
@@ -88,6 +90,8 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
   protected String snapshotTableName;
   protected Option<String> roTableName;
 
+  protected String hiveSyncTableStrategy;
+
   public HiveSyncTool(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf);
     HiveSyncConfig config = new HiveSyncConfig(props, hadoopConf);
@@ -119,6 +123,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
           this.roTableName = Option.empty();
           break;
         case MERGE_ON_READ:
+          this.hiveSyncTableStrategy = config.getStringOrDefault(HIVE_SYNC_TABLE_STRATEGY).toUpperCase();
           this.snapshotTableName = tableName + SUFFIX_SNAPSHOT_TABLE;
           this.roTableName = config.getBoolean(HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE)
               ? Option.of(tableName)
@@ -155,10 +160,21 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
         syncHoodieTable(snapshotTableName, false, false);
         break;
       case MERGE_ON_READ:
-        // sync a RO table for MOR
-        syncHoodieTable(roTableName.get(), false, true);
-        // sync a RT table for MOR
-        syncHoodieTable(snapshotTableName, true, false);
+        switch (HoodieSyncTableStrategy.valueOf(hiveSyncTableStrategy)) {
+          case RO :
+            // sync a RO table for MOR
+            syncHoodieTable(tableName, false, true);
+            break;
+          case RT :
+            // sync a RT table for MOR
+            syncHoodieTable(tableName, true, false);
+            break;
+          default:
+            // sync a RO table for MOR
+            syncHoodieTable(roTableName.get(), false, true);
+            // sync a RT table for MOR
+            syncHoodieTable(snapshotTableName, true, false);
+        }
         break;
       default:
         LOG.error("Unknown table type " + syncClient.getTableType());


### PR DESCRIPTION
### Change Logs
Support optional table synchronization to hive.
### Impact

This change does not affect performance.

### Risk level (write none, low medium or high below)
none

### Documentation Update
add new parameter  :
`hive_sync.table.strategy`  Available options ： RO , RT, ALL
`hoodie.datasource.hive_sync.table.strategy`  Available options ： RO , RT, ALL

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
