### PR TITLE
[HUDI-2175] Adding support for dynamic schemas

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -67,6 +67,14 @@ public class HoodieCommonConfig extends HoodieConfig {
       .defaultValue(true)
       .withDocumentation("Turn on compression for BITCASK disk map used by the External Spillable Map");
 
+  public static final String LEGACY_RECONCILE_STRATEGY = "legacy_reconcile_strategy";
+  public static final String DYNAMIC_SCHEMA_RECONCILE_STRATEGY = "dynamic_schema_reconcile_strategy";
+
+  public static final ConfigProperty<String> RECONCILE_SCHEMA_STRATEGY = ConfigProperty
+      .key("hoodie.datasource.write.reconcile.schema.strategy")
+      .defaultValue(LEGACY_RECONCILE_STRATEGY)
+      .withDocumentation("To be fixed");
+
   public ExternalSpillableMap.DiskMapType getSpillableDiskMapType() {
     return ExternalSpillableMap.DiskMapType.valueOf(getString(SPILLABLE_DISK_MAP_TYPE).toUpperCase(Locale.ROOT));
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -415,20 +415,19 @@ object HoodieSparkSqlWriter {
 
         val allowAutoEvolutionColumnDrop = opts.getOrDefault(HoodieWriteConfig.SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.key,
           HoodieWriteConfig.SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.defaultValue).toBoolean
+        val reconcileSchemaStrategy = opts.getOrDefault(HoodieCommonConfig.RECONCILE_SCHEMA_STRATEGY.key(),
+          HoodieCommonConfig.RECONCILE_SCHEMA_STRATEGY.defaultValue())
 
         if (shouldReconcileSchema) {
           internalSchemaOpt match {
             case Some(internalSchema) =>
               // Apply schema evolution, by auto-merging write schema and read schema
-              val mergedInternalSchema = AvroSchemaEvolutionUtils.reconcileSchema(canonicalizedSourceSchema, internalSchema)
-              val evolvedSchema = AvroInternalSchemaConverter.convert(mergedInternalSchema, latestTableSchema.getFullName)
-              val shouldRemoveMetaDataFromInternalSchema = sourceSchema.getFields().filter(f => f.name().equalsIgnoreCase(HoodieRecord.RECORD_KEY_METADATA_FIELD)).isEmpty
-              if (shouldRemoveMetaDataFromInternalSchema) HoodieAvroUtils.removeMetadataFields(evolvedSchema) else evolvedSchema
+              SchemaReconcileUtils.reconcileSchema(sourceSchema, canonicalizedSourceSchema, internalSchema, latestTableSchema.getFullName)
             case None =>
               // In case schema reconciliation is enabled we will employ (legacy) reconciliation
               // strategy to produce target writer's schema (see definition below)
               val (reconciledSchema, isCompatible) =
-                reconcileSchemasLegacy(latestTableSchema, canonicalizedSourceSchema)
+                SchemaReconcileUtils.reconcileSchemas(latestTableSchema, canonicalizedSourceSchema, reconcileSchemaStrategy)
 
               // NOTE: In some cases we need to relax constraint of incoming dataset's schema to be compatible
               //       w/ the table's one and allow schemas to diverge. This is required in cases where
@@ -538,31 +537,6 @@ object HoodieSparkSqlWriter {
     parameters ++ Map(HoodieWriteConfig.INTERNAL_SCHEMA_STRING.key() -> SerDeHelper.toJson(correctInternalSchema.getOrElse(null)),
       HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key() -> schemaEvolutionEnable,
       HoodieWriteConfig.AVRO_SCHEMA_VALIDATE_ENABLE.key()  -> schemaValidateEnable)
-  }
-
-  private def reconcileSchemasLegacy(tableSchema: Schema, newSchema: Schema): (Schema, Boolean) = {
-    // Legacy reconciliation implements following semantic
-    //    - In case new-schema is a "compatible" projection of the existing table's one (projection allowing
-    //      permitted type promotions), table's schema would be picked as (reconciled) writer's schema;
-    //    - Otherwise, we'd fall back to picking new (batch's) schema as a writer's schema;
-    //
-    // Philosophically, such semantic aims at always choosing a "wider" schema, ie the one containing
-    // the other one (schema A contains schema B, if schema B is a projection of A). This enables us,
-    // to always "extend" the schema during schema evolution and hence never lose the data (when, for ex
-    // existing column is being dropped in a new batch)
-    //
-    // NOTE: By default Hudi doesn't allow automatic schema evolution to drop the columns from the target
-    //       table. However, when schema reconciliation is turned on, we would allow columns to be dropped
-    //       in the incoming batch (as these would be reconciled in anyway)
-    if (isCompatibleProjectionOf(tableSchema, newSchema)) {
-      // Picking table schema as a writer schema we need to validate that we'd be able to
-      // rewrite incoming batch's data (written in new schema) into it
-      (tableSchema, isSchemaCompatible(newSchema, tableSchema, true))
-    } else {
-      // Picking new schema as a writer schema we need to validate that we'd be able to
-      // rewrite table's data into it
-      (newSchema, isSchemaCompatible(tableSchema, newSchema, true))
-    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SchemaReconcileUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SchemaReconcileUtils.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.avro.Schema
+import org.apache.hudi.avro.AvroSchemaUtils.{isCompatibleProjectionOf, isSchemaCompatible}
+import org.apache.hudi.avro.HoodieAvroUtils
+import org.apache.hudi.common.config.HoodieCommonConfig
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.internal.schema.InternalSchema
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter
+import org.apache.hudi.internal.schema.utils.AvroSchemaEvolutionUtils
+
+import scala.collection.JavaConversions.asScalaBuffer
+
+object SchemaReconcileUtils {
+
+  def reconcileSchema(sourceSchema: Schema, canonicalizedSourceSchema: Schema, internalSchema: InternalSchema, tableSchemaName: String) : Schema = {
+    val mergedInternalSchema = AvroSchemaEvolutionUtils.reconcileSchema(canonicalizedSourceSchema, internalSchema)
+    val evolvedSchema = AvroInternalSchemaConverter.convert(mergedInternalSchema, tableSchemaName)
+    val shouldRemoveMetaDataFromInternalSchema = sourceSchema.getFields().filter(f => f.name().equalsIgnoreCase(HoodieRecord.RECORD_KEY_METADATA_FIELD)).isEmpty
+    if (shouldRemoveMetaDataFromInternalSchema) HoodieAvroUtils.removeMetadataFields(evolvedSchema) else evolvedSchema
+  }
+
+  def reconcileSchemas(tableSchema: Schema, newSchema: Schema, reconcileStrategy: String): (Schema, Boolean) = {
+    if (reconcileStrategy.equalsIgnoreCase(HoodieCommonConfig.LEGACY_RECONCILE_STRATEGY)) {
+      // Legacy reconciliation implements following semantic
+      //    - In case new-schema is a "compatible" projection of the existing table's one (projection allowing
+      //      permitted type promotions), table's schema would be picked as (reconciled) writer's schema;
+      //    - Otherwise, we'd fall back to picking new (batch's) schema as a writer's schema;
+      //
+      // Philosophically, such semantic aims at always choosing a "wider" schema, ie the one containing
+      // the other one (schema A contains schema B, if schema B is a projection of A). This enables us,
+      // to always "extend" the schema during schema evolution and hence never lose the data (when, for ex
+      // existing column is being dropped in a new batch)
+      //
+      // NOTE: By default Hudi doesn't allow automatic schema evolution to drop the columns from the target
+      //       table. However, when schema reconciliation is turned on, we would allow columns to be dropped
+      //       in the incoming batch (as these would be reconciled in anyway)
+      if (isCompatibleProjectionOf(tableSchema, newSchema)) {
+        // Picking table schema as a writer schema we need to validate that we'd be able to
+        // rewrite incoming batch's data (written in new schema) into it
+        (tableSchema, isSchemaCompatible(newSchema, tableSchema, true))
+      } else {
+        // Picking new schema as a writer schema we need to validate that we'd be able to
+        // rewrite table's data into it
+        (newSchema, isSchemaCompatible(tableSchema, newSchema, true))
+      }
+    } else {
+      val mergedInternalSchema = AvroSchemaEvolutionUtils.reconcileSchema(newSchema, AvroInternalSchemaConverter.convert(tableSchema))
+      val evolvedSchema = AvroInternalSchemaConverter.convert(mergedInternalSchema, tableSchema.getFullName)
+      (evolvedSchema, isSchemaCompatible(evolvedSchema, tableSchema, true))
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

This patch introduce reconcile strategy and add dynamic schema strategy. Existing reconcile strategy is deemed as "legacy". 

Legacy reconcile strategy:
if newer incoming has more columns than table schema, newer incoming will be chosen as the new table schema. 
if newer incoming has few columns than table schema, table schema will remain as is. 
No other flows are supported. 

Dynamic schema reconcile strategy:
This is a super set of legacy. In this, newer incoming can have some dropped columns and could have new columns as well compared to table schema. New table schema will be last known table schema + new columns in new batch (even if new batch had some dropped columns, hudi will auto fill nulls) 

### Impact

More flexibility in evolving schemas w/ hudi. 

### Risk level (write none, low medium or high below)

low. 

### Documentation Update

Introducing a new config named `hoodie.datasource.write.reconcile.schema.strategy`. Default value is `legacy_reconcile_strategy`. and to leverage dynamic schema, value to set is `dynamic_schema_reconcile_strategy`. 
Users have to set reconcile `hoodie.datasource.write.reconcile.schema` to true to leverage this.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
