### PR TITLE
[HUDI-5558] Serializable interface implementation don't explicitly declare serialVersionUID

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/CleanFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/CleanFunction.java
@@ -43,6 +43,9 @@ import org.slf4j.LoggerFactory;
  */
 public class CleanFunction<T> extends AbstractRichFunction
     implements SinkFunction<T>, CheckpointedFunction, CheckpointListener {
+
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(CleanFunction.class);
 
   private final Configuration conf;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.streaming.api.operators.StreamSink;
  */
 public class StreamWriteOperator<I> extends AbstractWriteOperator<I> {
 
+  private static final long serialVersionUID = 1L;
+
   public StreamWriteOperator(Configuration conf) {
     super(new StreamWriteFunction<>(conf));
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class AppendWriteOperator<I> extends AbstractWriteOperator<I> {
 
+  private static final long serialVersionUID = 1L;
+
   public AppendWriteOperator(Configuration conf, RowType rowType) {
     super(new AppendWriteFunction<>(conf, rowType));
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
@@ -81,6 +81,8 @@ import static org.apache.hudi.util.StreamerUtil.isValidFile;
 public class BootstrapOperator<I, O extends HoodieRecord<?>>
     extends AbstractStreamOperator<O> implements OneInputStreamOperator<I, O> {
 
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(BootstrapOperator.class);
 
   protected HoodieTable<?, ?, ?, ?> hoodieTable;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/aggregate/BootstrapAggFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/aggregate/BootstrapAggFunction.java
@@ -25,6 +25,9 @@ import org.apache.flink.api.common.functions.AggregateFunction;
  * function {@link org.apache.hudi.sink.bootstrap.BootstrapOperator}.
  */
 public class BootstrapAggFunction implements AggregateFunction<Integer, BootstrapAccumulator, Integer> {
+
+  private static final long serialVersionUID = 1L;
+
   public static final String NAME = BootstrapAggFunction.class.getSimpleName();
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/batch/BatchBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/batch/BatchBootstrapOperator.java
@@ -42,6 +42,8 @@ import java.util.Set;
 public class BatchBootstrapOperator<I, O extends HoodieRecord<?>>
     extends BootstrapOperator<I, O> {
 
+  private static final long serialVersionUID = 1L;
+
   private Set<String> partitionPathSet;
   private boolean haveSuccessfulCommits;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -50,6 +50,8 @@ import java.util.Set;
  */
 public class BucketStreamWriteFunction<I> extends StreamWriteFunction<I> {
 
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(BucketStreamWriteFunction.class);
 
   private int parallelism;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteOperator.java
@@ -30,6 +30,8 @@ import org.apache.flink.configuration.Configuration;
  */
 public class BucketStreamWriteOperator<I> extends AbstractWriteOperator<I> {
 
+  private static final long serialVersionUID = 1L;
+
   public BucketStreamWriteOperator(Configuration conf) {
     super(new BucketStreamWriteFunction<>(conf));
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriteOperator.java
@@ -35,6 +35,8 @@ public class BulkInsertWriteOperator<I>
     extends AbstractWriteOperator<I>
     implements BoundedOneInput {
 
+  private static final long serialVersionUID = 1L;
+
   public BulkInsertWriteOperator(Configuration conf, RowType rowType) {
     super(new BulkInsertWriteFunction<>(conf, rowType));
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/sort/SortOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/sort/SortOperator.java
@@ -46,6 +46,8 @@ import org.slf4j.LoggerFactory;
 public class SortOperator extends TableStreamOperator<RowData>
     implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput {
 
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(SortOperator.class);
 
   private GeneratedNormalizedKeyComputer gComputer;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -64,6 +64,9 @@ import java.util.stream.Collectors;
  * the SQL API does not allow multiple sinks in one table sink provider.
  */
 public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
+
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(ClusteringCommitSink.class);
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -100,6 +100,9 @@ import static org.apache.hudi.table.format.FormatUtils.buildAvroRecordBySchema;
  */
 public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEvent> implements
     OneInputStreamOperator<ClusteringPlanEvent, ClusteringCommitEvent>, BoundedOneInput {
+
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(ClusteringOperator.class);
 
   private final Configuration conf;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanOperator.java
@@ -46,6 +46,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class ClusteringPlanOperator extends AbstractStreamOperator<ClusteringPlanEvent>
     implements OneInputStreamOperator<Object, ClusteringPlanEvent> {
 
+  private static final long serialVersionUID = 1L;
+
   /**
    * Config options.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanSourceFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanSourceFunction.java
@@ -48,6 +48,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ClusteringPlanSourceFunction extends AbstractRichFunction implements SourceFunction<ClusteringPlanEvent> {
 
+  private static final long serialVersionUID = 1L;
+
   protected static final Logger LOG = LoggerFactory.getLogger(ClusteringPlanSourceFunction.class);
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -58,6 +58,8 @@ public abstract class AbstractStreamWriteFunction<I>
     extends AbstractWriteFunction<I>
     implements CheckpointedFunction {
 
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(AbstractStreamWriteFunction.class);
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractWriteFunction.java
@@ -29,6 +29,9 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
  * @param <I> the input type
  */
 public abstract class AbstractWriteFunction<I> extends ProcessFunction<I, Object> implements BoundedOneInput {
+  
+  private static final long serialVersionUID = 1L;
+
   /**
    * Sets up the event gateway.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractWriteOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractWriteOperator.java
@@ -32,6 +32,9 @@ import org.apache.flink.streaming.api.operators.ProcessOperator;
 public abstract class AbstractWriteOperator<I>
     extends ProcessOperator<I, Object>
     implements OperatorEventHandler, BoundedOneInput {
+
+  private static final long serialVersionUID = 1L;
+
   private final AbstractWriteFunction<I> function;
 
   public AbstractWriteOperator(AbstractWriteFunction<I> function) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactOperator.java
@@ -51,6 +51,9 @@ import java.util.List;
  */
 public class CompactOperator extends TableStreamOperator<CompactionCommitEvent>
     implements OneInputStreamOperator<CompactionPlanEvent, CompactionCommitEvent> {
+
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(CompactOperator.class);
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -55,6 +55,9 @@ import java.util.stream.Collectors;
  * the SQL API does not allow multiple sinks in one table sink provider.
  */
 public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
+
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(CompactionCommitSink.class);
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanOperator.java
@@ -50,6 +50,8 @@ import static java.util.stream.Collectors.toList;
 public class CompactionPlanOperator extends AbstractStreamOperator<CompactionPlanEvent>
     implements OneInputStreamOperator<Object, CompactionPlanEvent>, BoundedOneInput {
 
+  private static final long serialVersionUID = 1L;
+
   /**
    * Config options.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanSourceFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanSourceFunction.java
@@ -50,6 +50,8 @@ import java.util.stream.Collectors;
  */
 public class CompactionPlanSourceFunction extends AbstractRichFunction implements SourceFunction<CompactionPlanEvent> {
 
+  private static final long serialVersionUID = 1L;
+
   protected static final Logger LOG = LoggerFactory.getLogger(CompactionPlanSourceFunction.class);
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
@@ -71,6 +71,8 @@ public class BucketAssignFunction<K, I, O extends HoodieRecord<?>>
     extends KeyedProcessFunction<K, I, O>
     implements CheckpointedFunction, CheckpointListener {
 
+  private static final long serialVersionUID = 1L;
+
   /**
    * Index cache(speed-up) state for the underneath file based(BloomFilter) indices.
    * When a record came in, we do these check:

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunction.java
@@ -45,6 +45,9 @@ import static org.apache.hudi.util.StreamerUtil.flinkConf2TypedProperties;
  */
 public class RowDataToHoodieFunction<I extends RowData, O extends HoodieRecord>
     extends RichMapFunction<I, O> {
+
+  private static final long serialVersionUID = 1L;
+
   /**
    * Row type of the input.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunctionWithRateLimit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/transform/RowDataToHoodieFunctionWithRateLimit.java
@@ -31,6 +31,9 @@ import org.apache.flink.table.types.logical.RowType;
  */
 public class RowDataToHoodieFunctionWithRateLimit<I extends RowData, O extends HoodieRecord>
     extends RowDataToHoodieFunction<I, O> {
+
+  private static final long serialVersionUID = 1L;
+
   /**
    * Total rate limit per second for this job.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
@@ -61,6 +61,8 @@ import java.util.concurrent.LinkedBlockingDeque;
 public class StreamReadOperator extends AbstractStreamOperatorAdapter<RowData>
     implements OneInputStreamOperator<MergeOnReadInputSplit, RowData> {
 
+  private static final long serialVersionUID = 1L;
+
   private static final Logger LOG = LoggerFactory.getLogger(StreamReadOperator.class);
 
   private static final int MINI_BATCH_SIZE = 2048;


### PR DESCRIPTION
### Change Logs

`Serializable` interface implementation don't explicitly declare `serialVersionUID`, which causes the `InvalidClassException` for the deserialization. `Serializable` interface implementation should explicitly declare serialVersionUID for all the implementation including their subclass implementation.

### Impact

Operators and functions of hudi-flink module explicitly declare `serialVersionUID`.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed