### PR TITLE
[HUDI-5799] Fix Spark partition validation in TestBulkInsertInternalPartitionerForRows

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests {@link BulkInsertPartitioner}s with Rows.
@@ -172,9 +173,14 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieClientTestHa
       return;
     }
     Dataset<Row> actualRecords = (Dataset<Row>) partitioner.repartitionRecords(rows, numPartitions);
-    assertEquals(
-        enforceNumOutputPartitions ? numPartitions : rows.rdd().getNumPartitions(),
-        actualRecords.rdd().getNumPartitions());
+    if (isGloballySorted) {
+      // For GLOBAL_SORT, `df.sort` may generate smaller number of partitions than the specified parallelism
+      assertTrue(actualRecords.rdd().getNumPartitions() <= numPartitions);
+    } else {
+      assertEquals(
+          enforceNumOutputPartitions ? numPartitions : rows.rdd().getNumPartitions(),
+          actualRecords.rdd().getNumPartitions());
+    }
 
     List<Row> collectedActualRecords = actualRecords.collectAsList();
     if (isGloballySorted) {


### PR DESCRIPTION
### Change Logs


This PR fixes the test failure in `TestBulkInsertInternalPartitionerForRows#testBulkInsertInternalPartitioner` with `GLOBAL_SORT`. The behavior of `GlobalSortPartitionerWithRows`(`BulkInsertSortMode.GLOBAL_SORT`) is the same as before.  The new assertion on the number of output partitions added in the test causes it to fail, because `df.sort` may generate smaller number of partitions than the specified parallelism.
```
[ERROR] testBulkInsertInternalPartitioner{BulkInsertSortMode, boolean, boolean, boolean, boolean}[1]  Time elapsed: 0.961 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <2> but was: <1>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:510)
	at org.apache.hudi.execution.bulkinsert.TestBulkInsertInternalPartitionerForRows.testBulkInsertInternalPartitioner(TestBulkInsertInternalPartitionerForRows.java:152)
	at org.apache.hudi.execution.bulkinsert.TestBulkInsertInternalPartitionerForRows.testBulkInsertInternalPartitioner(TestBulkInser
```

### Impact

NA

### Risk level (write none, low medium or high below)

LOW

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
