### PR TITLE
[HUDI-5469] Hive doesn't respect the space at the end of partition path, so remove it to avoid dupl…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -131,8 +131,7 @@ public class KeyGenUtils {
       } else {
         if (encodePartitionPath) {
           fieldVal = PartitionPathEncodeUtils.escapePathName(fieldVal);
-        }
-        else {
+        } else {
           // Hive doesn't respect the space at the end, so remove it to avoid duplicate keys error
           fieldVal = fieldVal.trim();
         }
@@ -160,8 +159,7 @@ public class KeyGenUtils {
     }
     if (encodePartitionPath) {
       partitionPath = PartitionPathEncodeUtils.escapePathName(partitionPath);
-    }
-    else{
+    } else {
       partitionPath = partitionPath.trim();
     }
     if (hiveStylePartitioning) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -132,6 +132,10 @@ public class KeyGenUtils {
         if (encodePartitionPath) {
           fieldVal = PartitionPathEncodeUtils.escapePathName(fieldVal);
         }
+        else {
+          // Hive doesn't respect the space at the end, so remove it to avoid duplicate keys error
+          fieldVal = fieldVal.trim();
+        }
         partitionPath.append(hiveStylePartitioning ? partitionPathField + "=" + fieldVal : fieldVal);
       }
       partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
@@ -156,6 +160,9 @@ public class KeyGenUtils {
     }
     if (encodePartitionPath) {
       partitionPath = PartitionPathEncodeUtils.escapePathName(partitionPath);
+    }
+    else{
+      partitionPath = partitionPath.trim();
     }
     if (hiveStylePartitioning) {
       partitionPath = partitionPathField + "=" + partitionPath;


### PR DESCRIPTION
…icate keys error

### Change Logs

let's say there are two partition paths: 

1.  "partition_path"
2. "partition_path "

the second one has a space at its end, the HMS will throw an error when doing hive sync since HMS treats them as the same

Caused by: com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException: Duplicate entry 'partition_path' for key 'UNIQUEPARTITION'

### Impact
no

### Risk level (write none, low medium or high below)
low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
