### PR TITLE
[HUDI-5805] Hive query on mor get empty result before compaction

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -39,6 +39,8 @@ import org.apache.hudi.sync.common.util.SparkDataSourceTableUtils;
 import com.beust.jcommander.JCommander;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.parquet.schema.MessageType;
@@ -290,6 +292,9 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       Map<String, String> sparkSerdeProperties = SparkDataSourceTableUtils.getSparkSerdeProperties(readAsOptimized, config.getString(META_SYNC_BASE_PATH));
       tableProperties.putAll(sparkTableProperties);
       serdeProperties.putAll(sparkSerdeProperties);
+    }
+    if (!tableProperties.containsKey(hive_metastoreConstants.META_TABLE_STORAGE)) {
+      tableProperties.put(hive_metastoreConstants.META_TABLE_STORAGE, DefaultStorageHandler.class.getName());
     }
     boolean schemaChanged = false;
     // Check and sync schema

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -439,7 +439,8 @@ public class TestHiveSyncTool {
             + "{\"name\":\"favorite_number\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},"
             + "{\"name\":\"favorite_color\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}},"
             + "{\"name\":\"datestr\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}}]}\n"
-            + "spark.sql.sources.schema.partCol.0\tdatestr\n";
+            + "spark.sql.sources.schema.partCol.0\tdatestr\n"
+            + "storage_handler\torg.apache.hadoop.hive.ql.metadata.DefaultStorageHandler\n";
       } else {
         return "spark.sql.sources.provider\thudi\n"
             + "spark.sql.sources.schema.numPartCols\t1\n"
@@ -449,10 +450,11 @@ public class TestHiveSyncTool {
             + "\"nullable\":false,\"metadata\":{}},{\"name\":\"favorite_color\",\"type\":\"string\",\"nullable\":false,"
             + "\"metadata\":{}}]}\n"
             + "{\"name\":\"datestr\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}}]}\n"
-            + "spark.sql.sources.schema.partCol.0\tdatestr\n";
+            + "spark.sql.sources.schema.partCol.0\tdatestr\n"
+            + "storage_handler\torg.apache.hadoop.hive.ql.metadata.DefaultStorageHandler\n";
       }
     } else {
-      return "";
+      return "storage_handler\torg.apache.hadoop.hive.ql.metadata.DefaultStorageHandler\n";
     }
   }
 


### PR DESCRIPTION
Change Logs
when a mor table write data with flink cdc only, then before compaction the partition will only have log file, and no base file. then befor compaction, hive query result will always be empty.

it's because when hive getSplit on a native table, hive will ignore a partition which only has files start with '.', and because hudi has not set storageHandle when sync hive meta, then hive treat it as native table. 

Impact
make storageHandle as DefaultStorageHandler when sync hive meta

Risk level (write none, low medium or high below)
none

Documentation Update
none

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
