### PR TITLE
[HUDI-5418] Remove misleading line about mor precombine from quickstart spark-sql guide

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -273,7 +273,7 @@ Spark SQL needs an explicit create table command.
 2. Similar to `hoodie.datasource.write.recordkey.field`, `uuid` is used as primary key by default; if that's the case
    for your table, you can skip setting `primaryKey` in `tblproperties`.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
-4. `preCombineField` is required for MOR tables.
+4. `preCombineField` is required for MOR tables but for COW tables it is not required for immutable workloads (no upserts).
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
 6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::

--- a/website/versioned_docs/version-0.11.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.0/quick-start-guide.md
@@ -244,7 +244,7 @@ Spark SQL needs an explicit create table command.
 2. Similar to `hoodie.datasource.write.recordkey.field`, `uuid` is used as primary key by default; if that's the case
    for your table, you can skip setting `primaryKey` in `tblproperties`.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
-4. `preCombineField` is required for MOR tables.
+4. `preCombineField` is required for MOR tables but for COW tables it is not required for immutable workloads (no upserts).
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
 6. A new Hudi table created by Spark SQL will by default
    set `hoodie.table.keygenerator.class=org.apache.hudi.keygen.ComplexKeyGenerator` and

--- a/website/versioned_docs/version-0.11.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/quick-start-guide.md
@@ -244,7 +244,7 @@ Spark SQL needs an explicit create table command.
 2. Similar to `hoodie.datasource.write.recordkey.field`, `uuid` is used as primary key by default; if that's the case
    for your table, you can skip setting `primaryKey` in `tblproperties`.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
-4. `preCombineField` is required for MOR tables.
+4. `preCombineField` is required for MOR tables but for COW tables it is not required for immutable workloads (no upserts).
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
 6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -270,7 +270,7 @@ Spark SQL needs an explicit create table command.
 2. Similar to `hoodie.datasource.write.recordkey.field`, `uuid` is used as primary key by default; if that's the case
    for your table, you can skip setting `primaryKey` in `tblproperties`.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
-4. `preCombineField` is required for MOR tables.
+4. `preCombineField` is required for MOR tables but for COW tables it is not required for immutable workloads (no upserts).
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
 6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -270,7 +270,7 @@ Spark SQL needs an explicit create table command.
 2. Similar to `hoodie.datasource.write.recordkey.field`, `uuid` is used as primary key by default; if that's the case
    for your table, you can skip setting `primaryKey` in `tblproperties`.
 3. `primaryKey`, `preCombineField`, and `type` are case-sensitive.
-4. `preCombineField` is required for MOR tables.
+4. `preCombineField` is required for MOR tables but for COW tables it is not required for immutable workloads (no upserts).
 5. When set `primaryKey`, `preCombineField`, `type` or other Hudi configs, `tblproperties` is preferred over `options`.
 6. A new Hudi table created by Spark SQL will by default set `hoodie.datasource.write.hive_style_partitioning=true`.
 :::


### PR DESCRIPTION
### Change Logs

There is a line saying that precombine field is required for mor tables. This lead me to believe that it was not required for cow tables when it actually is.

### Impact

Gets rid of a confusion point

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
