### PR TITLE
[HUDI-5563] Check table exist before drop table

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -617,7 +617,8 @@ case class HoodiePostAnalysisRule(sparkSession: SparkSession) extends Rule[Logic
         CreateHoodieTableCommand(table, ignoreIfExists)
       // Rewrite the DropTableCommand to DropHoodieTableCommand
       case DropTableCommand(tableName, ifExists, false, purge)
-        if sparkAdapter.isHoodieTable(tableName, sparkSession) =>
+        if sparkSession.sessionState.catalog.tableExists(tableName)
+          && sparkAdapter.isHoodieTable(tableName, sparkSession) =>
         DropHoodieTableCommand(tableName, ifExists, false, purge)
       // Rewrite the AlterTableDropPartitionCommand to AlterHoodieTableDropPartitionCommand
       case AlterTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi
 
 import org.apache.hadoop.fs.{LocalFileSystem, Path}
 import org.apache.hudi.common.fs.FSUtils
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 
@@ -48,6 +49,16 @@ class TestDropTable extends HoodieSparkSqlTestBase {
         checkAnswer(s"show tables like '$tableName'")()
         assertResult(true)(existsPath(s"${tmp.getCanonicalPath}/$tableName"))
       }
+    }
+  }
+
+  test("Test Drop Table if exists") {
+    // drop table if exists
+    spark.sql("drop table if exists non_existent_table")
+
+    // drop table
+    assertThrows[AnalysisException]{
+      spark.sql("drop table non_existent_table")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestDropTable.scala
@@ -52,7 +52,7 @@ class TestDropTable extends HoodieSparkSqlTestBase {
     }
   }
 
-  test("Test Drop Table if exists") {
+  test("Test Drop Table with non existent table") {
     // drop table if exists
     spark.sql("drop table if exists non_existent_table")
 


### PR DESCRIPTION
### Change Logs

Check table exist when drop table to avoid exec `drop table if exists non_existent_table` failure which caused by Exception thrown by `sparkAdapter.isHoodieTable`

### Impact

Drop table if exists will not fail when table does not exist

### Risk level (write none, low medium or high below)

none

### Documentation Update

None
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
