### PR TITLE
[HUDI-5627] Improve the usability of Hudi CLI bundle

### DIFF
--- a/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
+++ b/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
@@ -16,13 +16,32 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 
+JAKARTA_EL_VERSION=3.0.3
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "DIR is ${DIR}"
-CLI_BUNDLE_JAR=`ls $DIR/target/hudi-cli-bundle*.jar | grep -v source | grep -v javadoc`
-SPARK_BUNDLE_JAR=`ls $DIR/../hudi-spark-bundle/target/hudi-spark*-bundle*.jar | grep -v source | grep -v javadoc`
+
+if [ -z "$CLI_BUNDLE_JAR" ]; then
+  echo "Inferring CLI_BUNDLE_JAR path assuming this script is under Hudi repo"
+  CLI_BUNDLE_JAR=`ls $DIR/target/hudi-cli-bundle*.jar | grep -v source | grep -v javadoc`
+fi
+
+if [ -z "$SPARK_BUNDLE_JAR" ]; then
+  echo "Inferring SPARK_BUNDLE_JAR path assuming this script is under Hudi repo"
+  SPARK_BUNDLE_JAR=`ls $DIR/../hudi-spark-bundle/target/hudi-spark*-bundle*.jar | grep -v source | grep -v javadoc`
+fi
+
+echo "CLI_BUNDLE_JAR: $CLI_BUNDLE_JAR"
+echo "SPARK_BUNDLE_JAR: $SPARK_BUNDLE_JAR"
+
 HUDI_CONF_DIR="${DIR}"/conf
 # hudi aux lib contains jakarta.el jars, which need to be put directly on class path
 HUDI_AUX_LIB="${DIR}"/auxlib
+
+if [ ! -d $HUDI_AUX_LIB ]; then
+  echo "Downloading necessary auxiliary jars for Hudi CLI"
+  wget https://repo1.maven.org/maven2/org/glassfish/jakarta.el/$JAKARTA_EL_VERSION/jakarta.el-$JAKARTA_EL_VERSION.jar -P auxlib
+  wget https://repo1.maven.org/maven2/jakarta/el/jakarta.el-api/$JAKARTA_EL_VERSION/jakarta.el-api-$JAKARTA_EL_VERSION.jar -P auxlib
+fi
 
 . "${DIR}"/conf/hudi-env.sh
 


### PR DESCRIPTION
### Change Logs

This PR improves the usability of Hudi CLI bundle by changing `hudi-cli-with-bundle.sh`:
- Adds the ability to specify existing `hudi-cli-bundle` and `hudi-spark-bundle` jars downloaded by user, through environmental variables `CLI_BUNDLE_JAR` and `SPARK_BUNDLE_JAR`.  Currently it assumes that these jars are built inside Hudi repo and there is no way to specify the jars from another path.
- Automatically downloads the auxiliary jars to `auxlib/` for Hudi CLI.  Right now, Hudi CLI bundle still requires additional `org.glassfish:jakarta.el` and `jakarta.el:jakarta.el-api` jars in the Java classpath to start the Hudi CLI shell.  Auto-downloads make it easier for the users.

### Impact

Makes `hudi-cli-with-bundle.sh` easier to start Hudi CLI shell.

This is tested locally on Spark 3.3.  The Hudi CLI shell can start without any problem.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
