### PR TITLE
[DOCS] Fix dataframe write option in schema_evolution docs

### DIFF
--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -207,9 +207,9 @@ val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 var dfFromData1 = spark.createDataFrame(data1, schema)
 dfFromData1.write.format("hudi").
    options(getQuickstartWriteConfigs).
-   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+   option(PRECOMBINE_FIELD.key, "preComb").
+   option(RECORDKEY_FIELD.key, "rowId").
+   option(PARTITIONPATH_FIELD.key, "partitionId").
    option("hoodie.index.type","SIMPLE").
    option(TABLE_NAME.key, tableName).
    mode(Overwrite).
@@ -263,6 +263,7 @@ val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1"),
                Row("row_5", "part_0", 5L, "maroon", "v_2", 2L, "newField_1"),
                Row("row_9", "part_0", 5L, "michael", "v_2", 2L, "newField_1"))
 
+<<<<<<< HEAD
 var dfFromData2 = spark.createDataFrame(data2, newSchema)
 dfFromData2.write.format("hudi").
     options(getQuickstartWriteConfigs).
@@ -273,6 +274,18 @@ dfFromData2.write.format("hudi").
     option(TABLE_NAME.key, tableName).
     mode(Append).
     save(basePath)
+=======
+scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
+scala> dfFromData2.write.format("hudi").
+    |   options(getQuickstartWriteConfigs).
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
+    |   option("hoodie.index.type","SIMPLE").
+    |   option(TBL_NAME.key, tableName).
+    |   mode(Append).
+    |   save(basePath)
+>>>>>>> f38ba78aee1 ([DOCS] Fix schema_evolution docs)
 
 var tripsSnapshotDF2 = spark.read.format("hudi").load(basePath + "/*/*")
 tripsSnapshotDF2.createOrReplaceTempView("hudi_trips_snapshot")

--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -263,29 +263,16 @@ val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1"),
                Row("row_5", "part_0", 5L, "maroon", "v_2", 2L, "newField_1"),
                Row("row_9", "part_0", 5L, "michael", "v_2", 2L, "newField_1"))
 
-<<<<<<< HEAD
 var dfFromData2 = spark.createDataFrame(data2, newSchema)
 dfFromData2.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    option(PRECOMBINE_FIELD.key, "preComb").
+    option(RECORDKEY_FIELD.key, "rowId").
+    option(PARTITIONPATH_FIELD.key, "partitionId").
     option("hoodie.index.type","SIMPLE").
-    option(TABLE_NAME.key, tableName).
+    option(TBL_NAME.key, tableName).
     mode(Append).
     save(basePath)
-=======
-scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
-scala> dfFromData2.write.format("hudi").
-    |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD.key, "preComb").
-    |   option(RECORDKEY_FIELD.key, "rowId").
-    |   option(PARTITIONPATH_FIELD.key, "partitionId").
-    |   option("hoodie.index.type","SIMPLE").
-    |   option(TBL_NAME.key, tableName).
-    |   mode(Append).
-    |   save(basePath)
->>>>>>> f38ba78aee1 ([DOCS] Fix schema_evolution docs)
 
 var tripsSnapshotDF2 = spark.read.format("hudi").load(basePath + "/*/*")
 tripsSnapshotDF2.createOrReplaceTempView("hudi_trips_snapshot")

--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -211,7 +211,7 @@ dfFromData1.write.format("hudi").
    option(RECORDKEY_FIELD.key, "rowId").
    option(PARTITIONPATH_FIELD.key, "partitionId").
    option("hoodie.index.type","SIMPLE").
-   option(TABLE_NAME.key, tableName).
+   option(TBL_NAME.key, tableName).
    mode(Overwrite).
    save(basePath)
 

--- a/website/versioned_docs/version-0.10.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.10.0/schema_evolution.md
@@ -87,11 +87,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -147,11 +147,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.10.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.10.1/schema_evolution.md
@@ -87,11 +87,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -147,11 +147,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.11.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.11.0/schema_evolution.md
@@ -265,11 +265,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -325,11 +325,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.11.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.11.1/schema_evolution.md
@@ -265,11 +265,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -325,11 +325,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.12.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.0/schema_evolution.md
@@ -266,11 +266,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -326,11 +326,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.12.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.1/schema_evolution.md
@@ -266,11 +266,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -326,11 +326,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.12.2/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.2/schema_evolution.md
@@ -266,11 +266,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -326,11 +326,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.13.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.13.0/schema_evolution.md
@@ -266,11 +266,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -326,11 +326,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.13.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.13.1/schema_evolution.md
@@ -266,11 +266,11 @@ scala> val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 scala> var dfFromData1 = spark.createDataFrame(data1, schema)
 scala> dfFromData1.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Overwrite).
     |   save(basePath)
 
