### PR TITLE
[HUDI-5569] Fixing TableFileSystemView to detect early failed commits

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
@@ -273,6 +273,6 @@ public class FileSystemViewCommand {
 
     HoodieTimeline filteredTimeline = new HoodieDefaultTimeline(instantsStream,
         (Function<HoodieInstant, Option<byte[]>> & Serializable) metaClient.getActiveTimeline()::getInstantDetails);
-    return new HoodieTableFileSystemView(metaClient, filteredTimeline, writeTimeline.firstInstant(), statuses.toArray(new FileStatus[0]));
+    return new HoodieTableFileSystemView(metaClient, filteredTimeline, writeTimeline.getFirstNonSavepointCommit(), statuses.toArray(new FileStatus[0]));
   }
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/FileSystemViewCommand.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.NumericUtils;
 import org.apache.hudi.common.util.Option;
@@ -274,6 +273,6 @@ public class FileSystemViewCommand {
 
     HoodieTimeline filteredTimeline = new HoodieDefaultTimeline(instantsStream,
         (Function<HoodieInstant, Option<byte[]>> & Serializable) metaClient.getActiveTimeline()::getInstantDetails);
-    return new HoodieTableFileSystemView(metaClient, filteredTimeline, TimelineUtils.getFirstNotCompleted(writeTimeline), statuses.toArray(new FileStatus[0]));
+    return new HoodieTableFileSystemView(metaClient, filteredTimeline, writeTimeline.firstInstant(), statuses.toArray(new FileStatus[0]));
   }
 }

--- a/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
+++ b/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieBaseFile, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.TimelineUtils
+import org.apache.hudi.common.table.timeline.{HoodieInstant, TimelineUtils}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.exception.HoodieException
 import org.apache.logging.log4j.LogManager
@@ -80,7 +80,7 @@ class DedupeSparkJob(basePath: String,
 
     val allFiles = fs.listStatus(new org.apache.hadoop.fs.Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
-      TimelineUtils.getFirstNotCompleted(metadata.getActiveTimeline) , allFiles)
+      metadata.getActiveTimeline.getWriteTimeline.firstInstant(), allFiles)
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
     val filteredStatuses = latestFiles.map(f => f.getPath)
     LOG.info(s" List of files under partition: ${} =>  ${filteredStatuses.mkString(" ")}")
@@ -190,7 +190,7 @@ class DedupeSparkJob(basePath: String,
 
     val allFiles = fs.listStatus(new Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
-      TimelineUtils.getFirstNotCompleted(metadata.getActiveTimeline), allFiles)
+      metadata.getActiveTimeline.getCommitsTimeline.firstInstant(), allFiles)
 
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
 

--- a/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
+++ b/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
@@ -80,7 +80,7 @@ class DedupeSparkJob(basePath: String,
 
     val allFiles = fs.listStatus(new org.apache.hadoop.fs.Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
-      metadata.getActiveTimeline.getWriteTimeline.firstInstant(), allFiles)
+      metadata.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit, allFiles)
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
     val filteredStatuses = latestFiles.map(f => f.getPath)
     LOG.info(s" List of files under partition: ${} =>  ${filteredStatuses.mkString(" ")}")
@@ -190,7 +190,7 @@ class DedupeSparkJob(basePath: String,
 
     val allFiles = fs.listStatus(new Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
-      metadata.getActiveTimeline.getCommitsTimeline.firstInstant(), allFiles)
+      metadata.getActiveTimeline.getCommitsTimeline.getFirstNonSavepointCommit, allFiles)
 
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
 

--- a/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
+++ b/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieBaseFile, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.exception.HoodieException
 import org.apache.logging.log4j.LogManager
@@ -78,7 +79,8 @@ class DedupeSparkJob(basePath: String,
     val metadata = HoodieTableMetaClient.builder().setConf(fs.getConf).setBasePath(basePath).build()
 
     val allFiles = fs.listStatus(new org.apache.hadoop.fs.Path(s"$basePath/$duplicatedPartitionPath"))
-    val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(), allFiles)
+    val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
+      TimelineUtils.getFirstNotCompleted(metadata.getActiveTimeline) , allFiles)
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
     val filteredStatuses = latestFiles.map(f => f.getPath)
     LOG.info(s" List of files under partition: ${} =>  ${filteredStatuses.mkString(" ")}")
@@ -187,7 +189,8 @@ class DedupeSparkJob(basePath: String,
     val metadata = HoodieTableMetaClient.builder().setConf(fs.getConf).setBasePath(basePath).build()
 
     val allFiles = fs.listStatus(new Path(s"$basePath/$duplicatedPartitionPath"))
-    val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(), allFiles)
+    val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
+      TimelineUtils.getFirstNotCompleted(metadata.getActiveTimeline), allFiles)
 
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
 

--- a/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
+++ b/hudi-cli/src/main/scala/org/apache/hudi/cli/DedupeSparkJob.scala
@@ -190,7 +190,7 @@ class DedupeSparkJob(basePath: String,
 
     val allFiles = fs.listStatus(new Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitsTimeline.filterCompletedInstants(),
-      metadata.getActiveTimeline.getCommitsTimeline.getFirstNonSavepointCommit, allFiles)
+      metadata.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit, allFiles)
 
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.util.NumericUtils;
@@ -116,7 +117,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), true);
+    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()), true);
   }
 
   private void createPartitionedTable() throws IOException {
@@ -159,7 +160,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), true);
+    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()),true);
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
@@ -116,7 +116,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), metaClient.getActiveTimeline().getFirstNonSavepointCommit(), true);
+    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(), true);
   }
 
   private void createPartitionedTable() throws IOException {
@@ -159,7 +159,8 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),metaClient.getActiveTimeline().getFirstNonSavepointCommit(),true);
+    partitionedFsView = new HoodieTableFileSystemView(metaClient,
+        metaClient.getActiveTimeline(),metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(),true);
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
@@ -30,7 +30,6 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.util.NumericUtils;
@@ -117,7 +116,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()), true);
+    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), metaClient.getActiveTimeline().firstInstant(), true);
   }
 
   private void createPartitionedTable() throws IOException {
@@ -160,7 +159,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()),true);
+    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),metaClient.getActiveTimeline().firstInstant(),true);
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestFileSystemViewCommand.java
@@ -116,7 +116,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), metaClient.getActiveTimeline().firstInstant(), true);
+    nonpartitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), metaClient.getActiveTimeline().getFirstNonSavepointCommit(), true);
   }
 
   private void createPartitionedTable() throws IOException {
@@ -159,7 +159,7 @@ public class TestFileSystemViewCommand extends CLIFunctionalTestHarness {
     // Reload meta client and create fsView
     metaClient = HoodieTableMetaClient.reload(metaClient);
 
-    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),metaClient.getActiveTimeline().firstInstant(),true);
+    partitionedFsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),metaClient.getActiveTimeline().getFirstNonSavepointCommit(),true);
   }
 
   /**

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -170,7 +169,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // get fs and check number of latest files
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
+        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");
@@ -201,7 +200,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
+        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPathWithUpdates).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(2, filteredStatuses.size(), "There should be 2 files.");
@@ -232,7 +231,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
+        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPathWithUpserts).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");
@@ -266,7 +265,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
+        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedNoPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(2, filteredStatuses.size(), "There should be 2 files.");
@@ -301,7 +300,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // get fs and check number of latest files
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
+        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
@@ -169,7 +169,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // get fs and check number of latest files
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
+        metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");
@@ -200,7 +200,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
+        metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPathWithUpdates).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(2, filteredStatuses.size(), "There should be 2 files.");
@@ -231,7 +231,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
+        metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPathWithUpserts).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");
@@ -265,7 +265,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
+        metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedNoPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(2, filteredStatuses.size(), "There should be 2 files.");
@@ -300,7 +300,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // get fs and check number of latest files
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
+        metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit(),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestRepairsCommand.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -169,6 +170,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // get fs and check number of latest files
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");
@@ -199,6 +201,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPathWithUpdates).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(2, filteredStatuses.size(), "There should be 2 files.");
@@ -229,6 +232,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPathWithUpserts).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");
@@ -262,6 +266,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     connectTableAndReloadMetaClient(tablePath);
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedNoPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(2, filteredStatuses.size(), "There should be 2 files.");
@@ -296,6 +301,7 @@ public class ITTestRepairsCommand extends HoodieCLIIntegrationTestBase {
     // get fs and check number of latest files
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
         fs.listStatus(new Path(Paths.get(tablePath, duplicatedPartitionPath).toString())));
     List<String> filteredStatuses = fsView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
     assertEquals(3, filteredStatuses.size(), "There should be 3 files.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -82,7 +82,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
     HoodieCompactionPlan plan = getCompactionPlan(metaClient, compactionInstant);
     HoodieTableFileSystemView fsView =
         new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
-            .firstInstant());
+            .getFirstNonSavepointCommit());
 
     if (plan.getOperations() != null) {
       List<CompactionOperation> ops = plan.getOperations().stream()
@@ -205,7 +205,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
 
     final HoodieTableFileSystemView fsView =
         new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
-            .firstInstant());
+            .getFirstNonSavepointCommit());
     List<Pair<HoodieLogFile, HoodieLogFile>> renameActions =
         failed.stream().flatMap(v -> getRenamingActionsToAlignWithCompactionOperation(metaClient, compactionInstant,
             v.getOperation(), Option.of(fsView)).stream()).collect(Collectors.toList());
@@ -236,7 +236,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       Option<HoodieTableFileSystemView> fsViewOpt) {
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
         : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
-        .firstInstant());
+        .getFirstNonSavepointCommit());
     HoodieInstant lastInstant = metaClient.getCommitsAndCompactionTimeline().lastInstant().get();
     FileSlice merged =
         fileSystemView.getLatestMergedFileSlicesBeforeOrOn(op.getPartitionPath(), lastInstant.getTimestamp())
@@ -284,7 +284,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       CompactionOperation operation, Option<HoodieTableFileSystemView> fsViewOpt) throws IOException {
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
         : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
-        .firstInstant());
+        .getFirstNonSavepointCommit());
     Option<HoodieInstant> lastInstant = metaClient.getCommitsAndCompactionTimeline().lastInstant();
     try {
       if (lastInstant.isPresent()) {
@@ -393,7 +393,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       Option<HoodieTableFileSystemView> fsViewOpt, boolean skipValidation) throws IOException {
     HoodieTableFileSystemView fsView = fsViewOpt.isPresent() ? fsViewOpt.get()
         : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(),
-        metaClient.getCommitsAndCompactionTimeline().firstInstant());
+        metaClient.getCommitsAndCompactionTimeline().getFirstNonSavepointCommit());
     HoodieCompactionPlan plan = getCompactionPlan(metaClient, compactionInstant);
     if (plan.getOperations() != null) {
       LOG.info(
@@ -434,7 +434,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
     List<Pair<HoodieLogFile, HoodieLogFile>> result = new ArrayList<>();
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
         : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
-        .firstInstant());
+        .getFirstNonSavepointCommit());
     if (!skipValidation) {
       validateCompactionOperation(metaClient, compactionInstant, operation, Option.of(fileSystemView));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -33,7 +33,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
@@ -82,7 +81,8 @@ public class CompactionAdminClient extends BaseHoodieClient {
       int parallelism) throws IOException {
     HoodieCompactionPlan plan = getCompactionPlan(metaClient, compactionInstant);
     HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
+            .firstInstant());
 
     if (plan.getOperations() != null) {
       List<CompactionOperation> ops = plan.getOperations().stream()
@@ -204,7 +204,8 @@ public class CompactionAdminClient extends BaseHoodieClient {
     }
 
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
+            .firstInstant());
     List<Pair<HoodieLogFile, HoodieLogFile>> renameActions =
         failed.stream().flatMap(v -> getRenamingActionsToAlignWithCompactionOperation(metaClient, compactionInstant,
             v.getOperation(), Option.of(fsView)).stream()).collect(Collectors.toList());
@@ -234,7 +235,8 @@ public class CompactionAdminClient extends BaseHoodieClient {
       HoodieTableMetaClient metaClient, String compactionInstant, CompactionOperation op,
       Option<HoodieTableFileSystemView> fsViewOpt) {
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
+        .firstInstant());
     HoodieInstant lastInstant = metaClient.getCommitsAndCompactionTimeline().lastInstant().get();
     FileSlice merged =
         fileSystemView.getLatestMergedFileSlicesBeforeOrOn(op.getPartitionPath(), lastInstant.getTimestamp())
@@ -281,7 +283,8 @@ public class CompactionAdminClient extends BaseHoodieClient {
   private ValidationOpResult validateCompactionOperation(HoodieTableMetaClient metaClient, String compactionInstant,
       CompactionOperation operation, Option<HoodieTableFileSystemView> fsViewOpt) throws IOException {
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
+        .firstInstant());
     Option<HoodieInstant> lastInstant = metaClient.getCommitsAndCompactionTimeline().lastInstant();
     try {
       if (lastInstant.isPresent()) {
@@ -389,7 +392,8 @@ public class CompactionAdminClient extends BaseHoodieClient {
       HoodieTableMetaClient metaClient, String compactionInstant, int parallelism,
       Option<HoodieTableFileSystemView> fsViewOpt, boolean skipValidation) throws IOException {
     HoodieTableFileSystemView fsView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(),
+        metaClient.getCommitsAndCompactionTimeline().firstInstant());
     HoodieCompactionPlan plan = getCompactionPlan(metaClient, compactionInstant);
     if (plan.getOperations() != null) {
       LOG.info(
@@ -429,7 +433,8 @@ public class CompactionAdminClient extends BaseHoodieClient {
       Option<HoodieTableFileSystemView> fsViewOpt, boolean skipValidation) throws IOException {
     List<Pair<HoodieLogFile, HoodieLogFile>> result = new ArrayList<>();
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getCommitsAndCompactionTimeline()
+        .firstInstant());
     if (!skipValidation) {
       validateCompactionOperation(metaClient, compactionInstant, operation, Option.of(fileSystemView));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
@@ -81,7 +82,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       int parallelism) throws IOException {
     HoodieCompactionPlan plan = getCompactionPlan(metaClient, compactionInstant);
     HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
 
     if (plan.getOperations() != null) {
       List<CompactionOperation> ops = plan.getOperations().stream()
@@ -203,7 +204,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
     }
 
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
     List<Pair<HoodieLogFile, HoodieLogFile>> renameActions =
         failed.stream().flatMap(v -> getRenamingActionsToAlignWithCompactionOperation(metaClient, compactionInstant,
             v.getOperation(), Option.of(fsView)).stream()).collect(Collectors.toList());
@@ -233,7 +234,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       HoodieTableMetaClient metaClient, String compactionInstant, CompactionOperation op,
       Option<HoodieTableFileSystemView> fsViewOpt) {
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
     HoodieInstant lastInstant = metaClient.getCommitsAndCompactionTimeline().lastInstant().get();
     FileSlice merged =
         fileSystemView.getLatestMergedFileSlicesBeforeOrOn(op.getPartitionPath(), lastInstant.getTimestamp())
@@ -280,7 +281,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
   private ValidationOpResult validateCompactionOperation(HoodieTableMetaClient metaClient, String compactionInstant,
       CompactionOperation operation, Option<HoodieTableFileSystemView> fsViewOpt) throws IOException {
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
     Option<HoodieInstant> lastInstant = metaClient.getCommitsAndCompactionTimeline().lastInstant();
     try {
       if (lastInstant.isPresent()) {
@@ -388,7 +389,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       HoodieTableMetaClient metaClient, String compactionInstant, int parallelism,
       Option<HoodieTableFileSystemView> fsViewOpt, boolean skipValidation) throws IOException {
     HoodieTableFileSystemView fsView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
     HoodieCompactionPlan plan = getCompactionPlan(metaClient, compactionInstant);
     if (plan.getOperations() != null) {
       LOG.info(
@@ -428,7 +429,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       Option<HoodieTableFileSystemView> fsViewOpt, boolean skipValidation) throws IOException {
     List<Pair<HoodieLogFile, HoodieLogFile>> result = new ArrayList<>();
     HoodieTableFileSystemView fileSystemView = fsViewOpt.isPresent() ? fsViewOpt.get()
-        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        : new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()));
     if (!skipValidation) {
       validateCompactionOperation(metaClient, compactionInstant, operation, Option.of(fileSystemView));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -51,7 +51,6 @@ import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -297,7 +296,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * Get the view of the file system for this table.
    */
   public TableFileSystemView getFileSystemView() {
-    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()));
+    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline(), metaClient.getCommitsTimeline().firstInstant());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -51,6 +51,7 @@ import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -296,7 +297,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * Get the view of the file system for this table.
    */
   public TableFileSystemView getFileSystemView() {
-    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline());
+    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -296,7 +296,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * Get the view of the file system for this table.
    */
   public TableFileSystemView getFileSystemView() {
-    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline(), metaClient.getCommitsTimeline().firstInstant());
+    return new HoodieTableFileSystemView(metaClient, getCompletedCommitsTimeline(), metaClient.getCommitsTimeline().getFirstNonSavepointCommit());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/providers/HoodieMetaClientProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/providers/HoodieMetaClientProvider.java
@@ -22,6 +22,7 @@ package org.apache.hudi.testutils.providers;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -34,7 +35,7 @@ public interface HoodieMetaClientProvider {
   HoodieTableMetaClient getHoodieMetaClient(Configuration hadoopConf, String basePath, Properties props) throws IOException;
 
   default HoodieTableFileSystemView getHoodieTableFileSystemView(
-      HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, FileStatus[] fileStatuses) {
-    return new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, fileStatuses);
+      HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted, FileStatus[] fileStatuses) {
+    return new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, firstNotCompleted, fileStatuses);
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/providers/HoodieMetaClientProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/providers/HoodieMetaClientProvider.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.testutils.providers;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
@@ -35,7 +36,7 @@ public interface HoodieMetaClientProvider {
   HoodieTableMetaClient getHoodieMetaClient(Configuration hadoopConf, String basePath, Properties props) throws IOException;
 
   default HoodieTableFileSystemView getHoodieTableFileSystemView(
-      HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted, FileStatus[] fileStatuses) {
-    return new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, firstNotCompleted, fileStatuses);
+      HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant, FileStatus[] fileStatuses) {
+    return new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, firstActiveInstant, fileStatuses);
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.CompactionTestUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -241,7 +240,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     Set<HoodieLogFile> gotLogFilesToBeRenamed = renameFiles.stream().map(Pair::getLeft).collect(Collectors.toSet());
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
     Set<HoodieLogFile> expLogFilesToBeRenamed = fsView.getLatestFileSlices(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0])
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant)).flatMap(FileSlice::getLogFiles)
         .collect(Collectors.toSet());
