### PR TITLE
[HUDI-5351] Handle populateMetaFields when repartitioning in sort partitioner

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -207,9 +207,9 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
       }
     }).orElse(isRowPartitioner
         ? BulkInsertInternalPartitionerWithRowsFactory.get(
-        getWriteConfig().getBulkInsertSortMode(), getHoodieTable().isPartitioned(), true)
+        getWriteConfig().getBulkInsertSortMode(), getHoodieTable().isPartitioned(), true, getWriteConfig().populateMetaFields())
         : BulkInsertInternalPartitionerFactory.get(
-        getWriteConfig().getBulkInsertSortMode(), getHoodieTable().isPartitioned(), true));
+        getWriteConfig().getBulkInsertSortMode(), getHoodieTable().isPartitioned(), true, getWriteConfig().populateMetaFields()));
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -206,10 +206,8 @@ public abstract class MultipleSparkJobExecutionStrategy<T extends HoodieRecordPa
           throw new UnsupportedOperationException(String.format("Layout optimization strategy '%s' is not supported", layoutOptStrategy));
       }
     }).orElse(isRowPartitioner
-        ? BulkInsertInternalPartitionerWithRowsFactory.get(
-        getWriteConfig().getBulkInsertSortMode(), getHoodieTable().isPartitioned(), true, getWriteConfig().populateMetaFields())
-        : BulkInsertInternalPartitionerFactory.get(
-        getWriteConfig().getBulkInsertSortMode(), getHoodieTable().isPartitioned(), true, getWriteConfig().populateMetaFields()));
+        ? BulkInsertInternalPartitionerWithRowsFactory.get(getWriteConfig(), getHoodieTable().isPartitioned(), true)
+        : BulkInsertInternalPartitionerFactory.get(getHoodieTable(), getWriteConfig(), true));
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerFactory.java
@@ -42,24 +42,25 @@ public abstract class BulkInsertInternalPartitionerFactory {
         && config.getBucketIndexEngineType().equals(HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING)) {
       return new RDDConsistentBucketPartitioner(table);
     }
-    return get(config.getBulkInsertSortMode(), table.isPartitioned(), enforceNumOutputPartitions, config.populateMetaFields());
+    return get(config, table.isPartitioned(), enforceNumOutputPartitions);
   }
 
