### PR TITLE
[HUDI-5617] Rename configs for async conflict detector for clarity

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -93,8 +93,8 @@ public class EmbeddedTimelineService {
       timelineServiceConfBuilder.earlyConflictDetectionEnable(true)
           .earlyConflictDetectionStrategy(writeConfig.getEarlyConflictDetectionStrategyClassName())
           .earlyConflictDetectionCheckCommitConflict(writeConfig.earlyConflictDetectionCheckCommitConflict())
-          .asyncConflictDetectorBatchIntervalMs(writeConfig.getAsyncConflictDetectorBatchIntervalMs())
-          .asyncConflictDetectorBatchPeriodMs(writeConfig.getAsyncConflictDetectorPeriodMs())
+          .asyncConflictDetectorInitialDelayMs(writeConfig.getAsyncConflictDetectorInitialDelayMs())
+          .asyncConflictDetectorPeriodMs(writeConfig.getAsyncConflictDetectorPeriodMs())
           .earlyConflictDetectionMaxAllowableHeartbeatIntervalInMs(writeConfig.getHoodieClientHeartbeatIntervalInMs());
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -573,21 +573,21 @@ public class HoodieWriteConfig extends HoodieConfig {
           + "It eagerly detects writing conflict before create markers and fails fast if a "
           + "conflict is detected, to release cluster compute resources as soon as possible.");
 
-  public static final ConfigProperty<Long> ASYNC_CONFLICT_DETECTOR_BATCH_INTERVAL_MS = ConfigProperty
-      .key(CONCURRENCY_PREFIX + "early.conflict.async.detector.batch.interval_ms")
+  public static final ConfigProperty<Long> ASYNC_CONFLICT_DETECTOR_INITIAL_DELAY_MS = ConfigProperty
+      .key(CONCURRENCY_PREFIX + "async.conflict.detector.initial_delay_ms")
       .defaultValue(30000L)
       .sinceVersion("0.13.0")
       .withDocumentation("Used for timeline-server-based markers with "
           + "`AsyncTimelineServerBasedDetectionStrategy`. "
-          + "The time in milliseconds to delay first async marker conflict detection.");
+          + "The time in milliseconds to delay the first execution of async marker-based conflict detection.");
 
   public static final ConfigProperty<Long> ASYNC_CONFLICT_DETECTOR_PERIOD_MS = ConfigProperty
-      .key(CONCURRENCY_PREFIX + "early.conflict.async.detector.period_ms")
+      .key(CONCURRENCY_PREFIX + "async.conflict.detector.period_ms")
       .defaultValue(30000L)
       .sinceVersion("0.13.0")
       .withDocumentation("Used for timeline-server-based markers with "
           + "`AsyncTimelineServerBasedDetectionStrategy`. "
-          + "The period in milliseconds between consecutive runs of async marker conflict detection.");
+          + "The period in milliseconds between successive executions of async marker-based conflict detection.");
 
   public static final ConfigProperty<Boolean> EARLY_CONFLICT_DETECTION_CHECK_COMMIT_CONFLICT = ConfigProperty
       .key(CONCURRENCY_PREFIX + "early.conflict.check.commit.conflict")
@@ -2243,8 +2243,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return ReflectionUtils.loadClass(getString(HoodieLockConfig.WRITE_CONFLICT_RESOLUTION_STRATEGY_CLASS_NAME));
   }
 
