### PR TITLE
[HUDI-5800] Fix test failure in TestHoodieMergeOnReadTable

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieMergeOnReadTable.java
@@ -65,6 +65,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.storage.StorageLevel;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -96,6 +97,11 @@ public class TestHoodieMergeOnReadTable extends SparkClientFunctionalTestHarness
     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
     metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, properties);
     dataGen = new HoodieTestDataGenerator();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    jsc().getPersistentRDDs().values().forEach(JavaRDD::unpersist);
   }
 
   // Check if record level metadata is aggregated properly at the end of write.


### PR DESCRIPTION
### Change Logs

The PR fixes test failure in `TestHoodieMergeOnReadTable.testReleaseResource`
```
TestHoodieMergeOnReadTable.testReleaseResource:710 expected: <14> but was: <3>
```

### Impact

NA

### Risk level (write none, low medium or high below)

LOW

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
