### PR TITLE
[MINOR] Fixing `TestStructuredStreaming` test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -20,14 +20,15 @@ package org.apache.hudi.functional
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hudi.DataSourceWriteOptions.STREAMING_CHECKPOINT_IDENTIFIER
 import org.apache.hudi.HoodieSinkCheckpoint.SINK_CHECKPOINT_KEY
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider
 import org.apache.hudi.common.config.HoodieStorageConfig
-import org.apache.hudi.common.model.{FileSlice, HoodieTableType}
+import org.apache.hudi.common.model.{FileSlice, HoodieTableType, WriteConcurrencyMode}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestTable}
 import org.apache.hudi.common.util.{CollectionUtils, CommitUtils}
-import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieLockConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.TableNotFoundException
 import org.apache.hudi.testutils.HoodieClientTestBase
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers, HoodieSinkCheckpoint}
@@ -259,6 +260,11 @@ class TestStructuredStreaming extends HoodieClientTestBase {
   def testStructuredStreamingWithCheckpoint(): Unit = {
     val (sourcePath, destPath) = initStreamingSourceAndDestPath("source", "dest")
 
+    val opts: Map[String, String] = commonOpts ++ Map(
+      HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key -> WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name,
+      HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key -> classOf[InProcessLockProvider].getName
+    )
+
     val records1 = recordsToStrings(dataGen.generateInsertsForPartition("000", 100, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH)).toList
     val inputDF1 = spark.read.json(spark.sparkContext.parallelize(records1, 2))
     val schema = inputDF1.schema
@@ -270,7 +276,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
       .json(sourcePath)
       .writeStream
       .format("org.apache.hudi")
-      .options(commonOpts)
+      .options(opts)
       .outputMode(OutputMode.Append)
       .option(STREAMING_CHECKPOINT_IDENTIFIER.key(), "streaming_identifier1")
       .option("checkpointLocation", s"$basePath/checkpoint1")
@@ -293,7 +299,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
       .json(sourcePath)
       .writeStream
       .format("org.apache.hudi")
-      .options(commonOpts)
+      .options(opts)
       .outputMode(OutputMode.Append)
       .option(STREAMING_CHECKPOINT_IDENTIFIER.key(), "streaming_identifier2")
       .option("checkpointLocation", s"$basePath/checkpoint2")
@@ -318,7 +324,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
     assertTrue(lastCheckpointCommitMetadata.isPresent)
     val checkpointMap = HoodieSinkCheckpoint.fromJson(lastCheckpointCommitMetadata.get().getMetadata(SINK_CHECKPOINT_KEY))
 
-    assertEquals(checkpointMap.get(identifier).orNull, expectBatchId)
+    assertEquals(expectBatchId, checkpointMap.get(identifier).orNull)
   }
 
   def structuredStreamingForTestClusteringRunner(sourcePath: String, destPath: String, tableType: HoodieTableType,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -87,7 +87,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
         .option("checkpointLocation", basePath + "/checkpoint")
         .outputMode(OutputMode.Append)
         .start(destPath)
-        .awaitTermination(10000)
+        .awaitTermination(30000)
       println("streaming ends")
     }
   }
@@ -195,7 +195,8 @@ class TestStructuredStreaming extends HoodieClientTestBase {
       assertEquals(1, countsPerCommit.length)
       assertEquals(commitInstantTime2, countsPerCommit(0).get(0))
     }
-    Await.result(Future.sequence(Seq(f1, f2)), Duration.Inf)
+
+    Await.result(Future.sequence(Seq(f1, f2)), Duration("120s"))
   }
 
   @ParameterizedTest
@@ -370,7 +371,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
       val commitInstantTime2 = latestInstant(fs, destPath, HoodieTimeline.COMMIT_ACTION)
       assertEquals(commitInstantTime2, countsPerCommit.maxBy(row => row.getAs[String](0)).get(0))
     }
-    Await.result(Future.sequence(Seq(f1, f2)), Duration.Inf)
+    Await.result(Future.sequence(Seq(f1, f2)), Duration("120s"))
   }
 
   private def getLatestFileGroupsFileId(partition: String):Array[String] = {


### PR DESCRIPTION
### Change Logs

There are a few issues w/ this test currently:

  - One of the test essentially implements a multi-writer scenario, but doesn't configure any LockProvider (in-process one should suffice)
  - It's blocking on some operations indefinitely, which in some circumstances seems to cause test to be spinning forever

### Impact

Fixing the test flakiness

### Risk level (write none, low medium or high below)

N/A

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
