### PR TITLE
[HUDI-5585][flink]Fix flink creates and writes the table, the spark alter table reports an error

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HiveSchemaUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HiveSchemaUtils.java
@@ -181,9 +181,11 @@ public class HiveSchemaUtils {
    */
   public static List<FieldSchema> toHiveFieldSchema(TableSchema schema, boolean withOperationField) {
     List<FieldSchema> columns = new ArrayList<>();
-    Collection<String> metaFields = withOperationField
-        ? HoodieRecord.HOODIE_META_COLUMNS_WITH_OPERATION // caution that the set may break sequence
-        : HoodieRecord.HOODIE_META_COLUMNS;
+    Collection<String> metaFields = new ArrayList<>(HoodieRecord.HOODIE_META_COLUMNS);
+    if (withOperationField) {
+      metaFields.add(HoodieRecord.OPERATION_METADATA_FIELD);
+    }
+
     for (String metaField : metaFields) {
       columns.add(new FieldSchema(metaField, "string", null));
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.catalog;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -438,8 +439,10 @@ public class HoodieHiveCatalog extends AbstractCatalog {
       LOG.warn("{} does not have any hoodie schema, and use hive table schema to infer the table schema", tablePath);
       schema = HiveSchemaUtils.convertTableSchema(hiveTable);
     }
+    org.apache.flink.table.api.Schema resultSchema = DataTypeUtils.dropIfExistsColumns(schema, HoodieRecord.HOODIE_META_COLUMNS_WITH_OPERATION);
+
     Map<String, String> options = supplementOptions(tablePath, parameters);
-    return CatalogTable.of(schema, parameters.get(COMMENT),
+    return CatalogTable.of(resultSchema, parameters.get(COMMENT),
         HiveSchemaUtils.getFieldNames(hiveTable.getPartitionKeys()), options);
   }
 
@@ -819,7 +822,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
     try (HoodieFlinkWriteClient<?> writeClient = createWriteClient(tablePath, table)) {
       boolean hiveStylePartitioning = Boolean.parseBoolean(table.getOptions().get(FlinkOptions.HIVE_STYLE_PARTITIONING.key()));
       writeClient.deletePartitions(
-          Collections.singletonList(HoodieCatalogUtil.inferPartitionPath(hiveStylePartitioning, partitionSpec)),
+              Collections.singletonList(HoodieCatalogUtil.inferPartitionPath(hiveStylePartitioning, partitionSpec)),
               HoodieActiveTimeline.createNewInstantTime())
           .forEach(writeStatus -> {
             if (writeStatus.hasErrors()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table.catalog;
 
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -28,6 +29,8 @@ import org.apache.hudi.util.AvroSchemaConverter;
 
 import org.apache.avro.Schema;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -39,7 +42,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -49,6 +54,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+import static org.apache.hudi.common.model.HoodieRecord.OPERATION_METADATA_FIELD;
 import static org.apache.hudi.common.table.HoodieTableMetaClient.AUXILIARYFOLDER_NAME;
 
 /**
@@ -169,7 +175,8 @@ public class TableOptionProperties {
       Configuration hadoopConf,
       Map<String, String> properties,
       List<String> partitionKeys) {
-    Schema schema = AvroSchemaConverter.convertToSchema(catalogTable.getSchema().toPhysicalRowDataType().getLogicalType());
+    RowType containMetaFields = getContainMetaFields(catalogTable);
+    Schema schema = AvroSchemaConverter.convertToSchema(containMetaFields);
     MessageType messageType = TableSchemaResolver.convertAvroSchemaToParquet(schema, hadoopConf);
     String sparkVersion = catalogTable.getOptions().getOrDefault(SPARK_VERSION, DEFAULT_SPARK_VERSION);
     Map<String, String> sparkTableProperties = SparkDataSourceTableUtils.getSparkTableProperties(
@@ -182,6 +189,21 @@ public class TableOptionProperties {
         .filter(e -> KEY_MAPPING.containsKey(e.getKey()) && !catalogTable.getOptions().containsKey(KEY_MAPPING.get(e.getKey())))
         .collect(Collectors.toMap(e -> KEY_MAPPING.get(e.getKey()),
             e -> e.getKey().equalsIgnoreCase(FlinkOptions.TABLE_TYPE.key()) ? VALUE_MAPPING.get(e.getValue()) : e.getValue()));
+  }
+
+  private static RowType getContainMetaFields(CatalogTable catalogTable) {
+    RowType rowType = (RowType) catalogTable.getSchema().toPhysicalRowDataType().getLogicalType().copy();
+    boolean withOperationField = Boolean.parseBoolean(catalogTable.getOptions().getOrDefault(FlinkOptions.CHANGELOG_ENABLED.key(), "false"));
+    Collection<String> metaFields = new ArrayList<>(HoodieRecord.HOODIE_META_COLUMNS);
+    if (withOperationField) {
+      metaFields.add(OPERATION_METADATA_FIELD);
+    }
+    ArrayList<RowType.RowField> rowFields = new ArrayList<>();
+    for (String metaField : metaFields) {
+      rowFields.add(new RowType.RowField(metaField, new VarCharType(10000)));
+    }
+    rowFields.addAll(rowType.getFields());
+    return new RowType(false, rowFields);
   }
 
   public static Map<String, String> translateSparkTableProperties2Flink(Map<String, String> options) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
@@ -34,7 +34,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -166,29 +165,6 @@ public class DataTypeUtils {
       fields.add(DataTypes.FIELD(fieldNames.get(i), fieldTypes.get(i)));
     }
     return DataTypes.ROW(fields.stream().toArray(DataTypes.Field[]::new)).notNull();
-  }
-
-  /**
-   * drop some columns.
-   *
-   * @param schema
-   * @param dropCols
-   * @return
-   */
-  public static org.apache.flink.table.api.Schema dropIfExistsColumns(org.apache.flink.table.api.Schema schema, Collection<String> dropCols) {
-    ArrayList<org.apache.flink.table.api.Schema.UnresolvedColumn> unresolvedColumns = new ArrayList<>(schema.getColumns());
-    unresolvedColumns.removeIf(c -> dropCols.contains(c.getName()));
-    org.apache.flink.table.api.Schema.Builder builder =
-        org.apache.flink.table.api.Schema.newBuilder()
-            .fromColumns(unresolvedColumns);
-    if (schema.getPrimaryKey().isPresent()) {
-      builder.primaryKey(schema.getPrimaryKey().get().getColumnNames());
-    }
-    if (schema.getWatermarkSpecs() != null) {
-      schema.getWatermarkSpecs().forEach(w -> builder.watermark(w.getColumnName(), w.getWatermarkExpression()));
-    }
-    org.apache.flink.table.api.Schema resultSchema = builder.build();
-    return resultSchema;
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
@@ -34,6 +34,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -165,6 +166,29 @@ public class DataTypeUtils {
       fields.add(DataTypes.FIELD(fieldNames.get(i), fieldTypes.get(i)));
     }
     return DataTypes.ROW(fields.stream().toArray(DataTypes.Field[]::new)).notNull();
+  }
+
+  /**
+   * drop some columns.
+   *
+   * @param schema
+   * @param dropCols
+   * @return
+   */
+  public static org.apache.flink.table.api.Schema dropIfExistsColumns(org.apache.flink.table.api.Schema schema, Collection<String> dropCols) {
+    ArrayList<org.apache.flink.table.api.Schema.UnresolvedColumn> unresolvedColumns = new ArrayList<>(schema.getColumns());
+    unresolvedColumns.removeIf(c -> dropCols.contains(c.getName()));
+    org.apache.flink.table.api.Schema.Builder builder =
+        org.apache.flink.table.api.Schema.newBuilder()
+            .fromColumns(unresolvedColumns);
+    if (schema.getPrimaryKey().isPresent()) {
+      builder.primaryKey(schema.getPrimaryKey().get().getColumnNames());
+    }
+    if (schema.getWatermarkSpecs() != null) {
+      schema.getWatermarkSpecs().forEach(w -> builder.watermark(w.getColumnName(), w.getWatermarkExpression()));
+    }
+    org.apache.flink.table.api.Schema resultSchema = builder.build();
+    return resultSchema;
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
@@ -138,7 +138,11 @@ public class TestHoodieHiveCatalog {
         .map(f -> f.getName() + ":" + f.getType())
         .collect(Collectors.joining(","));
     assertEquals("par1:string", partitionSchema);
-
+    String avroSchemaStr = hiveTable.getParameters().get("spark.sql.sources.schema.part.0");
+    String expectAvroSchemaStr =
+        "{\"type\":\"struct\",\"fields\":[{\"name\":\"_hoodie_commit_time\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_commit_seqno\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_record_key\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_partition_path\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_file_name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"uuid\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"age\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"ts\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"par1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}";
+    assertEquals(avroSchemaStr, expectAvroSchemaStr);
+    
     // validate catalog table
     CatalogBaseTable table1 = hoodieCatalog.getTable(tablePath);
     assertEquals("hudi", table1.getOptions().get(CONNECTOR.key()));

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
@@ -138,11 +138,22 @@ public class TestHoodieHiveCatalog {
         .map(f -> f.getName() + ":" + f.getType())
         .collect(Collectors.joining(","));
     assertEquals("par1:string", partitionSchema);
+
+    // validate spark schema properties
     String avroSchemaStr = hiveTable.getParameters().get("spark.sql.sources.schema.part.0");
-    String expectAvroSchemaStr =
-        "{\"type\":\"struct\",\"fields\":[{\"name\":\"_hoodie_commit_time\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_commit_seqno\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_record_key\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_partition_path\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"_hoodie_file_name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"uuid\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"age\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"ts\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"par1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}";
-    assertEquals(avroSchemaStr, expectAvroSchemaStr);
-    
+    String expectedAvroSchemaStr = ""
+        + "{\"type\":\"struct\",\"fields\":[{\"name\":\"_hoodie_commit_time\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"_hoodie_commit_seqno\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"_hoodie_record_key\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"_hoodie_partition_path\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"_hoodie_file_name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"uuid\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},"
+        + "{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"age\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"ts\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"par1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}";
+    assertEquals(expectedAvroSchemaStr, avroSchemaStr);
+
     // validate catalog table
     CatalogBaseTable table1 = hoodieCatalog.getTable(tablePath);
     assertEquals("hudi", table1.getOptions().get(CONNECTOR.key()));


### PR DESCRIPTION

### Change Logs

Fix flink creates and writes the table, the spark alter table reports an error

After the flink hive catalog is created, it does not include meta information fields in the hive metadata, such as _hoodie_commit_time, etc. However, these fields are included in the spark creation table hive. So it leads to metadata incompatibility issues.

### Impact

Fix flink creates and writes the table, the spark alter table reports an error

### Risk level (write none, low medium or high below)

low

### Documentation Update


### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [X] Adequate tests were added if applicable
- [X] CI passed
