### PR TITLE
[HUDI-5631] Improve defaults of early conflict detection configs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -95,7 +95,9 @@ public class EmbeddedTimelineService {
           .earlyConflictDetectionCheckCommitConflict(writeConfig.earlyConflictDetectionCheckCommitConflict())
           .asyncConflictDetectorInitialDelayMs(writeConfig.getAsyncConflictDetectorInitialDelayMs())
           .asyncConflictDetectorPeriodMs(writeConfig.getAsyncConflictDetectorPeriodMs())
-          .earlyConflictDetectionMaxAllowableHeartbeatIntervalInMs(writeConfig.getHoodieClientHeartbeatIntervalInMs());
+          .earlyConflictDetectionMaxAllowableHeartbeatIntervalInMs(
+              writeConfig.getHoodieClientHeartbeatIntervalInMs()
+                  * writeConfig.getHoodieClientHeartbeatTolerableMisses());
     }
 
     server = new TimelineService(context, hadoopConf.newCopy(), timelineServiceConfBuilder.build(),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -582,7 +582,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public static final ConfigProperty<Long> ASYNC_CONFLICT_DETECTOR_INITIAL_DELAY_MS = ConfigProperty
       .key(CONCURRENCY_PREFIX + "async.conflict.detector.initial_delay_ms")
-      .defaultValue(30000L)
+      .defaultValue(0L)
       .sinceVersion("0.13.0")
       .withDocumentation("Used for timeline-server-based markers with "
           + "`AsyncTimelineServerBasedDetectionStrategy`. "

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
@@ -145,7 +145,7 @@ public class TimelineService {
         "Used for timeline-server-based markers with "
             + "`AsyncTimelineServerBasedDetectionStrategy`. "
             + "The time in milliseconds to delay the first execution of async marker-based conflict detection.")
-    public Long asyncConflictDetectorInitialDelayMs = 30000L;
+    public Long asyncConflictDetectorInitialDelayMs = 0L;
 
     @Parameter(names = {"--async-conflict-detector-period-ms"}, description =
         "Used for timeline-server-based markers with "
@@ -157,7 +157,7 @@ public class TimelineService {
         "Used for timeline-server-based markers with "
             + "`AsyncTimelineServerBasedDetectionStrategy`. "
             + "Instants whose heartbeat is greater than the current value will not be used in early conflict detection.")
-    public Long maxAllowableHeartbeatIntervalInMs = 60000L;
+    public Long maxAllowableHeartbeatIntervalInMs = 120000L;
 
     @Parameter(names = {"--help", "-h"})
     public Boolean help = false;
@@ -186,9 +186,9 @@ public class TimelineService {
       private String earlyConflictDetectionStrategy = "org.apache.hudi.timeline.service.handlers.marker.AsyncTimelineServerBasedDetectionStrategy";
       private Boolean checkCommitConflict = false;
       private Boolean earlyConflictDetectionEnable = false;
-      private Long asyncConflictDetectorInitialDelayMs = 30000L;
+      private Long asyncConflictDetectorInitialDelayMs = 0L;
       private Long asyncConflictDetectorPeriodMs = 30000L;
-      private Long maxAllowableHeartbeatIntervalInMs = 60000L;
+      private Long maxAllowableHeartbeatIntervalInMs = 120000L;
 
       public Builder() {
       }


### PR DESCRIPTION
### Change Logs

This PR improves the defaults of early conflict detection configs:
- `async.conflict.detector.initial_delay_ms`: 30,000 -> 0
- `maxAllowableHeartbeatIntervalInMs` for early conflict detection at the timeline server: 60,000 -> 120,000 to be aligned with existing heartbeat timeout

This PR also fixes a bug in `EmbeddedTimelineService` to set the correct `maxAllowableHeartbeatIntervalInMs` for early conflict detection.

### Impact

Gives better defaults for early conflict detection out of the box.

### Risk level

low

### Documentation Update

The defaults of the configs will be automatically updated on the Hudi website once the release docs are updated.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
