### PR TITLE
[HUDI-5703] Improve ConfigProperty APIs for docs generation

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -34,10 +34,11 @@ import static org.apache.hudi.common.config.LockConfiguration.LOCK_PREFIX;
  * Hoodie Configs for Locks.
  */
 @ConfigClassProperty(name = "DynamoDB based Locks Configurations",
-                     groupName = ConfigGroups.Names.WRITE_CLIENT,
-                     description = "Configs that control DynamoDB based locking mechanisms required for concurrency control "
-                                   + " between writers to a Hudi table. Concurrency between Hudi's own table services "
-                                   + " are auto managed internally.")
+    groupName = ConfigGroups.Names.WRITE_CLIENT,
+    subGroupName = ConfigGroups.Names.LOCK,
+    description = "Configs that control DynamoDB based locking mechanisms required for concurrency control "
+        + " between writers to a Hudi table. Concurrency between Hudi's own table services "
+        + " are auto managed internally.")
 public class DynamoDbBasedLockConfig extends HoodieConfig {
 
   // configs for DynamoDb based locks

--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -35,7 +35,7 @@ import static org.apache.hudi.common.config.LockConfiguration.LOCK_PREFIX;
  */
 @ConfigClassProperty(name = "DynamoDB based Locks Configurations",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.LOCK,
+    subGroupName = ConfigGroups.SubGroupNames.LOCK,
     description = "Configs that control DynamoDB based locking mechanisms required for concurrency control "
         + " between writers to a Hudi table. Concurrency between Hudi's own table services "
         + " are auto managed internally.")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieHBaseIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieHBaseIndexConfig.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 
 @ConfigClassProperty(name = "HBase Index Configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.INDEX,
+    subGroupName = ConfigGroups.SubGroupNames.INDEX,
     description = "Configurations that control indexing behavior "
         + "(when HBase based indexing is enabled), which tags incoming "
         + "records as either inserts or updates to older records.")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieHBaseIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieHBaseIndexConfig.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 
 @ConfigClassProperty(name = "HBase Index Configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
+    subGroupName = ConfigGroups.Names.INDEX,
     description = "Configurations that control indexing behavior "
         + "(when HBase based indexing is enabled), which tags incoming "
         + "records as either inserts or updates to older records.")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -59,10 +59,11 @@ import static org.apache.hudi.index.HoodieIndex.IndexType.SIMPLE;
  * Indexing related config.
  */
 @Immutable
-@ConfigClassProperty(name = "Index Configs",
+@ConfigClassProperty(name = "Common Index Configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    description = "Configurations that control indexing behavior, "
-        + "which tags incoming records as either inserts or updates to older records.")
+    subGroupName = ConfigGroups.Names.INDEX,
+    shouldPresentFirst = true,
+    description = "")
 public class HoodieIndexConfig extends HoodieConfig {
 
   private static final Logger LOG = LogManager.getLogger(HoodieIndexConfig.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -61,8 +61,8 @@ import static org.apache.hudi.index.HoodieIndex.IndexType.SIMPLE;
 @Immutable
 @ConfigClassProperty(name = "Common Index Configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.INDEX,
-    shouldPresentFirst = true,
+    subGroupName = ConfigGroups.SubGroupNames.INDEX,
+    areCommonConfigs = true,
     description = "")
 public class HoodieIndexConfig extends HoodieConfig {
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
@@ -62,8 +62,8 @@ import static org.apache.hudi.common.config.LockConfiguration.ZK_SESSION_TIMEOUT
  */
 @ConfigClassProperty(name = "Common Lock Configurations",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.LOCK,
-    shouldPresentFirst = true,
+    subGroupName = ConfigGroups.SubGroupNames.LOCK,
+    areCommonConfigs = true,
     description = "")
 public class HoodieLockConfig extends HoodieConfig {
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
@@ -60,11 +60,11 @@ import static org.apache.hudi.common.config.LockConfiguration.ZK_SESSION_TIMEOUT
 /**
  * Hoodie Configs for Locks.
  */
-@ConfigClassProperty(name = "Locks Configurations",
+@ConfigClassProperty(name = "Common Lock Configurations",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    description = "Configs that control locking mechanisms required for concurrency control "
-        + " between writers to a Hudi table. Concurrency between Hudi's own table services "
-        + " are auto managed internally.")
+    subGroupName = ConfigGroups.Names.LOCK,
+    shouldPresentFirst = true,
+    description = "")
 public class HoodieLockConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS = ConfigProperty

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteCommitCallbackConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteCommitCallbackConfig.java
@@ -32,8 +32,8 @@ import java.util.Properties;
  */
 @ConfigClassProperty(name = "Write commit callback configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.COMMIT_CALLBACK,
-    shouldPresentFirst = true,
+    subGroupName = ConfigGroups.SubGroupNames.COMMIT_CALLBACK,
+    areCommonConfigs = true,
     description = "")
 public class HoodieWriteCommitCallbackConfig extends HoodieConfig {
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteCommitCallbackConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteCommitCallbackConfig.java
@@ -32,8 +32,9 @@ import java.util.Properties;
  */
 @ConfigClassProperty(name = "Write commit callback configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    description = "Controls callback behavior into HTTP endpoints, to push "
-        + " notifications on commits on hudi tables.")
+    subGroupName = ConfigGroups.Names.COMMIT_CALLBACK,
+    shouldPresentFirst = true,
+    description = "")
 public class HoodieWriteCommitCallbackConfig extends HoodieConfig {
 
   public static final String CALLBACK_PREFIX = "hoodie.write.commit.callback.";

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigClassProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigClassProperty.java
@@ -36,9 +36,9 @@ public @interface ConfigClassProperty {
 
   ConfigGroups.Names groupName();
 
-  ConfigGroups.Names subGroupName() default ConfigGroups.Names.NONE;
+  ConfigGroups.SubGroupNames subGroupName() default ConfigGroups.SubGroupNames.NONE;
 
-  boolean shouldPresentFirst() default false;
+  boolean areCommonConfigs() default false;
 
   String description();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigClassProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigClassProperty.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation for superclasses of {@link HoodieConfig} that includes the
  * human-readable name of the config class, the config group ({@link ConfigGroups})
- * it belongs to (e.g., spark/ flink/ write)
+ * it belongs to (e.g., spark/ flink/ write), optional sub-group ({@link ConfigGroups}),
  * and the description of the config class.
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -35,6 +35,10 @@ public @interface ConfigClassProperty {
   String name();
 
   ConfigGroups.Names groupName();
+
+  ConfigGroups.Names subGroupName() default ConfigGroups.Names.NONE;
+
+  boolean shouldPresentFirst() default false;
 
   String description();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -32,11 +32,15 @@ public class ConfigGroups {
     SPARK_DATASOURCE("Spark Datasource Configs"),
     FLINK_SQL("Flink Sql Configs"),
     WRITE_CLIENT("Write Client Configs"),
+    INDEX("Index Configs"),
+    LOCK("Lock Configs"),
+    COMMIT_CALLBACK("Commit Callback Configs"),
     META_SYNC("Metastore and Catalog Sync Configs"),
     METRICS("Metrics Configs"),
     RECORD_PAYLOAD("Record Payload Config"),
     KAFKA_CONNECT("Kafka Connect Configs"),
-    AWS("Amazon Web Services Configs");
+    AWS("Amazon Web Services Configs"),
+    NONE("(No categorization)");
 
     public final String name;
 
@@ -66,8 +70,24 @@ public class ConfigGroups {
             + "write schema, cleaning etc. Although Hudi provides sane defaults, from time-time "
             + "these configs may need to be tweaked to optimize for specific workloads.";
         break;
+      case INDEX:
+        description = "Configurations that control indexing behavior, "
+            + "which tags incoming records as either inserts or updates to older records.";
+        break;
+      case LOCK:
+        description = "Configurations that control locking mechanisms required for concurrency control "
+            + " between writers to a Hudi table. Concurrency between Hudi's own table services "
+            + " are auto managed internally.";
+        break;
+      case COMMIT_CALLBACK:
+        description = "Configurations controling callback behavior into HTTP endpoints, to push "
+            + "notifications on commits on hudi tables.";
+        break;
+      case META_SYNC:
+        description = "Configurations used by the Hudi to sync metadata to external metastores and catalogs.";
+        break;
       case RECORD_PAYLOAD:
-        description =  "This is the lowest level of customization offered by Hudi. "
+        description = "This is the lowest level of customization offered by Hudi. "
             + "Record payloads define how to produce new values to upsert based on incoming "
             + "new record and stored old record. Hudi provides default implementations such as "
             + "OverwriteWithLatestAvroPayload which simply update table with the latest/last-written record. "
@@ -80,6 +100,9 @@ public class ConfigGroups {
         break;
       case KAFKA_CONNECT:
         description = "These set of configs are used for Kafka Connect Sink Connector for writing Hudi Tables";
+        break;
+      case AWS:
+        description = "Configurations specific to Amazon Web Services.";
         break;
       default:
         description = "Please fill in the description for Config Group Name: " + names.name;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -32,15 +32,11 @@ public class ConfigGroups {
     SPARK_DATASOURCE("Spark Datasource Configs"),
     FLINK_SQL("Flink Sql Configs"),
     WRITE_CLIENT("Write Client Configs"),
-    INDEX("Index Configs"),
-    LOCK("Lock Configs"),
-    COMMIT_CALLBACK("Commit Callback Configs"),
     META_SYNC("Metastore and Catalog Sync Configs"),
     METRICS("Metrics Configs"),
     RECORD_PAYLOAD("Record Payload Config"),
     KAFKA_CONNECT("Kafka Connect Configs"),
-    AWS("Amazon Web Services Configs"),
-    NONE("(No categorization)");
+    AWS("Amazon Web Services Configs");
 
     public final String name;
 
@@ -49,11 +45,42 @@ public class ConfigGroups {
     }
   }
 
+  public enum SubGroupNames {
+    INDEX(
+        "Index Configs",
+        "Configurations that control indexing behavior, "
+            + "which tags incoming records as either inserts or updates to older records."),
+    LOCK(
+        "Lock Configs",
+        "Configurations that control locking mechanisms required for concurrency control "
+            + " between writers to a Hudi table. Concurrency between Hudi's own table services "
+            + " are auto managed internally."),
+    COMMIT_CALLBACK(
+        "Commit Callback Configs",
+        "Configurations controling callback behavior into HTTP endpoints, to push "
+            + "notifications on commits on hudi tables."),
+    NONE(
+        "None",
+        "No subgroup. This description should be hidden.");
+
+    public final String name;
+    private final String description;
+
+    SubGroupNames(String name, String description) {
+      this.name = name;
+      this.description = description;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+  }
+
   public static String getDescription(Names names) {
     String description;
     switch (names) {
       case SPARK_DATASOURCE:
-        description =  "These configs control the Hudi Spark Datasource, "
+        description = "These configs control the Hudi Spark Datasource, "
             + "providing ability to define keys/partitioning, pick out the write operation, "
             + "specify how to merge records or choosing query type to read.";
         break;
@@ -69,19 +96,6 @@ public class ConfigGroups {
             + "lower level aspects like file sizing, compression, parallelism, compaction, "
             + "write schema, cleaning etc. Although Hudi provides sane defaults, from time-time "
             + "these configs may need to be tweaked to optimize for specific workloads.";
-        break;
-      case INDEX:
-        description = "Configurations that control indexing behavior, "
-            + "which tags incoming records as either inserts or updates to older records.";
-        break;
-      case LOCK:
-        description = "Configurations that control locking mechanisms required for concurrency control "
-            + " between writers to a Hudi table. Concurrency between Hudi's own table services "
-            + " are auto managed internally.";
-        break;
-      case COMMIT_CALLBACK:
-        description = "Configurations controling callback behavior into HTTP endpoints, to push "
-            + "notifications on commits on hudi tables.";
         break;
       case META_SYNC:
         description = "Configurations used by the Hudi to sync metadata to external metastores and catalogs.";

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -64,11 +64,22 @@ public class HoodieConfig implements Serializable {
     props.putAll(properties);
   }
 
+  /**
+   * Sets the default value of a config if user does not set it already.
+   * The default value can only be set if the config property has a built-in
+   * default value or an infer function.  When the infer function is present,
+   * the infer function is used first to derive the config value based on other
+   * configs.  If the config value cannot be inferred, the built-in default value
+   * is used if present.
+   *
+   * @param configProperty Config to set a default value.
+   * @param <T>            Data type of the config.
+   */
   public <T> void setDefaultValue(ConfigProperty<T> configProperty) {
     if (!contains(configProperty)) {
       Option<T> inferValue = Option.empty();
-      if (configProperty.getInferFunc().isPresent()) {
-        inferValue = configProperty.getInferFunc().get().apply(this);
+      if (configProperty.hasInferFunction()) {
+        inferValue = configProperty.getInferFunction().get().apply(this);
       }
       if (inferValue.isPresent() || configProperty.hasDefaultValue()) {
         props.setProperty(
@@ -120,7 +131,7 @@ public class HoodieConfig implements Serializable {
         .forEach(f -> {
           try {
             ConfigProperty<?> cfgProp = (ConfigProperty<?>) f.get("null");
-            if (cfgProp.hasDefaultValue() || cfgProp.getInferFunc().isPresent()) {
+            if (cfgProp.hasDefaultValue() || cfgProp.hasInferFunction()) {
               setDefaultValue(cfgProp);
             }
           } catch (IllegalAccessException e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -20,8 +20,6 @@ package org.apache.hudi.common.table;
 
 import org.apache.hudi.common.bootstrap.index.HFileBootstrapIndex;
 import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
-import org.apache.hudi.common.config.ConfigClassProperty;
-import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.OrderedProperties;
@@ -75,14 +73,6 @@ import static org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode.
  * @see HoodieTableMetaClient
  * @since 0.3.0
  */
-@ConfigClassProperty(name = "Table Configurations",
-    groupName = ConfigGroups.Names.WRITE_CLIENT,
-    description = "Configurations that persist across writes and read on a Hudi table "
-        + " like  base, log file formats, table name, creation schema, table version layouts. "
-        + " Configurations are loaded from hoodie.properties, these properties are usually set during "
-        + "initializing a path as hoodie base path and rarely changes during "
-        + "the lifetime of the table. Writers/Queries' configurations are validated against these "
-        + " each time for compatibility.")
 public class HoodieTableConfig extends HoodieConfig {
 
   private static final Logger LOG = LogManager.getLogger(HoodieTableConfig.class);

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -56,9 +56,10 @@ import static org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIO
  * Configs needed to sync data into external meta stores, catalogs, etc.
  */
 @Immutable
-@ConfigClassProperty(name = "Metadata Sync Configs",
+@ConfigClassProperty(name = "Common Metadata Sync Configs",
     groupName = ConfigGroups.Names.META_SYNC,
-    description = "Configurations used by the Hudi to sync metadata to external metastores and catalogs.")
+    shouldPresentFirst = true,
+    description = "")
 public class HoodieSyncConfig extends HoodieConfig {
 
   private static final Logger LOG = LogManager.getLogger(HoodieSyncConfig.class);

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -58,7 +58,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIO
 @Immutable
 @ConfigClassProperty(name = "Common Metadata Sync Configs",
     groupName = ConfigGroups.Names.META_SYNC,
-    shouldPresentFirst = true,
+    areCommonConfigs = true,
     description = "")
 public class HoodieSyncConfig extends HoodieConfig {
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallbackConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallbackConfig.java
@@ -29,7 +29,7 @@ import static org.apache.hudi.config.HoodieWriteCommitCallbackConfig.CALLBACK_PR
  */
 @ConfigClassProperty(name = "Write commit Kafka callback configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.COMMIT_CALLBACK,
+    subGroupName = ConfigGroups.SubGroupNames.COMMIT_CALLBACK,
     description = "Controls notifications sent to Kafka, on events happening to a hudi table.")
 public class HoodieWriteCommitKafkaCallbackConfig extends HoodieConfig {
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallbackConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallbackConfig.java
@@ -29,6 +29,7 @@ import static org.apache.hudi.config.HoodieWriteCommitCallbackConfig.CALLBACK_PR
  */
 @ConfigClassProperty(name = "Write commit Kafka callback configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
+    subGroupName = ConfigGroups.Names.COMMIT_CALLBACK,
     description = "Controls notifications sent to Kafka, on events happening to a hudi table.")
 public class HoodieWriteCommitKafkaCallbackConfig extends HoodieConfig {
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/pulsar/HoodieWriteCommitPulsarCallbackConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/pulsar/HoodieWriteCommitPulsarCallbackConfig.java
@@ -29,6 +29,7 @@ import static org.apache.hudi.config.HoodieWriteCommitCallbackConfig.CALLBACK_PR
  */
 @ConfigClassProperty(name = "Write commit pulsar callback configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
+    subGroupName = ConfigGroups.Names.COMMIT_CALLBACK,
     description = "Controls notifications sent to pulsar, on events happening to a hudi table.")
 public class HoodieWriteCommitPulsarCallbackConfig extends HoodieConfig {
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/pulsar/HoodieWriteCommitPulsarCallbackConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/pulsar/HoodieWriteCommitPulsarCallbackConfig.java
@@ -29,7 +29,7 @@ import static org.apache.hudi.config.HoodieWriteCommitCallbackConfig.CALLBACK_PR
  */
 @ConfigClassProperty(name = "Write commit pulsar callback configs",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    subGroupName = ConfigGroups.Names.COMMIT_CALLBACK,
+    subGroupName = ConfigGroups.SubGroupNames.COMMIT_CALLBACK,
     description = "Controls notifications sent to pulsar, on events happening to a hudi table.")
 public class HoodieWriteCommitPulsarCallbackConfig extends HoodieConfig {
 


### PR DESCRIPTION
### Change Logs

This PR makes a few improvements around the `ConfigProperty` for auto-generating configuration docs on our website:
- Adds `subGroupName` and `areCommonConfigs` in `ConfigClassProperty` annotation.  Now we can structures the configs in three-level hierarchy (previously, it's two-level): `groupName` -> `subGroupName` (optional) -> config class.  New `SubGroupNames` in `ConfigGroups` is added for the sub-group name.  `areCommonConfigs` indicates whether these are common configs, showing as the first in the sub-group if true.
- Restructures index, lock, and commit configs:
  - LOCK sub-group: `HoodieLockConfig`, `DynamoDbBasedLockConfig`
  - INDEX sub-group: `HoodieIndexConfig`, `HoodieHBaseIndexConfig`
  - COMMIT_CALLBACK sub-group: `HoodieWriteCommitCallbackConfig`, `HoodieWriteCommitKafkaCallbackConfig`, `HoodieWriteCommitPulsarCallbackConfig`
- Adds the ability to provide docs on the default value in `ConfigProperty`: `docOnDefaultValue`, `getDocOnDefaultValue()`, so that the note on default can be shown on the configuration page.
- Adds `hasInferFunction()` in `ConfigProperty`
- Removes `ConfigClassProperty` annotation for `HoodieTableConfig` so they do not show up on the configuration page, as these are not meant to be changed by the user.
- Adds description for `META_SYNC` and `AWS` config groups

### Impact

Adds `ConfigProperty` APIs and new fields in `ConfigClassProperty` annotation for auto-generating configuration docs.

### Risk level

none

### Documentation Update

As above

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