@@ -273,7 +272,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
     final HoodieTableFileSystemView newFsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
     // Expect each file-slice whose base-commit is same as compaction commit to contain no new Log files
     newFsView.getLatestFileSlicesBeforeOrOn(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0], compactionInstant, true)
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))
@@ -313,7 +312,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     Set<HoodieLogFile> gotLogFilesToBeRenamed = renameFiles.stream().map(Pair::getLeft).collect(Collectors.toSet());
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
     Set<HoodieLogFile> expLogFilesToBeRenamed = fsView.getLatestFileSlices(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0])
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))
         .filter(fs -> fs.getFileId().equals(op.getFileId())).flatMap(FileSlice::getLogFiles)
@@ -334,7 +333,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
     final HoodieTableFileSystemView newFsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
     // Expect all file-slice whose base-commit is same as compaction commit to contain no new Log files
     newFsView.getLatestFileSlicesBeforeOrOn(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0], compactionInstant, true)
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.CompactionTestUtils;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -240,7 +241,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     Set<HoodieLogFile> gotLogFilesToBeRenamed = renameFiles.stream().map(Pair::getLeft).collect(Collectors.toSet());
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
     Set<HoodieLogFile> expLogFilesToBeRenamed = fsView.getLatestFileSlices(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0])
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant)).flatMap(FileSlice::getLogFiles)
         .collect(Collectors.toSet());
@@ -272,7 +273,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
     final HoodieTableFileSystemView newFsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
     // Expect each file-slice whose base-commit is same as compaction commit to contain no new Log files
     newFsView.getLatestFileSlicesBeforeOrOn(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0], compactionInstant, true)
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))
@@ -312,7 +313,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     Set<HoodieLogFile> gotLogFilesToBeRenamed = renameFiles.stream().map(Pair::getLeft).collect(Collectors.toSet());
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
     Set<HoodieLogFile> expLogFilesToBeRenamed = fsView.getLatestFileSlices(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0])
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))
         .filter(fs -> fs.getFileId().equals(op.getFileId())).flatMap(FileSlice::getLogFiles)
@@ -333,7 +334,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
     final HoodieTableFileSystemView newFsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
     // Expect all file-slice whose base-commit is same as compaction commit to contain no new Log files
     newFsView.getLatestFileSlicesBeforeOrOn(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0], compactionInstant, true)
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
@@ -240,7 +240,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     Set<HoodieLogFile> gotLogFilesToBeRenamed = renameFiles.stream().map(Pair::getLeft).collect(Collectors.toSet());
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
     Set<HoodieLogFile> expLogFilesToBeRenamed = fsView.getLatestFileSlices(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0])
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant)).flatMap(FileSlice::getLogFiles)
         .collect(Collectors.toSet());
@@ -272,7 +272,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
     final HoodieTableFileSystemView newFsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
     // Expect each file-slice whose base-commit is same as compaction commit to contain no new Log files
     newFsView.getLatestFileSlicesBeforeOrOn(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0], compactionInstant, true)
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))
@@ -312,7 +312,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     Set<HoodieLogFile> gotLogFilesToBeRenamed = renameFiles.stream().map(Pair::getLeft).collect(Collectors.toSet());
     final HoodieTableFileSystemView fsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
     Set<HoodieLogFile> expLogFilesToBeRenamed = fsView.getLatestFileSlices(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0])
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))
         .filter(fs -> fs.getFileId().equals(op.getFileId())).flatMap(FileSlice::getLogFiles)
@@ -333,7 +333,7 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
 
     metaClient = HoodieTableMetaClient.builder().setConf(metaClient.getHadoopConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
     final HoodieTableFileSystemView newFsView =
-        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().firstInstant());
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitsAndCompactionTimeline(), metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
     // Expect all file-slice whose base-commit is same as compaction commit to contain no new Log files
     newFsView.getLatestFileSlicesBeforeOrOn(HoodieTestUtils.DEFAULT_PARTITION_PATHS[0], compactionInstant, true)
         .filter(fs -> fs.getBaseInstantTime().equals(compactionInstant))

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -60,7 +60,6 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
@@ -712,7 +711,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       final Map<String, MetadataPartitionType> metadataEnabledPartitionTypes = new HashMap<>();
       metadataWriter.getEnabledPartitionTypes().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
-          TimelineUtils.getFirstNotCompleted(metadataMetaClient.getActiveTimeline()));
+          metadataMetaClient.getActiveTimeline().firstInstant());
       metadataTablePartitions.forEach(partition -> {
         List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
         if (COLUMN_STATS.getPartitionPath().equals(partition)) {
@@ -2668,7 +2667,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // versions are +1 as autoclean / compaction happens end of commits
     int numFileVersions = metadataWriteConfig.getCleanerFileVersionsRetained() + 1;
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
-        TimelineUtils.getFirstNotCompleted(metadataMetaClient.getActiveTimeline()));
+        metadataMetaClient.getActiveTimeline().firstInstant());
     metadataTablePartitions.forEach(partition -> {
       List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
       assertTrue(latestSlices.stream().map(FileSlice::getBaseFile).count()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -60,6 +60,7 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
@@ -710,7 +711,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       final Map<String, MetadataPartitionType> metadataEnabledPartitionTypes = new HashMap<>();
       metadataWriter.getEnabledPartitionTypes().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
-      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline());
+      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
+          TimelineUtils.getFirstNotCompleted(metadataMetaClient.getActiveTimeline()));
       metadataTablePartitions.forEach(partition -> {
         List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
         if (COLUMN_STATS.getPartitionPath().equals(partition)) {
@@ -2665,7 +2667,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Metadata table should automatically compact and clean
     // versions are +1 as autoclean / compaction happens end of commits
     int numFileVersions = metadataWriteConfig.getCleanerFileVersionsRetained() + 1;
-    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline());
+    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
+        TimelineUtils.getFirstNotCompleted(metadataMetaClient.getActiveTimeline()));
     metadataTablePartitions.forEach(partition -> {
       List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
       assertTrue(latestSlices.stream().map(FileSlice::getBaseFile).count()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -711,7 +711,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       final Map<String, MetadataPartitionType> metadataEnabledPartitionTypes = new HashMap<>();
       metadataWriter.getEnabledPartitionTypes().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
-          metadataMetaClient.getActiveTimeline().firstInstant());
+          metadataMetaClient.getActiveTimeline().getFirstNonSavepointCommit());
       metadataTablePartitions.forEach(partition -> {
         List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
         if (COLUMN_STATS.getPartitionPath().equals(partition)) {
@@ -2667,7 +2667,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // versions are +1 as autoclean / compaction happens end of commits
     int numFileVersions = metadataWriteConfig.getCleanerFileVersionsRetained() + 1;
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
-        metadataMetaClient.getActiveTimeline().firstInstant());
+        metadataMetaClient.getActiveTimeline().getFirstNonSavepointCommit());
     metadataTablePartitions.forEach(partition -> {
       List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
       assertTrue(latestSlices.stream().map(FileSlice::getBaseFile).count()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -2736,7 +2736,6 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     // lets add 2nd commit which succeeds.
     String secondInstantTime = "20000";
     client.startCommitWithTime(secondInstantTime);
-    // do not commit first commit
     JavaRDD<HoodieRecord> writeRecords2 = jsc.parallelize(dataGen.generateInserts(secondInstantTime, numRecords), 1);
     JavaRDD<WriteStatus> result2 = client.bulkInsert(writeRecords2, secondInstantTime);
     assertTrue(client.commit(secondInstantTime, result2), "Commit should succeed");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -28,10 +28,12 @@ import org.apache.hudi.client.SparkTaskContextSupplier;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.clustering.plan.strategy.SparkSingleFileSortPlanStrategy;
 import org.apache.hudi.client.clustering.run.strategy.SparkSingleFileSortExecutionStrategy;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.client.validator.SparkPreCommitValidator;
 import org.apache.hudi.client.validator.SqlQueryEqualityPreCommitValidator;
 import org.apache.hudi.client.validator.SqlQuerySingleResultPreCommitValidator;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
@@ -62,7 +64,9 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.testutils.ClusteringTestUtils;
 import org.apache.hudi.common.testutils.FileCreateUtils;
@@ -2707,6 +2711,48 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     int totalRecords = 2 * numRecords;
     assertEquals(totalRecords, HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
         "Must contain " + totalRecords + " records");
+  }
+
+  @Test
+  public void testFailedFirstCommit() throws IOException {
+    HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder().withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build());
+    HoodieWriteConfig cfg = cfgBuilder.withAutoCommit(false)
+        .withCleanConfig(HoodieCleanConfig.newBuilder().withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
+            .withAutoClean(false).withAsyncClean(true).build())
+        .build();
+    SparkRDDWriteClient client = getHoodieWriteClient(cfg);
+    String firstInstantTime = "10000";
+    client.startCommitWithTime(firstInstantTime);
+    int numRecords = 100;
+    // do not commit first commit
+    JavaRDD<HoodieRecord> writeRecords1 = jsc.parallelize(dataGen.generateInserts(firstInstantTime, numRecords), 1);
+    JavaRDD<WriteStatus> result1 = client.bulkInsert(writeRecords1, firstInstantTime);
+    assertTrue(client.commit(firstInstantTime, result1), "Commit should succeed");
+    // remove complete meta file to mimic partial failure.
+    metaClient.getFs().delete(new Path(basePath + "/.hoodie/" + firstInstantTime + ".commit"));
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+
+    client = getHoodieWriteClient(cfg);
+    // lets add 2nd commit which succeeds.
+    String secondInstantTime = "20000";
+    client.startCommitWithTime(secondInstantTime);
+    // do not commit first commit
+    JavaRDD<HoodieRecord> writeRecords2 = jsc.parallelize(dataGen.generateInserts(secondInstantTime, numRecords), 1);
+    JavaRDD<WriteStatus> result2 = client.bulkInsert(writeRecords2, secondInstantTime);
+    assertTrue(client.commit(secondInstantTime, result2), "Commit should succeed");
+
+    // File listing using fs based listing.
+    HoodieSparkEngineContext context = new HoodieSparkEngineContext(jsc);
+    List<String> allPartitionPathsFromFS = FSUtils.getAllPartitionPaths(context, basePath, false, true);
+
+    HoodieTableFileSystemView fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(context,
+        metaClient, HoodieMetadataConfig.newBuilder().enable(false).build());
+
+    for (String partitionPath: allPartitionPathsFromFS) {
+      List<HoodieBaseFile> baseFiles = fileSystemView.getLatestBaseFiles(partitionPath).collect(Collectors.toList());
+      boolean invalidFilesPresent = baseFiles.stream().anyMatch(baseFile -> baseFile.getCommitTime().equals(firstInstantTime));
+      assertFalse(invalidFilesPresent); // no data files from firstCommit should be returned.
+    }
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -237,7 +236,7 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       // the state of the table
       HoodieTableFileSystemView tableView =
           getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
-              TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()), HoodieTestTable.of(metaClient).listAllBaseFiles());
+              metaClient.getActiveTimeline().firstInstant(), HoodieTestTable.of(metaClient).listAllBaseFiles());
 
       Set<String> latestBaseFileNames = tableView.getLatestBaseFiles()
           .map(BaseFile::getFileName)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -235,7 +236,8 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       // FILENAME_METADATA_FIELD payload (entailing that corresponding metadata is in-sync with
       // the state of the table
       HoodieTableFileSystemView tableView =
-          getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), HoodieTestTable.of(metaClient).listAllBaseFiles());
+          getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
+              TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()), HoodieTestTable.of(metaClient).listAllBaseFiles());
 
       Set<String> latestBaseFileNames = tableView.getLatestBaseFiles()
           .map(BaseFile::getFileName)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
@@ -236,7 +236,7 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       // the state of the table
       HoodieTableFileSystemView tableView =
           getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
