### PR TITLE
[HUDI-5246] Added validation for Partition Path to not begin with "/"

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -97,7 +97,6 @@ public final class HoodieKey implements Serializable, KryoSerializable {
 
   @Override
   public void read(Kryo kryo, Input input) {
-    validatePartitionPath(partitionPath);
     this.recordKey = input.readString();
     String partitionPath = input.readString();
     validatePartitionPath(partitionPath);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -104,7 +104,7 @@ public final class HoodieKey implements Serializable, KryoSerializable {
   }
 
   private static void validatePartitionPath(String partitionPath) {
-    if (partitionPath != null && partitionPath.startsWith("/")) {
+    if (partitionPath != null && partitionPath.charAt(0) == '/') {
       throw new IllegalArgumentException("Partition path cannot start with a /");
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -58,7 +58,7 @@ public final class HoodieKey implements Serializable, KryoSerializable {
   }
 
   public String getPartitionPath() {
-    if(partitionPath.startsWith("/")){
+    if (partitionPath.trim().startsWith("/")) {
       throw new IllegalArgumentException("Partition path cannot start with a /");
     }
     return partitionPath;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -41,6 +41,7 @@ public final class HoodieKey implements Serializable, KryoSerializable {
   public HoodieKey() {}
 
   public HoodieKey(String recordKey, String partitionPath) {
+    validatePartitionPath(partitionPath);
     this.recordKey = recordKey;
     this.partitionPath = partitionPath;
   }
@@ -54,13 +55,11 @@ public final class HoodieKey implements Serializable, KryoSerializable {
   }
 
   public void setPartitionPath(String partitionPath) {
+    validatePartitionPath(partitionPath);
     this.partitionPath = partitionPath;
   }
 
   public String getPartitionPath() {
-    if (partitionPath.trim().startsWith("/")) {
-      throw new IllegalArgumentException("Partition path cannot start with a /");
-    }
     return partitionPath;
   }
 
@@ -98,7 +97,16 @@ public final class HoodieKey implements Serializable, KryoSerializable {
 
   @Override
   public void read(Kryo kryo, Input input) {
+    validatePartitionPath(partitionPath);
     this.recordKey = input.readString();
-    this.partitionPath = input.readString();
+    String partitionPath = input.readString();
+    validatePartitionPath(partitionPath);
+    this.partitionPath = partitionPath;
+  }
+
+  private static void validatePartitionPath(String partitionPath) {
+    if (partitionPath != null && partitionPath.startsWith("/")) {
+      throw new IllegalArgumentException("Partition path cannot start with a /");
+    }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -58,6 +58,9 @@ public final class HoodieKey implements Serializable, KryoSerializable {
   }
 
   public String getPartitionPath() {
+    if(partitionPath.startsWith("/")){
+      throw new IllegalArgumentException("Partition path cannot start with a /");
+    }
     return partitionPath;
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieKey.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieKey.java
@@ -31,10 +31,10 @@ public class TestHoodieKey {
 
   @Test
   public void testPartitionPathValid() {
-    HoodieKey hoodieKey = new HoodieKey(UUID.randomUUID().toString(), "0000/00/00");
+    HoodieKey hoodieKey = new HoodieKey(UUID.randomUUID().toString(), "/0000/00/00");
     assertThrows(IllegalArgumentException.class, () -> {
       hoodieKey.getPartitionPath();
-      }, "should fail since partition path cannot begin with a /");
+    }, "should fail since partition path cannot begin with a /");
   }
 
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieKey.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieKey.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link HoodieKey}.
+ */
+public class TestHoodieKey {
+
+  @Test
+  public void testPartitionPathValid() {
+    HoodieKey hoodieKey = new HoodieKey(UUID.randomUUID().toString(), "0000/00/00");
+    assertThrows(IllegalArgumentException.class, () -> {
+      hoodieKey.getPartitionPath();
+      }, "should fail since partition path cannot begin with a /");
+  }
+
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieKey.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieKey.java
@@ -22,19 +22,27 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link HoodieKey}.
  */
 public class TestHoodieKey {
-
   @Test
   public void testPartitionPathValid() {
-    HoodieKey hoodieKey = new HoodieKey(UUID.randomUUID().toString(), "/0000/00/00");
+
     assertThrows(IllegalArgumentException.class, () -> {
-      hoodieKey.getPartitionPath();
+      new HoodieKey(UUID.randomUUID().toString(), "/0000/00/00");
     }, "should fail since partition path cannot begin with a /");
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      new HoodieKey().setPartitionPath("/0000/00/00");
+    }, "should fail since partition path cannot begin with a /");
+
+    assertDoesNotThrow(() -> {
+      new HoodieKey(UUID.randomUUID().toString(), "0000/00/00");
+    }, "should not fail for a valid partition path");
   }
 
 }


### PR DESCRIPTION
### Change Logs

Added validation for partition path to not start with "/".

### Impact

When using the Java Client, found that upserts have the behavior of inserts when partition path starts with "/".
The change is to validate and fail fast when partitionPath starts with a '/'.
Addresses action item from https://github.com/apache/hudi/issues/7247

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
