### PR TITLE
[HUDI-5561] The preCombine method of PartialUpdateAvroPayload is not called

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
@@ -50,7 +50,7 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger {
 
     switch (legacyOperatingMode) {
       case PRE_COMBINING:
-        HoodieRecord res = preCombine(older, newer);
+        HoodieRecord res = preCombine(older, newer, newSchema, props);
         if (res == older) {
           return Option.of(Pair.of(res, oldSchema));
         } else {
@@ -71,10 +71,10 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger {
     return HoodieRecordType.AVRO;
   }
 
-  private HoodieRecord preCombine(HoodieRecord older, HoodieRecord newer) {
-    HoodieRecordPayload picked = unsafeCast(((HoodieAvroRecord) newer).getData().preCombine(((HoodieAvroRecord) older).getData()));
-    if (picked instanceof HoodieMetadataPayload) {
-      // NOTE: HoodieMetadataPayload return a new payload
+  private HoodieRecord preCombine(HoodieRecord older, HoodieRecord newer, Schema schema, Properties props) {
+    HoodieRecordPayload picked = unsafeCast(((HoodieAvroRecord) newer).getData().preCombine(((HoodieAvroRecord) older).getData(), schema, props));
+    if (picked instanceof HoodieMetadataPayload || picked instanceof PartialUpdateAvroPayload) {
+      // NOTE: HoodieMetadataPayload or PartialUpdateAvroPayload return a new payload
       return new HoodieAvroRecord(newer.getKey(), picked, newer.getOperation());
     }
     return picked.equals(((HoodieAvroRecord) newer).getData()) ? newer : older;

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieAvroRecordMerger.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieAvroRecordMerger.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests {@link TestHoodieAvroRecordMerger}.
+ */
+public class TestHoodieAvroRecordMerger {
+  private Schema schema;
+
+  String jsonSchema = "{\n"
+      + "  \"type\": \"record\",\n"
+      + "  \"name\": \"testMerge\", \"namespace\":\"org.apache.hudi\",\n"
+      + "  \"fields\": [\n"
+      + "    {\"name\": \"id\", \"type\": [\"null\", \"string\"]},\n"
+      + "    {\"name\": \"ts\", \"type\": [\"null\", \"long\"]},\n"
+      + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"]},\n"
+      + "    {\"name\": \"price\", \"type\": [\"null\", \"int\"]},\n"
+      + "    {\"name\": \"partition\", \"type\": [\"null\", \"string\"]}\n"
+      + "  ]\n"
+      + "}";
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    schema = new Schema.Parser().parse(jsonSchema);
+  }
+
+  @Test
+  public void testMerge() throws IOException {
+    HoodieKey key = new HoodieKey("1", "partition1");
+
+    GenericRecord record1 = new GenericData.Record(schema);
+    record1.put("id", "1");
+    record1.put("ts", 0L);
+    record1.put("name", "name1");
+    record1.put("price", null);
+    record1.put("partition", "partition1");
+
+    GenericRecord record2 = new GenericData.Record(schema);
+    record2.put("id", "1");
+    record2.put("ts", 1L);
+    record2.put("name", null);
+    record2.put("price", 1);
+    record2.put("partition", "partition1");
+
+    GenericRecord mergedRecord = new GenericData.Record(schema);
+    mergedRecord.put("id", "1");
+    mergedRecord.put("ts", 1L);
+    mergedRecord.put("name", "name1");
+    mergedRecord.put("price", 1);
+    mergedRecord.put("partition", "partition1");
+
+    //test PartialUpdateAvroPayload
+    PartialUpdateAvroPayload payload1 = new PartialUpdateAvroPayload(record1, 0L);
+    PartialUpdateAvroPayload payload2 = new PartialUpdateAvroPayload(record2, 1L);
+
+    HoodieAvroRecordMerger merger = new HoodieAvroRecordMerger();
+
+    Option<Pair<HoodieRecord, Schema>> newRecord =
+        merger.merge(new HoodieAvroRecord<>(key, payload1), schema, new HoodieAvroRecord<>(key, payload2), schema, new TypedProperties());
+
+    assertTrue(newRecord.isPresent());
+    assertEquals(mergedRecord, newRecord.get().getKey().getData());
+
+    // test OverwriteWithLatestAvroPayload
+    OverwriteWithLatestAvroPayload payload3 = new OverwriteWithLatestAvroPayload(record1, 0L);
+    OverwriteWithLatestAvroPayload payload4 = new OverwriteWithLatestAvroPayload(record2, 1L);
+
+    Option<Pair<HoodieRecord, Schema>> latestRecord =
+        merger.merge(new HoodieAvroRecord<>(key, payload3), schema, new HoodieAvroRecord<>(key, payload4), schema, new TypedProperties());
+
+    assertTrue(latestRecord.isPresent());
+    assertEquals(record2, latestRecord.get().getKey().getData());
+  }
+
+}


### PR DESCRIPTION
### Change Logs

The preCombine method we are using is```T preCombine(T oldValue);```This method returns the newer record.

For PartialUpdateAvroPayload we should return a new merged record, and this is implemented by ```T preCombine(T oldValue, Schema schema, Properties properties)```.

With this change,  PartialUpdateAvroPayload will call ```T preCombine(T oldValue, Schema schema, Properties properties)``` , and other payloads still call ```T preCombine(T oldValue);```

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none

### Risk level (write none, low medium or high below)
none

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
