### PR TITLE
[HUDI-5737] Fix Deletes issued without any prior commits

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1218,7 +1218,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
           throw new HoodieIOException("Latest commit does not have any schema in commit metadata");
         }
       } else {
-        LOG.warn("Cannot find last instant in the timeline");
+        LOG.warn("How about 0 rows are deleted because the table is empty");
       }
     } catch (IOException e) {
       throw new HoodieIOException("IOException thrown while reading last commit metadata", e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1218,7 +1218,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
           throw new HoodieIOException("Latest commit does not have any schema in commit metadata");
         }
       } else {
-        LOG.warn("0 rows are deleted because the table is empty");
+        LOG.warn("None rows are deleted because the table is empty");
       }
     } catch (IOException e) {
       throw new HoodieIOException("IOException thrown while reading last commit metadata", e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1217,8 +1217,6 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         } else {
           throw new HoodieIOException("Latest commit does not have any schema in commit metadata");
         }
-      } else {
-        throw new HoodieIOException("Deletes issued without any prior commits");
       }
     } catch (IOException e) {
       throw new HoodieIOException("IOException thrown while reading last commit metadata", e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1218,7 +1218,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
           throw new HoodieIOException("Latest commit does not have any schema in commit metadata");
         }
       } else {
-        LOG.warn("How about 0 rows are deleted because the table is empty");
+        LOG.warn("0 rows are deleted because the table is empty");
       }
     } catch (IOException e) {
       throw new HoodieIOException("IOException thrown while reading last commit metadata", e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1217,6 +1217,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         } else {
           throw new HoodieIOException("Latest commit does not have any schema in commit metadata");
         }
+      } else {
+        LOG.warn("Cannot find last instant in the timeline");
       }
     } catch (IOException e) {
       throw new HoodieIOException("IOException thrown while reading last commit metadata", e);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
@@ -60,8 +60,6 @@ public abstract class HoodieFlinkTable<T>
             .setLoadActiveTimelineOnLoad(true).setConsistencyGuardConfig(config.getConsistencyGuardConfig())
             .setLayoutVersion(Option.of(new TimelineLayoutVersion(config.getTimelineLayoutVersion())))
             .setFileSystemRetryConfig(config.getFileSystemRetryConfig()).build();
-    // support flink hoodie.table.timeline.timezone config default local
-    metaClient.getTableConfig().setValue(TIMELINE_TIMEZONE.key(), config.getStringOrDefault(HoodieTableConfig.TIMELINE_TIMEZONE));
     return HoodieFlinkTable.create(config, context, metaClient);
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
@@ -60,6 +60,8 @@ public abstract class HoodieFlinkTable<T>
             .setLoadActiveTimelineOnLoad(true).setConsistencyGuardConfig(config.getConsistencyGuardConfig())
             .setLayoutVersion(Option.of(new TimelineLayoutVersion(config.getTimelineLayoutVersion())))
             .setFileSystemRetryConfig(config.getFileSystemRetryConfig()).build();
+    // support flink hoodie.table.timeline.timezone config default local
+    metaClient.getTableConfig().setValue(TIMELINE_TIMEZONE.key(), config.getStringOrDefault(HoodieTableConfig.TIMELINE_TIMEZONE));
     return HoodieFlinkTable.create(config, context, metaClient);
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -2219,9 +2219,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     List<HoodieRecord> dummyInserts = dataGen.generateInserts(commitTime1, 20);
     List<HoodieKey> hoodieKeysToDelete = randomSelectAsHoodieKeys(dummyInserts, 20);
     JavaRDD<HoodieKey> deleteKeys = jsc.parallelize(hoodieKeysToDelete, 1);
-    assertThrows(HoodieIOException.class, () -> {
-      client.delete(deleteKeys, commitTime1).collect();
-    }, "Should have thrown Exception");
+    client.delete(deleteKeys, commitTime1).collect();
   }
 
   /**


### PR DESCRIPTION
Change Logs
Delete data sql no exception throw when table empty

Impact
Low. 

Risk level (write none, low medium or high below)
None. 

Documentation Update
Change log warn information from delete empty table data

Contributor's checklist
[x ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
 Change Logs and Impact were stated clearly
 Adequate tests were added if applicable
 CI passed 