-              metaClient.getActiveTimeline().firstInstant(), HoodieTestTable.of(metaClient).listAllBaseFiles());
+              metaClient.getActiveTimeline().getFirstNonSavepointCommit(), HoodieTestTable.of(metaClient).listAllBaseFiles());
 
       Set<String> latestBaseFileNames = tableView.getLatestBaseFiles()
           .map(BaseFile::getFileName)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -160,13 +160,13 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       BaseFileOnlyView roView = getHoodieTableFileSystemView(metaClient,
           metaClient.getCommitsTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       Map<String, Long> fileIdToSize =
           dataFilesToRead.collect(Collectors.toMap(HoodieBaseFile::getFileId, HoodieBaseFile::getFileSize));
 
       roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> dataFilesList = dataFilesToRead.collect(Collectors.toList());
       assertTrue(dataFilesList.size() > 0,
@@ -196,7 +196,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       allFiles = listAllBaseFilesInPath(hoodieTable);
       roView = getHoodieTableFileSystemView(metaClient,
           hoodieTable.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants(),
-          hoodieTable.getActiveTimeline().reload().getCommitsTimeline().firstInstant(), allFiles);
+          hoodieTable.getActiveTimeline().reload().getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> newDataFilesList = dataFilesToRead.collect(Collectors.toList());
       Map<String, Long> fileIdToNewSize =
@@ -639,12 +639,12 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       BaseFileOnlyView roView =
           getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-              metaClient.getCommitsTimeline().firstInstant(), allFiles);
+              metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "should list the base files we wrote in the delta commit");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -35,7 +35,6 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.Transformations;
@@ -161,13 +160,13 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       BaseFileOnlyView roView = getHoodieTableFileSystemView(metaClient,
           metaClient.getCommitsTimeline().filterCompletedInstants(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       Map<String, Long> fileIdToSize =
           dataFilesToRead.collect(Collectors.toMap(HoodieBaseFile::getFileId, HoodieBaseFile::getFileSize));
 
       roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> dataFilesList = dataFilesToRead.collect(Collectors.toList());
       assertTrue(dataFilesList.size() > 0,
@@ -197,7 +196,7 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       allFiles = listAllBaseFilesInPath(hoodieTable);
       roView = getHoodieTableFileSystemView(metaClient,
           hoodieTable.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants(),
-          TimelineUtils.getFirstNotCompleted(hoodieTable.getActiveTimeline().reload().getCommitsTimeline()), allFiles);
+          hoodieTable.getActiveTimeline().reload().getCommitsTimeline().firstInstant(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> newDataFilesList = dataFilesToRead.collect(Collectors.toList());
       Map<String, Long> fileIdToNewSize =
@@ -640,12 +639,12 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       BaseFileOnlyView roView =
           getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-              TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+              metaClient.getCommitsTimeline().firstInstant(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "should list the base files we wrote in the delta commit");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.Transformations;
@@ -159,12 +160,14 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
 
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       BaseFileOnlyView roView = getHoodieTableFileSystemView(metaClient,
-          metaClient.getCommitsTimeline().filterCompletedInstants(), allFiles);
+          metaClient.getCommitsTimeline().filterCompletedInstants(),
+          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       Map<String, Long> fileIdToSize =
           dataFilesToRead.collect(Collectors.toMap(HoodieBaseFile::getFileId, HoodieBaseFile::getFileSize));
 
-      roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+      roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
+          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> dataFilesList = dataFilesToRead.collect(Collectors.toList());
       assertTrue(dataFilesList.size() > 0,
@@ -193,7 +196,8 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
 
       allFiles = listAllBaseFilesInPath(hoodieTable);
       roView = getHoodieTableFileSystemView(metaClient,
-          hoodieTable.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants(), allFiles);
+          hoodieTable.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants(),
+          TimelineUtils.getFirstNotCompleted(hoodieTable.getActiveTimeline().reload().getCommitsTimeline()), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> newDataFilesList = dataFilesToRead.collect(Collectors.toList());
       Map<String, Long> fileIdToNewSize =
@@ -635,11 +639,13 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
 
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       BaseFileOnlyView roView =
-          getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+          getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
+              TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
-      roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+      roView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
+          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "should list the base files we wrote in the delta commit");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -260,14 +259,14 @@ public class CompactionTestBase extends HoodieClientTestBase {
     FileStatus[] allBaseFiles = HoodieTestTable.of(table.getMetaClient()).listAllBaseFiles();
     HoodieTableFileSystemView view =
         getHoodieTableFileSystemView(table.getMetaClient(), table.getCompletedCommitsTimeline(),
-            TimelineUtils.getFirstNotCompleted(table.getMetaClient().getActiveTimeline().getWriteTimeline()), allBaseFiles);
+            table.getMetaClient().getActiveTimeline().getWriteTimeline().firstInstant(), allBaseFiles);
     return view.getLatestBaseFiles().collect(Collectors.toList());
   }
 
   protected List<FileSlice> getCurrentLatestFileSlices(HoodieTable table) {
     HoodieTableFileSystemView view = new HoodieTableFileSystemView(table.getMetaClient(),
         table.getMetaClient().getActiveTimeline().reload().getWriteTimeline(),
-        TimelineUtils.getFirstNotCompleted(table.getMetaClient().getActiveTimeline().reload().getWriteTimeline()));
+        table.getMetaClient().getActiveTimeline().reload().getWriteTimeline().firstInstant());
     return Arrays.stream(HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS)
         .flatMap(view::getLatestFileSlices).collect(Collectors.toList());
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -259,14 +259,14 @@ public class CompactionTestBase extends HoodieClientTestBase {
     FileStatus[] allBaseFiles = HoodieTestTable.of(table.getMetaClient()).listAllBaseFiles();
     HoodieTableFileSystemView view =
         getHoodieTableFileSystemView(table.getMetaClient(), table.getCompletedCommitsTimeline(),
-            table.getMetaClient().getActiveTimeline().getWriteTimeline().firstInstant(), allBaseFiles);
+            table.getMetaClient().getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(), allBaseFiles);
     return view.getLatestBaseFiles().collect(Collectors.toList());
   }
 
   protected List<FileSlice> getCurrentLatestFileSlices(HoodieTable table) {
     HoodieTableFileSystemView view = new HoodieTableFileSystemView(table.getMetaClient(),
         table.getMetaClient().getActiveTimeline().reload().getWriteTimeline(),
-        table.getMetaClient().getActiveTimeline().reload().getWriteTimeline().firstInstant());
+        table.getMetaClient().getActiveTimeline().reload().getWriteTimeline().getFirstNonSavepointCommit());
     return Arrays.stream(HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS)
         .flatMap(view::getLatestFileSlices).collect(Collectors.toList());
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -258,13 +259,15 @@ public class CompactionTestBase extends HoodieClientTestBase {
   protected List<HoodieBaseFile> getCurrentLatestBaseFiles(HoodieTable table) throws IOException {
     FileStatus[] allBaseFiles = HoodieTestTable.of(table.getMetaClient()).listAllBaseFiles();
     HoodieTableFileSystemView view =
-        getHoodieTableFileSystemView(table.getMetaClient(), table.getCompletedCommitsTimeline(), allBaseFiles);
+        getHoodieTableFileSystemView(table.getMetaClient(), table.getCompletedCommitsTimeline(),
+            TimelineUtils.getFirstNotCompleted(table.getMetaClient().getActiveTimeline().getWriteTimeline()), allBaseFiles);
     return view.getLatestBaseFiles().collect(Collectors.toList());
   }
 
   protected List<FileSlice> getCurrentLatestFileSlices(HoodieTable table) {
     HoodieTableFileSystemView view = new HoodieTableFileSystemView(table.getMetaClient(),
-        table.getMetaClient().getActiveTimeline().reload().getWriteTimeline());
+        table.getMetaClient().getActiveTimeline().reload().getWriteTimeline(),
+        TimelineUtils.getFirstNotCompleted(table.getMetaClient().getActiveTimeline().reload().getWriteTimeline()));
     return Arrays.stream(HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS)
         .flatMap(view::getLatestFileSlices).collect(Collectors.toList());
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -33,7 +33,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.testutils.FileCreateUtils;
@@ -120,7 +119,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
       hoodieTable.getHoodieView().sync();
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent());
 
@@ -274,12 +273,12 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "should list the base files we wrote in the delta commit");
@@ -317,7 +316,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
       allFiles = listAllBaseFilesInPath(hoodieTable);
       tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), allFiles);
+          metaClient.getCommitsTimeline().firstInstant(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent());
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -119,7 +119,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
       hoodieTable.getHoodieView().sync();
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent());
 
@@ -273,12 +273,12 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "should list the base files we wrote in the delta commit");
@@ -316,7 +316,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
       allFiles = listAllBaseFilesInPath(hoodieTable);
       tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent());
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -140,7 +140,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
       HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
 
       final String absentCommit = newCommitTime;
       assertAll(tableView.getLatestBaseFiles().map(file -> () -> assertNotEquals(absentCommit, file.getCommitTime())));
@@ -193,12 +193,12 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
 
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "should list the base files we wrote in the delta commit");
@@ -278,7 +278,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
         metaClient = HoodieTableMetaClient.reload(metaClient);
         hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
         tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-            metaClient.getCommitsTimeline().firstInstant(), allFiles);
+            metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
         inputPaths = tableView.getLatestBaseFiles()
             .map(baseFile -> new Path(baseFile.getPath()).getParent().toString())
             .collect(Collectors.toList());
@@ -316,7 +316,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
         allFiles = listAllBaseFilesInPath(hoodieTable);
         metaClient = HoodieTableMetaClient.reload(metaClient);
         tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitsTimeline(),
-            metaClient.getCommitsTimeline().firstInstant(), allFiles);
+            metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
 
         assertFalse(tableView.getLatestBaseFiles().anyMatch(file -> compactedCommitTime.equals(file.getCommitTime())));
         assertAll(tableView.getLatestBaseFiles().map(file -> () -> assertNotEquals(compactedCommitTime, file.getCommitTime())));
@@ -375,12 +375,12 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
 
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent(),
           "Should list the base files we wrote in the delta commit");
@@ -467,7 +467,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
       allFiles = listAllBaseFilesInPath(hoodieTable);
       metaClient = HoodieTableMetaClient.reload(metaClient);
       tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitsTimeline(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
 
       final String compactedCommitTime =
           metaClient.getActiveTimeline().reload().getCommitsTimeline().lastInstant().get().getTimestamp();
@@ -497,11 +497,11 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
       metaClient = HoodieTableMetaClient.reload(metaClient);
       allFiles = listAllBaseFilesInPath(hoodieTable);
       tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
       TableFileSystemView.SliceView rtView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       List<HoodieFileGroup> fileGroups =
           ((HoodieTableFileSystemView) rtView).getAllFileGroups().collect(Collectors.toList());
       assertTrue(fileGroups.isEmpty());
@@ -587,7 +587,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
       HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
       FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
       HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(), allFiles);
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = tableView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.anyMatch(file -> HoodieTimeline.compareTimestamps("002", HoodieTimeline.GREATER_THAN, file.getCommitTime())));
 
@@ -682,7 +682,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
     HoodieTable hoodieTable = HoodieSparkTable.create(cfg, context(), metaClient);
     FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
     HoodieTableFileSystemView tableView = getHoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(),
-        metaClient.getCommitsTimeline().firstInstant(), allFiles);
+        metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
     List<String> inputPaths = tableView.getLatestBaseFiles()
         .map(hf -> new Path(hf.getPath()).getParent().toString())
         .collect(Collectors.toList());
@@ -1010,7 +1010,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
     try {
       return new HoodieTableFileSystemView(metaClient,
           metaClient.getActiveTimeline(),
-          metaClient.getActiveTimeline().firstInstant(),
+          metaClient.getActiveTimeline().getFirstNonSavepointCommit(),
           HoodieTestTable.of(metaClient).listAllBaseAndLogFiles()
       );
     } catch (IOException ioe) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -40,7 +40,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -445,11 +444,11 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness {
   }
 
   public HoodieTableFileSystemView getHoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
-                                                                Option<String> firstNotCompleted, FileStatus[] fileStatuses) {
+                                                                Option<HoodieInstant> firstActiveInstant, FileStatus[] fileStatuses) {
     if (tableView == null) {
-      tableView = new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, firstNotCompleted, fileStatuses);
+      tableView = new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, firstActiveInstant, fileStatuses);
     } else {
-      tableView.init(metaClient, visibleActiveTimeline, firstNotCompleted, fileStatuses);
+      tableView.init(metaClient, visibleActiveTimeline, firstActiveInstant, fileStatuses);
     }
     return tableView;
   }
@@ -664,7 +663,7 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness {
     // versions are +1 as autoClean / compaction happens end of commits
     int numFileVersions = metadataWriteConfig.getCleanerFileVersionsRetained() + 1;
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
-        TimelineUtils.getFirstNotCompleted(metadataMetaClient.getActiveTimeline()));
+        metadataMetaClient.getActiveTimeline().firstInstant());
     metadataTablePartitions.forEach(partition -> {
       MetadataPartitionType partitionType = partitionTypeMap.get(partition);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -40,6 +40,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -444,11 +445,11 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness {
   }
 
   public HoodieTableFileSystemView getHoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
-                                                                FileStatus[] fileStatuses) {
+                                                                Option<String> firstNotCompleted, FileStatus[] fileStatuses) {
     if (tableView == null) {
-      tableView = new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, fileStatuses);
+      tableView = new HoodieTableFileSystemView(metaClient, visibleActiveTimeline, firstNotCompleted, fileStatuses);
     } else {
-      tableView.init(metaClient, visibleActiveTimeline, fileStatuses);
+      tableView.init(metaClient, visibleActiveTimeline, firstNotCompleted, fileStatuses);
     }
     return tableView;
   }
@@ -662,7 +663,8 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness {
     // Metadata table should automatically compact and clean
     // versions are +1 as autoClean / compaction happens end of commits
     int numFileVersions = metadataWriteConfig.getCleanerFileVersionsRetained() + 1;
-    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline());
+    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
+        TimelineUtils.getFirstNotCompleted(metadataMetaClient.getActiveTimeline()));
     metadataTablePartitions.forEach(partition -> {
       MetadataPartitionType partitionType = partitionTypeMap.get(partition);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -663,7 +663,7 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness {
     // versions are +1 as autoClean / compaction happens end of commits
     int numFileVersions = metadataWriteConfig.getCleanerFileVersionsRetained() + 1;
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metadataMetaClient, metadataMetaClient.getActiveTimeline(),
-        metadataMetaClient.getActiveTimeline().firstInstant());
+        metadataMetaClient.getActiveTimeline().getFirstNonSavepointCommit());
     metadataTablePartitions.forEach(partition -> {
       MetadataPartitionType partitionType = partitionTypeMap.get(partition);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -212,7 +212,7 @@ public class HoodieClientTestUtils {
       for (String path : paths) {
         BaseFileOnlyView fileSystemView = new HoodieTableFileSystemView(metaClient,
             metaClient.getCommitsTimeline().filterCompletedInstants(),
-            metaClient.getCommitsTimeline().firstInstant(), fs.globStatus(new Path(path)));
+            metaClient.getCommitsTimeline().getFirstNonSavepointCommit(), fs.globStatus(new Path(path)));
         latestFiles.addAll(fileSystemView.getLatestBaseFiles().collect(Collectors.toList()));
       }
     } catch (Exception e) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -211,7 +212,8 @@ public class HoodieClientTestUtils {
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
       for (String path : paths) {
         BaseFileOnlyView fileSystemView = new HoodieTableFileSystemView(metaClient,
-            metaClient.getCommitsTimeline().filterCompletedInstants(), fs.globStatus(new Path(path)));
+            metaClient.getCommitsTimeline().filterCompletedInstants(),
+            TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), fs.globStatus(new Path(path)));
         latestFiles.addAll(fileSystemView.getLatestBaseFiles().collect(Collectors.toList()));
       }
     } catch (Exception e) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -32,7 +32,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -213,7 +212,7 @@ public class HoodieClientTestUtils {
       for (String path : paths) {
         BaseFileOnlyView fileSystemView = new HoodieTableFileSystemView(metaClient,
             metaClient.getCommitsTimeline().filterCompletedInstants(),
-            TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), fs.globStatus(new Path(path)));
+            metaClient.getCommitsTimeline().firstInstant(), fs.globStatus(new Path(path)));
         latestFiles.addAll(fileSystemView.getLatestBaseFiles().collect(Collectors.toList()));
       }
     } catch (Exception e) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -266,12 +266,12 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
     FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
     TableFileSystemView.BaseFileOnlyView roView =
         getHoodieTableFileSystemView(reloadedMetaClient, reloadedMetaClient.getCommitTimeline().filterCompletedInstants(),
-            reloadedMetaClient.getCommitsTimeline().firstInstant(), allFiles);
+            reloadedMetaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
     Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
     roView = getHoodieTableFileSystemView(reloadedMetaClient, hoodieTable.getCompletedCommitsTimeline(),
-        reloadedMetaClient.getCommitsTimeline().firstInstant(), allFiles);
+        reloadedMetaClient.getCommitsTimeline().getFirstNonSavepointCommit(), allFiles);
     dataFilesToRead = roView.getLatestBaseFiles();
     return dataFilesToRead;
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -34,7 +34,6 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -267,12 +266,12 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
     FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
     TableFileSystemView.BaseFileOnlyView roView =
         getHoodieTableFileSystemView(reloadedMetaClient, reloadedMetaClient.getCommitTimeline().filterCompletedInstants(),
-            TimelineUtils.getFirstNotCompleted(reloadedMetaClient.getCommitsTimeline()), allFiles);
+            reloadedMetaClient.getCommitsTimeline().firstInstant(), allFiles);
     Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
     roView = getHoodieTableFileSystemView(reloadedMetaClient, hoodieTable.getCompletedCommitsTimeline(),
-        TimelineUtils.getFirstNotCompleted(reloadedMetaClient.getCommitsTimeline()), allFiles);
+        reloadedMetaClient.getCommitsTimeline().firstInstant(), allFiles);
     dataFilesToRead = roView.getLatestBaseFiles();
     return dataFilesToRead;
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -265,11 +266,13 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
 
     FileStatus[] allFiles = listAllBaseFilesInPath(hoodieTable);
     TableFileSystemView.BaseFileOnlyView roView =
