### PR TITLE
[MINOR] Added safety-net check to catch any potential issue to deduce parallelism from the incoming `Dataset` appropriately

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
@@ -203,6 +203,17 @@ object HoodieDatasetBulkInsertHelper
       .values
   }
 
+  override protected def deduceShuffleParallelism(input: DataFrame, configuredParallelism: Int): Int = {
+    val deduceParallelism = super.deduceShuffleParallelism(input, configuredParallelism)
+    // NOTE: In case parallelism deduction failed to accurately deduce parallelism level of the
+    //       incoming dataset we fallback to default parallelism level set for this Spark session
+    if (deduceParallelism > 0) {
+      deduceParallelism
+    } else {
+      input.sparkSession.sparkContext.defaultParallelism
+    }
+  }
+
   private def dropPartitionColumns(df: DataFrame, config: HoodieWriteConfig): DataFrame = {
     val partitionPathFields = getPartitionPathFields(config).toSet
     val nestedPartitionPathFields = partitionPathFields.filter(f => f.contains('.'))


### PR DESCRIPTION
### Change Logs

Adding safety-net check and fallback to catch any potential issue to deduce parallelism from the incoming `Dataset` appropriately.

The reason to add such a fallback is following: some `SparkPlan`s might not properly report output partitioning (unlike RDDs). However, currently some Hudi `Partitioner`s actually assume that parallelism level will always be present, which might not be the case now that we recently removed default parallelism levels.

Proper fix for this is to make sure that `Partitioner`s don't assume that parallelism is always present. However, for the sake of 0.13, i'm adding the fallback to use Spark's session default parallelism level instead.

Created HUDI-5716 to follow up after 0.13

### Impact

Low

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