@@ -326,11 +326,11 @@ scala> val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1
 scala> var dfFromData2 = spark.createDataFrame(data2, newSchema)
 scala> dfFromData2.write.format("hudi").
     |   options(getQuickstartWriteConfigs).
-    |   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    |   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    |   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    |   option(PRECOMBINE_FIELD.key, "preComb").
+    |   option(RECORDKEY_FIELD.key, "rowId").
+    |   option(PARTITIONPATH_FIELD.key, "partitionId").
     |   option("hoodie.index.type","SIMPLE").
-    |   option(TABLE_NAME.key, tableName).
+    |   option(TBL_NAME.key, tableName).
     |   mode(Append).
     |   save(basePath)
 

--- a/website/versioned_docs/version-0.14.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.14.0/schema_evolution.md
@@ -190,11 +190,11 @@ val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 var dfFromData1 = spark.createDataFrame(data1, schema)
 dfFromData1.write.format("hudi").
    options(getQuickstartWriteConfigs).
-   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+   option(PRECOMBINE_FIELD.key, "preComb").
+   option(RECORDKEY_FIELD.key, "rowId").
+   option(PARTITIONPATH_FIELD.key, "partitionId").
    option("hoodie.index.type","SIMPLE").
-   option(TABLE_NAME.key, tableName).
+   option(TBL_NAME.key, tableName).
    mode(Overwrite).
    save(basePath)
 
@@ -249,11 +249,11 @@ val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1"),
 var dfFromData2 = spark.createDataFrame(data2, newSchema)
 dfFromData2.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    option(PRECOMBINE_FIELD.key, "preComb").
+    option(RECORDKEY_FIELD.key, "rowId").
+    option(PARTITIONPATH_FIELD.key, "partitionId").
     option("hoodie.index.type","SIMPLE").
-    option(TABLE_NAME.key, tableName).
+    option(TBL_NAME.key, tableName).
     mode(Append).
     save(basePath)
 

--- a/website/versioned_docs/version-0.14.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.14.1/schema_evolution.md
@@ -207,11 +207,11 @@ val data1 = Seq(Row("row_1", "part_0", 0L, "bob", "v_0", 0),
 var dfFromData1 = spark.createDataFrame(data1, schema)
 dfFromData1.write.format("hudi").
    options(getQuickstartWriteConfigs).
-   option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-   option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-   option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+   option(PRECOMBINE_FIELD.key, "preComb").
+   option(RECORDKEY_FIELD.key, "rowId").
+   option(PARTITIONPATH_FIELD.key, "partitionId").
    option("hoodie.index.type","SIMPLE").
-   option(TABLE_NAME.key, tableName).
+   option(TBL_NAME.key, tableName).
    mode(Overwrite).
    save(basePath)
 
@@ -266,11 +266,11 @@ val data2 = Seq(Row("row_2", "part_0", 5L, "john", "v_3", 3L, "newField_1"),
 var dfFromData2 = spark.createDataFrame(data2, newSchema)
 dfFromData2.write.format("hudi").
     options(getQuickstartWriteConfigs).
-    option(PRECOMBINE_FIELD_OPT_KEY.key, "preComb").
-    option(RECORDKEY_FIELD_OPT_KEY.key, "rowId").
-    option(PARTITIONPATH_FIELD_OPT_KEY.key, "partitionId").
+    option(PRECOMBINE_FIELD.key, "preComb").
+    option(RECORDKEY_FIELD.key, "rowId").
+    option(PARTITIONPATH_FIELD.key, "partitionId").
     option("hoodie.index.type","SIMPLE").
-    option(TABLE_NAME.key, tableName).
+    option(TBL_NAME.key, tableName).
     mode(Append).
     save(basePath)
 


### PR DESCRIPTION
### Change Logs

Fix dataframe write option in `schema_evolution` docs

e.g.

`PRECOMBINE_FIELD_OPT_KEY` has no `key` attribute, and it is Deprecated, replace it with `PRECOMBINE_FIELD.key`

### Impact

low

### Risk level (write none, low medium or high below)

low

### Documentation Update

Fix schema_evolution docs

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
