### PR TITLE
[HUDI-5392] Fixing Bootstrapping flow handling of arrays

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/MergingIterator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/MergingIterator.java
@@ -24,13 +24,13 @@ import org.apache.hudi.common.util.ValidationUtils;
 import java.util.Iterator;
 import java.util.function.BiFunction;
 
-public class MergingIterator implements Iterator<HoodieRecord> {
+public class MergingIterator<T extends HoodieRecord> implements Iterator<T> {
 
-  private final Iterator<HoodieRecord> leftIterator;
-  private final Iterator<HoodieRecord> rightIterator;
-  private final BiFunction<HoodieRecord, HoodieRecord, HoodieRecord> mergeFunction;
+  private final Iterator<T> leftIterator;
+  private final Iterator<T> rightIterator;
+  private final BiFunction<T, T, T> mergeFunction;
 
-  public MergingIterator(Iterator<HoodieRecord> leftIterator, Iterator<HoodieRecord> rightIterator, BiFunction<HoodieRecord, HoodieRecord, HoodieRecord> mergeFunction) {
+  public MergingIterator(Iterator<T> leftIterator, Iterator<T> rightIterator, BiFunction<T, T, T> mergeFunction) {
     this.leftIterator = leftIterator;
     this.rightIterator = rightIterator;
     this.mergeFunction = mergeFunction;
@@ -45,7 +45,7 @@ public class MergingIterator implements Iterator<HoodieRecord> {
   }
 
   @Override
-  public HoodieRecord next() {
+  public T next() {
     return mergeFunction.apply(leftIterator.next(), rightIterator.next());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
@@ -60,8 +60,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.avro.AvroSchemaUtils.isStrictProjectionOf;
-import static org.apache.hudi.avro.HoodieAvroUtils.rewriteRecordWithNewSchema;
-import static org.apache.hudi.avro.HoodieAvroUtils.stitchRecords;
 
 public class HoodieMergeHelper<T> extends BaseMergeHelper {
 
@@ -135,7 +133,7 @@ public class HoodieMergeHelper<T> extends BaseMergeHelper {
         recordIterator = new MergingIterator<>(
             baseFileRecordIterator,
             bootstrapFileReader.getRecordIterator(bootstrapSchema),
-            (inputRecordPair) ->
+            (left, right) ->
                 left.joinWith(right, mergeHandle.getWriterSchemaWithMetaFields()));
         recordSchema = mergeHandle.getWriterSchemaWithMetaFields();
       } else if (schemaEvolutionTransformerOpt.isPresent()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
@@ -132,8 +132,11 @@ public class HoodieMergeHelper<T> extends BaseMergeHelper {
         //         qualified names of the structs, which could not be reconstructed when converting from
         //         Parquet to Avro (b/c Parquet doesn't bear these)
         Schema bootstrapSchema = mergeHandle.getWriterSchema();
-        recordIterator = new MergingIterator(baseFileRecordIterator, bootstrapFileReader.getRecordIterator(),
-            (left, right) -> left.joinWith(right, mergeHandle.getWriterSchemaWithMetaFields()));
+        recordIterator = new MergingIterator<>(
+            baseFileRecordIterator,
+            bootstrapFileReader.getRecordIterator(bootstrapSchema),
+            (inputRecordPair) ->
+                left.joinWith(right, mergeHandle.getWriterSchemaWithMetaFields()));
         recordSchema = mergeHandle.getWriterSchemaWithMetaFields();
       } else if (schemaEvolutionTransformerOpt.isPresent()) {
         recordIterator = new MappingIterator<>(baseFileRecordIterator,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieMergeHelper.java
@@ -123,16 +123,10 @@ public class HoodieMergeHelper<T> extends BaseMergeHelper {
         Configuration bootstrapFileConfig = new Configuration(table.getHadoopConf());
         bootstrapFileReader =
             HoodieFileReaderFactory.getReaderFactory(recordType).getFileReader(bootstrapFileConfig, bootstrapFilePath);
-        // NOTE: It's important for us to rely on writer's schema here
-        //         - When records will be read by Parquet reader, if schema will be decoded from the
-        //         file itself by taking its Parquet one and converting it to Avro. This will be problematic
-        //         w/ schema validations of the records since Avro's schemas also validate corresponding
-        //         qualified names of the structs, which could not be reconstructed when converting from
-        //         Parquet to Avro (b/c Parquet doesn't bear these)
-        Schema bootstrapSchema = mergeHandle.getWriterSchema();
+
         recordIterator = new MergingIterator<>(
             baseFileRecordIterator,
-            bootstrapFileReader.getRecordIterator(bootstrapSchema),
+            bootstrapFileReader.getRecordIterator(),
             (left, right) ->
                 left.joinWith(right, mergeHandle.getWriterSchemaWithMetaFields()));
         recordSchema = mergeHandle.getWriterSchemaWithMetaFields();

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -187,6 +187,7 @@ class TestDataSourceForBootstrap {
     // check marked directory clean up
     assert(!fs.exists(new Path(basePath, ".hoodie/.temp/00000000000001")))
 
+    // TODO(HUDI-5602) troubleshoot
     val expectedDF = bootstrapMode match {
       case "METADATA_ONLY" =>
         sort(sourceDF).withColumn("datestr", lit(null))


### PR DESCRIPTION
### Change Logs

This PR addresses an issue where in a Bootstrapping flow we're incorrectly configuring Parquet reader such that it reads arrays from Parquet being written in an older format (compatible w/ `AvroParquetWriter`) instead of the newer format (default in Spark):

```
 // Old
 optional group tip_history (LIST) {
    repeated group array {
      optional double amount;
      optional binary currency (UTF8);
    }
  }

 // new
 optional group tip_history (LIST) {
    repeated group list {
      optional group element {
        optional double amount;
        optional binary currency (UTF8);
      }
    }
  }
```

Since bootstrap files are usually a plain Parquet files (likely written w/ default Parquet writer in Spark), we should not try to read these w/ an older configuration of `parquet.avro.add-list-element-records=false` currently being set in Hudi to stay compatible w/ some of its Avro-based Parquet writers.

### Impact

No impact

### Risk level (write none, low medium or high below)

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
