### PR TITLE
[HUDI-5657] Fix NPE if filters condition contains null literal when using column stats data skipping for flink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ExpressionEvaluator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ExpressionEvaluator.java
@@ -40,6 +40,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Tool to evaluate the {@link org.apache.flink.table.expressions.ResolvedExpression}s.
@@ -237,6 +238,9 @@ public class ExpressionEvaluator {
 
     @Override
     public boolean eval() {
+      if (this.val == null) {
+        return false;
+      }
       // because the bounds are not necessarily a min or max value, this cannot be answered using
       // them. notEq(col, X) with (X, Y) doesn't guarantee that X is a value in col.
       return true;
@@ -282,6 +286,9 @@ public class ExpressionEvaluator {
 
     @Override
     public boolean eval() {
+      if (this.val == null) {
+        return false;
+      }
       if (this.minVal == null) {
         return false;
       }
@@ -299,6 +306,9 @@ public class ExpressionEvaluator {
 
     @Override
     public boolean eval() {
+      if (this.val == null) {
+        return false;
+      }
       if (this.maxVal == null) {
         return false;
       }
@@ -316,6 +326,9 @@ public class ExpressionEvaluator {
 
     @Override
     public boolean eval() {
+      if (this.val == null) {
+        return false;
+      }
       if (this.minVal == null) {
         return false;
       }
@@ -333,6 +346,9 @@ public class ExpressionEvaluator {
 
     @Override
     public boolean eval() {
+      if (this.val == null) {
+        return false;
+      }
       if (this.maxVal == null) {
         return false;
       }
@@ -352,6 +368,9 @@ public class ExpressionEvaluator {
 
     @Override
     public boolean eval() {
+      if (Arrays.stream(vals).anyMatch(Objects::isNull)) {
+        return false;
+      }
       if (this.minVal == null) {
         return false; // values are all null and literalSet cannot contain null.
       }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestExpressionEvaluator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestExpressionEvaluator.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import static org.apache.hudi.source.stats.ExpressionEvaluator.Evaluator.bindCall;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -108,9 +107,8 @@ public class TestExpressionEvaluator {
     equalTo.bindColStats(indexRow6, queryFields(2), rExpr);
     assertFalse(equalTo.eval(), "12 <> null");
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> equalTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT())));
+    equalTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    assertFalse(equalTo.eval(), "It is not possible to test for NULL values with '=' operator");
   }
 
   @Test
@@ -145,9 +143,8 @@ public class TestExpressionEvaluator {
     notEqualTo.bindColStats(indexRow6, queryFields(2), rExpr);
     assertTrue(notEqualTo.eval(), "12 <> null");
 
-    assertThrows(
-        IllegalStateException.class,
-        () ->  notEqualTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT())));
+    notEqualTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    assertFalse(notEqualTo.eval(), "It is not possible to test for NULL values with '<>' operator");
   }
 
   @Test
@@ -212,9 +209,8 @@ public class TestExpressionEvaluator {
     lessThan.bindColStats(indexRow6, queryFields(2), rExpr);
     assertFalse(lessThan.eval(), "12 <> null");
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> lessThan.bindVal(new ValueLiteralExpression(null, DataTypes.INT())));
+    lessThan.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    assertFalse(lessThan.eval(), "It is not possible to test for NULL values with '<' operator");
   }
 
   @Test
@@ -249,9 +245,8 @@ public class TestExpressionEvaluator {
     greaterThan.bindColStats(indexRow6, queryFields(2), rExpr);
     assertFalse(greaterThan.eval(), "12 <> null");
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> greaterThan.bindVal(new ValueLiteralExpression(null, DataTypes.INT())));
+    greaterThan.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    assertFalse(greaterThan.eval(), "It is not possible to test for NULL values with '>' operator");
   }
 
   @Test
@@ -286,9 +281,8 @@ public class TestExpressionEvaluator {
     lessThanOrEqual.bindColStats(indexRow6, queryFields(2), rExpr);
     assertFalse(lessThanOrEqual.eval(), "12 <> null");
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> lessThanOrEqual.bindVal(new ValueLiteralExpression(null, DataTypes.INT())));
+    lessThanOrEqual.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    assertFalse(lessThanOrEqual.eval(), "It is not possible to test for NULL values with '<=' operator");
   }
 
   @Test
@@ -323,9 +317,8 @@ public class TestExpressionEvaluator {
     greaterThanOrEqual.bindColStats(indexRow6, queryFields(2), rExpr);
     assertFalse(greaterThanOrEqual.eval(), "12 <> null");
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> greaterThanOrEqual.bindVal(new ValueLiteralExpression(null, DataTypes.INT())));
+    greaterThanOrEqual.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    assertFalse(greaterThanOrEqual.eval(), "It is not possible to test for NULL values with '>=' operator");
   }
 
   @Test
@@ -359,7 +352,8 @@ public class TestExpressionEvaluator {
     in.bindColStats(indexRow6, queryFields(2), rExpr);
     assertFalse(in.eval(), "12 <> null");
 
-    assertThrows(IllegalStateException.class, () -> in.bindVals((Object) null));
+    in.bindVals((Object) null);
+    assertFalse(in.eval(), "It is not possible to test for NULL values with 'in' operator");
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestExpressionEvaluator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestExpressionEvaluator.java
@@ -140,7 +140,8 @@ public class TestExpressionEvaluator {
     assertTrue(notEqualTo.eval(), "12 <> null");
 
     notEqualTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
-    assertTrue(notEqualTo.eval(), "null <> null");
+    notEqualTo.bindColStats(indexRow5, queryFields(2), rExpr);
+    assertFalse(notEqualTo.eval(), "null <> null");
   }
 
   @Test
@@ -206,6 +207,7 @@ public class TestExpressionEvaluator {
     assertFalse(lessThan.eval(), "12 <> null");
 
     lessThan.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    lessThan.bindColStats(indexRow4, queryFields(2), rExpr);
     assertFalse(lessThan.eval(), "null <> null");
   }
 
@@ -242,6 +244,7 @@ public class TestExpressionEvaluator {
     assertFalse(greaterThan.eval(), "12 <> null");
 
     greaterThan.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    greaterThan.bindColStats(indexRow5, queryFields(2), rExpr);
     assertFalse(greaterThan.eval(), "null <> null");
   }
 
@@ -278,6 +281,7 @@ public class TestExpressionEvaluator {
     assertFalse(lessThanOrEqual.eval(), "12 <> null");
 
     lessThanOrEqual.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    lessThanOrEqual.bindColStats(indexRow4, queryFields(2), rExpr);
     assertFalse(lessThanOrEqual.eval(), "null <> null");
   }
 
@@ -314,6 +318,7 @@ public class TestExpressionEvaluator {
     assertFalse(greaterThanOrEqual.eval(), "12 <> null");
 
     greaterThanOrEqual.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
+    greaterThanOrEqual.bindColStats(indexRow5, queryFields(2), rExpr);
     assertFalse(greaterThanOrEqual.eval(), "null <> null");
   }
 
@@ -349,6 +354,7 @@ public class TestExpressionEvaluator {
     assertFalse(in.eval(), "12 <> null");
 
     in.bindVals((Object) null);
+    in.bindColStats(indexRow3, queryFields(2), rExpr);
     assertFalse(in.eval(), "null <> null");
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestExpressionEvaluator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/stats/TestExpressionEvaluator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.source.stats;
 
+import org.apache.hudi.adapter.TestCallExpressions;
 import org.apache.hudi.utils.TestData;
 
 import org.apache.flink.table.api.DataTypes;
@@ -372,7 +373,7 @@ public class TestExpressionEvaluator {
         BuiltInFunctionDefinitions.IN};
     for (BuiltInFunctionDefinition funDef : funDefs) {
       CallExpression expr =
-          CallExpression.permanent(
+          TestCallExpressions.permanent(
               funDef,
               Arrays.asList(ref, nullLiteral),
               DataTypes.BOOLEAN());

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.types.DataType;
+
+import java.util.List;
+
+/**
+ * Call Expression creator for test goals.
+ */
+public class TestCallExpressions {
+
+  public static CallExpression permanent(
+      BuiltInFunctionDefinition builtInFunctionDefinition,
+      List<ResolvedExpression> args,
+      DataType dataType) {
+    return new CallExpression(
+        FunctionIdentifier.of(builtInFunctionDefinition.getName()),
+        builtInFunctionDefinition,
+        args,
+        dataType);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.types.DataType;
+
+import java.util.List;
+
+/**
+ * Call Expression creator for test goals.
+ */
+public class TestCallExpressions {
+
+  public static CallExpression permanent(
+      BuiltInFunctionDefinition builtInFunctionDefinition,
+      List<ResolvedExpression> args,
+      DataType dataType) {
+    return new CallExpression(
+        FunctionIdentifier.of(builtInFunctionDefinition.getName()),
+        builtInFunctionDefinition,
+        args,
+        dataType);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.types.DataType;
+
+import java.util.List;
+
+/**
+ * Call Expression creator for test goals.
+ */
+public class TestCallExpressions {
+
+  public static CallExpression permanent(
+      BuiltInFunctionDefinition builtInFunctionDefinition,
+      List<ResolvedExpression> args,
+      DataType dataType) {
+    return CallExpression.permanent(builtInFunctionDefinition, args, dataType);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/test/java/org/apache/hudi/adapter/TestCallExpressions.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.types.DataType;
+
+import java.util.List;
+
+/**
+ * Call Expression creator for test goals.
+ */
+public class TestCallExpressions {
+
+  public static CallExpression permanent(
+      BuiltInFunctionDefinition builtInFunctionDefinition,
+      List<ResolvedExpression> args,
+      DataType dataType) {
+    return CallExpression.permanent(builtInFunctionDefinition, args, dataType);
+  }
+}


### PR DESCRIPTION
[HUDI-5657] Fix NPE if filters condition contains null literal when using column stats data skipping for flink

### Change Logs

Fix NPE if filters condition contains null literal when using column stats data skipping for flink


### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
