### PR TITLE
[HUDI-5798] fix spark sql query error on mor table after flink cdc delete records

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -122,6 +122,7 @@
                   <include>commons-codec:commons-codec</include>
                   <include>commons-io:commons-io</include>
                   <include>org.openjdk.jol:jol-core</include>
+                  <include>org.apache.avro:avro</include>
                 </includes>
               </artifactSet>
               <relocations combine.children="append">
@@ -192,6 +193,10 @@
                 <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.avro.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
                 </relocation>
               </relocations>
               <filters>
@@ -327,6 +332,13 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>${javax.servlet.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.10.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <!-- TODO: Reinvestigate PR 633 -->


### PR DESCRIPTION
Change Logs
shade avro-1.10.0 at hudi-spark${sparkbundle.version}-bundle_${scala.binary.version} to avoid deserialize error for delete record which writted by flink cdc application.

Impact
NA

Risk level (write none, low medium or high below)
none

Documentation Update
NA


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
