### PR TITLE
[HUDI-5231] Suppress Checkstyle Warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,8 @@
           </dependency>
         </dependencies>
         <configuration>
-          <consoleOutput>true</consoleOutput>
+          <!-- Set consoleOutput to true to see minor checkstyle issues -->
+          <consoleOutput>false</consoleOutput>
           <encoding>UTF-8</encoding>
           <configLocation>style/checkstyle.xml</configLocation>
           <suppressionsLocation>style/checkstyle-suppressions.xml</suppressionsLocation>


### PR DESCRIPTION
### Change Logs

Due to different IDE configs, even if we fix all the warnings, the imports will get messed up again and we will have a bunch of warnings. I discussed with few other Hudi engineers and we came to a consensus that we should suppress those warnings. By changing this config, the `[INFO]` warnings will not show up when building. However, a message with information will show up as usual if you have a major violation that causes the build to fail.

### Impact

Less output when building

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
