### PR TITLE
[DOCS] fix when I click on Update or MergeInto link in spark quickstart it d…

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -696,6 +696,8 @@ select * from hudi_cow_pt_tbl timestamp as of '2022-03-08' where id = 1;
 This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a DataFrame 
 and write DataFrame into the hudi table.
 
+### Update
+
 <Tabs
 groupId="programming-language"
 defaultValue="python"
@@ -731,8 +733,6 @@ denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `d
 
 Spark SQL supports two kinds of DML to update hudi table: Merge-Into and Update.
 
-### Update
-
 **Syntax**
 ```sql
 UPDATE tableIdentifier SET column = EXPRESSION(,column = EXPRESSION) [ WHERE boolExpression]
@@ -750,7 +750,42 @@ update hudi_cow_pt_tbl set ts = 1001 where name = 'a1';
 `Update` operation requires `preCombineField` specified.
 :::
 
+</TabItem>
+<TabItem value="python">
+
+```python
+# pyspark
+updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
+df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
+df.write.format("hudi"). \
+  options(**hudi_options). \
+  mode("append"). \
+  save(basePath)
+```
+:::note
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+:::
+
+</TabItem>
+
+</Tabs
+>
+
 ### MergeInto
+
+<Tabs
+groupId="programming-language"
+defaultValue="python"
+values={[
+{ label: 'Scala', value: 'scala', },
+{ label: 'Python', value: 'python', },
+{ label: 'Spark SQL', value: 'sparksql', },
+]}
+>
+
+<TabItem value="sparksql">
 
 **Syntax**
 
@@ -802,24 +837,23 @@ when not matched then
 ;
 
 ```
+</TabItem>
+
+<TabItem value="scala">
+
+```scala
+// scala
+// MergeInto is only available when using Spark SQL. 
+```
 
 </TabItem>
 <TabItem value="python">
 
 ```python
 # pyspark
-updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
-df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
-df.write.format("hudi"). \
-  options(**hudi_options). \
-  mode("append"). \
-  save(basePath)
+# MergeInto is only available when using Spark SQL.
 ```
-:::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
-:::
+
 
 </TabItem>
 

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -690,8 +690,11 @@ select * from hudi_cow_pt_tbl timestamp as of '2022-03-08' where id = 1;
 This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a DataFrame 
 and write DataFrame into the hudi table.
 
+### Update
+
 <Tabs
-defaultValue="scala"
+groupId="programming-language"
+defaultValue="python"
 values={[
 { label: 'Scala', value: 'scala', },
 { label: 'Python', value: 'python', },
@@ -724,8 +727,6 @@ denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `d
 
 Spark SQL supports two kinds of DML to update hudi table: Merge-Into and Update.
 
-### Update
-
 **Syntax**
 ```sql
 UPDATE tableIdentifier SET column = EXPRESSION(,column = EXPRESSION) [ WHERE boolExpression]
@@ -743,7 +744,42 @@ update hudi_cow_pt_tbl set ts = 1001 where name = 'a1';
 `Update` operation requires `preCombineField` specified.
 :::
 
+</TabItem>
+<TabItem value="python">
+
+```python
+# pyspark
+updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
+df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
+df.write.format("hudi"). \
+  options(**hudi_options). \
+  mode("append"). \
+  save(basePath)
+```
+:::note
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+:::
+
+</TabItem>
+
+</Tabs
+>
+
 ### MergeInto
+
+<Tabs
+groupId="programming-language"
+defaultValue="python"
+values={[
+{ label: 'Scala', value: 'scala', },
+{ label: 'Python', value: 'python', },
+{ label: 'Spark SQL', value: 'sparksql', },
+]}
+>
+
+<TabItem value="sparksql">
 
 **Syntax**
 
@@ -795,24 +831,23 @@ when not matched then
 ;
 
 ```
+</TabItem>
+
+<TabItem value="scala">
+
+```scala
+// scala
+// MergeInto is only available when using Spark SQL. 
+```
 
 </TabItem>
 <TabItem value="python">
 
 ```python
 # pyspark
-updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
-df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
-df.write.format("hudi"). \
-  options(**hudi_options). \
-  mode("append"). \
-  save(basePath)
+# MergeInto is only available when using Spark SQL.
 ```
-:::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
-:::
+
 
 </TabItem>
 

--- a/website/versioned_docs/version-0.12.2/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.2/quick-start-guide.md
@@ -698,6 +698,8 @@ select * from hudi_cow_pt_tbl timestamp as of '2022-03-08' where id = 1;
 This is similar to inserting new data. Generate updates to existing trips using the data generator, load into a DataFrame 
 and write DataFrame into the hudi table.
 
+### Update
+
 <Tabs
 groupId="programming-language"
 defaultValue="python"
@@ -733,8 +735,6 @@ denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `d
 
 Spark SQL supports two kinds of DML to update hudi table: Merge-Into and Update.
 
-### Update
-
 **Syntax**
 ```sql
 UPDATE tableIdentifier SET column = EXPRESSION(,column = EXPRESSION) [ WHERE boolExpression]
@@ -752,7 +752,42 @@ update hudi_cow_pt_tbl set ts = 1001 where name = 'a1';
 `Update` operation requires `preCombineField` specified.
 :::
 
+</TabItem>
+<TabItem value="python">
+
+```python
+# pyspark
+updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
+df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
+df.write.format("hudi"). \
+  options(**hudi_options). \
+  mode("append"). \
+  save(basePath)
+```
+:::note
+Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
+[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
+denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
+:::
+
+</TabItem>
+
+</Tabs
+>
+
 ### MergeInto
+
+<Tabs
+groupId="programming-language"
+defaultValue="python"
+values={[
+{ label: 'Scala', value: 'scala', },
+{ label: 'Python', value: 'python', },
+{ label: 'Spark SQL', value: 'sparksql', },
+]}
+>
+
+<TabItem value="sparksql">
 
 **Syntax**
 
@@ -804,30 +839,28 @@ when not matched then
 ;
 
 ```
+</TabItem>
+
+<TabItem value="scala">
+
+```scala
+// scala
+// MergeInto is only available when using Spark SQL. 
+```
 
 </TabItem>
 <TabItem value="python">
 
 ```python
 # pyspark
-updates = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateUpdates(10))
-df = spark.read.json(spark.sparkContext.parallelize(updates, 2))
-df.write.format("hudi"). \
-  options(**hudi_options). \
-  mode("append"). \
-  save(basePath)
+# MergeInto is only available when using Spark SQL.
 ```
-:::note
-Notice that the save mode is now `Append`. In general, always use append mode unless you are trying to create the table for the first time.
-[Querying](#query-data) the data again will now show updated trips. Each write operation generates a new [commit](/docs/concepts)
-denoted by the timestamp. Look for changes in `_hoodie_commit_time`, `rider`, `driver` fields for the same `_hoodie_record_key`s in previous commit.
-:::
+
 
 </TabItem>
 
 </Tabs
 >
-
 
 ## Incremental query
 


### PR DESCRIPTION
…oes not bring me to the update/merge into documentation

### Change Logs

Split Update and MergeInto to two tables, now when I click on Update or MergeInto it brings me there. Before only URL was changing, I had to be in SparkSQL tab first to go straight to Update or MergeInto section of quickstart. Fixed in 0.12.1 and current.

### Impact

None

### Risk level (write none, low medium or high below)

Low

### Documentation Update

Split Update and MergeInto to two tables, now when I click on Update or MergeInto it brings me there. Before only URL was changing, I had to be in SparkSQL tab first to go straight to Update or MergeInto section of quickstart. Fixed in 0.12.1 and current.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
