### PR TITLE
[HUDI-4710]Fix flaky: TestKeyRangeLookupTree#testFileGroupLookUpManyEntriesWithSameStartValue

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestKeyRangeLookupTree.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestKeyRangeLookupTree.java
@@ -68,7 +68,7 @@ public class TestKeyRangeLookupTree {
     updateExpectedMatchesToTest(toInsert);
     keyRangeLookupTree.insert(toInsert);
     for (int i = 0; i < 10; i++) {
-      endKey += 1 + RANDOM.nextInt(100);
+      endKey += 1 + RANDOM.nextInt(50);
       toInsert = new KeyRangeNode(startKey, Long.toString(endKey), UUID.randomUUID().toString());
       updateExpectedMatchesToTest(toInsert);
       keyRangeLookupTree.insert(toInsert);


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
In test `testFileGroupLookUpManyEntriesWithSameStartValue`, before the fix, the endKey could be large than 1000, say if endKey is 1024, KeyRangeNode use String to compare the value, so "1024" could be smaller than "2xx", causing the test failure.

here we don't allow endKey to exceed 1000 to fix the issue.
### Impact

_Describe any public API or user-facing feature change or any performance impact._
None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
