### PR TITLE
[HUDI-5551] support seconds unit on event_time

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
@@ -101,7 +101,18 @@ public class WriteStatus implements Serializable {
       String eventTimeVal = optionalRecordMetadata.get().getOrDefault(METADATA_EVENT_TIME_KEY, null);
       try {
         if (!StringUtils.isNullOrEmpty(eventTimeVal)) {
-          long eventTime = DateTimeUtils.parseDateTime(eventTimeVal).toEpochMilli();
+          int length = eventTimeVal.length();
+          long millisEventTime;
+          // eventTimeVal in seconds unit
+          if (length == 10) {
+            millisEventTime = Long.parseLong(eventTimeVal) * 1000;
+          } else if (length == 13) {
+            // eventTimeVal in millis unit
+            millisEventTime = Long.parseLong(eventTimeVal);
+          } else {
+            throw new IllegalArgumentException("not support event_time format:" + eventTimeVal);
+          }
+          long eventTime = DateTimeUtils.parseDateTime(Long.toString(millisEventTime)).toEpochMilli();
           stat.setMinEventTime(eventTime);
           stat.setMaxEventTime(eventTime);
         }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestWriteStatus.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestWriteStatus.java
@@ -92,7 +92,8 @@ public class TestWriteStatus {
     // test with seconds eventTime
     status = new WriteStatus(false, 1.0);
     status.setStat(new HoodieWriteStat());
-    long minSeconds = 0L, maxSeconds = 0L;
+    long minSeconds = 0L;
+    long maxSeconds = 0L;
     for (int i = 0; i < 1000; i++) {
       Map<String, String> metadata = new HashMap<>();
       long eventTime = System.currentTimeMillis() / 1000;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestWriteStatus.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestWriteStatus.java
@@ -18,12 +18,19 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -52,5 +59,89 @@ public class TestWriteStatus {
     assertTrue(status.hasErrors());
     assertTrue(status.getWrittenRecords().isEmpty());
     assertEquals(2000, status.getTotalRecords());
+  }
+
+  @Test
+  public void testSuccessWithEventTime() {
+    // test with empty eventTime
+    WriteStatus status = new WriteStatus(false, 1.0);
+    status.setStat(new HoodieWriteStat());
+    for (int i = 0; i < 1000; i++) {
+      Map<String, String> metadata = new HashMap<>();
+      metadata.put(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY, "");
+      status.markSuccess(mock(HoodieRecord.class), Option.of(metadata));
+    }
+    assertEquals(1000, status.getTotalRecords());
+    assertFalse(status.hasErrors());
+    assertNull(status.getStat().getMaxEventTime());
+    assertNull(status.getStat().getMinEventTime());
+
+    // test with null eventTime
+    status = new WriteStatus(false, 1.0);
+    status.setStat(new HoodieWriteStat());
+    for (int i = 0; i < 1000; i++) {
+      Map<String, String> metadata = new HashMap<>();
+      metadata.put(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY, null);
+      status.markSuccess(mock(HoodieRecord.class), Option.of(metadata));
+    }
+    assertEquals(1000, status.getTotalRecords());
+    assertFalse(status.hasErrors());
+    assertNull(status.getStat().getMaxEventTime());
+    assertNull(status.getStat().getMinEventTime());
+
+    // test with seconds eventTime
+    status = new WriteStatus(false, 1.0);
+    status.setStat(new HoodieWriteStat());
+    long minSeconds = 0L, maxSeconds = 0L;
+    for (int i = 0; i < 1000; i++) {
+      Map<String, String> metadata = new HashMap<>();
+      long eventTime = System.currentTimeMillis() / 1000;
+      if (i == 0) {
+        minSeconds = eventTime;
+      } else if (i == 999) {
+        maxSeconds = eventTime;
+      }
+      metadata.put(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY, String.valueOf(eventTime));
+      status.markSuccess(mock(HoodieRecord.class), Option.of(metadata));
+    }
+    assertEquals(1000, status.getTotalRecords());
+    assertFalse(status.hasErrors());
+    assertEquals(maxSeconds * 1000L, status.getStat().getMaxEventTime());
+    assertEquals(minSeconds * 1000L, status.getStat().getMinEventTime());
+
+    // test with millis eventTime
+    status = new WriteStatus(false, 1.0);
+    status.setStat(new HoodieWriteStat());
+    minSeconds = 0L;
+    maxSeconds = 0L;
+    for (int i = 0; i < 1000; i++) {
+      Map<String, String> metadata = new HashMap<>();
+      long eventTime = System.currentTimeMillis();
+      if (i == 0) {
+        minSeconds = eventTime;
+      } else if (i == 999) {
+        maxSeconds = eventTime;
+      }
+      metadata.put(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY, String.valueOf(eventTime));
+      status.markSuccess(mock(HoodieRecord.class), Option.of(metadata));
+    }
+    assertEquals(1000, status.getTotalRecords());
+    assertFalse(status.hasErrors());
+    assertEquals(maxSeconds, status.getStat().getMaxEventTime());
+    assertEquals(minSeconds, status.getStat().getMinEventTime());
+
+    // test with error format eventTime
+    status = new WriteStatus(false, 1.0);
+    status.setStat(new HoodieWriteStat());
+    for (int i = 0; i < 1000; i++) {
+      Map<String, String> metadata = new HashMap<>();
+      metadata.put(DefaultHoodieRecordPayload.METADATA_EVENT_TIME_KEY, String.valueOf(i));
+      status.markSuccess(mock(HoodieRecord.class), Option.of(metadata));
+    }
+    assertEquals(1000, status.getTotalRecords());
+    assertFalse(status.hasErrors());
+    assertNull(status.getStat().getMaxEventTime());
+    assertNull(status.getStat().getMinEventTime());
+
   }
 }


### PR DESCRIPTION
### Change Logs
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/23207189/212252797-fcca4d17-d49b-48c0-970c-a576eaeed8ea.png">

When I used grafana to draw the metrics of commitFreshnessInMs, I found that the value of some tables was particularly large, and the tracking code found that it was the event_time unit of time is seconds, so submitting this pr supports the event_time in seconds
### Impact

event_time metrics

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
