### PR TITLE
[HUDI-5336] Fixing log file pattern match to ignore extraneous files

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -358,7 +358,7 @@ public class FSUtils {
    * Get the file extension from the log file.
    */
   public static String getFileExtensionFromLog(Path logPath) {
-    Matcher matcher =  LOG_FILE_PATTERN.matcher(logPath.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(logPath.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(logPath, "LogFile");
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -80,7 +80,10 @@ public class FSUtils {
   // Log files are of this pattern - .b5068208-e1a4-11e6-bf01-fe55135034f3_20170101134598.log.1_1-0-1
   // Archive log files are of this pattern - .commits_.archive.1_1-0-1
   public static final Pattern LOG_FILE_PATTERN =
-      Pattern.compile("\\.(.+)_(.*)\\.(.+)\\.(\\d+)(_((\\d+)-(\\d+)-(\\d+))(.cdc)?)?");
+      Pattern.compile("^\\.(.+)_(.*)\\.(log)\\.(\\d+)(_((\\d+)-(\\d+)-(\\d+))(.cdc)?)?");
+  public static final String ARCHIVED_LOG_PREFIX = ".commits_.archive";
+  public static final Pattern ARCHIVED_LOG_FILE_PATTERN =
+      Pattern.compile(ARCHIVED_LOG_PREFIX + ".(\\d+)(_((\\d+)-(\\d+)-(\\d+)))");
   private static final int MAX_ATTEMPTS_RECOVER_LEASE = 10;
   private static final long MIN_CLEAN_TO_KEEP = 10;
   private static final long MIN_ROLLBACK_TO_KEEP = 10;
@@ -358,7 +361,8 @@ public class FSUtils {
    * Get the file extension from the log file.
    */
   public static String getFileExtensionFromLog(Path logPath) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(logPath.getName());
+    Matcher matcher = logPath.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(logPath.getName()) :
+        LOG_FILE_PATTERN.matcher(logPath.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(logPath, "LogFile");
     }
@@ -403,7 +407,8 @@ public class FSUtils {
    * Get TaskPartitionId used in log-path.
    */
   public static Integer getTaskPartitionIdFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+        LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
@@ -415,7 +420,8 @@ public class FSUtils {
    * Get Write-Token used in log-path.
    */
   public static String getWriteTokenFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+        LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
@@ -426,7 +432,8 @@ public class FSUtils {
    * Get StageId used in log-path.
    */
   public static Integer getStageIdFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+        LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
@@ -438,7 +445,8 @@ public class FSUtils {
    * Get Task Attempt Id used in log-path.
    */
   public static Integer getTaskAttemptIdFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+        LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
@@ -454,7 +462,8 @@ public class FSUtils {
   }
 
   public static int getFileVersionFromLog(String logFileName) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(logFileName);
+    Matcher matcher = logFileName.contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(logFileName) :
+        LOG_FILE_PATTERN.matcher(logFileName);
     if (!matcher.find()) {
       throw new HoodieIOException("Invalid log file name: " + logFileName);
     }
@@ -479,7 +488,7 @@ public class FSUtils {
   }
 
   public static boolean isLogFile(String fileName) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(fileName);
+    Matcher matcher = fileName.contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(fileName) : LOG_FILE_PATTERN.matcher(fileName);
     return matcher.find() && fileName.contains(".log");
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -80,13 +80,7 @@ public class FSUtils {
   // Log files are of this pattern - .b5068208-e1a4-11e6-bf01-fe55135034f3_20170101134598.log.1_1-0-1
   // Archive log files are of this pattern - .commits_.archive.1_1-0-1
   public static final Pattern LOG_FILE_PATTERN =
-      Pattern.compile("^\\.(.+)_(.*)\\.(log)\\.(\\d+)(_((\\d+)-(\\d+)-(\\d+))(.cdc)?)?");
-  public static final String ARCHIVE_STR = "archive";
-  public static final String COMMITS_STR = "commits";
-  public static final String EMPTY_STR = "";
-  public static final String ARCHIVED_LOG_PREFIX = "." + COMMITS_STR + "_." + ARCHIVE_STR;
-  public static final Pattern ARCHIVED_LOG_FILE_PATTERN =
-      Pattern.compile(ARCHIVED_LOG_PREFIX + ".(\\d+)(_((\\d+)-(\\d+)-(\\d+)))");
+      Pattern.compile("^\\.(.+)_(.*)\\.(log|archive)\\.(\\d+)(_((\\d+)-(\\d+)-(\\d+))(.cdc)?)?");
   private static final int MAX_ATTEMPTS_RECOVER_LEASE = 10;
   private static final long MIN_CLEAN_TO_KEEP = 10;
   private static final long MIN_ROLLBACK_TO_KEEP = 10;
@@ -364,13 +358,11 @@ public class FSUtils {
    * Get the file extension from the log file.
    */
   public static String getFileExtensionFromLog(Path logPath) {
-    boolean isArchivedLog = logPath.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher =  isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(logPath.getName()) :
-        LOG_FILE_PATTERN.matcher(logPath.getName());
+    Matcher matcher =  LOG_FILE_PATTERN.matcher(logPath.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(logPath, "LogFile");
     }
-    return isArchivedLog ? ARCHIVE_STR : matcher.group(3);
+    return matcher.group(3);
   }
 
   /**
@@ -378,13 +370,11 @@ public class FSUtils {
    * the file name.
    */
   public static String getFileIdFromLogPath(Path path) {
-    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher =  isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName())
-        : LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher =  LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    return isArchivedLog ? COMMITS_STR : matcher.group(1);
+    return matcher.group(1);
   }
 
   /**
@@ -402,25 +392,22 @@ public class FSUtils {
    * the file name.
    */
   public static String getBaseCommitTimeFromLogPath(Path path) {
-    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) : LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    return isArchivedLog ? EMPTY_STR : matcher.group(2);
+    return matcher.group(2);
   }
 
   /**
    * Get TaskPartitionId used in log-path.
    */
   public static Integer getTaskPartitionIdFromLogPath(Path path) {
-    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
-        LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    String val = isArchivedLog ? matcher.group(4) : matcher.group(7);
+    String val = matcher.group(7);
     return val == null ? null : Integer.parseInt(val);
   }
 
@@ -428,26 +415,22 @@ public class FSUtils {
    * Get Write-Token used in log-path.
    */
   public static String getWriteTokenFromLogPath(Path path) {
-    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
-        LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    return isArchivedLog ? matcher.group(3) : matcher.group(6);
+    return matcher.group(6);
   }
 
   /**
    * Get StageId used in log-path.
    */
   public static Integer getStageIdFromLogPath(Path path) {
-    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
-        LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    String val = isArchivedLog ? matcher.group(5) : matcher.group(8);
+    String val = matcher.group(8);
     return val == null ? null : Integer.parseInt(val);
   }
 
@@ -455,13 +438,11 @@ public class FSUtils {
    * Get Task Attempt Id used in log-path.
    */
   public static Integer getTaskAttemptIdFromLogPath(Path path) {
-    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
-        LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    String val = isArchivedLog ? matcher.group(6) : matcher.group(9);
+    String val = matcher.group(9);
     return val == null ? null : Integer.parseInt(val);
   }
 
@@ -473,13 +454,11 @@ public class FSUtils {
   }
 
   public static int getFileVersionFromLog(String logFileName) {
-    boolean isArchivedLog = logFileName.contains(ARCHIVED_LOG_PREFIX);
-    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(logFileName) :
-        LOG_FILE_PATTERN.matcher(logFileName);
+    Matcher matcher = LOG_FILE_PATTERN.matcher(logFileName);
     if (!matcher.find()) {
       throw new HoodieIOException("Invalid log file name: " + logFileName);
     }
-    return Integer.parseInt(isArchivedLog ? matcher.group(1) : matcher.group(4));
+    return Integer.parseInt(matcher.group(4));
   }
 
   public static String makeLogFileName(String fileId, String logFileExtension, String baseCommitTime, int version,
@@ -500,7 +479,7 @@ public class FSUtils {
   }
 
   public static boolean isLogFile(String fileName) {
-    Matcher matcher = fileName.contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(fileName) : LOG_FILE_PATTERN.matcher(fileName);
+    Matcher matcher = LOG_FILE_PATTERN.matcher(fileName);
     return matcher.find() && fileName.contains(".log");
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -81,7 +81,10 @@ public class FSUtils {
   // Archive log files are of this pattern - .commits_.archive.1_1-0-1
   public static final Pattern LOG_FILE_PATTERN =
       Pattern.compile("^\\.(.+)_(.*)\\.(log)\\.(\\d+)(_((\\d+)-(\\d+)-(\\d+))(.cdc)?)?");
-  public static final String ARCHIVED_LOG_PREFIX = ".commits_.archive";
+  public static final String ARCHIVE_STR = "archive";
+  public static final String COMMITS_STR = "commits";
+  public static final String EMPTY_STR = "";
+  public static final String ARCHIVED_LOG_PREFIX = "." + COMMITS_STR + "_." + ARCHIVE_STR;
   public static final Pattern ARCHIVED_LOG_FILE_PATTERN =
       Pattern.compile(ARCHIVED_LOG_PREFIX + ".(\\d+)(_((\\d+)-(\\d+)-(\\d+)))");
   private static final int MAX_ATTEMPTS_RECOVER_LEASE = 10;
@@ -361,12 +364,13 @@ public class FSUtils {
    * Get the file extension from the log file.
    */
   public static String getFileExtensionFromLog(Path logPath) {
-    Matcher matcher = logPath.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(logPath.getName()) :
+    boolean isArchivedLog = logPath.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher =  isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(logPath.getName()) :
         LOG_FILE_PATTERN.matcher(logPath.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(logPath, "LogFile");
     }
-    return matcher.group(3);
+    return isArchivedLog ? ARCHIVE_STR : matcher.group(3);
   }
 
   /**
@@ -374,11 +378,13 @@ public class FSUtils {
    * the file name.
    */
   public static String getFileIdFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher =  isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName())
+        : LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    return matcher.group(1);
+    return isArchivedLog ? COMMITS_STR : matcher.group(1);
   }
 
   /**
@@ -396,23 +402,25 @@ public class FSUtils {
    * the file name.
    */
   public static String getBaseCommitTimeFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) : LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    return matcher.group(2);
+    return isArchivedLog ? EMPTY_STR : matcher.group(2);
   }
 
   /**
    * Get TaskPartitionId used in log-path.
    */
   public static Integer getTaskPartitionIdFromLogPath(Path path) {
-    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
         LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    String val = matcher.group(7);
+    String val = isArchivedLog ? matcher.group(4) : matcher.group(7);
     return val == null ? null : Integer.parseInt(val);
   }
 
@@ -420,24 +428,26 @@ public class FSUtils {
    * Get Write-Token used in log-path.
    */
   public static String getWriteTokenFromLogPath(Path path) {
-    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
         LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    return matcher.group(6);
+    return isArchivedLog ? matcher.group(3) : matcher.group(6);
   }
 
   /**
    * Get StageId used in log-path.
    */
   public static Integer getStageIdFromLogPath(Path path) {
-    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
         LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    String val = matcher.group(8);
+    String val = isArchivedLog ? matcher.group(5) : matcher.group(8);
     return val == null ? null : Integer.parseInt(val);
   }
 
@@ -445,12 +455,13 @@ public class FSUtils {
    * Get Task Attempt Id used in log-path.
    */
   public static Integer getTaskAttemptIdFromLogPath(Path path) {
-    Matcher matcher = path.getName().contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
+    boolean isArchivedLog = path.getName().contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(path.getName()) :
         LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
-    String val = matcher.group(9);
+    String val = isArchivedLog ? matcher.group(6) : matcher.group(9);
     return val == null ? null : Integer.parseInt(val);
   }
 
@@ -462,12 +473,13 @@ public class FSUtils {
   }
 
   public static int getFileVersionFromLog(String logFileName) {
-    Matcher matcher = logFileName.contains(ARCHIVED_LOG_PREFIX) ? ARCHIVED_LOG_FILE_PATTERN.matcher(logFileName) :
+    boolean isArchivedLog = logFileName.contains(ARCHIVED_LOG_PREFIX);
+    Matcher matcher = isArchivedLog ? ARCHIVED_LOG_FILE_PATTERN.matcher(logFileName) :
         LOG_FILE_PATTERN.matcher(logFileName);
     if (!matcher.find()) {
       throw new HoodieIOException("Invalid log file name: " + logFileName);
     }
-    return Integer.parseInt(matcher.group(4));
+    return Integer.parseInt(isArchivedLog ? matcher.group(1) : matcher.group(4));
   }
 
   public static String makeLogFileName(String fileId, String logFileExtension, String baseCommitTime, int version,

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -370,7 +370,7 @@ public class FSUtils {
    * the file name.
    */
   public static String getFileIdFromLogPath(Path path) {
-    Matcher matcher =  LOG_FILE_PATTERN.matcher(path.getName());
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -343,7 +343,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
     for (int i = 0; i < 2; i++) {
       Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(testPath)
-          .withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION).withFileId("commits.archive").overBaseCommit("")
+          .withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION).withFileId("commits").overBaseCommit("")
           .withFs(localFs).build();
       writer.appendBlock(dataBlock);
       writer.close();

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormatAppendFailure.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormatAppendFailure.java
@@ -103,7 +103,7 @@ public class TestHoodieLogFormatAppendFailure {
     HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, header, HoodieRecord.RECORD_KEY_METADATA_FIELD);
 
     Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(testPath)
-        .withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION).withFileId("commits.archive")
+        .withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION).withFileId("commits")
         .overBaseCommit("").withFs(fs).build();
 
     writer.appendBlock(dataBlock);
@@ -134,7 +134,7 @@ public class TestHoodieLogFormatAppendFailure {
     // Opening a new Writer right now will throw IOException. The code should handle this, rollover the logfile and
     // return a new writer with a bumped up logVersion
     writer = HoodieLogFormat.newWriterBuilder().onParentPath(testPath)
-        .withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION).withFileId("commits.archive")
+        .withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION).withFileId("commits")
         .overBaseCommit("").withFs(fs).build();
     header = new HashMap<>();
     header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -307,11 +307,13 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         FSUtils.makeLogFileName(fileId, HoodieLogFile.DELTA_EXTENSION, instantTime1, 1, TEST_WRITE_TOKEN);
     // create a dummy log file mimicing cloud stores marker files
     String fileName3 = "_GCS_SYNCABLE_TEMPFILE_" + fileName1;
+    String fileName4 = "_DUMMY_" + fileName1.substring(1, fileName1.length());
     // this file should not be deduced as a log file.
 
     Paths.get(basePath, partitionPath, fileName1).toFile().createNewFile();
     Paths.get(basePath, partitionPath, fileName2).toFile().createNewFile();
     Paths.get(basePath, partitionPath, fileName3).toFile().createNewFile();
+    Paths.get(basePath, partitionPath, fileName4).toFile().createNewFile();
     HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
 
     HoodieInstant instant1 = new HoodieInstant(true, HoodieTimeline.COMMIT_ACTION, instantTime1);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -306,7 +306,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     String fileName2 =
         FSUtils.makeLogFileName(fileId, HoodieLogFile.DELTA_EXTENSION, instantTime1, 1, TEST_WRITE_TOKEN);
     // create a dummy log file mimicing cloud stores marker files
-    String fileName3 = "_DUMMY_" + fileName1.substring(1, fileName1.length());
+    String fileName3 = "_GCS_SYNCABLE_TEMPFILE_" + fileName1;
     // this file should not be deduced as a log file.
 
     Paths.get(basePath, partitionPath, fileName1).toFile().createNewFile();


### PR DESCRIPTION
### Change Logs

GCS might create some marker files for log files created by hudi. While constructing the file groups w/ log files, we should ignore such files. Format of those marker file is "_GCS_SYNCABLE_TEMPFILE_" + [LOG_FILE_NAME]. Eg: "_GCS_SYNCABLE_TEMPFILE_.files-0000_20230104082331173001.log.10_0-52-553.1.8170c3dc-f1f0-474f-aabf-b53a474aa18d".

We did make an attempt to fix [before](https://github.com/apache/hudi/pull/7393), but looks like the file pattern is different. So, have made the pattern match more strict. 

This patch fixes the Log file pattern match to ensure we ignore such extraneous files.

### Impact

Queries and compaction may not fail occationally. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
