### PR TITLE
[HUDI-5519] Fix LogFileComparator with suffix for CDC

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -461,6 +461,15 @@ public class FSUtils {
     return Integer.parseInt(matcher.group(4));
   }
 
+  public static String getSuffixFromLogPath(Path path) {
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    if (!matcher.find()) {
+      throw new InvalidHoodiePathException(path, "LogFile");
+    }
+    String val = matcher.group(10);
+    return val == null ? "" : val;
+  }
+
   public static String makeLogFileName(String fileId, String logFileExtension, String baseCommitTime, int version,
       String writeToken) {
     String suffix = (writeToken == null)

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -99,6 +99,10 @@ public class HoodieLogFile implements Serializable {
     return FSUtils.getFileExtensionFromLog(getPath());
   }
 
+  public String getSuffix() {
+    return FSUtils.getSuffixFromLogPath(getPath());
+  }
+
   public Path getPath() {
     return new Path(pathStr);
   }
@@ -165,8 +169,16 @@ public class HoodieLogFile implements Serializable {
       if (baseInstantTime1.equals(baseInstantTime2)) {
 
         if (o1.getLogVersion() == o2.getLogVersion()) {
+
+          int compareWriteToken = getWriteTokenComparator().compare(o1.getLogWriteToken(), o2.getLogWriteToken());
+          if (compareWriteToken == 0) {
+
+            // Compare by suffix when write token is same
+            return o1.getSuffix().compareTo(o2.getSuffix());
+          }
+
           // Compare by write token when base-commit and log-version is same
-          return getWriteTokenComparator().compare(o1.getLogWriteToken(), o2.getLogWriteToken());
+          return compareWriteToken;
         }
 
         // compare by log-version when base-commit is same

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -324,6 +325,29 @@ public class TestFSUtils extends HoodieCommonTestHarness {
     assertEquals(log1Ver1W1, logFiles.get(3).getFileName());
     assertEquals(log1base2W0, logFiles.get(4).getFileName());
     assertEquals(log1base2W1, logFiles.get(5).getFileName());
+  }
+
+  @Test
+  public void testLogFilesComparisonWithCDCFile() {
+    HoodieLogFile log1 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "1", 0, "0-0-1")));
+    HoodieLogFile log2 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 0, "0-0-1")));
+    HoodieLogFile log3 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "0-0-1")));
+    HoodieLogFile log4 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "1-1-1")));
+    HoodieLogFile log5 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "1-1-1") + HoodieCDCUtils.CDC_LOGFILE_SUFFIX));
+
+    TreeSet<HoodieLogFile> logFilesSet = new TreeSet<>(HoodieLogFile.getLogFileComparator());
+    logFilesSet.add(log1);
+    logFilesSet.add(log2);
+    logFilesSet.add(log3);
+    logFilesSet.add(log4);
+    logFilesSet.add(log5);
+
+    List<HoodieLogFile> logFilesList = new ArrayList<>(logFilesSet);
+    assertEquals(log1, logFilesList.get(0));
+    assertEquals(log2, logFilesList.get(1));
+    assertEquals(log3, logFilesList.get(2));
+    assertEquals(log4, logFilesList.get(3));
+    assertEquals(log5, logFilesList.get(4));
   }
 
   public static String makeOldLogFileName(String fileId, String logFileExtension, String baseCommitTime, int version) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
@@ -335,7 +335,6 @@ public class TestFSUtils extends HoodieCommonTestHarness {
     HoodieLogFile log4 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "1-1-1")));
     HoodieLogFile log5 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "1-1-1") + HoodieCDCUtils.CDC_LOGFILE_SUFFIX));
 
-
     TreeSet<HoodieLogFile> logFilesSet = new TreeSet<>(HoodieLogFile.getLogFileComparator());
     logFilesSet.add(log1);
     logFilesSet.add(log2);

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
@@ -335,6 +335,7 @@ public class TestFSUtils extends HoodieCommonTestHarness {
     HoodieLogFile log4 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "1-1-1")));
     HoodieLogFile log5 = new HoodieLogFile(new Path(FSUtils.makeLogFileName("file1", ".log", "2", 1, "1-1-1") + HoodieCDCUtils.CDC_LOGFILE_SUFFIX));
 
+
     TreeSet<HoodieLogFile> logFilesSet = new TreeSet<>(HoodieLogFile.getLogFileComparator());
     logFilesSet.add(log1);
     logFilesSet.add(log2);


### PR DESCRIPTION
### Change Logs

LogFileComparator does not compare cdc suffix, for example, for the following logs, they will be considered equal:

```text
.file1_2.log.1_1-1-1
.file1_2.log.1_1-1-1.cdc
```

One problem it will bring is: because `new TreeSet<>(HoodieLogFile.getReverseLogFileComparator())` is used when constructing FG, when the two logs are exactly the same except for suffix, only one of them will exist in logFiles.

### Impact

Fix LogFileComparator

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
