### PR TITLE
[HUDI-5731] Cleaning up unnecessary relocation for com.google.common packages

### DIFF
--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -118,10 +118,6 @@
                   <shadedPattern>org.apache.hudi.org.apache.parquet.avro.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.common.</pattern>
-                  <shadedPattern>org.apache.hudi.com.google.common.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                 </relocation>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -190,10 +190,6 @@
                   <shadedPattern>org.apache.hudi.org.apache.jetty.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.common.</pattern>
-                  <shadedPattern>org.apache.hudi.com.google.common.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
### Change Logs

Addresses an issue of following relocations configs in MR/Spark bundles stranded after removal of Guava from Hudi Spark and MR bundles:

```
<relocation>
  <pattern>com.google.common.</pattern>
  <shadedPattern>org.apache.hudi.com.google.common.</shadedPattern>
</relocation> 
```

Such relocations entailed that all references from any class (included into the Hudi bundle) referencing Guava would be shaded, even though Hudi isn't packaging Guava anymore, potentially resulting in exception when these classes try to access Guava provided by Spark for ex:

```
Caused by: java.lang.NoClassDefFoundError: org/apache/hudi/com/google/common/base/Preconditions
	at org.apache.curator.ensemble.fixed.FixedEnsembleProvider.<init>(FixedEnsembleProvider.java:39)
	at org.apache.curator.framework.CuratorFrameworkFactory$Builder.connectString(CuratorFrameworkFactory.java:193)
	at org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider$.buildZookeeperClient(ZookeeperClientProvider.scala:62)
	at org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient.<init>(ZookeeperDiscoveryClient.scala:65)
	... 45 more 
```

### Impact

See above

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
