### PR TITLE
[HUDI-5802] Allow configuration for deletes in DefaultHoodieRecordPayload

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ValidationUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ValidationUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.common.util;
 
+import java.util.function.Supplier;
+
 /**
  * Simple utility to test validation conditions (to replace Guava's PreConditions)
  */
@@ -39,6 +41,13 @@ public class ValidationUtils {
     if (!expression) {
       throw new IllegalArgumentException(errorMessage);
     }
+  }
+
+  /**
+   * Ensures the truth of an expression, throwing the custom errorMessage otherwise.
+   */
+  public static void checkArgument(final boolean expression, final Supplier<String> errorMessageSupplier) {
+    checkArgument(expression, errorMessageSupplier.get());
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -33,9 +33,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
 
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests {@link DefaultHoodieRecordPayload}.
@@ -108,6 +111,66 @@ public class TestDefaultHoodieRecordPayload {
 
     assertEquals(payload1.combineAndGetUpdateValue(delRecord1, schema, props).get(), delRecord1);
     assertFalse(payload2.combineAndGetUpdateValue(record1, schema, props).isPresent());
+  }
+
+  @Test
+  public void testDeleteKey() throws IOException {
+    props.setProperty(DELETE_KEY, "ts");
+    props.setProperty(DELETE_MARKER, String.valueOf(1L));
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("id", "1");
+    record.put("partition", "partition0");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+
+    GenericRecord delRecord = new GenericData.Record(schema);
+    delRecord.put("id", "2");
+    delRecord.put("partition", "partition1");
+    delRecord.put("ts", 1L);
+    delRecord.put("_hoodie_is_deleted", false);
+
+    GenericRecord defaultDeleteRecord = new GenericData.Record(schema);
+    defaultDeleteRecord.put("id", "2");
+    defaultDeleteRecord.put("partition", "partition1");
+    defaultDeleteRecord.put("ts", 2L);
+    defaultDeleteRecord.put("_hoodie_is_deleted", true);
+
+    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, 1);
+    DefaultHoodieRecordPayload deletePayload = new DefaultHoodieRecordPayload(delRecord, 2);
+    DefaultHoodieRecordPayload defaultDeletePayload = new DefaultHoodieRecordPayload(defaultDeleteRecord, 2);
+
+    assertEquals(record, payload.getInsertValue(schema, props).get());
+    assertEquals(defaultDeleteRecord, defaultDeletePayload.getInsertValue(schema, props).get());
+    assertFalse(deletePayload.getInsertValue(schema, props).isPresent());
+
+    assertEquals(delRecord, payload.combineAndGetUpdateValue(delRecord, schema, props).get());
+    assertEquals(defaultDeleteRecord, payload.combineAndGetUpdateValue(defaultDeleteRecord, schema, props).get());
+    assertFalse(deletePayload.combineAndGetUpdateValue(record, schema, props).isPresent());
+  }
+
+  @Test
+  public void testDeleteKeyConfiguration() throws IOException {
+    props.setProperty(DELETE_KEY, "ts");
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("id", "1");
+    record.put("partition", "partition0");
+    record.put("ts", 0L);
+    record.put("_hoodie_is_deleted", false);
+
+    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, 1);
+
+    // Verify failure when DELETE_MARKER is not configured along with DELETE_KEY
+    try {
+      payload.getInsertValue(schema, props).get();
+      fail("Should fail");
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      payload.combineAndGetUpdateValue(record, schema, props).get();
+      fail("Should fail");
+    } catch (IllegalArgumentException e) {
+    }
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -164,12 +164,14 @@ public class TestDefaultHoodieRecordPayload {
       payload.getInsertValue(schema, props).get();
       fail("Should fail");
     } catch (IllegalArgumentException e) {
+      // Ignore
     }
 
     try {
       payload.combineAndGetUpdateValue(record, schema, props).get();
       fail("Should fail");
     } catch (IllegalArgumentException e) {
+      // Ignore
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/payload/ExpressionPayload.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 import org.apache.hudi.avro.AvroSchemaUtils.isNullable
 import org.apache.hudi.avro.HoodieAvroUtils
 import org.apache.hudi.avro.HoodieAvroUtils.bytesToAvro
-import org.apache.hudi.common.model.BaseAvroPayload.isDeleteRecord
+import org.apache.hudi.common.model.BaseAvroPayload
 import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodiePayloadProps, HoodieRecord}
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.{BinaryUtil, ValidationUtils, Option => HOption}
@@ -238,7 +238,7 @@ class ExpressionPayload(@transient record: GenericRecord,
     val recordSchema = getRecordSchema(properties)
     val incomingRecord = ConvertibleRecord(bytesToAvro(recordBytes, recordSchema))
 
-    if (isDeleteRecord(incomingRecord.asAvro)) {
+    if (BaseAvroPayload.isDeleteRecord(incomingRecord.asAvro)) {
       HOption.empty[IndexedRecord]()
     } else if (isMORTable(properties)) {
       // For the MOR table, both the matched and not-matched record will step into the getInsertValue() method.


### PR DESCRIPTION
### Change Logs

Modify DefaultHoodieRecordPayload to be able to handle a configured delete key and marker

### Impact

NA

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