-        getHoodieTableFileSystemView(reloadedMetaClient, reloadedMetaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+        getHoodieTableFileSystemView(reloadedMetaClient, reloadedMetaClient.getCommitTimeline().filterCompletedInstants(),
+            TimelineUtils.getFirstNotCompleted(reloadedMetaClient.getCommitsTimeline()), allFiles);
     Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
-    roView = getHoodieTableFileSystemView(reloadedMetaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+    roView = getHoodieTableFileSystemView(reloadedMetaClient, hoodieTable.getCompletedCommitsTimeline(),
+        TimelineUtils.getFirstNotCompleted(reloadedMetaClient.getCommitsTimeline()), allFiles);
     dataFilesToRead = roView.getLatestBaseFiles();
     return dataFilesToRead;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieTableQueryType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -251,7 +252,8 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     Option<HoodieInstant> latestInstant = activeTimeline.lastInstant();
 
     HoodieTableFileSystemView fileSystemView =
-        new HoodieTableFileSystemView(metaClient, activeTimeline, allFiles);
+        new HoodieTableFileSystemView(metaClient, activeTimeline,
+            TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()), allFiles);
 
     Option<String> queryInstant = specifiedQueryInstant.or(() -> latestInstant.map(HoodieInstant::getTimestamp));
 

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -252,7 +252,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     HoodieTableFileSystemView fileSystemView =
         new HoodieTableFileSystemView(metaClient, activeTimeline,
-            metaClient.getCommitsAndCompactionTimeline().firstInstant(), allFiles);
+            metaClient.getCommitsAndCompactionTimeline().getFirstNonSavepointCommit(), allFiles);
 
     Option<String> queryInstant = specifiedQueryInstant.or(() -> latestInstant.map(HoodieInstant::getTimestamp));
 

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.model.HoodieTableQueryType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -253,7 +252,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     HoodieTableFileSystemView fileSystemView =
         new HoodieTableFileSystemView(metaClient, activeTimeline,
-            TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()), allFiles);
+            metaClient.getCommitsAndCompactionTimeline().firstInstant(), allFiles);
 
     Option<String> queryInstant = specifiedQueryInstant.or(() -> latestInstant.map(HoodieInstant::getTimestamp));
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -141,13 +141,12 @@ public class HoodieFileGroup implements Serializable {
       return true;
     }
 
-    // if it was archived after a savepoint
-    Option<HoodieInstant> firstSavepoint = timeline.getFirstSavepointCommit();
-    if (firstSavepoint.isPresent() && compareTimestamps(slice.getBaseInstantTime(), GREATER_THAN_OR_EQUALS, firstSavepoint.get().getTimestamp())) {
-      return true;
-    }
+    if (firstActiveInstant.isPresent()
+        && compareTimestamps(slice.getBaseInstantTime(), GREATER_THAN_OR_EQUALS, firstActiveInstant.get().getTimestamp())) {
+      return false;
 
-    return !(firstActiveInstant.isPresent() && compareTimestamps(slice.getBaseInstantTime(), GREATER_THAN_OR_EQUALS, firstActiveInstant.get().getTimestamp()));
+    }
+    return timeline.isBeforeTimelineStarts(slice.getBaseInstantTime());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -191,7 +191,7 @@ public class HoodieCDCExtractor {
       return new HoodieTableFileSystemView(
           metaClient,
           metaClient.getCommitsTimeline().filterCompletedInstants(),
-          metaClient.getCommitsTimeline().firstInstant(),
+          metaClient.getCommitsTimeline().getFirstNonSavepointCommit(),
           touchedFiles.toArray(new FileStatus[0])
       );
     } catch (Exception e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -191,6 +191,7 @@ public class HoodieCDCExtractor {
       return new HoodieTableFileSystemView(
           metaClient,
           metaClient.getCommitsTimeline().filterCompletedInstants(),
+          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()),
           touchedFiles.toArray(new FileStatus[0])
       );
     } catch (Exception e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCExtractor.java
@@ -191,7 +191,7 @@ public class HoodieCDCExtractor {
       return new HoodieTableFileSystemView(
           metaClient,
           metaClient.getCommitsTimeline().filterCompletedInstants(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()),
+          metaClient.getCommitsTimeline().firstInstant(),
           touchedFiles.toArray(new FileStatus[0])
       );
     } catch (Exception e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -432,6 +432,10 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
     }
     return firstNonSavepointCommit;
   }
+
+  public Option<HoodieInstant> getFirstSavepointCommit() {
+    return  Option.fromJavaOptional(getInstantsAsStream().filter(entry -> entry.getAction().equals(HoodieTimeline.SAVEPOINT_ACTION)).findFirst());
+  }
   
   @Override
   public Option<byte[]> getInstantDetails(HoodieInstant instant) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -363,6 +363,8 @@ public interface HoodieTimeline extends Serializable {
    */
   Option<HoodieInstant> getFirstNonSavepointCommit();
 
+  Option<HoodieInstant> getFirstSavepointCommit();
+
   /**
    * Read the completed instant details.
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -295,4 +295,9 @@ public class TimelineUtils {
       return Option.empty();
     }
   }
+
+  public static Option<String> getFirstNotCompleted(HoodieTimeline timeline) {
+    Option<HoodieInstant> firstInstant = timeline.filterInflightsAndRequested().firstInstant();
+    return firstInstant.isPresent() ? Option.of(firstInstant.get().getTimestamp()) : Option.empty();
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -47,7 +47,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.SAVEPOINT_ACT
 
 /**
  * TimelineUtils provides a common way to query incremental meta-data changes for a hoodie table.
- *
+ * <p>
  * This is useful in multiple places including:
  * 1) HiveSync - this can be used to query partitions that changed since previous sync.
  * 2) Incremental reads - InputFormats can use this API to query
@@ -181,7 +181,7 @@ public class TimelineUtils {
 
   private static Option<String> getMetadataValue(HoodieTableMetaClient metaClient, String extraMetadataKey, HoodieInstant instant) {
     try {
-      LOG.info("reading checkpoint info for:"  + instant + " key: " + extraMetadataKey);
+      LOG.info("reading checkpoint info for:" + instant + " key: " + extraMetadataKey);
       HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
           metaClient.getCommitsTimeline().getInstantDetails(instant).get(), HoodieCommitMetadata.class);
 
@@ -234,7 +234,7 @@ public class TimelineUtils {
     return timeline.getCommitsTimeline()
         .findInstantsAfter(exclusiveStartInstantTime, Integer.MAX_VALUE);
   }
-  
+
   /**
    * Returns the commit metadata of the given instant.
    *
@@ -294,10 +294,5 @@ public class TimelineUtils {
     } else {
       return Option.empty();
     }
-  }
-
-  public static Option<String> getFirstNotCompleted(HoodieTimeline timeline) {
-    Option<HoodieInstant> firstInstant = timeline.filterInflightsAndRequested().firstInstant();
-    return firstInstant.isPresent() ? Option.of(firstInstant.get().getTimestamp()) : Option.empty();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
@@ -20,7 +20,6 @@ package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -51,7 +50,7 @@ public class FileGroupDTO {
 
   @JsonProperty("firstActiveInstant")
   @Nullable
-  HoodieInstant firstActiveInstant;
+  InstantDTO firstActiveInstant;
 
   public static FileGroupDTO fromFileGroup(HoodieFileGroup fileGroup) {
     FileGroupDTO dto = new FileGroupDTO();
@@ -59,14 +58,14 @@ public class FileGroupDTO {
     dto.id = fileGroup.getFileGroupId().getFileId();
     dto.slices = fileGroup.getAllRawFileSlices().map(FileSliceDTO::fromFileSlice).collect(Collectors.toList());
     dto.timeline = TimelineDTO.fromTimeline(fileGroup.getTimeline());
-    dto.firstActiveInstant = fileGroup.getFirstActiveInstant().isPresent() ? fileGroup.getFirstActiveInstant().get() : null;
+    dto.firstActiveInstant = InstantDTO.fromInstant(fileGroup.getFirstActiveInstant().isPresent() ? fileGroup.getFirstActiveInstant().get() : null);
     return dto;
   }
 
   public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient) {
     HoodieFileGroup fileGroup =
         new HoodieFileGroup(dto.partition, dto.id, TimelineDTO.toTimeline(dto.timeline, metaClient),
-            dto.firstActiveInstant != null ? Option.of(dto.firstActiveInstant) : Option.empty());
+            dto.firstActiveInstant == null ? Option.empty() : Option.of(InstantDTO.toInstant(dto.firstActiveInstant)));
     dto.slices.stream().map(FileSliceDTO::toFileSlice).forEach(fileSlice -> fileGroup.addFileSlice(fileSlice));
     return fileGroup;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -56,7 +57,8 @@ public class FileGroupDTO {
 
   public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient) {
     HoodieFileGroup fileGroup =
-        new HoodieFileGroup(dto.partition, dto.id, TimelineDTO.toTimeline(dto.timeline, metaClient));
+        new HoodieFileGroup(dto.partition, dto.id, TimelineDTO.toTimeline(dto.timeline, metaClient),
+            TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getWriteTimeline()));
     dto.slices.stream().map(FileSliceDTO::toFileSlice).forEach(fileSlice -> fileGroup.addFileSlice(fileSlice));
     return fileGroup;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -1270,7 +1270,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
     //Get first active instant
     Option<HoodieInstant> oldFirstActiveInstant = getFirstActiveInstant();
-    Option<HoodieInstant> newFirstActiveInstant = newTimeline.firstInstant();
+    Option<HoodieInstant> newFirstActiveInstant = newTimeline.getFirstNonSavepointCommit();
     try {
       writeLock.lock();
       runSync(oldCompletedTimeline, newCompletedTimeline, oldFirstActiveInstant, newFirstActiveInstant);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -1264,7 +1264,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   @Override
   public void sync() {
-    HoodieTimeline newTimeline = metaClient.reloadActiveTimeline().getWriteTimeline();
+    HoodieTimeline newTimeline = metaClient.reloadActiveTimeline();
 
     //Get first not completed instant
     Option<String> oldFirstNotCompleted = getFirstNotCompleted();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -1270,7 +1270,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
     //Get first active instant
     Option<HoodieInstant> oldFirstActiveInstant = getFirstActiveInstant();
-    Option<HoodieInstant> newFirstActiveInstant = newTimeline.getFirstNonSavepointCommit();
+    Option<HoodieInstant> newFirstActiveInstant = newTimeline.getWriteTimeline().getFirstNonSavepointCommit();
     try {
       writeLock.lock();
       runSync(oldCompletedTimeline, newCompletedTimeline, oldFirstActiveInstant, newFirstActiveInstant);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewManager.java
@@ -140,7 +140,7 @@ public class FileSystemViewManager {
   private static RocksDbBasedFileSystemView createRocksDBBasedFileSystemView(SerializableConfiguration conf,
       FileSystemViewStorageConfig viewConf, HoodieTableMetaClient metaClient) {
     return new RocksDbBasedFileSystemView(metaClient, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants(),
-        metaClient.getActiveTimeline().getWriteTimeline().firstInstant(), viewConf);
+        metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(), viewConf);
   }
 
   /**
@@ -155,7 +155,7 @@ public class FileSystemViewManager {
       FileSystemViewStorageConfig viewConf, HoodieTableMetaClient metaClient, HoodieCommonConfig commonConfig) {
     LOG.info("Creating SpillableMap based view for basePath " + metaClient.getBasePath());
     return new SpillableMapBasedFileSystemView(metaClient, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants(),
-        metaClient.getActiveTimeline().getWriteTimeline().firstInstant(), viewConf, commonConfig);
+        metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(), viewConf, commonConfig);
   }
 
   /**
@@ -169,7 +169,7 @@ public class FileSystemViewManager {
     if (metadataConfig.enabled()) {
       ValidationUtils.checkArgument(metadataSupplier != null, "Metadata supplier is null. Cannot instantiate metadata file system view");
       return new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants(),
-          metaClient.getActiveTimeline().getWriteTimeline().firstInstant(), metadataSupplier.get());
+          metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(), metadataSupplier.get());
     }
     if (metaClient.getMetaserverConfig().isMetaserverEnabled()) {
       return (HoodieTableFileSystemView) ReflectionUtils.loadClass(HOODIE_METASERVER_FILE_SYSTEM_VIEW_CLASS,
@@ -177,7 +177,7 @@ public class FileSystemViewManager {
           metaClient, metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(), metaClient.getMetaserverConfig());
     }
     return new HoodieTableFileSystemView(metaClient, timeline,
-        metaClient.getActiveTimeline().getWriteTimeline().firstInstant(),
+        metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(),
         viewConf.isIncrementalTimelineSyncEnabled());
   }
 
@@ -186,7 +186,7 @@ public class FileSystemViewManager {
     
     return createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig,
         metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-        metaClient.getActiveTimeline().getCommitsTimeline().firstInstant());
+        metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit());
   }
   
   public static HoodieTableFileSystemView createInMemoryFileSystemViewWithTimeline(HoodieEngineContext engineContext,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -94,28 +94,28 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   /**
    * Create a file system view, as of the given timeline.
    */
-  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline) {
-    this(metaClient, visibleActiveTimeline, false);
+  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted) {
+    this(metaClient, visibleActiveTimeline, firstNotCompleted, false);
   }
 
   /**
    * Create a file system view, as of the given timeline.
    */
-  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
+  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
       boolean enableIncrementalTimelineSync) {
     super(enableIncrementalTimelineSync);
-    init(metaClient, visibleActiveTimeline);
+    init(metaClient, visibleActiveTimeline, firstNotCompleted);
   }
 
   @Override
-  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline) {
+  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String>  firstNotCompleted) {
     this.partitionToFileGroupsMap = createPartitionToFileGroups();
-    super.init(metaClient, visibleActiveTimeline);
+    super.init(metaClient, visibleActiveTimeline, firstNotCompleted);
   }
 
-  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
+  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String>  firstNotCompleted,
       FileStatus[] fileStatuses) {
-    init(metaClient, visibleActiveTimeline);
+    init(metaClient, visibleActiveTimeline, firstNotCompleted);
     addFilesToView(fileStatuses);
   }
 
@@ -171,9 +171,9 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   /**
    * Create a file system view, as of the given timeline, with the provided file statuses.
    */
-  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
+  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
       FileStatus[] fileStatuses) {
-    this(metaClient, visibleActiveTimeline);
+    this(metaClient, visibleActiveTimeline, firstNotCompleted);
     addFilesToView(fileStatuses);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -94,28 +94,28 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   /**
    * Create a file system view, as of the given timeline.
    */
-  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted) {
-    this(metaClient, visibleActiveTimeline, firstNotCompleted, false);
+  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant) {
+    this(metaClient, visibleActiveTimeline, firstActiveInstant, false);
   }
 
   /**
    * Create a file system view, as of the given timeline.
    */
