### PR TITLE
[HUDI-5721] Add Github actions on source validation

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -22,6 +22,26 @@ env:
   MVN_ARGS: -e -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn
 
 jobs:
+  validate-source:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Check Binary Files
+        run: ./scripts/release/validate_source_binary_files.sh
+      - name: Check Copyright
+        run: |
+          ./scripts/release/create_source_directory.sh hudi-tmp-repo
+          cd hudi-tmp-repo
+          ./scripts/release/validate_source_copyright.sh
+      - name: RAT check
+        run: ./scripts/release/validate_source_rat.sh
+
   test-spark:
     runs-on: ubuntu-latest
     strategy:

--- a/scripts/release/create_source_directory.sh
+++ b/scripts/release/create_source_directory.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+rsync -a \
+  --exclude ".git" --exclude ".gitignore" --exclude ".gitattributes" --exclude ".travis.yml" \
+  --exclude ".github" --exclude "target" \
+  --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" --exclude "build-target" \
+  --exclude "docs/content" --exclude ".rubydeps" \
+  --exclude "rfc" \
+  --exclude "docker/images" \
+  . $1

--- a/scripts/release/create_source_release.sh
+++ b/scripts/release/create_source_release.sh
@@ -66,14 +66,7 @@ mkdir -p ${RELEASE_DIR}
 git clone ${HUDI_DIR} ${CLONE_DIR}
 cd ${CLONE_DIR}
 
-rsync -a \
-  --exclude ".git" --exclude ".gitignore" --exclude ".gitattributes" --exclude ".travis.yml" \
-  --exclude ".github" --exclude "target" \
-  --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" --exclude "build-target" \
-  --exclude "docs/content" --exclude ".rubydeps" \
-  --exclude "rfc" \
-  --exclude "docker/images" \
-  . hudi-$RELEASE_VERSION
+$CURR_DIR/release/create_source_directory.sh hudi-$RELEASE_VERSION
 
 tar czf ${RELEASE_DIR}/hudi-${RELEASE_VERSION}.src.tgz hudi-$RELEASE_VERSION
 gpg --armor --detach-sig ${RELEASE_DIR}/hudi-${RELEASE_VERSION}.src.tgz

--- a/scripts/release/validate_source_binary_files.sh
+++ b/scripts/release/validate_source_binary_files.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+echo "Checking for binary files in the source files"
+numBinaryFiles=`find . -iname '*' | xargs -I {} file -I {} | grep -va directory | grep -v "release/" | grep -v "/src/test/" | grep -va 'application/json' | grep -va 'text/' | grep -va 'application/xml' | grep -va 'application/json' | wc -l | sed -e s'/ //g'`
+
+if [ "$numBinaryFiles" -gt "0" ]; then
+  echo -e "There were non-text files in source release. [ERROR]\n Please check below\n"
+  find . -iname '*' | xargs -I {} file -I {} | grep -va directory | grep -v "release/release_guide" | grep -v "/src/test/" | grep -va 'application/json' | grep -va 'text/' |  grep -va 'application/xml'
+  exit 1
+fi
+echo -e "\t\tNo Binary Files in the source files? - [OK]\n"

--- a/scripts/release/validate_source_copyright.sh
+++ b/scripts/release/validate_source_copyright.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+### Checking for DISCLAIMER
+echo "Checking for DISCLAIMER"
+disclaimerFile="./DISCLAIMER"
+if [ -f "$disclaimerFile" ]; then
+  echo "DISCLAIMER file should not be present [ERROR]"
+  exit 1
+fi
+echo -e "\t\tDISCLAIMER file exists ? [OK]\n"
+
+### Checking for LICENSE and NOTICE
+echo "Checking for LICENSE and NOTICE"
+licenseFile="./LICENSE"
+noticeFile="./NOTICE"
+if [ ! -f "$licenseFile" ]; then
+  echo "License file missing [ERROR]"
+  exit 1
+fi
+echo -e "\t\tLicense file exists ? [OK]"
+
+if [ ! -f "$noticeFile" ]; then
+  echo "Notice file missing [ERROR]"
+  exit 1
+fi
+echo -e "\t\tNotice file exists ? [OK]\n"
+
+### Licensing Check
+echo "Performing custom Licensing Check "
+numfilesWithNoLicense=`find . -iname '*' -type f | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v DISCLAIMER | grep -v KEYS | grep -v '.mailmap' | grep -v '.sqltemplate' | grep -v 'banner.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)" | wc -l`
+if [ "$numfilesWithNoLicense" -gt  "0" ]; then
+  echo "There were some source files that did not have Apache License [ERROR]"
+  find . -iname '*' -type f | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v DISCLAIMER | grep -v '.sqltemplate' | grep -v KEYS | grep -v '.mailmap' | grep -v 'banner.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)"
+  exit 1
+fi
+echo -e "\t\tLicensing Check Passed [OK]\n"

