### PR TITLE
[HUDI-5261] Use Proper Parallelism for Engine Context APIs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -104,7 +104,8 @@ public class HoodieIndexUtils {
    */
   public static List<Pair<String, HoodieBaseFile>> getLatestBaseFilesForAllPartitions(final List<String> partitions,
                                                                                       final HoodieEngineContext context,
-                                                                                      final HoodieTable hoodieTable) {
+                                                                                      final HoodieTable hoodieTable,
+                                                                                      final int parallelism) {
     context.setJobStatus(HoodieIndexUtils.class.getSimpleName(), "Load latest base files from all partitions: " + hoodieTable.getConfig().getTableName());
     return context.flatMap(partitions, partitionPath -> {
       List<Pair<String, HoodieBaseFile>> filteredFiles =
@@ -113,7 +114,7 @@ public class HoodieIndexUtils {
               .collect(toList());
 
       return filteredFiles.stream();
-    }, Math.max(partitions.size(), 1));
+    }, Math.max(Math.min(parallelism, partitions.size()), 1));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/ListBasedHoodieBloomIndexHelper.java
@@ -71,7 +71,8 @@ public class ListBasedHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper 
 
     keyLookupResults = keyLookupResults.stream().filter(
         lr -> lr.getMatchingRecordKeys().size() > 0).collect(toList());
-    return context.parallelize(keyLookupResults).flatMap(lookupResult ->
+    return context.parallelize(keyLookupResults, Math.max(1, Math.min(config.getBloomIndexParallelism(), keyLookupResults.size())))
+        .flatMap(lookupResult ->
         lookupResult.getMatchingRecordKeys().stream()
             .map(recordKey -> new ImmutablePair<>(lookupResult, recordKey)).iterator()
     ).mapToPair(pair -> {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
@@ -103,7 +103,7 @@ public class HoodieGlobalSimpleIndex extends HoodieSimpleIndex {
     HoodieTableMetaClient metaClient = hoodieTable.getMetaClient();
     List<String> allPartitionPaths = FSUtils.getAllPartitionPaths(context, config.getMetadataConfig(), metaClient.getBasePath());
     // Obtain the latest data files from all the partitions.
-    return getLatestBaseFilesForAllPartitions(allPartitionPaths, context, hoodieTable);
+    return getLatestBaseFilesForAllPartitions(allPartitionPaths, context, hoodieTable, config.getGlobalSimpleIndexParallelism());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieSimpleIndex.java
@@ -141,7 +141,7 @@ public class HoodieSimpleIndex
     List<String> affectedPartitionPathList =
         hoodieKeys.map(HoodieKey::getPartitionPath).distinct().collectAsList();
     List<Pair<String, HoodieBaseFile>> latestBaseFiles =
-        getLatestBaseFilesForAllPartitions(affectedPartitionPathList, context, hoodieTable);
+        getLatestBaseFilesForAllPartitions(affectedPartitionPathList, context, hoodieTable, config.getSimpleIndexParallelism());
     return fetchRecordLocations(context, hoodieTable, parallelism, latestBaseFiles);
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1109,12 +1109,13 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   }
 
   private HoodieData<HoodieRecord> getFilesPartitionRecords(String createInstantTime, List<DirectoryInfo> partitionInfoList, HoodieRecord allPartitionRecord) {
+    //only 1 record so parallelism of  1
     HoodieData<HoodieRecord> filesPartitionRecords = engineContext.parallelize(Arrays.asList(allPartitionRecord), 1);
     if (partitionInfoList.isEmpty()) {
       return filesPartitionRecords;
     }
 
-    HoodieData<HoodieRecord> fileListRecords = engineContext.parallelize(partitionInfoList, partitionInfoList.size()).map(partitionInfo -> {
+    HoodieData<HoodieRecord> fileListRecords = engineContext.parallelize(partitionInfoList,Math.min(dataWriteConfig.getFileListingParallelism(), partitionInfoList.size())).map(partitionInfo -> {
       Map<String, Long> fileNameToSizeMap = partitionInfo.getFileNameToSizeMap();
       // filter for files that are part of the completed commits
       Map<String, Long> validFileNameToSizeMap = fileNameToSizeMap.entrySet().stream().filter(fileSizePair -> {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/bootstrap/BootstrapUtils.java
@@ -51,7 +51,7 @@ public class BootstrapUtils {
    * @throws IOException
    */
   public static List<Pair<String, List<HoodieFileStatus>>> getAllLeafFoldersWithFiles(HoodieTableMetaClient metaClient,
-      FileSystem fs, String basePathStr, HoodieEngineContext context) throws IOException {
+      FileSystem fs, String basePathStr, HoodieEngineContext context, int parallelism) throws IOException {
     final Path basePath = new Path(basePathStr);
     final String baseFileExtension = metaClient.getTableConfig().getBaseFileFormat().getFileExtension();
     final Map<Integer, List<String>> levelToPartitions = new HashMap<>();
@@ -92,7 +92,7 @@ public class BootstrapUtils {
           }
         }
         return res.stream();
-      }, subDirectories.size()));
+      }, Math.min(subDirectories.size(), parallelism)));
     }
 
     result.forEach(val -> {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -126,9 +126,9 @@ public class CleanActionExecutor<T extends HoodieRecordPayload, I, K, O> extends
    * @throws IllegalArgumentException if unknown cleaning policy is provided
    */
   List<HoodieCleanStat> clean(HoodieEngineContext context, HoodieCleanerPlan cleanerPlan) {
-    int cleanerParallelism = Math.min(
+    int cleanerParallelism = Math.max(Math.min(
         (int) (cleanerPlan.getFilePathsToBeDeletedPerPartition().values().stream().mapToInt(List::size).count()),
-        config.getCleanerParallelism());
+        config.getCleanerParallelism()), 1);
     LOG.info("Using cleanerParallelism: " + cleanerParallelism);
 
     context.setJobStatus(this.getClass().getSimpleName(), "Perform cleaning of partitions: " + config.getTableName());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -94,7 +94,7 @@ public abstract class PartitionAwareClusteringPlanStrategy<T extends HoodieRecor
               List<FileSlice> fileSlicesEligible = getFileSlicesEligibleForClustering(partitionPath).collect(Collectors.toList());
               return buildClusteringGroupsForPartition(partitionPath, fileSlicesEligible).limit(getWriteConfig().getClusteringMaxNumGroups());
             },
-            partitionPaths.size())
+            Math.max(1, Math.min(partitionPaths.size(), config.getClusteringMaxNumGroups())))
         .stream()
         .limit(getWriteConfig().getClusteringMaxNumGroups())
         .collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -127,7 +127,7 @@ public abstract class HoodieCompactor<T extends HoodieRecordPayload, I, K, O> im
 
     context.setJobStatus(this.getClass().getSimpleName(), "Compacting file slices: " + config.getTableName());
     TaskContextSupplier taskContextSupplier = table.getTaskContextSupplier();
-    return context.parallelize(operations).map(operation -> compact(
+    return context.parallelize(operations, Math.min(operations.size(), config.getUpsertShuffleParallelism())).map(operation -> compact(
         compactionHandler, metaClient, config, operation, compactionInstantTime, maxInstantTime, taskContextSupplier, executionHelper))
         .flatMap(List::iterator);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/BaseHoodieCompactionPlanGenerator.java
@@ -119,7 +119,7 @@ public abstract class BaseHoodieCompactionPlanGenerator<T extends HoodieRecordPa
           Option<HoodieBaseFile> dataFile = s.getBaseFile();
           return new CompactionOperation(dataFile, partitionPath, logFiles,
               writeConfig.getCompactionStrategy().captureMetrics(writeConfig, s));
-        }), partitionPaths.size()).stream()
+        }), Math.max(1, Math.min(partitionPaths.size(), writeConfig.getUpsertShuffleParallelism()))).stream()
         .map(CompactionUtils::buildHoodieCompactionOperation).collect(toList());
 
     LOG.info("Total of " + operations.size() + " compaction operations are retrieved");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackHelper.java
@@ -176,7 +176,7 @@ public class BaseRollbackHelper implements Serializable {
                     .build()))
             .stream();
       }
