### PR TITLE
[HUDI-5381] Fix for class cast exception when running with Flink 1.15

### DIFF
--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -23,6 +23,7 @@ import org.apache.hudi.table.data.vector.VectorizedColumnBatch;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.vector.ColumnVector;
 import org.apache.flink.table.data.vector.writable.WritableColumnVector;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -266,7 +267,7 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     return !ensureBatch();
   }
 
-  public ColumnarRowData nextRecord() {
+  public RowData nextRecord() {
     // return the next row
     row.setRowId(this.nextRow++);
     return row;

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.ColumnarRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.vector.ColumnVector;
 import org.apache.flink.table.data.vector.VectorizedColumnBatch;
 import org.apache.flink.table.data.vector.writable.WritableColumnVector;
@@ -266,7 +267,7 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     return !ensureBatch();
   }
 
-  public ColumnarRowData nextRecord() {
+  public RowData nextRecord() {
     // return the next row
     row.setRowId(this.nextRow++);
     return row;

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ParquetColumnarRowSplitReader.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.format.cow.vector.reader;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.columnar.ColumnarRowData;
 import org.apache.flink.table.data.columnar.vector.ColumnVector;
 import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
@@ -266,7 +267,7 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     return !ensureBatch();
   }
 
-  public ColumnarRowData nextRecord() {
+  public RowData nextRecord() {
     // return the next row
     row.setRowId(this.nextRow++);
     return row;


### PR DESCRIPTION
### Change Logs

Simple fix to avoid class-cast issue when running with Flink 1.15. [The issue](https://issues.apache.org/jira/browse/HUDI-5381) is that `ColumnarRowData` moved to a different package between Flink 1.13 and 1.15, so the common hudi-flink code can't use as that a return type from code that lives in the versioned hudi-flink jars. I believe hudi-flink is compiled against Flink 1.13, as it's expecting the old package location for this class.

I now return the more generic `RowData` type, which obviously loses some of the specificity of `ColumnarRowData`, but hasn't moved location.

### Impact

N/A

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
