### PR TITLE
[HUDI-5635] Fix release scripts

### DIFF
--- a/scripts/release/cut_release_branch.sh
+++ b/scripts/release/cut_release_branch.sh
@@ -56,12 +56,13 @@ else
 fi
 
 if [[ -z "$RELEASE" || -z "$NEXT_VERSION_IN_BASE_BRANCH" || -z "$RC_NUM" ]]; then
-	echo "This sricpt needs to be ran with params, please run with -h to get more instructions."
+	echo "This script needs to be ran with params, please run with -h to get more instructions."
 	exit
 fi
 
 
 MASTER_BRANCH=master
+NEXT_VERSION_BRANCH=MINOR-move-to-${NEXT_VERSION_IN_BASE_BRANCH}
 RELEASE_BRANCH=release-${RELEASE}
 GITHUB_REPO_URL=git@github.com:apache/hudi.git
 HUDI_ROOT_DIR=hudi
@@ -71,6 +72,7 @@ echo "=====================Environment Variables====================="
 echo "version: ${RELEASE}"
 echo "next_release: ${NEXT_VERSION_IN_BASE_BRANCH}"
 echo "working master branch: ${MASTER_BRANCH}"
+echo "working next-version branch: ${NEXT_VERSION_BRANCH}"
 echo "working release branch: ${RELEASE_BRANCH}"
 echo "local repo dir: ~/${LOCAL_CLONE_DIR}/${HUDI_ROOT_DIR}"
 echo "RC_NUM: $RC_NUM"
@@ -90,15 +92,16 @@ cd ${HUDI_ROOT_DIR}
 git branch ${RELEASE_BRANCH}
 
 git checkout ${MASTER_BRANCH}
+git checkout -b ${NEXT_VERSION_BRANCH}
 
 echo "====================Current working branch====================="
-echo ${MASTER_BRANCH}
+echo ${NEXT_VERSION_BRANCH}
 echo "==============================================================="
 
 # Update master branch
 mvn versions:set -DnewVersion=${NEXT_VERSION_IN_BASE_BRANCH}-SNAPSHOT
 
-echo "==============Update master branch as following================"
+echo "===========Update next-version branch as following============="
 git diff
 echo "==============================================================="
 
@@ -110,14 +113,11 @@ if [[ $confirmation != "y" ]]; then
   exit
 fi
 
-git commit -am "Moving to ${NEXT_VERSION_IN_BASE_BRANCH}-SNAPSHOT on master branch."
+git commit -am "[MINOR] Moving to ${NEXT_VERSION_IN_BASE_BRANCH}-SNAPSHOT on master branch."
 
-if git push origin ${MASTER_BRANCH}; then
-  break
-else
-  clean_up
-  exit
-fi
+echo "==============================================================="
+echo "!!Please open a PR based on ${NEXT_VERSION_BRANCH} branch for approval!! [Press ENTER to continue]"
+read confirmation
 
 # Checkout and update release branch
 git checkout ${RELEASE_BRANCH}

--- a/scripts/release/deploy_staging_jars.sh
+++ b/scripts/release/deploy_staging_jars.sh
@@ -102,8 +102,16 @@ for v in "${ALL_VERSION_OPTS[@]}"
 do
   # clean everything before any round of depoyment
   $MVN clean $COMMON_OPTIONS
-  echo "Building with options ${v}"
-  $MVN install $COMMON_OPTIONS ${v}
+  if [[ "$v" == *"$BUNDLE_MODULES_EXCLUDED"* ]]; then
+    # When deploying jars with bundle exclusions, we still need to build the bundles,
+    # by removing "-pl -packaging/hudi-aws-bundle...", otherwise the build fails.
+    v1=${v%${BUNDLE_MODULES_EXCLUDED}}
+    echo "Building with options ${v1%-pl }"
+    $MVN install $COMMON_OPTIONS ${v1%-pl }
+  else
+    echo "Building with options ${v}"
+    $MVN install $COMMON_OPTIONS ${v}
+  fi
   echo "Deploying to repository.apache.org with version options ${v%-am}"
   # remove `-am` option to only deploy intended modules
   $MVN deploy $COMMON_OPTIONS ${v%-am}

