### PR TITLE
[MINOR] Remove useless RollbackTimeline

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RollbacksCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RollbacksCommand.java
@@ -25,15 +25,15 @@ import org.apache.hudi.cli.HoodieTableHeaderFields;
 import org.apache.hudi.cli.TableHeader;
 import org.apache.hudi.cli.utils.InputStreamConsumer;
 import org.apache.hudi.cli.utils.SparkUtil;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
+
 import org.apache.spark.launcher.SparkLauncher;
+
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
@@ -59,7 +59,7 @@ public class RollbacksCommand {
       @ShellOption(value = {"--desc"}, help = "Ordering", defaultValue = "false") final boolean descending,
       @ShellOption(value = {"--headeronly"}, help = "Print Header Only",
           defaultValue = "false") final boolean headerOnly) {
-    HoodieActiveTimeline activeTimeline = new RollbackTimeline(HoodieCLI.getTableMetaClient());
+    HoodieActiveTimeline activeTimeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
     HoodieTimeline rollback = activeTimeline.getRollbackTimeline().filterCompletedInstants();
 
     final List<Comparable[]> rows = new ArrayList<>();
@@ -97,7 +97,7 @@ public class RollbacksCommand {
       @ShellOption(value = {"--headeronly"}, help = "Print Header Only",
               defaultValue = "false") final boolean headerOnly)
       throws IOException {
-    HoodieActiveTimeline activeTimeline = new RollbackTimeline(HoodieCLI.getTableMetaClient());
+    HoodieActiveTimeline activeTimeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
     final List<Comparable[]> rows = new ArrayList<>();
     HoodieRollbackMetadata metadata = TimelineMetadataUtils.deserializeAvroMetadata(
         activeTimeline.getInstantDetails(new HoodieInstant(State.COMPLETED, ROLLBACK_ACTION, rollbackInstant)).get(),
@@ -153,15 +153,5 @@ public class RollbacksCommand {
       return "Commit " + instantTime + " failed to roll back";
     }
     return "Commit " + instantTime + " rolled back";
-  }
-
-  /**
-   * An Active timeline containing only rollbacks.
-   */
-  public static class RollbackTimeline extends HoodieActiveTimeline {
-
-    public RollbackTimeline(HoodieTableMetaClient metaClient) {
-      super(metaClient, CollectionUtils.createImmutableSet(HoodieTimeline.ROLLBACK_EXTENSION));
-    }
   }
 }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRollbacksCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRollbacksCommand.java
@@ -127,7 +127,7 @@ public class TestRollbacksCommand extends CLIFunctionalTestHarness {
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
 
     // get rollback instants
-    HoodieActiveTimeline activeTimeline = new RollbacksCommand.RollbackTimeline(HoodieCLI.getTableMetaClient());
+    HoodieActiveTimeline activeTimeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
     Stream<HoodieInstant> rollback = activeTimeline.getRollbackTimeline().filterCompletedInstants().getInstantsAsStream();
 
     List<Comparable[]> rows = new ArrayList<>();
@@ -168,7 +168,7 @@ public class TestRollbacksCommand extends CLIFunctionalTestHarness {
   @Test
   public void testShowRollback() throws IOException {
     // get instant
-    HoodieActiveTimeline activeTimeline = new RollbacksCommand.RollbackTimeline(HoodieCLI.getTableMetaClient());
+    HoodieActiveTimeline activeTimeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
     Stream<HoodieInstant> rollback = activeTimeline.getRollbackTimeline().filterCompletedInstants().getInstantsAsStream();
     HoodieInstant instant = rollback.findFirst().orElse(null);
     assertNotNull(instant, "The instant can not be null.");

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCommitsCommand.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.cli.integ;
 
 import org.apache.hudi.cli.HoodieCLI;
-import org.apache.hudi.cli.commands.RollbacksCommand;
 import org.apache.hudi.cli.commands.TableCommand;
 import org.apache.hudi.cli.testutils.HoodieCLIIntegrationTestBase;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
@@ -111,7 +110,7 @@ public class ITTestCommitsCommand extends HoodieCLIIntegrationTestBase {
 
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
 
-    HoodieActiveTimeline rollbackTimeline = new RollbacksCommand.RollbackTimeline(metaClient);
+    HoodieActiveTimeline rollbackTimeline = metaClient.getActiveTimeline();
     assertEquals(1, rollbackTimeline.getRollbackTimeline().countInstants(), "There should have 1 rollback instant.");
 
     HoodieActiveTimeline timeline = metaClient.reloadActiveTimeline();
@@ -127,7 +126,7 @@ public class ITTestCommitsCommand extends HoodieCLIIntegrationTestBase {
 
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
 
-    HoodieActiveTimeline rollbackTimeline2 = new RollbacksCommand.RollbackTimeline(metaClient);
+    HoodieActiveTimeline rollbackTimeline2 = metaClient.getActiveTimeline();
     assertEquals(2, rollbackTimeline2.getRollbackTimeline().countInstants(), "There should have 2 rollback instant.");
 
     HoodieActiveTimeline timeline2 = metaClient.reloadActiveTimeline();
@@ -143,7 +142,7 @@ public class ITTestCommitsCommand extends HoodieCLIIntegrationTestBase {
         () -> assertEquals("Commit 100 rolled back", result3.toString()));
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
 
-    HoodieActiveTimeline rollbackTimeline3 = new RollbacksCommand.RollbackTimeline(metaClient);
+    HoodieActiveTimeline rollbackTimeline3 = metaClient.getActiveTimeline();
     assertEquals(3, rollbackTimeline3.getRollbackTimeline().countInstants(), "There should have 3 rollback instant.");
 
     HoodieActiveTimeline timeline3 = metaClient.reloadActiveTimeline();


### PR DESCRIPTION
### Change Logs

`HoodieActiveTimeline`'s `instants` contains ROLLBACK instants, and it has a method `getRollbackTimeline()` to get rollback timeline, which can replace `RollbackTimeline` class. 

Therefore, there is no need to inherit an additional `RollbackTimeline`.

In addition, for RFC-36, since its implementation of `HoodieMetaserverBasedTimeline` inherits from `HoodieActiveTimeline`, the existence of `RollbackTimeline` will disturb it.

### Impact

Remove class RollbackTimeline

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
