### PR TITLE
[HUDI-5695]Fix the wrong use of order field in PartialUpdateAvroPayload class.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/PartialUpdateAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/PartialUpdateAvroPayload.java
@@ -196,8 +196,7 @@ public class PartialUpdateAvroPayload extends OverwriteNonDefaultsWithLatestAvro
   /**
    * Returns whether the given record is newer than the record of this payload.
    *
-   * @param orderingVal
-   * @param schema
+   * @param schema      The schema
    * @param record      The record
    * @param prop        The payload properties
    * @return true if the given record is newer


### PR DESCRIPTION
### Change Logs

In the merge phase, when we call the combineAndGetUpdateValue method, the sorting field used is: house.payload.ordering.field instead of house.datasource.write.recombine.field.


### Impact

Fix the wrong use of order field in PartialUpdateAvroPayload class.

### Risk level (write none, low medium or high below)

high

### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