-    }, numPartitions);
+    },  Math.min(1, Math.max(numPartitions, config.getRollbackParallelism())));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -180,7 +180,7 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
               String.format("Unsupported table type: %s, during listing rollback of %s", tableType, instantToRollback));
         }
         return hoodieRollbackRequests.stream();
-      }, numPartitions);
+      }, Math.max(1, Math.min(numPartitions, config.getRollbackParallelism())));
     } catch (Exception e) {
       LOG.error("Generating rollback requests failed for " + instantToRollback.getTimestamp(), e);
       throw new HoodieRollbackException("Generating rollback requests failed for " + instantToRollback.getTimestamp(), e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -93,7 +93,7 @@ public class SavepointActionExecutor<T extends HoodieRecordPayload, I, K, O> ext
         List<String> latestFiles = view.getLatestBaseFilesBeforeOrOn(partitionPath, instantTime)
             .map(HoodieBaseFile::getFileName).collect(Collectors.toList());
         return new ImmutablePair<>(partitionPath, latestFiles);
-      }, null);
+      }, config.getFileListingParallelism());
       HoodieSavepointMetadata metadata = TimelineMetadataUtils.convertSavepointMetadata(user, comment, latestFilesMap);
       // Nothing to save in the savepoint
       table.getActiveTimeline().createNewInstant(

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkDeletePartitionCommitActionExecutor.java
@@ -66,7 +66,7 @@ public class FlinkDeletePartitionCommitActionExecutor<T extends HoodieRecordPayl
       HoodieTimer timer = new HoodieTimer().startTimer();
       context.setJobStatus(this.getClass().getSimpleName(), "Gather all file ids from all deleting partitions.");
       Map<String, List<String>> partitionToReplaceFileIds =
-          context.parallelize(partitions).distinct().collectAsList()
+          context.parallelize(partitions, Math.min(partitions.size(), config.getFileListingParallelism())).distinct().collectAsList()
               .stream().collect(Collectors.toMap(partitionPath -> partitionPath, this::getAllExistingFileIds));
       HoodieWriteMetadata<List<WriteStatus>> result = new HoodieWriteMetadata<>();
       result.setPartitionToReplaceFileIds(partitionToReplaceFileIds);

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaInsertOverwriteCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaInsertOverwriteCommitActionExecutor.java
@@ -68,7 +68,7 @@ public class JavaInsertOverwriteCommitActionExecutor<T extends HoodieRecordPaylo
     return context.mapToPair(
         writeResult.getWriteStatuses().stream().map(status -> status.getStat().getPartitionPath()).distinct().collect(Collectors.toList()),
         partitionPath ->
-            Pair.of(partitionPath, getAllExistingFileIds(partitionPath)), 1
+            Pair.of(partitionPath, getAllExistingFileIds(partitionPath)), config.getFileListingParallelism()
     );
   }
 

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaInsertOverwriteTableCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaInsertOverwriteTableCommitActionExecutor.java
@@ -56,7 +56,8 @@ public class JavaInsertOverwriteTableCommitActionExecutor<T extends HoodieRecord
 
     if (partitionPaths != null && partitionPaths.size() > 0) {
       partitionToExistingFileIds = context.mapToPair(partitionPaths,
-          partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)), 1);
+          partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)),
+          Math.min(partitionPaths.size(), config.getFileListingParallelism()));
     }
     return partitionToExistingFileIds;
   }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
