### PR TITLE
[HUDI-5778] support absolute path names for hierarchical configs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -38,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
@@ -67,7 +69,7 @@ public class DFSPropertiesConfiguration {
   @Nullable
   private final Configuration hadoopConfig;
 
-  private Path currentFilePath;
+  private Path mainFilePath;
 
   // props read from user defined configuration file or input stream
   private final HoodieConfig hoodieConfig;
@@ -77,7 +79,7 @@ public class DFSPropertiesConfiguration {
 
   public DFSPropertiesConfiguration(@Nonnull Configuration hadoopConf, @Nonnull Path filePath) {
     this.hadoopConfig = hadoopConf;
-    this.currentFilePath = filePath;
+    this.mainFilePath = filePath;
     this.hoodieConfig = new HoodieConfig();
     this.visitedFilePaths = new HashSet<>();
     addPropsFromFile(filePath);
@@ -85,7 +87,7 @@ public class DFSPropertiesConfiguration {
 
   public DFSPropertiesConfiguration() {
     this.hadoopConfig = null;
-    this.currentFilePath = null;
+    this.mainFilePath = null;
     this.hoodieConfig = new HoodieConfig();
     this.visitedFilePaths = new HashSet<>();
   }
@@ -101,8 +103,10 @@ public class DFSPropertiesConfiguration {
     URL configFile = Thread.currentThread().getContextClassLoader().getResource(DEFAULT_PROPERTIES_FILE);
     if (configFile != null) {
       try (BufferedReader br = new BufferedReader(new InputStreamReader(configFile.openStream()))) {
-        conf.addPropsFromStream(br);
+        conf.addPropsFromStream(br, new Path(configFile.toURI()));
         return conf.getProps();
+      } catch (URISyntaxException e) {
+        throw new HoodieException(String.format("Provided props file url is invalid %s", configFile), e);
       } catch (IOException ioe) {
         throw new HoodieIOException(
             String.format("Failed to read %s from class loader", DEFAULT_PROPERTIES_FILE), ioe);
@@ -156,8 +160,7 @@ public class DFSPropertiesConfiguration {
 
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(filePath)))) {
       visitedFilePaths.add(filePath.toString());
-      currentFilePath = filePath;
-      addPropsFromStream(reader);
+      addPropsFromStream(reader, filePath);
     } catch (IOException ioe) {
       LOG.error("Error reading in properties from dfs from file " + filePath);
       throw new HoodieIOException("Cannot read properties from dfs from file " + filePath, ioe);
@@ -170,7 +173,7 @@ public class DFSPropertiesConfiguration {
    * @param reader Buffered Reader
    * @throws IOException
    */
-  public void addPropsFromStream(BufferedReader reader) throws IOException {
+  public void addPropsFromStream(BufferedReader reader, Path cfgFilePath) throws IOException {
     try {
       reader.lines().forEach(line -> {
         if (!isValidLine(line)) {
@@ -178,8 +181,14 @@ public class DFSPropertiesConfiguration {
         }
         String[] split = splitProperty(line);
         if (line.startsWith("include=") || line.startsWith("include =")) {
-          Path includeFilePath = new Path(currentFilePath.getParent(), split[1]);
-          addPropsFromFile(includeFilePath);
+          Path providedPath = new Path(split[1]);
+          FileSystem providedFs = FSUtils.getFs(split[1], hadoopConfig);
+          // In the case that only filename is provided, assume it's in the same directory.
+          if ((!providedPath.isAbsolute() || StringUtils.isNullOrEmpty(providedFs.getScheme()))
+              && cfgFilePath != null) {
+            providedPath = new Path(cfgFilePath.getParent(), split[1]);
+          }
+          addPropsFromFile(providedPath);
         } else {
           hoodieConfig.setValue(split[0], split[1]);
         }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestDFSPropertiesConfiguration.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestDFSPropertiesConfiguration.java
@@ -73,11 +73,11 @@ public class TestDFSPropertiesConfiguration {
         "int.prop=123", "double.prop=113.4", "string.prop=str", "boolean.prop=true", "long.prop=1354354354"});
 
     filePath = new Path(dfsBasePath + "/t2.props");
-    writePropertiesFile(filePath, new String[] {"string.prop=ignored", "include=t1.props"});
+    writePropertiesFile(filePath, new String[] {"string.prop=ignored", "include=" + dfsBasePath + "/t1.props"});
 
     filePath = new Path(dfsBasePath + "/t3.props");
     writePropertiesFile(filePath,
-        new String[] {"double.prop=838.3", "include = t2.props", "double.prop=243.4", "string.prop=t3.value"});
+        new String[] {"double.prop=838.3", "include=" + "t2.props", "double.prop=243.4", "string.prop=t3.value"});
 
     filePath = new Path(dfsBasePath + "/t4.props");
     writePropertiesFile(filePath, new String[] {"double.prop=838.3", "include = t4.props"});

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -118,7 +118,7 @@ public class StreamerUtil {
     try {
       if (!overriddenProps.isEmpty()) {
         LOG.info("Adding overridden properties to file properties.");
-        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))));
+        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))), cfgPath);
       }
     } catch (IOException ioe) {
       throw new HoodieIOException("Unexpected error adding config overrides", ioe);

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/HDFSParquetImporterUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/HDFSParquetImporterUtils.java
@@ -253,7 +253,7 @@ public class HDFSParquetImporterUtils implements Serializable {
     try {
       if (!overriddenProps.isEmpty()) {
         LOG.info("Adding overridden properties to file properties.");
-        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))));
+        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))), cfgPath);
       }
     } catch (IOException ioe) {
       throw new HoodieIOException("Unexpected error adding config overrides", ioe);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -214,7 +214,7 @@ public class UtilHelpers {
     try {
       if (!overriddenProps.isEmpty()) {
         LOG.info("Adding overridden properties to file properties.");
-        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))));
+        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))), cfgPath);
       }
     } catch (IOException ioe) {
       throw new HoodieIOException("Unexpected error adding config overrides", ioe);
@@ -228,7 +228,7 @@ public class UtilHelpers {
     try {
       if (!overriddenProps.isEmpty()) {
         LOG.info("Adding overridden properties to file properties.");
-        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))));
+        conf.addPropsFromStream(new BufferedReader(new StringReader(String.join("\n", overriddenProps))), null);
       }
     } catch (IOException ioe) {
       throw new HoodieIOException("Unexpected error adding config overrides", ioe);


### PR DESCRIPTION
### Change Logs

Allow absolute paths in config includes.

### Impact

Easily allow include configs in other directories.

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
