### PR TITLE
[HUDI-5692] SpillableMapBasePath should be lazily loaded

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
@@ -218,7 +218,7 @@ public class HoodieLogFileCommand {
               .withBufferSize(HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE.defaultValue())
               .withMaxMemorySizeInBytes(
                   HoodieMemoryConfig.DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES)
-              .withSpillableMapBasePath(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.defaultValue())
+              .withSpillableMapBasePath(HoodieMemoryConfig.getDefaultSpillableMapBasePath())
               .withDiskMapType(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.defaultValue())
               .withBitCaskDiskMapCompressionEnabled(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue())
               .withRecordMerger(HoodieRecordUtils.loadRecordMerger(HoodieAvroRecordMerger.class.getName()))

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestHoodieLogFileCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestHoodieLogFileCommand.java
@@ -229,7 +229,7 @@ public class TestHoodieLogFileCommand extends CLIFunctionalTestHarness {
             Boolean.parseBoolean(
                 HoodieCompactionConfig.COMPACTION_REVERSE_LOG_READ_ENABLE.defaultValue()))
         .withBufferSize(HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE.defaultValue())
-        .withSpillableMapBasePath(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.defaultValue())
+        .withSpillableMapBasePath(HoodieMemoryConfig.getDefaultSpillableMapBasePath())
         .withDiskMapType(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.defaultValue())
         .withBitCaskDiskMapCompressionEnabled(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue())
         .withRecordMerger(HoodieRecordUtils.loadRecordMerger(HoodieAvroRecordMerger.class.getName()))

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieMemoryConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieMemoryConfig.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.util.FileIOUtils;
-import org.apache.hudi.common.util.Option;
 
 import javax.annotation.concurrent.Immutable;
 import java.io.File;
@@ -80,11 +79,7 @@ public class HoodieMemoryConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> SPILLABLE_MAP_BASE_PATH = ConfigProperty
       .key("hoodie.memory.spillable.map.path")
-      .defaultValue("/tmp/")
-      .withInferFunction(cfg -> {
-        String[] localDirs = FileIOUtils.getConfiguredLocalDirs();
-        return (localDirs != null && localDirs.length > 0) ? Option.of(localDirs[0]) : Option.empty();
-      })
+      .noDefaultValue()
       .withDocumentation("Default file path for spillable map");
 
   public static final ConfigProperty<Double> WRITESTATUS_FAILURE_FRACTION = ConfigProperty
@@ -121,9 +116,9 @@ public class HoodieMemoryConfig extends HoodieConfig {
   /** @deprecated Use {@link #SPILLABLE_MAP_BASE_PATH} and its methods instead */
   @Deprecated
   public static final String SPILLABLE_MAP_BASE_PATH_PROP = SPILLABLE_MAP_BASE_PATH.key();
-  /** @deprecated Use {@link #SPILLABLE_MAP_BASE_PATH} and its methods instead */
+  /** @deprecated Use getDefaultSpillableMapBasePath() instead */
   @Deprecated
-  public static final String DEFAULT_SPILLABLE_MAP_BASE_PATH = SPILLABLE_MAP_BASE_PATH.defaultValue();
+  public static final String DEFAULT_SPILLABLE_MAP_BASE_PATH = getDefaultSpillableMapBasePath();
   /** @deprecated Use {@link #WRITESTATUS_FAILURE_FRACTION} and its methods instead */
   @Deprecated
   public static final String WRITESTATUS_FAILURE_FRACTION_PROP = WRITESTATUS_FAILURE_FRACTION.key();
@@ -133,6 +128,11 @@ public class HoodieMemoryConfig extends HoodieConfig {
 
   private HoodieMemoryConfig() {
     super();
+  }
+
+  public static String getDefaultSpillableMapBasePath() {
+    String[] localDirs = FileIOUtils.getConfiguredLocalDirs();
+    return (localDirs != null && localDirs.length > 0) ? localDirs[0] : "/tmp/";
   }
 
   public static HoodieMemoryConfig.Builder newBuilder() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2090,7 +2090,8 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public String getSpillableMapBasePath() {
-    return getString(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH);
+    return Option.ofNullable(getString(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH))
+        .orElseGet(HoodieMemoryConfig::getDefaultSpillableMapBasePath);
   }
 
   public double getWriteStatusFailureFraction() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
@@ -123,7 +123,7 @@ public class FlinkCompactionConfig extends Configuration {
   public String compactionPlanInstant;
 
   @Parameter(names = {"--spillable_map_path"}, description = "Default file path prefix for spillable map.")
-  public String spillableMapPath = HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.defaultValue();
+  public String spillableMapPath = HoodieMemoryConfig.getDefaultSpillableMapBasePath();
 
   /**
    * Transforms a {@code HoodieFlinkCompaction.config} into {@code Configuration}.

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
@@ -287,7 +287,7 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
           .withReadBlocksLazily(true)
           .withReverseReader(false)
           .withBufferSize(HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE.defaultValue())
-          .withSpillableMapBasePath(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.defaultValue())
+          .withSpillableMapBasePath(HoodieMemoryConfig.getDefaultSpillableMapBasePath())
           .withDiskMapType(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.defaultValue())
           .withBitCaskDiskMapCompressionEnabled(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue())
           .withOptimizedLogBlocksScan(Boolean.parseBoolean(HoodieCompactionConfig.ENABLE_OPTIMIZED_LOG_BLOCKS_SCAN.defaultValue()))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileRecordsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileRecordsProcedure.scala
@@ -73,7 +73,7 @@ class ShowHoodieLogFileRecordsProcedure extends BaseProcedure with ProcedureBuil
         .withReverseReader(java.lang.Boolean.parseBoolean(HoodieCompactionConfig.COMPACTION_REVERSE_LOG_READ_ENABLE.defaultValue))
         .withBufferSize(HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE.defaultValue)
         .withMaxMemorySizeInBytes(HoodieMemoryConfig.DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES)
-        .withSpillableMapBasePath(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.defaultValue)
+        .withSpillableMapBasePath(HoodieMemoryConfig.getDefaultSpillableMapBasePath)
         .withDiskMapType(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.defaultValue)
         .withBitCaskDiskMapCompressionEnabled(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue)
         .withRecordMerger(HoodieRecordUtils.loadRecordMerger(classOf[HoodieAvroRecordMerger].getName))


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
If we use `withInferFunction` to set the default value of `SPILLABLE_MAP_BASE_PATH`, this default value will be set to `HoodieWriteConfig`'s `properties`, and will be serialized to all executors. This could introduce the issue that if the driver doesn't have the same temporary location with the executors side(e.g. driver: /mnt/disk1, executor: /mnt/disk2), the executor would throw error to create the spilled map path(since the executor machine doesn't have the directory /mnt/disk1).

```java
Caused by: org.apache.hudi.exception.HoodieIOException: Unable to create :/mnt/ssd/0/yarn/nm-local-dir/usercache/test/appcache/application_1673593627114_3970647/hudi-BITCASK-e3741235-6571-4112-8b20-271408148238
	at org.apache.hudi.common.util.collection.ExternalSpillableMap.getDiskBasedMap(ExternalSpillableMap.java:119)
	at org.apache.hudi.common.util.collection.ExternalSpillableMap.getDiskBasedMapNumEntries(ExternalSpillableMap.java:138)
	at org.apache.hudi.io.HoodieMergeHandle.init(HoodieMergeHandle.java:268)
	at org.apache.hudi.io.HoodieMergeHandle.(HoodieMergeHandle.java:129)
	at org.apache.hudi.io.HoodieMergeHandle.(HoodieMergeHandle.java:121)
	at org.apache.hudi.io.HoodieConcatHandle.(HoodieConcatHandle.java:81)
	at org.apache.hudi.io.HoodieMergeHandleFactory.create(HoodieMergeHandleFactory.java:60)
	at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.getUpdateHandle(BaseSparkCommitActionExecutor.java:386)
	at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpdate(BaseSparkCommitActionExecutor.java:363)
	at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpsertPartition(BaseSparkCommitActionExecutor.java:330)
	... 29 more
Caused by: java.io.IOException: Unable to create :/mnt/ssd/0/yarn/nm-local-dir/usercache/test/appcache/application_1673593627114_3970647/hudi-BITCASK-e3741235-6571-4112-8b20-271408148238
	at org.apache.hudi.common.util.FileIOUtils.mkdir(FileIOUtils.java:70)
	at org.apache.hudi.common.util.collection.DiskMap.(DiskMap.java:55)
	at org.apache.hudi.common.util.collection.BitCaskDiskMap.(BitCaskDiskMap.java:98)
	at org.apache.hudi.common.util.collection.ExternalSpillableMap.getDiskBasedMap(ExternalSpillableMap.java:116)
	... 38 more
```

A better solution is to calculate the temporary location when calling `getSpillableMapBasePath`


### Impact

_Describe any public API or user-facing feature change or any performance impact._
no

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
