### PR TITLE
[HUDI-5540] Close write client after usage of DeleteMarker/RollbackTo…

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -62,10 +62,11 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
         true
       case Failure(e) =>
         logWarning(s"Failed: Could not clean marker instantTime: $instantTime.", e)
-        if (client != null) {
-          client.close()
-        }
         false
+    }
+
+    if (client != null) {
+      client.close()
     }
 
     Seq(Row(result))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi.command.procedures
 
+import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.table.marker.WriteMarkersFactory
 import org.apache.spark.internal.Logging
@@ -47,8 +48,9 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
     val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
     val basePath = getBasePath(tableName)
 
+    var client: SparkRDDWriteClient[_] = null
     val result = Try {
-      val client = createHoodieClient(jsc, basePath)
+      client = createHoodieClient(jsc, basePath)
       val config = client.getConfig
       val context = client.getEngineContext
       val table = HoodieSparkTable.create(config, context)
@@ -60,6 +62,9 @@ class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Log
         true
       case Failure(e) =>
         logWarning(s"Failed: Could not clean marker instantTime: $instantTime.", e)
+        if (client != null) {
+          client.close()
+        }
         false
     }
 


### PR DESCRIPTION
…InstantTime/RunClean/RunCompactionProcedure

### Change Logs

Close SparkRDDWriteClient after usage of DeleteMarker/RollbackToInstantTime/RunClean/RunCompactionProcedure so that the sparksql process can exit correctly 

### Impact

the sparksql process can exit correctly 

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
