### PR TITLE
[MINOR] Make `data_before_after` the default cdc logging mode

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -140,7 +140,7 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> CDC_SUPPLEMENTAL_LOGGING_MODE = ConfigProperty
       .key("hoodie.table.cdc.supplemental.logging.mode")
-      .defaultValue(op_key_only.name())
+      .defaultValue(data_before_after.name())
       .withValidValues(
           op_key_only.name(),
           data_before.name(),


### PR DESCRIPTION
### Change Logs

`hoodie.table.cdc.supplemental.logging.mode` default changed from `op_key_only` to `data_before_after`

### Impact

By default, cdc logging stores more data.

### Risk level

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
