### PR TITLE
[HUDI-5479] Avoid to read the archived timeline each time for meta sync

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -211,6 +211,23 @@ public class TimelineUtils {
   }
 
   /**
+   * Returns the incremental timeline for meta sync.
+   *
+   * <p>The archived timeline may be parsed if the last synced commit time
+   * is far behind, the parsing of archived timeline is expensive, for most of the time,
+   * there is no need to do that, if the metadata is synced in time regularly.
+   *
+   * @param metaClient           The meta client
+   * @param lastCommitTimeSynced The last synced commit time
+   */
+  public static HoodieTimeline getIncSyncTimeline(HoodieTableMetaClient metaClient, String lastCommitTimeSynced) {
+    final HoodieDefaultTimeline timeline = metaClient.getActiveTimeline().isBeforeTimelineStarts(lastCommitTimeSynced)
+        ? metaClient.getArchivedTimeline(lastCommitTimeSynced).mergeTimeline(metaClient.getActiveTimeline())
+        : metaClient.getActiveTimeline();
+    return timeline.getCommitsTimeline().findInstantsAfter(lastCommitTimeSynced, Integer.MAX_VALUE);
+  }
+
+  /**
    * Returns the commit metadata of the given instant.
    *
    * @param instant   The hoodie instant


### PR DESCRIPTION
The user reports OOM error usually because of the archived timeline deserialization, which occurs for every meta sync after an instant is committed.

### Change Logs

Avoid to dese the archived timeline each instant commit.

### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
