### PR TITLE
[HUDI-2608] Support json schema in SchemaRegistryProvider

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -142,4 +142,20 @@ public class StringUtils {
     }
     return Stream.of(input.split(delimiter)).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());
   }
+
+  public static String getSuffixBy(String input, int ch) {
+    int i = input.lastIndexOf(ch);
+    if (i == -1) {
+      return input;
+    }
+    return input.substring(i);
+  }
+
+  public static String removeSuffixBy(String input, int ch) {
+    int i = input.lastIndexOf(ch);
+    if (i == -1) {
+      return input;
+    }
+    return input.substring(0, i);
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -69,7 +69,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
 
   public Schema parseSchemaFromRegistry(String registryUrl) throws IOException {
     String schema = fetchSchemaFromRegistry(registryUrl);
-    SchemaConverter converter = config.contains(Config.SCHEMA_CONVERTER_PROP)
+    SchemaConverter converter = config.containsKey(Config.SCHEMA_CONVERTER_PROP)
         ? ReflectionUtils.loadClass(config.getString(Config.SCHEMA_CONVERTER_PROP))
         : s -> s;
     return new Schema.Parser().parse(converter.convert(schema));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.schema.converter;
+
+import org.apache.hudi.common.util.JsonUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.util.StringUtils.getSuffixBy;
+import static org.apache.hudi.common.util.StringUtils.removeSuffixBy;
+
+public class JsonToAvroSchemaConverter implements SchemaRegistryProvider.SchemaConverter {
+
+  private static final ObjectMapper MAPPER = JsonUtils.getObjectMapper();
+  private static final Map<String, String> JSON_TO_AVRO_TYPE = Stream.of(new String[][] {
+      {"string", "string"},
+      {"null", "null"},
+      {"boolean", "boolean"},
+      {"integer", "long"},
+      {"number", "double"}
+  }).collect(Collectors.collectingAndThen(Collectors.toMap(p -> p[0], p -> p[1]), Collections::<String, String>unmodifiableMap));
+  private static final Pattern SYMBOL_REGEX = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
+
+  @Override
+  public String convert(String jsonSchema) throws IOException {
+    JsonNode jsonNode = MAPPER.readTree(jsonSchema);
+    ObjectNode avroRecord = MAPPER.createObjectNode()
+        .put("type", "record")
+        .put("name", getAvroSchemaRecordName(jsonNode))
+        .put("doc", getAvroDoc(jsonNode));
+    Option<String> namespace = getAvroSchemaRecordNamespace(jsonNode);
+    if (namespace.isPresent()) {
+      avroRecord.put("namespace", namespace.get());
+    }
+    if (jsonNode.hasNonNull("properties")) {
+      avroRecord.set("fields", convertProperties(jsonNode.get("properties"), getRequired(jsonNode)));
+    } else {
+      avroRecord.set("fields", MAPPER.createArrayNode());
+    }
+    return avroRecord.toString();
+  }
+
+  private static ArrayNode convertProperties(JsonNode jsonProperties, Set<String> required) {
+    List<JsonNode> avroFields = new ArrayList<>();
+    jsonProperties.fieldNames().forEachRemaining(name ->
+        avroFields.add(tryConvertNestedProperty(name, jsonProperties.get(name))
+            .or(tryConvertArrayProperty(name, jsonProperties.get(name)))
+            .or(tryConvertEnumProperty(name, jsonProperties.get(name)))
+            .orElse(convertProperty(name, jsonProperties.get(name), required.contains(name)))));
+    return MAPPER.createArrayNode().addAll(avroFields);
+  }
+
+  private static Option<JsonNode> tryConvertNestedProperty(String name, JsonNode jsonProperty) {
+    if (!isJsonNestedType(jsonProperty)) {
+      return Option.empty();
+    }
+    JsonNode avroNode = MAPPER.createObjectNode()
+        .put("name", sanitizeAsAvroName(name))
+        .put("doc", getAvroDoc(jsonProperty))
+        .set("type", MAPPER.createObjectNode()
+            .put("type", "record")
+            .put("name", getAvroTypeName(jsonProperty, name))
+            .set("fields", convertProperties(jsonProperty.get("properties"), getRequired(jsonProperty))));
+
+    return Option.of(avroNode);
+  }
+
+  private static Option<JsonNode> tryConvertArrayProperty(String name, JsonNode jsonProperty) {
+    if (!isJsonArrayType(jsonProperty)) {
+      return Option.empty();
+    }
+    JsonNode avroItems;
+    JsonNode jsonItems = jsonProperty.get("items");
+    String itemName = getAvroTypeName(jsonItems, name) + "_child";
+    if (isJsonNestedType(jsonItems)) {
+      avroItems = MAPPER.createObjectNode()
+          .put("type", "record")
+          .put("name", itemName)
+          .set("fields", convertProperties(jsonItems.get("properties"), getRequired(jsonItems)));
+    } else {
+      avroItems = convertProperty(itemName, jsonItems, true);
+    }
+    JsonNode avroNode = MAPPER.createObjectNode()
+        .put("name", sanitizeAsAvroName(name))
+        .put("doc", getAvroDoc(jsonProperty))
+        .set("type", MAPPER.createObjectNode()
+            .put("type", "array")
+            .set("items", avroItems));
+
+    return Option.of(avroNode);
+  }
+
+  private static Option<JsonNode> tryConvertEnumProperty(String name, JsonNode jsonProperty) {
+    if (!isJsonEnumType(jsonProperty)) {
+      return Option.empty();
+    }
+    List<String> enums = new ArrayList<>();
+    jsonProperty.get("enum").iterator().forEachRemaining(e -> enums.add(e.asText()));
+    JsonNode avroType = enums.stream().allMatch(e -> SYMBOL_REGEX.matcher(e).matches())
+        ? MAPPER.createObjectNode()
+        .put("type", "enum")
+        .put("name", getAvroTypeName(jsonProperty, name))
+        .set("symbols", jsonProperty.get("enum"))
+        : TextNode.valueOf("string");
+    JsonNode avroNode = MAPPER.createObjectNode()
+        .put("name", sanitizeAsAvroName(name))
+        .put("doc", getAvroDoc(jsonProperty))
+        .set("type", avroType);
+
+    return Option.of(avroNode);
+  }
+
+  private static JsonNode convertProperty(String name, JsonNode jsonProperty, boolean isRequired) {
+    ObjectNode avroNode = MAPPER.createObjectNode()
+        .put("name", sanitizeAsAvroName(name))
+        .put("doc", getAvroDoc(jsonProperty));
+
+    // infer `default`
+    boolean nullable = !isRequired;
+    if (jsonProperty.has("default")) {
+      avroNode.set("default", jsonProperty.get("default"));
+    } else if (nullable) {
+      avroNode.set("default", NullNode.getInstance());
+    }
+
+    // infer `types`
+    Set<String> avroTypeSet = new HashSet<>();
+    if (jsonProperty.hasNonNull("oneOf") || jsonProperty.hasNonNull("allOf")) {
+      // prefer to look for `oneOf` and `allOf` for types
+      Option<JsonNode> oneOfTypes = Option.ofNullable(jsonProperty.get("oneOf"));
+      if (oneOfTypes.isPresent()) {
+        oneOfTypes.get().elements().forEachRemaining(e -> avroTypeSet.add(JSON_TO_AVRO_TYPE.get(e.get("type").asText())));
+      }
+      Option<JsonNode> allOfTypes = Option.ofNullable(jsonProperty.get("allOf"));
+      if (allOfTypes.isPresent()) {
+        allOfTypes.get().elements().forEachRemaining(e -> avroTypeSet.add(JSON_TO_AVRO_TYPE.get(e.get("type").asText())));
+      }
+    } else if (jsonProperty.has("type")) {
+      // fall back to `type` parameter
+      JsonNode jsonType = jsonProperty.get("type");
+      if (jsonType.isArray()) {
+        jsonType.elements().forEachRemaining(e -> avroTypeSet.add(JSON_TO_AVRO_TYPE.get(e.asText())));
+      } else {
+        avroTypeSet.add(JSON_TO_AVRO_TYPE.get(jsonType.asText()));
+      }
+    }
+    List<String> avroTypes = new ArrayList<>();
+    if (nullable || avroTypeSet.contains("null")) {
+      avroTypes.add("null");
+    }
+    avroTypeSet.remove("null");
+    avroTypes.addAll(avroTypeSet);
+    avroNode.set("type", avroTypes.size() > 1
+        ? MAPPER.createArrayNode().addAll(avroTypes.stream().map(TextNode::valueOf).collect(Collectors.toList()))
+        : TextNode.valueOf(avroTypes.get(0)));
+    return avroNode;
+  }
+
+  private static boolean isJsonNestedType(JsonNode jsonNode) {
+    return jsonNode.has("type") && Objects.equals(jsonNode.get("type").asText(), "object");
+  }
+
+  private static boolean isJsonArrayType(JsonNode jsonNode) {
+    return jsonNode.has("type") && Objects.equals(jsonNode.get("type").asText(), "array");
+  }
+
+  private static boolean isJsonEnumType(JsonNode jsonNode) {
+    return jsonNode.hasNonNull("enum") && jsonNode.get("enum").isArray();
+  }
+
+  private static Option<String> getAvroSchemaRecordNamespace(JsonNode jsonNode) {
+    if (jsonNode.hasNonNull("$id")) {
+      return Option.of(URI.create(jsonNode.get("$id").asText()).getHost());
+    }
+    return Option.empty();
+  }
+
+  private static String getAvroSchemaRecordName(JsonNode jsonNode) {
+    if (jsonNode.hasNonNull("title")) {
+      return sanitizeAsAvroName(jsonNode.get("title").asText());
+    }
+    if (jsonNode.hasNonNull("$id")) {
+      // infer name from host: http://www.my-example.com => "my_example"
+      String host = URI.create(jsonNode.get("$id").asText()).getHost();
+      String domain = removeSuffixBy(host, '.');
+      return sanitizeAsAvroName(getSuffixBy(domain, '.'));
+    }
+    // avro schema requires non-empty record name
+    return "no_name";
+  }
+
+  private static String sanitizeAsAvroName(String s) {
+    return s.replaceAll("[^A-Za-z0-9_]+", "_");
+  }
+
+  private static Set<String> getRequired(JsonNode jsonNode) {
+    if (!jsonNode.hasNonNull("required")) {
+      return Collections.emptySet();
+    }
+    JsonNode requiredNode = jsonNode.get("required");
+    Set<String> required = new HashSet<>(requiredNode.size());
+    jsonNode.get("required").elements().forEachRemaining(e -> required.add(e.asText()));
+    return required;
+  }
+
+  private static String getAvroTypeName(JsonNode jsonNode, String defaultName) {
+    return jsonNode.hasNonNull("title") ? jsonNode.get("title").asText() : defaultName;
+  }
+
+  private static String getAvroDoc(JsonNode jsonNode) {
+    return jsonNode.hasNonNull("description") ? jsonNode.get("description").asText() : "";
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/converter/JsonToAvroSchemaConverter.java
@@ -207,7 +207,11 @@ public class JsonToAvroSchemaConverter implements SchemaRegistryProvider.SchemaC
 
   private static Option<String> getAvroSchemaRecordNamespace(JsonNode jsonNode) {
     if (jsonNode.hasNonNull("$id")) {
-      return Option.of(URI.create(jsonNode.get("$id").asText()).getHost());
+      String host = URI.create(jsonNode.get("$id").asText()).getHost();
+      String avroNamespace = Stream.of(host.split("\\."))
+          .map(JsonToAvroSchemaConverter::sanitizeAsAvroName)
+          .collect(Collectors.joining("."));
+      return Option.of(avroNamespace);
     }
     return Option.empty();
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -41,12 +41,12 @@ import static org.mockito.Mockito.verify;
 
 class TestSchemaRegistryProvider {
 
-  private final static String BASIC_AUTH = "foo:bar";
+  private static final String BASIC_AUTH = "foo:bar";
 
-  private final static String REGISTRY_RESPONSE = "{\"schema\":\"{\\\"type\\\": \\\"record\\\", \\\"namespace\\\": \\\"example\\\", "
+  private static final String REGISTRY_RESPONSE = "{\"schema\":\"{\\\"type\\\": \\\"record\\\", \\\"namespace\\\": \\\"example\\\", "
       + "\\\"name\\\": \\\"FullName\\\",\\\"fields\\\": [{ \\\"name\\\": \\\"first\\\", \\\"type\\\": "
       + "\\\"string\\\" }]}\"}";
-  private final static String CONVERTED_SCHEMA = "{\"type\": \"record\", \"namespace\": \"com.example.hoodie\", "
+  private static final String CONVERTED_SCHEMA = "{\"type\": \"record\", \"namespace\": \"com.example.hoodie\", "
       + "\"name\": \"FullName\",\"fields\": [{ \"name\": \"first\", \"type\": "
       + "\"string\" }]}";
 
@@ -60,7 +60,7 @@ class TestSchemaRegistryProvider {
         put("hoodie.deltastreamer.schemaprovider.registry.baseUrl", "http://" + BASIC_AUTH + "@localhost");
         put("hoodie.deltastreamer.schemaprovider.registry.urlSuffix", "-value");
         put("hoodie.deltastreamer.schemaprovider.registry.url", "http://foo:bar@localhost");
-        put("hoodie.deltastreamer.schemaprovider.registry.schemaconverter", "org.apache.hudi.utilities.schema.TestSchemaRegistryProvider.DummySchemaConverter");
+        put("hoodie.deltastreamer.schemaprovider.registry.schemaconverter", DummySchemaConverter.class.getName());
         put("hoodie.deltastreamer.source.kafka.topic", "foo");
       }
     };

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -18,10 +18,12 @@
 
 package org.apache.hudi.utilities.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.avro.Schema;
 import org.apache.hudi.common.config.TypedProperties;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -39,30 +41,33 @@ import static org.mockito.Mockito.verify;
 
 class TestSchemaRegistryProvider {
 
-  private final String basicAuth = "foo:bar";
+  private final static String BASIC_AUTH = "foo:bar";
 
-  private final String json = "{\"schema\":\"{\\\"type\\\": \\\"record\\\", \\\"namespace\\\": \\\"example\\\", "
+  private final static String REGISTRY_RESPONSE = "{\"schema\":\"{\\\"type\\\": \\\"record\\\", \\\"namespace\\\": \\\"example\\\", "
       + "\\\"name\\\": \\\"FullName\\\",\\\"fields\\\": [{ \\\"name\\\": \\\"first\\\", \\\"type\\\": "
       + "\\\"string\\\" }]}\"}";
+  private final static String CONVERTED_SCHEMA = "{\"type\": \"record\", \"namespace\": \"com.example.hoodie\", "
+      + "\"name\": \"FullName\",\"fields\": [{ \"name\": \"first\", \"type\": "
+      + "\"string\" }]}";
 
-  private TypedProperties getProps() {
-    return new TypedProperties() {{
-        put("hoodie.deltastreamer.schemaprovider.registry.baseUrl", "http://" + basicAuth + "@localhost");
+  private static Schema getExpectedSchema() {
+    return new Schema.Parser().parse(CONVERTED_SCHEMA);
+  }
+
+  private static TypedProperties getProps() {
+    return new TypedProperties() {
+      {
+        put("hoodie.deltastreamer.schemaprovider.registry.baseUrl", "http://" + BASIC_AUTH + "@localhost");
         put("hoodie.deltastreamer.schemaprovider.registry.urlSuffix", "-value");
         put("hoodie.deltastreamer.schemaprovider.registry.url", "http://foo:bar@localhost");
+        put("hoodie.deltastreamer.schemaprovider.registry.schemaconverter", "org.apache.hudi.utilities.schema.TestSchemaRegistryProvider.DummySchemaConverter");
         put("hoodie.deltastreamer.source.kafka.topic", "foo");
       }
     };
   }
 
-  private Schema getExpectedSchema(String response) throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode node = mapper.readTree(new ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8)));
-    return (new Schema.Parser()).parse(node.get("schema").asText());
-  }
-
-  private SchemaRegistryProvider getUnderTest(TypedProperties props) throws IOException {
-    InputStream is = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+  private static SchemaRegistryProvider getUnderTest(TypedProperties props) throws IOException {
+    InputStream is = new ByteArrayInputStream(REGISTRY_RESPONSE.getBytes(StandardCharsets.UTF_8));
     SchemaRegistryProvider spyUnderTest = Mockito.spy(new SchemaRegistryProvider(props, null));
     Mockito.doReturn(is).when(spyUnderTest).getStream(Mockito.any());
     return spyUnderTest;
@@ -73,8 +78,8 @@ class TestSchemaRegistryProvider {
     SchemaRegistryProvider spyUnderTest = getUnderTest(getProps());
     Schema actual = spyUnderTest.getSourceSchema();
     assertNotNull(actual);
-    assertEquals(actual, getExpectedSchema(json));
-    verify(spyUnderTest, times(1)).setAuthorizationHeader(eq(basicAuth),
+    assertEquals(getExpectedSchema(), actual);
+    verify(spyUnderTest, times(1)).setAuthorizationHeader(eq(BASIC_AUTH),
         Mockito.any(HttpURLConnection.class));
   }
 
@@ -83,8 +88,8 @@ class TestSchemaRegistryProvider {
     SchemaRegistryProvider spyUnderTest = getUnderTest(getProps());
     Schema actual = spyUnderTest.getTargetSchema();
     assertNotNull(actual);
-    assertEquals(actual, getExpectedSchema(json));
-    verify(spyUnderTest, times(1)).setAuthorizationHeader(eq(basicAuth),
+    assertEquals(getExpectedSchema(), actual);
+    verify(spyUnderTest, times(1)).setAuthorizationHeader(eq(BASIC_AUTH),
         Mockito.any(HttpURLConnection.class));
   }
 
@@ -95,7 +100,7 @@ class TestSchemaRegistryProvider {
     SchemaRegistryProvider spyUnderTest = getUnderTest(props);
     Schema actual = spyUnderTest.getSourceSchema();
     assertNotNull(actual);
-    assertEquals(actual, getExpectedSchema(json));
+    assertEquals(getExpectedSchema(), actual);
     verify(spyUnderTest, times(0)).setAuthorizationHeader(Mockito.any(), Mockito.any());
   }
 
@@ -106,7 +111,18 @@ class TestSchemaRegistryProvider {
     SchemaRegistryProvider spyUnderTest = getUnderTest(props);
     Schema actual = spyUnderTest.getTargetSchema();
     assertNotNull(actual);
-    assertEquals(actual, getExpectedSchema(json));
+    assertEquals(getExpectedSchema(), actual);
     verify(spyUnderTest, times(0)).setAuthorizationHeader(Mockito.any(), Mockito.any());
+  }
+
+  public static class DummySchemaConverter implements SchemaRegistryProvider.SchemaConverter {
+
+    @Override
+    public String convert(String schema) throws IOException {
+      return ((ObjectNode) new ObjectMapper()
+          .readTree(schema))
+          .set("namespace", TextNode.valueOf("com.example.hoodie"))
+          .toString();
+    }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
@@ -32,6 +32,7 @@ class TestJsonToAvroSchemaConverter {
 
   @ParameterizedTest
   @ValueSource(strings = {
+      "enum-properties",
       "example-address",
       "example-calendar",
       "example-card",
@@ -44,7 +45,6 @@ class TestJsonToAvroSchemaConverter {
     String jsonSchema = loadJsonSchema(inputCase);
     String avroSchema = new JsonToAvroSchemaConverter().convert(jsonSchema);
     Schema schema = new Schema.Parser().parse(avroSchema);
-    System.out.println(schema.toString(true));
     Schema expected = new Schema.Parser().parse(loadAvroSchema(inputCase));
     assertEquals(expected, schema);
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/converter/TestJsonToAvroSchemaConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.schema.converter;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.apache.hudi.common.util.FileIOUtils.readAsUTFString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestJsonToAvroSchemaConverter {
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "example-address",
+      "example-calendar",
+      "example-card",
+      "example-geographical-location",
+      "multiple-properties",
+      "nested-properties",
+      "single-properties"
+  })
+  void testConvertJsonSchemaToAvroSchema(String inputCase) throws IOException {
+    String jsonSchema = loadJsonSchema(inputCase);
+    String avroSchema = new JsonToAvroSchemaConverter().convert(jsonSchema);
+    Schema schema = new Schema.Parser().parse(avroSchema);
+    System.out.println(schema.toString(true));
+    Schema expected = new Schema.Parser().parse(loadAvroSchema(inputCase));
+    assertEquals(expected, schema);
+  }
+
+  private String loadJsonSchema(String inputCase) throws IOException {
+    return readAsUTFString(getClass()
+        .getClassLoader()
+        .getResourceAsStream(String.format("schema-provider/json/%s/input.json", inputCase)));
+  }
+
+  private String loadAvroSchema(String inputCase) throws IOException {
+    return readAsUTFString(getClass()
+        .getClassLoader()
+        .getResourceAsStream(String.format("schema-provider/json/%s/expected.json", inputCase)));
+  }
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/enum-properties/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/enum-properties/expected.json
@@ -1,0 +1,24 @@
+{
+  "type" : "record",
+  "name" : "my_example",
+  "namespace" : "my_example.com",
+  "doc" : "User info",
+  "fields" : [ {
+    "name" : "name",
+    "type" : "string",
+    "doc" : ""
+  }, {
+    "name" : "gender",
+    "type" : {
+      "type" : "enum",
+      "name" : "gender",
+      "symbols" : [ "Male", "Female" ]
+    },
+    "doc" : "the gender"
+  }, {
+    "name" : "address",
+    "type" : [ "null", "string" ],
+    "doc" : "",
+    "default" : null
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/enum-properties/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/enum-properties/input.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://my-example.com/user.schema.json",
+  "description": "User info",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "gender": {
+      "description": "the gender",
+      "type": "string",
+      "enum": ["Male", "Female"]
+    },
+    "address": {
+      "type": "string"
+    }
+  },
+  "required": ["name", "gender"]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-address/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-address/expected.json
@@ -1,0 +1,39 @@
+{
+  "type" : "record",
+  "name" : "example",
+  "doc" : "An address similar to http://microformats.org/wiki/h-card",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "post_office_box",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "extended_address",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "street_address",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "locality",
+    "doc" : "",
+    "type" : "string"
+  }, {
+    "name" : "region",
+    "doc" : "",
+    "type" : "string"
+  }, {
+    "name" : "postal_code",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "country_name",
+    "doc" : "",
+    "type" : "string"
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-address/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-address/input.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://example.com/address.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "An address similar to http://microformats.org/wiki/h-card",
+  "type": "object",
+  "properties": {
+    "post-office-box": {
+      "type": "string"
+    },
+    "extended-address": {
+      "type": "string"
+    },
+    "street-address": {
+      "type": "string"
+    },
+    "locality": {
+      "type": "string"
+    },
+    "region": {
+      "type": "string"
+    },
+    "postal-code": {
+      "type": "string"
+    },
+    "country-name": {
+      "type": "string"
+    }
+  },
+  "required": [ "locality", "region", "country-name" ],
+  "dependentRequired": {
+    "post-office-box": [ "street-address" ],
+    "extended-address": [ "street-address" ]
+  }
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-calendar/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-calendar/expected.json
@@ -1,0 +1,60 @@
+{
+  "type" : "record",
+  "name" : "example",
+  "doc" : "A representation of an event",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "dtstart",
+    "doc" : "Event starting time",
+    "type" : "string"
+  }, {
+    "name" : "dtend",
+    "doc" : "Event ending time",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "summary",
+    "doc" : "",
+    "type" : "string"
+  }, {
+    "name" : "location",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "url",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "duration",
+    "doc" : "Event duration",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "rdate",
+    "doc" : "Recurrence date",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "rrule",
+    "doc" : "Recurrence rule",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "category",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "description",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "geo",
+    "doc" : "",
+    "default" : null,
+    "type" : "null"
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-calendar/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-calendar/input.json
@@ -1,0 +1,47 @@
+{
+  "$id": "https://example.com/calendar.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A representation of an event",
+  "type": "object",
+  "required": [ "dtstart", "summary" ],
+  "properties": {
+    "dtstart": {
+      "type": "string",
+      "description": "Event starting time"
+    },
+    "dtend": {
+      "type": "string",
+      "description": "Event ending time"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "duration": {
+      "type": "string",
+      "description": "Event duration"
+    },
+    "rdate": {
+      "type": "string",
+      "description": "Recurrence date"
+    },
+    "rrule": {
+      "type": "string",
+      "description": "Recurrence rule"
+    },
+    "category": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "geo": {
+      "$ref": "https://example.com/geographical-location.schema.json"
+    }
+  }
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-card/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-card/expected.json
@@ -1,0 +1,162 @@
+{
+  "type" : "record",
+  "name" : "example",
+  "doc" : "A representation of a person, company, organization, or place",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "fn",
+    "doc" : "Formatted Name",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "familyName",
+    "doc" : "",
+    "type" : "string"
+  }, {
+    "name" : "givenName",
+    "doc" : "",
+    "type" : "string"
+  }, {
+    "name" : "additionalName",
+    "doc" : "",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "name" : "additionalName_child",
+        "doc" : "",
+        "type" : "string"
+      }
+    }
+  }, {
+    "name" : "honorificPrefix",
+    "doc" : "",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "name" : "honorificPrefix_child",
+        "doc" : "",
+        "type" : "string"
+      }
+    }
+  }, {
+    "name" : "honorificSuffix",
+    "doc" : "",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "name" : "honorificSuffix_child",
+        "doc" : "",
+        "type" : "string"
+      }
+    }
+  }, {
+    "name" : "nickname",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "url",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "email",
+    "doc" : "",
+    "type" : {
+      "type" : "record",
+      "name" : "email",
+      "fields" : [ {
+        "name" : "type",
+        "doc" : "",
+        "default" : null,
+        "type" : [ "null", "string" ]
+      }, {
+        "name" : "value",
+        "doc" : "",
+        "default" : null,
+        "type" : [ "null", "string" ]
+      } ]
+    }
+  }, {
+    "name" : "tel",
+    "doc" : "",
+    "type" : {
+      "type" : "record",
+      "name" : "tel",
+      "fields" : [ {
+        "name" : "type",
+        "doc" : "",
+        "default" : null,
+        "type" : [ "null", "string" ]
+      }, {
+        "name" : "value",
+        "doc" : "",
+        "default" : null,
+        "type" : [ "null", "string" ]
+      } ]
+    }
+  }, {
+    "name" : "adr",
+    "doc" : "",
+    "default" : null,
+    "type" : "null"
+  }, {
+    "name" : "geo",
+    "doc" : "",
+    "default" : null,
+    "type" : "null"
+  }, {
+    "name" : "tz",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "photo",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "logo",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "sound",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "bday",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "title",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "role",
+    "doc" : "",
+    "default" : null,
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "org",
+    "doc" : "",
+    "type" : {
+      "type" : "record",
+      "name" : "org",
+      "fields" : [ {
+        "name" : "organizationName",
+        "doc" : "",
+        "default" : null,
+        "type" : [ "null", "string" ]
+      }, {
+        "name" : "organizationUnit",
+        "doc" : "",
+        "default" : null,
+        "type" : [ "null", "string" ]
+      } ]
+    }
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-card/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-card/input.json
@@ -1,0 +1,99 @@
+{
+  "$id": "https://example.com/card.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A representation of a person, company, organization, or place",
+  "type": "object",
+  "required": [ "familyName", "givenName" ],
+  "properties": {
+    "fn": {
+      "description": "Formatted Name",
+      "type": "string"
+    },
+    "familyName": {
+      "type": "string"
+    },
+    "givenName": {
+      "type": "string"
+    },
+    "additionalName": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "honorificPrefix": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "honorificSuffix": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "nickname": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "email": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "tel": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "adr": { "$ref": "https://example.com/address.schema.json" },
+    "geo": { "$ref": "https://example.com/geographical-location.schema.json" },
+    "tz": {
+      "type": "string"
+    },
+    "photo": {
+      "type": "string"
+    },
+    "logo": {
+      "type": "string"
+    },
+    "sound": {
+      "type": "string"
+    },
+    "bday": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "org": {
+      "type": "object",
+      "properties": {
+        "organizationName": {
+          "type": "string"
+        },
+        "organizationUnit": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-geographical-location/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-geographical-location/expected.json
@@ -1,0 +1,15 @@
+{
+  "type" : "record",
+  "name" : "Longitude_and_Latitude_Values",
+  "doc" : "A geographical coordinate.",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "latitude",
+    "doc" : "",
+    "type" : "double"
+  }, {
+    "name" : "longitude",
+    "doc" : "",
+    "type" : "double"
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/example-geographical-location/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/example-geographical-location/input.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://example.com/geographical-location.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Longitude and Latitude Values",
+  "description": "A geographical coordinate.",
+  "required": [ "latitude", "longitude" ],
+  "type": "object",
+  "properties": {
+    "latitude": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "longitude": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    }
+  }
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/multiple-properties/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/multiple-properties/expected.json
@@ -1,0 +1,15 @@
+{
+  "type" : "record",
+  "name" : "Product",
+  "doc" : "A product from Acme's catalog",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "productId",
+    "doc" : "The unique identifier for a product",
+    "type" : "long"
+  }, {
+    "name" : "productName",
+    "doc" : "Name of the product",
+    "type" : "string"
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/multiple-properties/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/multiple-properties/input.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    },
+    "productName": {
+      "description": "Name of the product",
+      "type": "string"
+    }
+  },
+  "required": [ "productId", "productName" ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/nested-properties/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/nested-properties/expected.json
@@ -1,0 +1,70 @@
+{
+  "type" : "record",
+  "name" : "Product",
+  "doc" : "A product from Acme's catalog",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "productId",
+    "doc" : "The unique identifier for a product",
+    "type" : "long"
+  }, {
+    "name" : "productName",
+    "doc" : "Name of the product",
+    "type" : "string"
+  }, {
+    "name" : "price",
+    "doc" : "The price of the product",
+    "type" : "double"
+  }, {
+    "name" : "tags",
+    "doc" : "Tags for the product",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "name" : "tags_child",
+        "doc" : "",
+        "type" : "string"
+      }
+    }
+  }, {
+    "name" : "dimensions",
+    "doc" : "",
+    "type" : {
+      "type" : "record",
+      "name" : "dimensions",
+      "fields" : [ {
+        "name" : "length",
+        "doc" : "",
+        "type" : "double"
+      }, {
+        "name" : "width",
+        "doc" : "",
+        "type" : "double"
+      }, {
+        "name" : "height",
+        "doc" : "",
+        "type" : "double"
+      } ]
+    }
+  }, {
+    "name" : "owners",
+    "doc" : "Owners for the product",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "type" : "record",
+        "name" : "owners_child",
+        "fields" : [ {
+          "name" : "name",
+          "doc" : "",
+          "type" : "string"
+        }, {
+          "name" : "company",
+          "doc" : "",
+          "default" : null,
+          "type" : [ "null", "string" ]
+        } ]
+      }
+    }
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/nested-properties/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/nested-properties/input.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    },
+    "productName": {
+      "description": "Name of the product",
+      "type": "string"
+    },
+    "price": {
+      "description": "The price of the product",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "tags": {
+      "description": "Tags for the product",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "dimensions": {
+      "type": "object",
+      "properties": {
+        "length": {
+          "type": "number"
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [ "length", "width", "height" ]
+    },
+    "owners": {
+      "description": "Owners for the product",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          }
+        },
+        "required": [ "name" ]
+      }
+    }
+  },
+  "required": [ "productId", "productName", "price" ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/single-properties/expected.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/single-properties/expected.json
@@ -1,0 +1,11 @@
+{
+  "type" : "record",
+  "name" : "Product",
+  "doc" : "A product from Acme's catalog",
+  "namespace" : "example.com",
+  "fields" : [ {
+    "name" : "productId",
+    "doc" : "The unique identifier for a product",
+    "type" : "long"
+  } ]
+}

--- a/hudi-utilities/src/test/resources/schema-provider/json/single-properties/input.json
+++ b/hudi-utilities/src/test/resources/schema-provider/json/single-properties/input.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    }
+  },
+  "required": [ "productId" ]
+}


### PR DESCRIPTION
### Change Logs

- Add config `hoodie.deltastreamer.schemaprovider.registry.schemaconverter` to support schema conversion in `SchemaRegistryProvider`
- Allow custom conversion by implementing `org.apache.hudi.utilities.schema.SchemaRegistryProvider.SchemaConverter`
- Add `JsonToAvroSchemaConverter` for json conversion.

Related https://github.com/apache/hudi/issues/3835

### Impact

Support more schema types with schema registry.

### Risk level

Low.

### Documentation Update

- [ ] Update website and release notes

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
