### PR TITLE
[HUDI-5785] Enhance Spark Datasource tests

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -20,10 +20,12 @@
 package org.apache.hudi.testutils;
 
 import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -41,7 +43,6 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
-import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieIOException;
@@ -107,6 +108,17 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
   protected boolean initialized = false;
   @TempDir
   protected java.nio.file.Path tempDir;
+
+  public static Map<String, String> getSparkSqlConf() {
+    Map<String, String> sqlConf = new HashMap<>();
+    sqlConf.put("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension");
+
+    if (HoodieSparkUtils.gteqSpark3_2()) {
+      sqlConf.put("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.hudi.catalog.HoodieCatalog");
+    }
+
+    return sqlConf;
+  }
 
   public String basePath() {
     return tempDir.toAbsolutePath().toUri().toString();

--- a/hudi-examples/hudi-examples-spark/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieSparkQuickstart.java
+++ b/hudi-examples/hudi-examples-spark/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieSparkQuickstart.java
@@ -20,6 +20,7 @@ package org.apache.hudi.examples.quickstart;
 
 import org.apache.hudi.client.SparkRDDReadClient;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.testutils.providers.SparkProvider;
 
 import org.apache.spark.HoodieSparkKryoRegistrar$;
@@ -54,6 +55,11 @@ public class TestHoodieSparkQuickstart implements SparkProvider {
   @Override
   public SparkSession spark() {
     return spark;
+  }
+
+  @Override
+  public SparkConf conf() {
+    return conf(SparkClientFunctionalTestHarness.getSparkSqlConf());
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
@@ -29,7 +29,9 @@ import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.keygen.TimestampBasedKeyGenerator
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, lit}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
@@ -57,6 +59,8 @@ class TestCOWDataSourceStorage extends SparkClientFunctionalTestHarness {
 
   val verificationCol: String = "driver"
   val updatedVerificationVal: String = "driver_update"
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
 
   @ParameterizedTest
   @CsvSource(value = Array(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
@@ -26,8 +26,10 @@ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
 import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, lit}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
@@ -56,6 +58,8 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
 
   val verificationCol: String = "driver"
   val updatedVerificationVal: String = "driver_update"
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
 
   @ParameterizedTest
   @CsvSource(Array(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -20,14 +20,18 @@ package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.common.config.HoodieMetadataConfig
-import org.apache.hudi.common.model.HoodieAvroRecordMerger
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.{Tag, Test}
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
 import scala.collection.JavaConverters._
 
 @Tag("functional")
@@ -45,8 +49,11 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
   )
 
-  @Test
-  def testReadability(): Unit = {
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @ParameterizedTest
+  @ValueSource(ints = Array(1, 5))
+  def testReadability(compactNumDeltaCommits: Int): Unit = {
     val dataGen = new HoodieTestDataGenerator()
 
     val metadataOpts: Map[String, String] = Map(
@@ -55,7 +62,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
     )
 
     val combinedOpts: Map[String, String] = commonOpts ++ metadataOpts ++
-      Map(HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1")
+      Map(HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> compactNumDeltaCommits.toString)
 
     // Insert records
     val newRecords = dataGen.generateInserts("001", 100)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
@@ -27,8 +27,10 @@ import org.apache.hudi.common.testutils.{HadoopMapRedUtils, HoodieTestDataGenera
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.keygen.NonpartitionedKeyGenerator
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, DefaultSource, HoodieBaseRelation, HoodieSparkUtils, HoodieUnsafeRDD}
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.{Dataset, HoodieUnsafeUtils, Row, SaveMode}
@@ -54,6 +56,8 @@ class TestParquetColumnProjection extends SparkClientFunctionalTestHarness with 
     //       non-partitioned makes it much more likely just a single file will be written
     DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getName
   )
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
 
   @Disabled("Currently disabled b/c of the fallback to HadoopFsRelation")
   @Test


### PR DESCRIPTION
### Change Logs

Previously, we found that Spark Datasource read of metadata table was broken and the issue is fixed by #7924.  However, the `TestMetadataTableWithSparkDataSource` guarding the exact same functionality did not fail in CI or local mvn command below.  After investigation, the Hudi Spark configs (`spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog`, `spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension`) are not properly added to the Spark session in the test environment.

This PR sets the proper Hudi Spark configs for Spark Datasource tests and adds one more test on reading metadata table through Spark Datasource.

### Impact

After this change, without the fix #7924, the following test fails which is consistent with the behavior of spark-shell (previously it passed without raising the alarm).
```
mvn clean test -Dspark3.3 -Dscala-2.12 -DwildcardSuites="abc" -Dtest=TestMetadataTableWithSparkDataSource -DfailIfNoTests=false -pl hudi-spark-datasource/hudi-spark -am
```

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
