### PR TITLE
[HUDI-5606] Update to handle deletes in postgres debezium

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -34,7 +34,9 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerMetrics;
+import org.apache.hudi.utilities.deser.KafkaAvroSchemaDeserializer;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
 import org.apache.hudi.utilities.sources.RowSource;
@@ -56,6 +58,8 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.streaming.kafka010.KafkaUtils;
 import org.apache.spark.streaming.kafka010.LocationStrategies;
 import org.apache.spark.streaming.kafka010.OffsetRange;
+
+import static org.apache.hudi.utilities.sources.AvroKafkaSource.KAFKA_AVRO_VALUE_DESERIALIZER_SCHEMA;
 
 /**
  * Base class for Debezium streaming source which expects change events as Kafka Avro records.
@@ -86,19 +90,26 @@ public abstract class DebeziumSource extends RowSource {
     deserializerClassName = props.getString(DataSourceWriteOptions.KAFKA_AVRO_VALUE_DESERIALIZER_CLASS().key(),
         DataSourceWriteOptions.KAFKA_AVRO_VALUE_DESERIALIZER_CLASS().defaultValue());
 
+    // Currently, debezium source requires Confluent/Kafka schema-registry to fetch the latest schema.
+    if (schemaProvider == null || !(schemaProvider instanceof SchemaRegistryProvider)) {
+      schemaRegistryProvider = new SchemaRegistryProvider(props, sparkContext);
+      schemaProvider = schemaRegistryProvider;
+    } else {
+      schemaRegistryProvider = (SchemaRegistryProvider) schemaProvider;
+    }
+
     try {
       props.put(NATIVE_KAFKA_VALUE_DESERIALIZER_PROP, Class.forName(deserializerClassName).getName());
+      if (deserializerClassName.equals(KafkaAvroSchemaDeserializer.class.getName())) {
+        if (schemaProvider == null) {
+          throw new HoodieIOException("SchemaProvider has to be set to use KafkaAvroSchemaDeserializer");
+        }
+        props.put(KAFKA_AVRO_VALUE_DESERIALIZER_SCHEMA, schemaProvider.getSourceSchema().toString());
+      }
     } catch (ClassNotFoundException e) {
       String error = "Could not load custom avro kafka deserializer: " + deserializerClassName;
       LOG.error(error);
       throw new HoodieException(error, e);
-    }
-
-    // Currently, debezium source requires Confluent/Kafka schema-registry to fetch the latest schema.
-    if (schemaProvider == null || !(schemaProvider instanceof SchemaRegistryProvider)) {
-      schemaRegistryProvider = new SchemaRegistryProvider(props, sparkContext);
-    } else {
-      schemaRegistryProvider = (SchemaRegistryProvider) schemaProvider;
     }
 
     offsetGen = new KafkaOffsetGen(props);


### PR DESCRIPTION
### Change Logs

When a record is deleted in AbstractDebeziumAvroPayload,  we are trying to get using this method
```
super.getInsertValue(schema).get() 

```
however, this is throwing null pointer exception since recordBytes.length == 0 and it return empty Option. handled this with the code change in AbstractDebeziumAvroPayload. 

When there is a schema update and Confluent schema registry is being used, we have to fetch source schema in DebeziumSource class before deserialising the data into data frame , that change is handled. 

### Impact

Deletes are handled gracefully. 
Schema changes with schema registry are also handled gracefully.

### Risk level (write none, low medium or high below)

low

### Documentation Update

No changes in the configuration, features.

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
