### PR TITLE
[HUDI-5350] Fix oom cause compaction event lost problem

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/NonThrownExecutor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/NonThrownExecutor.java
@@ -136,15 +136,15 @@ public class NonThrownExecutor implements AutoCloseable {
   }
 
   private void handleException(Throwable t, ExceptionHook hook, Supplier<String> actionString) {
-    // if we have a JVM critical error, promote it immediately, there is a good
-    // chance the
-    // logging or job failing will not succeed any more
-    ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
     final String errMsg = String.format("Executor executes action [%s] error", actionString.get());
     logger.error(errMsg, t);
     if (hook != null) {
       hook.apply(errMsg, t);
     }
+    // if we have a JVM critical error, promote it immediately, there is a good
+    // chance the
+    // logging or job failing will not succeed any more
+    ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
   }
 
   private Supplier<String> getActionString(String actionName, Object... actionParams) {


### PR DESCRIPTION
### Change Logs

code from `org.apache.hudi.sink.compact.CompactOperator`: 

![image](https://user-images.githubusercontent.com/8900183/206414512-c4d2ff09-a550-4b4d-997b-c0fc4d54403c.png)


In flink inline async compaction, if OOM error happen during execution of `doCompaction(...)`, exception hook will not be executed, and no CompactionCommitEvent is sent to `CompactionCommitSink`. Result in compaction instant stuck in "inflight" state, never succeed or rollback, in fact the compaction is failed.

I change the execute sequence: run ExceptionHook before re-throw FatalErrorOrOOM.

I tested and it can sent `CompactionCommitEvent` to compaction sink to rollback the failed compaction when OOM happen during compaction.

### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

no

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
