### PR TITLE
[HUDI-5688] Small workaround that can prevent NPE of EmptyRelation.schema

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -241,7 +241,12 @@ object DefaultSource {
     }
 
     if (metaClient.getCommitsTimeline.filterCompletedInstants.countInstants() == 0) {
-      new EmptyRelation(sqlContext, resolveSchema(metaClient, parameters, Some(schema)))
+      val structType = resolveSchema(metaClient, parameters, Some(schema))
+      if (structType == null) {
+        new EmptyRelation(sqlContext, new StructType())
+      } else {
+        new EmptyRelation(sqlContext, structType)
+      }
     } else if (isCdcQuery) {
       CDCRelation.getCDCRelation(sqlContext, metaClient, parameters)
     } else {


### PR DESCRIPTION
Relates to: https://issues.apache.org/jira/browse/HUDI-5688

A small workaround change that shows how creating EmptyRelation using an empty StructType() (instead of null for StructType). can make the NPE go away. Don't consider this as a fix yet, but just a validation of the bug report.