-  public Long getAsyncConflictDetectorBatchIntervalMs() {
-    return getLong(ASYNC_CONFLICT_DETECTOR_BATCH_INTERVAL_MS);
+  public Long getAsyncConflictDetectorInitialDelayMs() {
+    return getLong(ASYNC_CONFLICT_DETECTOR_INITIAL_DELAY_MS);
   }
 
   public Long getAsyncConflictDetectorPeriodMs() {
@@ -2810,8 +2810,8 @@ public class HoodieWriteConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withAsyncConflictDetectorBatchIntervalMs(long intervalMs) {
-      writeConfig.setValue(ASYNC_CONFLICT_DETECTOR_BATCH_INTERVAL_MS, String.valueOf(intervalMs));
+    public Builder withAsyncConflictDetectorInitialDelayMs(long intervalMs) {
+      writeConfig.setValue(ASYNC_CONFLICT_DETECTOR_INITIAL_DELAY_MS, String.valueOf(intervalMs));
       return this;
     }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -812,7 +812,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
           .withMarkersType(MarkerType.DIRECT.name())
           .withEarlyConflictDetectionEnable(true)
           .withEarlyConflictDetectionStrategy(earlyConflictDetectionStrategy)
-          .withAsyncConflictDetectorBatchIntervalMs(0)
+          .withAsyncConflictDetectorInitialDelayMs(0)
           .withAsyncConflictDetectorPeriodMs(100)
           .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(lockProvider).build())
           .withAutoCommit(false).withProperties(properties).build();
@@ -838,7 +838,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
           .withLockConfig(HoodieLockConfig.newBuilder().withLockProvider(lockProvider).build())
           .withEarlyConflictDetectionEnable(true)
           .withEarlyConflictDetectionStrategy(earlyConflictDetectionStrategy)
-          .withAsyncConflictDetectorBatchIntervalMs(0)
+          .withAsyncConflictDetectorInitialDelayMs(0)
           .withAsyncConflictDetectorPeriodMs(100)
           .withAutoCommit(false).withProperties(properties).build();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/conflict/detection/TimelineServerBasedDetectionStrategy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/conflict/detection/TimelineServerBasedDetectionStrategy.java
@@ -48,7 +48,7 @@ public abstract class TimelineServerBasedDetectionStrategy implements EarlyConfl
   /**
    * Starts the async conflict detection thread.
    *
-   * @param batchIntervalMs                   Batch internal in milliseconds.
+   * @param initialDelayMs                    Initial delay in milliseconds.
    * @param periodMs                          Scheduling period in milliseconds.
    * @param markerDir                         Marker directory.
    * @param basePath                          Base path of the table.
@@ -57,7 +57,7 @@ public abstract class TimelineServerBasedDetectionStrategy implements EarlyConfl
    * @param markerHandler                     Marker handler.
    * @param completedCommits                  Completed Hudi commits.
    */
-  public abstract void startAsyncDetection(Long batchIntervalMs, Long periodMs, String markerDir,
+  public abstract void startAsyncDetection(Long initialDelayMs, Long periodMs, String markerDir,
                                            String basePath, Long maxAllowableHeartbeatIntervalInMs,
                                            FileSystem fileSystem, Object markerHandler,
                                            Set<HoodieInstant> completedCommits);

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
@@ -141,17 +141,17 @@ public class TimelineService {
             + "conflict is detected, to release cluster compute resources as soon as possible.")
     public Boolean earlyConflictDetectionEnable = false;
 
-    @Parameter(names = {"--async-conflict-detector-batch-interval-ms"}, description =
+    @Parameter(names = {"--async-conflict-detector-initial-delay-ms"}, description =
         "Used for timeline-server-based markers with "
             + "`AsyncTimelineServerBasedDetectionStrategy`. "
-            + "The time in milliseconds to delay first async marker conflict detection.")
-    public Long asyncConflictDetectorBatchIntervalMs = 30000L;
+            + "The time in milliseconds to delay the first execution of async marker-based conflict detection.")
+    public Long asyncConflictDetectorInitialDelayMs = 30000L;
 
-    @Parameter(names = {"--async-conflict-detector-batch-period-ms"}, description =
+    @Parameter(names = {"--async-conflict-detector-period-ms"}, description =
         "Used for timeline-server-based markers with "
             + "`AsyncTimelineServerBasedDetectionStrategy`. "
-            + "The period in milliseconds between consecutive runs of async marker conflict detection.")
-    public Long asyncConflictDetectorBatchPeriodMs = 30000L;
+            + "The period in milliseconds between successive executions of async marker-based conflict detection.")
+    public Long asyncConflictDetectorPeriodMs = 30000L;
 
     @Parameter(names = {"--early-conflict-detection-max-heartbeat-interval-ms"}, description =
         "Used for timeline-server-based markers with "
@@ -186,8 +186,8 @@ public class TimelineService {
       private String earlyConflictDetectionStrategy = "org.apache.hudi.timeline.service.handlers.marker.AsyncTimelineServerBasedDetectionStrategy";
       private Boolean checkCommitConflict = false;
       private Boolean earlyConflictDetectionEnable = false;
-      private Long asyncConflictDetectorBatchIntervalMs = 30000L;
-      private Long asyncConflictDetectorBatchPeriodMs = 30000L;
+      private Long asyncConflictDetectorInitialDelayMs = 30000L;
+      private Long asyncConflictDetectorPeriodMs = 30000L;
       private Long maxAllowableHeartbeatIntervalInMs = 60000L;
 
       public Builder() {
@@ -273,13 +273,13 @@ public class TimelineService {
         return this;
       }
 
-      public Builder asyncConflictDetectorBatchIntervalMs(Long asyncConflictDetectorBatchIntervalMs) {
-        this.asyncConflictDetectorBatchIntervalMs = asyncConflictDetectorBatchIntervalMs;
+      public Builder asyncConflictDetectorInitialDelayMs(Long asyncConflictDetectorInitialDelayMs) {
+        this.asyncConflictDetectorInitialDelayMs = asyncConflictDetectorInitialDelayMs;
         return this;
       }
 
-      public Builder asyncConflictDetectorBatchPeriodMs(Long asyncConflictDetectorBatchPeriodMs) {
-        this.asyncConflictDetectorBatchPeriodMs = asyncConflictDetectorBatchPeriodMs;
+      public Builder asyncConflictDetectorPeriodMs(Long asyncConflictDetectorPeriodMs) {
+        this.asyncConflictDetectorPeriodMs = asyncConflictDetectorPeriodMs;
         return this;
       }
 
@@ -306,8 +306,8 @@ public class TimelineService {
         config.earlyConflictDetectionStrategy = this.earlyConflictDetectionStrategy;
         config.checkCommitConflict = this.checkCommitConflict;
         config.earlyConflictDetectionEnable = this.earlyConflictDetectionEnable;
-        config.asyncConflictDetectorBatchIntervalMs = this.asyncConflictDetectorBatchIntervalMs;
-        config.asyncConflictDetectorBatchPeriodMs = this.asyncConflictDetectorBatchPeriodMs;
+        config.asyncConflictDetectorInitialDelayMs = this.asyncConflictDetectorInitialDelayMs;
+        config.asyncConflictDetectorPeriodMs = this.asyncConflictDetectorPeriodMs;
         config.maxAllowableHeartbeatIntervalInMs = this.maxAllowableHeartbeatIntervalInMs;
         return config;
       }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/MarkerHandler.java
@@ -215,8 +215,8 @@ public class MarkerHandler extends Handler {
                     .getInstants());
 
             earlyConflictDetectionStrategy.startAsyncDetection(
-                timelineServiceConfig.asyncConflictDetectorBatchIntervalMs,
-                timelineServiceConfig.asyncConflictDetectorBatchPeriodMs,
+                timelineServiceConfig.asyncConflictDetectorInitialDelayMs,
+                timelineServiceConfig.asyncConflictDetectorPeriodMs,
                 markerDir, basePath, timelineServiceConfig.maxAllowableHeartbeatIntervalInMs,
                 fileSystem, this, completedCommits);
           }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/AsyncTimelineServerBasedDetectionStrategy.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/AsyncTimelineServerBasedDetectionStrategy.java
@@ -61,7 +61,7 @@ public class AsyncTimelineServerBasedDetectionStrategy extends TimelineServerBas
   }
 
   @Override
-  public void startAsyncDetection(Long batchIntervalMs, Long periodMs, String markerDir,
+  public void startAsyncDetection(Long initialDelayMs, Long periodMs, String markerDir,
                                   String basePath, Long maxAllowableHeartbeatIntervalInMs,
                                   FileSystem fileSystem, Object markerHandler,
                                   Set<HoodieInstant> completedCommits) {
@@ -74,7 +74,7 @@ public class AsyncTimelineServerBasedDetectionStrategy extends TimelineServerBas
         new MarkerBasedEarlyConflictDetectionRunnable(
             hasConflict, (MarkerHandler) markerHandler, markerDir, basePath,
             fileSystem, maxAllowableHeartbeatIntervalInMs, completedCommits, checkCommitConflict),
-        batchIntervalMs, periodMs, TimeUnit.MILLISECONDS);
+        initialDelayMs, periodMs, TimeUnit.MILLISECONDS);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

This PR renames the following configs for async conflict detector:
- `hoodie.write.concurrency.early.conflict.async.detector.batch.interval_ms` -> `hoodie.write.concurrency.async.conflict.detector.initial_delay_ms`
- `hoodie.write.concurrency.early.conflict.async.detector.period_ms` -> `hoodie.write.concurrency.async.conflict.detector.period_ms`

### Impact

These configs are for 0.13.0 release so there is no impact at this point.

### Risk level

none

### Documentation Update

The documentation is going to be updated automatically once 0.13.0 release docs is built.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
