### PR TITLE
Hudi 5729

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/RowDataParquetWriteSupport.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/RowDataParquetWriteSupport.java
@@ -53,7 +53,7 @@ public class RowDataParquetWriteSupport extends WriteSupport<RowData> {
   @Override
   public void prepareForWrite(RecordConsumer recordConsumer) {
     // should make the utc timestamp configurable
-    this.writer = new ParquetRowDataWriter(recordConsumer, rowType, schema, true);
+    this.writer = new ParquetRowDataWriter(recordConsumer, rowType, schema, false);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -275,7 +275,7 @@ public class FlinkOptions extends HoodieConfig {
   public static final ConfigOption<Boolean> UTC_TIMEZONE = ConfigOptions
       .key("read.utc-timezone")
       .booleanType()
-      .defaultValue(true)
+      .defaultValue(false)
       .withDescription("Use UTC timezone or local timezone to the conversion between epoch"
           + " time and LocalDateTime. Hive 0.x/1.x/2.x use local timezone. But Hive 3.x"
           + " use UTC timezone, by default true");

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGen.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieKeyException;
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.util.RowDataProjection;
 import org.apache.hudi.util.StreamerUtil;
 
@@ -66,6 +67,7 @@ public class RowDataKeyGen implements Serializable {
 
   private final boolean hiveStylePartitioning;
   private final boolean encodePartitionPath;
+  private final boolean consistentLogicalTimestampEnabled;
 
   private final Option<TimestampBasedAvroKeyGenerator> keyGenOpt;
 
@@ -84,6 +86,7 @@ public class RowDataKeyGen implements Serializable {
       RowType rowType,
       boolean hiveStylePartitioning,
       boolean encodePartitionPath,
+      boolean consistentLogicalTimestampEnabled,
       Option<TimestampBasedAvroKeyGenerator> keyGenOpt) {
     this.recordKeyFields = recordKeys.split(",");
     this.partitionPathFields = partitionFields.split(",");
@@ -92,6 +95,7 @@ public class RowDataKeyGen implements Serializable {
 
     this.hiveStylePartitioning = hiveStylePartitioning;
     this.encodePartitionPath = encodePartitionPath;
+    this.consistentLogicalTimestampEnabled = consistentLogicalTimestampEnabled;
 
     this.hasRecordKey = hasRecordKey(fieldNames);
     if (!hasRecordKey) {
@@ -138,9 +142,11 @@ public class RowDataKeyGen implements Serializable {
         throw new HoodieKeyException("Initialize TimestampBasedAvroKeyGenerator error", e);
       }
     }
+    boolean consistentLogicalTimestampEnabled = conf.getBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+        Boolean.parseBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
     return new RowDataKeyGen(conf.getString(FlinkOptions.RECORD_KEY_FIELD), conf.getString(FlinkOptions.PARTITION_PATH_FIELD),
         rowType, conf.getBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING), conf.getBoolean(FlinkOptions.URL_ENCODE_PARTITIONING),
-        keyGeneratorOpt);
+        consistentLogicalTimestampEnabled,keyGeneratorOpt);
   }
 
   public HoodieKey getHoodieKey(RowData rowData) {
@@ -153,10 +159,10 @@ public class RowDataKeyGen implements Serializable {
       // for e.g, fileId + auto inc integer
       return EMPTY_RECORDKEY_PLACEHOLDER;
     } else if (this.simpleRecordKey) {
-      return getRecordKey(recordKeyFieldGetter.getFieldOrNull(rowData), this.recordKeyFields[0]);
+      return getRecordKey(recordKeyFieldGetter.getFieldOrNull(rowData), this.recordKeyFields[0],consistentLogicalTimestampEnabled);
     } else {
       Object[] keyValues = this.recordKeyProjection.projectAsValues(rowData);
-      return getRecordKey(keyValues, this.recordKeyFields);
+      return getRecordKey(keyValues, this.recordKeyFields,consistentLogicalTimestampEnabled);
     }
   }
 
@@ -173,12 +179,14 @@ public class RowDataKeyGen implements Serializable {
   }
 
   // reference: org.apache.hudi.keygen.KeyGenUtils.getRecordPartitionPath
-  private static String getRecordKey(Object[] keyValues, String[] keyFields) {
+  private static String getRecordKey(Object[] keyValues, String[] keyFields,boolean consistentLogicalTimestampEnabled) {
     boolean keyIsNullEmpty = true;
     StringBuilder recordKey = new StringBuilder();
     for (int i = 0; i < keyValues.length; i++) {
       String recordKeyField = keyFields[i];
-      String recordKeyValue = StringUtils.objToString(keyValues[i]);
+      Object value = keyValues[i];
+      value = getTimestampValue(consistentLogicalTimestampEnabled, value);
+      String recordKeyValue = StringUtils.objToString(value);
       if (recordKeyValue == null) {
         recordKey.append(recordKeyField).append(":").append(NULL_RECORDKEY_PLACEHOLDER).append(",");
       } else if (recordKeyValue.isEmpty()) {
@@ -194,6 +202,16 @@ public class RowDataKeyGen implements Serializable {
           + Arrays.toString(keyFields) + " cannot be entirely null or empty.");
     }
     return recordKey.toString();
+  }
+
+  private static Object getTimestampValue(boolean consistentLogicalTimestampEnabled, Object value) {
+    if(!consistentLogicalTimestampEnabled) {
+      if(value instanceof TimestampData) {
+        TimestampData timestampData = (TimestampData) value;
+        value = timestampData.toTimestamp().toInstant().toEpochMilli();
+      }
+    }
+    return value;
   }
 
   // reference: org.apache.hudi.keygen.KeyGenUtils.getRecordPartitionPath
@@ -222,7 +240,8 @@ public class RowDataKeyGen implements Serializable {
   }
 
   // reference: org.apache.hudi.keygen.KeyGenUtils.getRecordKey
-  public static String getRecordKey(Object recordKeyValue, String recordKeyField) {
+  public static String getRecordKey(Object recordKeyValue, String recordKeyField,boolean consistentLogicalTimestampEnabled) {
+    recordKeyValue = getTimestampValue(consistentLogicalTimestampEnabled, recordKeyValue);
     String recordKey = StringUtils.objToString(recordKeyValue);
     if (recordKey == null || recordKey.isEmpty()) {
       throw new HoodieKeyException("recordKey value: \"" + recordKey + "\" for field: \"" + recordKeyField + "\" cannot be null or empty.");

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -166,7 +166,7 @@ public class RowDataToAvroConverters {
 
                 @Override
                 public Object convert(Schema schema, Object object) {
-                  return ((TimestampData) object).toInstant().toEpochMilli();
+                  return ((TimestampData) object).toTimestamp().getTime();
                 }
               };
         } else if (precision <= 6) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -166,7 +166,7 @@ public class RowDataToAvroConverters {
 
                 @Override
                 public Object convert(Schema schema, Object object) {
-                  return ((TimestampData) object).toTimestamp().getTime();
+                  return ((TimestampData) object).toTimestamp().toInstant().toEpochMilli();
                 }
               };
         } else if (precision <= 6) {
@@ -176,7 +176,7 @@ public class RowDataToAvroConverters {
 
                 @Override
                 public Object convert(Schema schema, Object object) {
-                  return ChronoUnit.MICROS.between(Instant.EPOCH, ((TimestampData) object).toInstant());
+                  return ChronoUnit.MICROS.between(Instant.EPOCH, ((TimestampData) object).toTimestamp().toInstant());
                 }
               };
         } else {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestRowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestRowDataKeyGen.java
@@ -20,6 +20,7 @@ package org.apache.hudi.sink.bulk;
 
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieKeyException;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.table.HoodieTableFactory;
 import org.apache.hudi.utils.TestConfigurations;
 
@@ -31,6 +32,8 @@ import org.apache.flink.table.data.TimestampData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.sql.Timestamp;
 
 import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
 import static org.apache.hudi.utils.TestData.insertRow;
@@ -185,4 +188,23 @@ public class TestRowDataKeyGen {
         TimestampData.fromEpochMillis(1), StringData.fromString(""));
     assertThat(keyGen1.getRecordKey(rowData3), is("__empty__"));
   }
+
+  @Test
+  void testRecoredKeyContainsTimestamp() {
+    Configuration conf = TestConfigurations.getDefaultConf("path1");
+    conf.setString(FlinkOptions.RECORD_KEY_FIELD, "uuid,ts");
+    conf.setString(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(), "true");
+    final RowData rowData1 = insertRow(StringData.fromString("id1"), StringData.fromString("Danny"), 23,
+        TimestampData.fromTimestamp(new Timestamp(1675841687000l)), StringData.fromString("par1"));
+    final RowDataKeyGen keyGen1 = RowDataKeyGen.instance(conf, TestConfigurations.ROW_TYPE);
+
+    assertThat(keyGen1.getRecordKey(rowData1), is("uuid:id1,ts:2023-02-08T15:34:47"));
+
+    conf.setString(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(), "false");
+    final RowDataKeyGen keyGen2 = RowDataKeyGen.instance(conf, TestConfigurations.ROW_TYPE);
+
+    assertThat(keyGen2.getRecordKey(rowData1), is("uuid:id1,ts:1675841687000"));
+
+  }
+
 }


### PR DESCRIPTION
### Change Logs

When recordKey  contains timestamp field , bulkInsert mode generated recordKey like “id:11,ts:2022-10-12T18:30:03”.
But upsert mode according to config “hoodie.datasource.write.keygenerator.consistent.logical.timestamp.enabled” generated recordKey is  “id:11,ts:2022-10-12T18:30:03” or “id:11,ts:167462460000”

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
