### PR TITLE
[HUDI-5486][DOCS] Update 0.12.x release notes with Long Term Support

### DIFF
--- a/website/releases/download.md
+++ b/website/releases/download.md
@@ -7,14 +7,17 @@ last_modified_at: 2022-12-27T15:59:57-04:00
 ---
 
 ### Release 0.12.2
+* [Long Term Support](/releases/release-0.12.2#long-term-support): this is the latest stable release
 * Source Release : [Apache Hudi 0.12.2 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.12.2/hudi-0.12.2.src.tgz) ([asc](https://downloads.apache.org/hudi/0.12.2/hudi-0.12.2.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.12.2/hudi-0.12.2.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.12.2](/releases/release-0.12.2))
 
 ### Release 0.12.1
+* [Long Term Support](/releases/release-0.12.1#long-term-support): upgrade to [0.12.2](/releases/release-0.12.2) for the latest stable release
 * Source Release : [Apache Hudi 0.12.1 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.12.1/hudi-0.12.1.src.tgz) ([asc](https://downloads.apache.org/hudi/0.12.1/hudi-0.12.1.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.12.1/hudi-0.12.1.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.12.1](/releases/release-0.12.1))
 
 ### Release 0.12.0
+* [Long Term Support](/releases/release-0.12.0#long-term-support): upgrade to [0.12.2](/releases/release-0.12.2) for the latest stable release
 * Source Release : [Apache Hudi 0.12.0 Source Release](https://www.apache.org/dyn/closer.lua/hudi/0.12.0/hudi-0.12.0.src.tgz) ([asc](https://downloads.apache.org/hudi/0.12.0/hudi-0.12.0.src.tgz.asc), [sha512](https://downloads.apache.org/hudi/0.12.0/hudi-0.12.0.src.tgz.sha512))
 * Release Note : ([Release Note for Apache Hudi 0.12.0](/releases/release-0.12.0))
 

--- a/website/releases/release-0.12.0.md
+++ b/website/releases/release-0.12.0.md
@@ -7,6 +7,11 @@ last_modified_at: 2022-08-17T10:30:00+05:30
 ---
 # [Release 0.12.0](https://github.com/apache/hudi/releases/tag/release-0.12.0) ([docs](/docs/quick-start-guide))
 
+## Long Term Support
+
+We aim to maintain 0.12 for a longer period of time and provide a stable release through the latest 0.12.x release for
+users to migrate to.  The latest 0.12 release is [0.12.2](/releases/release-0.12.2).
+
 ## Migration Guide
 
 In this release, there have been a few API and configuration updates listed below that warranted a new table version.

--- a/website/releases/release-0.12.1.md
+++ b/website/releases/release-0.12.1.md
@@ -7,6 +7,11 @@ last_modified_at: 2022-08-17T10:30:00+05:30
 ---
 # [Release 0.12.1](https://github.com/apache/hudi/releases/tag/release-0.12.1) ([docs](/docs/quick-start-guide))
 
+## Long Term Support
+
+We aim to maintain 0.12 for a longer period of time and provide a stable release through the latest 0.12.x release for
+users to migrate to.  The latest 0.12 release is [0.12.2](/releases/release-0.12.2).
+
 ## Migration Guide
 
 * This release (0.12.1) does not introduce any new table version, thus no migration is needed if you are on 0.12.0.

--- a/website/releases/release-0.12.2.md
+++ b/website/releases/release-0.12.2.md
@@ -7,6 +7,11 @@ last_modified_at: 2022-12-27T10:30:00+05:30
 ---
 # [Release 0.12.2](https://github.com/apache/hudi/releases/tag/release-0.12.2) ([docs](/docs/quick-start-guide))
 
+## Long Term Support
+
+We aim to maintain 0.12 for a longer period of time and provide a stable release through the latest 0.12.x release for
+users to migrate to.  This release (0.12.2) is the latest 0.12 release.
+
 ## Migration Guide
 
 * This release (0.12.2) does not introduce any new table version, thus no migration is needed if you are on 0.12.0.


### PR DESCRIPTION
### Change Logs

This PR updates 0.12.x release notes with Long Term Support.
<img width="1419" alt="Screen Shot 2022-12-28 at 12 49 02" src="https://user-images.githubusercontent.com/2497195/209870881-fbd766cc-60e2-4441-b404-9046f9d42f29.png">

<img width="1420" alt="Screen Shot 2022-12-28 at 12 49 14" src="https://user-images.githubusercontent.com/2497195/209870890-a14add66-e054-454e-a7ce-3d3f10389475.png">
<img width="1423" alt="Screen Shot 2022-12-28 at 12 49 22" src="https://user-images.githubusercontent.com/2497195/209870895-10e331c8-d268-4875-a271-6b0b1ad2a014.png">
<img width="1423" alt="Screen Shot 2022-12-28 at 12 49 28" src="https://user-images.githubusercontent.com/2497195/209870904-e7483ddc-fccf-4783-ad95-5cc493a7064f.png">

### Impact

Documents the Long Term Support for 0.12.x releases.

### Risk level

none

### Documentation Update

As above.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
