### PR TITLE
[HUDI-915][HUDI-5656] Rebased `HoodieBootstrapRelation` onto `HoodieBaseRelation`

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -66,7 +66,12 @@ import scala.util.{Failure, Success, Try}
 
 trait HoodieFileSplit {}
 
-case class HoodieTableSchema(structTypeSchema: StructType, avroSchemaStr: String, internalSchema: Option[InternalSchema] = None)
+case class HoodieTableSchema(structTypeSchema: StructType, avroSchemaStr: String, internalSchema: Option[InternalSchema] = None) {
+
+  def this(structTypeSchema: StructType) =
+    this(structTypeSchema, convertToAvroSchema(structTypeSchema).toString)
+
+}
 
 case class HoodieTableState(tablePath: String,
                             latestCommitTimestamp: Option[String],
@@ -604,8 +609,8 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
       val prunedRequiredSchema = prunePartitionColumns(requiredSchema.structTypeSchema)
 
       (partitionSchema,
-        HoodieTableSchema(prunedDataStructSchema, convertToAvroSchema(prunedDataStructSchema).toString),
-        HoodieTableSchema(prunedRequiredSchema, convertToAvroSchema(prunedRequiredSchema).toString))
+        new HoodieTableSchema(prunedDataStructSchema),
+        new HoodieTableSchema(prunedRequiredSchema))
     } else {
       (StructType(Nil), tableSchema, requiredSchema)
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
@@ -83,12 +83,8 @@ class HoodieBootstrapRDD(@transient spark: SparkSession,
       }
 
       override def next(): InternalRow = {
-        combinedRow.withLeft(skeletonFileIterator.next())
-        combinedRow.withRight(dataFileIterator.next())
-
-        unsafeProjection(combinedRow)
+        unsafeProjection(combinedRow(skeletonFileIterator.next(), dataFileIterator.next()))
       }
-
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 class HoodieBootstrapRDD(@transient spark: SparkSession,
                          bootstrapDataFileReader: BaseFileReader,
                          bootstrapSkeletonFileReader: BaseFileReader,
-                         nativeFileReader: BaseFileReader,
+                         regularFileReader: BaseFileReader,
                          requiredColumns: Array[String],
                          @transient splits: Seq[HoodieBootstrapSplit])
   extends RDD[InternalRow](spark.sparkContext, Nil) {
@@ -62,8 +62,7 @@ class HoodieBootstrapRDD(@transient spark: SparkSession,
           merge(skeletonFileIterator, dataFileIterator)
         }
 
-      case _ =>
-        nativeFileReader.read(bootstrapPartition.split.dataFile)
+      case _ => regularFileReader.read(bootstrapPartition.split.dataFile)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
@@ -73,8 +73,6 @@ class HoodieBootstrapRDD(@transient spark: SparkSession,
   def merge(skeletonFileIterator: Iterator[InternalRow], dataFileIterator: Iterator[InternalRow]): Iterator[InternalRow] = {
     new Iterator[InternalRow] {
       private val combinedRow = new JoinedRow()
-      private val combinedSchema: StructType = StructType(bootstrapSkeletonFileReader.schema.fields ++ bootstrapDataFileReader.schema.fields)
-      private val unsafeProjection = generateUnsafeProjection(combinedSchema, requiredSchema.structTypeSchema)
 
       override def hasNext: Boolean = {
         checkState(dataFileIterator.hasNext == skeletonFileIterator.hasNext,
@@ -83,7 +81,7 @@ class HoodieBootstrapRDD(@transient spark: SparkSession,
       }
 
       override def next(): InternalRow = {
-        unsafeProjection(combinedRow(skeletonFileIterator.next(), dataFileIterator.next()))
+        combinedRow(skeletonFileIterator.next(), dataFileIterator.next())
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRDD.scala
@@ -20,13 +20,13 @@ package org.apache.hudi
 
 import org.apache.hudi.HoodieBaseRelation.BaseFileReader
 import org.apache.hudi.common.util.ValidationUtils.checkState
-import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.generateUnsafeProjection
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{JoinedRow, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.{Partition, TaskContext}
 
 class HoodieBootstrapRDD(@transient spark: SparkSession,
                          bootstrapDataFileReader: BaseFileReader,
@@ -53,20 +53,33 @@ class HoodieBootstrapRDD(@transient spark: SparkSession,
     bootstrapPartition.split.skeletonFile match {
       case Some(skeletonFile) =>
         // It is a bootstrap split. Check both skeleton and data files.
-        if (bootstrapDataFileReader.schema.isEmpty) {
+        val (iterator, schema) = if (bootstrapDataFileReader.schema.isEmpty) {
           // No data column to fetch, hence fetch only from skeleton file
-          bootstrapSkeletonFileReader.read(skeletonFile)
+          (bootstrapSkeletonFileReader.read(skeletonFile), bootstrapSkeletonFileReader.schema)
         } else if (bootstrapSkeletonFileReader.schema.isEmpty) {
           // No metadata column to fetch, hence fetch only from data file
-          bootstrapDataFileReader.read(bootstrapPartition.split.dataFile)
+          (bootstrapDataFileReader.read(bootstrapPartition.split.dataFile), bootstrapDataFileReader.schema)
         } else {
           // Fetch from both data and skeleton file, and merge
           val dataFileIterator = bootstrapDataFileReader.read(bootstrapPartition.split.dataFile)
           val skeletonFileIterator = bootstrapSkeletonFileReader.read(skeletonFile)
-          merge(skeletonFileIterator, dataFileIterator)
+          val mergedSchema = StructType(bootstrapSkeletonFileReader.schema.fields ++ bootstrapDataFileReader.schema.fields)
+
+          (merge(skeletonFileIterator, dataFileIterator), mergedSchema)
         }
 
-      case _ => regularFileReader.read(bootstrapPartition.split.dataFile)
+        // NOTE: Here we have to project the [[InternalRow]]s fetched into the expected target schema.
+        //       These could diverge for ex, when requested schema contains partition columns which might not be
+        //       persisted w/in the data file, but instead would be parsed from the partition path. In that case
+        //       output of the file-reader will have different ordering of the fields than the original required
+        //       schema (for more details please check out [[ParquetFileFormat]] implementation).
+        val unsafeProjection = generateUnsafeProjection(schema, requiredSchema.structTypeSchema)
+
+        iterator.map(unsafeProjection)
+
+      case _ =>
+        // NOTE: Regular file-reader is already projected into the required schema
+        regularFileReader.read(bootstrapPartition.split.dataFile)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -110,7 +110,7 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
       dataSchema = dataFileSchema,
       partitionSchema = partitionSchema,
       requiredSchema = requiredDataFileSchema,
-      // TODO elaborate
+      // TODO elaborate (we can't filter as we need record sequences to be aligned b/w data and skeleton files)
       filters = if (requiredSkeletonFileSchema.isEmpty) filters else Seq(),
       options = optParams,
       hadoopConf = sqlContext.sparkSession.sessionState.newHadoopConf()
@@ -121,7 +121,7 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
       dataSchema = skeletonSchema,
       partitionSchema = partitionSchema,
       requiredSchema = requiredSkeletonFileSchema,
-      // TODO elaborate
+      // TODO elaborate (we can't filter as we need record sequences to be aligned b/w data and skeleton files)
       filters = if (requiredDataFileSchema.isEmpty) filters else Seq(),
       options = optParams,
       hadoopConf = sqlContext.sparkSession.sessionState.newHadoopConf()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -102,7 +102,7 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
     val regularFileReader = createRegularFileReader(tableSchema, requiredSchema, filters)
 
     new HoodieBootstrapRDD(sqlContext.sparkSession, bootstrapDataFileReader, bootstrapSkeletonFileReader, regularFileReader,
-      requestedColumns, fileSplits)
+      requiredSchema, fileSplits)
   }
 
   private def createBootstrapFileReaders(tableSchema: HoodieTableSchema,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -67,6 +67,12 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
 
   override val mandatoryFields: Seq[String] = Seq.empty
 
+  // NOTE: Bootstrap relation have to always extract partition values from the partition-path as this is a
+  //       default Spark behavior: Spark by default strips partition-columns from the data schema and does
+  //       NOT persist them in the data files, instead parsing them from partition-paths (on the fly) whenever
+  //       table is queried
+  override protected val shouldExtractPartitionValuesFromPartitionPath: Boolean = true
+
   protected override def collectFileSplits(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[FileSplit] = {
     val fileSlices = listLatestFileSlices(globPaths, partitionFilters, dataFilters)
     fileSlices.map { fileSlice =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -62,8 +62,6 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
   override type FileSplit = HoodieBootstrapSplit
   override type Relation = HoodieBootstrapRelation
 
-  private val resolver = sqlContext.sparkSession.sessionState.analyzer.resolver
-
   private lazy val skeletonSchema = HoodieSparkUtils.getMetaSchema
 
   override val mandatoryFields: Seq[String] = Seq.empty

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -134,17 +134,6 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
       shouldAppendPartitionValuesOverride = Some(true)
     )
 
-    // NOTE: In some case schema of the reader's output (reader's schema) might not match the schema expected by the caller.
-    //       This could occur for ex, when requested schema contains partition columns which might not be persisted w/in the
-    //       data file, but instead would be parsed from the partition path. In that case output of the file-reader will have
-    //       different ordering of the fields than the original required schema (for more details please check out
-    //       [[ParquetFileFormat]] impl). In that case we have to project the rows from the file-reader's schema
-    //       back into the one expected by the caller.
-    //       Meta-fields will be fetched from the skeleton file and therefore we have to strip them from the required
-    //       schema
-    val projectedBootstrapDataFileReader =
-      projectReader(bootstrapDataFileReader, removeMetaFields(requiredSchema.structTypeSchema))
-
     val boostrapSkeletonFileReader = createBaseFileReader(
       spark = sqlContext.sparkSession,
       dataSchema = new HoodieTableSchema(skeletonSchema),
@@ -162,7 +151,7 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
       shouldAppendPartitionValuesOverride = Some(false)
     )
 
-    (projectedBootstrapDataFileReader, boostrapSkeletonFileReader)
+    (bootstrapDataFileReader, boostrapSkeletonFileReader)
   }
 
   private def createRegularFileReader(tableSchema: HoodieTableSchema,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -190,7 +190,7 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
           StructType(requiredDataSchema.structTypeSchema.fields
             .filterNot(f => unusedMandatoryColumnNames.contains(f.name)))
 
-        HoodieTableSchema(prunedStructSchema, convertToAvroSchema(prunedStructSchema).toString)
+        new HoodieTableSchema(prunedStructSchema)
       }
 
       val requiredSchemaReaderSkipMerging = createBaseFileReader(

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -23,9 +23,11 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieMetadataConfig}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieRecord
-import org.apache.hudi.common.table.timeline.{HoodieActiveTimeline, HoodieInstantTimeGenerator}
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline.parseDateFromInstantTime
+import org.apache.hudi.common.table.timeline.{HoodieActiveTimeline, HoodieInstantTimeGenerator, HoodieTimeline}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
+import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.{AvroConversionUtils, DataSourceOptionsHelper, DataSourceReadOptions, SparkAdapterSupport}
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -42,6 +44,7 @@ import java.text.SimpleDateFormat
 import java.util.{Locale, Properties}
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Map
+import scala.util.Try
 
 object HoodieSqlCommonUtils extends SparkAdapterSupport {
   // NOTE: {@code SimpleDataFormat} is NOT thread-safe
@@ -251,11 +254,13 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
    */
   def formatQueryInstant(queryInstant: String): String = {
     val instantLength = queryInstant.length
-    if (instantLength == 19 || instantLength == 23) { // for yyyy-MM-dd HH:mm:ss[.SSS]
+    if (instantLength == 19 || instantLength == 23) {
+      // Handle "yyyy-MM-dd HH:mm:ss[.SSS]" format
       HoodieInstantTimeGenerator.getInstantForDateString(queryInstant)
     } else if (instantLength == HoodieInstantTimeGenerator.SECS_INSTANT_ID_LENGTH
-      || instantLength  == HoodieInstantTimeGenerator.MILLIS_INSTANT_ID_LENGTH) { // for yyyyMMddHHmmss[SSS]
-      HoodieActiveTimeline.parseDateFromInstantTime(queryInstant) // validate the format
+      || instantLength  == HoodieInstantTimeGenerator.MILLIS_INSTANT_ID_LENGTH) {
+      // Handle already serialized "yyyyMMddHHmmss[SSS]" format
+      validateInstant(queryInstant)
       queryInstant
     } else if (instantLength == 10) { // for yyyy-MM-dd
       HoodieActiveTimeline.formatDate(defaultDateFormat.get().parse(queryInstant))
@@ -355,5 +360,22 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
       }.mkString("/")
     }.mkString(",")
     partitionsToDrop
+  }
+
+  private def validateInstant(queryInstant: String): Unit = {
+    // Provided instant has to either
+    //  - Match one of the bootstrapping instants
+    //  - Be parse-able (as a date)
+    val valid = queryInstant match {
+      case HoodieTimeline.INIT_INSTANT_TS |
+           HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS |
+           HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS => true
+
+      case _ => Try(parseDateFromInstantTime(queryInstant)).isSuccess
+    }
+
+    if (!valid) {
+      throw new HoodieException(s"Got an invalid instant ($queryInstant)")
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -20,14 +20,16 @@ package org.apache.hudi.functional
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hudi.bootstrap.SparkParquetBootstrapDataProvider
 import org.apache.hudi.client.bootstrap.selector.FullRecordBootstrapModeSelector
+import org.apache.hudi.common.config.HoodieStorageConfig
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.functional.TestDataSourceForBootstrap.{dropMetaCols, sort}
 import org.apache.hudi.keygen.{NonpartitionedKeyGenerator, SimpleKeyGenerator}
 import org.apache.hudi.testutils.HoodieClientTestUtils
-import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers, HoodieSparkRecordMerger}
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
@@ -35,7 +37,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.{CsvSource, EnumSource, ValueSource}
 
 import java.time.Instant
 import java.util.Collections
@@ -56,6 +58,12 @@ class TestDataSourceForBootstrap {
     DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
   )
+
+  val sparkRecordTypeOpts = Map(
+    HoodieWriteConfig.RECORD_MERGER_IMPLS.key -> classOf[HoodieSparkRecordMerger].getName,
+    HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet"
+  )
+
   var basePath: String = _
   var srcPath: String = _
   var fs: FileSystem = _
@@ -157,8 +165,11 @@ class TestDataSourceForBootstrap {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("METADATA_ONLY", "FULL_RECORD"))
-  def testMetadataBootstrapCOWHiveStylePartitioned(bootstrapMode: String): Unit = {
+  @CsvSource(value = Array(
+    "METADATA_ONLY,AVRO", "METADATA_ONLY,SPARK",
+    "FULL_RECORD,AVRO", "FULL_RECORD,SPARK"
+  ))
+  def testMetadataBootstrapCOWHiveStylePartitioned(bootstrapMode: String, recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
 
@@ -181,7 +192,7 @@ class TestDataSourceForBootstrap {
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
       DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL,
-      readOpts,
+      readOpts ++ getRecordTypeOpts(recordType),
       classOf[SimpleKeyGenerator].getName)
 
     // check marked directory clean up
@@ -208,9 +219,11 @@ class TestDataSourceForBootstrap {
     val updateDF = TestBootstrap.generateTestRawTripDataset(updateTimestamp, 0, numRecordsUpdate, partitionPaths.asJava,
       jsc, spark.sqlContext)
 
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType)
+
     updateDF.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
@@ -234,28 +247,27 @@ class TestDataSourceForBootstrap {
     verifyIncrementalViewResult(commitInstantTime1, commitInstantTime2, isPartitioned = true, isHiveStylePartitioned = true)
   }
 
-  @Test def testMetadataBootstrapCOWPartitioned(): Unit = {
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieRecordType], names = Array("AVRO", "SPARK"))
+  def testMetadataBootstrapCOWPartitioned(recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
 
     val sourceDF = TestBootstrap.generateTestRawTripDataset(timestamp, 0, numRecords, partitionPaths.asJava, jsc,
       spark.sqlContext)
 
-    // Writing data for each partition instead of using partitionBy to avoid hive-style partitioning and hence
-    // have partitioned columns stored in the data file
-    partitionPaths.foreach(partitionPath => {
-      sourceDF
-        .filter(sourceDF("datestr").equalTo(lit(partitionPath)))
-        .write
-        .format("parquet")
-        .mode(SaveMode.Overwrite)
-        .save(srcPath + "/" + partitionPath)
-    })
+    sourceDF.write.format("parquet")
+      .partitionBy("datestr")
+      .mode(SaveMode.Overwrite)
+      .save(srcPath)
+
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
+      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
 
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
       DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL,
-      commonOpts.updated(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr"),
+      writeOpts,
       classOf[SimpleKeyGenerator].getName)
 
     // Read bootstrapped table and verify count using glob path
@@ -270,10 +282,9 @@ class TestDataSourceForBootstrap {
     val updateDf1 = hoodieROViewDF1.filter(col("_row_key") === verificationRowKey).withColumn(verificationCol, lit(updatedVerificationVal))
     updateDf1.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .mode(SaveMode.Append)
       .save(basePath)
 
@@ -290,10 +301,9 @@ class TestDataSourceForBootstrap {
 
     updateDF2.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .mode(SaveMode.Append)
       .save(basePath)
 
@@ -312,28 +322,27 @@ class TestDataSourceForBootstrap {
     verifyIncrementalViewResult(commitInstantTime1, commitInstantTime3, isPartitioned = true, isHiveStylePartitioned = false)
   }
 
-  @Test def testMetadataBootstrapMORPartitionedInlineCompactionOn(): Unit = {
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieRecordType], names = Array("AVRO", "SPARK"))
+  def testMetadataBootstrapMORPartitionedInlineCompactionOn(recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
 
     val sourceDF = TestBootstrap.generateTestRawTripDataset(timestamp, 0, numRecords, partitionPaths.asJava, jsc,
       spark.sqlContext)
 
-    // Writing data for each partition instead of using partitionBy to avoid hive-style partitioning and hence
-    // have partitioned columns stored in the data file
-    partitionPaths.foreach(partitionPath => {
-      sourceDF
-        .filter(sourceDF("datestr").equalTo(lit(partitionPath)))
-        .write
-        .format("parquet")
-        .mode(SaveMode.Overwrite)
-        .save(srcPath + "/" + partitionPath)
-    })
+    sourceDF.write.format("parquet")
+      .partitionBy("datestr")
+      .mode(SaveMode.Overwrite)
+      .save(srcPath)
+
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
+      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
 
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
       DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
-      commonOpts.updated(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr"),
+      writeOpts,
       classOf[SimpleKeyGenerator].getName)
 
     // Read bootstrapped table and verify count
@@ -350,10 +359,9 @@ class TestDataSourceForBootstrap {
 
     updateDF.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .option(HoodieCompactionConfig.INLINE_COMPACT.key, "true")
       .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key, "1")
       .mode(SaveMode.Append)
@@ -379,28 +387,27 @@ class TestDataSourceForBootstrap {
     assertEquals(numRecordsUpdate, hoodieROViewDFWithBasePath.filter(s"timestamp == $updateTimestamp").count())
   }
 
-  @Test def testMetadataBootstrapMORPartitioned(): Unit = {
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieRecordType], names = Array("AVRO", "SPARK"))
+  def testMetadataBootstrapMORPartitioned(recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
 
     val sourceDF = TestBootstrap.generateTestRawTripDataset(timestamp, 0, numRecords, partitionPaths.asJava, jsc,
       spark.sqlContext)
 
-    // Writing data for each partition instead of using partitionBy to avoid hive-style partitioning and hence
-    // have partitioned columns stored in the data file
-    partitionPaths.foreach(partitionPath => {
-      sourceDF
-        .filter(sourceDF("datestr").equalTo(lit(partitionPath)))
-        .write
-        .format("parquet")
-        .mode(SaveMode.Overwrite)
-        .save(srcPath + "/" + partitionPath)
-    })
+    sourceDF.write.format("parquet")
+      .partitionBy("datestr")
+      .mode(SaveMode.Overwrite)
+      .save(srcPath)
+
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
+      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
 
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
       DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
-      commonOpts.updated(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr"),
+      writeOpts,
       classOf[SimpleKeyGenerator].getName)
 
     // Read bootstrapped table and verify count
@@ -423,10 +430,9 @@ class TestDataSourceForBootstrap {
     val updateDf1 = hoodieROViewDF1.filter(col("_row_key") === verificationRowKey).withColumn(verificationCol, lit(updatedVerificationVal))
     updateDf1.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .mode(SaveMode.Append)
       .save(basePath)
 
@@ -446,10 +452,9 @@ class TestDataSourceForBootstrap {
 
     updateDF2.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .mode(SaveMode.Append)
       .save(basePath)
 
@@ -466,31 +471,29 @@ class TestDataSourceForBootstrap {
     assertEquals(0, hoodieROViewDF3.filter(s"timestamp == $updateTimestamp").count())
   }
 
-  @Test def testFullBootstrapCOWPartitioned(): Unit = {
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieRecordType], names = Array("AVRO", "SPARK"))
+  def testFullBootstrapCOWPartitioned(recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
 
     val sourceDF = TestBootstrap.generateTestRawTripDataset(timestamp, 0, numRecords, partitionPaths.asJava, jsc,
       spark.sqlContext)
 
-    // Writing data for each partition instead of using partitionBy to avoid hive-style partitioning and hence
-    // have partitioned columns stored in the data file
-    partitionPaths.foreach(partitionPath => {
-      sourceDF
-        .filter(sourceDF("datestr").equalTo(lit(partitionPath)))
-        .write
-        .format("parquet")
-        .mode(SaveMode.Overwrite)
-        .save(srcPath + "/" + partitionPath)
-    })
+    sourceDF.write.format("parquet")
+      .partitionBy("datestr")
+      .mode(SaveMode.Overwrite)
+      .save(srcPath)
+
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
+      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
 
     // Perform bootstrap
     val bootstrapDF = spark.emptyDataFrame
     bootstrapDF.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .option(HoodieBootstrapConfig.BASE_PATH.key, srcPath)
       .option(HoodieBootstrapConfig.KEYGEN_CLASS_NAME.key, classOf[SimpleKeyGenerator].getName)
       .option(HoodieBootstrapConfig.MODE_SELECTOR_CLASS_NAME.key, classOf[FullRecordBootstrapModeSelector].getName)
@@ -515,10 +518,9 @@ class TestDataSourceForBootstrap {
 
     updateDF.write
       .format("hudi")
-      .options(commonOpts)
+      .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
-      .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "datestr")
       .mode(SaveMode.Append)
       .save(basePath)
 
@@ -596,6 +598,12 @@ class TestDataSourceForBootstrap {
         hoodieIncViewDF3.count())
     }
   }
+
+  def getRecordTypeOpts(recordType: HoodieRecordType): Map[String, String] =
+    recordType match {
+      case HoodieRecordType.SPARK => sparkRecordTypeOpts
+      case _ => Map.empty
+    }
 }
 
 object TestDataSourceForBootstrap {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -201,7 +201,6 @@ class TestDataSourceForBootstrap {
     // check marked directory clean up
     assert(!fs.exists(new Path(basePath, ".hoodie/.temp/00000000000001")))
 
-    // TODO(HUDI-5602) troubleshoot
     val expectedDF = bootstrapMode match {
       case "METADATA_ONLY" =>
         sort(sourceDF)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -161,7 +161,7 @@ class TestDataSourceForBootstrap {
     assertEquals(numRecords, hoodieROViewDF1WithBasePath.count())
     assertEquals(numRecordsUpdate, hoodieROViewDF1WithBasePath.filter(s"timestamp == $updateTimestamp").count())
 
-    verifyIncrementalViewResult(commitInstantTime1, commitInstantTime2, isPartitioned = false, isHiveStylePartitioned = false)
+    verifyIncrementalViewResult(commitInstantTime1, commitInstantTime2, isPartitioned = false, isHiveStylePartitioned = true)
   }
 
   @ParameterizedTest
@@ -261,8 +261,10 @@ class TestDataSourceForBootstrap {
       .mode(SaveMode.Overwrite)
       .save(srcPath)
 
-    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
-      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++ Map(
+      DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "true",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr"
+    )
 
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
@@ -319,7 +321,7 @@ class TestDataSourceForBootstrap {
     assertEquals(numRecords, hoodieROViewDF4.count())
     assertEquals(numRecordsUpdate, hoodieROViewDF4.filter(s"timestamp == $updateTimestamp").count())
 
-    verifyIncrementalViewResult(commitInstantTime1, commitInstantTime3, isPartitioned = true, isHiveStylePartitioned = false)
+    verifyIncrementalViewResult(commitInstantTime1, commitInstantTime3, isPartitioned = true, isHiveStylePartitioned = true)
   }
 
   @ParameterizedTest
@@ -336,8 +338,10 @@ class TestDataSourceForBootstrap {
       .mode(SaveMode.Overwrite)
       .save(srcPath)
 
-    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
-      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++ Map(
+      DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "true",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr"
+    )
 
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
@@ -401,8 +405,10 @@ class TestDataSourceForBootstrap {
       .mode(SaveMode.Overwrite)
       .save(srcPath)
 
-    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
-      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++ Map(
+      DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "true",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr"
+    )
 
     // Perform bootstrap
     val commitInstantTime1 = runMetadataBootstrapAndVerifyCommit(
@@ -485,8 +491,10 @@ class TestDataSourceForBootstrap {
       .mode(SaveMode.Overwrite)
       .save(srcPath)
 
-    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++
-      Map(DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr")
+    val writeOpts = commonOpts ++ getRecordTypeOpts(recordType) ++ Map(
+      DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "true",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "datestr"
+    )
 
     // Perform bootstrap
     val bootstrapDF = spark.emptyDataFrame
@@ -532,7 +540,7 @@ class TestDataSourceForBootstrap {
     assertEquals(numRecords, hoodieROViewDF2.count())
     assertEquals(numRecordsUpdate, hoodieROViewDF2.filter(s"timestamp == $updateTimestamp").count())
 
-    verifyIncrementalViewResult(commitInstantTime1, commitInstantTime2, isPartitioned = true, isHiveStylePartitioned = false)
+    verifyIncrementalViewResult(commitInstantTime1, commitInstantTime2, isPartitioned = true, isHiveStylePartitioned = true)
   }
 
   def runMetadataBootstrapAndVerifyCommit(tableType: String,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -190,7 +190,7 @@ class TestDataSourceForBootstrap {
     // TODO(HUDI-5602) troubleshoot
     val expectedDF = bootstrapMode match {
       case "METADATA_ONLY" =>
-        sort(sourceDF).withColumn("datestr", lit(null))
+        sort(sourceDF)
       case "FULL_RECORD" =>
         sort(sourceDF)
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -166,8 +166,11 @@ class TestDataSourceForBootstrap {
 
   @ParameterizedTest
   @CsvSource(value = Array(
-    "METADATA_ONLY,AVRO", "METADATA_ONLY,SPARK",
-    "FULL_RECORD,AVRO", "FULL_RECORD,SPARK"
+    "METADATA_ONLY,AVRO",
+    // TODO(HUDI-5807) enable for spark native records
+    /* "METADATA_ONLY,SPARK", */
+    "FULL_RECORD,AVRO",
+    "FULL_RECORD,SPARK"
   ))
   def testMetadataBootstrapCOWHiveStylePartitioned(bootstrapMode: String, recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
@@ -248,7 +251,9 @@ class TestDataSourceForBootstrap {
   }
 
   @ParameterizedTest
-  @EnumSource(value = classOf[HoodieRecordType], names = Array("AVRO", "SPARK"))
+  @EnumSource(value = classOf[HoodieRecordType],
+    // TODO(HUDI-5807) enable for spark native records
+    names = Array("AVRO" /*, "SPARK" */))
   def testMetadataBootstrapCOWPartitioned(recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
@@ -325,7 +330,9 @@ class TestDataSourceForBootstrap {
   }
 
   @ParameterizedTest
-  @EnumSource(value = classOf[HoodieRecordType], names = Array("AVRO", "SPARK"))
+  @EnumSource(value = classOf[HoodieRecordType],
+    // TODO(HUDI-5807) enable for spark native records
+    names = Array("AVRO" /*, "SPARK" */))
   def testMetadataBootstrapMORPartitionedInlineCompactionOn(recordType: HoodieRecordType): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -650,6 +650,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     cfg.configs.add(String.format("hoodie.bootstrap.base.path=%s", bootstrapSourcePath));
     cfg.configs.add(String.format("%s=%s", DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "rider"));
     cfg.configs.add(String.format("hoodie.bootstrap.keygen.class=%s", SimpleKeyGenerator.class.getName()));
+    cfg.configs.add("hoodie.datasource.write.hive_style_partitioning=true");
     cfg.configs.add("hoodie.bootstrap.parallelism=5");
     cfg.targetBasePath = newDatasetBasePath;
     new HoodieDeltaStreamer(cfg, jsc).sync();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -660,6 +660,9 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     TestHelpers.assertRecordCount(1950, newDatasetBasePath, sqlContext);
     res.registerTempTable("bootstrapped");
     assertEquals(1950, sqlContext.sql("select distinct _hoodie_record_key from bootstrapped").count());
+    // NOTE: To fetch record's count Spark will optimize the query fetching minimal possible amount
+    //       of data, which might not provide adequate amount of test coverage
+    sqlContext.sql("select * from bootstrapped").show();
 
     StructField[] fields = res.schema().fields();
     List<String> fieldNames = Arrays.asList(res.schema().fieldNames());


### PR DESCRIPTION
### Change Logs

Currently `HoodieBootstrapRelation` is treats partitioned tables improperly resulting in NPE while trying to read bootstrapped table. 

To address that `HoodieBootstrapRelation` have been rebased onto `HoodieBaseRelation` sharing core of the reading semantic with other Hudi's file-based Relation implementations for COW, MOR (such as schema handling, file-listing, etc)

### Impact

Addresses many issues and inconsistencies stemming from `HoodieBootstrapRelation` diverging from other Hudi `Relation` impls (including aforementioned NPE)

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
