### PR TITLE
[HUDI-5374] Use KeyGeneratorFactory class for instantiating a KeyGenerator

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -25,8 +25,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.PartitionPathEncodeUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
-import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieKeyException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.keygen.parser.BaseHoodieDateTimeParser;
@@ -180,25 +178,5 @@ public class KeyGenUtils {
         throw new HoodieNotSupportedException("Required property " + prop + " is missing");
       }
     });
-  }
-
-  /**
-   * Create a key generator class via reflection, passing in any configs needed.
-   * <p>
-   * This method is for user-defined classes. To create hudi's built-in key generators, please set proper
-   * {@link org.apache.hudi.keygen.constant.KeyGeneratorType} conf, and use the relevant factory, see
-   * {@link org.apache.hudi.keygen.factory.HoodieAvroKeyGeneratorFactory}.
-   */
-  public static KeyGenerator createKeyGeneratorByClassName(TypedProperties props) throws IOException {
-    KeyGenerator keyGenerator = null;
-    String keyGeneratorClass = props.getString(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), null);
-    if (!StringUtils.isNullOrEmpty(keyGeneratorClass)) {
-      try {
-        keyGenerator = (KeyGenerator) ReflectionUtils.loadClass(keyGeneratorClass, props);
-      } catch (Throwable e) {
-        throw new IOException("Could not load key generator class " + keyGeneratorClass, e);
-      }
-    }
-    return keyGenerator;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/factory/KeyGeneratorFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/factory/KeyGeneratorFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.keygen.factory;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.CheckedBiFunction;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieKeyGeneratorException;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.keygen.constant.KeyGeneratorType;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Base class for creating {@link org.apache.hudi.keygen.KeyGenerator}.
+ * <p>
+ * This factory will try {@link HoodieWriteConfig#KEYGENERATOR_CLASS_NAME} firstly, this ensures the class prop
+ * will not be overwritten by {@link KeyGeneratorType}
+ */
+public class KeyGeneratorFactory {
+
+  static KeyGenerator createKeyGenerator(TypedProperties props, Logger log,
+      CheckedBiFunction<KeyGeneratorType, TypedProperties, IOException, KeyGenerator> typeToKeyGeneratorFunction)
+      throws IOException {
+    // keyGenerator class name has higher priority
+    KeyGenerator keyGenerator = createKeyGeneratorByClassName(props);
+    return Objects.isNull(keyGenerator)
+        ? createKeyGeneratorByType(props, log, typeToKeyGeneratorFunction)
+        : keyGenerator;
+  }
+
+  private static KeyGenerator createKeyGeneratorByClassName(TypedProperties props) throws IOException {
+    KeyGenerator keyGenerator = null;
+    String keyGeneratorClass = props.getString(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), null);
+    if (!StringUtils.isNullOrEmpty(keyGeneratorClass)) {
+      try {
+        keyGenerator = (KeyGenerator) ReflectionUtils.loadClass(keyGeneratorClass, props);
+      } catch (Throwable e) {
+        throw new IOException("Could not load key generator class " + keyGeneratorClass, e);
+      }
+    }
+    return keyGenerator;
+  }
+
+  private static KeyGenerator createKeyGeneratorByType(TypedProperties props, Logger log,
+      CheckedBiFunction<KeyGeneratorType, TypedProperties, IOException, KeyGenerator> typeToKeyGeneratorFunction)
+      throws IOException {
+    // Use KeyGeneratorType.SIMPLE as default keyGeneratorType
+    String keyGeneratorType =
+        props.getString(HoodieWriteConfig.KEYGENERATOR_TYPE.key(), null);
+
+    if (StringUtils.isNullOrEmpty(keyGeneratorType)) {
+      log.info("The value of {} is empty, using SIMPLE", HoodieWriteConfig.KEYGENERATOR_TYPE.key());
+      keyGeneratorType = KeyGeneratorType.SIMPLE.name();
+    }
+
+    KeyGeneratorType keyGeneratorTypeEnum;
+    try {
+      keyGeneratorTypeEnum = KeyGeneratorType.valueOf(keyGeneratorType.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new HoodieKeyGeneratorException("Unsupported keyGenerator Type " + keyGeneratorType);
+    }
+
+    return typeToKeyGeneratorFunction.apply(keyGeneratorTypeEnum, props);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CheckedBiFunction.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CheckedBiFunction.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+/**
+ * Represents a function that accepts two arguments, produces a result and can throw an exception.
+ * <T> – Type of First argument to the function
+ * <U> – Type of Second argument to the function
+ * <R> – Type of Result of the function
+ * <E> - Type of Throwable which can be thrown by the function
+ */
+@FunctionalInterface
+public interface CheckedBiFunction<T, U, E extends Throwable, R> {
+  R apply(T t, U u) throws E;
+}

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectTransactionServices.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectTransactionServices.java
@@ -84,7 +84,7 @@ public class KafkaConnectTransactionServices implements ConnectTransactionServic
     context = new HoodieJavaEngineContext(hadoopConf);
 
     try {
-      KeyGenerator keyGenerator = HoodieAvroKeyGeneratorFactory.createAvroKeyGeneratorByType(
+      KeyGenerator keyGenerator = HoodieAvroKeyGeneratorFactory.createKeyGenerator(
           new TypedProperties(connectConfigs.getProps()));
       String recordKeyFields = KafkaConnectUtils.getRecordKeyColumns(keyGenerator);
       String partitionColumns = KafkaConnectUtils.getPartitionColumns(keyGenerator,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.hudi.command
 
 import org.apache.avro.generic.GenericRecord
 import org.apache.hudi.common.config.TypedProperties
-import org.apache.hudi.common.model.HoodieKey
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
 import org.apache.hudi.config.HoodieWriteConfig
@@ -63,7 +62,7 @@ class SqlKeyGenerator(props: TypedProperties) extends BuiltinKeyGenerator(props)
         keyGenProps.remove(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME)
         keyGenProps.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key, convertedKeyGenClassName)
 
-        KeyGenUtils.createKeyGeneratorByClassName(keyGenProps).asInstanceOf[SparkKeyGeneratorInterface]
+        HoodieSparkKeyGeneratorFactory.createKeyGenerator(keyGenProps).asInstanceOf[SparkKeyGeneratorInterface]
       }
 
   override def getRecordKey(record: GenericRecord): String =


### PR DESCRIPTION
### Change Logs

Currently the configs hoodie.datasource.write.keygenerator.class and hoodie.datasource.write.keygenerator.type are used in multiple areas to create a key generator. The idea is to reuse the *KeyGeneratorFactory classes for instantiating KeyGenerator.

The Jira adds a KeyGeneratorFactory base class and HoodieSparkKeyGeneratorFactory, HoodieAvroKeyGeneratorFactory extends this base class. These classes are then used in code for creating KeyGenerator.

Fixes https://github.com/apache/hudi/issues/7291

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
