### PR TITLE
[HUDI-5759] Supports add column on mor table with log

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
@@ -204,4 +204,49 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
       }
     })
   }
+
+  test("Test Add Column and Update Table") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        // create table
+        spark.sql("SET hoodie.datasource.read.extract.partition.values.from.path=true")
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |  type = '$tableType',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+          """.stripMargin)
+
+        // insert data to table
+        spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
+        checkAnswer(s"select id, name, price, ts from $tableName")(
+          Seq(1, "a1", 10.0, 1000)
+        )
+
+        spark.sql(s"alter table $tableName add columns (new_col1 int)")
+
+        // update data
+        spark.sql(s"update $tableName set price = 22 where id = 1")
+        checkAnswer(s"select id, name, price, ts, new_col1 from $tableName")(
+          Seq(1, "a1", 22.0, 1000, null)
+        )
+
+        // update and check again
+        spark.sql(s"update $tableName set price = price * 2 where id = 1")
+        checkAnswer(s"select id, name, price, ts, new_col1 from $tableName")(
+          Seq(1, "a1", 44.0, 1000, null)
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Change Logs
Hudi do not support add column on mor table with log when `extractPartitionValuesFromPartitionPath` is turned on. 

If partition pruning is enable, it will pruned out default values from avro schema, which is due to incorrect conversion logic in SchemaConverters::toAvroType. This PR fixed the issue by adding a default null value when converting StructType to Avro FieldType.

Thus, HoodieBaseRelation::convertToAvroSchema has the correct behavior and the mor table is queryable.

### Impact

None.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