-  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
+  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant,
       boolean enableIncrementalTimelineSync) {
     super(enableIncrementalTimelineSync);
-    init(metaClient, visibleActiveTimeline, firstNotCompleted);
+    init(metaClient, visibleActiveTimeline, firstActiveInstant);
   }
 
   @Override
-  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String>  firstNotCompleted) {
+  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant>  firstActiveInstant) {
     this.partitionToFileGroupsMap = createPartitionToFileGroups();
-    super.init(metaClient, visibleActiveTimeline, firstNotCompleted);
+    super.init(metaClient, visibleActiveTimeline, firstActiveInstant);
   }
 
-  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String>  firstNotCompleted,
+  public void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant>  firstActiveInstant,
       FileStatus[] fileStatuses) {
-    init(metaClient, visibleActiveTimeline, firstNotCompleted);
+    init(metaClient, visibleActiveTimeline, firstActiveInstant);
     addFilesToView(fileStatuses);
   }
 
@@ -171,9 +171,9 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   /**
    * Create a file system view, as of the given timeline, with the provided file statuses.
    */
-  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
+  public HoodieTableFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant,
       FileStatus[] fileStatuses) {
-    this(metaClient, visibleActiveTimeline, firstNotCompleted);
+    this(metaClient, visibleActiveTimeline, firstActiveInstant);
     addFilesToView(fileStatuses);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
@@ -71,25 +71,25 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
 
   private boolean closed = false;
 
-  public RocksDbBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
+  public RocksDbBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant,
       FileSystemViewStorageConfig config) {
     super(config.isIncrementalTimelineSyncEnabled());
     this.config = config;
     this.schemaHelper = new RocksDBSchemaHelper(metaClient);
     this.rocksDB = new RocksDBDAO(metaClient.getBasePath(), config.getRocksdbBasePath());
-    init(metaClient, visibleActiveTimeline, firstNotCompleted);
+    init(metaClient, visibleActiveTimeline, firstActiveInstant);
   }
 
-  public RocksDbBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
+  public RocksDbBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant,
       FileStatus[] fileStatuses, FileSystemViewStorageConfig config) {
-    this(metaClient, visibleActiveTimeline, firstNotCompleted, config);
+    this(metaClient, visibleActiveTimeline, firstActiveInstant, config);
     addFilesToView(fileStatuses);
   }
 
   @Override
-  protected void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted) {
+  protected void init(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant) {
     schemaHelper.getAllColumnFamilies().forEach(rocksDB::addColumnFamily);
-    super.init(metaClient, visibleActiveTimeline, firstNotCompleted);
+    super.init(metaClient, visibleActiveTimeline, firstActiveInstant);
     LOG.info("Created ROCKSDB based file-system view at " + config.getRocksdbBasePath());
   }
 
@@ -547,7 +547,7 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
     return sliceStream.map(s -> Pair.of(Pair.of(s.getPartitionPath(), s.getFileId()), s))
         .collect(Collectors.groupingBy(Pair::getKey)).entrySet().stream().map(slicePair -> {
           HoodieFileGroup fg = new HoodieFileGroup(slicePair.getKey().getKey(), slicePair.getKey().getValue(),
-              getVisibleCommitsAndCompactionTimeline(), getFirstNotCompleted());
+              getVisibleCommitsAndCompactionTimeline(), getFirstActiveInstant());
           slicePair.getValue().forEach(e -> fg.addFileSlice(e.getValue()));
           return fg;
         });

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
@@ -60,7 +60,7 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
   private final boolean isBitCaskDiskMapCompressionEnabled;
 
   public SpillableMapBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
-                                         Option<String> firstNotCompleted, FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
+                                         Option<HoodieInstant> firstActiveInstant, FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
     super(config.isIncrementalTimelineSyncEnabled());
     this.maxMemoryForFileGroupMap = config.getMaxMemoryForFileGroupMap();
     this.maxMemoryForPendingCompaction = config.getMaxMemoryForPendingCompaction();
@@ -71,12 +71,12 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
     this.baseStoreDir = config.getSpillableDir();
     diskMapType = commonConfig.getSpillableDiskMapType();
     isBitCaskDiskMapCompressionEnabled = commonConfig.isBitCaskDiskMapCompressionEnabled();
-    init(metaClient, visibleActiveTimeline, firstNotCompleted);
+    init(metaClient, visibleActiveTimeline, firstActiveInstant);
   }
 
-  public SpillableMapBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
+  public SpillableMapBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<HoodieInstant> firstActiveInstant,
                                          FileStatus[] fileStatuses, FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
-    this(metaClient, visibleActiveTimeline, firstNotCompleted, config, commonConfig);
+    this(metaClient, visibleActiveTimeline, firstActiveInstant, config, commonConfig);
     addFilesToView(fileStatuses);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
@@ -60,7 +60,7 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
   private final boolean isBitCaskDiskMapCompressionEnabled;
 
   public SpillableMapBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
-      FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
+                                         Option<String> firstNotCompleted, FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
     super(config.isIncrementalTimelineSyncEnabled());
     this.maxMemoryForFileGroupMap = config.getMaxMemoryForFileGroupMap();
     this.maxMemoryForPendingCompaction = config.getMaxMemoryForPendingCompaction();
@@ -71,12 +71,12 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
     this.baseStoreDir = config.getSpillableDir();
     diskMapType = commonConfig.getSpillableDiskMapType();
     isBitCaskDiskMapCompressionEnabled = commonConfig.isBitCaskDiskMapCompressionEnabled();
-    init(metaClient, visibleActiveTimeline);
+    init(metaClient, visibleActiveTimeline, firstNotCompleted);
   }
 
-  public SpillableMapBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline,
-      FileStatus[] fileStatuses, FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
-    this(metaClient, visibleActiveTimeline, config, commonConfig);
+  public SpillableMapBasedFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline visibleActiveTimeline, Option<String> firstNotCompleted,
+                                         FileStatus[] fileStatuses, FileSystemViewStorageConfig config, HoodieCommonConfig commonConfig) {
+    this(metaClient, visibleActiveTimeline, firstNotCompleted, config, commonConfig);
     addFilesToView(fileStatuses);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
@@ -21,6 +21,7 @@ package org.apache.hudi.metadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -41,18 +42,18 @@ public class HoodieMetadataFileSystemView extends HoodieTableFileSystemView {
 
   public HoodieMetadataFileSystemView(HoodieTableMetaClient metaClient,
                                       HoodieTimeline visibleActiveTimeline,
-                                      Option<String> firstNotCompleted,
+                                      Option<HoodieInstant> firstActiveInstant,
                                       HoodieTableMetadata tableMetadata) {
-    super(metaClient, visibleActiveTimeline, firstNotCompleted);
+    super(metaClient, visibleActiveTimeline, firstActiveInstant);
     this.tableMetadata = tableMetadata;
   }
 
   public HoodieMetadataFileSystemView(HoodieEngineContext engineContext,
                                       HoodieTableMetaClient metaClient,
                                       HoodieTimeline visibleActiveTimeline,
-                                      Option<String> firstNotCompleted,
+                                      Option<HoodieInstant> firstActiveInstant,
                                       HoodieMetadataConfig metadataConfig) {
-    super(metaClient, visibleActiveTimeline, firstNotCompleted);
+    super(metaClient, visibleActiveTimeline, firstActiveInstant);
     this.tableMetadata = HoodieTableMetadata.create(engineContext, metadataConfig, metaClient.getBasePath(),
         FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue(), true);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -40,16 +41,18 @@ public class HoodieMetadataFileSystemView extends HoodieTableFileSystemView {
 
   public HoodieMetadataFileSystemView(HoodieTableMetaClient metaClient,
                                       HoodieTimeline visibleActiveTimeline,
+                                      Option<String> firstNotCompleted,
                                       HoodieTableMetadata tableMetadata) {
-    super(metaClient, visibleActiveTimeline);
+    super(metaClient, visibleActiveTimeline, firstNotCompleted);
     this.tableMetadata = tableMetadata;
   }
 
   public HoodieMetadataFileSystemView(HoodieEngineContext engineContext,
                                       HoodieTableMetaClient metaClient,
                                       HoodieTimeline visibleActiveTimeline,
+                                      Option<String> firstNotCompleted,
                                       HoodieMetadataConfig metadataConfig) {
-    super(metaClient, visibleActiveTimeline);
+    super(metaClient, visibleActiveTimeline, firstNotCompleted);
     this.tableMetadata = HoodieTableMetadata.create(engineContext, metadataConfig, metaClient.getBasePath(),
         FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue(), true);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -72,7 +72,7 @@ public class HoodieMetadataMetrics implements Serializable {
     try {
       metaClient.reloadActiveTimeline();
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
-          metaClient.getActiveTimeline().getFirstNonSavepointCommit());
+          metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
       return getStats(fsView, detailed, metadata);
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to get metadata stats.", ioe);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -72,7 +72,7 @@ public class HoodieMetadataMetrics implements Serializable {
     try {
       metaClient.reloadActiveTimeline();
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
-          metaClient.getActiveTimeline().firstInstant());
+          metaClient.getActiveTimeline().getFirstNonSavepointCommit());
       return getStats(fsView, detailed, metadata);
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to get metadata stats.", ioe);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -22,7 +22,6 @@ import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.exception.HoodieIOException;
 
@@ -73,7 +72,7 @@ public class HoodieMetadataMetrics implements Serializable {
     try {
       metaClient.reloadActiveTimeline();
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
-          TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()));
+          metaClient.getActiveTimeline().firstInstant());
       return getStats(fsView, detailed, metadata);
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to get metadata stats.", ioe);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.exception.HoodieIOException;
 
@@ -71,7 +72,8 @@ public class HoodieMetadataMetrics implements Serializable {
   public Map<String, String> getStats(boolean detailed, HoodieTableMetaClient metaClient, HoodieTableMetadata metadata) {
     try {
       metaClient.reloadActiveTimeline();
-      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
+      HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(),
+          TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()));
       return getStats(fsView, detailed, metadata);
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to get metadata stats.", ioe);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -45,7 +45,6 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
@@ -1047,7 +1046,7 @@ public class HoodieTableMetadataUtil {
           HoodieActiveTimeline.createNewInstantTime());
       timeline = new HoodieDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline()::getInstantDetails);
     }
-    return new HoodieTableFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline));
+    return new HoodieTableFileSystemView(metaClient, timeline, timeline.firstInstant());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1046,7 +1046,7 @@ public class HoodieTableMetadataUtil {
           HoodieActiveTimeline.createNewInstantTime());
       timeline = new HoodieDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline()::getInstantDetails);
     }
-    return new HoodieTableFileSystemView(metaClient, timeline, timeline.firstInstant());
+    return new HoodieTableFileSystemView(metaClient, timeline, timeline.getFirstNonSavepointCommit());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1046,7 +1046,7 @@ public class HoodieTableMetadataUtil {
           HoodieActiveTimeline.createNewInstantTime());
       timeline = new HoodieDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline()::getInstantDetails);
     }
-    return new HoodieTableFileSystemView(metaClient, timeline, timeline.getFirstNonSavepointCommit());
+    return new HoodieTableFileSystemView(metaClient, timeline, timeline.getWriteTimeline().getFirstNonSavepointCommit());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -45,6 +45,7 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
@@ -1046,7 +1047,7 @@ public class HoodieTableMetadataUtil {
           HoodieActiveTimeline.createNewInstantTime());
       timeline = new HoodieDefaultTimeline(Stream.of(instant), metaClient.getActiveTimeline()::getInstantDetails);
     }
-    return new HoodieTableFileSystemView(metaClient, timeline);
+    return new HoodieTableFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline));
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.testutils.MockHoodieTimeline;
 
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,8 @@ public class TestHoodieFileGroup {
     Stream<String> inflight = Arrays.asList("002").stream();
     MockHoodieTimeline activeTimeline = new MockHoodieTimeline(completed, inflight);
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data",
-        activeTimeline.getCommitsTimeline().filterCompletedInstants());
+        activeTimeline.getCommitsTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(activeTimeline.getCommitsTimeline()));
     for (int i = 0; i < 3; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i);
       fileGroup.addBaseFile(baseFile);
@@ -65,7 +67,8 @@ public class TestHoodieFileGroup {
         new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.SAVEPOINT_ACTION, "03"),
         new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "05") // this can be DELTA_COMMIT/REPLACE_COMMIT as well
     ).collect(Collectors.toList()));
-    HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants());
+    HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants(),
+        TimelineUtils.getFirstNotCompleted(activeTimeline.getWriteTimeline()));
     for (int i = 0; i < 7; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_0" + i);
       fileGroup.addBaseFile(baseFile);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -45,7 +45,7 @@ public class TestHoodieFileGroup {
     MockHoodieTimeline activeTimeline = new MockHoodieTimeline(completed, inflight);
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data",
         activeTimeline.getCommitsTimeline().filterCompletedInstants(),
-        activeTimeline.getCommitsTimeline().firstInstant());
+        activeTimeline.getCommitsTimeline().getFirstNonSavepointCommit());
     for (int i = 0; i < 3; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i);
       fileGroup.addBaseFile(baseFile);
@@ -67,7 +67,7 @@ public class TestHoodieFileGroup {
         new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "05") // this can be DELTA_COMMIT/REPLACE_COMMIT as well
     ).collect(Collectors.toList()));
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants(),
-        activeTimeline.getWriteTimeline().firstInstant());
+        activeTimeline.getWriteTimeline().getFirstNonSavepointCommit());
     for (int i = 0; i < 7; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_0" + i);
       fileGroup.addBaseFile(baseFile);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -20,7 +20,6 @@ package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.testutils.MockHoodieTimeline;
 
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ public class TestHoodieFileGroup {
     MockHoodieTimeline activeTimeline = new MockHoodieTimeline(completed, inflight);
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data",
         activeTimeline.getCommitsTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(activeTimeline.getCommitsTimeline()));
+        activeTimeline.getCommitsTimeline().firstInstant());
     for (int i = 0; i < 3; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i);
       fileGroup.addBaseFile(baseFile);
@@ -68,7 +67,7 @@ public class TestHoodieFileGroup {
         new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "05") // this can be DELTA_COMMIT/REPLACE_COMMIT as well
     ).collect(Collectors.toList()));
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants(),
-        TimelineUtils.getFirstNotCompleted(activeTimeline.getWriteTimeline()));
+        activeTimeline.getWriteTimeline().firstInstant());
     for (int i = 0; i < 7; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_0" + i);
       fileGroup.addBaseFile(baseFile);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -890,7 +890,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     filenames = new HashSet<>();
     List<HoodieLogFile> logFilesList = rtView.getLatestFileSlicesBeforeOrOn("2016/05/01", commitTime4, true)
         .map(FileSlice::getLogFiles).flatMap(logFileList -> logFileList).collect(Collectors.toList());
-    assertEquals(logFilesList.size(), 4);
+    assertEquals(4, logFilesList.size());
     for (HoodieLogFile logFile : logFilesList) {
       filenames.add(logFile.getFileName());
     }
@@ -922,8 +922,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     logFilesList = rtView.getLatestFileSlicesBeforeOrOn("2016/05/01", commitTime3, true)
         .map(FileSlice::getLogFiles).flatMap(logFileList -> logFileList).collect(Collectors.toList());
-    assertEquals(logFilesList.size(), 1);
-    assertEquals(logFilesList.get(0).getFileName(), FSUtils.makeLogFileName(fileId2, HoodieLogFile.DELTA_EXTENSION, commitTime3, 0, TEST_WRITE_TOKEN));
+    assertEquals(1, logFilesList.size());
+    assertEquals(FSUtils.makeLogFileName(fileId2, HoodieLogFile.DELTA_EXTENSION, commitTime3, 0, TEST_WRITE_TOKEN), logFilesList.get(0).getFileName());
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestPriorityBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestPriorityBasedFileSystemView.java
@@ -512,7 +512,7 @@ public class TestPriorityBasedFileSystemView {
     String partitionPath = "/table2";
     Stream<HoodieFileGroup> expected = Collections.singleton(
         new HoodieFileGroup(partitionPath, "id1",
-            new MockHoodieTimeline(Stream.empty(), Stream.empty()))).stream();
+            new MockHoodieTimeline(Stream.empty(), Stream.empty()), Option.empty())).stream();
 
     when(primary.getAllFileGroups(partitionPath)).thenReturn(expected);
     actual = fsView.getAllFileGroups(partitionPath);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDBBasedIncrementalFSViewSync.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDBBasedIncrementalFSViewSync.java
