### PR TITLE
[HUDI-5276] Fix getting partition paths under relative paths

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
@@ -74,11 +74,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.model.WriteOperationType.INSERT;
-import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.apache.hudi.common.model.WriteOperationType.INSERT;
+import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -278,7 +278,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
   protected List<PartitionPath> listPartitionPaths(List<String> relativePartitionPaths) {
     List<String> matchedPartitionPaths;
     try {
-      matchedPartitionPaths = tableMetadata.getPartitionPathsWithPrefixes(relativePartitionPaths);
+      matchedPartitionPaths = tableMetadata.getPartitionPathsInDirs(relativePartitionPaths);
     } catch (IOException e) {
       throw new HoodieIOException("Error fetching partition paths", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -81,23 +81,23 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
       return FSUtils.getAllPartitionFoldersThreeLevelsDown(fs, datasetBasePath);
     }
 
-    return getPartitionPathsWithPrefixes(Collections.singletonList(""));
+    return getPartitionPathsInDirs(Collections.singletonList(""));
   }
 
   @Override
-  public List<String> getPartitionPathsWithPrefixes(List<String> prefixes) {
-    return prefixes.stream().flatMap(prefix -> {
+  public List<String> getPartitionPathsInDirs(List<String> relativePaths) {
+    return relativePaths.stream().flatMap(relativePath -> {
       try {
-        return getPartitionPathsWithPrefix(prefix).stream();
+        return getPartitionPathsInDir(relativePath).stream();
       } catch (IOException e) {
-        throw new HoodieIOException("Error fetching partition paths with prefix: " + prefix, e);
+        throw new HoodieIOException("Error fetching partition paths with relative path: " + relativePath, e);
       }
     }).collect(Collectors.toList());
   }
 
-  private List<String> getPartitionPathsWithPrefix(String prefix) throws IOException {
+  private List<String> getPartitionPathsInDir(String relativePath) throws IOException {
     List<Path> pathsToList = new CopyOnWriteArrayList<>();
-    pathsToList.add(StringUtils.isNullOrEmpty(prefix) ? new Path(datasetBasePath) : new Path(datasetBasePath, prefix));
+    pathsToList.add(StringUtils.isNullOrEmpty(relativePath) ? new Path(datasetBasePath) : new Path(datasetBasePath, relativePath));
     List<String> partitionPaths = new CopyOnWriteArrayList<>();
 
     while (!pathsToList.isEmpty()) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -18,9 +18,6 @@
 
 package org.apache.hudi.metadata;
 
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
@@ -50,6 +47,7 @@ import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SpillableMapUtils;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -57,6 +55,10 @@ import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieSeekingFileReader;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -150,9 +152,11 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
   }
 
   @Override
-  public List<String> getPartitionPathsWithPrefixes(List<String> prefixes) throws IOException {
+  public List<String> getPartitionPathsInDirs(List<String> relativePaths) throws IOException {
     return getAllPartitionPaths().stream()
-        .filter(p -> prefixes.stream().anyMatch(p::startsWith))
+        .filter(p -> relativePaths.stream().anyMatch(relativePath ->
+            StringUtils.isNullOrEmpty(relativePath)
+                || p.equals(relativePath) || p.startsWith(relativePath + "/")))
         .collect(Collectors.toList());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -138,12 +138,15 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
   FileStatus[] getAllFilesInPartition(Path partitionPath) throws IOException;
 
   /**
-   * Fetch list of all partitions path that whose relative partition paths match the given prefixes
+   * Fetch list of all partitions path that whose relative partition paths is under the
+   * directories based on the given relative paths.
+   * <p>
    * E.g., Table has partition 4 partitions:
-   *  year=2022/month=08/day=30, year=2022/month=08/day=31, year=2022/month=07/day=03, year=2022/month=07/day=04
-   *  Prefix "year=2022" will return all partitions, while prefix "year=2022/month=07" will output only two partitions.
+   * year=2022/month=08/day=30, year=2022/month=08/day=31, year=2022/month=07/day=03, year=2022/month=07/day=04
+   * The relative path "year=2022" returns all partitions, while the relative path
+   * "year=2022/month=07" returns only two partitions.
    */
-  List<String> getPartitionPathsWithPrefixes(List<String> prefixes) throws IOException;
+  List<String> getPartitionPathsInDirs(List<String> relativePaths) throws IOException;
 
   /**
    * Fetch list of all partition paths, per the latest snapshot of the metadata.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -223,7 +223,7 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
       //       we might not be able to properly parse partition-values from the listed partition-paths.
       //       In that case, we simply could not apply partition pruning and will have to regress to scanning
       //       the whole table
-      if (haveProperPartitionValues(partitionPaths)) {
+      if (haveProperPartitionValues(partitionPaths) && partitionSchema.nonEmpty) {
         val predicate = partitionPruningPredicates.reduce(expressions.And)
         val boundPredicate = InterpretedPredicate(predicate.transform {
           case a: AttributeReference =>
@@ -241,7 +241,7 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
         prunedPartitionPaths
       } else {
         logWarning(s"Unable to apply partition pruning, due to failure to parse partition values from the" +
-          s" following path(s): ${partitionPaths.filter(_.values.length == 0).head.path}")
+          s" following path(s): ${partitionPaths.find(_.values.length == 0).map(e => e.getPath)}")
 
         partitionPaths
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -18,6 +18,7 @@
 package org.apache.hudi
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 import org.apache.hudi.DataSourceReadOptions.{FILE_INDEX_LISTING_MODE_EAGER, FILE_INDEX_LISTING_MODE_LAZY, QUERY_TYPE, QUERY_TYPE_SNAPSHOT_OPT_VAL}
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
@@ -26,6 +27,7 @@ import org.apache.hudi.client.HoodieJavaWriteClient
 import org.apache.hudi.client.common.HoodieJavaEngineContext
 import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.engine.EngineType
+import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
@@ -39,14 +41,15 @@ import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.keygen.ComplexKeyGenerator
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator.TimestampType
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config
+import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.hudi.testutils.HoodieClientTestBase
 import org.apache.hudi.util.JFunction
+import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, GreaterThanOrEqual, LessThan, Literal}
 import org.apache.spark.sql.execution.datasources.{NoopCache, PartitionDirectory}
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.types.{IntegerType, StringType}
-import org.apache.spark.sql.{DataFrameWriter, Row, SaveMode, SparkSession, SparkSessionExtensions}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -441,12 +444,130 @@ class TestHoodieFileIndex extends HoodieClientTestBase with ScalaAssertionSuppor
   }
 
   @ParameterizedTest
-  @CsvSource(Array("true,a.b.c","false,a.b.c","true,c","false,c"))
-  def testQueryPartitionPathsForNestedPartition(useMetaFileList:Boolean, partitionBy:String): Unit = {
+  @CsvSource(value = Array("true,true", "true,false", "false,true", "false,false"))
+  def testFileListingWithPartitionPrefixPruning(enableMetadataTable: Boolean,
+                                                enablePartitionPathPrefixAnalysis: Boolean):
+  Unit = {
+    val _spark = spark
+    import _spark.implicits._
+
+    val writerOpts: Map[String, String] = commonOpts ++ Map(
+      DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      HoodieMetadataConfig.ENABLE.key -> enableMetadataTable.toString,
+      RECORDKEY_FIELD.key -> "id",
+      PARTITIONPATH_FIELD.key -> "region_code,dt",
+      KEYGENERATOR_CLASS_NAME.key -> classOf[ComplexKeyGenerator].getName
+    )
+
+    val readerOpts: Map[String, String] = queryOpts ++ Map(
+      HoodieMetadataConfig.ENABLE.key -> enableMetadataTable.toString,
+      DataSourceReadOptions.FILE_INDEX_LISTING_MODE_OVERRIDE.key -> "eager",
+      DataSourceReadOptions.FILE_INDEX_LISTING_PARTITION_PATH_PREFIX_ANALYSIS_ENABLED.key -> enablePartitionPathPrefixAnalysis.toString
+    )
+
+    // The following partitions are generated:
+    // ("1", "2023/01/01"), ("1", "2023/01/02"),
+    // ("10", "2023/01/01"), ("10", "2023/01/02"),
+    // ("100", "2023/01/01"), ("100", "2023/01/02"),
+    // ("2", "2023/01/01"), ("2", "2023/01/02"),
+    // ("20", "2023/01/01"), ("20", "2023/01/02"),
+    // ("200", "2023/01/01"), ("200", "2023/01/02")
+    val inputDF1 = (for (i <- 0 until 100) yield
+      (i, s"a$i", 10 + i, s"${if (i < 50) 1 else 2}" + "0" * (i % 3), s"2023/01/0${i % 2 + 1}"))
+      .toDF("id", "name", "price", "region_code", "dt")
+
+    inputDF1.write.format("hudi")
+      .options(writerOpts)
+      .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key, "false")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+
+    // Test getting partition paths in a subset of directories
+    val metadata = HoodieTableMetadata.create(context,
+      HoodieMetadataConfig.newBuilder().enable(enableMetadataTable).build(),
+      metaClient.getBasePathV2.toString,
+      metaClient.getBasePathV2.getParent.toString)
+    assertEquals(
+      Seq("1/2023/01/01", "1/2023/01/02"),
+      metadata.getPartitionPathsInDirs(Seq("1")).sorted)
+    assertEquals(
+      Seq("1/2023/01/01", "1/2023/01/02", "10/2023/01/01", "10/2023/01/02",
+        "100/2023/01/01", "100/2023/01/02", "2/2023/01/01", "2/2023/01/02",
+        "20/2023/01/01", "20/2023/01/02", "200/2023/01/01", "200/2023/01/02"),
+      metadata.getPartitionPathsInDirs(Seq("")).sorted)
+    assertEquals(
+      Seq("1/2023/01/01"),
+      metadata.getPartitionPathsInDirs(Seq("1/2023/01/01")).sorted)
+
+    val fileIndex = HoodieFileIndex(spark, metaClient, None, readerOpts)
+    val readDF = spark.read.format("hudi").options(readerOpts).load()
+
+    // Partition predicates, SQL predicate expression, whether prefix pruning should kick in,
+    // expected partitions after pruning with partition prefix
+    val testCases = Seq(
+      // prefix pruning should kick in
+      (Seq(EqualTo(attribute("region_code"), literal("1"))),
+        "region_code = '1'",
+        enablePartitionPathPrefixAnalysis,
+        Seq(("1", "2023/01/01"), ("1", "2023/01/02"))),
+      // prefix pruning does not kick in and fall back to full listing
+      (Seq(EqualTo(attribute("dt"), literal("2023/01/01"))),
+        "dt = '2023/01/01'",
+        false,
+        Seq(("1", "2023/01/01"), ("10", "2023/01/01"), ("100", "2023/01/01"),
+          ("2", "2023/01/01"), ("20", "2023/01/01"), ("200", "2023/01/01"))),
+      // Exact matching should kick in
+      (Seq(EqualTo(attribute("dt"), literal("2023/01/01")),
+        EqualTo(attribute("region_code"), literal("1"))),
+        "dt = '2023/01/01' and region_code = '1'",
+        enablePartitionPathPrefixAnalysis,
+        Seq(("1", "2023/01/01")))
+    )
+
+    testCases.foreach(testCase => {
+      val partitionAndFilesAfterPruning = fileIndex.listFiles(testCase._1, Seq.empty)
+      assertEquals(1, partitionAndFilesAfterPruning.size)
+      val (partitionValuesSeq, perPartitionFilesSeq) = partitionAndFilesAfterPruning.map {
+        case PartitionDirectory(values, files) =>
+          (values.toSeq(Seq(StringType)), files)
+      }.unzip
+      val partitionPaths = perPartitionFilesSeq.flatten
+        .map(file => extractPartitionPathFromFilePath(file.getPath))
+        .distinct
+        .sorted
+      val expectedPartitionPaths = if (testCase._3) {
+        testCase._4.map(e => e._1 + "/" + e._2)
+      } else {
+        fileIndex.allFiles
+          .map(file => extractPartitionPathFromFilePath(file.getPath))
+          .distinct
+          .sorted
+      }
+      assertEquals(expectedPartitionPaths, partitionPaths)
+      assertEquals(
+        testCase._4,
+        readDF.filter(testCase._2)
+          .select("region_code", "dt").distinct().collect()
+          .map(row => (row.getString(0), row.getString(1))).sorted.toSeq)
+    })
+  }
+
+  private def extractPartitionPathFromFilePath(filePath: Path): String = {
+    val relativeFilePath = FSUtils.getRelativePartitionPath(metaClient.getBasePathV2, filePath)
+    val names = relativeFilePath.split("/")
+    val fileName = names(names.length - 1)
+    relativeFilePath.stripSuffix(fileName).stripSuffix("/")
+  }
+
+  @ParameterizedTest
+  @CsvSource(Array("true,a.b.c", "false,a.b.c", "true,c", "false,c"))
+  def testQueryPartitionPathsForNestedPartition(useMetaFileList: Boolean, partitionBy: String): Unit = {
     val inputDF = spark.range(100)
-      .withColumn("c",lit("c"))
-      .withColumn("b",struct("c"))
-      .withColumn("a",struct("b"))
+      .withColumn("c", lit("c"))
+      .withColumn("b", struct("c"))
+      .withColumn("a", struct("b"))
     inputDF.write.format("hudi")
       .options(commonOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)


### PR DESCRIPTION
### Change Logs

When the metadata table is enabled and used for getting the partition paths under certain directories (listing by partition path prefix in `SparkHoodieTableFileIndex` and getting query partition paths in `BaseHoodieTableFileIndex`), the following logic in `HoodieBackedTableMetadata` is invoked

```
  public List<String> getPartitionPathsWithPrefixes(List<String> prefixes) throws IOException {
    return getAllPartitionPaths().stream()
        .filter(p -> prefixes.stream().anyMatch(p::startsWith))
        .collect(Collectors.toList());
  }
```

If all the partition paths contain `1`, `10`, and `100`, listing using `1` returns all three, which is incorrect.  The `prefixes` should serve as the exact relative path and the naming itself is misleading.

This PR made the following change to correct the issue:
- Renames `getPartitionPathsWithPrefixes` to `getPartitionPathsInDirs` in `HoodieTableMetadata` and update relevant variable naming and docs
- Fixes the logic in `HoodieBackedTableMetadata#getPartitionPathsInDirs` to do exact parent directory matching
- Adds new tests in `TestHoodieFileIndex` to guard around the logic.  These tests fail before this PR.

This PR fixes #7298.

### Impact

Fixes the bug of getting irrelevant partition paths given a relative path/prefix.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
