### PR TITLE
[MINOR]: Fix usage of SchemaRegistryProvider with Row source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/SourceFormatAdapter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/SourceFormatAdapter.java
@@ -25,6 +25,7 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
 import org.apache.hudi.utilities.sources.InputBatch;
 import org.apache.hudi.utilities.sources.Source;
 import org.apache.hudi.utilities.sources.helpers.AvroConvertor;
@@ -72,7 +73,7 @@ public final class SourceFormatAdapter implements Closeable {
         return new InputBatch<>(Option.ofNullable(r.getBatch().map(
             rdd -> {
               SchemaProvider originalProvider = UtilHelpers.getOriginalSchemaProvider(r.getSchemaProvider());
-              return (originalProvider instanceof FilebasedSchemaProvider)
+              return ((originalProvider instanceof FilebasedSchemaProvider) || (originalProvider instanceof SchemaRegistryProvider))
                   // If the source schema is specified through Avro schema,
                   // pass in the schema for the Row-to-Avro conversion
                   // to avoid nullability mismatch between Avro schema and Row schema


### PR DESCRIPTION
### Change Logs

Added check for SchemaRegistryProvider with row source. For more context, see https://github.com/apache/hudi/issues/7064.

### Impact

No. Users will be able to use SchemaRegistryProvider with row source like CsvDFSSource.

### Risk level (write none, low medium or high below)

None

### Documentation Update

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
