### PR TITLE
[HUDI-5538] Fix ContinuousFileSource and ITTestDataStreamWrite for flink 1.16 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ parameters:
       - 'hudi-flink-datasource/hudi-flink1.13.x'
       - 'hudi-flink-datasource/hudi-flink1.14.x'
       - 'hudi-flink-datasource/hudi-flink1.15.x'
+      - 'hudi-flink-datasource/hudi-flink1.16.x'
   - name: job2Modules
     type: object
     default:
@@ -58,6 +59,7 @@ parameters:
       - '!hudi-flink-datasource/hudi-flink1.13.x'
       - '!hudi-flink-datasource/hudi-flink1.14.x'
       - '!hudi-flink-datasource/hudi-flink1.15.x'
+      - '!hudi-flink-datasource/hudi-flink1.16.x'
       - '!hudi-spark-datasource'
       - '!hudi-spark-datasource/hudi-spark'
       - '!hudi-spark-datasource/hudi-spark2'
@@ -78,9 +80,10 @@ parameters:
       - '!hudi-flink-datasource/hudi-flink1.13.x'
       - '!hudi-flink-datasource/hudi-flink1.14.x'
       - '!hudi-flink-datasource/hudi-flink1.15.x'
+      - '!hudi-flink-datasource/hudi-flink1.16.x'
 
 variables:
-  BUILD_PROFILES: '-Dscala-2.11 -Dspark2.4 -Dflink1.14'
+  BUILD_PROFILES: '-Dscala-2.11 -Dspark2.4 -Dflink1.16'
   PLUGIN_OPTS: '-Dcheckstyle.skip=true -Drat.skip=true -Djacoco.skip=true -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn'
   MVN_OPTS_INSTALL: '-DskipTests $(BUILD_PROFILES) $(PLUGIN_OPTS)'
   MVN_OPTS_TEST: '-fae -Pwarn-log $(BUILD_PROFILES) $(PLUGIN_OPTS)'

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/source/ContinuousFileSource.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/source/ContinuousFileSource.java
@@ -19,12 +19,11 @@
 package org.apache.hudi.examples.quickstart.source;
 
 import org.apache.hudi.adapter.DataStreamScanProviderAdapter;
+import org.apache.hudi.util.JsonDeserializationFunction;
 
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.formats.common.TimestampFormat;
-import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -37,7 +36,6 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -49,7 +47,7 @@ import static org.apache.hudi.examples.quickstart.factory.ContinuousFileSourceFa
  * A continuous file source that can trigger checkpoints continuously.
  *
  * <p>It loads the data in the specified file and split the data into number of checkpoints batches.
- * Say, if you want 4 checkpoints and there are 8 records in the file, the emit strategy is:
+ * Say, if you want 4 checkpoints and there are 8 records in the file, the emission strategy is:
  *
  * <pre>
  *   | 2 records | 2 records | 2 records | 2 records |
@@ -57,6 +55,8 @@ import static org.apache.hudi.examples.quickstart.factory.ContinuousFileSourceFa
  * </pre>
  *
  * <p>If all the data are flushed out, it waits for the next checkpoint to finish and tear down the source.
+ *
+ * <p>NOTE: this class is represented twice: in test utils and in quickstart. Don't forget to update both files.
  */
 public class ContinuousFileSource implements ScanTableSource {
 
@@ -85,18 +85,10 @@ public class ContinuousFileSource implements ScanTableSource {
       @Override
       public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
         final RowType rowType = (RowType) tableSchema.toSourceRowDataType().getLogicalType();
-        JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-            rowType,
-            InternalTypeInfo.of(rowType),
-            false,
-            true,
-            TimestampFormat.ISO_8601);
-
         return execEnv.addSource(new BoundedSourceFunction(path, conf.getInteger(CHECKPOINTS)))
             .name("continuous_file_source")
             .setParallelism(1)
-            .map(record -> deserializationSchema.deserialize(record.getBytes(StandardCharsets.UTF_8)),
-                InternalTypeInfo.of(rowType));
+            .map(JsonDeserializationFunction.getInstance(rowType), InternalTypeInfo.of(rowType));
       }
     };
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/JsonDeserializationFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/JsonDeserializationFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Wrapper function that manages the lifecycle of the JSON deserialization schema.
+ */
+public final class JsonDeserializationFunction
+    extends AbstractRichFunction
+    implements MapFunction<String, RowData> {
+  private final JsonRowDataDeserializationSchema deserializationSchema;
+
+  public static JsonDeserializationFunction getInstance(Configuration conf) {
+    // Read from file source
+    RowType rowType =
+        (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf))
+            .getLogicalType();
+    return getInstance(rowType);
+  }
+
+  public static JsonDeserializationFunction getInstance(RowType rowType) {
+    JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
+        rowType,
+        InternalTypeInfo.of(rowType),
+        false,
+        true,
+        TimestampFormat.ISO_8601
+    );
+    return new JsonDeserializationFunction(deserializationSchema);
+  }
+
+  public JsonDeserializationFunction(JsonRowDataDeserializationSchema deserializationSchema) {
+    this.deserializationSchema = deserializationSchema;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    this.deserializationSchema.open(null);
+  }
+
+  @Override
+  public RowData map(String record) throws Exception {
+    return deserializationSchema.deserialize(record.getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
As mentioned here https://github.com/apache/hudi/pull/7584#issuecomment-1370531069, `JsonRowDataDeserializationSchema` should be opened in flink 1.16. This PR does opening of deserializer in all places of use

### Change Logs

1. Updated azure to run flink tests with 1.16 version

1. Moved `JsonDeserializationFunction` from test utils to main utils. It is needed to do the fixes below

1. Synchronized quickstart `ContinuousFileSource` with test utils `ContinuousFileSource`

1. Fixed several tests freezing with NPE in `ITTestDataStreamWrite` on flink 1.16

```
[Map -> row_data_to_hoodie_record (4/4)#3] WARN  org.apache.flink.runtime.taskmanager.Task [] - Map -> row_data_to_hoodie_record (4/4)#3 (c24fd03f94105404d61b4e42c1d737cb_20ba6b65f97481d5570070de90e4e791_3_3) 
switched from RUNNING to FAILED with failure cause: java.lang.NullPointerException
	at org.apache.hudi.avro.HoodieAvroUtils.getFieldVal(HoodieAvroUtils.java:515)
	at org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldVal(HoodieAvroUtils.java:548)
	at org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldValAsString(HoodieAvroUtils.java:533)
	at org.apache.hudi.keygen.KeyGenUtils.getRecordKey(KeyGenUtils.java:144)
```

### Impact

Fixed NPE in `ContinuousFileSource` and in `ITTestDataStreamWrite` on flink 1.16

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