-  public static BulkInsertPartitioner get(BulkInsertSortMode sortMode,
+  public static BulkInsertPartitioner get(HoodieWriteConfig config,
                                           boolean isTablePartitioned,
-                                          boolean enforceNumOutputPartitions,
-                                          boolean populateMetaFields) {
+                                          boolean enforceNumOutputPartitions) {
+    BulkInsertSortMode sortMode = config.getBulkInsertSortMode();
+
     switch (sortMode) {
       case NONE:
         return new NonSortPartitioner(enforceNumOutputPartitions);
       case GLOBAL_SORT:
-        return new GlobalSortPartitioner(populateMetaFields);
+        return new GlobalSortPartitioner(config);
       case PARTITION_SORT:
-        return new RDDPartitionSortPartitioner(populateMetaFields);
+        return new RDDPartitionSortPartitioner(config);
       case PARTITION_PATH_REPARTITION:
-        return new PartitionPathRepartitionPartitioner(isTablePartitioned, populateMetaFields);
+        return new PartitionPathRepartitionPartitioner(isTablePartitioned, config);
       case PARTITION_PATH_REPARTITION_AND_SORT:
-        return new PartitionPathRepartitionAndSortPartitioner(isTablePartitioned, populateMetaFields);
+        return new PartitionPathRepartitionAndSortPartitioner(isTablePartitioned, config);
       default:
         throw new HoodieException("The bulk insert sort mode \"" + sortMode.name() + "\" is not supported.");
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerWithRowsFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerWithRowsFactory.java
@@ -30,23 +30,26 @@ import org.apache.spark.sql.Row;
 public abstract class BulkInsertInternalPartitionerWithRowsFactory {
 
   public static BulkInsertPartitioner<Dataset<Row>> get(BulkInsertSortMode sortMode,
-                                                        boolean isTablePartitioned) {
-    return get(sortMode, isTablePartitioned, false);
+                                                        boolean isTablePartitioned,
+                                                        boolean populateMetaFields) {
+    return get(sortMode, isTablePartitioned, false, populateMetaFields);
   }
 
-  public static BulkInsertPartitioner<Dataset<Row>> get(
-      BulkInsertSortMode sortMode, boolean isTablePartitioned, boolean enforceNumOutputPartitions) {
+  public static BulkInsertPartitioner<Dataset<Row>> get(BulkInsertSortMode sortMode,
+                                                        boolean isTablePartitioned,
+                                                        boolean enforceNumOutputPartitions,
+                                                        boolean populateMetaFields) {
     switch (sortMode) {
       case NONE:
         return new NonSortPartitionerWithRows(enforceNumOutputPartitions);
       case GLOBAL_SORT:
-        return new GlobalSortPartitionerWithRows();
+        return new GlobalSortPartitionerWithRows(populateMetaFields);
       case PARTITION_SORT:
-        return new PartitionSortPartitionerWithRows();
+        return new PartitionSortPartitionerWithRows(populateMetaFields);
       case PARTITION_PATH_REPARTITION:
-        return new PartitionPathRepartitionPartitionerWithRows(isTablePartitioned);
+        return new PartitionPathRepartitionPartitionerWithRows(isTablePartitioned, populateMetaFields);
       case PARTITION_PATH_REPARTITION_AND_SORT:
-        return new PartitionPathRepartitionAndSortPartitionerWithRows(isTablePartitioned);
+        return new PartitionPathRepartitionAndSortPartitionerWithRows(isTablePartitioned, populateMetaFields);
       default:
         throw new UnsupportedOperationException("The bulk insert sort mode \"" + sortMode.name() + "\" is not supported.");
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerWithRowsFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BulkInsertInternalPartitionerWithRowsFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Dataset;
@@ -29,27 +30,26 @@ import org.apache.spark.sql.Row;
  */
 public abstract class BulkInsertInternalPartitionerWithRowsFactory {
 
-  public static BulkInsertPartitioner<Dataset<Row>> get(BulkInsertSortMode sortMode,
-                                                        boolean isTablePartitioned,
-                                                        boolean populateMetaFields) {
-    return get(sortMode, isTablePartitioned, false, populateMetaFields);
+  public static BulkInsertPartitioner<Dataset<Row>> get(HoodieWriteConfig config,
+                                                        boolean isTablePartitioned) {
+    return get(config, isTablePartitioned, false);
   }
 
-  public static BulkInsertPartitioner<Dataset<Row>> get(BulkInsertSortMode sortMode,
+  public static BulkInsertPartitioner<Dataset<Row>> get(HoodieWriteConfig config,
                                                         boolean isTablePartitioned,
-                                                        boolean enforceNumOutputPartitions,
-                                                        boolean populateMetaFields) {
+                                                        boolean enforceNumOutputPartitions) {
+    BulkInsertSortMode sortMode = config.getBulkInsertSortMode();
     switch (sortMode) {
       case NONE:
         return new NonSortPartitionerWithRows(enforceNumOutputPartitions);
       case GLOBAL_SORT:
-        return new GlobalSortPartitionerWithRows(populateMetaFields);
+        return new GlobalSortPartitionerWithRows(config);
       case PARTITION_SORT:
-        return new PartitionSortPartitionerWithRows(populateMetaFields);
+        return new PartitionSortPartitionerWithRows(config);
       case PARTITION_PATH_REPARTITION:
-        return new PartitionPathRepartitionPartitionerWithRows(isTablePartitioned, populateMetaFields);
+        return new PartitionPathRepartitionPartitionerWithRows(isTablePartitioned, config);
       case PARTITION_PATH_REPARTITION_AND_SORT:
-        return new PartitionPathRepartitionAndSortPartitionerWithRows(isTablePartitioned, populateMetaFields);
+        return new PartitionPathRepartitionAndSortPartitionerWithRows(isTablePartitioned, config);
       default:
         throw new UnsupportedOperationException("The bulk insert sort mode \"" + sortMode.name() + "\" is not supported.");
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/GlobalSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/GlobalSortPartitioner.java
@@ -24,6 +24,8 @@ import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.api.java.JavaRDD;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does global sorting for the input records across partitions
  * after repartition for bulk insert operation, corresponding to the
@@ -34,9 +36,16 @@ import org.apache.spark.api.java.JavaRDD;
 public class GlobalSortPartitioner<T extends HoodieRecordPayload>
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {
 
+  private final boolean populateMetaFields;
+
+  public GlobalSortPartitioner(boolean populateMetaFields) {
+    this.populateMetaFields = populateMetaFields;
+  }
+
   @Override
   public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records,
                                                      int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     // Now, sort the records and line them up nicely for loading.
     return records.sortBy(record -> {
       // Let's use "partitionPath + key" as the sort key. Spark, will ensure

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/GlobalSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/GlobalSortPartitionerWithRows.java
@@ -19,28 +19,33 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.functions;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.execution.bulkinsert.BulkInsertSortMode.GLOBAL_SORT;
 
 /**
  * A built-in partitioner that does global sorting for the input Rows across partitions after repartition for bulk insert operation, corresponding to the {@code BulkInsertSortMode.GLOBAL_SORT} mode.
  */
 public class GlobalSortPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
-  private final boolean populateMetaFields;
+  private final boolean shouldPopulateMetaFields;
 
-  public GlobalSortPartitionerWithRows(boolean populateMetaFields) {
-    this.populateMetaFields = populateMetaFields;
+  public GlobalSortPartitionerWithRows(HoodieWriteConfig config) {
+    this.shouldPopulateMetaFields = config.populateMetaFields();
   }
 
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
-    checkState(populateMetaFields, "Meta fields are disabled!");
+    if (!shouldPopulateMetaFields) {
+      throw new HoodieException(GLOBAL_SORT.name() + " mode requires meta-fields to be enabled");
+    }
+
     // Now, sort the records and line them up nicely for loading.
     // Let's use "partitionPath + key" as the sort key.
     return rows.sort(functions.col(HoodieRecord.PARTITION_PATH_METADATA_FIELD), functions.col(HoodieRecord.RECORD_KEY_METADATA_FIELD))

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/GlobalSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/GlobalSortPartitionerWithRows.java
@@ -25,13 +25,22 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.functions;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does global sorting for the input Rows across partitions after repartition for bulk insert operation, corresponding to the {@code BulkInsertSortMode.GLOBAL_SORT} mode.
  */
 public class GlobalSortPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
+  private final boolean populateMetaFields;
+
+  public GlobalSortPartitionerWithRows(boolean populateMetaFields) {
+    this.populateMetaFields = populateMetaFields;
+  }
+
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     // Now, sort the records and line them up nicely for loading.
     // Let's use "partitionPath + key" as the sort key.
     return rows.sort(functions.col(HoodieRecord.PARTITION_PATH_METADATA_FIELD), functions.col(HoodieRecord.RECORD_KEY_METADATA_FIELD))

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
@@ -21,13 +21,15 @@ package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.api.java.JavaRDD;
 
 import scala.Tuple2;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.execution.bulkinsert.BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT;
 
 /**
  * A built-in partitioner that does the following for input records for bulk insert operation
@@ -47,17 +49,20 @@ public class PartitionPathRepartitionAndSortPartitioner<T extends HoodieRecordPa
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {
 
   private final boolean isTablePartitioned;
-  private final boolean populateMetaFields;
+  private final boolean shouldPopulateMetaFields;
 
-  public PartitionPathRepartitionAndSortPartitioner(boolean isTablePartitioned, boolean populateMetaFields) {
+  public PartitionPathRepartitionAndSortPartitioner(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
-    this.populateMetaFields = populateMetaFields;
+    this.shouldPopulateMetaFields = config.populateMetaFields();
   }
 
   @Override
   public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records,
                                                      int outputSparkPartitions) {
-    checkState(populateMetaFields, "Meta fields are disabled!");
+    if (!shouldPopulateMetaFields) {
+      throw new HoodieException(PARTITION_PATH_REPARTITION_AND_SORT.name() + " mode requires meta-fields to be enabled");
+    }
+
     if (isTablePartitioned) {
       PartitionPathRDDPartitioner partitioner = new PartitionPathRDDPartitioner(
           (partitionPath) -> (String) partitionPath, outputSparkPartitions);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
@@ -27,6 +27,8 @@ import org.apache.spark.api.java.JavaRDD;
 
 import scala.Tuple2;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does the following for input records for bulk insert operation
  * <p>
@@ -45,14 +47,17 @@ public class PartitionPathRepartitionAndSortPartitioner<T extends HoodieRecordPa
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {
 
   private final boolean isTablePartitioned;
+  private final boolean populateMetaFields;
 
-  public PartitionPathRepartitionAndSortPartitioner(boolean isTablePartitioned) {
+  public PartitionPathRepartitionAndSortPartitioner(boolean isTablePartitioned, boolean populateMetaFields) {
     this.isTablePartitioned = isTablePartitioned;
+    this.populateMetaFields = populateMetaFields;
   }
 
   @Override
   public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records,
                                                      int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     if (isTablePartitioned) {
       PartitionPathRDDPartitioner partitioner = new PartitionPathRDDPartitioner(
           (partitionPath) -> (String) partitionPath, outputSparkPartitions);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
@@ -20,13 +20,15 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.execution.bulkinsert.BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT;
 
 /**
  * A built-in partitioner that does the following for input rows for bulk insert operation
@@ -43,16 +45,19 @@ import static org.apache.hudi.common.util.ValidationUtils.checkState;
 public class PartitionPathRepartitionAndSortPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
   private final boolean isTablePartitioned;
-  private final boolean populateMetaFields;
+  private final boolean shouldPopulateMetaFields;
 
-  public PartitionPathRepartitionAndSortPartitionerWithRows(boolean isTablePartitioned, boolean populateMetaFields) {
+  public PartitionPathRepartitionAndSortPartitionerWithRows(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
-    this.populateMetaFields = populateMetaFields;
+    this.shouldPopulateMetaFields = config.populateMetaFields();
   }
 
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
-    checkState(populateMetaFields, "Meta fields are disabled!");
+    if (!shouldPopulateMetaFields) {
+      throw new HoodieException(PARTITION_PATH_REPARTITION_AND_SORT.name() + " mode requires meta-fields to be enabled");
+    }
+
     if (isTablePartitioned) {
       return rows.repartition(outputSparkPartitions, new Column(HoodieRecord.PARTITION_PATH_METADATA_FIELD))
           .sortWithinPartitions(new Column(HoodieRecord.PARTITION_PATH_METADATA_FIELD));

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
@@ -26,6 +26,8 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does the following for input rows for bulk insert operation
  * <p>
@@ -41,13 +43,16 @@ import org.apache.spark.sql.Row;
 public class PartitionPathRepartitionAndSortPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
   private final boolean isTablePartitioned;
+  private final boolean populateMetaFields;
 
-  public PartitionPathRepartitionAndSortPartitionerWithRows(boolean isTablePartitioned) {
+  public PartitionPathRepartitionAndSortPartitionerWithRows(boolean isTablePartitioned, boolean populateMetaFields) {
     this.isTablePartitioned = isTablePartitioned;
+    this.populateMetaFields = populateMetaFields;
   }
 
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     if (isTablePartitioned) {
       return rows.repartition(outputSparkPartitions, new Column(HoodieRecord.PARTITION_PATH_METADATA_FIELD))
           .sortWithinPartitions(new Column(HoodieRecord.PARTITION_PATH_METADATA_FIELD));

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
@@ -27,6 +27,8 @@ import org.apache.spark.api.java.JavaRDD;
 
 import scala.Tuple2;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does the following for input records for bulk insert operation
  * <p>
@@ -44,14 +46,17 @@ public class PartitionPathRepartitionPartitioner<T extends HoodieRecordPayload>
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {
 
   private final boolean isTablePartitioned;
+  private final boolean populateMetaFields;
 
-  public PartitionPathRepartitionPartitioner(boolean isTablePartitioned) {
+  public PartitionPathRepartitionPartitioner(boolean isTablePartitioned, boolean populateMetaFields) {
     this.isTablePartitioned = isTablePartitioned;
+    this.populateMetaFields = populateMetaFields;
   }
 
   @Override
   public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records,
                                                      int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     if (isTablePartitioned) {
       PartitionPathRDDPartitioner partitioner = new PartitionPathRDDPartitioner(
           (partitionPath) -> (String) partitionPath, outputSparkPartitions);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
@@ -21,13 +21,15 @@ package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.api.java.JavaRDD;
 
 import scala.Tuple2;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.execution.bulkinsert.BulkInsertSortMode.PARTITION_PATH_REPARTITION;
 
 /**
  * A built-in partitioner that does the following for input records for bulk insert operation
@@ -46,17 +48,20 @@ public class PartitionPathRepartitionPartitioner<T extends HoodieRecordPayload>
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {
 
   private final boolean isTablePartitioned;
-  private final boolean populateMetaFields;
+  private final boolean shouldPopulateMetaFields;
 
-  public PartitionPathRepartitionPartitioner(boolean isTablePartitioned, boolean populateMetaFields) {
+  public PartitionPathRepartitionPartitioner(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
-    this.populateMetaFields = populateMetaFields;
+    this.shouldPopulateMetaFields = config.populateMetaFields();
   }
 
   @Override
   public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records,
                                                      int outputSparkPartitions) {
-    checkState(populateMetaFields, "Meta fields are disabled!");
+    if (!shouldPopulateMetaFields) {
+      throw new HoodieException(PARTITION_PATH_REPARTITION.name() + " mode requires meta-fields to be enabled");
+    }
+
     if (isTablePartitioned) {
       PartitionPathRDDPartitioner partitioner = new PartitionPathRDDPartitioner(
           (partitionPath) -> (String) partitionPath, outputSparkPartitions);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
@@ -20,13 +20,15 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.execution.bulkinsert.BulkInsertSortMode.PARTITION_PATH_REPARTITION;
 
 /**
  * A built-in partitioner that does the following for input rows for bulk insert operation
@@ -42,16 +44,19 @@ import static org.apache.hudi.common.util.ValidationUtils.checkState;
 public class PartitionPathRepartitionPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
   private final boolean isTablePartitioned;
-  private final boolean populateMetaFields;
+  private final boolean shouldPopulateMetaFields;
 
-  public PartitionPathRepartitionPartitionerWithRows(boolean isTablePartitioned, boolean populateMetaFields) {
+  public PartitionPathRepartitionPartitionerWithRows(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
-    this.populateMetaFields = populateMetaFields;
+    this.shouldPopulateMetaFields = config.populateMetaFields();
   }
 
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
-    checkState(populateMetaFields, "Meta fields are disabled!");
+    if (!shouldPopulateMetaFields) {
+      throw new HoodieException(PARTITION_PATH_REPARTITION.name() + " mode requires meta-fields to be enabled");
+    }
+
     if (isTablePartitioned) {
       return rows.repartition(outputSparkPartitions, new Column(HoodieRecord.PARTITION_PATH_METADATA_FIELD));
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
@@ -26,6 +26,8 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does the following for input rows for bulk insert operation
  * <p>
@@ -40,13 +42,16 @@ import org.apache.spark.sql.Row;
 public class PartitionPathRepartitionPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
   private final boolean isTablePartitioned;
+  private final boolean populateMetaFields;
 
-  public PartitionPathRepartitionPartitionerWithRows(boolean isTablePartitioned) {
+  public PartitionPathRepartitionPartitionerWithRows(boolean isTablePartitioned, boolean populateMetaFields) {
     this.isTablePartitioned = isTablePartitioned;
+    this.populateMetaFields = populateMetaFields;
   }
 
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     if (isTablePartitioned) {
       return rows.repartition(outputSparkPartitions, new Column(HoodieRecord.PARTITION_PATH_METADATA_FIELD));
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionSortPartitionerWithRows.java
@@ -24,13 +24,22 @@ import org.apache.hudi.table.BulkInsertPartitioner;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does local sorting for each spark partitions after coalesce for bulk insert operation, corresponding to the {@code BulkInsertSortMode.PARTITION_SORT} mode.
  */
 public class PartitionSortPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
+  private final boolean populateMetaFields;
+
+  public PartitionSortPartitionerWithRows(boolean populateMetaFields) {
+    this.populateMetaFields = populateMetaFields;
+  }
+
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     return rows.coalesce(outputSparkPartitions).sortWithinPartitions(HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.RECORD_KEY_METADATA_FIELD);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionSortPartitionerWithRows.java
@@ -19,27 +19,32 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.execution.bulkinsert.BulkInsertSortMode.PARTITION_SORT;
 
 /**
  * A built-in partitioner that does local sorting for each spark partitions after coalesce for bulk insert operation, corresponding to the {@code BulkInsertSortMode.PARTITION_SORT} mode.
  */
 public class PartitionSortPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
 
-  private final boolean populateMetaFields;
+  private final boolean shouldPopulateMetaFields;
 
-  public PartitionSortPartitionerWithRows(boolean populateMetaFields) {
-    this.populateMetaFields = populateMetaFields;
+  public PartitionSortPartitionerWithRows(HoodieWriteConfig config) {
+    this.shouldPopulateMetaFields = config.populateMetaFields();
   }
 
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
-    checkState(populateMetaFields, "Meta fields are disabled!");
+    if (!shouldPopulateMetaFields) {
+      throw new HoodieException(PARTITION_SORT.name() + " mode requires meta-fields to be enabled");
+    }
+
     return rows.coalesce(outputSparkPartitions).sortWithinPartitions(HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.RECORD_KEY_METADATA_FIELD);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDPartitionSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDPartitionSortPartitioner.java
@@ -30,6 +30,8 @@ import java.util.List;
 
 import scala.Tuple2;
 
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
 /**
  * A built-in partitioner that does local sorting for each RDD partition
  * after coalesce for bulk insert operation, corresponding to the
@@ -40,9 +42,16 @@ import scala.Tuple2;
 public class RDDPartitionSortPartitioner<T extends HoodieRecordPayload>
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {
 
+  private final boolean populateMetaFields;
+
+  public RDDPartitionSortPartitioner(boolean populateMetaFields) {
+    this.populateMetaFields = populateMetaFields;
+  }
+
   @Override
   public JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records,
                                                      int outputSparkPartitions) {
+    checkState(populateMetaFields, "Meta fields are disabled!");
     return records.coalesce(outputSparkPartitions)
         .mapToPair(record ->
             new Tuple2<>(

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase implements Serializable {
   private static final Comparator<HoodieRecord<? extends HoodieRecordPayload>> KEY_COMPARATOR =
@@ -83,16 +84,21 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
     //   boolean isTablePartitioned,
     //   boolean enforceNumOutputPartitions,
     //   boolean isGloballySorted,
-    //   boolean isLocallySorted
+    //   boolean isLocallySorted,
+    //   boolean populateMetaFields
     Object[][] data = new Object[][] {
-        {BulkInsertSortMode.GLOBAL_SORT, true, true, true, true},
-        {BulkInsertSortMode.PARTITION_SORT, true, true, false, true},
-        {BulkInsertSortMode.PARTITION_PATH_REPARTITION, true, true, false, false},
-        {BulkInsertSortMode.PARTITION_PATH_REPARTITION, false, true, false, false},
-        {BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT, true, true, false, false},
-        {BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT, false, true, false, false},
-        {BulkInsertSortMode.NONE, true, true, false, false},
-        {BulkInsertSortMode.NONE, true, false, false, false}
+        {BulkInsertSortMode.GLOBAL_SORT, true, true, true, true, true},
+        {BulkInsertSortMode.PARTITION_SORT, true, true, false, true, true},
+        {BulkInsertSortMode.PARTITION_PATH_REPARTITION, true, true, false, false, true},
+        {BulkInsertSortMode.PARTITION_PATH_REPARTITION, false, true, false, false, true},
+        {BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT, true, true, false, false, true},
+        {BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT, false, true, false, false, true},
+        {BulkInsertSortMode.NONE, true, true, false, false, true},
+        {BulkInsertSortMode.NONE, true, false, false, false, true},
+        {BulkInsertSortMode.GLOBAL_SORT, true, true, true, true, false},
+        {BulkInsertSortMode.PARTITION_SORT, true, true, false, true, false},
+        {BulkInsertSortMode.PARTITION_PATH_REPARTITION, true, true, false, false, false},
+        {BulkInsertSortMode.PARTITION_PATH_REPARTITION_AND_SORT, true, true, false, false, false}
     };
     return Stream.of(data).map(Arguments::of);
   }
@@ -109,7 +115,8 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
                                                  boolean enforceNumOutputPartitions,
                                                  boolean isGloballySorted,
                                                  boolean isLocallySorted,
-                                                 Map<String, Long> expectedPartitionNumRecords) {
+                                                 Map<String, Long> expectedPartitionNumRecords,
+                                                 boolean populateMetaFields) {
     testBulkInsertInternalPartitioner(
         partitioner,
         records,
@@ -117,7 +124,8 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
         isGloballySorted,
         isLocallySorted,
         expectedPartitionNumRecords,
-        Option.empty());
+        Option.empty(),
+        populateMetaFields);
   }
 
   private void testBulkInsertInternalPartitioner(BulkInsertPartitioner partitioner,
@@ -126,35 +134,40 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
                                                  boolean isGloballySorted,
                                                  boolean isLocallySorted,
                                                  Map<String, Long> expectedPartitionNumRecords,
-                                                 Option<Comparator<HoodieRecord<? extends HoodieRecordPayload>>> comparator) {
+                                                 Option<Comparator<HoodieRecord<? extends HoodieRecordPayload>>> comparator,
+                                                 boolean populateMetaFields) {
     int numPartitions = 2;
-    JavaRDD<HoodieRecord<? extends HoodieRecordPayload>> actualRecords =
-        (JavaRDD<HoodieRecord<? extends HoodieRecordPayload>>) partitioner.repartitionRecords(records, numPartitions);
-    assertEquals(
-        enforceNumOutputPartitions ? numPartitions : records.getNumPartitions(),
-        actualRecords.getNumPartitions());
-    List<HoodieRecord<? extends HoodieRecordPayload>> collectedActualRecords = actualRecords.collect();
-    if (isGloballySorted) {
-      // Verify global order
-      verifyRecordAscendingOrder(collectedActualRecords, comparator);
-    } else if (isLocallySorted) {
-      // Verify local order
-      actualRecords.mapPartitions(partition -> {
-        List<HoodieRecord<? extends HoodieRecordPayload>> partitionRecords = new ArrayList<>();
-        partition.forEachRemaining(partitionRecords::add);
-        verifyRecordAscendingOrder(partitionRecords, comparator);
-        return Collections.emptyList().iterator();
-      }).collect();
-    }
+    if (!populateMetaFields) {
+      assertThrows(IllegalStateException.class, () -> partitioner.repartitionRecords(records, numPartitions));
+    } else {
+      JavaRDD<HoodieRecord<? extends HoodieRecordPayload>> actualRecords =
+          (JavaRDD<HoodieRecord<? extends HoodieRecordPayload>>) partitioner.repartitionRecords(records, numPartitions);
+      assertEquals(
+          enforceNumOutputPartitions ? numPartitions : records.getNumPartitions(),
+          actualRecords.getNumPartitions());
+      List<HoodieRecord<? extends HoodieRecordPayload>> collectedActualRecords = actualRecords.collect();
+      if (isGloballySorted) {
+        // Verify global order
+        verifyRecordAscendingOrder(collectedActualRecords, comparator);
+      } else if (isLocallySorted) {
+        // Verify local order
+        actualRecords.mapPartitions(partition -> {
+          List<HoodieRecord<? extends HoodieRecordPayload>> partitionRecords = new ArrayList<>();
+          partition.forEachRemaining(partitionRecords::add);
+          verifyRecordAscendingOrder(partitionRecords, comparator);
+          return Collections.emptyList().iterator();
+        }).collect();
+      }
 
-    // Verify number of records per partition path
-    Map<String, Long> actualPartitionNumRecords = new HashMap<>();
-    for (HoodieRecord record : collectedActualRecords) {
-      String partitionPath = record.getPartitionPath();
-      actualPartitionNumRecords.put(partitionPath,
-          actualPartitionNumRecords.getOrDefault(partitionPath, 0L) + 1);
+      // Verify number of records per partition path
+      Map<String, Long> actualPartitionNumRecords = new HashMap<>();
+      for (HoodieRecord record : collectedActualRecords) {
+        String partitionPath = record.getPartitionPath();
+        actualPartitionNumRecords.put(partitionPath,
+            actualPartitionNumRecords.getOrDefault(partitionPath, 0L) + 1);
+      }
+      assertEquals(expectedPartitionNumRecords, actualPartitionNumRecords);
     }
-    assertEquals(expectedPartitionNumRecords, actualPartitionNumRecords);
   }
 
   @ParameterizedTest(name = "[{index}] {0} isTablePartitioned={1} enforceNumOutputPartitions={2}")
@@ -163,25 +176,28 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
                                                 boolean isTablePartitioned,
                                                 boolean enforceNumOutputPartitions,
                                                 boolean isGloballySorted,
-                                                boolean isLocallySorted) {
+                                                boolean isLocallySorted,
+                                                boolean populateMetaFields) {
     JavaRDD<HoodieRecord> records1 = generateTestRecordsForBulkInsert(jsc);
     JavaRDD<HoodieRecord> records2 = generateTripleTestRecordsForBulkInsert(jsc);
     testBulkInsertInternalPartitioner(
         BulkInsertInternalPartitionerFactory.get(
-            sortMode, isTablePartitioned, enforceNumOutputPartitions),
+            sortMode, isTablePartitioned, enforceNumOutputPartitions, populateMetaFields),
         records1,
         enforceNumOutputPartitions,
         isGloballySorted,
         isLocallySorted,
-        generateExpectedPartitionNumRecords(records1));
+        generateExpectedPartitionNumRecords(records1),
+        populateMetaFields);
     testBulkInsertInternalPartitioner(
         BulkInsertInternalPartitionerFactory.get(
-            sortMode, isTablePartitioned, enforceNumOutputPartitions),
+            sortMode, isTablePartitioned, enforceNumOutputPartitions, populateMetaFields),
         records2,
         enforceNumOutputPartitions,
         isGloballySorted,
         isLocallySorted,
-        generateExpectedPartitionNumRecords(records2));
+        generateExpectedPartitionNumRecords(records2),
+        populateMetaFields);
   }
 
   @Test
@@ -193,22 +209,21 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
     JavaRDD<HoodieRecord> records1 = generateTestRecordsForBulkInsert(jsc);
     JavaRDD<HoodieRecord> records2 = generateTripleTestRecordsForBulkInsert(jsc);
     testBulkInsertInternalPartitioner(new RDDCustomColumnsSortPartitioner(sortColumns, HoodieTestDataGenerator.AVRO_SCHEMA, false),
-        records1, true, true, true, generateExpectedPartitionNumRecords(records1), Option.of(columnComparator));
+        records1, true, true, true, generateExpectedPartitionNumRecords(records1), Option.of(columnComparator), true);
     testBulkInsertInternalPartitioner(new RDDCustomColumnsSortPartitioner(sortColumns, HoodieTestDataGenerator.AVRO_SCHEMA, false),
-        records2, true, true, true, generateExpectedPartitionNumRecords(records2), Option.of(columnComparator));
+        records2, true, true, true, generateExpectedPartitionNumRecords(records2), Option.of(columnComparator), true);
 
     HoodieWriteConfig config = HoodieWriteConfig
-            .newBuilder()
-            .withPath("/")
-            .withSchema(TRIP_EXAMPLE_SCHEMA)
-            .withUserDefinedBulkInsertPartitionerClass(RDDCustomColumnsSortPartitioner.class.getName())
-            .withUserDefinedBulkInsertPartitionerSortColumns(sortColumnString)
-            .build();
+        .newBuilder()
+        .withPath("/")
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withUserDefinedBulkInsertPartitionerClass(RDDCustomColumnsSortPartitioner.class.getName())
+        .withUserDefinedBulkInsertPartitionerSortColumns(sortColumnString)
+        .build();
     testBulkInsertInternalPartitioner(new RDDCustomColumnsSortPartitioner(config),
-        records1, true, true, true, generateExpectedPartitionNumRecords(records1), Option.of(columnComparator));
+        records1, true, true, true, generateExpectedPartitionNumRecords(records1), Option.of(columnComparator), true);
     testBulkInsertInternalPartitioner(new RDDCustomColumnsSortPartitioner(config),
-        records2, true, true, true, generateExpectedPartitionNumRecords(records2), Option.of(columnComparator));
-
+        records2, true, true, true, generateExpectedPartitionNumRecords(records2), Option.of(columnComparator), true);
   }
 
   private Comparator<HoodieRecord<? extends HoodieRecordPayload>> getCustomColumnComparator(Schema schema, String[] sortColumns) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -735,8 +735,7 @@ object HoodieSparkSqlWriter {
       if (userDefinedBulkInsertPartitionerOpt.isPresent) {
         userDefinedBulkInsertPartitionerOpt.get
       } else {
-        BulkInsertInternalPartitionerWithRowsFactory.get(
-          writeConfig.getBulkInsertSortMode, isTablePartitioned, writeConfig.populateMetaFields)
+        BulkInsertInternalPartitionerWithRowsFactory.get(writeConfig, isTablePartitioned)
       }
     } else {
       // Sort modes are not yet supported when meta fields are disabled
@@ -981,7 +980,7 @@ object HoodieSparkSqlWriter {
   }
 
   private def mergeParamsAndGetHoodieConfig(optParams: Map[String, String],
-      tableConfig: HoodieTableConfig, mode: SaveMode): (Map[String, String], HoodieConfig) = {
+                                            tableConfig: HoodieTableConfig, mode: SaveMode): (Map[String, String], HoodieConfig) = {
     val translatedOptions = DataSourceWriteOptions.translateSqlOptions(optParams)
     val mergedParams = mutable.Map.empty ++ HoodieWriterUtils.parametersWithWriteDefaults(translatedOptions)
     if (!mergedParams.contains(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -736,7 +736,7 @@ object HoodieSparkSqlWriter {
         userDefinedBulkInsertPartitionerOpt.get
       } else {
         BulkInsertInternalPartitionerWithRowsFactory.get(
-          writeConfig.getBulkInsertSortMode, isTablePartitioned)
+          writeConfig.getBulkInsertSortMode, isTablePartitioned, writeConfig.populateMetaFields)
       }
     } else {
       // Sort modes are not yet supported when meta fields are disabled


### PR DESCRIPTION
### Change Logs

Handle populateMetaFields when repartitioning in bulk insert sort partitioners. Follow-up to #7402 

Passes a boolean field to `BulkInsertPartitioner#repartitionRecords` and if meta field is not enabled then simply coalesces to the given output partitions.

### Impact

Affects bulk insert sort modes.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