@@ -232,7 +232,7 @@ public class JavaUpsertPartitioner<T extends HoodieRecordPayload<T>> implements 
     if (partitionPaths != null && partitionPaths.size() > 0) {
       context.setJobStatus(this.getClass().getSimpleName(), "Getting small files from partitions: " + config.getTableName());
       partitionSmallFilesMap = context.mapToPair(partitionPaths,
-          partitionPath -> new ImmutablePair<>(partitionPath, getSmallFiles(partitionPath)), 0);
+          partitionPath -> new ImmutablePair<>(partitionPath, getSmallFiles(partitionPath)), Math.min(partitionPaths.size(), config.getFileListingParallelism()));
     }
     return partitionSmallFilesMap;
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
@@ -105,7 +105,8 @@ public class HoodieSparkConsistentBucketIndex extends HoodieBucketIndex {
     }
 
     HoodieClusteringPlan plan = instantPlanPair.get().getRight();
-    HoodieJavaRDD.getJavaRDD(context.parallelize(plan.getInputGroups().stream().map(HoodieClusteringGroup::getExtraMetadata).collect(Collectors.toList())))
+    List<Map<String, String>> planList = plan.getInputGroups().stream().map(HoodieClusteringGroup::getExtraMetadata).collect(Collectors.toList());
+    HoodieJavaRDD.getJavaRDD(context.parallelize(planList, Math.min(planList.size(), config.getMetadataInsertParallelism())))
         .mapToPair(m -> new Tuple2<>(m.get(SparkConsistentBucketClusteringPlanStrategy.METADATA_PARTITION_KEY), m)
     ).groupByKey().foreach((input) -> {
       // Process each partition

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
@@ -311,7 +311,7 @@ public class SparkBootstrapCommitActionExecutor<T extends HoodieRecordPayload<T>
    */
   private Map<BootstrapMode, List<Pair<String, List<HoodieFileStatus>>>> listAndProcessSourcePartitions() throws IOException {
     List<Pair<String, List<HoodieFileStatus>>> folders = BootstrapUtils.getAllLeafFoldersWithFiles(
-            table.getMetaClient(), bootstrapSourceFileSystem, config.getBootstrapSourceBasePath(), context);
+            table.getMetaClient(), bootstrapSourceFileSystem, config.getBootstrapSourceBasePath(), context, config.getBootstrapParallelism());
 
     LOG.info("Fetching Bootstrap Schema !!");
     HoodieBootstrapSchemaProvider sourceSchemaProvider = new HoodieSparkBootstrapSchemaProvider(config);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
@@ -64,7 +64,7 @@ public class SparkDeletePartitionCommitActionExecutor<T extends HoodieRecordPayl
       HoodieTimer timer = HoodieTimer.start();
       context.setJobStatus(this.getClass().getSimpleName(), "Gather all file ids from all deleting partitions.");
       Map<String, List<String>> partitionToReplaceFileIds =
-          HoodieJavaPairRDD.getJavaPairRDD(context.parallelize(partitions).distinct()
+          HoodieJavaPairRDD.getJavaPairRDD(context.parallelize(partitions, Math.min(partitions.size(), config.getFileListingParallelism())).distinct()
               .mapToPair(partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
       HoodieWriteMetadata<HoodieData<WriteStatus>> result = new HoodieWriteMetadata<>();
       result.setPartitionToReplaceFileIds(partitionToReplaceFileIds);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwriteTableCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkInsertOverwriteTableCommitActionExecutor.java
@@ -51,7 +51,7 @@ public class SparkInsertOverwriteTableCommitActionExecutor<T extends HoodieRecor
       return Collections.emptyMap();
     }
     context.setJobStatus(this.getClass().getSimpleName(), "Getting ExistingFileIds of all partitions");
-    return HoodieJavaPairRDD.getJavaPairRDD(context.parallelize(partitionPaths, partitionPaths.size()).mapToPair(
-        partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
+    return HoodieJavaPairRDD.getJavaPairRDD(context.parallelize(partitionPaths, Math.min(config.getMetadataInsertParallelism(),
+        partitionPaths.size())).mapToPair(partitionPath -> Pair.of(partitionPath, getAllExistingFileIds(partitionPath)))).collectAsMap();
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieKeyLocationFetchHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieKeyLocationFetchHandle.java
@@ -102,7 +102,7 @@ public class TestHoodieKeyLocationFetchHandle extends HoodieClientTestHarness {
     Map<Tuple2<String, String>, List<Tuple2<HoodieKey, HoodieRecordLocation>>> expectedList =
         writeToParquetAndGetExpectedRecordLocations(partitionRecordsMap, testTable);
 
-    List<Tuple2<String, HoodieBaseFile>> partitionPathFileIdPairs = loadAllFilesForPartitions(new ArrayList<>(partitionRecordsMap.keySet()), context, hoodieTable);
+    List<Tuple2<String, HoodieBaseFile>> partitionPathFileIdPairs = loadAllFilesForPartitions(new ArrayList<>(partitionRecordsMap.keySet()), context, hoodieTable, 4);
 
     BaseKeyGenerator keyGenerator = (BaseKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(new TypedProperties(getPropertiesForKeyGen()));
 
@@ -157,9 +157,9 @@ public class TestHoodieKeyLocationFetchHandle extends HoodieClientTestHarness {
   }
 
   private static List<Tuple2<String, HoodieBaseFile>> loadAllFilesForPartitions(List<String> partitions, HoodieEngineContext context,
-      HoodieTable hoodieTable) {
+      HoodieTable hoodieTable, int parallelism) {
     // Obtain the latest data files from all the partitions.
-    List<Pair<String, HoodieBaseFile>> partitionPathFileIDList = HoodieIndexUtils.getLatestBaseFilesForAllPartitions(partitions, context, hoodieTable);
+    List<Pair<String, HoodieBaseFile>> partitionPathFileIDList = HoodieIndexUtils.getLatestBaseFilesForAllPartitions(partitions, context, hoodieTable, parallelism);
     return partitionPathFileIDList.stream()
         .map(pf -> new Tuple2<>(pf.getKey(), pf.getValue())).collect(toList());
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/bootstrap/TestBootstrapUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/bootstrap/TestBootstrapUtils.java
@@ -68,14 +68,14 @@ public class TestBootstrapUtils extends HoodieClientTestBase {
     });
 
     List<Pair<String, List<HoodieFileStatus>>> collected = BootstrapUtils.getAllLeafFoldersWithFiles(metaClient,
-            metaClient.getFs(), basePath, context);
+            metaClient.getFs(), basePath, context, 3);
     assertEquals(3, collected.size());
     collected.stream().forEach(k -> {
       assertEquals(2, k.getRight().size());
     });
 
     // Simulate reading from un-partitioned dataset
-    collected = BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), basePath + "/" + folders.get(0), context);
+    collected = BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), basePath + "/" + folders.get(0), context, 3);
     assertEquals(1, collected.size());
     collected.stream().forEach(k -> {
       assertEquals(2, k.getRight().size());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -334,7 +334,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
 
     // Insert new records
     BaseSparkCommitActionExecutor actionExecutor = new SparkInsertCommitActionExecutor(context, config, table,
-        firstCommitTime, context.parallelize(records));
+        firstCommitTime, context.parallelize(records, 4));
     List<WriteStatus> writeStatuses = jsc.parallelize(Arrays.asList(1)).map(x -> {
       return actionExecutor.handleInsert(FSUtils.createNewFileIdPfx(), records.iterator());
     }).flatMap(Transformations::flattenAsIterator).collect();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -171,7 +171,8 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(
             metadataMetaClient, metadataFileSystemView, partitionName);
 
-    return (shouldLoadInMemory ? HoodieListData.lazy(partitionFileSlices) : engineContext.parallelize(partitionFileSlices))
+    return (shouldLoadInMemory ? HoodieListData.lazy(partitionFileSlices) : engineContext.parallelize(partitionFileSlices, Math.min(partitionFileSlices.size(),
+        metadataConfig.getFileListingParallelism())))
         .flatMap((SerializableFunction<FileSlice, Iterator<HoodieRecord<HoodieMetadataPayload>>>) fileSlice -> {
           // NOTE: Since this will be executed by executors, we can't access previously cached
           //       readers, and therefore have to always open new ones

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestOrcBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestOrcBootstrap.java
@@ -160,7 +160,7 @@ public class TestOrcBootstrap extends HoodieClientTestBase {
       df.write().format("orc").mode(SaveMode.Overwrite).save(srcPath);
     }
     String filePath = FileStatusUtils.toPath(BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(),
-        srcPath, context).stream().findAny().map(p -> p.getValue().stream().findAny())
+        srcPath, context, 3).stream().findAny().map(p -> p.getValue().stream().findAny())
         .orElse(null).get().getPath()).toString();
     Reader orcReader = OrcFile.createReader(new Path(filePath), OrcFile.readerOptions(metaClient.getHadoopConf()));
 
@@ -265,7 +265,7 @@ public class TestOrcBootstrap extends HoodieClientTestBase {
     client.rollbackFailedBootstrap();
     metaClient.reloadActiveTimeline();
     assertEquals(0, metaClient.getCommitsTimeline().countInstants());
-    assertEquals(0L, BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), basePath, context)
+    assertEquals(0L, BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), basePath, context, 3)
         .stream().flatMap(f -> f.getValue().stream()).count());
 
     BootstrapIndex index = BootstrapIndex.getBootstrapIndex(metaClient);
@@ -291,7 +291,7 @@ public class TestOrcBootstrap extends HoodieClientTestBase {
     String updateSPath = tmpFolder.toAbsolutePath().toString() + "/data2";
     generateNewDataSetAndReturnSchema(updateTimestamp, totalRecords, partitions, updateSPath);
     JavaRDD<HoodieRecord> updateBatch =
-        generateInputBatch(jsc, BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), updateSPath, context),
+        generateInputBatch(jsc, BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), updateSPath, context, 3),
             schema);
     String newInstantTs = client.startCommit();
     client.upsert(updateBatch, newInstantTs);
