### PR TITLE
[HUDI-5578] Upgrade base docker image for java 8

### DIFF
--- a/docker/hoodie/hadoop/base/Dockerfile
+++ b/docker/hoodie/hadoop/base/Dockerfile
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8u212-jdk-slim-stretch
+FROM openjdk:8u342-jdk-slim-bullseye
 MAINTAINER Hoodie
 USER root
 


### PR DESCRIPTION
Base Hudi image is based on pretty old openjdk:8u212-jdk-slim-stretch. 
This PR upgrades it to the latest openjdk:8u342-jdk-slim-bullseye. This syncs with the existing java 11 base image distro.
openjdk:8u342-jdk-slim-bullseye comes with python3.9 available via apt-get, so it makes this image compatible with Spark 3.

### Change Logs

Change base docker image for Hudi from old openjdk:8u212-jdk-slim-stretch to latest openjdk:8u342-jdk-slim-bullseye.

### Impact

No impact on APIs

### Risk level (write none, low medium or high below)

Low, onl updates jdk 8 and linux distro version

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
