### PR TITLE
[HUDI-5725] Creating Hudi table with misspelled table type in Flink l…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -143,9 +144,26 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
    * @param schema The table schema
    */
   private void sanityCheck(Configuration conf, ResolvedSchema schema) {
+    checkTableType(conf);
+
     if (!OptionsResolver.isAppendMode(conf)) {
       checkRecordKey(conf, schema);
       checkPreCombineKey(conf, schema);
+    }
+  }
+
+  /**
+   * Validate the table type.
+   */
+  private void checkTableType(Configuration conf) {
+    String tableType = conf.get(FlinkOptions.TABLE_TYPE);
+    if (StringUtils.nonEmpty(tableType)) {
+      try {
+        HoodieTableType.valueOf(tableType);
+      } catch (IllegalArgumentException e) {
+        throw new HoodieValidationException("Invalid table type: " + tableType + ". Table type should be either "
+                + HoodieTableType.MERGE_ON_READ + " or " + HoodieTableType.COPY_ON_WRITE + ".");
+      }
     }
   }
 


### PR DESCRIPTION
…eads to Flink cluster crash

### Change Logs

Added sanity check for Flink table type option.

Files updated:

- hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTable
Factory.java
- hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieT
ableFactory.java

### Impact

No

### Risk level (write none, low medium or high below)

low

### Documentation Update

No need to update

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
