### PR TITLE
[HUDI-5192] Prevent GH actions from running on trivial file changes

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -6,6 +6,15 @@ on:
       - master
       - 'release-*'
   pull_request:
+    paths-ignore:
+      - '**.bmp'
+      - '**.gif'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.md'
+      - '**.pdf'
+      - '**.png'
+      - '**.svg'
     branches:
       - master
       - 'release-*'


### PR DESCRIPTION
### Change Logs

If a pr only has changes to files with extensions of `bmp, gif, jpg, jpeg, md, pdf, png, svg` do not run GH actions. 

### Impact

Reduce waiting time before gh actions starts running

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
