### PR TITLE
update hudi-flink exception string

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -228,7 +228,7 @@ public class MergeOnReadInputFormat
           + "file path: " + split.getBasePath()
           + "log paths: " + split.getLogPaths()
           + "hoodie table path: " + split.getTablePath()
-          + "spark partition Index: " + split.getSplitNumber()
+          + "flink partition Index: " + split.getSplitNumber()
           + "merge type: " + split.getMergeType());
     }
   }


### PR DESCRIPTION
the text 'spark' should not show in the  hudi-flink exception

### Change Logs

I try to use hudi-flink ， there is an exception  which confused me . then i found the exception and change it  

### Impact

No

### Risk level (write none, low medium or high below)

none

### Documentation Update

No

### Contributor's checklist

no