@@ -33,7 +33,7 @@ public class TestRocksDBBasedIncrementalFSViewSync extends TestIncrementalFSView
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline)
       throws IOException {
     String subdirPath = Files.createTempDirectory(tempDir, null).toAbsolutePath().toString();
-    return new RocksDbBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(), FileSystemViewStorageConfig.newBuilder()
+    return new RocksDbBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().getFirstNonSavepointCommit(), FileSystemViewStorageConfig.newBuilder()
         .withRocksDBPath(subdirPath).withIncrementalTimelineSync(true).build());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDBBasedIncrementalFSViewSync.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDBBasedIncrementalFSViewSync.java
@@ -20,7 +20,6 @@ package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,7 +33,7 @@ public class TestRocksDBBasedIncrementalFSViewSync extends TestIncrementalFSView
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline)
       throws IOException {
     String subdirPath = Files.createTempDirectory(tempDir, null).toAbsolutePath().toString();
-    return new RocksDbBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()), FileSystemViewStorageConfig.newBuilder()
+    return new RocksDbBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(), FileSystemViewStorageConfig.newBuilder()
         .withRocksDBPath(subdirPath).withIncrementalTimelineSync(true).build());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDBBasedIncrementalFSViewSync.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDBBasedIncrementalFSViewSync.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,7 +34,7 @@ public class TestRocksDBBasedIncrementalFSViewSync extends TestIncrementalFSView
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline)
       throws IOException {
     String subdirPath = Files.createTempDirectory(tempDir, null).toAbsolutePath().toString();
-    return new RocksDbBasedFileSystemView(metaClient, timeline, FileSystemViewStorageConfig.newBuilder()
+    return new RocksDbBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()), FileSystemViewStorageConfig.newBuilder()
         .withRocksDBPath(subdirPath).withIncrementalTimelineSync(true).build());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDbBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDbBasedFileSystemView.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,7 +32,7 @@ public class TestRocksDbBasedFileSystemView extends TestHoodieTableFileSystemVie
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) throws IOException {
     String subdirPath = Files.createTempDirectory(tempDir, null).toAbsolutePath().toString();
-    return new RocksDbBasedFileSystemView(metaClient, timeline,
+    return new RocksDbBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()),
         FileSystemViewStorageConfig.newBuilder().withRocksDBPath(subdirPath).build());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDbBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDbBasedFileSystemView.java
@@ -31,7 +31,7 @@ public class TestRocksDbBasedFileSystemView extends TestHoodieTableFileSystemVie
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) throws IOException {
     String subdirPath = Files.createTempDirectory(tempDir, null).toAbsolutePath().toString();
-    return new RocksDbBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(),
+    return new RocksDbBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().getFirstNonSavepointCommit(),
         FileSystemViewStorageConfig.newBuilder().withRocksDBPath(subdirPath).build());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDbBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestRocksDbBasedFileSystemView.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,7 +31,7 @@ public class TestRocksDbBasedFileSystemView extends TestHoodieTableFileSystemVie
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) throws IOException {
     String subdirPath = Files.createTempDirectory(tempDir, null).toAbsolutePath().toString();
-    return new RocksDbBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()),
+    return new RocksDbBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(),
         FileSystemViewStorageConfig.newBuilder().withRocksDBPath(subdirPath).build());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedFileSystemView.java
