### PR TITLE
[HUDI-5138][RFC-64] Implementation of table APIs such as FileSliceReader and the rest

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/FileSliceReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/FileSliceReader.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi;
+
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableQueryType;
+import org.apache.hudi.internal.schema.InternalSchema;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.util.Iterator;
+import java.util.Set;
+
+public interface FileSliceReader extends AutoCloseable {
+
+  /**
+   * Projects output of this reader as a projection of the provided Hudi's internal schema.
+   * NOTE: Provided schema could be an evolved schema.
+   */
+  FileSliceReader project(InternalSchema schema);
+
+  /**
+   * Projects output of this reader as a projection of the provided avro schema.
+   */
+  FileSliceReader project(Schema schema);
+
+  /**
+   * Pushes down filters to low-level file-format readers (if supported).
+   */
+  // TODO: Should it take a generic type instead of string filters?
+  FileSliceReader pushDownFilters(Set<String> filters);
+
+  /**
+   * Specifies {@link HoodieTableQueryType} for this reader.
+   */
+  FileSliceReader readingMode(HoodieTableQueryType queryType);
+
+  /**
+   * Produces an iterable sequence of records from the given file slice.
+   */
+  Iterator<HoodieRecord> open(FileSlice fileSlice);
+
+  /**
+   * Produces an iterable sequence of records from the given file split.
+   */
+  Iterator<HoodieRecord> open(FileSplit fileSplit);
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionDescriptor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionDescriptor.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public class HoodiePartitionDescriptor {
+  // Relative partition path within the dataset
+  private final String partitionPath;
+
+  // List of values for corresponding partition columns
+  private final List<Object> partitionColumnValues;
+
+  public HoodiePartitionDescriptor(String partitionPath, List<Object> partitionColumnValues) {
+    this.partitionPath = partitionPath;
+    this.partitionColumnValues = partitionColumnValues;
+  }
+
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public List<Object> getPartitionColumnValues() {
+    return partitionColumnValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodiePartitionDescriptor that = (HoodiePartitionDescriptor) o;
+    return Objects.equals(partitionPath, that.partitionPath) && Objects.equals(partitionColumnValues, that.partitionColumnValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionPath, partitionColumnValues);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodiePartitionDescriptor{"
+        + "partitionPath='" + partitionPath + '\''
+        + ", partitionColumnValues=" + partitionColumnValues
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionIncrementalSnapshot.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionIncrementalSnapshot.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+
+import java.util.List;
+import java.util.Objects;
+
+public class HoodiePartitionIncrementalSnapshot {
+
+  HoodiePartitionDescriptor partitionDescriptor;
+
+  // Timeline starting at T_x and ending at T_y, completed actions thereof represent state of the partition
+  HoodieTimeline timeline;
+
+  // File-slices current at the instant T_y
+  List<FileSlice> fileSlices;
+
+  public HoodiePartitionIncrementalSnapshot(HoodiePartitionDescriptor partitionDescriptor, HoodieTimeline timeline, List<FileSlice> fileSlices) {
+    this.partitionDescriptor = partitionDescriptor;
+    this.timeline = timeline;
+    this.fileSlices = fileSlices;
+  }
+
+  public HoodiePartitionDescriptor getPartitionDescriptor() {
+    return partitionDescriptor;
+  }
+
+  public HoodieTimeline getTimeline() {
+    return timeline;
+  }
+
+  public List<FileSlice> getFileSlices() {
+    return fileSlices;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodiePartitionIncrementalSnapshot that = (HoodiePartitionIncrementalSnapshot) o;
+    return Objects.equals(partitionDescriptor, that.partitionDescriptor) && Objects.equals(timeline, that.timeline) && Objects.equals(fileSlices, that.fileSlices);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionDescriptor, timeline, fileSlices);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodiePartitionIncrementalSnapshot{"
+        + "partitionDescriptor=" + partitionDescriptor
+        + ", timeline=" + timeline
+        + ", fileSlices=" + fileSlices
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionSnapshot.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionSnapshot.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+
+import java.util.List;
+import java.util.Objects;
+
+public class HoodiePartitionSnapshot {
+
+  HoodiePartitionDescriptor partitionDescriptor;
+
+  // (Latest) Instant T as of which partition's state is represented
+  HoodieInstant latestInstant;
+
+  // File-slices current at the instant T
+  List<FileSlice> fileSlices;
+
+  public HoodiePartitionSnapshot(HoodiePartitionDescriptor partitionDescriptor, HoodieInstant latestInstant, List<FileSlice> fileSlices) {
+    this.partitionDescriptor = partitionDescriptor;
+    this.latestInstant = latestInstant;
+    this.fileSlices = fileSlices;
+  }
+
+  public HoodiePartitionDescriptor getPartitionDescriptor() {
+    return partitionDescriptor;
+  }
+
+  public HoodieInstant getLatestInstant() {
+    return latestInstant;
+  }
+
+  public List<FileSlice> getFileSlices() {
+    return fileSlices;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodiePartitionSnapshot that = (HoodiePartitionSnapshot) o;
+    return Objects.equals(partitionDescriptor, that.partitionDescriptor)
+        && Objects.equals(latestInstant, that.latestInstant)
+        && Objects.equals(fileSlices, that.fileSlices);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionDescriptor, latestInstant, fileSlices);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodiePartitionSnapshot{"
+        + "partitionDescriptor=" + partitionDescriptor
+        + ", latestInstant=" + latestInstant
+        + ", fileSlices=" + fileSlices
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -433,6 +433,6 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   }
 
   public enum HoodieRecordType {
-    AVRO, SPARK
+    AVRO, SPARK, HIVE
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieTableDef.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieTableDef.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.internal.schema.InternalSchema;
+
+import java.util.Objects;
+
+public class HoodieTableDef {
+
+  private final HoodieTableId tableId;
+
+  // Table's base path
+  private final String basePath;
+
+  // Table's latest schema
+  private final InternalSchema schema;
+
+  // Table's type (COW, MOR)
+  private final HoodieTableType tableType;
+
+  public HoodieTableDef(HoodieTableId tableId, String basePath, InternalSchema schema, HoodieTableType tableType) {
+    this.tableId = tableId;
+    this.basePath = basePath;
+    this.schema = schema;
+    this.tableType = tableType;
+  }
+
+  public HoodieTableId getTableId() {
+    return tableId;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public InternalSchema getSchema() {
+    return schema;
+  }
+
+  public HoodieTableType getTableType() {
+    return tableType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodieTableDef that = (HoodieTableDef) o;
+    return Objects.equals(tableId, that.tableId) && Objects.equals(basePath, that.basePath) && Objects.equals(schema, that.schema) && tableType == that.tableType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableId, basePath, schema, tableType);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieTableDef{"
+        + "tableId=" + tableId
+        + ", basePath='" + basePath + '\''
+        + ", schema=" + schema
+        + ", tableType=" + tableType
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieTableId.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieTableId.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import java.util.Objects;
+
+public class HoodieTableId {
+
+  private final String databaseName;
+  private final String tableName;
+
+  public HoodieTableId(String databaseName, String tableName) {
+    this.databaseName = databaseName;
+    this.tableName = tableName;
+  }
+
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodieTableId that = (HoodieTableId) o;
+    return Objects.equals(databaseName, that.databaseName) && Objects.equals(tableName, that.tableName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(databaseName, tableName);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieTableId{"
+        + "databaseName='" + databaseName + '\''
+        + ", tableName='" + tableName + '\''
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -662,7 +662,7 @@ public abstract class AbstractHoodieLogRecordReader {
    *
    * @param hoodieRecord Hoodie Record to process
    */
-  protected abstract <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception;
+  public abstract <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception;
 
   /**
    * Process next deleted record.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -22,9 +22,9 @@ import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
-import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.DefaultSizeEstimator;
@@ -150,7 +150,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
   }
 
   @Override
-  protected <T> void processNextRecord(HoodieRecord<T> newRecord) throws IOException {
+  public <T> void processNextRecord(HoodieRecord<T> newRecord) throws IOException {
     String key = newRecord.getRecordKey();
     if (records.containsKey(key)) {
       // Merge and store the merged record. The HoodieRecordPayload implementation is free to decide what should be

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -56,7 +56,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
   }
 
   @Override
-  protected <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception {
+  public  <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception {
     // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
     //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
     //       it since these records will be put into queue of BoundedInMemoryExecutor.

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
@@ -18,14 +18,14 @@
 
 package org.apache.hudi.io.storage;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.exception.HoodieException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 
@@ -41,6 +41,7 @@ public class HoodieFileReaderFactory {
   public static HoodieFileReaderFactory getReaderFactory(HoodieRecord.HoodieRecordType recordType) {
     switch (recordType) {
       case AVRO:
+      case HIVE:
         return new HoodieAvroFileReaderFactory();
       case SPARK:
         try {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieTableFileIndex.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieTableFileIndex.java
@@ -18,15 +18,19 @@
 
 package org.apache.hudi.hadoop;
 
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.BaseHoodieTableFileIndex;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodiePartitionIncrementalSnapshot;
+import org.apache.hudi.common.model.HoodiePartitionSnapshot;
 import org.apache.hudi.common.model.HoodieTableQueryType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,6 +81,16 @@ public class HiveHoodieTableFileIndex extends BaseHoodieTableFileIndex {
     //       since Hive does partition pruning in a different way (based on the input-path being
     //       fetched by the query engine)
     return new Object[0];
+  }
+
+  @Override
+  public List<HoodiePartitionSnapshot> listFilesAt(HoodieInstant instant, List<?> filters) {
+    return super.listFilesAt(instant, filters);
+  }
+
+  @Override
+  public List<HoodiePartitionIncrementalSnapshot> listFilesBetween(HoodieInstant from, HoodieInstant to, List<?> filters) {
+    return super.listFilesBetween(from, to, filters);
   }
 
   static class NoopCache implements FileStatusCache {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveFileSliceReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveFileSliceReader.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.FileSliceReader;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
+import org.apache.hudi.common.model.HoodiePayloadProps;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableQueryType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
+import org.apache.hudi.hadoop.realtime.RealtimeSplit;
+import org.apache.hudi.hadoop.utils.HoodieHiveUtils;
+import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.hudi.io.storage.HoodieFileReader;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplitWithLocationInfo;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils.getMergedLogRecordScanner;
+import static org.apache.hudi.io.storage.HoodieFileReaderFactory.getReaderFactory;
+
+public class HoodieHiveFileSliceReader implements FileSliceReader {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieHiveFileSliceReader.class);
+
+  private final FileSplit split;
+  private final JobConf jobConf;
+  private final HoodieTableMetaClient metaClient;
+  private final Properties payloadProps = new Properties();
+
+  // table schema from metadata
+  private final Schema schema;
+  private final SchemaEvolutionContext schemaEvolutionContext;
+
+  // other schema handles
+  private Schema readerSchema;
+  private Schema writerSchema;
+
+  private String readMode;
+
+  public HoodieHiveFileSliceReader(InputSplitWithLocationInfo split, JobConf jobConf) {
+    this.split = (FileSplit) split;
+    this.jobConf = jobConf;
+    try {
+      Path path = this.split.getPath();
+      HoodiePartitionMetadata metadata = new HoodiePartitionMetadata(path.getFileSystem(jobConf), path);
+      metadata.readFromFS();
+      String basePath = String.valueOf(HoodieHiveUtils.getNthParent(path, metadata.getPartitionDepth()));
+      this.metaClient = HoodieTableMetaClient.builder().setConf(jobConf).setBasePath(basePath).build();
+      this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineField());
+      this.schema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+      this.schemaEvolutionContext = new SchemaEvolutionContext(split, jobConf, Option.of(metaClient));
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to initialize metaclient for split: " + this.split);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get table avro schema.");
+    }
+  }
+
+  @Override
+  public FileSliceReader project(InternalSchema internalSchema) {
+    return project(AvroInternalSchemaConverter.convert(internalSchema, schema.getFullName()));
+  }
+
+  @Override
+  public FileSliceReader project(Schema requiredSchema) {
+    String partitionFields = jobConf.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "");
+    List<String> partitioningFields =
+        partitionFields.length() > 0 ? Arrays.stream(partitionFields.split("/")).collect(Collectors.toList())
+            : new ArrayList<>();
+    this.writerSchema = HoodieRealtimeRecordReaderUtils.addPartitionFields(schema, partitioningFields);
+
+    List<String> projectionFields = HoodieRealtimeRecordReaderUtils.orderFields(jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR),
+        jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR), partitioningFields);
+    Map<String, Schema.Field> schemaFieldsMap = HoodieRealtimeRecordReaderUtils.getNameToFieldMap(writerSchema);
+    this.readerSchema = HoodieRealtimeRecordReaderUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields);
+
+    return this;
+  }
+
+  @Override
+  public FileSliceReader pushDownFilters(Set<String> filters) {
+    String tableName = metaClient.getTableConfig().getTableName();
+
+    if (HoodieTableQueryType.INCREMENTAL.name().equals(readMode)) {
+      // TODO: construct predicate
+      // FilterPredicate predicate = constructHoodiePredicate(jobConf, tableName, split);
+      // LOG.info("Setting parquet predicate push down as " + predicate);
+      // ParquetInputFormat.setFilterPredicate(jobConf, predicate);
+    }
+
+    return this;
+  }
+
+  @Override
+  public FileSliceReader readingMode(HoodieTableQueryType queryType) {
+    this.readMode = queryType.name();
+    return this;
+  }
+
+  @Override
+  public Iterator<HoodieRecord> open(FileSlice fileSlice) {
+    if (fileSlice.isEmpty() || !fileSlice.getBaseFile().isPresent()) {
+      throw new HoodieIOException("Reading empty file slice or file slice has no base file: %s" + fileSlice);
+    }
+    HoodieBaseFile baseFile = fileSlice.getBaseFile().get();
+    HoodieRealtimeFileSplit split = null;
+
+    try {
+      split = new HoodieRealtimeFileSplit(
+          new FileSplit(baseFile.getHadoopPath(), 0, baseFile.getFileLen(), jobConf),
+          metaClient.getBasePath(),
+          fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
+              .collect(Collectors.toList()),
+          baseFile.getCommitTime(),
+          false,
+          Option.empty());
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to create realtime file split for file slice: " + fileSlice);
+    }
+
+    return getRecordIteratorFromSplit(split);
+  }
+
+  @Override
+  public Iterator<HoodieRecord> open(FileSplit fileSplit) {
+    return getRecordIteratorFromSplit(fileSplit);
+  }
+
+  private Iterator<HoodieRecord> getRecordIteratorFromSplit(FileSplit fileSplit) {
+    try (HoodieFileReader baseFileReader = getReaderFactory(HoodieRecord.HoodieRecordType.HIVE).getFileReader(jobConf, fileSplit.getPath())) {
+      Iterator<HoodieRecord> baseFileIterator = baseFileReader.getRecordIterator(readerSchema);
+      if (fileSplit instanceof RealtimeSplit) {
+        HoodieMergedLogRecordScanner logRecordScanner = getMergedLogRecordScanner(
+            (RealtimeSplit) fileSplit,
+            jobConf,
+            readerSchema,
+            schemaEvolutionContext,
+            HoodieHiveRecordMerger.class.getName());
+
+        return new HoodieLogFileIterator(
+            (RealtimeSplit) fileSplit,
+            jobConf,
+            baseFileReader,
+            logRecordScanner.getRecords(),
+            schema,
+            readerSchema,
+            metaClient);
+      } else {
+        return baseFileIterator;
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to open file slice: " + fileSplit);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+
+  }
+
+  public Schema getReaderSchema() {
+    return readerSchema;
+  }
+
+  public Schema getWriterSchema() {
+    return writerSchema;
+  }
+
+  public FileSplit getSplit() {
+    return split;
+  }
+
+  public JobConf getJobConf() {
+    return jobConf;
+  }
+
+  public boolean useCustomPayload() {
+    return !(metaClient.getTableConfig().getPayloadClass().contains(HoodieAvroPayload.class.getName())
+        || metaClient.getTableConfig().getPayloadClass().contains("org.apache.hudi.OverwriteWithLatestAvroPayload"));
+  }
+
+  public Properties getPayloadProps() {
+    return payloadProps;
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.MetadataValues;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.keygen.BaseKeyGenerator;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.avro.Schema;
+import org.apache.hadoop.io.ArrayWritable;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Hive specific implementation of {@link HoodieRecord}
+ */
+public class HoodieHiveRecord extends HoodieRecord<ArrayWritable> {
+
+  private transient Schema schema;
+
+  public HoodieHiveRecord(HoodieRecord<ArrayWritable> record) {
+    super(record);
+  }
+
+  public HoodieHiveRecord(ArrayWritable arrayWritable) {
+    this(arrayWritable, null);
+  }
+
+  public HoodieHiveRecord(ArrayWritable arrayWritable, Schema schema) {
+    super(null, arrayWritable);
+    this.schema = schema;
+  }
+
+  public HoodieHiveRecord(HoodieKey key, ArrayWritable arrayWritable, Schema schema) {
+    super(key, arrayWritable);
+    this.schema = schema;
+  }
+
+  public HoodieHiveRecord(HoodieKey key, ArrayWritable arrayWritable, HoodieOperation operation, Schema schema) {
+    super(key, arrayWritable, operation, Option.empty());
+    this.schema = schema;
+  }
+
+  public HoodieHiveRecord() {
+  }
+
+  @Override
+  public HoodieRecord<ArrayWritable> newInstance() {
+    return new HoodieHiveRecord(this);
+  }
+
+  @Override
+  public HoodieRecord<ArrayWritable> newInstance(HoodieKey key, HoodieOperation op) {
+    return new HoodieHiveRecord(key, this.data, op, this.schema);
+  }
+
+  @Override
+  public HoodieRecord<ArrayWritable> newInstance(HoodieKey key) {
+    return new HoodieHiveRecord(key, this.data, this.schema);
+  }
+
+  @Override
+  public Comparable<?> getOrderingValue(Schema recordSchema, Properties props) {
+    String orderingField = ConfigUtils.getOrderingField(props);
+    if (recordSchema.getField(orderingField) == null) {
+      return 0;
+    }
+    // TODO: handle nested fields
+    int index = recordSchema.getField(orderingField).pos();
+    return String.valueOf(data.get()[index]);
+  }
+
+  @Override
+  public HoodieRecordType getRecordType() {
+    return HoodieRecordType.HIVE;
+  }
+
+  @Override
+  public String getRecordKey(Schema recordSchema, Option<BaseKeyGenerator> keyGeneratorOpt) {
+    if (key != null) {
+      return getRecordKey();
+    }
+    return String.valueOf(data.get()[HoodieMetadataField.RECORD_KEY_METADATA_FIELD.ordinal()]);
+  }
+
+  @Override
+  public String getRecordKey(Schema recordSchema, String keyFieldName) {
+    if (key != null) {
+      return getRecordKey();
+    }
+    if (recordSchema.getField(keyFieldName) == null) {
+      throw new HoodieException(String.format("Record key field: %s not present in schema: %s", keyFieldName, recordSchema));
+    }
+    // TODO: handle nested fields
+    int index = recordSchema.getField(keyFieldName).pos();
+    return String.valueOf(data.get()[index]);
+  }
+
+  @Override
+  protected void writeRecordPayload(ArrayWritable payload, Kryo kryo, Output output) {
+
+  }
+
+  @Override
+  protected ArrayWritable readRecordPayload(Kryo kryo, Input input) {
+    return kryo.readObjectOrNull(input, ArrayWritable.class);
+  }
+
+  @Override
+  public Object[] getColumnValues(Schema recordSchema, String[] columns, boolean consistentLogicalTimestampEnabled) {
+    return new Object[0];
+  }
+
+  @Override
+  public HoodieRecord joinWith(HoodieRecord other, Schema targetSchema) {
+    return null;
+  }
+
+  @Override
+  public HoodieRecord rewriteRecord(Schema recordSchema, Properties props, Schema targetSchema) throws IOException {
+    return null;
+  }
+
+  @Override
+  public HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols) throws IOException {
+    return null;
+  }
+
+  @Override
+  public HoodieRecord updateMetadataValues(Schema recordSchema, Properties props, MetadataValues metadataValues) throws IOException {
+    return null;
+  }
+
+  @Override
+  public boolean isDelete(Schema recordSchema, Properties props) throws IOException {
+    return false;
+  }
+
+  @Override
+  public boolean shouldIgnore(Schema recordSchema, Properties props) throws IOException {
+    return false;
+  }
+
+  @Override
+  public HoodieRecord<ArrayWritable> copy() {
+    return null;
+  }
+
+  @Override
+  public Option<Map<String, String>> getMetadata() {
+    return null;
+  }
+
+  @Override
+  public HoodieRecord wrapIntoHoodieRecordPayloadWithParams(Schema recordSchema, Properties props, Option<Pair<String, String>> simpleKeyGenFieldsOpt, Boolean withOperation,
+                                                            Option<String> partitionNameOp, Boolean populateMetaFieldsOp) throws IOException {
+    return null;
+  }
+
+  @Override
+  public HoodieRecord wrapIntoHoodieRecordPayloadWithKeyGen(Schema recordSchema, Properties props, Option<BaseKeyGenerator> keyGen) {
+    return null;
+  }
+
+  @Override
+  public HoodieRecord truncateRecordKey(Schema recordSchema, Properties props, String keyFieldName) throws IOException {
+    return null;
+  }
+
+  @Override
+  public Option<HoodieAvroIndexedRecord> toIndexedRecord(Schema recordSchema, Properties props) throws IOException {
+    return null;
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecordMerger.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecordMerger.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+
+import java.io.IOException;
+
+public class HoodieHiveRecordMerger implements HoodieRecordMerger {
+
+  @Override
+  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    ValidationUtils.checkArgument(older.getRecordType() == HoodieRecordType.HIVE);
+    ValidationUtils.checkArgument(newer.getRecordType() == HoodieRecordType.HIVE);
+
+    if (newer.getData() == null) {
+      // Delete record
+      return Option.empty();
+    }
+    if (older.getData() == null) {
+      // use natural order for delete record
+      return Option.of(Pair.of(newer, newSchema));
+    }
+    if (older.getOrderingValue(oldSchema, props).compareTo(newer.getOrderingValue(newSchema, props)) > 0) {
+      return Option.of(Pair.of(older, oldSchema));
+    } else {
+      return Option.of(Pair.of(newer, newSchema));
+    }
+  }
+
+  @Override
+  public HoodieRecordType getRecordType() {
+    return HoodieRecordType.HIVE;
+  }
+
+  @Override
+  public String getMergingStrategy() {
+    return DEFAULT_MERGER_STRATEGY_UUID;
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLogFileIterator.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLogFileIterator.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodiePayloadProps;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ClosableIterator;
+import org.apache.hudi.common.util.HoodieRecordUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.realtime.HoodieVirtualKeyInfo;
+import org.apache.hudi.hadoop.realtime.RealtimeSplit;
+import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.util.Lazy;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+
+public class HoodieLogFileIterator implements ClosableIterator<HoodieRecord> {
+
+  private final RealtimeSplit split;
+  private final JobConf jobConf;
+  private final HoodieFileReader baseFileReader;
+  private final Iterator<HoodieRecord> baseFileIterator;
+  private final Map<String, HoodieRecord> logRecords;
+  private final Properties payloadProps = new Properties();
+  private final Schema dataSchema;
+  private final Schema readerSchema;
+  private final HoodieRecordMerger recordMerger;
+  private final int recordKeyIndex;
+  private final HoodieTableMetaClient metaClient;
+
+  private HoodieRecord record;
+  private Lazy<Iterator<Option<HoodieRecord>>> logRecordsIterator;
+
+  public HoodieLogFileIterator(RealtimeSplit split,
+                               JobConf jobConf,
+                               HoodieFileReader baseFileReader,
+                               Map<String, HoodieRecord> logRecords,
+                               Schema dataSchema,
+                               Schema readerSchema) {
+    this.split = split;
+    this.jobConf = jobConf;
+    this.baseFileReader = baseFileReader;
+    this.logRecords = logRecords;
+    this.metaClient = HoodieTableMetaClient.builder().setConf(jobConf).setBasePath(split.getBasePath()).build();
+    setPayloadProperties(metaClient);
+    this.dataSchema = dataSchema;
+    this.readerSchema = readerSchema;
+    this.recordMerger = HoodieRecordUtils.loadRecordMerger(HoodieHiveRecordMerger.class.getName());
+    this.recordKeyIndex = split.getVirtualKeyInfo()
+        .map(HoodieVirtualKeyInfo::getRecordKeyFieldIndex)
+        .orElse(HoodieInputFormatUtils.HOODIE_RECORD_KEY_COL_POS);
+    this.logRecordsIterator = Lazy.lazily(() -> logRecords.values().stream().map(Option::of).iterator());
+    try {
+      this.baseFileIterator = baseFileReader.getRecordIterator(readerSchema);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to get base records iterator.", e);
+    }
+  }
+
+  public HoodieLogFileIterator(RealtimeSplit split,
+                               JobConf jobConf,
+                               HoodieFileReader baseFileReader,
+                               Map<String, HoodieRecord> logRecords,
+                               Schema dataSchema,
+                               Schema readerSchema,
+                               HoodieTableMetaClient metaClient) {
+    this.split = split;
+    this.jobConf = jobConf;
+    this.baseFileReader = baseFileReader;
+    this.logRecords = logRecords;
+    this.metaClient = metaClient;
+    setPayloadProperties(metaClient);
+    this.dataSchema = dataSchema;
+    this.readerSchema = readerSchema;
+    this.recordMerger = HoodieRecordUtils.loadRecordMerger(HoodieHiveRecordMerger.class.getName());
+    this.recordKeyIndex = split.getVirtualKeyInfo()
+        .map(HoodieVirtualKeyInfo::getRecordKeyFieldIndex)
+        .orElse(HoodieInputFormatUtils.HOODIE_RECORD_KEY_COL_POS);
+    this.logRecordsIterator = Lazy.lazily(() -> logRecords.values().stream().map(Option::of).iterator());
+    try {
+      this.baseFileIterator = baseFileReader.getRecordIterator(readerSchema);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to get base records iterator.", e);
+    }
+  }
+
+  private void setPayloadProperties(HoodieTableMetaClient metaClient) {
+    if (metaClient.getTableConfig().getPreCombineField() != null) {
+      this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineField());
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return hasNextInternal();
+  }
+
+  private boolean hasNextInternal() {
+    if (baseFileIterator.hasNext()) {
+      HoodieRecord baseRecord = baseFileIterator.next();
+      String curKey = baseRecord.getKey().getRecordKey();
+      Option<HoodieRecord> updatedRecordOpt = removeLogRecord(curKey);
+
+      if (!updatedRecordOpt.isPresent()) {
+        // No merge is required, simply load current row and project into required schema
+        record = baseRecord;
+        return true;
+      }
+
+      try {
+        Option<Pair<HoodieRecord, Schema>> mergedRecord = recordMerger.merge(baseRecord, baseFileReader.getSchema(), updatedRecordOpt.get(), readerSchema, new TypedProperties(payloadProps));
+        record = mergedRecord.map(Pair::getLeft).orElse(new HoodieEmptyRecord(baseRecord.getKey(), baseRecord.getRecordType()));
+        return true;
+      } catch (IOException e) {
+        throw new HoodieException("Failed to merge");
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public HoodieRecord next() {
+    return record;
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  private Option<HoodieRecord> removeLogRecord(String key) {
+    return Option.ofNullable(logRecords.remove(key));
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -66,7 +66,7 @@ public abstract class AbstractRealtimeRecordReader {
   private Schema readerSchema;
   private Schema writerSchema;
   private Schema hiveSchema;
-  private HoodieTableMetaClient metaClient;
+  private final HoodieTableMetaClient metaClient;
   protected SchemaEvolutionContext schemaEvolutionContext;
   // support merge operation
   protected boolean supportPayload = true;

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeRecordReader.java
@@ -43,7 +43,7 @@ public class HoodieRealtimeRecordReader implements RecordReader<NullWritable, Ar
   private final RecordReader<NullWritable, ArrayWritable> reader;
 
   public HoodieRealtimeRecordReader(RealtimeSplit split, JobConf job,
-      RecordReader<NullWritable, ArrayWritable> realReader) {
+                                    RecordReader<NullWritable, ArrayWritable> realReader) {
     this.reader = constructRecordReader(split, job, realReader);
   }
 
@@ -54,19 +54,21 @@ public class HoodieRealtimeRecordReader implements RecordReader<NullWritable, Ar
   /**
    * Construct record reader based on job configuration.
    *
-   * @param split File Split
-   * @param jobConf Job Configuration
+   * @param split      File Split
+   * @param jobConf    Job Configuration
    * @param realReader Parquet Record Reader
    * @return Realtime Reader
    */
   private static RecordReader<NullWritable, ArrayWritable> constructRecordReader(RealtimeSplit split,
-      JobConf jobConf, RecordReader<NullWritable, ArrayWritable> realReader) {
+                                                                                 JobConf jobConf, RecordReader<NullWritable, ArrayWritable> realReader) {
     try {
       if (canSkipMerging(jobConf)) {
         LOG.info("Enabling un-merged reading of realtime records");
         return new RealtimeUnmergedRecordReader(split, jobConf, realReader);
       }
       LOG.info("Enabling merged reading of realtime records for split " + split);
+      // TODO: add switch to new `HoodieRealtimeRecordReader` here
+      // return new HoodieRealtimeMergedRecordReader(split, jobConf, realReader);
       return new RealtimeCompactedRecordReader(split, jobConf, realReader);
     } catch (IOException ex) {
       LOG.error("Got exception when constructing record reader", ex);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeSplit.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeSplit.java
@@ -18,11 +18,12 @@
 
 package org.apache.hudi.hadoop.realtime;
 
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.InputSplitWithLocationInfo;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.InputSplitUtils;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.InputSplitWithLocationInfo;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -38,6 +39,7 @@ public interface RealtimeSplit extends InputSplitWithLocationInfo {
 
   /**
    * Return Log File Paths.
+   *
    * @return
    */
   default List<String> getDeltaLogPaths() {
@@ -50,18 +52,21 @@ public interface RealtimeSplit extends InputSplitWithLocationInfo {
 
   /**
    * Return Max Instant Time.
+   *
    * @return
    */
   String getMaxCommitTime();
 
   /**
    * Return Base Path of the dataset.
+   *
    * @return
    */
   String getBasePath();
 
   /**
    * Returns Virtual key info if meta fields are disabled.
+   *
    * @return
    */
   Option<HoodieVirtualKeyInfo> getVirtualKeyInfo();
@@ -73,12 +78,14 @@ public interface RealtimeSplit extends InputSplitWithLocationInfo {
 
   /**
    * Update Maximum valid instant time.
+   *
    * @param maxCommitTime
    */
   void setMaxCommitTime(String maxCommitTime);
 
   /**
    * Set Base Path.
+   *
    * @param basePath
    */
   void setBasePath(String basePath);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -25,7 +25,8 @@ import org.apache.hudi.SparkHoodieTableFileIndex._
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex
 import org.apache.hudi.common.config.TypedProperties
-import org.apache.hudi.common.model.{FileSlice, HoodieTableQueryType}
+import org.apache.hudi.common.model.{FileSlice, HoodiePartitionIncrementalSnapshot, HoodiePartitionSnapshot, HoodieTableQueryType}
+import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.hadoop.CachingPath
@@ -43,18 +44,19 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
+import java.util.List
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 
 /**
  * Implementation of the [[BaseHoodieTableFileIndex]] for Spark
  *
- * @param spark spark session
- * @param metaClient Hudi table's meta-client
- * @param schemaSpec optional table's schema
- * @param configProperties unifying configuration (in the form of generic properties)
+ * @param spark                 spark session
+ * @param metaClient            Hudi table's meta-client
+ * @param schemaSpec            optional table's schema
+ * @param configProperties      unifying configuration (in the form of generic properties)
  * @param specifiedQueryInstant instant as of which table is being queried
- * @param fileStatusCache transient cache of fetched [[FileStatus]]es
+ * @param fileStatusCache       transient cache of fetched [[FileStatus]]es
  */
 class SparkHoodieTableFileIndex(spark: SparkSession,
                                 metaClient: HoodieTableMetaClient,
@@ -170,6 +172,18 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
     getInputFileSlices(prunedPartitions: _*).asScala.map {
       case (partition, fileSlices) => (partition.path, fileSlices.asScala)
     }.toMap
+  }
+
+  override def listFilesAt(instant: HoodieInstant, filters: List[_]): List[HoodiePartitionSnapshot] = {
+    // TODO
+    super.listFilesAt(instant, filters)
+  }
+
+  override def listFilesBetween(from: HoodieInstant,
+                                to: HoodieInstant,
+                                filters: List[_]): List[HoodiePartitionIncrementalSnapshot] = {
+    // TODO
+    super.listFilesBetween(from, to, filters)
   }
 
   /**
@@ -433,30 +447,30 @@ object SparkHoodieTableFileIndex {
    *
    * For example, following struct
    * <pre>
-   *   StructType(
-   *     StructField("a",
-   *       StructType(
-   *          StructField("b", StringType),
-   *          StructField("c", IntType)
-   *       )
-   *     )
-   *   )
+   * StructType(
+   * StructField("a",
+   * StructType(
+   * StructField("b", StringType),
+   * StructField("c", IntType)
+   * )
+   * )
+   * )
    * </pre>
    *
    * will be converted into following mapping:
    *
    * <pre>
-   *   "a.b" -> StructField("b", StringType),
-   *   "a.c" -> StructField("c", IntType),
+   * "a.b" -> StructField("b", StringType),
+   * "a.c" -> StructField("c", IntType),
    * </pre>
    */
-  private def generateFieldMap(structType: StructType) : Map[String, StructField] = {
-    def traverse(structField: Either[StructField, StructType]) : Map[String, StructField] = {
+  private def generateFieldMap(structType: StructType): Map[String, StructField] = {
+    def traverse(structField: Either[StructField, StructType]): Map[String, StructField] = {
       structField match {
         case Right(struct) => struct.fields.flatMap(f => traverse(Left(f))).toMap
         case Left(field) => field.dataType match {
           case struct: StructType => traverse(Right(struct)).map {
-            case (key, structField)  => (s"${field.name}.$key", structField)
+            case (key, structField) => (s"${field.name}.$key", structField)
           }
           case _ => Map(field.name -> field)
         }
@@ -471,14 +485,16 @@ object SparkHoodieTableFileIndex {
       case QUERY_TYPE_SNAPSHOT_OPT_VAL => HoodieTableQueryType.SNAPSHOT
       case QUERY_TYPE_INCREMENTAL_OPT_VAL => HoodieTableQueryType.INCREMENTAL
       case QUERY_TYPE_READ_OPTIMIZED_OPT_VAL => HoodieTableQueryType.READ_OPTIMIZED
-      case _ @ qt => throw new IllegalArgumentException(s"query-type ($qt) not supported")
+      case _@qt => throw new IllegalArgumentException(s"query-type ($qt) not supported")
     }
   }
 
   private def adapt(cache: FileStatusCache): BaseHoodieTableFileIndex.FileStatusCache = {
     new BaseHoodieTableFileIndex.FileStatusCache {
       override def get(path: Path): org.apache.hudi.common.util.Option[Array[FileStatus]] = toJavaOption(cache.getLeafFiles(path))
+
       override def put(path: Path, leafFiles: Array[FileStatus]): Unit = cache.putLeafFiles(path, leafFiles)
+
       override def invalidate(): Unit = cache.invalidateAll()
     }
   }


### PR DESCRIPTION
### Change Logs

Implements `FileSliceReader` for Hive as specified in https://github.com/apache/hudi/pull/7080. This is still WIP. Please do not merge.

- Add Hive-specific implementations for `HoodieRecord` and `HoodieRecordMerger` interfaces.
- Implement `FileSliceReader` for Hive: `HoodieHiveFileSliceReader`.
- Implement log file iterator based on merging iterator.
- Abstractions for partition snapshot: `HoodiePartitionDescriptor`, `HoodiePartitionSnapshot`, `HoodiePartitionIncrementalSnapshot`.
- Use these in file index.
 
### Impact

Core APIs to integrate with query engines easily and efficiently.

### Risk level (write none, low medium or high below)

high

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
