### PR TITLE
[HUDI-5511] Do not clean the CkpMetadata dir when restart the job

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -92,13 +92,14 @@ public class CkpMetadata implements Serializable {
   // -------------------------------------------------------------------------
 
   /**
-   * Initialize the message bus, would clean all the messages
+   * Initialize the message bus, would keep all the messages.
    *
    * <p>This expects to be called by the driver.
    */
   public void bootstrap() throws IOException {
-    fs.delete(path, true);
-    fs.mkdirs(path);
+    if (!fs.exists(path)) {
+      fs.mkdirs(path);
+    }
   }
 
   public void startInstant(String instant) {


### PR DESCRIPTION
At the beginning, we bootstrap the ckp metadata by cleaning all the messages. This brings in some corner case like 'the write task can not fetch the pending instant correctly when restartting the job', if a checkpoint succeed and the job crashes suddenly, the instant hasn't had time to commit, then the data loss happens, because the last pending instant would be rolled back, while the Flink engin thinks the checkpint/instant is successful.

Q: Why we clean the messages here ?
A: To prevent inconsistencies between timeline and the messages.

Q: Why we decide to keep the messages ?
A: There are two cases for the inconsistency:

1. the timeline instant is complete but the ckp message is inflight (for committing instant);
2. the timeline instant is pending while the ckp message does not start (for starting a new instant);

For case1, there is no need to re-commit the instant, so it's okey the write task does not get any pending instant when recovering, for case2, the instant is basically pending, it would be rolled back which is in line with expectations. so keeping the ckp messages as is can actually maintain correctness.

### Change Logs

Keep the ckp messages instead of cleaning it.

### Impact

No impact

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
