### PR TITLE
[HUDI-5544] Improve log msgs during bulk insert

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -107,7 +107,6 @@ public class BulkInsertWriterHelper {
           : keyGen.getPartitionPath(record);
 
       if ((lastKnownPartitionPath == null) || !lastKnownPartitionPath.equals(partitionPath) || !handle.canWrite()) {
-        LOG.info("Creating new file for partition path " + partitionPath);
         handle = getRowCreateHandle(partitionPath);
         lastKnownPartitionPath = partitionPath;
       }
@@ -130,12 +129,15 @@ public class BulkInsertWriterHelper {
       if (isInputSorted) {
         close();
       }
+
+      LOG.info("Creating new file for partition path " + partitionPath);
       HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, getNextFileId(),
           instantTime, taskPartitionId, taskId, taskEpochId, rowType, preserveHoodieMetadata);
       handles.put(partitionPath, rowCreateHandle);
     } else if (!handles.get(partitionPath).canWrite()) {
       // even if there is a handle to the partition path, it could have reached its max size threshold. So, we close the handle here and
       // create a new one.
+      LOG.info("Rolling max-size file for partition path " + partitionPath);
       writeStatusList.add(handles.remove(partitionPath).close());
       HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, getNextFileId(),
           instantTime, taskPartitionId, taskId, taskEpochId, rowType, preserveHoodieMetadata);
@@ -146,6 +148,7 @@ public class BulkInsertWriterHelper {
 
   public void close() throws IOException {
     for (HoodieRowDataCreateHandle rowCreateHandle : handles.values()) {
+      LOG.info("Closing bulk insert file " + rowCreateHandle.getFileName());
       writeStatusList.add(rowCreateHandle.close());
     }
     handles.clear();


### PR DESCRIPTION
### Change Logs

Currently a log msg that says "Creating new file for partition path" is generated every time the current partition changes, even when no new file is being created (which is confusing).

Also if you have data flowing from multiple topics, with even a slight lag between them, you can wind up with current partition bouncing back and forth when the event time is close to the partition boundary. This in turn generates (in our case) upwards of 1M messages, given our data rate is between 5 and 20M records/second.

### Impact

N/A

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [X] Adequate tests were added if applicable
- [ ] CI passed
