### PR TITLE
[MINOR] Rebalance Azure CI jobs to save total time

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ parameters:
     type: object
     default:
       - 'hudi-client/hudi-spark-client'
-  - name: job3Modules
+  - name: job3UTModules
     type: object
     default:
       - 'hudi-spark-datasource'
@@ -43,7 +43,7 @@ parameters:
       - 'hudi-spark-datasource/hudi-spark2'
       - 'hudi-spark-datasource/hudi-spark2-common'
       - 'hudi-spark-datasource/hudi-spark-common'
-  - name: job4Modules
+  - name: job4UTModules
     type: object
     default:
       - '!hudi-client/hudi-spark-client'
@@ -63,6 +63,21 @@ parameters:
       - '!hudi-spark-datasource/hudi-spark2'
       - '!hudi-spark-datasource/hudi-spark2-common'
       - '!hudi-spark-datasource/hudi-spark-common'
+  - name: job4FTModules
+      type: object
+      default:
+        - '!hudi-client/hudi-spark-client'
+        - '!hudi-common'
+        - '!hudi-examples'
+        - '!hudi-examples/hudi-examples-common'
+        - '!hudi-examples/hudi-examples-flink'
+        - '!hudi-examples/hudi-examples-java'
+        - '!hudi-examples/hudi-examples-spark'
+        - '!hudi-flink-datasource'
+        - '!hudi-flink-datasource/hudi-flink'
+        - '!hudi-flink-datasource/hudi-flink1.13.x'
+        - '!hudi-flink-datasource/hudi-flink1.14.x'
+        - '!hudi-flink-datasource/hudi-flink1.15.x'
 
 variables:
   BUILD_PROFILES: '-Dscala-2.11 -Dspark2.4 -Dflink1.14'
@@ -74,8 +89,9 @@ variables:
   SPARK_ARCHIVE: spark-$(SPARK_VERSION)-bin-hadoop$(HADOOP_VERSION)
   JOB1_MODULES: ${{ join(',',parameters.job1Modules) }}
   JOB2_MODULES: ${{ join(',',parameters.job2Modules) }}
-  JOB3_MODULES: ${{ join(',',parameters.job3Modules) }}
-  JOB4_MODULES: ${{ join(',',parameters.job4Modules) }}
+  JOB3_MODULES: ${{ join(',',parameters.job3UTModules) }}
+  JOB4_UT_MODULES: ${{ join(',',parameters.job4UTModules) }}
+  JOB4_FT_MODULES: ${{ join(',',parameters.job4FTModules) }}
 
 stages:
   - stage: test
@@ -138,7 +154,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_3
-        displayName: UT FT spark-datasource
+        displayName: UT spark-datasource
         timeoutInMinutes: '150'
         steps:
           - task: Maven@4
@@ -155,15 +171,6 @@ stages:
               mavenPomFile: 'pom.xml'
               goals: 'test'
               options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB3_MODULES)
-              publishJUnitResults: false
-              jdkVersionOption: '1.8'
-              mavenOptions: '-Xmx4g'
-          - task: Maven@4
-            displayName: FT spark-datasource
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests -pl $(JOB3_MODULES)
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
@@ -187,7 +194,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB4_MODULES)
+              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB4_UT_MODULES)
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
@@ -196,7 +203,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests -pl $(JOB4_MODULES)
+              options: $(MVN_OPTS_TEST) -Pfunctional-tests -pl $(JOB4_FT_MODULES)
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,20 +64,20 @@ parameters:
       - '!hudi-spark-datasource/hudi-spark2-common'
       - '!hudi-spark-datasource/hudi-spark-common'
   - name: job4FTModules
-      type: object
-      default:
-        - '!hudi-client/hudi-spark-client'
-        - '!hudi-common'
-        - '!hudi-examples'
-        - '!hudi-examples/hudi-examples-common'
-        - '!hudi-examples/hudi-examples-flink'
-        - '!hudi-examples/hudi-examples-java'
-        - '!hudi-examples/hudi-examples-spark'
-        - '!hudi-flink-datasource'
-        - '!hudi-flink-datasource/hudi-flink'
-        - '!hudi-flink-datasource/hudi-flink1.13.x'
-        - '!hudi-flink-datasource/hudi-flink1.14.x'
-        - '!hudi-flink-datasource/hudi-flink1.15.x'
+    type: object
+    default:
+      - '!hudi-client/hudi-spark-client'
+      - '!hudi-common'
+      - '!hudi-examples'
+      - '!hudi-examples/hudi-examples-common'
+      - '!hudi-examples/hudi-examples-flink'
+      - '!hudi-examples/hudi-examples-java'
+      - '!hudi-examples/hudi-examples-spark'
+      - '!hudi-flink-datasource'
+      - '!hudi-flink-datasource/hudi-flink'
+      - '!hudi-flink-datasource/hudi-flink1.13.x'
+      - '!hudi-flink-datasource/hudi-flink1.14.x'
+      - '!hudi-flink-datasource/hudi-flink1.15.x'
 
 variables:
   BUILD_PROFILES: '-Dscala-2.11 -Dspark2.4 -Dflink1.14'


### PR DESCRIPTION
### Change Logs

This PR rebalances Azure CI jobs to save total time and avoid timeout.  The functional tests of Spark datasource are moved from Job 3 to Job 4 in Azure CI, based on the previous runs shown below: Job 3 takes 2h+ on average, Job 4 takes 1h to 1h20min, and the Spark datasource functional tests take around 20min.

Master
<img width="302" alt="Screen Shot 2022-12-10 at 11 52 29" src="https://user-images.githubusercontent.com/2497195/206873653-f2556f50-363a-4b09-8a64-3847e9cc4916.png">
<img width="304" alt="Screen Shot 2022-12-10 at 11 53 32" src="https://user-images.githubusercontent.com/2497195/206873655-3444a253-388d-49d1-983b-974402cbddd4.png">
<img width="302" alt="Screen Shot 2022-12-10 at 11 54 07" src="https://user-images.githubusercontent.com/2497195/206873656-9dd86170-57d2-4397-9668-1b5eb4c6d16a.png">
<img width="305" alt="Screen Shot 2022-12-10 at 11 54 48" src="https://user-images.githubusercontent.com/2497195/206873657-4947a80e-f346-4e3a-9748-9bd03651a5ed.png">

Branch
<img width="316" alt="Screen Shot 2022-12-10 at 11 59 39" src="https://user-images.githubusercontent.com/2497195/206873661-5a72a66c-397d-4e23-9660-20c657eafd36.png">
<img width="310" alt="Screen Shot 2022-12-10 at 11 59 59" src="https://user-images.githubusercontent.com/2497195/206873662-c296223a-af66-4769-858e-31d431d1a7ad.png">


### Impact

Reducing Azure CI total finishing time.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