--- a/scripts/release/validate_source_rat.sh
+++ b/scripts/release/validate_source_rat.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+echo "Running RAT Check"
+(bash -c "mvn apache-rat:check -DdeployArtifacts=true") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
+echo -e "\t\tRAT Check Passed [OK]\n"

--- a/scripts/release/validate_staged_release.sh
+++ b/scripts/release/validate_staged_release.sh
@@ -129,55 +129,13 @@ echo "Checking Signature"
 cd hudi-${ARTIFACT_SUFFIX}
 
 ### BEGIN: Binary Files Check
-echo "Checking for binary files in source release"
-numBinaryFiles=`find . -iname '*' | xargs -I {} file -I {} | grep -va directory | grep -v "release/" | grep -v "/src/test/" | grep -va 'application/json' | grep -va 'text/' | grep -va 'application/xml' | grep -va 'application/json' | wc -l | sed -e s'/ //g'`
-
-if [ "$numBinaryFiles" -gt "0" ]; then
-  echo -e "There were non-text files in source release. [ERROR]\n Please check below\n"
-  find . -iname '*' | xargs -I {} file -I {} | grep -va directory | grep -v "release/release_guide" | grep -v "/src/test/" | grep -va 'application/json' | grep -va 'text/' |  grep -va 'application/xml'
-  exit 1
-fi
-echo -e "\t\tNo Binary Files in Source Release? - [OK]\n"
+$CURR_DIR/release/validate_source_binary_files.sh
 ### END: Binary Files Check
 
-### Checking for DISCLAIMER
-echo "Checking for DISCLAIMER"
-disclaimerFile="./DISCLAIMER"
-if [ -f "$disclaimerFile" ]; then
-  echo "DISCLAIMER file should not be present [ERROR]"
-  exit 1
-fi
-echo -e "\t\tDISCLAIMER file exists ? [OK]\n"
-
-### Checking for LICENSE and NOTICE
-echo "Checking for LICENSE and NOTICE"
-licenseFile="./LICENSE"
-noticeFile="./NOTICE"
-if [ ! -f "$licenseFile" ]; then
-  echo "License file missing [ERROR]"
-  exit 1
-fi
-echo -e "\t\tLicense file exists ? [OK]"
-
-if [ ! -f "$noticeFile" ]; then
-  echo "Notice file missing [ERROR]"
-  exit 1
-fi
-echo -e "\t\tNotice file exists ? [OK]\n"
-
-### Licensing Check
-echo "Performing custom Licensing Check "
-numfilesWithNoLicense=`find . -iname '*' -type f | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v DISCLAIMER | grep -v KEYS | grep -v '.mailmap' | grep -v '.sqltemplate' | grep -v 'banner.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)" | wc -l`
-if [ "$numfilesWithNoLicense" -gt  "0" ]; then
-  echo "There were some source files that did not have Apache License [ERROR]"
-  find . -iname '*' -type f | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v DISCLAIMER | grep -v '.sqltemplate' | grep -v KEYS | grep -v '.mailmap' | grep -v 'banner.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)"
-  exit 1
-fi
-echo -e "\t\tLicensing Check Passed [OK]\n"
+### Checking for DISCLAIMER, LICENSE, NOTICE and source file license
+$CURR_DIR/release/validate_source_copyright.sh
 
 ### Checking for RAT
-echo "Running RAT Check"
-(bash -c "mvn apache-rat:check -DdeployArtifacts=true $REDIRECT") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
-echo -e "\t\tRAT Check Passed [OK]\n"
+$CURR_DIR/release/validate_source_rat.sh
 
 popd


### PR DESCRIPTION
### Change Logs

This PR adds the following validation on the source files to Github actions, based on source release validation, so that any validation failure is caught early before the release:
- Binary files should not be present
- DISCLAIMER file should not be present
- LICENSE and NOTICE should exist
- Licensing check
- RAT check

### Impact

Any validation failure is caught early before the release.
Validation passes on this PR:
<img width="1041" alt="Screen Shot 2023-02-07 at 13 50 52" src="https://user-images.githubusercontent.com/2497195/217374838-716a28cc-262c-4f0f-86ac-d40a4db9c4f3.png">
Any issue like missing license fails the validation:
<img width="1378" alt="Screen Shot 2023-02-07 at 13 54 45" src="https://user-images.githubusercontent.com/2497195/217375556-b82f1d93-68c2-4af1-9cd2-58eb1ac91f75.png">

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
