### PR TITLE
[HUDI-5349] Clean up partially failed restore

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -849,8 +849,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), initialMetadataTableIfNecessary);
       Option<HoodieInstant> failedRestore = table.getRestoreTimeline().filterInflightsAndRequested().lastInstant();
       if (failedRestore.isPresent() && instantTime.equals(RestoreUtils.getRestoreTime(table, failedRestore.get()))) {
-        if (failedRestore.get().isInflight()) {
-          table.getActiveTimeline().transitionRestoreInflightToRequested(failedRestore.get());
+        if (failedRestore.get().isRequested()) {
+          table.getActiveTimeline().transitionRestoreRequestedToInflight(failedRestore.get());
         }
         restoreInstantTime = failedRestore.get().getTimestamp();
         restorePlanOption = Option.of(RestoreUtils.getRestorePlan(table.getMetaClient(), failedRestore.get()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -61,6 +61,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
@@ -837,31 +838,19 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * NOTE : This action requires all writers (ingest and compact) to a table to be stopped before proceeding. Revert
    * the (inflight/committed) record changes for all commits after the provided instant time.
    *
-   * @param instantTime Instant time to which restoration is requested
+   * @param savepointToRestoreTimestamp savepoint intstant time to which restoration is requested
    */
-  public HoodieRestoreMetadata restoreToInstant(final String instantTime, boolean initialMetadataTableIfNecessary) throws HoodieRestoreException {
-    LOG.info("Begin restore to instant " + instantTime);
-    final String restoreInstantTime;
+  public HoodieRestoreMetadata restoreToInstant(final String savepointToRestoreTimestamp, boolean initialMetadataTableIfNecessary) throws HoodieRestoreException {
+    LOG.info("Begin restore to instant " + savepointToRestoreTimestamp);
     Timer.Context timerContext = metrics.getRollbackCtx();
-    Option<HoodieRestorePlan> restorePlanOption;
     try {
-      //Use the previous restore if it failed
-      HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), initialMetadataTableIfNecessary);
-      Option<HoodieInstant> failedRestore = table.getRestoreTimeline().filterInflightsAndRequested().lastInstant();
-      if (failedRestore.isPresent() && instantTime.equals(RestoreUtils.getRestoreTime(table, failedRestore.get()))) {
-        if (failedRestore.get().isRequested()) {
-          table.getActiveTimeline().transitionRestoreRequestedToInflight(failedRestore.get());
-        }
-        restoreInstantTime = failedRestore.get().getTimestamp();
-        restorePlanOption = Option.of(RestoreUtils.getRestorePlan(table.getMetaClient(), failedRestore.get()));
-      } else {
-        restoreInstantTime = HoodieActiveTimeline.createNewInstantTime();
-        table = initTable(WriteOperationType.UNKNOWN, Option.of(restoreInstantTime), initialMetadataTableIfNecessary);
-        restorePlanOption = table.scheduleRestore(context, restoreInstantTime, instantTime);
-      }
+      Triple<String, Option<HoodieRestorePlan>, HoodieTable<T, I, K, O>> restorePlanReturn = getRestorePlan(savepointToRestoreTimestamp, initialMetadataTableIfNecessary);
+      final String restoreInstantTimestamp = restorePlanReturn.getLeft();
+      Option<HoodieRestorePlan> restorePlanOption = restorePlanReturn.getMiddle();
+      HoodieTable<T, I, K, O> table = restorePlanReturn.getRight();
 
       if (restorePlanOption.isPresent()) {
-        HoodieRestoreMetadata restoreMetadata = table.restore(context, restoreInstantTime, instantTime);
+        HoodieRestoreMetadata restoreMetadata = table.restore(context, restoreInstantTimestamp, savepointToRestoreTimestamp);
         if (timerContext != null) {
           final long durationInMs = metrics.getDurationInMs(timerContext.stop());
           final long totalFilesDeleted = restoreMetadata.getHoodieRestoreMetadata().values().stream()
@@ -872,11 +861,29 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         }
         return restoreMetadata;
       } else {
-        throw new HoodieRestoreException("Failed to restore " + config.getBasePath() + " to commit " + instantTime);
+        throw new HoodieRestoreException("Failed to restore " + config.getBasePath() + " to commit " + savepointToRestoreTimestamp);
       }
     } catch (Exception e) {
-      throw new HoodieRestoreException("Failed to restore to " + instantTime, e);
+      throw new HoodieRestoreException("Failed to restore to " + savepointToRestoreTimestamp, e);
     }
+  }
+
+  private Triple<String, Option<HoodieRestorePlan>, HoodieTable<T, I, K, O>> getRestorePlan(final String savepointToRestoreTimestamp, boolean initialMetadataTableIfNecessary) throws IOException {
+    //Use the previous restore if it failed
+    HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), initialMetadataTableIfNecessary);
+    Option<HoodieInstant> failedRestore = table.getRestoreTimeline().filterInflightsAndRequested().lastInstant();
+    final String restoreInstantTimestamp;
+    Option<HoodieRestorePlan> restorePlanOption;
+    if (failedRestore.isPresent() && savepointToRestoreTimestamp.equals(RestoreUtils.getSavepointToRestoreTimestamp(table, failedRestore.get()))) {
+      restoreInstantTimestamp = failedRestore.get().getTimestamp();
+      restorePlanOption = Option.of(RestoreUtils.getRestorePlan(table.getMetaClient(), failedRestore.get()));
+      table = initTable(WriteOperationType.UNKNOWN, Option.of(restoreInstantTimestamp), initialMetadataTableIfNecessary);
+    } else {
+      restoreInstantTimestamp = HoodieActiveTimeline.createNewInstantTime();
+      table = initTable(WriteOperationType.UNKNOWN, Option.of(restoreInstantTimestamp), initialMetadataTableIfNecessary);
+      restorePlanOption = table.scheduleRestore(context, restoreInstantTimestamp, savepointToRestoreTimestamp);
+    }
+    return Triple.of(restoreInstantTimestamp, restorePlanOption, table);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -560,15 +560,15 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * that would cause any running queries that are accessing file slices written after the instant to fail.
    */
   public abstract HoodieRestoreMetadata restore(HoodieEngineContext context,
-                                                String restoreInstantTime,
-                                                String instantToRestore);
+                                                String restoreInstantTimestamp,
+                                                String savepointToRestoreTimestamp);
 
   /**
    * Schedules Restore for the table to the given instant.
    */
   public abstract Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context,
-                                                    String restoreInstantTime,
-                                                    String instantToRestore);
+                                                    String restoreInstantTimestamp,
+                                                    String savepointToRestoreTimestamp);
 
   public void rollbackInflightCompaction(HoodieInstant inflightInstant) {
     rollbackInflightCompaction(inflightInstant, s -> Option.empty());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
@@ -35,8 +35,8 @@ public class CopyOnWriteRestoreActionExecutor<T, I, K, O>
                                           HoodieWriteConfig config,
                                           HoodieTable table,
                                           String instantTime,
-                                          String restoreInstantTime) {
-    super(context, config, table, instantTime, restoreInstantTime);
+                                          String savepointToRestoreTimestamp) {
+    super(context, config, table, instantTime, savepointToRestoreTimestamp);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/MergeOnReadRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/MergeOnReadRestoreActionExecutor.java
@@ -31,8 +31,8 @@ import org.apache.hudi.table.action.rollback.MergeOnReadRollbackActionExecutor;
 public class MergeOnReadRestoreActionExecutor<T, I, K, O>
     extends BaseRestoreActionExecutor<T, I, K, O> {
   public MergeOnReadRestoreActionExecutor(HoodieEngineContext context, HoodieWriteConfig config, HoodieTable<T, I, K, O> table,
-                                          String instantTime, String restoreInstantTime) {
-    super(context, config, table, instantTime, restoreInstantTime);
+                                          String instantTime, String savepointToRestoreTimestamp) {
+    super(context, config, table, instantTime, savepointToRestoreTimestamp);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/RestoreUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/RestoreUtils.java
@@ -48,17 +48,17 @@ public class RestoreUtils {
   }
 
   /**
-   * Get the restore time for a restore instant
+   * Get the savepoint timestamp that this restore instant is restoring
    * @param table          the HoodieTable
    * @param restoreInstant Instant referring to restore action
-   * @return restore time of the rollback instant
+   * @return timestamp of the savepoint we are restoring
    * @throws IOException
    *
    * */
-  public static String getRestoreTime(HoodieTable table, HoodieInstant restoreInstant) throws IOException {
+  public static String getSavepointToRestoreTimestamp(HoodieTable table, HoodieInstant restoreInstant) throws IOException {
     HoodieRestorePlan plan = getRestorePlan(table.getMetaClient(), restoreInstant);
     if (plan.getVersion().compareTo(RestorePlanActionExecutor.RESTORE_PLAN_VERSION_1) > 0) {
-      return plan.getSavepointTimestamp();
+      return plan.getSavepointToRestoreTimestamp();
     }
     //get earliest rollback
     String firstRollback = plan.getInstantsToRollback().get(plan.getInstantsToRollback().size() - 1).getCommitTime();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/RestoreUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/RestoreUtils.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.rollback.RestorePlanActionExecutor;
 
 import java.io.IOException;
 
@@ -56,6 +57,9 @@ public class RestoreUtils {
    * */
   public static String getRestoreTime(HoodieTable table, HoodieInstant restoreInstant) throws IOException {
     HoodieRestorePlan plan = getRestorePlan(table.getMetaClient(), restoreInstant);
+    if (plan.getVersion().compareTo(RestorePlanActionExecutor.RESTORE_PLAN_VERSION_1) > 0) {
+      return plan.getSavepointTimestamp();
+    }
     //get earliest rollback
     String firstRollback = plan.getInstantsToRollback().get(plan.getInstantsToRollback().size() - 1).getCommitTime();
     //find last instant before first rollback

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -52,15 +52,15 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
   public static final Integer RESTORE_PLAN_VERSION_1 = 1;
   public static final Integer RESTORE_PLAN_VERSION_2 = 2;
   public static final Integer LATEST_RESTORE_PLAN_VERSION = RESTORE_PLAN_VERSION_2;
-  private final String restoreInstantTime;
+  private final String savepointToRestoreTimestamp;
 
   public RestorePlanActionExecutor(HoodieEngineContext context,
                                    HoodieWriteConfig config,
                                    HoodieTable<T, I, K, O> table,
                                    String instantTime,
-                                   String restoreInstantTime) {
+                                   String savepointToRestoreTimestamp) {
     super(context, config, table, instantTime);
-    this.restoreInstantTime = restoreInstantTime;
+    this.savepointToRestoreTimestamp = savepointToRestoreTimestamp;
   }
 
   @Override
@@ -73,13 +73,13 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
               // filter only clustering related replacecommits (Not insert_overwrite related commits)
               .filter(instant -> ClusteringUtils.isPendingClusteringInstant(table.getMetaClient(), instant))
               .getReverseOrderedInstants()
-              .filter(instant -> HoodieActiveTimeline.GREATER_THAN.test(instant.getTimestamp(), restoreInstantTime))
+              .filter(instant -> HoodieActiveTimeline.GREATER_THAN.test(instant.getTimestamp(), savepointToRestoreTimestamp))
               .collect(Collectors.toList());
 
       // Get all the commits on the timeline after the provided commit time
       List<HoodieInstant> commitInstantsToRollback = table.getActiveTimeline().getWriteTimeline()
               .getReverseOrderedInstants()
-              .filter(instant -> HoodieActiveTimeline.GREATER_THAN.test(instant.getTimestamp(), restoreInstantTime))
+              .filter(instant -> HoodieActiveTimeline.GREATER_THAN.test(instant.getTimestamp(), savepointToRestoreTimestamp))
               .filter(instant -> !pendingClusteringInstantsToRollback.contains(instant))
               .collect(Collectors.toList());
 
@@ -88,7 +88,7 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
               .map(entry -> new HoodieInstantInfo(entry.getTimestamp(), entry.getAction()))
               .collect(Collectors.toList());
 
-      HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, restoreInstantTime, LATEST_RESTORE_PLAN_VERSION);
+      HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, LATEST_RESTORE_PLAN_VERSION, savepointToRestoreTimestamp);
       table.getActiveTimeline().saveToRestoreRequested(restoreInstant, TimelineMetadataUtils.serializeRestorePlan(restorePlan));
       table.getMetaClient().reloadActiveTimeline();
       LOG.info("Requesting Restore with instant time " + restoreInstant);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -50,7 +50,8 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
   private static final Logger LOG = LogManager.getLogger(RestorePlanActionExecutor.class);
 
   public static final Integer RESTORE_PLAN_VERSION_1 = 1;
-  public static final Integer LATEST_RESTORE_PLAN_VERSION = RESTORE_PLAN_VERSION_1;
+  public static final Integer RESTORE_PLAN_VERSION_2 = 2;
+  public static final Integer LATEST_RESTORE_PLAN_VERSION = RESTORE_PLAN_VERSION_2;
   private final String restoreInstantTime;
 
   public RestorePlanActionExecutor(HoodieEngineContext context,
@@ -87,7 +88,7 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
               .map(entry -> new HoodieInstantInfo(entry.getTimestamp(), entry.getAction()))
               .collect(Collectors.toList());
 
-      HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, LATEST_RESTORE_PLAN_VERSION);
+      HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, restoreInstantTime, LATEST_RESTORE_PLAN_VERSION);
       table.getActiveTimeline().saveToRestoreRequested(restoreInstant, TimelineMetadataUtils.serializeRestorePlan(restorePlan));
       table.getMetaClient().reloadActiveTimeline();
       LOG.info("Requesting Restore with instant time " + restoreInstant);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
@@ -344,12 +344,12 @@ public class HoodieFlinkCopyOnWriteTable<T>
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTime, String instantToRestore) {
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
     throw new HoodieNotSupportedException("Restore is not supported yet");
   }
 
   @Override
-  public HoodieRestoreMetadata restore(HoodieEngineContext context, String restoreInstantTime, String instantToRestore) {
+  public HoodieRestoreMetadata restore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
     throw new HoodieNotSupportedException("Savepoint and restore is not supported yet");
   }
 

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
@@ -250,16 +250,16 @@ public class HoodieJavaCopyOnWriteTable<T>
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTime, String instantToRestore) {
-    return new RestorePlanActionExecutor(context, config, this, restoreInstantTime, instantToRestore).execute();
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
+    return new RestorePlanActionExecutor(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
   }
 
   @Override
   public HoodieRestoreMetadata restore(HoodieEngineContext context,
-                                       String restoreInstantTime,
-                                       String instantToRestore) {
+                                       String restoreInstantTimestamp,
+                                       String savepointToRestoreTimestamp) {
     return new CopyOnWriteRestoreActionExecutor(
-        context, config, this, restoreInstantTime, instantToRestore).execute();
+        context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
@@ -286,12 +286,12 @@ public class HoodieSparkCopyOnWriteTable<T>
   }
 
   @Override
-  public HoodieRestoreMetadata restore(HoodieEngineContext context, String restoreInstantTime, String instantToRestore) {
-    return new CopyOnWriteRestoreActionExecutor<>(context, config, this, restoreInstantTime, instantToRestore).execute();
+  public HoodieRestoreMetadata restore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
+    return new CopyOnWriteRestoreActionExecutor<>(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTime, String instantToRestore) {
-    return new RestorePlanActionExecutor<>(context, config, this, restoreInstantTime, instantToRestore).execute();
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
+    return new RestorePlanActionExecutor<>(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
@@ -195,8 +195,8 @@ public class HoodieSparkMergeOnReadTable<T> extends HoodieSparkCopyOnWriteTable<
   }
 
   @Override
-  public HoodieRestoreMetadata restore(HoodieEngineContext context, String restoreInstantTime, String instantToRestore) {
-    return new MergeOnReadRestoreActionExecutor<>(context, config, this, restoreInstantTime, instantToRestore).execute();
+  public HoodieRestoreMetadata restore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
+    return new MergeOnReadRestoreActionExecutor<>(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
@@ -38,7 +38,6 @@ import org.apache.hudi.common.testutils.FileCreateUtils;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
@@ -259,6 +258,7 @@ public class TestClientRollback extends HoodieClientTestBase {
       assertEquals("002", getSavepointToRestoreTimestampV1Schema(table, plan));
     }
   }
+  
   /**
    * Test case for rollback-savepoint with KEEP_LATEST_FILE_VERSIONS policy.
    */

--- a/hudi-common/src/main/avro/HoodieRestorePlan.avsc
+++ b/hudi-common/src/main/avro/HoodieRestorePlan.avsc
@@ -30,8 +30,13 @@
            }
     },
     {
+            "name": "savepointTimestamp",
+            "type": ["string", "null"],
+            "default": "0"
+    },
+    {
            "name":"version",
            "type":["int", "null"],
-           "default": 1
+           "default": 2
     }]
 }

--- a/hudi-common/src/main/avro/HoodieRestorePlan.avsc
+++ b/hudi-common/src/main/avro/HoodieRestorePlan.avsc
@@ -36,7 +36,7 @@
     },
     {
            "name": "savepointToRestoreTimestamp",
-           "type": ["string", "null"],
+           "type": ["null", "string"],
            "default": null
     }
     ]

