### PR TITLE
[HUDI-5394] Fix RowCustomColumnsSortPartitioner

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
@@ -44,8 +44,8 @@ public class RowCustomColumnsSortPartitioner implements BulkInsertPartitioner<Da
   @Override
   public Dataset<Row> repartitionRecords(Dataset<Row> records, int outputSparkPartitions) {
     final String[] sortColumns = this.sortColumnNames;
-    return records.coalesce(outputSparkPartitions)
-        .sortWithinPartitions(HoodieRecord.PARTITION_PATH_METADATA_FIELD, sortColumns);
+    return records.sort(HoodieRecord.PARTITION_PATH_METADATA_FIELD, sortColumns)
+        .coalesce(outputSparkPartitions);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
@@ -21,6 +21,7 @@ package org.apache.hudi.execution.bulkinsert;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
+
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 


### PR DESCRIPTION
### Change Logs

`RowCustomColumnsSortPartitioner` should not use `sortWithinPartitions`

### Impact

May reduce performance of those operations that use `RowCustomColumnsSortPartitioner`
E.g: Cluster with linear layout strategy when enabled `hoodie.datasource.write.row.writer.enable`

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
