### PR TITLE
[HUDI-6356] Fix rollback logic on AbstractHoodieLogRecordReader when roll backed blocks are created with same instant

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -499,6 +499,8 @@ public abstract class AbstractHoodieLogRecordReader {
               String targetInstantForCommandBlock =
                   logBlock.getLogBlockHeader().get(TARGET_INSTANT_TIME);
               targetRollbackInstants.add(targetInstantForCommandBlock);
+              orderedInstantsList.remove(targetInstantForCommandBlock);
+              instantToBlocksMap.remove(targetInstantForCommandBlock);
             } else {
               throw new UnsupportedOperationException("Command type not yet supported.");
             }
@@ -527,13 +529,6 @@ public abstract class AbstractHoodieLogRecordReader {
        */
       for (int i = orderedInstantsList.size() - 1; i >= 0; i--) {
         String instantTime = orderedInstantsList.get(i);
-
-        // Exclude the blocks which are included in targetRollbackInstants set.
-        // Here, rollback can include instants affiliated to deltacommits or log compaction commits.
-        if (targetRollbackInstants.contains(instantTime)) {
-          numBlocksRolledBack += instantToBlocksMap.get(instantTime).size();
-          continue;
-        }
         List<HoodieLogBlock> instantsBlocks = instantToBlocksMap.get(instantTime);
         if (instantsBlocks.size() == 0) {
           throw new HoodieException("Data corrupted while writing. Found zero blocks for an instant " + instantTime);

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -1471,7 +1471,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         throw new UncheckedIOException(io);
       }
     });
-    assertEquals(200, readKeys.size(), "Stream collect should return all 200 records.");
+    assertEquals(200, readKeys.size(), "Stream collect should return all 200 records");
     assertEquals(50, newEmptyPayloads.size(), "Stream collect should return 50 records with empty payloads.");
     List<String> recordKeysInserted = allRecordsInserted.stream().map(s -> ((GenericRecord) s).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString())
         .collect(Collectors.toList());


### PR DESCRIPTION
### Change Logs

On metadata table deltacommmit timestamp is equivalent to main table commit's timestamp. So, if metadata sync fails it reuses the same timestamp. This change fixes the case where the log blocks are treated as valid if their corresponding rollback is already visited.

So, rollback block follow the ordering and do not effect the blocks that arrive later.
Ex:
LogBlock1 (Data log block with instant1)
LogBlock2 (Data log block with instant2)
LogBlock3 (Rollback block with instant3 and rolling back instant2)
LogBlock4 (Data log block with instant2)
After processing this change returns LogBlock1 and LogBlock4 as valid blocks.

### Impact

This change provides a bug fix for metadata table rollbacks. No impact to end users.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

Required documentation is already added within the code.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
