### PR TITLE
[HUDI-5509] check if dfs support atomic creation when using filesyste…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -19,8 +19,10 @@
 
 package org.apache.hudi.client.transaction.lock;
 
+import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.fs.StorageSchemes;
 import org.apache.hudi.common.lock.LockProvider;
 import org.apache.hudi.common.lock.LockState;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -42,6 +44,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
@@ -70,13 +75,17 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     String lockDirectory = lockConfiguration.getConfig().getString(FILESYSTEM_LOCK_PATH_PROP_KEY, null);
     if (StringUtils.isNullOrEmpty(lockDirectory)) {
       lockDirectory = lockConfiguration.getConfig().getString(HoodieWriteConfig.BASE_PATH.key())
-            + Path.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
+          + Path.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
     }
     this.lockTimeoutMinutes = lockConfiguration.getConfig().getInteger(FILESYSTEM_LOCK_EXPIRE_PROP_KEY);
     this.lockFile = new Path(lockDirectory + Path.SEPARATOR + LOCK_FILE_NAME);
     this.lockInfo = new LockInfo();
     this.sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     this.fs = FSUtils.getFs(this.lockFile.toString(), configuration);
+    List<String> customSupportedFSs = lockConfiguration.getConfig().getStringList(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key(), ",", new ArrayList<>());
+    if (!customSupportedFSs.contains(this.fs.getScheme()) && !StorageSchemes.isAtomicCreationSupported(this.fs.getScheme())) {
+      throw new HoodieLockException("Unsupported scheme :" + this.fs.getScheme() + ", since this fs can not support atomic creation");
+    }
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -75,10 +75,10 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<String> HOODIE_FS_ATOMIC_CREATION_SUPPORT = ConfigProperty
       .key("hoodie.fs.atomic_creation.support")
       .defaultValue("")
