### PR TITLE
[HUDI-5577] Validate option catalog.path in dfs mode

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -34,6 +34,7 @@ import org.apache.hudi.util.StreamerUtil;
 import org.apache.avro.Schema;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
@@ -99,6 +100,8 @@ public class HoodieCatalog extends AbstractCatalog {
 
   public HoodieCatalog(String name, Configuration options) {
     super(name, options.get(DEFAULT_DATABASE));
+    options.getOptional(CATALOG_PATH).orElseThrow(() ->
+        new ValidationException("Option [catalog.path] should not be empty."));
     this.catalogPathStr = options.get(CATALOG_PATH);
     this.hadoopConf = HadoopConfigurations.getHadoopConf(options);
     this.tableCommonOptions = CatalogOptions.tableCommonOptions(options);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -150,6 +151,8 @@ public class TestHoodieCatalog {
     File testDb = new File(tempFile, TEST_DEFAULT_DATABASE);
     testDb.mkdir();
     Map<String, String> catalogOptions = new HashMap<>();
+    assertThrows(ValidationException.class,
+        () -> catalog = new HoodieCatalog("hudi", Configuration.fromMap(catalogOptions)));
     catalogPathStr = tempFile.getAbsolutePath();
     catalogOptions.put(CATALOG_PATH.key(), catalogPathStr);
     catalogOptions.put(DEFAULT_DATABASE.key(), TEST_DEFAULT_DATABASE);


### PR DESCRIPTION
### Change Logs
It will throw `IllegalArgumentException` If `catalog.path` is `empty` in `dfs` mode, as below:
```java
Caused by: java.lang.IllegalArgumentException: Can not create a Path from a null string
    at org.apache.hadoop.fs.Path.checkPathArg(Path.java:125)
    at org.apache.hadoop.fs.Path.<init>(Path.java:137)
    at org.apache.hudi.common.fs.FSUtils.getFs(FSUtils.java:102)
    at org.apache.hudi.table.catalog.HoodieCatalog.open(HoodieCatalog.java:103)
    at org.apache.flink.table.catalog.CatalogManager.registerCatalog(CatalogManager.java:195)
    at org.apache.flink.table.api.internal.TableEnvironmentImpl.createCatalog(TableEnvironmentImpl.java:1297)
    at org.apache.flink.table.api.internal.TableEnvironmentImpl.executeInternal(TableEnvironmentImpl.java:1122)
    at org.apache.flink.table.api.internal.TableEnvironmentImpl.executeSql(TableEnvironmentImpl.java:742)
    at com.jd.flink.sql.runtime.SQLExecHelper.execSQL(SQLExecHelper.java:326)
    at com.jd.flink.sql.NGMain.main(NGMain.java:41)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:356) 
```


### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
