### PR TITLE
[MINOR] Fix wrong assertion in TestHoodieTableFactory.java

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -189,7 +189,7 @@ public class TestHoodieTableFactory {
 
     // Table type unset. The default value will be ok
     final MockContext sourceContext1 = MockContext.getInstance(this.conf, schema, "f2");
-    assertThrows(HoodieValidationException.class, () -> new HoodieTableFactory().createDynamicTableSink(sourceContext1));
+    assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(sourceContext1));
 
     // Invalid table type will throw exception
     this.conf.set(FlinkOptions.TABLE_TYPE, "INVALID_TABLE_TYPE");


### PR DESCRIPTION
### Change Logs

This PR is a hotfix of HUDI-5725 PR https://github.com/apache/hudi/pull/7888

One of the unit test is wrong in HUDI-5725 but it is weird that GitHub check could pass. The unit test now can run without failure.

File updated:

- hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java

### Impact

No impact.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

No need to update.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