@@ -353,7 +353,7 @@ public class TestOrcBootstrap extends HoodieClientTestBase {
     original.registerTempTable("original");
     if (checkNumRawFiles) {
       List<HoodieFileStatus> files = BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(),
-          bootstrapBasePath, context).stream().flatMap(x -> x.getValue().stream()).collect(Collectors.toList());
+          bootstrapBasePath, context, 3).stream().flatMap(x -> x.getValue().stream()).collect(Collectors.toList());
       assertEquals(files.size() * numVersions,
           sqlContext.sql("select distinct _hoodie_file_name from bootstrapped").count());
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDataTableValidator.java
@@ -337,7 +337,7 @@ public class HoodieDataTableValidator implements Serializable {
           } else {
             return Stream.empty();
           }
-        }, hoodieInstants.size()).stream().collect(Collectors.toList());
+        }, Math.max(1, Math.min(hoodieInstants.size(), cfg.parallelism))).stream().collect(Collectors.toList());
 
         if (!danglingFiles.isEmpty()) {
           LOG.error("Data table validation failed due to extra files found for completed commits " + danglingFiles.size());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -443,7 +443,7 @@ public class HoodieMetadataTableValidator implements Serializable {
         new HoodieMetadataValidationContext(engineContext, cfg, metaClient, false);
 
     Set<String> finalBaseFilesForCleaning = baseFilesForCleaning;
-    List<Boolean> result = engineContext.parallelize(allPartitions, allPartitions.size()).map(partitionPath -> {
+    List<Boolean> result = engineContext.parallelize(allPartitions, Math.min(cfg.parallelism, allPartitions.size())).map(partitionPath -> {
       try {
         validateFilesInPartition(metadataTableBasedContext, fsBasedContext, partitionPath, finalBaseFilesForCleaning);
         LOG.info(String.format("Metadata table validation succeeded for partition %s (partition %s)", partitionPath, taskLabels));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
@@ -61,6 +61,8 @@ public class HoodieWithTimelineServer implements Serializable {
     public Integer serverPort = 26754;
     @Parameter(names = {"--delay-secs", "-d"}, description = "Delay(sec) before client connects")
     public Integer delaySecs = 30;
+    @Parameter(names = {"--parallelism", "-pl"}, description = "Spark parallelism")
+    public Integer parallelism = 4;
     @Parameter(names = {"--help", "-h"}, help = true)
     public Boolean help = false;
   }
@@ -91,7 +93,7 @@ public class HoodieWithTimelineServer implements Serializable {
 
     HoodieEngineContext context = new HoodieSparkEngineContext(jsc);
     context.setJobStatus(this.getClass().getSimpleName(), "Sending requests to driver host");
-    List<String> gotMessages = context.map(messages, msg -> sendRequest(driverHost, cfg.serverPort), messages.size());
+    List<String> gotMessages = context.map(messages, msg -> sendRequest(driverHost, cfg.serverPort),  Math.min(cfg.parallelism, messages.size()));
     System.out.println("Got Messages :" + gotMessages);
     ValidationUtils.checkArgument(gotMessages.equals(messages), "Got expected reply from Server");
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotCopier.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotCopier.java
@@ -71,7 +71,7 @@ public class TestHoodieSnapshotCopier extends FunctionalTestHarness {
     // Do the snapshot
     HoodieSnapshotCopier copier = new HoodieSnapshotCopier();
     copier.snapshot(jsc(), basePath, outputPath, true,
-        HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS);
+        HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS, 0);
 
     // Nothing changed; we just bail out
     assertEquals(fs.listStatus(new Path(basePath)).length, 1);
@@ -124,7 +124,7 @@ public class TestHoodieSnapshotCopier extends FunctionalTestHarness {
 
     // Do a snapshot copy
     HoodieSnapshotCopier copier = new HoodieSnapshotCopier();
-    copier.snapshot(jsc(), basePath, outputPath, false, HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS);
+    copier.snapshot(jsc(), basePath, outputPath, false, HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS, 0);
 
     // Check results
     assertTrue(fs.exists(new Path(outputPath + "/2016/05/01/" + file11.getName())));


### PR DESCRIPTION
### Change Logs

A lot of occurrences are using number of items as parallelism, which affect performance. Parallelism should be based on num cores available in the cluster and set by user via parallelism configs.

### Impact

Better, more tunable performance.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
