### PR TITLE
[HUDI-5689] Make CDC config working for DeltaStreamer path

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -342,6 +342,10 @@ public class DeltaSync implements Serializable, Closeable {
         .setPreCombineField(cfg.sourceOrderingField)
         .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
             HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
+        .setCDCEnabled(props.getBoolean(HoodieTableConfig.CDC_ENABLED.key(),
+            HoodieTableConfig.CDC_ENABLED.defaultValue()))
+        .setCDCSupplementalLoggingMode(props.getString(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.key(),
+            HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.defaultValue()))
         .setShouldDropPartitionColumns(isDropPartitionColumns())
         .initTable(new Configuration(jssc.hadoopConfiguration()),
             cfg.targetBasePath);


### PR DESCRIPTION
### Change Logs

As of now, CDC configs are ignored by deltastreamer writer path. This PR makes CDC config persisted when DeltaStreamer table init.

### Impact

CDC will be activated when users set `--hoodie-conf ` for CDC configs for running deltastreamer.

### Risk level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
