### PR TITLE
[HUDI-5375] Fixing reusing file readers with Metadata reader within FileIndex

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -270,7 +270,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     long startTime = System.currentTimeMillis();
 
     HoodieTableMetadata newTableMetadata = HoodieTableMetadata.create(engineContext, metadataConfig, basePath.toString(),
-        FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue());
+        FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue(), true);
 
     resetTableMetadata(newTableMetadata);
 


### PR DESCRIPTION
### Change Logs

Fixing reuse of file readers for metadata table in FileIndex. 

### Impact

Fixing reuse of file readers for metadata table in FileIndex. This was the case from the starting. but one of the earlier refactoring reverted it ([offending commit](https://github.com/apache/hudi/pull/6016/files#diff-0115903d86444e5decbeac54ac873d08cbf4175268e6c1b7fe3dc59591f73970)). Master is already fixed with [this](https://github.com/apache/hudi/pull/6680/files#diff-0115903d86444e5decbeac54ac873d08cbf4175268e6c1b7fe3dc59591f73970), but we are not pulling the large patch into 0.12.2 and so, here is the fix against 0.12.2.

### Risk level (write none, low medium or high below)

low. 

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
