### PR TITLE
[HUDI-5376] Remove incorrect spark-sql keygen info from quickstart guide

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -275,9 +275,7 @@ Spark SQL needs an explicit create table command.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
 4. `preCombineField` is required for MOR tables.
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
-6. A new Hudi table created by Spark SQL will by default
-   set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and
-   `hoodie.datasource.write.hive_style_partitioning=true`.
+6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::
 
 **Create a Non-Partitioned Table**

--- a/website/versioned_docs/version-0.11.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/quick-start-guide.md
@@ -246,9 +246,7 @@ Spark SQL needs an explicit create table command.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
 4. `preCombineField` is required for MOR tables.
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
-6. A new Hudi table created by Spark SQL will by default
-   set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and
-   `hoodie.datasource.write.hive_style_partitioning=true`.
+6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::
 
 **Create a Non-Partitioned Table**

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -272,9 +272,7 @@ Spark SQL needs an explicit create table command.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
 4. `preCombineField` is required for MOR tables.
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
-6. A new Hudi table created by Spark SQL will by default
-   set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and
-   `hoodie.datasource.write.hive_style_partitioning=true`.
+6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::
 
 **Create a Non-Partitioned Table**

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -272,9 +272,7 @@ Spark SQL needs an explicit create table command.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
 4. `preCombineField` is required for MOR tables.
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
-6. A new Hudi table created by Spark SQL will by default
-   set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and
-   `hoodie.datasource.write.hive_style_partitioning=true`.
+6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::
 
 **Create a Non-Partitioned Table**


### PR DESCRIPTION
### Change Logs

since 0.11.1 keygen logic in spark-sql is the same as everywhere else but the quickstart guide was never updated.

### Impact

Documentation is correct now.

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
