### PR TITLE
[HUDI-5720] Improve the validation script of the staged source release

### DIFF
--- a/scripts/release/validate_staged_release.sh
+++ b/scripts/release/validate_staged_release.sh
@@ -177,7 +177,7 @@ echo -e "\t\tLicensing Check Passed [OK]\n"
 
 ### Checking for RAT
 echo "Running RAT Check"
-(bash -c "mvn apache-rat:check -Pintegration-tests -Phudi-platform-service $REDIRECT") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
+(bash -c "mvn apache-rat:check -DdeployArtifacts=true $REDIRECT") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
 echo -e "\t\tRAT Check Passed [OK]\n"
 
 popd

--- a/scripts/release/validate_staged_release.sh
+++ b/scripts/release/validate_staged_release.sh
@@ -88,16 +88,6 @@ else
     ARTIFACT_SUFFIX=${RELEASE_VERSION}-rc${RC_NUM}
 fi
 
-
-rm -rf $LOCAL_SVN_DIR
-mkdir $LOCAL_SVN_DIR
-cd $LOCAL_SVN_DIR
-
-echo "Downloading from svn co ${ROOT_SVN_URL}/${REPO_TYPE}/${HUDI_REPO}"
-
-(bash -c "svn co ${ROOT_SVN_URL}/${REPO_TYPE}/${HUDI_REPO} $REDIRECT") || (echo -e "\t\t Unable to checkout  ${ROOT_SVN_URL}/${REPO_TYPE}/${HUDI_REPO} to $REDIRECT. Please run with --verbose to get details\n" && exit -1)
-
-echo "Validating hudi-${ARTIFACT_SUFFIX} with release type \"${REPO_TYPE}\""
 if [ $RELEASE_TYPE == "release" ]; then
   ARTIFACT_PREFIX=
 elif [ $RELEASE_TYPE == "dev" ]; then
@@ -106,7 +96,21 @@ else
   echo "Unexpected RELEASE_TYPE: $RELEASE_TYPE"
   exit 1;
 fi
-cd ${HUDI_REPO}/${ARTIFACT_PREFIX}${ARTIFACT_SUFFIX}
+
+rm -rf $LOCAL_SVN_DIR
+mkdir $LOCAL_SVN_DIR
+cd $LOCAL_SVN_DIR
+
+echo "Current directory: `pwd`"
+
+FULL_SVN_URL=${ROOT_SVN_URL}/${REPO_TYPE}/${HUDI_REPO}/${ARTIFACT_PREFIX}${ARTIFACT_SUFFIX}
+
+echo "Downloading from svn co $FULL_SVN_URL"
+
+(bash -c "svn co $FULL_SVN_URL $REDIRECT") || (echo -e "\t\t Unable to checkout  $FULL_SVN_URL to $REDIRECT. Please run with --verbose to get details\n" && exit -1)
+
+echo "Validating hudi-${ARTIFACT_SUFFIX} with release type \"${REPO_TYPE}\""
+cd ${ARTIFACT_PREFIX}${ARTIFACT_SUFFIX}
 $SHASUM hudi-${ARTIFACT_SUFFIX}.src.tgz > got.sha512
 
 echo "Checking Checksum of Source Release"

--- a/scripts/release/validate_staged_release.sh
+++ b/scripts/release/validate_staged_release.sh
@@ -177,7 +177,7 @@ echo -e "\t\tLicensing Check Passed [OK]\n"
 
 ### Checking for RAT
 echo "Running RAT Check"
-(bash -c "mvn apache-rat:check $REDIRECT") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
+(bash -c "mvn apache-rat:check -Pintegration-tests -Phudi-platform-service $REDIRECT") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
 echo -e "\t\tRAT Check Passed [OK]\n"
 
 popd


### PR DESCRIPTION
### Change Logs

Currently the `validate_staged_release.sh` script downloads source files of all versions under hudi folder.  Instead, we should only download the source release of interest for validation.

This PR also adds missing modules in RAT check.

### Impact

Makes the validation of the staged source release faster.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
