### PR TITLE
[DOC] Remove duplicated match clause in MergeInto syntax

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -759,7 +759,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.10.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.10.0/quick-start-guide.md
@@ -666,7 +666,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.10.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.10.1/quick-start-guide.md
@@ -683,7 +683,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.11.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.0/quick-start-guide.md
@@ -721,7 +721,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.11.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.11.1/quick-start-guide.md
@@ -719,7 +719,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -752,7 +752,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -752,7 +752,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.12.2/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.2/quick-start-guide.md
@@ -761,7 +761,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 

--- a/website/versioned_docs/version-0.9.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.9.0/quick-start-guide.md
@@ -610,7 +610,6 @@ MERGE INTO tableIdentifier AS target_alias
 USING (sub_query | tableIdentifier) AS source_alias
 ON <merge_condition>
 [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
-[ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
 [ WHEN NOT MATCHED [ AND <condition> ]  THEN <not_matched_action> ]
 
 <merge_condition> =A equal bool condition 


### PR DESCRIPTION
### Documentation Update

remove duplicated match clause in MergeInto syntax

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
