### PR TITLE
[MINOR] Avoid running tests as part of bundle uploads

### DIFF
--- a/scripts/release/deploy_staging_jars.sh
+++ b/scripts/release/deploy_staging_jars.sh
@@ -102,8 +102,8 @@ do
   # clean everything before any round of depoyment
   $MVN clean
   echo "Building with options ${v}"
-  $MVN install "$COMMON_OPTIONS" "${v}"
+  $MVN install ${v} $COMMON_OPTIONS
   echo "Deploying to repository.apache.org with version options ${v%-am}"
   # remove `-am` option to only deploy intended modules
-  $MVN deploy "$COMMON_OPTIONS" "${v%-am}"
+  $MVN deploy ${v%-am} $COMMON_OPTIONS
 done


### PR DESCRIPTION
### Change Logs

minor edit to deploy scripts to avoid running tests as part of bundle uploads

### Impact

Deploy is lot simpler. Tests are run already before deploy steps

### Risk level (write none, low medium or high below)

Low 

### Documentation Update

None
### Contributor's checklist

- [X ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ X] Change Logs and Impact were stated clearly
- [ X] Adequate tests were added if applicable
- [ X] CI passed
