### PR TITLE
[HUDI-5769][WIP] Fixing deletion of metadata partitions based on explicit configs set by user

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1778,8 +1778,22 @@ public class HoodieWriteConfig extends HoodieConfig {
     return isMetadataTableEnabled() && getMetadataConfig().isBloomFilterIndexEnabled();
   }
 
+  /**
+   * @returns true if the config is explicitly set to true by the user. disregards any default value set from within code.
+   */
+  public boolean isMetadataBloomFilterIndexEnabledByUser() {
+    return isMetadataTableEnabled() && getProps().getBoolean(HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER_BY_USER);
+  }
+
   public boolean isMetadataColumnStatsIndexEnabled() {
     return isMetadataTableEnabled() && getMetadataConfig().isColumnStatsIndexEnabled();
+  }
+
+  /**
+   * @returns true if the config is explicitly set to true by the user. disregards any default value set from within code.
+   */
+  public boolean isMetadataColumnStatsIndexEnabledByUser() {
+    return isMetadataTableEnabled() && getProps().getBoolean(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS_BY_USER);
   }
 
   public List<String> getColumnsEnabledForColumnStatsIndex() {
@@ -2893,6 +2907,7 @@ public class HoodieWriteConfig extends HoodieConfig {
           HoodieWriteCommitCallbackConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultOnCondition(!isPayloadConfigSet,
           HoodiePayloadConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
+      setMetadataConfigsSetByUser();
       writeConfig.setDefaultOnCondition(!isMetadataConfigSet,
           HoodieMetadataConfig.newBuilder().withEngineType(engineType).fromProperties(writeConfig.getProps()).build());
       writeConfig.setDefaultOnCondition(!isPreCommitValidationConfigSet,
@@ -2909,6 +2924,19 @@ public class HoodieWriteConfig extends HoodieConfig {
           HoodieLockConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
 
       autoAdjustConfigsForConcurrencyMode(isLockProviderPropertySet);
+    }
+
+    /**
+     * We need to track explicit value set for enabling/disabling metadata partitions disregarding default value set by the code.
+     * This method assists in tracking such values.
+     */
+    private void setMetadataConfigsSetByUser() {
+      writeConfig.setValue(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS_BY_USER,
+          Boolean.toString(writeConfig.getProps().containsKey(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key())
+              && writeConfig.getProps().getBoolean(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key())));
+      writeConfig.setValue(HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER_BY_USER,
+          Boolean.toString(writeConfig.getProps().containsKey(HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER.key())
+              && writeConfig.getProps().getBoolean(HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER.key())));
     }
 
     private void autoAdjustConfigsForConcurrencyMode(boolean isLockProviderPropertySet) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -268,7 +268,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
             .withAutoClean(false)
             .withCleanerParallelism(parallelism)
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
-            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.EAGER)
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
             .retainCommits(HoodieMetadataConfig.CLEANER_COMMITS_RETAINED.defaultValue())
             .build())
         // we will trigger archive manually, to ensure only regular writer invokes it

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -952,7 +952,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   private boolean shouldDeleteMetadataPartition(MetadataPartitionType partitionType) {
     // Only delete metadata table partition when all the following conditions are met:
     // (1) This is data table.
-    // (2) Index corresponding to this metadata partition is disabled in HoodieWriteConfig.
+    // (2) Index corresponding to this metadata partition is explicitly disabled by the user.
     // (3) The completed metadata partitions in table config contains this partition.
     // NOTE: Inflight metadata partitions are not considered as they could have been inflight due to async indexer.
     if (HoodieTableMetadata.isMetadataTable(metaClient.getBasePath()) || !config.isMetadataTableEnabled()) {
@@ -963,10 +963,10 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
       // NOTE: FILES partition type is always considered in sync with hoodie.metadata.enable.
       //       It cannot be the case that metadata is enabled but FILES is disabled.
       case COLUMN_STATS:
-        metadataIndexDisabled = !config.isMetadataColumnStatsIndexEnabled();
+        metadataIndexDisabled = !config.isMetadataColumnStatsIndexEnabledByUser();
         break;
       case BLOOM_FILTERS:
-        metadataIndexDisabled = !config.isMetadataBloomFilterIndexEnabled();
+        metadataIndexDisabled = !config.isMetadataBloomFilterIndexEnabledByUser();
         break;
       default:
         LOG.debug("Not a valid metadata partition type: " + partitionType.name());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -386,6 +386,46 @@ public class TestHoodieWriteConfig {
   }
 
   @Test
+  public void testMetadataConfigsSetByUser() {
+    Properties props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props).build())
+        .build();
+    assertMetadataConfigs(writeConfig, false, false, HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.defaultValue(),
+        HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER.defaultValue());
+
+    // explicitly enable by user.
+    props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    props.setProperty(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
+    props.setProperty(HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER.key(),"true");
+
+    writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props).build())
+        .build();
+    assertMetadataConfigs(writeConfig, true, true, true, true);
+
+    // explicitly disable by user
+    props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    props.setProperty(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "false");
+    props.setProperty(HoodieMetadataConfig.ENABLE_METADATA_INDEX_BLOOM_FILTER.key(),"false");
+
+    writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props).build())
+        .build();
+    assertMetadataConfigs(writeConfig, false, false, false, false);
+  }
+
+  private void assertMetadataConfigs(HoodieWriteConfig writeConfig, boolean colStatsByUser, boolean bloomFilterByUser, boolean colStatsValue, boolean bloomFilterValue) {
+    assertEquals(writeConfig.isMetadataColumnStatsIndexEnabledByUser(), colStatsByUser);
+    assertEquals(writeConfig.isMetadataBloomFilterIndexEnabledByUser(), bloomFilterByUser);
+    assertEquals(writeConfig.isMetadataColumnStatsIndexEnabled(), colStatsValue);
+    assertEquals(writeConfig.isMetadataBloomFilterIndexEnabled(), bloomFilterByUser);
+  }
+
+  @Test
   public void testConsistentBucketIndexInvalidClusteringConfig() {
     Properties props = new Properties();
     props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -27,7 +27,6 @@ import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.CommitUtils;
@@ -136,9 +135,9 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     engineContext.setJobStatus(this.getClass().getName(), "Committing " + instantTime + " to metadata table " + metadataWriteConfig.getTableName());
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, metadataWriteConfig)) {
       // rollback partially failed writes if any.
-      if (writeClient.rollbackFailedWrites()) {
+      /*if (writeClient.rollbackFailedWrites()) {
         metadataMetaClient = HoodieTableMetaClient.reload(metadataMetaClient);
-      }
+      }*/
       if (canTriggerTableService) {
         // trigger compaction before doing the delta commit. this is to ensure, if this delta commit succeeds in metadata table, but failed in data table,
         // we would have compacted metadata table and so could have included uncommitted data which will never be ignored while reading from metadata

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -148,6 +148,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "metadata table will have a partition to store the bloom filter index and will be "
           + "used during the index lookups.");
 
+  // internal property to track whether explicit value set by the use to enable/disable bloom filter partition in metadata table.
+  public static final String ENABLE_METADATA_INDEX_BLOOM_FILTER_BY_USER = ENABLE_METADATA_INDEX_BLOOM_FILTER.key() + ".by.user";
+
   public static final ConfigProperty<Integer> METADATA_INDEX_BLOOM_FILTER_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.bloom.filter.file.group.count")
       .defaultValue(4)
@@ -169,6 +172,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("Enable indexing column ranges of user data files under metadata table key lookups. When "
           + "enabled, metadata table will have a partition to store the column ranges and will be "
           + "used for pruning files during the index lookups.");
+
+  // internal property to track whether explicit value set by the use to enable/disable col stats partition in metadata table.
+  public static final String ENABLE_METADATA_INDEX_COLUMN_STATS_BY_USER = ENABLE_METADATA_INDEX_COLUMN_STATS.key() + ".by.user";
 
   public static final ConfigProperty<Integer> METADATA_INDEX_COLUMN_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.file.group.count")

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -138,8 +138,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH;
 import static org.apache.hudi.config.metrics.HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE;
 import static org.apache.hudi.config.metrics.HoodieMetricsConfig.TURN_METRICS_ON;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.utilities.UtilHelpers.EXECUTE;
@@ -1185,6 +1187,10 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       }
       return true;
     });
