### PR TITLE
[HUDI-5496] Prevent unnecessary rewrites when performing clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -102,6 +102,7 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
             },
             partitionPaths.size())
         .stream()
+        .filter(clusteringGroup -> clusteringGroup.getSlices().size() > 1)
         .limit(getWriteConfig().getClusteringMaxNumGroups())
         .collect(Collectors.toList());
 


### PR DESCRIPTION
### Change Logs
Prevent unnecessary rewrites when performing clustering by only selecting _HoodieClusteringGroup_ with more than 1 fileSlice as candidates for clustering.

Link to Jira issue: https://issues.apache.org/jira/browse/HUDI-5496

### Impact

_Describe any public API or user-facing feature change or any performance impact._
None

### Risk level (write none, low medium or high below)
None

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
