### PR TITLE
[HUDI-5402] Fix flink job wait ckpMeta timeout when partial failed

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -213,6 +213,10 @@ public abstract class AbstractStreamWriteFunction<I>
   private void sendBootstrapEvent() {
     int attemptId = getRuntimeContext().getAttemptNumber();
     if (attemptId > 0) {
+      if (Objects.isNull(lastPendingInstant())) {
+        this.eventGateway.sendEventToCoordinator(WriteMetadataEvent.emptyBootstrap(taskID));
+        return;
+      }
       // either a partial or global failover, reuses the current inflight instant
       if (this.currentInstant != null) {
         LOG.info("Recover task[{}] for instant [{}] with attemptId [{}]", taskID, this.currentInstant, attemptId);


### PR DESCRIPTION
### Change Logs

Currently when flink job start , `StreamWriteOperatorCoordinator` will bootstrap cpkMeta path (clean the path and make new dir) .

By now if taskmanager partital failed then the job could not resume any more

### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

nothing

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
