### PR TITLE
[HUDI-5811] Specify the artifact of protoc to solve the problem that cannot be compiled on m1 mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -761,6 +761,7 @@
             </execution>
           </executions>
           <configuration>
+            <protocArtifact>com.google.protobuf:protoc:${proto.version}</protocArtifact>
             <protocVersion>${protoc.version}</protocVersion>
             <includeStdTypes>true</includeStdTypes>
           </configuration>


### PR DESCRIPTION
[HUDI-5811](https://issues.apache.org/jira/browse/HUDI-5811)
### Background

I encountered the same problem as in the [issue](https://github.com/apache/hudi/issues/6724). I couldn’t compile Hudi on the m1 mac. Following the suggestions in the issue still couldn’t solve it. Because I have encountered similar problems on spark. By referring to the configuration of [pom.xml](https://github.com/apache/spark/blob/master/connector/protobuf/pom.xml#L174) in spark, the configuration of protoc artifact is added to Hudi, and the problem is solved.

### Change Logs

add the artifact of protoc to pom.xml

### Impact

no

### Risk level (write none, low medium or high below)

none

### Documentation Update

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
