### PR TITLE
[HUDI-5514] Adding auto generation of record keys/Keyless support to Hudi

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -473,6 +473,12 @@ object DataSourceWriteOptions {
         + "null records from the table (for updating, for ex). Note, that this config has only effect when "
         + "'hoodie.datasource.write.reconcile.schema' is set to false.")
 
+  val AUTO_GENERATE_RECORD_KEYS: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.auto.generate.record.keys")
+    .defaultValue("false")
+    .withDocumentation("When enabled, auto generates record keys for incoming records. Every record will be given a new " +
+      "record key and so updates via spark-datasource is not feasible when enabling this.")
+
   // HIVE SYNC SPECIFIC CONFIGS
   // NOTE: DO NOT USE uppercase for the keys as they are internally lower-cased. Using upper-cases causes
   // unexpected issues with config getting reset

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -2403,6 +2403,32 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     assertTrue(hiveClient.tableExists(tableName), "Table " + tableName + " should exist");
   }
 
+  @Test
+  public void testAutoGenerateRecordKeys() throws Exception {
+    boolean useSchemaProvider = false;
+    List<String> transformerClassNames = null;
+    PARQUET_SOURCE_ROOT = basePath + "/parquetFilesDfs" + testNum;
+    int parquetRecordsCount = 100;
+    boolean hasTransformer = transformerClassNames != null && !transformerClassNames.isEmpty();
+    prepareParquetDFSFiles(parquetRecordsCount, PARQUET_SOURCE_ROOT, FIRST_PARQUET_FILE_NAME, false, null, null);
+    prepareParquetDFSSource(useSchemaProvider, hasTransformer, "source.avsc", "target.avsc", PROPS_FILENAME_TEST_PARQUET,
+        PARQUET_SOURCE_ROOT, false, "partition_path", "");
+
+    String tableBasePath = basePath + "/test_parquet_table" + testNum;
+    HoodieDeltaStreamer.Config config = TestHelpers.makeConfig(tableBasePath, WriteOperationType.INSERT, ParquetDFSSource.class.getName(),
+        transformerClassNames, PROPS_FILENAME_TEST_PARQUET, false,
+        useSchemaProvider, 100000, false, null, null, "timestamp", null);
+    config.configs.add(DataSourceWriteOptions.AUTO_GENERATE_RECORD_KEYS().key() + "=true");
+    HoodieDeltaStreamer deltaStreamer = new HoodieDeltaStreamer(config, jsc);
+    deltaStreamer.sync();
+    TestHelpers.assertRecordCount(parquetRecordsCount, tableBasePath, sqlContext);
+
+    prepareParquetDFSFiles(200, PARQUET_SOURCE_ROOT, "2.parquet", false, null, null);
+    deltaStreamer.sync();
+    TestHelpers.assertRecordCount(parquetRecordsCount + 200, tableBasePath, sqlContext);
+    testNum++;
+  }
+
   class TestDeltaSync extends DeltaSync {
 
     public TestDeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider, TypedProperties props,


### PR DESCRIPTION
### Change Logs

Hudi has a requirement to set record keys/primary keys by the user. But some use-cases like ingesting log events, users may not have any column that can act as a primary key field. So, would be good to expose an auto generation record keys internally within hudi for such immutable use-cases. 
So, adding keyless support to Hudi in this patch. In other words, adding auto generation of record keys to Hudi. 

### Impact

Users no longer need to set primary key/record key fields for immutable use-cases or similar workloads and let hudi generate keys internally. Understandably, few configs are not supported in this flow like updates, de-dup are not supported. To leverage this, users need to enable a new config `hoodie.auto.generate.record.keys` 

### Risk level (write none, low medium or high below)

Medium

### Documentation Update

Might have to add a FAQ or website update on the keyless support. 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
