### PR TITLE
[HUDI-5368] decouple GlueCatalogSyncTool by using reflecting instead of import class directly.

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -18,9 +18,9 @@
 
 package org.apache.hudi.sink.utils;
 
-import org.apache.hudi.aws.sync.AwsGlueCatalogSyncTool;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.hive.HiveSyncTool;
@@ -75,9 +75,15 @@ public class HiveSyncContext {
   public HiveSyncTool hiveSyncTool() {
     HiveSyncMode syncMode = HiveSyncMode.of(props.getProperty(HIVE_SYNC_MODE.key()));
     if (syncMode == HiveSyncMode.GLUE) {
-      return new AwsGlueCatalogSyncTool(props, hiveConf);
+      return loadAwsGlueCatalogSyncTool();
     }
     return new HiveSyncTool(props, hiveConf);
+  }
+
+  private HiveSyncTool loadAwsGlueCatalogSyncTool() {
+    Class<?>[] argTypes = {Properties.class, org.apache.hadoop.conf.Configuration.class};
+    return (HiveSyncTool) ReflectionUtils.loadClass("org.apache.hudi.aws.sync.AwsGlueCatalogSyncTool",
+            argTypes, props, hiveConf);
   }
 
   public static HiveSyncContext create(Configuration conf, SerializableConfiguration serConf) {


### PR DESCRIPTION
### Change Logs

- instantiate AwsGlueCatalogSyncTool via reflection instead of new AwsGlueCatalogSyncTool.

### Impact

- no need to depend `hudi-aws` jar if just sync metadata to HMS

### Risk level (write none, low medium or high below)

low

### Documentation Update

No

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
