### PR TITLE
[HUDI-5347] Cleaned up transient state from `ExpressionPayload` making it non-serializable

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -413,8 +413,8 @@ object ExpressionPayload {
                 // NOTE: We reuse Spark's [[Projection]]s infra for actual evaluation of the
                 //       expressions, allowing us to execute arbitrary expression against input
                 //       [[InternalRow]] producing another [[InternalRow]] as an outcome
-                val conditionEvaluator = GenerateSafeProjection.generate(Seq(condition))
-                val assignmentEvaluator = GenerateSafeProjection.generate(assignments)
+                val conditionEvaluator = SafeProjection.create(Seq(condition))
+                val assignmentEvaluator = SafeProjection.create(assignments)
 
                 conditionEvaluator -> assignmentEvaluator
             }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -187,11 +187,11 @@ class ExpressionPayload(@transient record: GenericRecord,
    * @return The result of the record to insert.
    */
   private def processNotMatchedRecord(inputRecord: ConvertibleRecord, properties: Properties): HOption[IndexedRecord] = {
-    val insertConditionAndAssignmentsText =
-      properties.get(ExpressionPayload.PAYLOAD_INSERT_CONDITION_AND_ASSIGNMENTS)
+    val insertConditionAndAssignmentsText: String =
+      properties.get(ExpressionPayload.PAYLOAD_INSERT_CONDITION_AND_ASSIGNMENTS).toString
     // Get the evaluator for each condition and insert assignment.
     val insertConditionAndAssignments =
-      ExpressionPayload.getEvaluator(insertConditionAndAssignmentsText.toString, inputRecord.asAvro.getSchema)
+      ExpressionPayload.getEvaluator(insertConditionAndAssignmentsText, inputRecord.asAvro.getSchema)
     var resultRecordOpt: HOption[IndexedRecord] = null
     for ((conditionEvaluator, assignmentEvaluator) <- insertConditionAndAssignments
          if resultRecordOpt == null) {

--- a/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/catalyst/expressions/SafeProjection.scala
+++ b/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/catalyst/expressions/SafeProjection.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateSafeProjection
+import org.apache.spark.sql.types.{DataType, StructType}
+
+/**
+ * A projection that could turn UnsafeRow into GenericInternalRow
+ *
+ * NOTE: PLEASE REFRAIN MAKING ANY CHANGES TO THIS CODE UNLESS ABSOLUTELY NECESSARY
+ *       This code is borrowed from Spark 3.1.x
+ *       This code is borrowed, to fill in the gaps of Spark 2.x
+ */
+object SafeProjection extends CodeGeneratorWithInterpretedFallback[Seq[Expression], Projection] {
+
+  override protected def createCodeGeneratedObject(in: Seq[Expression]): Projection = {
+    GenerateSafeProjection.generate(in)
+  }
+
+  override protected def createInterpretedObject(in: Seq[Expression]): Projection = {
+    throw new UnsupportedOperationException("Interpreted safe projection is not supported for Spark 2.x!")
+  }
+
+  /**
+   * Returns a SafeProjection for given StructType.
+   */
+  def create(schema: StructType): Projection = create(schema.fields.map(_.dataType))
+
+  /**
+   * Returns a SafeProjection for given Array of DataTypes.
+   */
+  def create(fields: Array[DataType]): Projection = {
+    createObject(fields.zipWithIndex.map(x => new BoundReference(x._2, x._1, true)))
+  }
+
+  /**
+   * Returns a SafeProjection for given sequence of Expressions (bounded).
+   */
+  def create(exprs: Seq[Expression]): Projection = {
+    createObject(exprs)
+  }
+
+  /**
+   * Returns a SafeProjection for given sequence of Expressions, which will be bound to
+   * `inputSchema`.
+   */
+  def create(exprs: Seq[Expression], inputSchema: Seq[Attribute]): Projection = {
+    create(bindReferences(exprs, inputSchema))
+  }
+
+  /**
+   * A helper function to bind given expressions to an input schema.
+   */
+  private def bindReferences[A <: Expression](
+                                       expressions: Seq[A],
+                                       input: AttributeSeq): Seq[A] = {
+    expressions.map(BindReferences.bindReference(_, input))
+  }
+}


### PR DESCRIPTION
### Change Logs

This is a follow-up for #7395. In particular:

 - Internal state (cached record's, writer's schemas) are removed to make sure that `ExpressionPayload` object is serializable at all times
 - `ExpressionPayload` caches are scoped down to `ThreadLocal` since some of the re-used components (`AvroSerializer`, `AvroDeserializer`, `SafeProjection`) have internal mutable state and therefore are not thread-safe

### Impact

No impact

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
