### PR TITLE
[MINOR] Fix hard-coded storage level for indexing

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -91,7 +91,8 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
 
     // Cache the result, for subsequent stages.
     if (config.getBloomIndexUseCaching()) {
-      keyFilenamePairs.persist("MEMORY_AND_DISK_SER");
+      keyFilenamePairs.persist(new HoodieConfig(config.getProps())
+          .getString(HoodieIndexConfig.BLOOM_INDEX_INPUT_STORAGE_LEVEL_VALUE));
     }
     if (LOG.isDebugEnabled()) {
       long totalTaggedRecords = keyFilenamePairs.count();


### PR DESCRIPTION
### Change Logs

Change the hard-coded storage in `org.apache.hudi.index.bloom.HoodieBloomIndex#tagLocation` to configurable value.

### Impact

Fix indexing storage level.

### Risk level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
