### PR TITLE
[HUDI-5630] Fixing flaky parquet projection tests

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
@@ -31,8 +31,9 @@ import org.apache.parquet.hadoop.util.counters.BenchmarkCounter
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.{Dataset, HoodieUnsafeUtils, Row, SaveMode}
-import org.junit.jupiter.api.Assertions.{assertEquals, fail}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
 import org.junit.jupiter.api.{Disabled, Tag, Test}
+
 import scala.collection.JavaConverters._
 
 @Tag("functional")
@@ -327,7 +328,9 @@ class TestParquetColumnProjection extends SparkClientFunctionalTestHarness with 
 
       assertEquals(expectedRecordCount, rows.length)
       if (expectedBytesRead != -1) {
-        assertEquals(expectedBytesRead, bytesRead)
+        // verify within 10% of margin.
+        val ten_perc: Double = expectedBytesRead * 0.1;
+        assertTrue((expectedBytesRead + ten_perc) >= bytesRead && bytesRead >= (expectedBytesRead - ten_perc))
       } else {
         logWarning(s"Not matching bytes read ($bytesRead)")
       }


### PR DESCRIPTION
### Change Logs

Fixing flaky parquet projection tests. Added 10% margin for expected bytes from col projection. 

### Impact

Stable CI

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
