### PR TITLE
[DOCS] improve spark quickstart, info about MT and async services

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -1086,14 +1086,17 @@ Target table must exist before write.
 :::
 
 ### Table maintenance
-Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning and compaction. There's no operational overhead for the user.
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
 
-Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table in metastore aftear each streaming write.
+:::note
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/next/metadata#deployment-considerations) for detailed instructions.
 
-:::info
-If you're using Foreach or ForeachBatch streaming sink you must explicitly use inline table services. 
-Async table services are not supported.
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
 :::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
 
 ## Point in time query
 

--- a/website/versioned_docs/version-0.10.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.10.0/quick-start-guide.md
@@ -982,6 +982,19 @@ Spark SQL can be used within ForeachBatch sink to do INSERT, UPDATE, DELETE and 
 Target table must exist before write.
 :::
 
+### Table maintenance
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
+
+:::note
+In Hudi 0.10 Metadata Table was introduced. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/0.10.0/metadata#deployment-considerations) for detailed instructions.
+
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
+:::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
+
 ## Point in time query
 
 Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a

--- a/website/versioned_docs/version-0.10.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.10.1/quick-start-guide.md
@@ -999,6 +999,19 @@ Spark SQL can be used within ForeachBatch sink to do INSERT, UPDATE, DELETE and 
 Target table must exist before write.
 :::
 
+### Table maintenance
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
+
+:::note
+In Hudi 0.10 Metadata Table was introduced. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/0.10.1/metadata#deployment-considerations) for detailed instructions.
+
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
+:::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
+
 ## Point in time query
 
 Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 

--- a/website/versioned_docs/version-0.11.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.0/quick-start-guide.md
@@ -1043,6 +1043,19 @@ Spark SQL can be used within ForeachBatch sink to do INSERT, UPDATE, DELETE and 
 Target table must exist before write.
 :::
 
+### Table maintenance
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
+
+:::note
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/0.11.0/metadata#deployment-considerations) for detailed instructions.
+
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
+:::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
+
 ## Point in time query
 
 Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 

--- a/website/versioned_docs/version-0.11.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/quick-start-guide.md
@@ -1041,6 +1041,19 @@ Spark SQL can be used within ForeachBatch sink to do INSERT, UPDATE, DELETE and 
 Target table must exist before write.
 :::
 
+### Table maintenance
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
+
+:::note
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/0.11.1/metadata#deployment-considerations) for detailed instructions.
+
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
+:::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
+
 ## Point in time query
 
 Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -1074,6 +1074,19 @@ Spark SQL can be used within ForeachBatch sink to do INSERT, UPDATE, DELETE and 
 Target table must exist before write.
 :::
 
+### Table maintenance
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
+
+:::note
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/0.12.0/metadata#deployment-considerations) for detailed instructions.
+
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
+:::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
+
 ## Point in time query
 
 Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -1074,6 +1074,19 @@ Spark SQL can be used within ForeachBatch sink to do INSERT, UPDATE, DELETE and 
 Target table must exist before write.
 :::
 
+### Table maintenance
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
+
+:::note
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/metadata#deployment-considerations) for detailed instructions.
+
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
+:::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
+
 ## Point in time query
 
 Lets look at how to query data as of a specific time. The specific time can be represented by pointing endTime to a 

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -1080,7 +1080,7 @@ For CoW tables, table services work in inline mode by default.
 For MoR tables, some async services are enabled by default.
 
 :::note
-Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/metadata#deployment-considerations) for detailed instructions.
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/0.12.0/metadata#deployment-considerations) for detailed instructions.
 
 If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
 :::

--- a/website/versioned_docs/version-0.12.2/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.2/quick-start-guide.md
@@ -1088,14 +1088,17 @@ Target table must exist before write.
 :::
 
 ### Table maintenance
-Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning and compaction. There's no operational overhead for the user.
+Hudi can run async or inline table services while running Strucrured Streaming query and takes care of cleaning, compaction and clustering. There's no operational overhead for the user.  
+For CoW tables, table services work in inline mode by default.  
+For MoR tables, some async services are enabled by default.
 
-Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table in metastore aftear each streaming write.
+:::note
+Since Hudi 0.11 Metadata Table is enabled by default. When using async table services with Metadata Table enabled you must use Optimistic Concurrency Control to avoid the risk of data loss (even in single writer scenario). See [Metadata Table deployment considerations](/docs/metadata#deployment-considerations) for detailed instructions.
 
-:::info
-If you're using Foreach or ForeachBatch streaming sink you must explicitly use inline table services. 
-Async table services are not supported.
+If you're using Foreach or ForeachBatch streaming sink you must use inline table services, async table services are not supported.
 :::
+
+Hive Sync works with Structured Streaming, it will create table if not exists and synchronize table to metastore aftear each streaming write.
 
 ## Point in time query
 


### PR DESCRIPTION
### Change Logs

Improve spark quickstart, add info about table maintenance and async services when metadata table is enabled (one should be aware OCC needs to be enabled even in single writer mode)
I  as a user would like to be informed about this in quick start, since I rarely read pages under "concepts" where this information is provided. It's esp. important since MT is enabled by default starting from 0.11, and misconfiguration can cause data loss since for MoR some async services are also enabled by default.
Fixes spark quickstart from 0.10 to current, bc metadata table was introduced in 0.10.

### Impact

None

### Risk level (write none, low medium or high below)

Low

### Documentation Update

improve spark quickstart, add info about table maintenance and async services when metadata table is enabled (one should be aware OCC needs to be enabled even in single writer mode)
I  as a user would like to be informed about this in quick start, since I rarely read pages under "concepts" where this information is provided. It's esp. important since MT is enabled by default starting from 0.11, and misconfiguration can cause data loss.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
