### PR TITLE
[HUDI-5377] Write call stack information to lock file

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockInfo.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.transaction.lock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.hudi.common.util.JsonUtils;
+
+import java.util.ArrayList;
+
+public class LockInfo {
+  private String lockCreateTime;
+  private String lockThreadName;
+  private ArrayList<String> lockStacksInfo;
+
+  public String getLockCreateTime() {
+    return lockCreateTime;
+  }
+
+  public void setLockCreateTime(String lockCreateTime) {
+    this.lockCreateTime = lockCreateTime;
+  }
+
+  public String getLockThreadName() {
+    return lockThreadName;
+  }
+
+  public void setLockThreadName(String lockThreadName) {
+    this.lockThreadName = lockThreadName;
+  }
+
+  public ArrayList<String> getLockStacksInfo() {
+    return lockStacksInfo;
+  }
+
+  public void setLockStacksInfo(StackTraceElement[] stacks) {
+    lockStacksInfo = new ArrayList<>();
+    for (StackTraceElement ste : stacks) {
+      lockStacksInfo.add(String.format("%s.%s (%s:%s)", ste.getClassName(), ste.getMethodName(), ste.getFileName(), ste.getLineNumber()));
+    }
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return JsonUtils.getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      return e.toString();
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -76,8 +76,7 @@ public class LockManager implements Serializable, AutoCloseable {
             break;
           }
           metrics.updateLockNotAcquiredMetric();
-          LOG.warn("Current lock owner information : " + lockProvider.getCurrentOwnerLockInfo());
-          LOG.info("Retrying to acquire lock...");
+          LOG.info("Retrying to acquire lock. Current lock owner information : " + lockProvider.getCurrentOwnerLockInfo());
           Thread.sleep(maxWaitTimeInMs);
         } catch (HoodieLockException | InterruptedException e) {
           metrics.updateLockNotAcquiredMetric();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -76,7 +76,7 @@ public class LockManager implements Serializable, AutoCloseable {
             break;
           }
           metrics.updateLockNotAcquiredMetric();
-          LOG.warn("Current lock owner information ： " + lockProvider.getCurrentOwnerLockInfo());
+          LOG.warn("Current lock owner information : " + lockProvider.getCurrentOwnerLockInfo());
           LOG.info("Retrying to acquire lock...");
           Thread.sleep(maxWaitTimeInMs);
         } catch (HoodieLockException | InterruptedException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -76,6 +76,7 @@ public class LockManager implements Serializable, AutoCloseable {
             break;
           }
           metrics.updateLockNotAcquiredMetric();
+          LOG.warn("Current lock owner information ： " + lockProvider.getCurrentOwnerLockInfo());
           LOG.info("Retrying to acquire lock...");
           Thread.sleep(maxWaitTimeInMs);
         } catch (HoodieLockException | InterruptedException e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/lock/LockProvider.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/lock/LockProvider.java
@@ -50,6 +50,10 @@ public interface LockProvider<T> extends Lock, AutoCloseable {
     throw new IllegalArgumentException();
   }
 
+  default String getCurrentOwnerLockInfo() {
+    return "";
+  }
+
   @Override
   default void close() {
   }


### PR DESCRIPTION
### Change Logs

Add call stack information to lock file.

### Impact
When Occ is enabled, Sometimes an exception is thrown 'Unable  to acquire lock',
We need to know which step caused the deadlock.
### Risk level (write none, low medium or high below)
none
### Documentation Update
none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
