### PR TITLE
[HUDI-5791] Handle empty payloads for AbstractDebeziumAvroPayload

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -56,15 +56,19 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
 
   @Override
   public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
-    IndexedRecord insertRecord = getInsertRecord(schema);
-    return handleDeleteOperation(insertRecord);
+    Option<IndexedRecord> insertValue = getInsertRecord(schema);
+    return insertValue.isPresent() ? handleDeleteOperation(insertValue.get()) : Option.empty();
   }
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
     // Step 1: If the time occurrence of the current record in storage is higher than the time occurrence of the
     // insert record (including a delete record), pick the current record.
-    if (shouldPickCurrentRecord(currentValue, getInsertRecord(schema), schema)) {
+    Option<IndexedRecord> insertValue = getInsertRecord(schema);
+    if (!insertValue.isPresent()) {
+      return Option.empty();
+    }
+    if (shouldPickCurrentRecord(currentValue, insertValue.get(), schema)) {
       return Option.of(currentValue);
     }
     // Step 2: Pick the insert record (as a delete record if its a deleted event)
@@ -84,7 +88,7 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
     return delete ? Option.empty() : Option.of(insertRecord);
   }
 
-  private IndexedRecord getInsertRecord(Schema schema) throws IOException {
-    return super.getInsertValue(schema).get();
+  private Option<IndexedRecord> getInsertRecord(Schema schema) throws IOException {
+    return super.getInsertValue(schema);
   }
 }


### PR DESCRIPTION
### Change Logs

HoodieMergeHandle is deciding we no longer need to copy the old record using `hoodieRecord.getData().combineAndGetUpdateValue` and this was not being handled properly in `AbstractDebeziumAvroPayload`


### Impact

Gets rid of failure case

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
