### PR TITLE
[MINOR] Close InflaterInputStream in finally when calling decompressBytes in BitCaskDiskMap

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
@@ -442,8 +442,7 @@ public final class BitCaskDiskMap<T extends Serializable, R extends Serializable
 
     private byte[] decompressBytes(final byte[] bytes) throws IOException {
       decompressBaos.reset();
-      InputStream in = new InflaterInputStream(new ByteArrayInputStream(bytes));
-      try {
+      try (InputStream in = new InflaterInputStream(new ByteArrayInputStream(bytes))) {
         int len;
         while ((len = in.read(decompressIntermediateBuffer)) > 0) {
           decompressBaos.write(decompressIntermediateBuffer, 0, len);


### PR DESCRIPTION
### Change Logs

Close InflaterInputStream in finally when calling decompressBytes in BitCaskDiskMap. It will cause off heap memory leak if not close properly.

### Impact

No impact

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
