### PR TITLE
[HUDI-5520] Fail MDT when list of log files grow unboundedly

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1056,7 +1056,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       logSize = metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().countInstants();
     }
     if (logSize > MAX_LOG_FILE_LIST_LENGTH) {
-      throw new HoodieException("List of log files has grown beyond " + MAX_LOG_FILE_LIST_LENGTH + ".");
+      throw new HoodieException("The metadata table log files appear to be growing unbounded due to a pending instant in the data table timeline. "
+          + "Please fix that and restart the pipeline.");
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -886,7 +886,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         }
       }
     });
-    assertTrue(e.getMessage().contains("List of log files has grown beyond"));
+    assertTrue(e.getMessage().contains("The metadata table log files appear to be growing unbounded due to a pending instant in the data table timeline."));
   }
 
   /**


### PR DESCRIPTION
### Change Logs

If there is an instance stuck pending then compaction will never occur. This change throws an exception if 1000 log files are created without a compaction occurring.

### Impact

Logfiles will no longer grow unbounded.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
