### PR TITLE
[MINOR] Filter out empty GCS objects in events table.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/MetadataMessage.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/MetadataMessage.java
@@ -18,7 +18,14 @@
 
 package org.apache.hudi.utilities.sources.helpers.gcs;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.pubsub.v1.PubsubMessage;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 import static org.apache.hudi.utilities.sources.helpers.gcs.MessageValidity.ProcessingDecision.DO_SKIP;
 
@@ -29,6 +36,8 @@ import static org.apache.hudi.utilities.sources.helpers.gcs.MessageValidity.Proc
  */
 public class MetadataMessage {
 
+  private static final Logger LOG = LogManager.getLogger(MetadataMessage.class);
+
   // The CSPN message to wrap
   private final PubsubMessage message;
 
@@ -37,6 +46,7 @@ public class MetadataMessage {
   private static final String ATTR_EVENT_TYPE = "eventType";
   private static final String ATTR_OBJECT_ID = "objectId";
   private static final String ATTR_OVERWROTE_GENERATION = "overwroteGeneration";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public MetadataMessage(PubsubMessage message) {
     this.message = message;
@@ -63,6 +73,14 @@ public class MetadataMessage {
       );
     }
 
+    try {
+      if (isEmptyFile()) {
+        return new MessageValidity(DO_SKIP, "Object " + getObjectId() + " is empty.");
+      }
+    } catch (IOException e) {
+      LOG.error("Exception while extracting the size for object " + getObjectId(), e);
+    }
+
     return MessageValidity.DEFAULT_VALID_MESSAGE;
   }
 
@@ -82,6 +100,12 @@ public class MetadataMessage {
     return EVENT_NAME_OBJECT_FINALIZE.equals(getEventType());
   }
 
+  private boolean isEmptyFile() throws IOException {
+    String sizeValue = getDataField("size");
+    long size = Long.parseLong(sizeValue);
+    return size <= 0;
+  }
+
   public String getEventType() {
     return getAttr(ATTR_EVENT_TYPE);
   }
@@ -96,6 +120,12 @@ public class MetadataMessage {
 
   private String getAttr(String attrName) {
     return message.getAttributesMap().get(attrName);
+  }
+
+  private String getDataField(String fieldName) throws IOException {
+    JsonNode root = OBJECT_MAPPER.readValue(toStringUtf8(), JsonNode.class);
+    JsonNode fieldNode = root.get(fieldName);
+    return fieldNode.asText();
   }
 
 }


### PR DESCRIPTION
### Change Logs

Fix to filter out empty objects in GCS object events. Folders in GCS have different schema in pubsub notification message. As notifications for folders are anyway not needed, filter them out.

### Impact

GCS incremental.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