--- a/hudi-common/src/main/avro/HoodieRestorePlan.avsc
+++ b/hudi-common/src/main/avro/HoodieRestorePlan.avsc
@@ -30,13 +30,14 @@
            }
     },
     {
-            "name": "savepointTimestamp",
-            "type": ["string", "null"],
-            "default": "0"
-    },
-    {
            "name":"version",
            "type":["int", "null"],
            "default": 2
-    }]
+    },
+    {
+           "name": "savepointToRestoreTimestamp",
+           "type": ["string", "null"],
+           "default": "0"
+    }
+    ]
 }

--- a/hudi-common/src/main/avro/HoodieRestorePlan.avsc
+++ b/hudi-common/src/main/avro/HoodieRestorePlan.avsc
@@ -37,7 +37,7 @@
     {
            "name": "savepointToRestoreTimestamp",
            "type": ["string", "null"],
-           "default": "0"
+           "default": null
     }
     ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -579,6 +579,21 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
   }
 
   /**
+   * Transition Restore State from inflight to requested.
+   *
+   * @param inflightInstant inflight instant
+   * @return commit instant
+   */
+  public HoodieInstant transitionRestoreInflightToRequested(HoodieInstant inflightInstant) {
+    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.RESTORE_ACTION), "Transition to requested attempted for a restore instant with diff action "
+        + inflightInstant);
+    ValidationUtils.checkArgument(inflightInstant.isInflight(), "Transition to requested attempted for an instant not in inflight state " + inflightInstant);
+    HoodieInstant requested = new HoodieInstant(State.REQUESTED, RESTORE_ACTION, inflightInstant.getTimestamp());
+    transitionState(inflightInstant, requested, Option.empty());
+    return requested;
+  }
+
+  /**
    * Transition replace requested file to replace inflight.
    *
    * @param requestedInstant Requested instant

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -579,21 +579,6 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
   }
 
   /**
-   * Transition Restore State from inflight to requested.
-   *
-   * @param inflightInstant inflight instant
-   * @return commit instant
-   */
-  public HoodieInstant transitionRestoreInflightToRequested(HoodieInstant inflightInstant) {
-    ValidationUtils.checkArgument(inflightInstant.getAction().equals(HoodieTimeline.RESTORE_ACTION), "Transition to requested attempted for a restore instant with diff action "
-        + inflightInstant);
-    ValidationUtils.checkArgument(inflightInstant.isInflight(), "Transition to requested attempted for an instant not in inflight state " + inflightInstant);
-    HoodieInstant requested = new HoodieInstant(State.REQUESTED, RESTORE_ACTION, inflightInstant.getTimestamp());
-    transitionState(inflightInstant, requested, Option.empty());
-    return requested;
-  }
-
-  /**
    * Transition replace requested file to replace inflight.
    *
    * @param requestedInstant Requested instant


### PR DESCRIPTION
### Change Logs

If a table was attempted w/ "restore" operation and if it failed mid-way, restore could still be lying around. when re-attempted, a new instant time will be allotted and re-attempted from scratch. but this may thwart compaction progression in MDT. so we need to ensure for a given savepoint, we always re-use restore instant if any. 

### Impact

MDT compaction progression no longer thwarted?

### Risk level (write none, low medium or high below)
 
low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
