### PR TITLE
[HUDI-5434] Fix archival in metadata table to not rely on completed rollback or clean in data table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -516,14 +516,14 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
           .setConf(metaClient.getHadoopConf())
           .build();
       Option<HoodieInstant> qualifiedEarliestInstant =
-          TimelineUtils.getEarliestInstantForMetadataArchival(dataMetaClient.getActiveTimeline());
+          TimelineUtils.getEarliestInstantForMetadataArchival(
+              dataMetaClient.getActiveTimeline(), config.shouldArchiveBeyondSavepoint());
 
       // Do not archive the instants after the earliest commit (COMMIT, DELTA_COMMIT, and
-      // REPLACE_COMMIT only) and the earliest inflight instant (all actions).
+      // REPLACE_COMMIT only, considering non-savepoint commit only if enabling archive
+      // beyond savepoint) and the earliest inflight instant (all actions).
       // This is required by metadata table, see HoodieTableMetadataUtil#processRollbackMetadata
       // for details.
-      // The savepoints are seamlessly handled here, i.e., the completed savepoints do not affect
-      // the archive process in the metadata table.
       // Note that we cannot blindly use the earliest instant of all actions, because CLEAN and
       // ROLLBACK instants are archived separately apart from commits (check
       // HoodieTimelineArchiver#getCleanInstantsToArchive).  If we do so, a very old completed

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -1301,8 +1301,15 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
         .setLoadActiveTimelineOnLoad(true).build();
 
     for (int i = 1; i <= 17; i++) {
-      testTable.doWriteOperation("000000" + String.format("%02d", i), WriteOperationType.UPSERT,
-          i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+      if (i != 2) {
+        testTable.doWriteOperation("000000" + String.format("%02d", i), WriteOperationType.UPSERT,
+            i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+      } else {
+        // For i == 2, roll back the first commit "00000001", so the active timeline of the
+        // data table has one rollback instant
+        // The completed rollback should not block the archival in the metadata table
+        testTable.doRollback("00000001", "00000002");
+      }
       // archival
       archiveAndGetCommitsList(writeConfig);
 
@@ -1323,10 +1330,9 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       } else if (i == 8) {
         // i == 8
         // The instant "00000000000000" was archived since it's less than
-        // the earliest instant on the dataset active timeline,
-        // the dataset active timeline has instants of range [00000001 ~ 00000008]
-        // because when it does the archiving, no compaction instant on the
-        // metadata active timeline exists yet.
+        // the earliest commit on the dataset active timeline,
+        // the dataset active timeline has instants:
+        //   00000002.rollback, 00000007.commit, 00000008.commit
         assertEquals(9, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
             new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000007001")));


### PR DESCRIPTION
### Change Logs

Before this PR, the archival for the metadata table uses the earliest instant of all actions from the active timeline of the data table.  In the archival process, CLEAN and ROLLBACK instants are archived separately apart from commits (check HoodieTimelineArchiver#getCleanInstantsToArchive).  Because of this, a very old completed CLEAN or ROLLBACK instant in the data table can block the archive of the metadata table timeline and causes the active timeline of the metadata table to be extremely long, leading to performance issues for loading the timeline.

This PR changes the archival in metadata table to not rely on completed rollback or clean in data table, by archiving the metadata table's instants after the earliest commit (COMMIT, DELTA_COMMIT, and REPLACE_COMMIT only, considering non-savepoint commit only if enabling archive beyond savepoint) and the earliest inflight instant (all actions) in the data table's active timeline.

New tests are added and an existing test around the archival in the metadata table is adjusted to verify that the archival in the metadata table does not depend on the completed rollback in the data table.

This PR is tested locally to ensure the metadata table's archival works as expected.

### Impact

Makes the active timeline of the metadata table shorter and improves the performance of loading the active timeline of the metadata table.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
