### PR TITLE
[HUDI-5691] Fixing `HoodiePruneFileSourcePartitions` to properly handle non-partitioned tables

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
@@ -41,7 +41,7 @@ case class HoodiePruneFileSourcePartitions(spark: SparkSession) extends Rule[Log
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     case op @ PhysicalOperation(projects, filters, lr @ LogicalRelation(HoodieRelationMatcher(fileIndex), _, _, _))
-      if sparkAdapter.isHoodieTable(lr, spark) && fileIndex.partitionSchema.nonEmpty && !fileIndex.hasPredicatesPushedDown =>
+      if sparkAdapter.isHoodieTable(lr, spark) && !fileIndex.hasPredicatesPushedDown =>
 
       val deterministicFilters = filters.filter(f => f.deterministic && !SubqueryExpression.hasSubquery(f))
       val normalizedFilters = exprUtils.normalizeExprs(deterministicFilters, lr.output)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
@@ -126,13 +126,15 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
             case _ => throw new UnsupportedOperationException()
           }
 
-          val executionPlan = df.queryExecution.executedPlan
-          val expectedPhysicalPlanPartitionFiltersClause = tableType match {
-            case "cow" => s"PartitionFilters: [isnotnull($attr), ($attr = 2021-01-05)]"
-            case "mor" => s"PushedFilters: [IsNotNull(partition), EqualTo(partition,2021-01-05)]"
-          }
+          if (partitioned) {
+            val executionPlan = df.queryExecution.executedPlan
+            val expectedPhysicalPlanPartitionFiltersClause = tableType match {
+              case "cow" => s"PartitionFilters: [isnotnull($attr), ($attr = 2021-01-05)]"
+              case "mor" => s"PushedFilters: [IsNotNull(partition), EqualTo(partition,2021-01-05)]"
+            }
 
-          Assertions.assertTrue(executionPlan.toString().contains(expectedPhysicalPlanPartitionFiltersClause))
+            Assertions.assertTrue(executionPlan.toString().contains(expectedPhysicalPlanPartitionFiltersClause))
+          }
 
         case _ =>
           val failureHint =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
@@ -111,8 +111,8 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
                 assertEquals(1275, f.stats.sizeInBytes.longValue() / 1024)
                 assertEquals(1275, lr.stats.sizeInBytes.longValue() / 1024)
               } else {
-                assertEquals(424, f.stats.sizeInBytes.longValue() / 1024)
-                assertEquals(424, lr.stats.sizeInBytes.longValue() / 1024)
+                assertEquals(425, (f.stats.sizeInBytes.longValue() + 512) / 1024)
+                assertEquals(425, (lr.stats.sizeInBytes.longValue() + 512) / 1024)
               }
 
             // Case #2: Lazy listing (default mode).
@@ -120,8 +120,8 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
             //          eagerly pushed down (w/ help of [[HoodiePruneFileSourcePartitions]]) avoiding the necessity to
             //          list the whole table
             case "lazy" =>
-              assertEquals(425, f.stats.sizeInBytes.longValue() / 1024)
-              assertEquals(425, lr.stats.sizeInBytes.longValue() / 1024)
+              assertEquals(425, (f.stats.sizeInBytes.longValue() + 512) / 1024)
+              assertEquals(425, (lr.stats.sizeInBytes.longValue() + 512) / 1024)
 
             case _ => throw new UnsupportedOperationException()
           }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
@@ -111,8 +111,8 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
                 assertEquals(1275, f.stats.sizeInBytes.longValue() / 1024)
                 assertEquals(1275, lr.stats.sizeInBytes.longValue() / 1024)
               } else {
-                assertEquals(425, f.stats.sizeInBytes.longValue() / 1024)
-                assertEquals(425, lr.stats.sizeInBytes.longValue() / 1024)
+                assertEquals(424, f.stats.sizeInBytes.longValue() / 1024)
+                assertEquals(424, lr.stats.sizeInBytes.longValue() / 1024)
               }
 
             // Case #2: Lazy listing (default mode).
@@ -232,6 +232,5 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
       }
     }
   }
-
 
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
@@ -111,6 +111,7 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
                 assertEquals(1275, f.stats.sizeInBytes.longValue() / 1024)
                 assertEquals(1275, lr.stats.sizeInBytes.longValue() / 1024)
               } else {
+                // NOTE: We're adding 512 to make sure we always round to the next integer value
                 assertEquals(425, (f.stats.sizeInBytes.longValue() + 512) / 1024)
                 assertEquals(425, (lr.stats.sizeInBytes.longValue() + 512) / 1024)
               }
@@ -120,6 +121,7 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
             //          eagerly pushed down (w/ help of [[HoodiePruneFileSourcePartitions]]) avoiding the necessity to
             //          list the whole table
             case "lazy" =>
+              // NOTE: We're adding 512 to make sure we always round to the next integer value
               assertEquals(425, (f.stats.sizeInBytes.longValue() + 512) / 1024)
               assertEquals(425, (lr.stats.sizeInBytes.longValue() + 512) / 1024)
 


### PR DESCRIPTION
### Change Logs

This change addresses the issue of `HoodiePruneFileSourcePartition` rule not being applied to non-partitioned table resulting into their corresponding size being incorrectly estimated by Spark

### Impact

Addresses issue of Spark applying optimization based on incorrect stats

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
