### PR TITLE
[HUDI-5348] Cache file slices in HoodieBackedTableMetadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -991,13 +991,15 @@ public class HoodieTableMetadataUtil {
    * just before the compaction instant time. The list of file slices returned is
    * sorted in the correct order of file group name.
    *
-   * @param metaClient - Instance of {@link HoodieTableMetaClient}.
-   * @param partition  - The name of the partition whose file groups are to be loaded.
+   * @param metaClient Instance of {@link HoodieTableMetaClient}.
+   * @param fsView     Metadata table filesystem view.
+   * @param partition  The name of the partition whose file groups are to be loaded.
    * @return List of latest file slices for all file groups in a given partition.
    */
-  public static List<FileSlice> getPartitionLatestMergedFileSlices(HoodieTableMetaClient metaClient, String partition) {
+  public static List<FileSlice> getPartitionLatestMergedFileSlices(
+      HoodieTableMetaClient metaClient, HoodieTableFileSystemView fsView, String partition) {
     LOG.info("Loading latest merged file slices for metadata table partition " + partition);
-    return getPartitionFileSlices(metaClient, Option.empty(), partition, true);
+    return getPartitionFileSlices(metaClient, Option.of(fsView), partition, true);
   }
 
   /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -56,6 +56,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.reload;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getFileSystemView;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.metadataPartitionExists;
 import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
@@ -175,7 +176,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
 
     HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(metaClient.getMetaPath() + "/metadata").build();
     List<FileSlice> partitionFileSlices =
-        HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(metadataMetaClient, COLUMN_STATS.getPartitionPath());
+        HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(
+            metadataMetaClient, getFileSystemView(metadataMetaClient), COLUMN_STATS.getPartitionPath());
     assertEquals(partitionFileSlices.size(), colStatsFileGroupCount);
   }
 
@@ -220,7 +222,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
 
     HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(metaClient.getMetaPath() + "/metadata").build();
     List<FileSlice> partitionFileSlices =
-        HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(metadataMetaClient, COLUMN_STATS.getPartitionPath());
+        HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(
+            metadataMetaClient, getFileSystemView(metadataMetaClient), COLUMN_STATS.getPartitionPath());
     assertEquals(partitionFileSlices.size(), HoodieMetadataConfig.METADATA_INDEX_COLUMN_STATS_FILE_GROUP_COUNT.defaultValue());
   }
 


### PR DESCRIPTION
### Change Logs

As of now, we only cache the log file reader inside `HoodieBackedTableMetadata`.  Each time the metadata table is looked up with `getRecordByKey` or `getRecordsByKeyPrefixes` in `HoodieBackedTableMetadata`, the corresponding MT partition is listed through `HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices` because a file system view is constructed each time.  This causes repeated FS list calls on MT partitions and increases the latency for reading metadata table and listing files for data table, affecting Presto query latency for example (sample S3 access log from Presto below for listing `files` partition in MT).

```
2022-11-24T22:06:43.009Z	INFO	hive-hive-2	org.apache.hudi.common.table.view.AbstractTableFileSystemView	Building file system view for partition (files)
2022-11-24T22:06:43.009Z	DEBUG	hive-hive-2	com.amazonaws.request	Sending Request: GET https://<redacted>.s3.us-east-2.amazonaws.com / Parameters: ({"prefix":["<redacted>/store_sales/.hoodie/metadata/files/"],"delimiter":["/"],"encoding-type":["url"]}Headers: (amz-sdk-invocation-id: 9e963ae0-f2e4-738e-691f-073c5a43264d, Content-Type: application/octet-stream, User-Agent: , aws-sdk-java/1.11.697 Linux/5.4.219-126.411.amzn2.x86_64 OpenJDK_64-Bit_Server_VM/25.342-b07 java/1.8.0_342 vendor/Oracle_Corporation, presto, ) 
2022-11-24T22:06:43.022Z	DEBUG	hive-hive-2	com.amazonaws.request	Received successful response: 200, AWS Request ID: Y4KHZHYVG7SSB0J4
```

This PR makes the changes to cache the file system view of the metadata table and thus the latest file slices at the partition level for metadata table inside `HoodieBackedTableMetadata` to avoid FS list calls.

### Impact

This PR avoids repeated file listing on the metadata table and thus reduces the latency for reading metadata table.  This reduces the latency of the overall metadata-table-based file listing and thus improves the query performance.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