-      .withDocumentation("This config is used to specify the file system which supports atomic file creation . " +
-          "atomic means that an operation either succeeds and has an effect or has fails and has no effect;" +
-          " now this feature is used by FileSystemLockProvider to guaranteeing that only one writer can create the lock file at a time." +
-          " since some FS does not support atomic file creation (eg: S3), we decide the FileSystemLockProvider only support HDFS,local FS"
+      .withDocumentation("This config is used to specify the file system which supports atomic file creation . "
+          + "atomic means that an operation either succeeds and has an effect or has fails and has no effect;"
+          + " now this feature is used by FileSystemLockProvider to guaranteeing that only one writer can create the lock file at a time."
+          + " since some FS does not support atomic file creation (eg: S3), we decide the FileSystemLockProvider only support HDFS,local FS"
           + " and View FS as default. if you want to use FileSystemLockProvider with other FS, you can set this config with the FS scheme, eg: fs1,fs2");
 
   public ExternalSpillableMap.DiskMapType getSpillableDiskMapType() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -72,6 +72,15 @@ public class HoodieCommonConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Turn on compression for BITCASK disk map used by the External Spillable Map");
 
+  public static final ConfigProperty<String> HOODIE_FS_ATOMIC_CREATION_SUPPORT = ConfigProperty
+      .key("hoodie.fs.atomic_creation.support")
+      .defaultValue("")
+      .withDocumentation("This config is used to specify the file system which supports atomic file creation . " +
+          "atomic means that an operation either succeeds and has an effect or has fails and has no effect;" +
+          " now this feature is used by FileSystemLockProvider to guaranteeing that only one writer can create the lock file at a time." +
+          " since some FS does not support atomic file creation (eg: S3), we decide the FileSystemLockProvider only support HDFS,local FS"
+          + " and View FS as default. if you want to use FileSystemLockProvider with other FS, you can set this config with the FS scheme, eg: fs1,fs2");
+
   public ExternalSpillableMap.DiskMapType getSpillableDiskMapType() {
     return ExternalSpillableMap.DiskMapType.valueOf(getString(SPILLABLE_DISK_MAP_TYPE).toUpperCase(Locale.ROOT));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
@@ -47,6 +47,7 @@ public enum StorageSchemes {
   // Aliyun OSS
   OSS("oss", false, null, null),
   // View FS for federated setups. If federating across cloud stores, then append support is false
+  // View FS support atomic creation
   VIEWFS("viewfs", true, null, true),
   //ALLUXIO
   ALLUXIO("alluxio", false, null, null),

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/StorageSchemes.java
@@ -25,65 +25,68 @@ import java.util.Arrays;
  */
 public enum StorageSchemes {
   // Local filesystem
-  FILE("file", false, false),
+  FILE("file", false, false, true),
   // Hadoop File System
-  HDFS("hdfs", true, false),
+  HDFS("hdfs", true, false, true),
   // Baidu Advanced File System
-  AFS("afs", true, null),
+  AFS("afs", true, null, null),
   // Mapr File System
-  MAPRFS("maprfs", true, null),
+  MAPRFS("maprfs", true, null, null),
   // Apache Ignite FS
-  IGNITE("igfs", true, null),
+  IGNITE("igfs", true, null, null),
   // AWS S3
-  S3A("s3a", false, true), S3("s3", false, true),
+  S3A("s3a", false, true, null), S3("s3", false, true, null),
   // Google Cloud Storage
-  GCS("gs", false, true),
+  GCS("gs", false, true, null),
   // Azure WASB
-  WASB("wasb", false, null), WASBS("wasbs", false, null),
+  WASB("wasb", false, null, null), WASBS("wasbs", false, null, null),
   // Azure ADLS
-  ADL("adl", false, null),
+  ADL("adl", false, null, null),
   // Azure ADLS Gen2
-  ABFS("abfs", false, null), ABFSS("abfss", false, null),
+  ABFS("abfs", false, null, null), ABFSS("abfss", false, null, null),
   // Aliyun OSS
-  OSS("oss", false, null),
+  OSS("oss", false, null, null),
   // View FS for federated setups. If federating across cloud stores, then append support is false
-  VIEWFS("viewfs", true, null),
+  VIEWFS("viewfs", true, null, true),
   //ALLUXIO
-  ALLUXIO("alluxio", false, null),
+  ALLUXIO("alluxio", false, null, null),
   // Tencent Cloud Object Storage
-  COSN("cosn", false, null),
+  COSN("cosn", false, null, null),
   // Tencent Cloud HDFS
-  CHDFS("ofs", true, null),
+  CHDFS("ofs", true, null, null),
   // Tencent Cloud CacheFileSystem
-  GOOSEFS("gfs", false, null),
+  GOOSEFS("gfs", false, null, null),
   // Databricks file system
-  DBFS("dbfs", false, null),
+  DBFS("dbfs", false, null, null),
   // IBM Cloud Object Storage
-  COS("cos", false, null),
+  COS("cos", false, null, null),
   // Huawei Cloud Object Storage
-  OBS("obs", false, null),
+  OBS("obs", false, null, null),
   // Kingsoft Standard Storage ks3
-  KS3("ks3", false, null),
+  KS3("ks3", false, null, null),
   // JuiceFileSystem
-  JFS("jfs", true, null),
+  JFS("jfs", true, null, null),
   // Baidu Object Storage
-  BOS("bos", false, null),
+  BOS("bos", false, null, null),
   // Oracle Cloud Infrastructure Object Storage
-  OCI("oci", false, null),
+  OCI("oci", false, null, null),
   // Volcengine Object Storage
-  TOS("tos", false, null),
+  TOS("tos", false, null, null),
   // Volcengine Cloud HDFS
-  CFS("cfs", true, null);
+  CFS("cfs", true, null, null);
 
   private String scheme;
   private boolean supportsAppend;
   // null for uncertain if write is transactional, please update this for each FS
   private Boolean isWriteTransactional;
+  // null for uncertain if dfs support atomic create&delete, please update this for each FS
+  private Boolean supportAtomicCreation;
 
-  StorageSchemes(String scheme, boolean supportsAppend, Boolean isWriteTransactional) {
+  StorageSchemes(String scheme, boolean supportsAppend, Boolean isWriteTransactional, Boolean supportAtomicCreation) {
     this.scheme = scheme;
     this.supportsAppend = supportsAppend;
     this.isWriteTransactional = isWriteTransactional;
+    this.supportAtomicCreation = supportAtomicCreation;
   }
 
   public String getScheme() {
@@ -96,6 +99,10 @@ public enum StorageSchemes {
 
   public boolean isWriteTransactional() {
     return isWriteTransactional != null && isWriteTransactional;
+  }
+
+  public boolean isAtomicCreationSupported() {
+    return supportAtomicCreation != null && supportAtomicCreation;
   }
 
   public static boolean isSchemeSupported(String scheme) {
@@ -115,5 +122,12 @@ public enum StorageSchemes {
     }
 
     return Arrays.stream(StorageSchemes.values()).anyMatch(s -> s.isWriteTransactional() && s.scheme.equals(scheme));
+  }
+
+  public static boolean isAtomicCreationSupported(String scheme) {
+    if (!isSchemeSupported(scheme)) {
+      throw new IllegalArgumentException("Unsupported scheme :" + scheme);
+    }
+    return Arrays.stream(StorageSchemes.values()).anyMatch(s -> s.isAtomicCreationSupported() && s.scheme.equals(scheme));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
@@ -54,6 +54,28 @@ public class TestStorageSchemes {
     assertFalse(StorageSchemes.isAppendSupported("oci"));
     assertFalse(StorageSchemes.isAppendSupported("tos"));
     assertTrue(StorageSchemes.isAppendSupported("cfs"));
+
+    assertTrue(StorageSchemes.isAtomicCreationSupported("file"));
+    assertTrue(StorageSchemes.isAtomicCreationSupported("hdfs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("afs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("s3a"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("gs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("wasb"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("adl"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("abfs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("oss"));
+    assertTrue(StorageSchemes.isAtomicCreationSupported("viewfs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("alluxio"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("cosn"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("dbfs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("cos"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("jfs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("bos"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("ks3"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("ofs"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("oci"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("tos"));
+    assertFalse(StorageSchemes.isAtomicCreationSupported("cfs"));
     assertThrows(IllegalArgumentException.class, () -> {
       StorageSchemes.isAppendSupported("s2");
     }, "Should throw exception for unsupported schemes");


### PR DESCRIPTION
…m base lock provider

### Change Logs

check if the dfs support atomic creation when using the filesystem base lock provider

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
