### PR TITLE
[HUDI-5825] disable Spark UI in tests if SPARK_EVLOG_DIR not set

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -116,6 +116,9 @@ public class HoodieClientTestUtils {
     if (evlogDir != null) {
       sparkConf.set("spark.eventLog.enabled", "true");
       sparkConf.set("spark.eventLog.dir", evlogDir);
+      sparkConf.set("spark.ui.enable", "true");
+    } else {
+      sparkConf.set("spark.ui.enable", "false");
     }
 
     return SparkRDDReadClient.addHoodieSupport(sparkConf);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -116,9 +116,9 @@ public class HoodieClientTestUtils {
     if (evlogDir != null) {
       sparkConf.set("spark.eventLog.enabled", "true");
       sparkConf.set("spark.eventLog.dir", evlogDir);
-      sparkConf.set("spark.ui.enable", "true");
+      sparkConf.set("spark.ui.enabled", "true");
     } else {
-      sparkConf.set("spark.ui.enable", "false");
+      sparkConf.set("spark.ui.enabled", "false");
     }
 
     return SparkRDDReadClient.addHoodieSupport(sparkConf);


### PR DESCRIPTION
### Change Logs

Disable spark UI in tests if no SPARK_EVLOG_DIR is specified.
There's no reason for Spark UI to be enabled for tests in most cases.
If that's a requirement one can set SPARK_EVLOG_DIR to enable it, otherwise why would one be interested in UI and not in the event log.
In the Spark project UI is disabled for tests, with some minor exceptions like testing metrics available via UI.
I think we can follow.

### Impact

No public API changes.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
