### PR TITLE
[HUDI-5488] Make sure Disrupt queue start first, then insert records

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/TestDisruptorMessageQueue.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/TestDisruptorMessageQueue.java
@@ -325,7 +325,7 @@ public class TestDisruptorMessageQueue extends HoodieClientTestHarness {
     };
 
     DisruptorExecutor<HoodieRecord, Tuple2<HoodieRecord, Option<IndexedRecord>>, Integer> exec = new DisruptorExecutor(Option.of(1024),
-        producers, Option.of(consumer), getCloningTransformer(HoodieTestDataGenerator.AVRO_SCHEMA),
+        producers, consumer, getCloningTransformer(HoodieTestDataGenerator.AVRO_SCHEMA),
         Option.of(WaitStrategyFactory.DEFAULT_STRATEGY), getPreExecuteRunnable());
 
     final Throwable thrown = assertThrows(HoodieException.class, exec::execute,

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BaseHoodieQueueBasedExecutor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/BaseHoodieQueueBasedExecutor.java
@@ -93,6 +93,8 @@ public abstract class BaseHoodieQueueBasedExecutor<I, O, E> implements HoodieExe
 
   protected abstract void doConsume(HoodieMessageQueue<I, O> queue, HoodieConsumer<O, E> consumer);
 
+  protected void setUp() {}
+
   /**
    * Start producing
    */
@@ -165,6 +167,7 @@ public abstract class BaseHoodieQueueBasedExecutor<I, O, E> implements HoodieExe
   public E execute() {
     try {
       checkState(this.consumer.isPresent());
+      setUp();
       // Start consuming/producing asynchronously
       CompletableFuture<Void> consuming = startConsumingAsync();
       CompletableFuture<Void> producing = startProducingAsync();

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorExecutor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorExecutor.java
@@ -34,21 +34,24 @@ public class DisruptorExecutor<I, O, E> extends BaseHoodieQueueBasedExecutor<I, 
 
   public DisruptorExecutor(final Option<Integer> bufferSize, final Iterator<I> inputItr,
                            HoodieConsumer<O, E> consumer, Function<I, O> transformFunction, Option<String> waitStrategy, Runnable preExecuteRunnable) {
-    this(bufferSize, Collections.singletonList(new IteratorBasedQueueProducer<>(inputItr)), Option.of(consumer),
+    this(bufferSize, Collections.singletonList(new IteratorBasedQueueProducer<>(inputItr)), consumer,
         transformFunction, waitStrategy, preExecuteRunnable);
   }
 
   public DisruptorExecutor(final Option<Integer> bufferSize, List<HoodieProducer<I>> producers,
-                           Option<HoodieConsumer<O, E>> consumer, final Function<I, O> transformFunction,
+                           HoodieConsumer<O, E> consumer, final Function<I, O> transformFunction,
                            final Option<String> waitStrategy, Runnable preExecuteRunnable) {
-    super(producers, consumer, new DisruptorMessageQueue<>(bufferSize, transformFunction, waitStrategy, producers.size(), preExecuteRunnable), preExecuteRunnable);
+    super(producers, Option.of(consumer), new DisruptorMessageQueue<>(bufferSize, transformFunction, waitStrategy, producers.size(), preExecuteRunnable), preExecuteRunnable);
   }
 
   @Override
-  protected void doConsume(HoodieMessageQueue<I, O> queue, HoodieConsumer<O, E> consumer) {
+  protected void setUp() {
     DisruptorMessageQueue<I, O> disruptorQueue = (DisruptorMessageQueue<I, O>) queue;
     // Before we start producing, we need to set up Disruptor's queue
-    disruptorQueue.setHandlers(consumer);
+    disruptorQueue.setHandlers(consumer.get());
     disruptorQueue.start();
   }
+
+  @Override
+  protected void doConsume(HoodieMessageQueue<I, O> queue, HoodieConsumer<O, E> consumer) {}
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
@@ -43,7 +43,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
   private final RingBuffer<HoodieDisruptorEvent> ringBuffer;
 
   private boolean isShutdown = false;
-  private boolean isStart = false;
+  private boolean isStarted = false;
 
   public DisruptorMessageQueue(Option<Integer> bufferSize, Function<I, O> transformFunction, Option<String> waitStrategyName, int totalProducers, Runnable preExecuteRunnable) {
     WaitStrategy waitStrategy = WaitStrategyFactory.build(waitStrategyName);
@@ -61,7 +61,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
 
   @Override
   public void insertRecord(I value) throws Exception {
-    if (!isStart) {
+    if (!isStarted) {
       throw new HoodieException("Can't insert into the queue since the queue is not started yet");
     }
 
@@ -97,7 +97,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
     synchronized (this) {
       if (!isShutdown) {
         isShutdown = true;
-        isStart = false;
+        isStarted = false;
         queue.shutdown();
       }
     }
@@ -111,9 +111,9 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
 
   protected void start() {
     synchronized (this) {
-      if (!isStart) {
+      if (!isStarted) {
         queue.start();
-        isStart = true;
+        isStarted = true;
       }
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
@@ -43,6 +43,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
   private final RingBuffer<HoodieDisruptorEvent> ringBuffer;
 
   private boolean isShutdown = false;
+  private boolean isStart = false;
 
   public DisruptorMessageQueue(Option<Integer> bufferSize, Function<I, O> transformFunction, Option<String> waitStrategyName, int totalProducers, Runnable preExecuteRunnable) {
     WaitStrategy waitStrategy = WaitStrategyFactory.build(waitStrategyName);
@@ -60,6 +61,12 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
 
   @Override
   public void insertRecord(I value) throws Exception {
+    if (!isStart) {
+      synchronized (this) {
+        wait();
+      }
+    }
+
     if (isShutdown) {
       throw new HoodieException("Can't insert into the queue after it had already been closed");
     }
@@ -93,6 +100,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
       if (!isShutdown) {
         isShutdown = true;
         queue.shutdown();
+        notifyAll();
       }
     }
   }
@@ -105,6 +113,12 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
 
   protected void start() {
     queue.start();
+    synchronized (this) {
+      if (!isStart) {
+        isStart = true;
+        notifyAll();
+      }
+    }
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
@@ -97,6 +97,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
     synchronized (this) {
       if (!isShutdown) {
         isShutdown = true;
+        isStart = false;
         queue.shutdown();
       }
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
@@ -62,9 +62,7 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
   @Override
   public void insertRecord(I value) throws Exception {
     if (!isStart) {
-      synchronized (this) {
-        wait();
-      }
+      throw new HoodieException("Can't insert into the queue since the queue is not started yet");
     }
 
     if (isShutdown) {
@@ -100,7 +98,6 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
       if (!isShutdown) {
         isShutdown = true;
         queue.shutdown();
-        notifyAll();
       }
     }
   }
@@ -112,11 +109,10 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
   }
 
   protected void start() {
-    queue.start();
     synchronized (this) {
       if (!isStart) {
+        queue.start();
         isStart = true;
-        notifyAll();
       }
     }
   }


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
We must to make sure to set up Disruptor's queue first, then producer can insert records to the queue. But currently we have no idea which thread start first, so this pr tries to fix it.

```java
CompletableFuture<Void> consuming = startConsumingAsync();
CompletableFuture<Void> producing = startProducingAsync();
```

Also, I think the test `TestDisruptorExecutionInSpark#testExecutor` and `TestDisruptorMessageQueue#testRecordReading` failures relate to this bug.

<img width="1585" alt="Screenshot 2022-12-29 at 10 07 21" src="https://user-images.githubusercontent.com/10115332/210033047-7b3573ec-c43b-44b3-a898-c4269b6bfd14.png">

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
