### PR TITLE
[HUDI-5433] Fix the way we deduce the pending instants for MDT writes

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -807,7 +807,12 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
       if (enableMetadata) {
-        assertEquals(originalCommits, commitsAfterArchival);
+        if (i != 6) {
+          assertEquals(originalCommits, commitsAfterArchival);
+        } else {
+          // on 6th commit, archival will kick in. but will archive only one commit since 2nd compaction commit is inflight.
+          assertEquals(originalCommits.size() - commitsAfterArchival.size(), 1);
+        }
       } else {
         if (i != 6) {
           assertEquals(originalCommits, commitsAfterArchival);


### PR DESCRIPTION
### Change Logs

Compaction in metadata table (MDT) is triggered only when there are no pending inflight instants apart from the one that's currently updating (let's say C3) the MDT. The current code only checks for inflight instants before C3. Instead we need to check any inflights compared to latest detla commit. bcoz, thats what is used as compaction instant's base time. This PR fixes that behavior.

### Impact

MDT compaction.

### Risk level (write none, low medium or high below)

medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
