### PR TITLE
[HUDI-5731] Add guava dependency to Spark and MR bundle

### DIFF
--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -77,6 +77,7 @@
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>org.apache.avro:avro</include>
                   <include>com.yammer.metrics:metrics-core</include>
+                  <include>com.google.guava:guava</include>
                   <include>commons-io:commons-io</include>
                   <include>org.openjdk.jol:jol-core</include>
                   <include>com.github.ben-manes.caffeine:caffeine</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -109,6 +109,7 @@
                   <include>io.prometheus:simpleclient_pushgateway</include>
                   <include>io.prometheus:simpleclient_common</include>
                   <include>com.yammer.metrics:metrics-core</include>
+                  <include>com.google.guava:guava</include>
 
                   <include>org.apache.hive:hive-common</include>
                   <include>org.apache.hive:hive-service</include>


### PR DESCRIPTION
### Change Logs

Add guava dependency to Spark and MR bundle

### Impact

Configure guava relocation in Spark and MR bundle pom.xml, but there is no guava dependency, resulting in failure of guava-related class loading.

[HUDI-4482] remove guava and use caffeine instead for cache (#6240)

### Risk level (write none, low medium or high below)


### Documentation Update



### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
