### PR TITLE
[MINOR] Fix parameter parsing in hudi utilities

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -228,7 +228,8 @@ public class UtilHelpers {
   public static TypedProperties buildProperties(List<String> props) {
     TypedProperties properties = DFSPropertiesConfiguration.getGlobalProps();
     props.forEach(x -> {
-      String[] kv = x.split("=");
+      // Some values may contain '=', such as the partition path
+      String[] kv = x.split("=", 2);
       ValidationUtils.checkArgument(kv.length == 2);
       properties.setProperty(kv[0], kv[1]);
     });
@@ -236,7 +237,7 @@ public class UtilHelpers {
   }
 
   public static void validateAndAddProperties(String[] configs, SparkLauncher sparkLauncher) {
-    Arrays.stream(configs).filter(config -> config.contains("=") && config.split("=").length == 2).forEach(sparkLauncher::addAppArgs);
+    Arrays.stream(configs).filter(config -> config.contains("=") && config.split("=", 2).length == 2).forEach(sparkLauncher::addAppArgs);
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Some values may contain '=', such as the partition path, when using --hoodie-conf to add configuration, the verification will fail, for example:

```shell
spark-submit \
--class org.apache.hudi.utilities.HoodieClusteringJob \
hudi-utilities-bundle_2.11-0.12.0.jar \
--mode scheduleAndExecute \
--base-path xxx \
--table-name xxx \
--spark-memory 16g \
--hoodie-conf hoodie.clustering.plan.partition.filter.mode=SELECTED_PARTITIONS \
--hoodie-conf hoodie.clustering.plan.strategy.cluster.begin.partition=ds=2022-12-03/hour=21 \
--hoodie-conf hoodie.clustering.plan.strategy.cluster.end.partition=ds=2022-12-03/hour=21
```
`begin.partition` and `end.partition` will be verified as failed

### Impact

After adding the patch, hudi-utilities supports parsing the value containing '=' when using --hoodie-conf

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
