### PR TITLE
hash partition in spark datasoure

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -78,7 +78,9 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
   private static final Logger LOG = LogManager.getLogger(BaseHoodieTableFileIndex.class);
 
   private final String[] partitionColumns;
-
+  private final String[] hashPartitionColumns;
+  private final int hashPartitionNum;
+  
   protected final HoodieMetadataConfig metadataConfig;
 
   private final Option<String> specifiedQueryInstant;
@@ -128,6 +130,10 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     this.partitionColumns = metaClient.getTableConfig().getPartitionFields()
         .orElse(new String[0]);
 
+    this.hashPartitionColumns = metaClient.getTableConfig().getHashPartitionFields()
+        .orElse(new String[0]);
+    this.hashPartitionNum = Integer.parseInt((metaClient.getTableConfig().getHashPartitionNum()));
+    
     this.metadataConfig = HoodieMetadataConfig.newBuilder()
         .fromProperties(configProperties)
         .enable(configProperties.getBoolean(ENABLE.key(), DEFAULT_METADATA_ENABLE_FOR_READERS)
@@ -190,6 +196,14 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
     return partitionColumns;
   }
 
+  protected int getHashPartitionNum() {
+    return hashPartitionNum;
+  }
+
+  protected String[] getHashPartitionColumns() {
+    return hashPartitionColumns;
+  }
+  
   protected List<Path> getQueryPaths() {
     return queryPaths;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -52,6 +52,8 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   public static final String FILENAME_METADATA_FIELD = HoodieMetadataField.FILENAME_METADATA_FIELD.getFieldName();
   public static final String OPERATION_METADATA_FIELD = HoodieMetadataField.OPERATION_METADATA_FIELD.getFieldName();
   public static final String HOODIE_IS_DELETED_FIELD = "_hoodie_is_deleted";
+  public static final String HASH_PARTITION_FIELD = "_hoodie_hash_partition";
+
 
   public enum HoodieMetadataField {
     COMMIT_TIME_METADATA_FIELD("_hoodie_commit_time"),

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -54,7 +54,6 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   public static final String HOODIE_IS_DELETED_FIELD = "_hoodie_is_deleted";
   public static final String HASH_PARTITION_FIELD = "_hoodie_hash_partition";
 
-
   public enum HoodieMetadataField {
     COMMIT_TIME_METADATA_FIELD("_hoodie_commit_time"),
     COMMIT_SEQNO_METADATA_FIELD("_hoodie_commit_seqno"),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -116,6 +116,16 @@ public class HoodieTableConfig extends HoodieConfig {
       .withDocumentation("Fields used to partition the table. Concatenated values of these fields are used as "
           + "the partition path, by invoking toString()");
 
+  public static final ConfigProperty<String> HASH_PARTITION_NUM = ConfigProperty
+      .key("hoodie.table.hash.partition.num")
+      .defaultValue("256")
+      .withDocumentation("Determine the number of hash partitions in the hudi table ");
+
+  public static final ConfigProperty<String> HASH_PARTITION_FIELDS = ConfigProperty
+          .key("hoodie.table.hash.partition.fields")
+          .noDefaultValue()
+          .withDocumentation("Hash partition field. Use its value to generate the hash value of the hash partition field. ");
+          
   public static final ConfigProperty<String> RECORDKEY_FIELDS = ConfigProperty
       .key("hoodie.table.recordkey.fields")
       .noDefaultValue()
@@ -541,6 +551,21 @@ public class HoodieTableConfig extends HoodieConfig {
     return Option.empty();
   }
 
+  public Option<String[]> getHashPartitionFields() {
+    if (contains(HASH_PARTITION_FIELDS)) {
+      return Option.of(Arrays.stream(getString(HASH_PARTITION_FIELDS).split(","))
+              .filter(p -> p.length() > 0).collect(Collectors.toList()).toArray(new String[] {}));
+    }
+    return Option.empty();
+  }
+
+  public String getHashPartitionNum() {
+    if (contains(HASH_PARTITION_NUM)) {
+      return getString(HASH_PARTITION_NUM);
+    }
+    return HASH_PARTITION_NUM.defaultValue();
+  }
+  
   public boolean isTablePartitioned() {
     return getPartitionFields().map(pfs -> pfs.length > 0).orElse(false);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -794,6 +794,8 @@ public class HoodieTableMetaClient implements Serializable {
     private String baseFileFormat;
     private String preCombineField;
     private String partitionFields;
+    private String hashPartitionFields;
+    private Integer hashPartitionNum;
     private Boolean cdcEnabled;
     private String cdcSupplementalLoggingMode;
     private String bootstrapIndexClass;
@@ -885,6 +887,16 @@ public class HoodieTableMetaClient implements Serializable {
 
     public PropertyBuilder setPartitionFields(String partitionFields) {
       this.partitionFields = partitionFields;
+      return this;
+    }
+    
+    public PropertyBuilder setHashPartitionFields(String hashPartitionFields) {
+      this.hashPartitionFields = hashPartitionFields;
+      return this;
+    }
+
+    public PropertyBuilder setHashPartitionNum(int num) {
+      this.hashPartitionNum = num;
       return this;
     }
 
@@ -1044,6 +1056,14 @@ public class HoodieTableMetaClient implements Serializable {
         setPartitionFields(
             hoodieConfig.getString(HoodieTableConfig.PARTITION_FIELDS));
       }
+      if (hoodieConfig.contains(HoodieTableConfig.HASH_PARTITION_FIELDS)) {
+        setHashPartitionFields(
+                hoodieConfig.getString(HoodieTableConfig.HASH_PARTITION_FIELDS));
+      }
+      if (hoodieConfig.contains(HoodieTableConfig.HASH_PARTITION_NUM)) {
+        setHashPartitionNum(
+                hoodieConfig.getInt(HoodieTableConfig.HASH_PARTITION_NUM));
+      }
       if (hoodieConfig.contains(HoodieTableConfig.RECORDKEY_FIELDS)) {
         setRecordKeyFields(hoodieConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));
       }
@@ -1145,6 +1165,12 @@ public class HoodieTableMetaClient implements Serializable {
 
       if (null != partitionFields) {
         tableConfig.setValue(HoodieTableConfig.PARTITION_FIELDS, partitionFields);
+      }
+      if (null != hashPartitionFields) {
+        tableConfig.setValue(HoodieTableConfig.HASH_PARTITION_FIELDS, hashPartitionFields);
+      }
+      if (null != hashPartitionNum) {
+        tableConfig.setValue(HoodieTableConfig.HASH_PARTITION_NUM, hashPartitionNum.toString());
       }
       if (null != recordKeyFields) {
         tableConfig.setValue(HoodieTableConfig.RECORDKEY_FIELDS, recordKeyFields);

--- a/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
@@ -59,6 +59,16 @@ public class KeyGeneratorOptions extends HoodieConfig {
       .withDocumentation("Partition path field. Value to be used at the partitionPath component of HoodieKey. "
           + "Actual value ontained by invoking .toString()");
 
+  public static final ConfigProperty<Integer> HASH_PARTITION_NUM = ConfigProperty
+      .key("hoodie.datasource.write.hash.partition.num")
+      .defaultValue(256)
+      .withDocumentation("Determine the number of hash partitions in the hudi table ");
+
+  public static final ConfigProperty<String> HASH_PARTITION_FIELD_NAME = ConfigProperty
+      .key("hoodie.datasource.write.hash.partition.field")
+      .noDefaultValue()
+      .withDocumentation("Hash partition field. Use its value to generate the hash value of the hash partition field. ");
+      
   public static final ConfigProperty<String> KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED = ConfigProperty
       .key("hoodie.datasource.write.keygenerator.consistent.logical.timestamp.enabled")
       .defaultValue("false")
@@ -123,4 +133,3 @@ public class KeyGeneratorOptions extends HoodieConfig {
     public static final String DATE_TIME_PARSER_PROP = "hoodie.deltastreamer.keygen.datetime.parser.class";
   }
 }
-

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -365,7 +365,16 @@ object DataSourceWriteOptions {
    * value obtained by invoking .toString()
    */
   val PARTITIONPATH_FIELD = KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME
+  /**
+    * Determine the number of hash partitions in the hudi table
+    */
+  val HASH_PARTITION_NUM = KeyGeneratorOptions.HASH_PARTITION_NUM
 
+  /**
+    * Hash partition field. Use its value to generate the hash value of the hash partition field. 
+    * value obtained by invoking .toString() 
+    */
+  val HASH_PARTITION_FIELD = KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME
   /**
    * Flag to indicate whether to use Hive style partitioning.
    * If set true, the names of partition folders follow <partition_column_name>=<partition_value> format.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -371,8 +371,8 @@ object DataSourceWriteOptions {
   val HASH_PARTITION_NUM = KeyGeneratorOptions.HASH_PARTITION_NUM
 
   /**
-    * Hash partition field. Use its value to generate the hash value of the hash partition field. 
-    * value obtained by invoking .toString() 
+    * Hash partition field. Use its value to generate the hash value of the hash partition field.
+    * value obtained by invoking .toString()
     */
   val HASH_PARTITION_FIELD = KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -141,7 +141,8 @@ class DefaultSource extends RelationProvider
                               mode: SaveMode,
                               optParams: Map[String, String],
                               df: DataFrame): BaseRelation = {
-    val dfWithoutMetaCols = df.drop(HoodieRecord.HOODIE_META_COLUMNS.asScala:_*)
+   val dropColList = HoodieRecord.HOODIE_META_COLUMNS.asScala.:+ (HoodieRecord.HASH_PARTITION_FIELD)
+   val dfWithoutMetaCols = df.drop(dropColList:_*)
 
     if (optParams.get(OPERATION.key).contains(BOOTSTRAP_OPERATION_OPT_VAL)) {
       HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, dfWithoutMetaCols)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -29,7 +29,7 @@ import org.apache.hudi.keygen.{TimestampBasedAvroKeyGenerator, TimestampBasedKey
 import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{And, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{And, EqualTo, Expression, Literal}
 import org.apache.spark.sql.execution.datasources.{FileIndex, FileStatusCache, NoopCache, PartitionDirectory}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
@@ -139,11 +139,16 @@ case class HoodieFileIndex(spark: SparkSession,
 
     var totalFileSize = 0
     var candidateFileSize = 0
+    val hashPartionFilterOption = createHashPartionFilter(partitionFilters ++ dataFilters)
 
     // Prune the partition path by the partition filters
     // NOTE: Non-partitioned tables are assumed to consist from a single partition
     //       encompassing the whole table
-    val prunedPartitions = listMatchingPartitionPaths(partitionFilters)
+    def getPrunedPartitions(hashPartionFilterOption: Option[Expression]) = hashPartionFilterOption match{
+      case None => listMatchingPartitionPaths(partitionFilters)
+      case Some(hashPartionFilter) => listMatchingPartitionPaths(partitionFilters.:+ (hashPartionFilter))
+    }
+    val prunedPartitions = getPrunedPartitions(hashPartionFilterOption)
     val listedPartitions = getInputFileSlices(prunedPartitions: _*).asScala.toSeq.map {
       case (partition, fileSlices) =>
         val baseFileStatuses: Seq[FileStatus] =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -65,6 +65,8 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.{SPARK_VERSION, SparkContext}
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
+import org.apache.spark.sql.functions._
 
 import java.util.function.BiConsumer
 import scala.collection.JavaConversions._
@@ -103,7 +105,7 @@ object HoodieSparkSqlWriter {
   def write(sqlContext: SQLContext,
             mode: SaveMode,
             optParams: Map[String, String],
-            df: DataFrame,
+            dataFrame: DataFrame,
             hoodieTableConfigOpt: Option[HoodieTableConfig] = Option.empty,
             hoodieWriteClient: Option[SparkRDDWriteClient[_]] = Option.empty,
             asyncCompactionTriggerFn: Option[SparkRDDWriteClient[_] => Unit] = Option.empty,
@@ -186,7 +188,7 @@ object HoodieSparkSqlWriter {
         val archiveLogFolder = hoodieConfig.getStringOrDefault(HoodieTableConfig.ARCHIVELOG_FOLDER)
         val populateMetaFields = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS)
         val useBaseFormatMetaFile = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT);
-        HoodieTableMetaClient.withPropertyBuilder()
+        val hoodieTableMetaClient = HoodieTableMetaClient.withPropertyBuilder()
           .setTableType(tableType)
           .setDatabaseName(databaseName)
           .setTableName(tblName)
@@ -208,9 +210,23 @@ object HoodieSparkSqlWriter {
           .setPartitionMetafileUseBaseFormat(useBaseFormatMetaFile)
           .setShouldDropPartitionColumns(hoodieConfig.getBooleanOrDefault(HoodieTableConfig.DROP_PARTITION_COLUMNS))
           .setCommitTimezone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getStringOrDefault(HoodieTableConfig.TIMELINE_TIMEZONE)))
-          .initTable(sparkContext.hadoopConfiguration, path)
+        val (hashPartitionFields, hashPartitionNum) = getHashPartitionParam(optParams)
+        if(containHashPartitionParam(partitionColumns, hashPartitionFields)){
+          hoodieConfig.setValue(HoodieTableConfig.HASH_PARTITION_FIELDS,hashPartitionFields)
+
+          hoodieConfig.setValue(HoodieTableConfig.HASH_PARTITION_NUM,hashPartitionNum.toString)
+          hoodieTableMetaClient.setHashPartitionNum(hashPartitionNum)
+            .setHashPartitionFields(hashPartitionFields)
+        }
+        hoodieTableMetaClient.initTable(sparkContext.hadoopConfiguration, path)
       }
       tableConfig = tableMetaClient.getTableConfig
+
+      val hashPartitionFields = tableConfig.getHashPartitionFields.orElse(null)
+      val df = if(containHashPartitionParam(partitionColumns, hashPartitionFields))
+        addHashPartitionCol(hashPartitionFields,
+          Integer.parseInt(tableConfig.getHashPartitionNum), dataFrame)
+      else dataFrame
 
       val commitActionType = CommitUtils.getCommitActionType(operation, tableConfig.getTableType)
 
@@ -282,7 +298,7 @@ object HoodieSparkSqlWriter {
             } else {
               val genericRecords = HoodieSparkUtils.createRdd(df, avroRecordName, avroRecordNamespace)
               genericRecords.map(gr => keyGenerator.getKey(gr).getPartitionPath).toJavaRDD().distinct().collect()
-            }
+              }
 
             // Create a HoodieWriteClient & issue the delete.
             val tableMetaClient = HoodieTableMetaClient.builder
@@ -382,6 +398,59 @@ object HoodieSparkSqlWriter {
         }
       }
     }
+  }
+
+  private def getHashPartitionParam(optParams: Map[String, String]): ( String, Integer)  = {
+    val hashPartitionFields = optParams.get(KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key).getOrElse(
+      optParams.get(HoodieTableConfig.HASH_PARTITION_FIELDS.key).getOrElse("")
+    )
+    val hashPartitionNum = optParams.get(KeyGeneratorOptions.HASH_PARTITION_NUM.key).getOrElse(
+        optParams.get(HoodieTableConfig.HASH_PARTITION_NUM.key).getOrElse(KeyGeneratorOptions.HASH_PARTITION_NUM.defaultValue())
+    )
+    (hashPartitionFields, Integer.parseInt(hashPartitionNum.toString))
+  }
+
+  private def containHashPartitionParam(
+                                   partitionFields: String,
+                                   hashPartitionFields: String): Boolean = {
+    if(partitionFields != null && partitionFields.split(",").map(x => x.trim).contains(HoodieRecord.HASH_PARTITION_FIELD)){
+      if(hashPartitionFields.isEmpty)
+        throw new HoodieException(s"${KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key} is empty," +
+          s" but ${KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key} contains ${HoodieRecord.HASH_PARTITION_FIELD}")
+      true
+    }else{
+      if(!hashPartitionFields.isEmpty)
+        throw new HoodieException(s"${KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key} is not empty," +
+          s" but ${KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key} does not contain ${HoodieRecord.HASH_PARTITION_FIELD}")
+      else false
+    }
+  }
+
+  private def containHashPartitionParam(
+                                         partitionFields: String,
+                                         hashPartitionFields:  Array[String]): Boolean = {
+    if(partitionFields != null && partitionFields.split(",").map(x => x.trim).contains(HoodieRecord.HASH_PARTITION_FIELD)){
+      if(hashPartitionFields == null || hashPartitionFields.size == 0)
+        throw new HoodieException(s"${HoodieTableConfig.HASH_PARTITION_FIELDS.key} is empty," +
+          s" but ${HoodieTableConfig.PARTITION_FIELDS.key} contains ${HoodieRecord.HASH_PARTITION_FIELD}")
+      true
+    }else{
+      if(hashPartitionFields != null && hashPartitionFields.size != 0)
+        throw new HoodieException(s"${HoodieTableConfig.PARTITION_FIELDS.key}  does not contain ${HoodieRecord.HASH_PARTITION_FIELD}," +
+          s" but ${HoodieTableConfig.HASH_PARTITION_FIELDS.key}  is not empty.")
+      false
+    }
+  }
+
+  private def addHashPartitionCol(
+                                   hashPartitionFields: Array[String],
+                                   num: Integer,
+                                   df: DataFrame): DataFrame = {
+    val getHashPartitionValue = (cols: Seq[Any], num : Int) => ((cols.filter(_ != null).mkString.trim.hashCode & Integer.MAX_VALUE) % num).toString
+    val addHashPartitionColUdf = udf(getHashPartitionValue)
+    val hashPartitionFieldCols = hashPartitionFields.map(hashPartitionField => col(hashPartitionField.trim))
+    //df.withColumn(HoodieRecord.HASH_PARTITION_FIELD, addCol(hashPartitionCols, lit(num)))
+    df.select(addHashPartitionColUdf(array(hashPartitionFieldCols:_*), lit(num)).as(HoodieRecord.HASH_PARTITION_FIELD), expr("*"))
   }
 
   /**
@@ -705,7 +774,7 @@ object HoodieSparkSqlWriter {
           String.valueOf(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue())
         ))
 
-        HoodieTableMetaClient.withPropertyBuilder()
+        val hoodieTableMetaClient = HoodieTableMetaClient.withPropertyBuilder()
           .setTableType(HoodieTableType.valueOf(tableType))
           .setTableName(tableName)
           .setRecordKeyFields(recordKeyFields)
@@ -725,7 +794,15 @@ object HoodieSparkSqlWriter {
           .setUrlEncodePartitioning(hoodieConfig.getBoolean(URL_ENCODE_PARTITIONING))
           .setCommitTimezone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getStringOrDefault(HoodieTableConfig.TIMELINE_TIMEZONE)))
           .setPartitionMetafileUseBaseFormat(useBaseFormatMetaFile)
-          .initTable(sparkContext.hadoopConfiguration, path)
+        if(partitionColumns.split(",").map(x => x.trim).contains(HoodieRecord.HASH_PARTITION_FIELD)){
+          val hashPartitionNum = java.lang.Integer.parseInt(parameters.getOrElse(
+            HoodieTableConfig.HASH_PARTITION_NUM.key(),
+            String.valueOf(HoodieTableConfig.HASH_PARTITION_NUM.defaultValue())
+          ))
+          hoodieTableMetaClient.setHashPartitionNum(hashPartitionNum)
+          .setHashPartitionFields(parameters.getOrElse(HoodieTableConfig.HASH_PARTITION_FIELDS.key(),null))
+        }
+        hoodieTableMetaClient.initTable(sparkContext.hadoopConfiguration, path)
       }
 
       val jsc = new JavaSparkContext(sqlContext.sparkContext)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.catalog
 import org.apache.hudi.DataSourceWriteOptions.OPERATION
 import org.apache.hudi.HoodieWriterUtils._
 import org.apache.hudi.common.config.DFSPropertiesConfiguration
-import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.util.StringUtils
@@ -33,8 +33,11 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.hudi.HoodieOptionConfig
 import org.apache.spark.sql.hudi.HoodieOptionConfig._
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
-import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
+
 
 import java.util.{Locale, Properties}
 import scala.collection.JavaConverters._
@@ -193,9 +196,39 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
       val (recordName, namespace) = AvroConversionUtils.getAvroRecordNameAndNamespace(table.identifier.table)
       val schema = SchemaConverters.toAvroType(finalSchema, false, recordName, namespace)
       val partitionColumns = if (table.partitionColumnNames.isEmpty) {
-        null
+        val (partitionFields, hashPartitionFields, hashPartitionNum) = getHashPartitionParam(tableConfigs)
+
+        if (containHashPartitionParam(partitionFields, hashPartitionFields)) {
+          properties.setProperty(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key, "org.apache.hudi.keygen.ComplexKeyGenerator")
+          properties.setProperty(HoodieTableConfig.HASH_PARTITION_FIELDS.key, hashPartitionFields)
+          properties.setProperty(HoodieTableConfig.HASH_PARTITION_NUM.key, hashPartitionNum.toString)
+        }
+        if (!partitionFields.isEmpty) partitionFields else null
       } else {
-        table.partitionColumnNames.mkString(",")
+      if (properties.getProperty(HoodieTableConfig.PARTITION_FIELDS.key) != null)
+          throw new HoodieException(s"Parameter ${HoodieTableConfig.PARTITION_FIELDS.key} cannot be specified " +
+            "as SQL contain [partitioned by].}")
+        if (properties.getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key) != null)
+          throw new HoodieException(s"Parameter ${KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME} cannot be specified " +
+            "as SQL contain [partitioned by].}")
+        if (properties.getProperty(KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key) != null) {
+          properties.setProperty(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key, "org.apache.hudi.keygen.ComplexKeyGenerator")
+          properties.setProperty(HoodieTableConfig.HASH_PARTITION_FIELDS.key,
+            properties.getProperty(KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key))
+          if (properties.getProperty(KeyGeneratorOptions.HASH_PARTITION_NUM.key) != null)
+            properties.setProperty(HoodieTableConfig.HASH_PARTITION_NUM.key, properties.getProperty(KeyGeneratorOptions.HASH_PARTITION_NUM.key))
+          if (properties.getProperty(HoodieTableConfig.HASH_PARTITION_NUM.key) == null)
+            properties.setProperty(HoodieTableConfig.HASH_PARTITION_NUM.key, HoodieTableConfig.HASH_PARTITION_NUM.defaultValue)
+          s"${table.partitionColumnNames.mkString(",")},${HoodieRecord.HASH_PARTITION_FIELD}"
+        }
+        else if (properties.getProperty(HoodieTableConfig.HASH_PARTITION_FIELDS.key) != null) {
+          val keyGenerator = properties.getProperty(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key)
+          if(keyGenerator == null || !keyGenerator.contains("Complex"))
+            properties.setProperty(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key, "org.apache.hudi.keygen.ComplexKeyGenerator")
+          if (properties.getProperty(HoodieTableConfig.HASH_PARTITION_NUM.key) == null)
+            properties.setProperty(HoodieTableConfig.HASH_PARTITION_NUM.key, HoodieTableConfig.HASH_PARTITION_NUM.defaultValue)
+          s"${table.partitionColumnNames.mkString(",")},${HoodieRecord.HASH_PARTITION_FIELD}"
+        } else table.partitionColumnNames.mkString(",")
       }
 
       HoodieTableMetaClient.withPropertyBuilder()
@@ -237,7 +270,8 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         val schema = if (schemaFromMetaOpt.nonEmpty) {
           schemaFromMetaOpt.get
         } else if (table.schema.nonEmpty) {
-          addMetaFields(table.schema)
+          //addMetaFields(table.schema)
+          addMetaFieldsWithHashFieldIfNeeded(table.schema, options)
         } else {
           throw new AnalysisException(
             s"Missing schema fields when applying CREATE TABLE clause for ${catalogTableName}")
@@ -250,7 +284,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         val schema = table.schema
         val options = extraTableConfig(tableExists = false, globalTableConfigs) ++
           mapSqlOptionsToTableConfigs(sqlOptions)
-        (addMetaFields(schema), options)
+          (addMetaFieldsWithHashFieldIfNeeded(schema, options), options)
 
       case (CatalogTableType.MANAGED, true) =>
         throw new AnalysisException(s"Can not create the managed table('$catalogTableName')" +
@@ -266,6 +300,48 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
     verifyDataSchema(table.identifier, table.tableType, dataSchema)
 
     (finalSchema, tableConfigs)
+  }
+
+  private def getHashPartitionParam(optParams: Map[String, String]): (String, String, Integer) = {
+    val partitionFields = optParams.get(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key).getOrElse(
+      optParams.get(HoodieTableConfig.PARTITION_FIELDS.key).getOrElse("")
+    )
+    val hashPartitionFields = optParams.get(KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key).getOrElse(
+      optParams.get(HoodieTableConfig.HASH_PARTITION_FIELDS.key).getOrElse("")
+    )
+    val hashPartitionNum = optParams.get(KeyGeneratorOptions.HASH_PARTITION_NUM.key).getOrElse(
+      optParams.get(HoodieTableConfig.HASH_PARTITION_NUM.key).getOrElse(KeyGeneratorOptions.HASH_PARTITION_NUM.defaultValue())
+    )
+    (partitionFields, hashPartitionFields, Integer.parseInt(hashPartitionNum.toString))
+  }
+
+  private def containHashPartitionParam(
+                                         partitionFields: String,
+                                         hashPartitionFields: String): Boolean = {
+    if (partitionFields.split(",").contains(HoodieRecord.HASH_PARTITION_FIELD)) {
+      if (hashPartitionFields.isEmpty)
+        throw new HoodieException(s"${HoodieTableConfig.HASH_PARTITION_FIELDS.key} is empty," +
+          s" but ${HoodieTableConfig.PARTITION_FIELDS.key} contains ${HoodieRecord.HASH_PARTITION_FIELD}")
+      true
+    } else {
+      if (!hashPartitionFields.isEmpty)
+        throw new HoodieException(s"${HoodieTableConfig.HASH_PARTITION_FIELDS.key} is not empty," +
+          s" but ${HoodieTableConfig.PARTITION_FIELDS.key} does not contain ${HoodieRecord.HASH_PARTITION_FIELD}")
+      else false
+    }
+  }
+
+  private def addMetaFieldsWithHashFieldIfNeeded(
+      schema: StructType,
+      option: Map[String, String]): StructType = {
+    val hashPartitionFields = option.getOrElse(HoodieTableConfig.HASH_PARTITION_FIELDS.key, null)
+    val metaFieldsWithHashFieldIfNeeded = if(hashPartitionFields != null)
+      HoodieRecord.HOODIE_META_COLUMNS.asScala.:+ (HoodieRecord.HASH_PARTITION_FIELD)
+    else HoodieRecord.HOODIE_META_COLUMNS.asScala
+    // filter the meta field to avoid duplicate field.
+    val dataFields = schema.fields.filterNot(f => metaFieldsWithHashFieldIfNeeded.contains(f.name))
+    val fields = metaFieldsWithHashFieldIfNeeded.map(StructField(_, StringType)) ++ dataFields
+    StructType(fields)
   }
 
   private def extraTableConfig(tableExists: Boolean,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -52,6 +52,10 @@ import org.mockito.Mockito.{spy, times, verify}
 import org.scalatest.Assertions.assertThrows
 import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, intercept}
 
+import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
+import org.apache.spark.sql.SaveMode.{Append, Overwrite}
+
 import java.io.IOException
 import java.time.Instant
 import java.util.{Collections, Date, UUID}
@@ -1193,6 +1197,138 @@ class TestHoodieSparkSqlWriter {
   }
 
   /**
+    * Test case for hash partition.
+    * When hash.partition.fields is specified and partition.fields contains _hoodie_hash_partition,
+    * a column named _hoodie_hash_partition will be added in this table as one of the partition key.
+    *
+    * If predicates of hash.partition.fields appear in the query statement, 
+    * the _hoodie_hash_partition = X  predicate will be automatically added
+    * to the query statement for partition pruning.
+    */
+  @Test
+  def testHashPartition(): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    val tablePath = tempBasePath
+    // case 1: test table which created by data frame
+    val insertDf = Seq((1, "a1", 10, 1000, "2021"),
+      (4, "a4", 10, 1000, "2021"),
+      (5, "a5", 10, 1000, "2021"),
+      (6, "a6", 10, 1000, "2021"),
+      (7, "a6", 10, 1000, "2021"),
+      (2, "a2", 20, 2000, "2022"),
+      (3, "a3", 30, 3000, "2023")).toDF("id", "name", "value", "ts", "dt")
+    val options = Map(
+      HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key -> "ts",
+      KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key -> "id",
+      KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key -> "dt,_hoodie_hash_partition",
+      KeyGeneratorOptions.HASH_PARTITION_FIELD_NAME.key -> "id,name",
+      KeyGeneratorOptions.HASH_PARTITION_NUM.key -> "16"
+    )
+    val tableName1 = "hoodie_test_params_1"
+    insertDf.write.format("hudi")
+      .options(options)
+      .option(TBL_NAME.key, tableName1)
+      .mode(Overwrite)
+      .save(s"${tablePath}/${tableName1}")
+    val snapshotQuery = s"SELECT id, name, value, ts, dt FROM ${tableName1}"
+    val roViewDF = spark.read.format("hudi").load(s"${tablePath}/${tableName1}")
+    roViewDF.createOrReplaceTempView(tableName1)
+    assert(insertDf.except(spark.sql(snapshotQuery)).count == 0)
+    // select data only in the pruned partition.
+    // If predicates of hash.partition.fields appear in the query statement,
+    // then the __hoodie_hash_partition = X  predicate will be automatically added
+    // to the query for partition pruning
+    spark.sql(s"select * from  $tableName1 where id = 1 and name = 'a1' and dt = '2021'").show()
+    val upsertDf = Seq((1, "a1", 12, 1002, "2021"),   // update
+      (2, "a2", 22, 2002, "2022"),   // update
+      (3, "a3", 32, 3002, "2023"),   // update
+      (8, "a8", 22, 2002, "2021")    // insert
+    ).toDF("id", "name", "value", "ts", "dt")
+    upsertDf.write.format("hudi")
+      .options(options)
+      .option(TBL_NAME.key, tableName1)
+      .mode(Append)
+      .save(s"${tablePath}/${tableName1}")
+    val roViewDF1 = spark.read.format("hudi").load(s"${tablePath}/${tableName1}")
+    roViewDF1.createOrReplaceTempView(tableName1)
+    spark.sql(s"select * from  $tableName1").show()
+
+    // case 2: test table which created by sql, without using partitioned by ()
+    val tableName2 = "hoodie_test_params_2"
+    val sparksql = s"""
+                      | create table $tableName2 (
+                      |   id int,
+                      |   name string,
+                      |   value int,
+                      |   ts long,
+                      |   dt string
+                      | ) using hudi
+                      | options (
+                      | primaryKey = 'id,name',
+                      | preCombineField = 'ts',
+                      | hoodie.table.partition.fields = 'dt,_hoodie_hash_partition',
+                      | hoodie.table.hash.partition.num = 16,
+                      | hoodie.table.hash.partition.fields = 'id,name'
+                      | )
+                      | location '${tablePath}/${tableName2}'
+       """.stripMargin
+    spark.sql(sparksql)
+    spark.sql(
+      s"""
+         | insert into $tableName2 values
+         | (1, 'a1', 10, 1000, "2021-12-22"),
+         | (4, 'a4', 10, 1000, "2021-12-22"),
+         | (5, 'a5', 10, 1000, "2021-12-22"),
+         | (6, 'a6', 10, 1000, "2021-12-22"),
+         | (7, 'a6', 10, 1000, "2021-12-22"),
+         | (2, 'a2', 20, 2000, "2022-12-22"),
+         | (3, 'a3', 30, 3000, "2023-12-22")
+              """.stripMargin)
+    //update 1 record. tag data only in the pruned partitions.
+    spark.sql(
+      s"update $tableName2 set value = value + 2 where id = 1 and name = 'a1'")
+    spark.sql(s"select * from  $tableName2 ").show()
+
+    // case 3: test table which created by sql, using partitioned by ().
+    // A column named _hoodie_hash_partition will be added in this table as one of the partition key.
+    val tableName3 = "hoodie_test_params_3"
+    val sparksql3 = s"""
+                       | create table $tableName3 (
+                       |   id int,
+                       |   name string,
+                       |   value int,
+                       |   ts long,
+                       |   dt string
+                       | ) using hudi
+                       |  partitioned by (dt)
+                       | tblproperties (
+                       | primaryKey = 'id,name',
+                       | preCombineField = 'ts',
+                       | hoodie.table.hash.partition.num = 16,
+                       | hoodie.table.hash.partition.fields = 'id,name'
+                       | )
+                       | location '${tablePath}/${tableName3}'
+       """.stripMargin
+    spark.sql(sparksql3)
+    spark.sql(
+      s"""
+         | insert into $tableName3 values
+         | (1, 'a1', 10, 1000, "2021-12-22"),
+         | (4, 'a4', 10, 1000, "2021-12-22"),
+         | (5, 'a5', 10, 1000, "2021-12-22"),
+         | (6, 'a6', 10, 1000, "2021-12-22"),
+         | (7, 'a6', 10, 1000, "2021-12-22"),
+         | (2, 'a2', 20, 2000, "2022-12-22"),
+         | (3, 'a3', 30, 3000, "2023-12-22")
+              """.stripMargin)
+    spark.sql(s"select * from  $tableName3 ").show()
+    //update 1 record. tag data only in the pruned partitions.
+    spark.sql(s"update $tableName3 set value = value + 2 where id = 1 and name = 'a1' ")
+    spark.sql(s"select * from  $tableName3 ").show()
+  }
+
+  /**
    *
    * Test that you can't have consistent hashing bucket index on a COW table
    * */
@@ -1228,6 +1364,8 @@ class TestHoodieSparkSqlWriter {
     new TableSchemaResolver(tableMetaClient).getTableAvroSchemaWithoutMetadataFields
   }
 }
+
+
 
 object TestHoodieSparkSqlWriter {
   def testDatasourceInsert: java.util.stream.Stream[Arguments] = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -1201,7 +1201,7 @@ class TestHoodieSparkSqlWriter {
     * When hash.partition.fields is specified and partition.fields contains _hoodie_hash_partition,
     * a column named _hoodie_hash_partition will be added in this table as one of the partition key.
     *
-    * If predicates of hash.partition.fields appear in the query statement, 
+    * If predicates of hash.partition.fields appear in the query statement,
     * the _hoodie_hash_partition = X  predicate will be automatically added
     * to the query statement for partition pruning.
     */


### PR DESCRIPTION
### Change Logs

Add hash partition in spark datasoure.
 It is often difficult to find an appropriate partition key in the existing data. Hash partitioning can easily solve this problem.

How to use hash partition in spark data source can refer to hudi/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala#testHashPartition

### Impact

No public API or user-facing feature change or any performance impact if the hash partition parameters are not specified.

When hash.partition.fields is specified and partition.fields contains _hoodie_hash_partition, a column named _hoodie_hash_partition will be added in this table as one of the partition key.

If predicates of hash.partition.fields appear in the query statement, the _hoodie_hash_partition = X predicate will be automatically added to the query statement for partition pruning.

### Risk level (write none, low medium or high below)

Low .

### Documentation Update

To be continued.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
