### PR TITLE
[HUDI-5640] Add missing profiles in `deploy_staging_jars.sh`

### DIFF
--- a/scripts/release/deploy_staging_jars.sh
+++ b/scripts/release/deploy_staging_jars.sh
@@ -104,7 +104,8 @@ fi
 COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=10"
 for v in "${ALL_VERSION_OPTS[@]}"
 do
-  if [[ "$v" == *"$BUNDLE_MODULES_EXCLUDED"* ]]; then
+  # TODO: consider cleaning all modules by listing directories instead of specifying profile
+  if [[ "$v" == *"$BUNDLE_MODULES_EXCLUDED" ]]; then
     # When deploying jars with bundle exclusions, we still need to build the bundles,
     # by removing "-pl -packaging/hudi-aws-bundle...", otherwise the build fails.
     v1=${v%${BUNDLE_MODULES_EXCLUDED}}

--- a/scripts/release/deploy_staging_jars.sh
+++ b/scripts/release/deploy_staging_jars.sh
@@ -60,8 +60,12 @@ declare -a ALL_VERSION_OPTS=(
 "-Dscala-2.12 -Dspark3 -pl packaging/hudi-spark-bundle -am" # for legacy bundle name hudi-spark3-bundle_2.12
 
 # utilities bundles (legacy) (overwriting previous uploads)
-"-Dscala-2.11 -Dspark2.4 -pl packaging/hudi-utilities-bundle -am" # utilities-bundle_2.11 is for spark 2.4 only
-"-Dscala-2.12 -Dspark3.1 -pl packaging/hudi-utilities-bundle -am" # utilities-bundle_2.12 is for spark 3.1 only
+"-Dscala-2.11 -Dspark2.4 -pl packaging/hudi-utilities-bundle -am" # hudi-utilities-bundle_2.11 is for spark 2.4 only
+"-Dscala-2.12 -Dspark3.1 -pl packaging/hudi-utilities-bundle -am" # hudi-utilities-bundle_2.12 is for spark 3.1 only
+
+# utilities slim bundles
+"-Dscala-2.11 -Dspark2.4 -pl packaging/hudi-utilities-slim-bundle -am" # hudi-utilities-slim-bundle_2.11
+"-Dscala-2.12 -Dspark3.1 -pl packaging/hudi-utilities-slim-bundle -am" # hudi-utilities-slim-bundle_2.12
 
 # flink bundles (overwriting previous uploads)
 "-Dscala-2.12 -Dflink1.13 -Davro.version=1.10.0 -pl packaging/hudi-flink-bundle -am"
@@ -100,15 +104,17 @@ fi
 COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=10"
 for v in "${ALL_VERSION_OPTS[@]}"
 do
-  # clean everything before any round of depoyment
-  $MVN clean $COMMON_OPTIONS
   if [[ "$v" == *"$BUNDLE_MODULES_EXCLUDED"* ]]; then
     # When deploying jars with bundle exclusions, we still need to build the bundles,
     # by removing "-pl -packaging/hudi-aws-bundle...", otherwise the build fails.
     v1=${v%${BUNDLE_MODULES_EXCLUDED}}
+    echo "Cleaning everything before any deployment"
+    $MVN clean $COMMON_OPTIONS ${v1%-pl }
     echo "Building with options ${v1%-pl }"
     $MVN install $COMMON_OPTIONS ${v1%-pl }
   else
+    echo "Cleaning everything before any deployment"
+    $MVN clean $COMMON_OPTIONS ${v}
     echo "Building with options ${v}"
     $MVN install $COMMON_OPTIONS ${v}
   fi


### PR DESCRIPTION
### Change Logs

This PR adds the mvn build profiles for `hudi-utilities-slim-bundle` to `deploy_staging_jars.sh` as currently it does not generate `hudi-utilities-slim-bundle_2.11`.

Also improves the mvn clean commands to properly clean all relevant modules before installation and deployment.

This is validated by running it for 0.13.0 RC1.

### Impact

Fixes `deploy_staging_jars.sh` to generate all `hudi-utilities-slim-bundle`.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
