### PR TITLE
[HUDI-5623] Increase default time to wait between retries by lock provider client

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
@@ -81,7 +81,7 @@ public class HoodieLockConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS = ConfigProperty
       .key(LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY)
-      .defaultValue(String.valueOf(2000L))
+      .defaultValue(String.valueOf(5000L))
       .sinceVersion("0.8.0")
       .withDocumentation("Amount of time to wait between retries on the lock provider by the lock manager");
 


### PR DESCRIPTION
### Change Logs

This PR increases the default time to wait between retries by lock provider client (`hoodie.write.lock.client.wait_time_ms_between_retry`) from 2s to 5s as 2s is too aggressive.

### Impact

Reduces the number of aggressive retries.

### Risk level

none

### Documentation Update

The config default value will be automatically updated on the website once the release docs is cut.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