@@ -28,7 +28,7 @@ public class TestSpillableMapBasedFileSystemView extends TestHoodieTableFileSyst
 
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) {
-    return new SpillableMapBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(), FileSystemViewStorageConfig.newBuilder()
+    return new SpillableMapBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().getFirstNonSavepointCommit(), FileSystemViewStorageConfig.newBuilder()
         // pure disk base View
         .withStorageType(FileSystemViewStorageType.SPILLABLE_DISK).withMaxMemoryForView(0L).build(),
         HoodieCommonConfig.newBuilder().build());

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedFileSystemView.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 /**
  * Tests spillable map based file system view {@link SpillableMapBasedFileSystemView}.
@@ -28,7 +29,7 @@ public class TestSpillableMapBasedFileSystemView extends TestHoodieTableFileSyst
 
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) {
-    return new SpillableMapBasedFileSystemView(metaClient, timeline, FileSystemViewStorageConfig.newBuilder()
+    return new SpillableMapBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()), FileSystemViewStorageConfig.newBuilder()
         // pure disk base View
         .withStorageType(FileSystemViewStorageType.SPILLABLE_DISK).withMaxMemoryForView(0L).build(),
         HoodieCommonConfig.newBuilder().build());

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedFileSystemView.java
@@ -20,7 +20,6 @@ package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 /**
  * Tests spillable map based file system view {@link SpillableMapBasedFileSystemView}.
@@ -29,7 +28,7 @@ public class TestSpillableMapBasedFileSystemView extends TestHoodieTableFileSyst
 
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline) {
-    return new SpillableMapBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()), FileSystemViewStorageConfig.newBuilder()
+    return new SpillableMapBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(), FileSystemViewStorageConfig.newBuilder()
         // pure disk base View
         .withStorageType(FileSystemViewStorageType.SPILLABLE_DISK).withMaxMemoryForView(0L).build(),
         HoodieCommonConfig.newBuilder().build());

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedIncrementalFSViewSync.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedIncrementalFSViewSync.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.view;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 /**
  * Tests spillable map based incremental fs view sync {@link SpillableMapBasedFileSystemView}.
@@ -29,7 +30,7 @@ public class TestSpillableMapBasedIncrementalFSViewSync extends TestIncrementalF
 
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline) {
-    return new SpillableMapBasedFileSystemView(metaClient, timeline,
+    return new SpillableMapBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()),
         FileSystemViewStorageConfig.newBuilder().withMaxMemoryForView(0L).withIncrementalTimelineSync(true).build(),
         HoodieCommonConfig.newBuilder().build());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedIncrementalFSViewSync.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedIncrementalFSViewSync.java
@@ -29,7 +29,7 @@ public class TestSpillableMapBasedIncrementalFSViewSync extends TestIncrementalF
 
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline) {
-    return new SpillableMapBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(),
+    return new SpillableMapBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().getFirstNonSavepointCommit(),
         FileSystemViewStorageConfig.newBuilder().withMaxMemoryForView(0L).withIncrementalTimelineSync(true).build(),
         HoodieCommonConfig.newBuilder().build());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedIncrementalFSViewSync.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestSpillableMapBasedIncrementalFSViewSync.java
@@ -21,7 +21,6 @@ package org.apache.hudi.common.table.view;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 
 /**
  * Tests spillable map based incremental fs view sync {@link SpillableMapBasedFileSystemView}.
@@ -30,7 +29,7 @@ public class TestSpillableMapBasedIncrementalFSViewSync extends TestIncrementalF
 
   @Override
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient, HoodieTimeline timeline) {
-    return new SpillableMapBasedFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline.getWriteTimeline()),
+    return new SpillableMapBasedFileSystemView(metaClient, timeline, timeline.getWriteTimeline().firstInstant(),
         FileSystemViewStorageConfig.newBuilder().withMaxMemoryForView(0L).withIncrementalTimelineSync(true).build(),
         HoodieCommonConfig.newBuilder().build());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -37,7 +37,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.Option;
@@ -445,7 +444,8 @@ public class FileCreateUtils {
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
       for (String path : paths) {
         TableFileSystemView.BaseFileOnlyView fileSystemView = new HoodieTableFileSystemView(metaClient,
-            metaClient.getCommitsTimeline().filterCompletedInstants(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), fs.globStatus(new org.apache.hadoop.fs.Path(path)));
+            metaClient.getCommitsTimeline().filterCompletedInstants(), metaClient.getCommitsTimeline().firstInstant(),
+            fs.globStatus(new org.apache.hadoop.fs.Path(path)));
         toReturn.put(path, fileSystemView.getLatestBaseFiles().count());
       }
       return toReturn;

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -444,7 +444,7 @@ public class FileCreateUtils {
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
       for (String path : paths) {
         TableFileSystemView.BaseFileOnlyView fileSystemView = new HoodieTableFileSystemView(metaClient,
-            metaClient.getCommitsTimeline().filterCompletedInstants(), metaClient.getCommitsTimeline().firstInstant(),
+            metaClient.getCommitsTimeline().filterCompletedInstants(), metaClient.getCommitsTimeline().getFirstNonSavepointCommit(),
             fs.globStatus(new org.apache.hadoop.fs.Path(path)));
         toReturn.put(path, fileSystemView.getLatestBaseFiles().count());
       }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -37,6 +37,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.Option;
@@ -444,7 +445,7 @@ public class FileCreateUtils {
       HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).setLoadActiveTimelineOnLoad(true).build();
       for (String path : paths) {
         TableFileSystemView.BaseFileOnlyView fileSystemView = new HoodieTableFileSystemView(metaClient,
-            metaClient.getCommitsTimeline().filterCompletedInstants(), fs.globStatus(new org.apache.hadoop.fs.Path(path)));
+            metaClient.getCommitsTimeline().filterCompletedInstants(), TimelineUtils.getFirstNotCompleted(metaClient.getCommitsTimeline()), fs.globStatus(new org.apache.hadoop.fs.Path(path)));
         toReturn.put(path, fileSystemView.getLatestBaseFiles().count());
       }
       return toReturn;

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -21,7 +21,6 @@ package org.apache.hudi.common.testutils;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.exception.HoodieIOException;
@@ -110,7 +109,7 @@ public class HoodieCommonTestHarness {
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline, boolean enableIncrementalTimelineSync) {
-    return new HoodieTableFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline), enableIncrementalTimelineSync);
+    return new HoodieTableFileSystemView(metaClient, timeline, timeline.firstInstant(), enableIncrementalTimelineSync);
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient) throws IOException {
@@ -125,7 +124,7 @@ public class HoodieCommonTestHarness {
   protected SyncableFileSystemView getFileSystemViewWithUnCommittedSlices(HoodieTableMetaClient metaClient) {
     try {
       return new HoodieTableFileSystemView(metaClient,
-          metaClient.getActiveTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()),
+          metaClient.getActiveTimeline(), metaClient.getActiveTimeline().firstInstant(),
           HoodieTestTable.of(metaClient).listAllBaseAndLogFiles()
       );
     } catch (IOException ioe) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -109,7 +109,7 @@ public class HoodieCommonTestHarness {
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline, boolean enableIncrementalTimelineSync) {
-    return new HoodieTableFileSystemView(metaClient, timeline, timeline.getFirstNonSavepointCommit(), enableIncrementalTimelineSync);
+    return new HoodieTableFileSystemView(metaClient, timeline, timeline.getWriteTimeline().getFirstNonSavepointCommit(), enableIncrementalTimelineSync);
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient) throws IOException {
@@ -124,7 +124,7 @@ public class HoodieCommonTestHarness {
   protected SyncableFileSystemView getFileSystemViewWithUnCommittedSlices(HoodieTableMetaClient metaClient) {
     try {
       return new HoodieTableFileSystemView(metaClient,
-          metaClient.getActiveTimeline(), metaClient.getActiveTimeline().getFirstNonSavepointCommit(),
+          metaClient.getActiveTimeline(), metaClient.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit(),
           HoodieTestTable.of(metaClient).listAllBaseAndLogFiles()
       );
     } catch (IOException ioe) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.testutils;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.exception.HoodieIOException;
@@ -109,7 +110,7 @@ public class HoodieCommonTestHarness {
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline, boolean enableIncrementalTimelineSync) {
-    return new HoodieTableFileSystemView(metaClient, timeline, enableIncrementalTimelineSync);
+    return new HoodieTableFileSystemView(metaClient, timeline, TimelineUtils.getFirstNotCompleted(timeline), enableIncrementalTimelineSync);
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient) throws IOException {
@@ -124,7 +125,7 @@ public class HoodieCommonTestHarness {
   protected SyncableFileSystemView getFileSystemViewWithUnCommittedSlices(HoodieTableMetaClient metaClient) {
     try {
       return new HoodieTableFileSystemView(metaClient,
-          metaClient.getActiveTimeline(),
+          metaClient.getActiveTimeline(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()),
           HoodieTestTable.of(metaClient).listAllBaseAndLogFiles()
       );
     } catch (IOException ioe) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieCommonTestHarness.java
@@ -109,7 +109,7 @@ public class HoodieCommonTestHarness {
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTimeline timeline, boolean enableIncrementalTimelineSync) {
-    return new HoodieTableFileSystemView(metaClient, timeline, timeline.firstInstant(), enableIncrementalTimelineSync);
+    return new HoodieTableFileSystemView(metaClient, timeline, timeline.getFirstNonSavepointCommit(), enableIncrementalTimelineSync);
   }
 
   protected SyncableFileSystemView getFileSystemView(HoodieTableMetaClient metaClient) throws IOException {
@@ -124,7 +124,7 @@ public class HoodieCommonTestHarness {
   protected SyncableFileSystemView getFileSystemViewWithUnCommittedSlices(HoodieTableMetaClient metaClient) {
     try {
       return new HoodieTableFileSystemView(metaClient,
-          metaClient.getActiveTimeline(), metaClient.getActiveTimeline().firstInstant(),
+          metaClient.getActiveTimeline(), metaClient.getActiveTimeline().getFirstNonSavepointCommit(),
           HoodieTestTable.of(metaClient).listAllBaseAndLogFiles()
       );
     } catch (IOException ioe) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -481,7 +481,7 @@ public class IncrementalInputSplits implements Serializable {
   }
 
   private Option<HoodieInstant> getFirstActiveInstant(HoodieTableMetaClient metaClient) {
-    return filterInstantsByCondition(metaClient.getCommitsAndCompactionTimeline()).firstInstant();
+    return filterInstantsByCondition(metaClient.getCommitsAndCompactionTimeline()).getFirstNonSavepointCommit();
   }
 
   private HoodieTimeline getArchivedReadTimeline(HoodieTableMetaClient metaClient, String startInstant) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -319,7 +319,7 @@ public class HoodieTableSource implements
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         // file-slice after pending compaction-requested instant-time is also considered valid
         metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants(),
-        metaClient.getCommitsAndCompactionTimeline().firstInstant(), fileStatuses);
+        metaClient.getCommitsAndCompactionTimeline().getFirstNonSavepointCommit(), fileStatuses);
     String latestCommit = fsView.getLastInstant().get().getTimestamp();
     final String mergeType = this.conf.getString(FlinkOptions.MERGE_TYPE);
     final AtomicInteger cnt = new AtomicInteger(0);
@@ -496,7 +496,7 @@ public class HoodieTableSource implements
 
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(),
-        metaClient.getCommitsAndCompactionTimeline().firstInstant(),
+        metaClient.getCommitsAndCompactionTimeline().getFirstNonSavepointCommit(),
         fileStatuses);
     Path[] paths = fsView.getLatestBaseFiles()
         .map(HoodieBaseFile::getFileStatus)

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -320,7 +319,7 @@ public class HoodieTableSource implements
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         // file-slice after pending compaction-requested instant-time is also considered valid
         metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()), fileStatuses);
+        metaClient.getCommitsAndCompactionTimeline().firstInstant(), fileStatuses);
     String latestCommit = fsView.getLastInstant().get().getTimestamp();
     final String mergeType = this.conf.getString(FlinkOptions.MERGE_TYPE);
     final AtomicInteger cnt = new AtomicInteger(0);
@@ -497,7 +496,8 @@ public class HoodieTableSource implements
 
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()), fileStatuses);
+        metaClient.getCommitsAndCompactionTimeline().firstInstant(),
+        fileStatuses);
     Path[] paths = fsView.getLatestBaseFiles()
         .map(HoodieBaseFile::getFileStatus)
         .map(FileStatus::getPath).toArray(Path[]::new);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -318,7 +319,8 @@ public class HoodieTableSource implements
 
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         // file-slice after pending compaction-requested instant-time is also considered valid
-        metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants(), fileStatuses);
+        metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()), fileStatuses);
     String latestCommit = fsView.getLastInstant().get().getTimestamp();
     final String mergeType = this.conf.getString(FlinkOptions.MERGE_TYPE);
     final AtomicInteger cnt = new AtomicInteger(0);
@@ -494,7 +496,8 @@ public class HoodieTableSource implements
     }
 
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
-        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(), fileStatuses);
+        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(metaClient.getCommitsAndCompactionTimeline()), fileStatuses);
     Path[] paths = fsView.getLatestBaseFiles()
         .map(HoodieBaseFile::getFileStatus)
         .map(FileStatus::getPath).toArray(Path[]::new);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
@@ -169,7 +169,7 @@ public class HoodieCopyOnWriteTableInputFormat extends HoodieTableInputFormat {
                                                           List<Path> inputPaths,
                                                           String incrementalTable) throws IOException {
     Job jobContext = Job.getInstance(job);
-    Pair<Option<HoodieTimeline>, Option<String>> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
+    Pair<Option<HoodieTimeline>, Option<HoodieInstant>> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
     if (!timeline.getLeft().isPresent()) {
       return null;
     }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.utils.HoodieHiveUtils;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
@@ -168,22 +169,22 @@ public class HoodieCopyOnWriteTableInputFormat extends HoodieTableInputFormat {
                                                           List<Path> inputPaths,
                                                           String incrementalTable) throws IOException {
     Job jobContext = Job.getInstance(job);
-    Option<HoodieTimeline> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
-    if (!timeline.isPresent()) {
+    Pair<Option<HoodieTimeline>, Option<String>> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
+    if (!timeline.getLeft().isPresent()) {
       return null;
     }
-    Option<List<HoodieInstant>> commitsToCheck = HoodieInputFormatUtils.getCommitsForIncrementalQuery(jobContext, incrementalTable, timeline.get());
+    Option<List<HoodieInstant>> commitsToCheck = HoodieInputFormatUtils.getCommitsForIncrementalQuery(jobContext, incrementalTable, timeline.getLeft().get());
     if (!commitsToCheck.isPresent()) {
       return null;
     }
-    Option<String> incrementalInputPaths = HoodieInputFormatUtils.getAffectedPartitions(commitsToCheck.get(), tableMetaClient, timeline.get(), inputPaths);
+    Option<String> incrementalInputPaths = HoodieInputFormatUtils.getAffectedPartitions(commitsToCheck.get(), tableMetaClient, timeline.getLeft().get(), inputPaths);
     // Mutate the JobConf to set the input paths to only partitions touched by incremental pull.
     if (!incrementalInputPaths.isPresent()) {
       return null;
     }
     setInputPaths(job, incrementalInputPaths.get());
     FileStatus[] fileStatuses = doListStatus(job);
-    return HoodieInputFormatUtils.filterIncrementalFileStatus(jobContext, tableMetaClient, timeline.get(), fileStatuses, commitsToCheck.get());
+    return HoodieInputFormatUtils.filterIncrementalFileStatus(jobContext, tableMetaClient, timeline.getLeft().get(), timeline.getRight(), fileStatuses, commitsToCheck.get());
   }
 
   protected FileStatus createFileStatusUnchecked(FileSlice fileSlice, HiveHoodieTableFileIndex fileIndex, HoodieTableMetaClient metaClient) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -192,7 +192,7 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
             fsView = FileSystemViewManager.createInMemoryFileSystemViewWithTimeline(engineContext,
                 metaClient, HoodieInputFormatUtils.buildMetadataConfig(getConf()),
                 metaClient.getActiveTimeline().filterCompletedInstants().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())),
-                metaClient.getActiveTimeline().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())).firstInstant());
+                metaClient.getActiveTimeline().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())).getFirstNonSavepointCommit());
           } else {
             fsView = FileSystemViewManager.createInMemoryFileSystemView(engineContext,
                 metaClient, HoodieInputFormatUtils.buildMetadataConfig(getConf()));

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.exception.HoodieException;
@@ -191,7 +192,8 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
             // which contains old version files, if not specify this value, these files will be filtered.
             fsView = FileSystemViewManager.createInMemoryFileSystemViewWithTimeline(engineContext,
                 metaClient, HoodieInputFormatUtils.buildMetadataConfig(getConf()),
-                metaClient.getActiveTimeline().filterCompletedInstants().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())));
+                metaClient.getActiveTimeline().filterCompletedInstants().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())),
+                TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key()))));
           } else {
             fsView = FileSystemViewManager.createInMemoryFileSystemView(engineContext,
                 metaClient, HoodieInputFormatUtils.buildMetadataConfig(getConf()));

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.exception.HoodieException;
@@ -193,7 +192,7 @@ public class HoodieROTablePathFilter implements Configurable, PathFilter, Serial
             fsView = FileSystemViewManager.createInMemoryFileSystemViewWithTimeline(engineContext,
                 metaClient, HoodieInputFormatUtils.buildMetadataConfig(getConf()),
                 metaClient.getActiveTimeline().filterCompletedInstants().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())),
-                TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key()))));
+                metaClient.getActiveTimeline().findInstantsBeforeOrEquals(getConf().get(TIMESTAMP_AS_OF.key())).firstInstant());
           } else {
             fsView = FileSystemViewManager.createInMemoryFileSystemView(engineContext,
                 metaClient, HoodieInputFormatUtils.buildMetadataConfig(getConf()));

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
@@ -149,7 +149,7 @@ public class HoodieMergeOnReadTableInputFormat extends HoodieCopyOnWriteTableInp
     Job jobContext = Job.getInstance(job);
 
     // step1
-    Pair<Option<HoodieTimeline>, Option<String>> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
+    Pair<Option<HoodieTimeline>, Option<HoodieInstant>> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
     if (!timeline.getLeft().isPresent()) {
       return result;
     }
@@ -173,8 +173,8 @@ public class HoodieMergeOnReadTableInputFormat extends HoodieCopyOnWriteTableInp
     List<FileStatus> affectedFileStatus = Arrays.asList(HoodieInputFormatUtils
         .listAffectedFilesForCommits(job, new Path(tableMetaClient.getBasePath()), metadataList));
     // step3
-    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(tableMetaClient, commitsTimelineToReturn, TimelineUtils.getFirstNotCompleted(commitsTimelineToReturn),
-        affectedFileStatus.toArray(new FileStatus[0]));
+    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(tableMetaClient, commitsTimelineToReturn, commitsTimelineToReturn
+        .firstInstant(), affectedFileStatus.toArray(new FileStatus[0]));
     // build fileGroup from fsView
     Path basePath = new Path(tableMetaClient.getBasePath());
     // filter affectedPartition by inputPaths

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.BootstrapBaseFileSplit;
@@ -148,11 +149,11 @@ public class HoodieMergeOnReadTableInputFormat extends HoodieCopyOnWriteTableInp
     Job jobContext = Job.getInstance(job);
 
     // step1
-    Option<HoodieTimeline> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
-    if (!timeline.isPresent()) {
+    Pair<Option<HoodieTimeline>, Option<String>> timeline = HoodieInputFormatUtils.getFilteredCommitsTimeline(jobContext, tableMetaClient);
+    if (!timeline.getLeft().isPresent()) {
       return result;
     }
-    HoodieTimeline commitsTimelineToReturn = HoodieInputFormatUtils.getHoodieTimelineForIncrementalQuery(jobContext, incrementalTableName, timeline.get());
+    HoodieTimeline commitsTimelineToReturn = HoodieInputFormatUtils.getHoodieTimelineForIncrementalQuery(jobContext, incrementalTableName, timeline.getLeft().get());
     Option<List<HoodieInstant>> commitsToCheck = Option.of(commitsTimelineToReturn.getInstants());
     if (!commitsToCheck.isPresent()) {
       return result;
@@ -172,7 +173,8 @@ public class HoodieMergeOnReadTableInputFormat extends HoodieCopyOnWriteTableInp
     List<FileStatus> affectedFileStatus = Arrays.asList(HoodieInputFormatUtils
         .listAffectedFilesForCommits(job, new Path(tableMetaClient.getBasePath()), metadataList));
     // step3
-    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(tableMetaClient, commitsTimelineToReturn, affectedFileStatus.toArray(new FileStatus[0]));
+    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(tableMetaClient, commitsTimelineToReturn, TimelineUtils.getFirstNotCompleted(commitsTimelineToReturn),
+        affectedFileStatus.toArray(new FileStatus[0]));
     // build fileGroup from fsView
     Path basePath = new Path(tableMetaClient.getBasePath());
     // filter affectedPartition by inputPaths

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
@@ -174,7 +174,7 @@ public class HoodieMergeOnReadTableInputFormat extends HoodieCopyOnWriteTableInp
         .listAffectedFilesForCommits(job, new Path(tableMetaClient.getBasePath()), metadataList));
     // step3
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(tableMetaClient, commitsTimelineToReturn, commitsTimelineToReturn
-        .firstInstant(), affectedFileStatus.toArray(new FileStatus[0]));
+        .getFirstNonSavepointCommit(), affectedFileStatus.toArray(new FileStatus[0]));
     // build fileGroup from fsView
     Path basePath = new Path(tableMetaClient.getBasePath());
     // filter affectedPartition by inputPaths

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -274,7 +274,7 @@ public class HoodieInputFormatUtils {
       baseTimeline = tableMetaClient.getActiveTimeline();
     }
     return Pair.of(Option.of(baseTimeline.getCommitsTimeline().filterCompletedInstants()), baseTimeline.getCommitsTimeline()
-        .firstInstant());
+        .getFirstNonSavepointCommit());
   }
 
   /**

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
@@ -36,7 +36,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.HoodieRecordUtils;
@@ -110,7 +109,7 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
   private JavaPairRDD<String, Iterator<FileSlice>> getPartitionToFileSlice(HoodieTableMetaClient metaClient,
       List<String> partitionPaths) {
     TableFileSystemView.SliceView fileSystemView = new HoodieTableFileSystemView(metaClient,
-        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()));
+        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(), metaClient.getActiveTimeline().firstInstant());
     // pass num partitions to another method
     JavaPairRDD<String, Iterator<FileSlice>> partitionToFileSliceList = jsc.parallelize(partitionPaths).mapToPair(p -> {
       return new Tuple2<>(p, fileSystemView.getLatestFileSlices(p).iterator());

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.HoodieRecordUtils;
@@ -109,7 +110,7 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
   private JavaPairRDD<String, Iterator<FileSlice>> getPartitionToFileSlice(HoodieTableMetaClient metaClient,
       List<String> partitionPaths) {
     TableFileSystemView.SliceView fileSystemView = new HoodieTableFileSystemView(metaClient,
-        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants());
+        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(), TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline()));
     // pass num partitions to another method
     JavaPairRDD<String, Iterator<FileSlice>> partitionToFileSliceList = jsc.parallelize(partitionPaths).mapToPair(p -> {
       return new Tuple2<>(p, fileSystemView.getLatestFileSlices(p).iterator());

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
@@ -109,7 +109,7 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
   private JavaPairRDD<String, Iterator<FileSlice>> getPartitionToFileSlice(HoodieTableMetaClient metaClient,
       List<String> partitionPaths) {
     TableFileSystemView.SliceView fileSystemView = new HoodieTableFileSystemView(metaClient,
-        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(), metaClient.getActiveTimeline().firstInstant());
+        metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants(), metaClient.getActiveTimeline().getFirstNonSavepointCommit());
     // pass num partitions to another method
     JavaPairRDD<String, Iterator<FileSlice>> partitionToFileSliceList = jsc.parallelize(partitionPaths).mapToPair(p -> {
       return new Tuple2<>(p, fileSystemView.getLatestFileSlices(p).iterator());

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -266,7 +266,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
   protected def timeline: HoodieTimeline =
   // NOTE: We're including compaction here since it's not considering a "commit" operation
     metaClient.getCommitsAndCompactionTimeline.filterCompletedInstants
-  protected def firstActiveInstant: org.apache.hudi.common.util.Option[HoodieInstant] = metaClient.getCommitsAndCompactionTimeline.getWriteTimeline.firstInstant()
+  protected def firstActiveInstant: org.apache.hudi.common.util.Option[HoodieInstant] = metaClient.getCommitsAndCompactionTimeline.getWriteTimeline.getFirstNonSavepointCommit
 
   private def queryTimestamp: Option[String] =
     specifiedQueryTimestamp.orElse(toScalaOption(timeline.lastInstant()).map(_.getTimestamp))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -169,7 +169,7 @@ class HoodieBootstrapRelation(@transient val _sqlContext: SQLContext,
     }
 
     val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitsTimeline
-      .filterCompletedInstants, metaClient.getActiveTimeline.getCommitsTimeline.firstInstant(), fileStatuses.toArray)
+      .filterCompletedInstants, metaClient.getActiveTimeline.getCommitsTimeline.getFirstNonSavepointCommit, fileStatuses.toArray)
     val latestFiles: List[HoodieBaseFile] = fsView.getLatestBaseFiles.iterator().asScala.toList
 
     if (log.isDebugEnabled) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -169,7 +169,7 @@ class HoodieBootstrapRelation(@transient val _sqlContext: SQLContext,
     }
 
     val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitsTimeline
-      .filterCompletedInstants, metaClient.getActiveTimeline.getCommitsTimeline.getFirstNonSavepointCommit, fileStatuses.toArray)
+      .filterCompletedInstants, metaClient.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit, fileStatuses.toArray)
     val latestFiles: List[HoodieBaseFile] = fsView.getLatestBaseFiles.iterator().asScala.toList
 
     if (log.isDebugEnabled) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -169,7 +169,7 @@ class HoodieBootstrapRelation(@transient val _sqlContext: SQLContext,
     }
 
     val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitsTimeline
-      .filterCompletedInstants, TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitsTimeline), fileStatuses.toArray)
+      .filterCompletedInstants, metaClient.getActiveTimeline.getCommitsTimeline.firstInstant(), fileStatuses.toArray)
     val latestFiles: List[HoodieBaseFile] = fsView.getLatestBaseFiles.iterator().asScala.toList
 
     if (log.isDebugEnabled) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -20,6 +20,7 @@ package org.apache.hudi
 
 import org.apache.hadoop.fs.Path
 import org.apache.hudi.common.model.HoodieBaseFile
+import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.exception.HoodieException
@@ -168,7 +169,7 @@ class HoodieBootstrapRelation(@transient val _sqlContext: SQLContext,
     }
 
     val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitsTimeline
-      .filterCompletedInstants, fileStatuses.toArray)
+      .filterCompletedInstants, TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitsTimeline), fileStatuses.toArray)
     val latestFiles: List[HoodieBaseFile] = fsView.getLatestBaseFiles.iterator().asScala.toList
 
     if (log.isDebugEnabled) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.TimelineUtils.getCommitMetadata
-import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline, TimelineUtils}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.HoodieException
@@ -99,7 +99,7 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
       } else {
         val latestCommit = includedCommits.last.getTimestamp
 
-        val fsView = new HoodieTableFileSystemView(metaClient, timeline, affectedFilesInCommits)
+        val fsView = new HoodieTableFileSystemView(metaClient, timeline, super.firstNotCompleted , affectedFilesInCommits)
 
         val modifiedPartitions = getWritePartitionPaths(commitsMetadata)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.TimelineUtils.getCommitMetadata
-import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline, TimelineUtils}
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.HoodieException
@@ -99,7 +99,7 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
       } else {
         val latestCommit = includedCommits.last.getTimestamp
 
-        val fsView = new HoodieTableFileSystemView(metaClient, timeline, super.firstNotCompleted , affectedFilesInCommits)
+        val fsView = new HoodieTableFileSystemView(metaClient, timeline, super.firstActiveInstant , affectedFilesInCommits)
 
         val modifiedPartitions = getWritePartitionPaths(commitsMetadata)
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/DedupeSparkJob.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/DedupeSparkJob.scala
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieBaseFile, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.exception.HoodieException
 import org.apache.log4j.Logger
@@ -76,7 +75,7 @@ class DedupeSparkJob(basePath: String,
 
     val allFiles = fs.listStatus(new org.apache.hadoop.fs.Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata, metadata.getActiveTimeline.getCommitTimeline.filterCompletedInstants(),
-      TimelineUtils.getFirstNotCompleted(metadata.getActiveTimeline.getCommitTimeline), allFiles)
+      metadata.getActiveTimeline.getCommitTimeline.firstInstant(), allFiles)
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
     val filteredStatuses = latestFiles.map(f => f.getPath)
     LOG.info(s" List of files under partition: ${} =>  ${filteredStatuses.mkString(" ")}")
@@ -187,7 +186,7 @@ class DedupeSparkJob(basePath: String,
     val allFiles = fs.listStatus(new Path(s"$basePath/$duplicatedPartitionPath"))
     val fsView = new HoodieTableFileSystemView(metadata,
       metadata.getActiveTimeline.getCommitTimeline.filterCompletedInstants(),
-      TimelineUtils.getFirstNotCompleted(metadata.getActiveTimeline.getCommitTimeline), allFiles)
+      metadata.getActiveTimeline.getCommitTimeline.firstInstant(), allFiles)
 
     val latestFiles: java.util.List[HoodieBaseFile] = fsView.getLatestBaseFiles().collect(Collectors.toList[HoodieBaseFile]())
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
@@ -121,7 +121,7 @@ class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure wit
 
     val filteredTimeline = new HoodieDefaultTimeline(
       new java.util.ArrayList[HoodieInstant](JavaConversions.asJavaCollection(instants.toList)).stream(), details)
-    new HoodieTableFileSystemView(metaClient, filteredTimeline, filteredTimeline.firstInstant(),
+    new HoodieTableFileSystemView(metaClient, filteredTimeline, filteredTimeline.getFirstNonSavepointCommit,
       statuses.toArray(new Array[FileStatus](0)))
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.{HoodieDefaultTimeline, HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.table.timeline.{HoodieDefaultTimeline, HoodieInstant, HoodieTimeline, TimelineUtils}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.util
 import org.apache.spark.sql.Row
@@ -121,7 +121,8 @@ class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure wit
 
     val filteredTimeline = new HoodieDefaultTimeline(
       new java.util.ArrayList[HoodieInstant](JavaConversions.asJavaCollection(instants.toList)).stream(), details)
-    new HoodieTableFileSystemView(metaClient, filteredTimeline, statuses.toArray(new Array[FileStatus](0)))
+    new HoodieTableFileSystemView(metaClient, filteredTimeline, TimelineUtils.getFirstNotCompleted(filteredTimeline),
+      statuses.toArray(new Array[FileStatus](0)))
   }
 
   private def showAllFileSlices(fsView: HoodieTableFileSystemView): java.util.List[Row] = {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.{HoodieDefaultTimeline, HoodieInstant, HoodieTimeline, TimelineUtils}
+import org.apache.hudi.common.table.timeline.{HoodieDefaultTimeline, HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.util
 import org.apache.spark.sql.Row
@@ -121,7 +121,7 @@ class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure wit
 
     val filteredTimeline = new HoodieDefaultTimeline(
       new java.util.ArrayList[HoodieInstant](JavaConversions.asJavaCollection(instants.toList)).stream(), details)
-    new HoodieTableFileSystemView(metaClient, filteredTimeline, TimelineUtils.getFirstNotCompleted(filteredTimeline),
+    new HoodieTableFileSystemView(metaClient, filteredTimeline, filteredTimeline.firstInstant(),
       statuses.toArray(new Array[FileStatus](0)))
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -680,7 +680,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase with ScalaAssertionSuppor
     metaClient.reloadActiveTimeline()
     val activeInstants = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants
     val fileSystemView = new HoodieTableFileSystemView(metaClient, activeInstants,
-      metaClient.getActiveTimeline.getCommitsTimeline.firstInstant())
+      metaClient.getActiveTimeline.getCommitsTimeline.getFirstNonSavepointCommit)
     fileSystemView.getAllBaseFiles(partitionPath).iterator().asScala.toSeq.length
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -680,7 +680,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase with ScalaAssertionSuppor
     metaClient.reloadActiveTimeline()
     val activeInstants = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants
     val fileSystemView = new HoodieTableFileSystemView(metaClient, activeInstants,
-      metaClient.getActiveTimeline.getCommitsTimeline.getFirstNonSavepointCommit)
+      metaClient.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit)
     fileSystemView.getAllBaseFiles(partitionPath).iterator().asScala.toSeq.length
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -29,6 +29,7 @@ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.engine.EngineType
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
+import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime
@@ -679,7 +680,8 @@ class TestHoodieFileIndex extends HoodieClientTestBase with ScalaAssertionSuppor
   private def getFileCountInPartitionPath(partitionPath: String): Int = {
     metaClient.reloadActiveTimeline()
     val activeInstants = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants
-    val fileSystemView = new HoodieTableFileSystemView(metaClient, activeInstants)
+    val fileSystemView = new HoodieTableFileSystemView(metaClient, activeInstants,
+      TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitsTimeline))
     fileSystemView.getAllBaseFiles(partitionPath).iterator().asScala.toSeq.length
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -29,7 +29,6 @@ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.engine.EngineType
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
-import org.apache.hudi.common.table.timeline.TimelineUtils
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime
@@ -681,7 +680,7 @@ class TestHoodieFileIndex extends HoodieClientTestBase with ScalaAssertionSuppor
     metaClient.reloadActiveTimeline()
     val activeInstants = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants
     val fileSystemView = new HoodieTableFileSystemView(metaClient, activeInstants,
-      TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitsTimeline))
+      metaClient.getActiveTimeline.getCommitsTimeline.firstInstant())
     fileSystemView.getAllBaseFiles(partitionPath).iterator().asScala.toSeq.length
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -379,7 +379,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
   }
 
   private def getLatestFileGroupsFileId(partition: String):Array[String] = {
-    getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline, TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline),
+    getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline, metaClient.getActiveTimeline.firstInstant(),
       HoodieTestTable.of(metaClient).listAllBaseFiles())
     tableView.getLatestFileSlices(partition)
       .toArray().map(slice => slice.asInstanceOf[FileSlice].getFileGroupId.getFileId)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -379,7 +379,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
   }
 
   private def getLatestFileGroupsFileId(partition: String):Array[String] = {
-    getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline, metaClient.getActiveTimeline.firstInstant(),
+    getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline, metaClient.getActiveTimeline.getFirstNonSavepointCommit,
       HoodieTestTable.of(metaClient).listAllBaseFiles())
     tableView.getLatestFileSlices(partition)
       .toArray().map(slice => slice.asInstanceOf[FileSlice].getFileGroupId.getFileId)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.client.transaction.lock.InProcessLockProvider
 import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.model.{FileSlice, HoodieTableType, WriteConcurrencyMode}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.HoodieTimeline
+import org.apache.hudi.common.table.timeline.{HoodieTimeline, TimelineUtils}
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestTable}
 import org.apache.hudi.common.util.{CollectionUtils, CommitUtils}
@@ -379,7 +379,7 @@ class TestStructuredStreaming extends HoodieClientTestBase {
   }
 
   private def getLatestFileGroupsFileId(partition: String):Array[String] = {
-    getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline,
+    getHoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline, TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline),
       HoodieTestTable.of(metaClient).listAllBaseFiles())
     tableView.getLatestFileSlices(partition)
       .toArray().map(slice => slice.asInstanceOf[FileSlice].getFileGroupId.getFileId)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
@@ -229,7 +229,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
+        metaClient.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -290,7 +290,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
+        metaClient.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpdates)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 2 files
@@ -352,7 +352,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
+        metaClient.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpserts)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -414,7 +414,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
+        metaClient.getActiveTimeline.getWriteTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
@@ -229,7 +229,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
+        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -290,7 +290,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
+        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpdates)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 2 files
@@ -352,7 +352,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
+        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpserts)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -414,7 +414,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
+        metaClient.getActiveTimeline.getCommitTimeline.getFirstNonSavepointCommit,
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieFileFormat
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.{HoodieTimeline, TimelineUtils}
+import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, SchemaTestUtil}
 import org.apache.hudi.testutils.HoodieSparkWriteableTestTable
@@ -229,7 +229,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
+        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -290,7 +290,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
+        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpdates)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 2 files
@@ -352,7 +352,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
+        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpserts)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -414,7 +414,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
-        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
+        metaClient.getActiveTimeline.getCommitTimeline.firstInstant(),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieFileFormat
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.HoodieTimeline
+import org.apache.hudi.common.table.timeline.{HoodieTimeline, TimelineUtils}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, SchemaTestUtil}
 import org.apache.hudi.testutils.HoodieSparkWriteableTestTable
@@ -229,6 +229,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -289,6 +290,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpdates)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 2 files
@@ -350,6 +352,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPathWithUpserts)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files
@@ -411,6 +414,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
 
       // get fs and check number of latest files
       val fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants,
+        TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline.getCommitTimeline),
         metaClient.getFs.listStatus(new Path(duplicatedPartitionPath)))
       val filteredStatuses = fsView.getLatestBaseFiles.iterator().asScala.map(value => value.getPath).toList
       // there should be 3 files

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
@@ -93,7 +93,7 @@ public class ManifestFileWriter {
         HoodieLocalEngineContext engContext = new HoodieLocalEngineContext(hadoopConf);
         HoodieMetadataFileSystemView fsView = new HoodieMetadataFileSystemView(engContext, metaClient,
             metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-            metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
+            metaClient.getActiveTimeline().getCommitsTimeline().getFirstNonSavepointCommit(),
             HoodieMetadataConfig.newBuilder().enable(useFileListingFromMetadata).withAssumeDatePartitioning(assumeDatePartitioning).build());
         return fsView.getLatestBaseFiles(p).map(HoodieBaseFile::getFileName);
       });

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieMetadataFileSystemView;
@@ -94,7 +93,7 @@ public class ManifestFileWriter {
         HoodieLocalEngineContext engContext = new HoodieLocalEngineContext(hadoopConf);
         HoodieMetadataFileSystemView fsView = new HoodieMetadataFileSystemView(engContext, metaClient,
             metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-            TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
+            metaClient.getActiveTimeline().getCommitsTimeline().firstInstant(),
             HoodieMetadataConfig.newBuilder().enable(useFileListingFromMetadata).withAssumeDatePartitioning(assumeDatePartitioning).build());
         return fsView.getLatestBaseFiles(p).map(HoodieBaseFile::getFileName);
       });

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/ManifestFileWriter.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieMetadataFileSystemView;
@@ -93,6 +94,7 @@ public class ManifestFileWriter {
         HoodieLocalEngineContext engContext = new HoodieLocalEngineContext(hadoopConf);
         HoodieMetadataFileSystemView fsView = new HoodieMetadataFileSystemView(engContext, metaClient,
             metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
+            TimelineUtils.getFirstNotCompleted(metaClient.getActiveTimeline().getCommitsTimeline()),
             HoodieMetadataConfig.newBuilder().enable(useFileListingFromMetadata).withAssumeDatePartitioning(assumeDatePartitioning).build());
         return fsView.getLatestBaseFiles(p).map(HoodieBaseFile::getFileName);
       });

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java
@@ -86,7 +86,7 @@ public class HoodieSnapshotCopier implements Serializable {
     final HoodieTableMetaClient tableMetadata = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(baseDir).build();
     final BaseFileOnlyView fsView = new HoodieTableFileSystemView(tableMetadata,
         tableMetadata.getActiveTimeline().getWriteTimeline().filterCompletedInstants(),
-        tableMetadata.getActiveTimeline().getWriteTimeline().firstInstant());
+        tableMetadata.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
     HoodieEngineContext context = new HoodieSparkEngineContext(jsc);
     // Get the latest commit
     Option<HoodieInstant> latestCommit =

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.Option;
@@ -85,7 +86,8 @@ public class HoodieSnapshotCopier implements Serializable {
     final SerializableConfiguration serConf = new SerializableConfiguration(jsc.hadoopConfiguration());
     final HoodieTableMetaClient tableMetadata = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(baseDir).build();
     final BaseFileOnlyView fsView = new HoodieTableFileSystemView(tableMetadata,
-        tableMetadata.getActiveTimeline().getWriteTimeline().filterCompletedInstants());
+        tableMetadata.getActiveTimeline().getWriteTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(tableMetadata.getActiveTimeline().getWriteTimeline()));
     HoodieEngineContext context = new HoodieSparkEngineContext(jsc);
     // Get the latest commit
     Option<HoodieInstant> latestCommit =

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.Option;
@@ -87,7 +86,7 @@ public class HoodieSnapshotCopier implements Serializable {
     final HoodieTableMetaClient tableMetadata = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(baseDir).build();
     final BaseFileOnlyView fsView = new HoodieTableFileSystemView(tableMetadata,
         tableMetadata.getActiveTimeline().getWriteTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(tableMetadata.getActiveTimeline().getWriteTimeline()));
+        tableMetadata.getActiveTimeline().getWriteTimeline().firstInstant());
     HoodieEngineContext context = new HoodieSparkEngineContext(jsc);
     // Get the latest commit
     Option<HoodieInstant> latestCommit =

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -277,7 +278,8 @@ public class HoodieSnapshotExporter {
         .setBasePath(cfg.sourceBasePath)
         .build();
     return new HoodieTableFileSystemView(tableMetadata, tableMetadata
-        .getActiveTimeline().getWriteTimeline().filterCompletedInstants());
+        .getActiveTimeline().getWriteTimeline().filterCompletedInstants(),
+        TimelineUtils.getFirstNotCompleted(tableMetadata.getActiveTimeline().getWriteTimeline()));
   }
 
   public static void main(String[] args) throws IOException {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.CollectionUtils;
@@ -279,7 +278,7 @@ public class HoodieSnapshotExporter {
         .build();
     return new HoodieTableFileSystemView(tableMetadata, tableMetadata
         .getActiveTimeline().getWriteTimeline().filterCompletedInstants(),
-        TimelineUtils.getFirstNotCompleted(tableMetadata.getActiveTimeline().getWriteTimeline()));
+        tableMetadata.getActiveTimeline().getWriteTimeline().firstInstant());
   }
 
   public static void main(String[] args) throws IOException {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotExporter.java
@@ -278,7 +278,7 @@ public class HoodieSnapshotExporter {
         .build();
     return new HoodieTableFileSystemView(tableMetadata, tableMetadata
         .getActiveTimeline().getWriteTimeline().filterCompletedInstants(),
-        tableMetadata.getActiveTimeline().getWriteTimeline().firstInstant());
+        tableMetadata.getActiveTimeline().getWriteTimeline().getFirstNonSavepointCommit());
   }
 
   public static void main(String[] args) throws IOException {


### PR DESCRIPTION
### Change Logs

When we have some failed commits in the timeline before first successful commit, FS based listing could return data from the failed commit. This is not an issue w/ single writer. Could only happen when multi-writers are enabled or when async table services are enabled along w/ deltastreamer. 

For eg, if timeline is:
c1.inflight, c2.complete,c3.complete
when we query hudi, data files from c1 is also returned. Fixing it as part of this patch.
### Impact

FS based listing will not return data from failed commit.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
