### PR TITLE
[HUDI-5419] Revert spark configs after each sql test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
@@ -94,8 +94,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
           }
         }
         for ((k, v) <- spark.sessionState.conf.getAllConfs) {
+          println(s"k: $k, v: $v")
           //some configs like spark.driver.port or spark.app.startTime may change
-          if (!k.startsWith("spark.")) {
+          if (k.startsWith("hoodie")) {
             if (!conf.contains(k)) {
               spark.sessionState.conf.unsetConf(k)
             } else if (!conf(k).equals(v)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
@@ -94,10 +94,13 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
           }
         }
         for ((k, v) <- spark.sessionState.conf.getAllConfs) {
-          if (!conf.contains(k)) {
-            spark.sessionState.conf.unsetConf(k)
-          } else if (!conf(k).equals(v)) {
-            spark.sessionState.conf.setConfString(k, conf(k))
+          //some configs like spark.driver.port or spark.app.startTime may change
+          if (!k.startsWith("spark.")) {
+            if (!conf.contains(k)) {
+              spark.sessionState.conf.unsetConf(k)
+            } else if (!conf(k).equals(v)) {
+              spark.sessionState.conf.setConfString(k, conf(k))
+            }
           }
         }
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
@@ -83,6 +83,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
     val conf = spark.sessionState.conf.getAllConfs
+    println(s"Before $testName")
+    for ((k, v) <- conf) {
+      println(s"k: $k, v: $v")
+    }
     super.test(testName, testTags: _*)(
       try {
         testFun
@@ -93,15 +97,21 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
             catalog.dropTable(table, true, true)
           }
         }
+        println(s"After $testName")
         for ((k, v) <- spark.sessionState.conf.getAllConfs) {
-          println(s"k: $k, v: $v")
           //some configs like spark.driver.port or spark.app.startTime may change
           if (k.startsWith("hoodie")) {
             if (!conf.contains(k)) {
+              println(s"unsetting k: $k, v: $v")
               spark.sessionState.conf.unsetConf(k)
             } else if (!conf(k).equals(v)) {
+              println(s"overwriting k: $k, v: $v with ${conf(k)}")
               spark.sessionState.conf.setConfString(k, conf(k))
+            } else {
+              println(s"keeping k: $k, v: $v")
             }
+          } else {
+            println(s"Doesn't start with hoodie k: $k, v: $v")
           }
         }
       }


### PR DESCRIPTION
### Change Logs

Before each test, we now save the configs in a map and after we undo any changes to configs that occurred during the test

### Impact

less interference between tests

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