+    // Verify that col stats partition is fully built out and is part of tableConfig entry tracking fully built out metadata partitions
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(tableBasePath).build();
+    assertTrue(metaClient.getFs().exists(new Path(tableBasePath + "/" + METADATA_TABLE_FOLDER_PATH + "/" + PARTITION_NAME_COLUMN_STATS)));
+    assertTrue(metaClient.getTableConfig().getMetadataPartitions().contains(PARTITION_NAME_COLUMN_STATS));
     UtilitiesTestBase.Helpers.deleteFileFromDfs(fs, tableBasePath);
   }
 


### PR DESCRIPTION
### Change Logs

Partitions created by Async indexer could be deleted by regular writers. This patch is fixing this flow.

Details of how this could happen: 
In regular writer we have a flow, where we detect if some MDT partition is not enabled, but the partition is found in storage and as part of table config's fully built out partitions, hudi deletes the metadata partition with the intent that user wishes to disable it. 

But this does not sit well w/ async indexer. 

process1 -> Deltastreamer runs continuously. 
no metadata configs set. 
which means, default value for metadata enable = true and hence "files" partition will be instantiated inline on first commit. 
no value set for col stats enable. So, no action will be taken. 

process2: user starts HoodieIndexer for col stats partition. 
Once indexer completes, tableConfig will add "col stats" as part of fully built out metadata partition.  

While in process1, when deltastreamer goes to next write(after indexer completes), it will detect that col stats wasn't enabled (default value as per code), but tableConfig shows that col stats is fully built out, and hence decides to delete the col stats partition and updates the tableConfig. Essentially the partition built by async indexer will immediately be deleted by regular writer.

Fix: 
Added explicit tracking to value set by the user for col stats enable and bloom filter enable and use it for deducing deleting metadata table partitions. This is just an internal property tracker which cannot be set by the user. 

### Impact

Async indexer can be used by users in all diff scenarios. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
