### PR TITLE
[HUDI-5717] Precision field is not need in FixedLenBytesColumnReader

### DIFF
--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -354,7 +354,7 @@ public class ParquetSplitReaderUtil {
             return new BytesColumnReader(descriptor, pageReader);
           case FIXED_LEN_BYTE_ARRAY:
             return new FixedLenBytesColumnReader(
-                descriptor, pageReader, ((DecimalType) fieldType).getPrecision());
+                descriptor, pageReader);
           default:
             throw new AssertionError();
         }

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
@@ -39,7 +39,7 @@ public class FixedLenBytesColumnReader<V extends WritableColumnVector>
     extends AbstractColumnReader<V> {
 
   public FixedLenBytesColumnReader(
-      ColumnDescriptor descriptor, PageReader pageReader, int precision) throws IOException {
+      ColumnDescriptor descriptor, PageReader pageReader) throws IOException {
     super(descriptor, pageReader);
     checkTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
   }

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -354,7 +354,7 @@ public class ParquetSplitReaderUtil {
             return new BytesColumnReader(descriptor, pageReader);
           case FIXED_LEN_BYTE_ARRAY:
             return new FixedLenBytesColumnReader(
-                descriptor, pageReader, ((DecimalType) fieldType).getPrecision());
+                descriptor, pageReader);
           default:
             throw new AssertionError();
         }

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
@@ -39,7 +39,7 @@ public class FixedLenBytesColumnReader<V extends WritableColumnVector>
     extends AbstractColumnReader<V> {
 
   public FixedLenBytesColumnReader(
-      ColumnDescriptor descriptor, PageReader pageReader, int precision) throws IOException {
+      ColumnDescriptor descriptor, PageReader pageReader) throws IOException {
     super(descriptor, pageReader);
     checkTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
   }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -354,7 +354,7 @@ public class ParquetSplitReaderUtil {
             return new BytesColumnReader(descriptor, pageReader);
           case FIXED_LEN_BYTE_ARRAY:
             return new FixedLenBytesColumnReader(
-                descriptor, pageReader, ((DecimalType) fieldType).getPrecision());
+                descriptor, pageReader);
           default:
             throw new AssertionError();
         }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
@@ -39,7 +39,7 @@ public class FixedLenBytesColumnReader<V extends WritableColumnVector>
     extends AbstractColumnReader<V> {
 
   public FixedLenBytesColumnReader(
-      ColumnDescriptor descriptor, PageReader pageReader, int precision) throws IOException {
+      ColumnDescriptor descriptor, PageReader pageReader) throws IOException {
     super(descriptor, pageReader);
     checkTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
   }

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -354,7 +354,7 @@ public class ParquetSplitReaderUtil {
             return new BytesColumnReader(descriptor, pageReader);
           case FIXED_LEN_BYTE_ARRAY:
             return new FixedLenBytesColumnReader(
-                descriptor, pageReader, ((DecimalType) fieldType).getPrecision());
+                descriptor, pageReader);
           default:
             throw new AssertionError();
         }

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/FixedLenBytesColumnReader.java
@@ -39,7 +39,7 @@ public class FixedLenBytesColumnReader<V extends WritableColumnVector>
     extends AbstractColumnReader<V> {
 
   public FixedLenBytesColumnReader(
-      ColumnDescriptor descriptor, PageReader pageReader, int precision) throws IOException {
+      ColumnDescriptor descriptor, PageReader pageReader) throws IOException {
     super(descriptor, pageReader);
     checkTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
   }


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
