### PR TITLE
[HUDI-5380] Fixing change table path but table location in metastore …

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -34,6 +34,7 @@ import org.apache.hudi.hive.ddl.JDBCExecutor;
 import org.apache.hudi.sync.common.HoodieSyncClient;
 import org.apache.hudi.sync.common.model.FieldSchema;
 import org.apache.hudi.sync.common.model.Partition;
+import org.apache.hudi.sync.common.util.SparkDataSourceTableUtils;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -56,6 +57,7 @@ import static org.apache.hudi.hadoop.utils.HoodieHiveUtils.GLOBALLY_CONSISTENT_R
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_MODE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_USE_JDBC;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.util.TableUtils.tableId;
 
@@ -312,6 +314,16 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     if (lastCommitSynced.isPresent()) {
       try {
         Table table = client.getTable(databaseName, tableName);
+        String basePath = config.getString(META_SYNC_BASE_PATH);
+        StorageDescriptor sd = table.getSd();
+        sd.setLocation(basePath);
+        SerDeInfo serdeInfo = sd.getSerdeInfo();
+        Map<String, String> serdePathProperties = SparkDataSourceTableUtils.getSparkSerdePathProperties(basePath);
+        for (Map.Entry<String, String> entry : serdePathProperties.entrySet()) {
+          String key = entry.getKey();
+          String value = entry.getValue();
+          serdeInfo.putToParameters(key, value);
+        }
         table.putToParameters(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitSynced.get());
         client.alter_table(databaseName, tableName, table);
       } catch (Exception e) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -34,7 +34,7 @@ import org.apache.hudi.hive.ddl.JDBCExecutor;
 import org.apache.hudi.sync.common.HoodieSyncClient;
 import org.apache.hudi.sync.common.model.FieldSchema;
 import org.apache.hudi.sync.common.model.Partition;
-import org.apache.hudi.sync.common.util.SparkDataSourceTableUtils;
+import org.apache.hudi.sync.common.util.ConfigUtils;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -318,12 +318,7 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
         StorageDescriptor sd = table.getSd();
         sd.setLocation(basePath);
         SerDeInfo serdeInfo = sd.getSerdeInfo();
-        Map<String, String> serdePathProperties = SparkDataSourceTableUtils.getSparkSerdePathProperties(basePath);
-        for (Map.Entry<String, String> entry : serdePathProperties.entrySet()) {
-          String key = entry.getKey();
-          String value = entry.getValue();
-          serdeInfo.putToParameters(key, value);
-        }
+        serdeInfo.putToParameters(ConfigUtils.TABLE_SERDE_PATH, basePath);
         table.putToParameters(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitSynced.get());
         client.alter_table(databaseName, tableName, table);
       } catch (Exception e) {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -38,8 +38,12 @@ import org.apache.hudi.sync.common.util.ConfigUtils;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -50,6 +54,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,6 +82,7 @@ import static org.apache.hudi.hive.testutils.HiveTestUtil.basePath;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.ddlExecutor;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.getHiveConf;
 import static org.apache.hudi.hive.testutils.HiveTestUtil.hiveSyncProps;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_CONDITIONAL_SYNC;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
@@ -83,6 +90,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_F
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -160,6 +168,52 @@ public class TestHiveSyncTool {
   @AfterEach
   public void teardown() throws Exception {
     HiveTestUtil.clear();
+  }
+
+  @ParameterizedTest
+  @MethodSource({"syncModeAndSchemaFromCommitMetadata"})
+  public void testUpdateBasePath(boolean useSchemaFromCommitMetadata, String syncMode, String enablePushDown) throws Exception {
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), syncMode);
+    hiveSyncProps.setProperty(HIVE_SYNC_FILTER_PUSHDOWN_ENABLED.key(), enablePushDown);
+    String instantTime = "100";
+    // create a cow table and sync to hive
+    HiveTestUtil.createCOWTable(instantTime, 1, useSchemaFromCommitMetadata);
+    reinitHiveSyncClient();
+    reSyncHiveTable();
+    assertTrue(hiveClient.tableExists(HiveTestUtil.TABLE_NAME),
+        "Table " + HiveTestUtil.TABLE_NAME + " should exist after sync completes");
+    IMetaStoreClient client = Hive.get(getHiveConf()).getMSC();
+    Option<String> locationOption = getMetastoreLocation(client, HiveTestUtil.DB_NAME, HiveTestUtil.TABLE_NAME);
+    assertTrue(locationOption.isPresent(),
+        "The location of Table " + HiveTestUtil.TABLE_NAME + " is not present in metastore");
+    String oldLocation = locationOption.get();
+
+    // we change the base path, so we need to delete temp directory manually
+    HiveTestUtil.fileSystem.delete(new Path(basePath), true);
+
+    // create a new cow table and reSync
+    basePath = Files.createTempDirectory("hivesynctest" + Instant.now().toEpochMilli()).toUri().toString();
+    hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
+    HiveTestUtil.createCOWTable(instantTime, 1, useSchemaFromCommitMetadata);
+    reinitHiveSyncClient();
+    reSyncHiveTable();
+    client.reconnect();
+    Option<String> newLocationOption = getMetastoreLocation(client, HiveTestUtil.DB_NAME, HiveTestUtil.TABLE_NAME);
+    assertTrue(newLocationOption.isPresent(),
+        "The location of Table " + HiveTestUtil.TABLE_NAME + " is not present in metastore");
+    String newLocation = newLocationOption.get();
+    assertNotEquals(oldLocation, newLocation, "Update base path failed");
+    client.close();
+  }
+
+  public Option<String> getMetastoreLocation(IMetaStoreClient client, String databaseName, String tableName) {
+    try {
+      Table table = client.getTable(databaseName, tableName);
+      StorageDescriptor sd = table.getSd();
+      return Option.ofNullable(sd.getLocation());
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException("Failed to get the metastore location from the table " + tableName, e);
+    }
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ConfigUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ConfigUtils.java
@@ -34,6 +34,12 @@ public class ConfigUtils {
   public static final String IS_QUERY_AS_RO_TABLE = "hoodie.query.as.ro.table";
 
   /**
+   * Config stored in hive serde properties to tell query engine (spark) the
+   * location to read.
+   */
+  public static final String TABLE_SERDE_PATH = "path";
+
+  /**
    * Convert the key-value config to a map.The format of the config
    * is a key-value pair just like "k1=v1\nk2=v2\nk3=v3".
    *

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
@@ -102,4 +102,10 @@ public class SparkDataSourceTableUtils {
     sparkSerdeProperties.put(ConfigUtils.IS_QUERY_AS_RO_TABLE, String.valueOf(readAsOptimized));
     return sparkSerdeProperties;
   }
+
+  public static Map<String, String> getSparkSerdePathProperties(String basePath) {
+    Map<String, String> sparkSerdePathProperties = new HashMap<>();
+    sparkSerdePathProperties.put("path", basePath);
+    return sparkSerdePathProperties;
+  }
 }

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
@@ -98,14 +98,9 @@ public class SparkDataSourceTableUtils {
 
   public static Map<String, String> getSparkSerdeProperties(boolean readAsOptimized, String basePath) {
     Map<String, String> sparkSerdeProperties = new HashMap<>();
-    sparkSerdeProperties.put("path", basePath);
+    sparkSerdeProperties.put(ConfigUtils.TABLE_SERDE_PATH, basePath);
     sparkSerdeProperties.put(ConfigUtils.IS_QUERY_AS_RO_TABLE, String.valueOf(readAsOptimized));
     return sparkSerdeProperties;
   }
 
-  public static Map<String, String> getSparkSerdePathProperties(String basePath) {
-    Map<String, String> sparkSerdePathProperties = new HashMap<>();
-    sparkSerdePathProperties.put("path", basePath);
-    return sparkSerdePathProperties;
-  }
 }


### PR DESCRIPTION
If we change the table path, the table location in metastore will not change after hive-sync. This PR fixes the behavior.

Fixes #7422 

### Change Logs

Add some code to change the table's storage descriptor when running hive-sync.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
