### PR TITLE
[HUDI-5758] Restoring state of `HoodieKey` to make sure it's binary compatible w/ its state in 0.12

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -46,7 +46,6 @@ import org.apache.spark.serializer.KryoRegistrator
  */
 class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegistrator {
 
-  // TODO(HUDI-5760) avoid using Kryo for serialization here
   override def registerClasses(kryo: Kryo): Unit = {
     ///////////////////////////////////////////////////////////////////////////
     // NOTE: DO NOT REORDER REGISTRATIONS

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -70,17 +70,13 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
    */
   class HoodieKeySerializer extends Serializer[HoodieKey] {
     override def write(kryo: Kryo, output: Output, key: HoodieKey): Unit = {
-      val stringSerializer = kryo.getDefaultSerializer(classOf[String])
-        .asInstanceOf[Serializer[String]]
-      stringSerializer.write(kryo, output, key.getRecordKey)
-      stringSerializer.write(kryo, output, key.getPartitionPath)
+      output.writeString(key.getRecordKey)
+      output.writeString(key.getPartitionPath)
     }
 
     override def read(kryo: Kryo, input: Input, klass: Class[HoodieKey]): HoodieKey = {
-      val stringSerializer = kryo.getDefaultSerializer(classOf[String])
-        .asInstanceOf[Serializer[String]]
-      val recordKey = stringSerializer.read(kryo, input, classOf[String])
-      val partitionPath = stringSerializer.read(kryo, input, classOf[String])
+      val recordKey = input.readString()
+      val partitionPath = input.readString()
       new HoodieKey(recordKey, partitionPath)
     }
   }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -18,11 +18,12 @@
 
 package org.apache.spark
 
-import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.serializers.JavaSerializer
 import org.apache.hudi.client.model.HoodieInternalRow
 import org.apache.hudi.common.config.SerializableConfiguration
-import org.apache.hudi.common.model.HoodieSparkRecord
+import org.apache.hudi.common.model.{HoodieKey, HoodieSparkRecord}
 import org.apache.hudi.common.util.HoodieCommonKryoRegistrar
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.spark.serializer.KryoRegistrator
@@ -44,11 +45,15 @@ import org.apache.spark.serializer.KryoRegistrator
  * </ol>
  */
 class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegistrator {
+
+  // TODO(HUDI-5760) avoid using Kryo for serialization here
   override def registerClasses(kryo: Kryo): Unit = {
     ///////////////////////////////////////////////////////////////////////////
     // NOTE: DO NOT REORDER REGISTRATIONS
     ///////////////////////////////////////////////////////////////////////////
     super[HoodieCommonKryoRegistrar].registerClasses(kryo)
+
+    kryo.register(classOf[HoodieKey], new HoodieKeySerializer)
 
     kryo.register(classOf[HoodieWriteConfig])
 
@@ -58,6 +63,27 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
     // NOTE: Hadoop's configuration is not a serializable object by itself, and hence
     //       we're relying on [[SerializableConfiguration]] wrapper to work it around
     kryo.register(classOf[SerializableConfiguration], new JavaSerializer())
+  }
+
+  /**
+   * NOTE: This {@link Serializer} could deserialize instance of {@link HoodieKey} serialized
+   *       by implicitly generated Kryo serializer (based on {@link com.esotericsoftware.kryo.serializers.FieldSerializer}
+   */
+  class HoodieKeySerializer extends Serializer[HoodieKey] {
+    override def write(kryo: Kryo, output: Output, key: HoodieKey): Unit = {
+      val stringSerializer = kryo.getDefaultSerializer(classOf[String])
+        .asInstanceOf[Serializer[String]]
+      stringSerializer.write(kryo, output, key.getRecordKey)
+      stringSerializer.write(kryo, output, key.getPartitionPath)
+    }
+
+    override def read(kryo: Kryo, input: Input, klass: Class[HoodieKey]): HoodieKey = {
+      val stringSerializer = kryo.getDefaultSerializer(classOf[String])
+        .asInstanceOf[Serializer[String]]
+      val recordKey = stringSerializer.read(kryo, input, classOf[String])
+      val partitionPath = stringSerializer.read(kryo, input, classOf[String])
+      new HoodieKey(recordKey, partitionPath)
+    }
   }
 }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DeleteRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DeleteRecord.java
@@ -28,6 +28,15 @@ import java.util.Objects;
  * we need to keep the ordering val to combine with the data records when merging, or the data loss
  * may occur if there are intermediate deletions for the inputs
  * (a new INSERT comes after a DELETE in one input batch).
+ *
+ * NOTE: PLEASE READ CAREFULLY BEFORE CHANGING
+ *
+ *       This class is serialized (using Kryo) as part of {@code HoodieDeleteBlock} to make
+ *       sure this stays backwards-compatible we can't MAKE ANY CHANGES TO THIS CLASS (add,
+ *       delete, reorder or change types of the fields in this class, make class final, etc)
+ *       as this would break its compatibility with already persisted blocks.
+ *
+ *       Check out HUDI-5760 for more details
  */
 public class DeleteRecord implements Serializable {
   private static final long serialVersionUID = 1L;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieKey.java
@@ -18,11 +18,6 @@
 
 package org.apache.hudi.common.model;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoSerializable;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -31,8 +26,17 @@ import java.util.Objects;
  * <p>
  * - recordKey : a recordKey that acts as primary key for a record.
  * - partitionPath : the partition path of a record.
+ *
+ * NOTE: PLEASE READ CAREFULLY BEFORE CHANGING
+ *
+ *       This class is serialized (using Kryo) as part of {@code HoodieDeleteBlock} to make
+ *       sure this stays backwards-compatible we can't MAKE ANY CHANGES TO THIS CLASS (add,
+ *       delete, reorder or change types of the fields in this class, make class final, etc)
+ *       as this would break its compatibility with already persisted blocks.
+ *
+ *       Check out HUDI-5760 for more details
  */
-public final class HoodieKey implements Serializable, KryoSerializable {
+public class HoodieKey implements Serializable {
 
   private String recordKey;
   private String partitionPath;
@@ -85,17 +89,5 @@ public final class HoodieKey implements Serializable, KryoSerializable {
     sb.append(" partitionPath=").append(partitionPath);
     sb.append('}');
     return sb.toString();
-  }
-
-  @Override
-  public void write(Kryo kryo, Output output) {
-    output.writeString(recordKey);
-    output.writeString(partitionPath);
-  }
-
-  @Override
-  public void read(Kryo kryo, Input input) {
-    this.recordKey = input.readString();
-    this.partitionPath = input.readString();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
@@ -97,6 +97,7 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
     }
   }
 
+  // TODO(HUDI-5760) avoid using Kryo for serialization here
   private static DeleteRecord[] deserialize(int version, byte[] data) {
     if (version == 1) {
       // legacy version

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
@@ -68,6 +68,7 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream output = new DataOutputStream(baos);
+    // TODO(HUDI-5760) avoid using Kryo for serialization here
     byte[] bytesToWrite = SerializationUtils.serialize(getRecordsToDelete());
     output.writeInt(version);
     output.writeInt(bytesToWrite.length);


### PR DESCRIPTION
### Change Logs

RFC-46 modified `HoodieKey` to substantially optimize its serialized footprint (while using Kryo) by making it explicitly serializable by Kryo (inheriting form `KryoSerializable`, making it final).

However, this broken its binary compatibility w/ the state as it was in 0.12.2. 

Unfortunately, this entailed that as this class is used in `DeleteRecord` w/in `HoodieDeleteBlock` that it also made impossible to read such blocks created by prior Hudi versions (more details in HUDI-5758).

This PR restores previous state for `HoodieKey` to make sure it stays binary compatible w/ existing persisted `HoodieDeleteBlock` created by prior Hudi versions

### Impact

See above

### Risk level (write none, low medium or high below)

Low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
