### PR TITLE
[HUDI-5456] Flink streaming read skips uncommitted instants

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,8 +66,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import scala.Serializable;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN_OR_EQUALS;
@@ -482,7 +481,7 @@ public class IncrementalInputSplits implements Serializable {
     HoodieTimeline completedTimeline = commitTimeline.filterCompletedInstants();
     if (issuedInstant != null) {
       // returns early for streaming mode
-      return commitTimeline
+      return completedTimeline
           .getInstantsAsStream()
           .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), GREATER_THAN, issuedInstant))
           .collect(Collectors.toList());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -83,6 +83,14 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     List<HoodieInstant> instantRange3 = iis.filterInstantsWithRange(timeline, null);
     assertEquals(3, instantRange3.size());
     assertIterableEquals(Arrays.asList(commit1, commit2, commit3), instantRange3);
+
+    // add an inflight instant which should be excluded
+    HoodieInstant commit4 = new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "4");
+    timeline.createNewInstant(commit4);
+    timeline = timeline.reload();
+    assertEquals(4, timeline.getInstants().size());
+    List<HoodieInstant> instantRange4 = iis.filterInstantsWithRange(timeline, null);
+    assertEquals(3, instantRange4.size());
   }
 
 }


### PR DESCRIPTION
Actually introduced by HUDI-5234.

### Change Logs

The commit metadata should be resolved from a committed instant.

### Impact

Fix the metadata parsing error.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
