### PR TITLE
[MINOR] Eliminating Kryo from `hudi-integ-test-bundle`

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -87,11 +87,6 @@
                   <include>org.apache.hudi:hudi-timeline-service</include>
                   <include>org.apache.hudi:hudi-integ-test</include>
 
-                  <!-- Kryo -->
-                  <include>com.esotericsoftware:kryo-shaded</include>
-                  <include>com.esotericsoftware:minlog</include>
-                  <include>org.objenesis:objenesis</include>
-
                   <include>org.apache.hbase:hbase-common</include>
                   <include>org.apache.hbase:hbase-client</include>
                   <include>org.apache.hbase:hbase-hadoop-compat</include>
@@ -190,24 +185,6 @@
                 <relocation>
                   <pattern>org.apache.spark.sql.avro.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.spark.sql.avro.</shadedPattern>
-                </relocation>
-
-                <!-- Kryo -->
-                <relocation>
-                  <pattern>com.esotericsoftware.kryo.</pattern>
-                  <shadedPattern>org.apache.hudi.com.esotericsoftware.kryo.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.esotericsoftware.reflectasm.</pattern>
-                  <shadedPattern>org.apache.hudi.com.esotericsoftware.reflectasm.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.esotericsoftware.minlog.</pattern>
-                  <shadedPattern>org.apache.hudi.com.esotericsoftware.minlog.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.objenesis.</pattern>
-                  <shadedPattern>org.apache.hudi.org.objenesis.</shadedPattern>
                 </relocation>
 
                 <relocation>
@@ -480,14 +457,6 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-integ-test</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <!-- Kryo -->
-    <dependency>
-      <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo-shaded</artifactId>
-      <version>${kryo.shaded.version}</version>
-      <scope>compile</scope>
     </dependency>
 
     <!-- Hoodie - Tests -->


### PR DESCRIPTION
### Change Logs

"hudi-integ-test-bundle" is used w/ Spark, and therefore it can't shade Avro, currently breaking `HoodieSparkKryoRegistrar`

### Impact

Low

### Risk level (write none, low medium or high below)

N/A

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