--- a/scripts/release/deploy_staging_jars.sh
+++ b/scripts/release/deploy_staging_jars.sh
@@ -48,9 +48,9 @@ declare -a ALL_VERSION_OPTS=(
 "-Dscala-2.12 -Dspark3.1"  # this profile goes last in this section to ensure bundles use avro 1.8
 
 # spark bundles
-"-Dscala-2.11 -Dspark2.4 -pl packaging/hudi-spark-bundle -am"
+"-Dscala-2.11 -Dspark2.4 -pl packaging/hudi-spark-bundle,packaging/hudi-cli-bundle -am"
 "-Dscala-2.12 -Dspark2.4 -pl packaging/hudi-spark-bundle -am"
-"-Dscala-2.12 -Dspark3.3 -pl packaging/hudi-spark-bundle -am"
+"-Dscala-2.12 -Dspark3.3 -pl packaging/hudi-spark-bundle,packaging/hudi-cli-bundle -am"
 "-Dscala-2.12 -Dspark3.2 -pl packaging/hudi-spark-bundle -am"
 "-Dscala-2.12 -Dspark3.1 -pl packaging/hudi-spark-bundle -am"
 
@@ -101,10 +101,10 @@ COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=
 for v in "${ALL_VERSION_OPTS[@]}"
 do
   # clean everything before any round of depoyment
-  $MVN clean
+  $MVN clean $COMMON_OPTIONS
   echo "Building with options ${v}"
-  $MVN install "$COMMON_OPTIONS" "${v}"
+  $MVN install $COMMON_OPTIONS ${v}
   echo "Deploying to repository.apache.org with version options ${v%-am}"
   # remove `-am` option to only deploy intended modules
-  $MVN deploy "$COMMON_OPTIONS" "${v%-am}"
+  $MVN deploy $COMMON_OPTIONS ${v%-am}
 done

--- a/scripts/release/validate_staged_bundles.sh
+++ b/scripts/release/validate_staged_bundles.sh
@@ -29,6 +29,9 @@ VERSION=$2
 STAGING_REPO="https://repository.apache.org/content/repositories/${REPO}/org/apache/hudi"
 
 declare -a BUNDLE_URLS=(
+"${STAGING_REPO}/hudi-aws-bundle/${VERSION}/hudi-aws-bundle-${VERSION}.jar"
+"${STAGING_REPO}/hudi-cli-bundle_2.11/${VERSION}/hudi-cli-bundle_2.11-${VERSION}.jar"
+"${STAGING_REPO}/hudi-cli-bundle_2.12/${VERSION}/hudi-cli-bundle_2.12-${VERSION}.jar"
 "${STAGING_REPO}/hudi-datahub-sync-bundle/${VERSION}/hudi-datahub-sync-bundle-${VERSION}.jar"
 "${STAGING_REPO}/hudi-flink1.13-bundle/${VERSION}/hudi-flink1.13-bundle-${VERSION}.jar"
 "${STAGING_REPO}/hudi-flink1.14-bundle/${VERSION}/hudi-flink1.14-bundle-${VERSION}.jar"
@@ -39,6 +42,7 @@ declare -a BUNDLE_URLS=(
 "${STAGING_REPO}/hudi-hive-sync-bundle/${VERSION}/hudi-hive-sync-bundle-${VERSION}.jar"
 "${STAGING_REPO}/hudi-integ-test-bundle/${VERSION}/hudi-integ-test-bundle-${VERSION}.jar"
 "${STAGING_REPO}/hudi-kafka-connect-bundle/${VERSION}/hudi-kafka-connect-bundle-${VERSION}.jar"
+"${STAGING_REPO}/hudi-metaserver-server-bundle/${VERSION}/hudi-metaserver-server-bundle-${VERSION}.jar"
 "${STAGING_REPO}/hudi-presto-bundle/${VERSION}/hudi-presto-bundle-${VERSION}.jar"
 "${STAGING_REPO}/hudi-spark-bundle_2.11/${VERSION}/hudi-spark-bundle_2.11-${VERSION}.jar"
 "${STAGING_REPO}/hudi-spark-bundle_2.12/${VERSION}/hudi-spark-bundle_2.12-${VERSION}.jar"


### PR DESCRIPTION
### Change Logs

This PR fix the release scripts:
- `cut_release_branch.sh`: `git push` to master is no longer allowed.  Any commit to merge to master needs approval from a committer.  So `git push origin ${MASTER_BRANCH}` is removed from the script.  A new branch is created for the version upgrade on the master, and the script prompts the release manager to manually open a PR for this.
- `deploy_staging_jars.sh`: Previously, both mvn commands for each profile run tests and upload the jars to the staging area, which is a waste of time.  This issue is fixed in this PR.  Also, adjusts the profiles to add `hudi-cli-bundle`.
- `validate_staged_bundles.sh`: Adds new bundles generated.

### Impact

Makes sure the scripts run smoothly, efficiently, up to date based on the new bundles.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
