### PR TITLE
[HUDI-4442] [HUDI-5001] Sanitize JsonConversion and RowSource

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -82,6 +82,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.avro.Schema.Type.UNION;
@@ -106,8 +107,8 @@ public class HoodieAvroUtils {
   public static final Conversions.DecimalConversion DECIMAL_CONVERSION = new Conversions.DecimalConversion();
 
   // As per https://avro.apache.org/docs/current/spec.html#names
-  private static final String INVALID_AVRO_CHARS_IN_NAMES = "[^A-Za-z0-9_]";
-  private static final String INVALID_AVRO_FIRST_CHAR_IN_NAMES = "[^A-Za-z_]";
+  private static final Pattern INVALID_AVRO_CHARS_IN_NAMES_PATTERN = Pattern.compile("[^A-Za-z0-9_]");
+  private static final Pattern INVALID_AVRO_FIRST_CHAR_IN_NAMES_PATTERN = Pattern.compile("[^A-Za-z_]");
   private static final String MASK_FOR_INVALID_CHARS_IN_NAMES = "__";
 
   // All metadata fields are optional strings.
@@ -721,10 +722,22 @@ public class HoodieAvroUtils {
    * @return sanitized name
    */
   public static String sanitizeName(String name) {
-    if (name.substring(0, 1).matches(INVALID_AVRO_FIRST_CHAR_IN_NAMES)) {
-      name = name.replaceFirst(INVALID_AVRO_FIRST_CHAR_IN_NAMES, MASK_FOR_INVALID_CHARS_IN_NAMES);
+    return sanitizeName(name, MASK_FOR_INVALID_CHARS_IN_NAMES);
+  }
+
+  /**
+   * Sanitizes Name according to Avro rule for names.
+   * Removes characters other than the ones mentioned in https://avro.apache.org/docs/current/spec.html#names .
+   *
+   * @param name input name
+   * @param invalidCharMask replacement for invalid characters.
+   * @return sanitized name
+   */
+  public static String sanitizeName(String name, String invalidCharMask) {
+    if (INVALID_AVRO_FIRST_CHAR_IN_NAMES_PATTERN.matcher(name.substring(0, 1)).matches()) {
+      name = INVALID_AVRO_FIRST_CHAR_IN_NAMES_PATTERN.matcher(name).replaceFirst(invalidCharMask);
     }
-    return name.replaceAll(INVALID_AVRO_CHARS_IN_NAMES, MASK_FOR_INVALID_CHARS_IN_NAMES);
+    return INVALID_AVRO_CHARS_IN_NAMES_PATTERN.matcher(name).replaceAll(invalidCharMask);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
@@ -52,7 +52,7 @@ public class MercifulJsonConverter {
 
   private final String invalidCharMask;
   private final boolean shouldSanitize;
-
+  
   /**
    * Build type processor map for each avro type.
    */
@@ -79,7 +79,7 @@ public class MercifulJsonConverter {
    * Uses a default objectMapper to deserialize a json string.
    */
   public MercifulJsonConverter() {
-    this(false, "");
+    this(false, "__");
   }
 
 

--- a/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Converts Json record to Avro Generic Record.
@@ -44,7 +45,13 @@ public class MercifulJsonConverter {
 
   private static final Map<Schema.Type, JsonToAvroFieldProcessor> FIELD_TYPE_PROCESSORS = getFieldTypeProcessors();
 
+  // For each schema (keyed by full name), stores a mapping of schema field name to json field name to account for sanitization of fields
+  private static final Map<String, Map<String, String>> SANITIZED_FIELD_MAPPINGS = new ConcurrentHashMap<>();
+
   private final ObjectMapper mapper;
+
+  private final String invalidCharMask;
+  private final boolean shouldSanitize;
 
   /**
    * Build type processor map for each avro type.
@@ -72,18 +79,30 @@ public class MercifulJsonConverter {
    * Uses a default objectMapper to deserialize a json string.
    */
   public MercifulJsonConverter() {
-    this(new ObjectMapper());
+    this(false, "");
+  }
+
+
+  /**
+   * Allows enabling sanitization and allows choice of invalidCharMask for sanitization
+   */
+  public MercifulJsonConverter(boolean shouldSanitize, String invalidCharMask) {
+    this(new ObjectMapper(), shouldSanitize, invalidCharMask);
   }
 
   /**
    * Allows a configured ObjectMapper to be passed for converting json records to avro record.
    */
-  public MercifulJsonConverter(ObjectMapper mapper) {
+  public MercifulJsonConverter(ObjectMapper mapper, boolean shouldSanitize, String invalidCharMask) {
     this.mapper = mapper;
+    this.shouldSanitize = shouldSanitize;
+    this.invalidCharMask = invalidCharMask;
   }
 
   /**
    * Converts json to Avro generic record.
+   * NOTE: if sanitization is needed for avro conversion, the schema input to this method is already sanitized.
+   *       During the conversion here, we sanitize the fields in the data
    *
    * @param json Json record
    * @param schema Schema
@@ -91,21 +110,54 @@ public class MercifulJsonConverter {
   public GenericRecord convert(String json, Schema schema) {
     try {
       Map<String, Object> jsonObjectMap = mapper.readValue(json, Map.class);
-      return convertJsonToAvro(jsonObjectMap, schema);
+      return convertJsonToAvro(jsonObjectMap, schema, shouldSanitize, invalidCharMask);
     } catch (IOException e) {
       throw new HoodieIOException(e.getMessage(), e);
     }
   }
 
-  private static GenericRecord convertJsonToAvro(Map<String, Object> inputJson, Schema schema) {
+  /**
+   * Clear between fetches. If the schema changes or if two tables have the same schemaFullName then
+   * can be issues
+   */
+  public static void clearCache(String schemaFullName) {
+    SANITIZED_FIELD_MAPPINGS.remove(schemaFullName);
+  }
+
+  private static GenericRecord convertJsonToAvro(Map<String, Object> inputJson, Schema schema, boolean shouldSanitize, String invalidCharMask) {
     GenericRecord avroRecord = new GenericData.Record(schema);
     for (Schema.Field f : schema.getFields()) {
-      Object val = inputJson.get(f.name());
+      Object val = shouldSanitize ? getFieldFromJson(f, inputJson, schema.getFullName(), invalidCharMask) : inputJson.get(f.name());
       if (val != null) {
-        avroRecord.put(f.pos(), convertJsonToAvroField(val, f.name(), f.schema()));
+        avroRecord.put(f.pos(), convertJsonToAvroField(val, f.name(), f.schema(), shouldSanitize, invalidCharMask));
       }
     }
     return avroRecord;
+  }
+
+  private static Object getFieldFromJson(final Schema.Field fieldSchema, final Map<String, Object> inputJson, final String schemaFullName, final String invalidCharMask) {
+    Map<String, String> schemaToJsonFieldNames = SANITIZED_FIELD_MAPPINGS.computeIfAbsent(schemaFullName, unused -> new ConcurrentHashMap<>());
+    if (!schemaToJsonFieldNames.containsKey(fieldSchema.name())) {
+      // if we don't have field mapping, proactively populate as many as possible based on input json
+      for (String inputFieldName : inputJson.keySet()) {
+        // we expect many fields won't need sanitization so check if un-sanitized field name is already present
+        if (!schemaToJsonFieldNames.containsKey(inputFieldName)) {
+          String sanitizedJsonFieldName = HoodieAvroUtils.sanitizeName(inputFieldName, invalidCharMask);
+          schemaToJsonFieldNames.putIfAbsent(sanitizedJsonFieldName, inputFieldName);
+        }
+      }
+    }
+    Object match = inputJson.get(schemaToJsonFieldNames.getOrDefault(fieldSchema.name(), fieldSchema.name()));
+    if (match != null) {
+      return match;
+    }
+    // Check if there is an alias match
+    for (String alias : fieldSchema.aliases()) {
+      if (inputJson.containsKey(alias)) {
+        return inputJson.get(alias);
+      }
+    }
+    return null;
   }
 
   private static Schema getNonNull(Schema schema) {
@@ -120,7 +172,7 @@ public class MercifulJsonConverter {
             || schema.getTypes().get(1).getType().equals(Schema.Type.NULL));
   }
 
-  private static Object convertJsonToAvroField(Object value, String name, Schema schema) {
+  private static Object convertJsonToAvroField(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
 
     if (isOptional(schema)) {
       if (value == null) {
@@ -130,12 +182,12 @@ public class MercifulJsonConverter {
       }
     } else if (value == null) {
       // Always fail on null for non-nullable schemas
-      throw new HoodieJsonToAvroConversionException(null, name, schema);
+      throw new HoodieJsonToAvroConversionException(null, name, schema, shouldSanitize, invalidCharMask);
     }
 
     JsonToAvroFieldProcessor processor = FIELD_TYPE_PROCESSORS.get(schema.getType());
     if (null != processor) {
-      return processor.convertToAvro(value, name, schema);
+      return processor.convertToAvro(value, name, schema, shouldSanitize, invalidCharMask);
     }
     throw new IllegalArgumentException("JsonConverter cannot handle type: " + schema.getType());
   }
@@ -145,21 +197,21 @@ public class MercifulJsonConverter {
    */
   private abstract static class JsonToAvroFieldProcessor implements Serializable {
 
-    public Object convertToAvro(Object value, String name, Schema schema) {
-      Pair<Boolean, Object> res = convert(value, name, schema);
+    public Object convertToAvro(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
+      Pair<Boolean, Object> res = convert(value, name, schema, shouldSanitize, invalidCharMask);
       if (!res.getLeft()) {
-        throw new HoodieJsonToAvroConversionException(value, name, schema);
+        throw new HoodieJsonToAvroConversionException(value, name, schema, shouldSanitize, invalidCharMask);
       }
       return res.getRight();
     }
 
-    protected abstract Pair<Boolean, Object> convert(Object value, String name, Schema schema);
+    protected abstract Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask);
   }
 
   private static JsonToAvroFieldProcessor generateBooleanTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         if (value instanceof Boolean) {
           return Pair.of(true, value);
         }
@@ -171,7 +223,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateIntTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         if (value instanceof Number) {
           return Pair.of(true, ((Number) value).intValue());
         } else if (value instanceof String) {
@@ -185,7 +237,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateDoubleTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         if (value instanceof Number) {
           return Pair.of(true, ((Number) value).doubleValue());
         } else if (value instanceof String) {
@@ -199,7 +251,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateFloatTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         if (value instanceof Number) {
           return Pair.of(true, ((Number) value).floatValue());
         } else if (value instanceof String) {
@@ -213,7 +265,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateLongTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         if (value instanceof Number) {
           return Pair.of(true, ((Number) value).longValue());
         } else if (value instanceof String) {
@@ -227,7 +279,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateStringTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         return Pair.of(true, value.toString());
       }
     };
@@ -236,7 +288,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateBytesTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         // Should return ByteBuffer (see GenericData.isBytes())
         return Pair.of(true, ByteBuffer.wrap(value.toString().getBytes()));
       }
@@ -246,7 +298,7 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateFixedTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         // The ObjectMapper use List to represent FixedType
         // eg: "decimal_val": [0, 0, 14, -63, -52] will convert to ArrayList<Integer>
         List<Integer> converval = (List<Integer>) value;
@@ -264,12 +316,12 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateEnumTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         if (schema.getEnumSymbols().contains(value.toString())) {
           return Pair.of(true, new GenericData.EnumSymbol(schema, value.toString()));
         }
         throw new HoodieJsonToAvroConversionException(String.format("Symbol %s not in enum", value.toString()),
-            schema.getFullName(), schema);
+            schema.getFullName(), schema, shouldSanitize, invalidCharMask);
       }
     };
   }
@@ -277,9 +329,9 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateRecordTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         GenericRecord result = new GenericData.Record(schema);
-        return Pair.of(true, convertJsonToAvro((Map<String, Object>) value, schema));
+        return Pair.of(true, convertJsonToAvro((Map<String, Object>) value, schema, shouldSanitize, invalidCharMask));
       }
     };
   }
@@ -287,11 +339,11 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateArrayTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         Schema elementSchema = schema.getElementType();
         List<Object> listRes = new ArrayList<>();
         for (Object v : (List) value) {
-          listRes.add(convertJsonToAvroField(v, name, elementSchema));
+          listRes.add(convertJsonToAvroField(v, name, elementSchema, shouldSanitize, invalidCharMask));
         }
         return Pair.of(true, new GenericData.Array<>(schema, listRes));
       }
@@ -301,11 +353,11 @@ public class MercifulJsonConverter {
   private static JsonToAvroFieldProcessor generateMapTypeHandler() {
     return new JsonToAvroFieldProcessor() {
       @Override
-      public Pair<Boolean, Object> convert(Object value, String name, Schema schema) {
+      public Pair<Boolean, Object> convert(Object value, String name, Schema schema, boolean shouldSanitize, String invalidCharMask) {
         Schema valueSchema = schema.getValueType();
         Map<String, Object> mapRes = new HashMap<>();
         for (Map.Entry<String, Object> v : ((Map<String, Object>) value).entrySet()) {
-          mapRes.put(v.getKey(), convertJsonToAvroField(v.getValue(), name, valueSchema));
+          mapRes.put(v.getKey(), convertJsonToAvroField(v.getValue(), name, valueSchema, shouldSanitize, invalidCharMask));
         }
         return Pair.of(true, mapRes);
       }
@@ -321,14 +373,22 @@ public class MercifulJsonConverter {
     private String fieldName;
     private Schema schema;
 
-    public HoodieJsonToAvroConversionException(Object value, String fieldName, Schema schema) {
+    private boolean shouldSanitize;
+    private String invalidCharMask;
+
+    public HoodieJsonToAvroConversionException(Object value, String fieldName, Schema schema, boolean shouldSanitize, String invalidCharMask) {
       this.value = value;
       this.fieldName = fieldName;
       this.schema = schema;
+      this.shouldSanitize = shouldSanitize;
+      this.invalidCharMask = invalidCharMask;
     }
 
     @Override
     public String toString() {
+      if (shouldSanitize) {
+        return String.format("Json to Avro Type conversion error for field %s, %s for %s. Field sanitization is enabled with a mask of %s.", fieldName, value, schema, invalidCharMask);
+      }
       return String.format("Json to Avro Type conversion error for field %s, %s for %s", fieldName, value, schema);
     }
   }

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldSchemaFromWriteSchema;
+import static org.apache.hudi.avro.HoodieAvroUtils.sanitizeName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -425,5 +426,15 @@ public class TestHoodieAvroUtils {
     Date now = new Date(System.currentTimeMillis());
     int days = HoodieAvroUtils.fromJavaDate(now);
     assertEquals(now.toLocalDate(), HoodieAvroUtils.toJavaDate(days).toLocalDate());
+  }
+
+  @Test
+  public void testSanitizeName() {
+    assertEquals("__23456", sanitizeName("123456"));
+    assertEquals("abcdef", sanitizeName("abcdef"));
+    assertEquals("_1", sanitizeName("_1"));
+    assertEquals("a*bc", sanitizeName("a.bc", "*"));
+    assertEquals("abcdef___", sanitizeName("abcdef_."));
+    assertEquals("__ab__cd__", sanitizeName("1ab*cd?"));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestMercifulJsonConverter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.avro;
+
+import org.apache.hudi.common.testutils.SchemaTestUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestMercifulJsonConverter {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final MercifulJsonConverter CONVERTER = new MercifulJsonConverter(true,"__");
+
+  @Test
+  public void basicConversion() throws IOException {
+    Schema simpleSchema = SchemaTestUtil.getSimpleSchema();
+    String name = "John Smith";
+    int number = 1337;
+    String color = "Blue. No yellow!";
+    Map<String, Object> data = new HashMap<>();
+    data.put("name", name);
+    data.put("favorite_number", number);
+    data.put("favorite_color", color);
+    String json = MAPPER.writeValueAsString(data);
+
+    GenericRecord rec = new GenericData.Record(simpleSchema);
+    rec.put("name", name);
+    rec.put("favorite_number", number);
+    rec.put("favorite_color", color);
+
+    Assertions.assertEquals(rec, CONVERTER.convert(json, simpleSchema));
+  }
+
+  @Test
+  public void conversionWithFieldNameSanitization() throws IOException {
+    String sanitizedSchemaString = "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"User\", \"fields\": [{\"name\": \"__name\", \"type\": \"string\"}, "
+        + "{\"name\": \"favorite__number\", \"type\": \"int\"}, {\"name\": \"favorite__color__\", \"type\": \"string\"}]}";
+    Schema sanitizedSchema = Schema.parse(sanitizedSchemaString);
+    String name = "John Smith";
+    int number = 1337;
+    String color = "Blue. No yellow!";
+    Map<String, Object> data = new HashMap<>();
+    data.put("$name", name);
+    data.put("favorite-number", number);
+    data.put("favorite.color!", color);
+    String json = MAPPER.writeValueAsString(data);
+
+    GenericRecord rec = new GenericData.Record(sanitizedSchema);
+    rec.put("__name", name);
+    rec.put("favorite__number", number);
+    rec.put("favorite__color__", color);
+
+    Assertions.assertEquals(rec, CONVERTER.convert(json, sanitizedSchema));
+  }
+
+  @Test
+  public void conversionWithFieldNameAliases() throws IOException {
+    String schemaStringWithAliases = "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"User\", \"fields\": [{\"name\": \"name\", \"type\": \"string\", \"aliases\": [\"$name\"]}, "
+        + "{\"name\": \"favorite_number\",  \"type\": \"int\", \"aliases\": [\"unused\", \"favorite-number\"]}, {\"name\": \"favorite_color\", \"type\": \"string\", \"aliases\": "
+        + "[\"favorite.color!\"]}, {\"name\": \"unmatched\", \"type\": \"string\", \"default\": \"default_value\"}]}";
+    Schema sanitizedSchema = Schema.parse(schemaStringWithAliases);
+    String name = "John Smith";
+    int number = 1337;
+    String color = "Blue. No yellow!";
+    Map<String, Object> data = new HashMap<>();
+    data.put("$name", name);
+    data.put("favorite-number", number);
+    data.put("favorite.color!", color);
+    String json = MAPPER.writeValueAsString(data);
+
+    GenericRecord rec = new GenericData.Record(sanitizedSchema);
+    rec.put("name", name);
+    rec.put("favorite_number", number);
+    rec.put("favorite_color", color);
+
+    Assertions.assertEquals(rec, CONVERTER.convert(json, sanitizedSchema));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -298,7 +298,7 @@ public class DeltaSync implements Serializable, Closeable {
     }
     this.formatAdapter = new SourceFormatAdapter(
         UtilHelpers.createSource(cfg.sourceClassName, props, jssc, sparkSession, schemaProvider, metrics),
-        this.errorTableWriter);
+        this.errorTableWriter, Option.of(props));
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -21,9 +21,12 @@ package org.apache.hudi.utilities.schema;
 import org.apache.hudi.DataSourceUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.utilities.sources.helpers.SanitizationUtils;
 
 import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -54,15 +57,12 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     super(props, jssc);
     DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(Config.SOURCE_SCHEMA_FILE_PROP));
     String sourceFile = props.getString(Config.SOURCE_SCHEMA_FILE_PROP);
+    boolean shouldSanitize = props.getBoolean(SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES,false);
+    String invalidCharMask = props.getString(SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK,"__");
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
-    try {
-      this.sourceSchema = new Schema.Parser().parse(this.fs.open(new Path(sourceFile)));
-      if (props.containsKey(Config.TARGET_SCHEMA_FILE_PROP)) {
-        this.targetSchema =
-            new Schema.Parser().parse(fs.open(new Path(props.getString(Config.TARGET_SCHEMA_FILE_PROP))));
-      }
-    } catch (IOException ioe) {
-      throw new HoodieIOException("Error reading schema", ioe);
+    this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);
+    if (props.containsKey(Config.TARGET_SCHEMA_FILE_PROP)) {
+      this.targetSchema = readAvroSchemaFromFile(props.getString(Config.TARGET_SCHEMA_FILE_PROP), this.fs, shouldSanitize, invalidCharMask);
     }
   }
 
@@ -78,5 +78,15 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     } else {
       return super.getTargetSchema();
     }
+  }
+
+  private static Schema readAvroSchemaFromFile(String schemaPath, FileSystem fs, boolean sanitizeSchema, String invalidCharMask) {
+    String schemaStr;
+    try (FSDataInputStream in = fs.open(new Path(schemaPath))) {
+      schemaStr = FileIOUtils.readAsUTFString(in);
+    } catch (IOException ioe) {
+      throw new HoodieIOException(String.format("Error reading schema from file %s", schemaPath), ioe);
+    }
+    return SanitizationUtils.parseAvroSchema(schemaStr, sanitizeSchema, invalidCharMask);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -57,8 +57,8 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     super(props, jssc);
     DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(Config.SOURCE_SCHEMA_FILE_PROP));
     String sourceFile = props.getString(Config.SOURCE_SCHEMA_FILE_PROP);
-    boolean shouldSanitize = props.getBoolean(SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES,false);
-    String invalidCharMask = props.getString(SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK,"__");
+    boolean shouldSanitize = SanitizationUtils.getShouldSanitize(props);
+    String invalidCharMask = SanitizationUtils.getInvalidCharMask(props);
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
     this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);
     if (props.containsKey(Config.TARGET_SCHEMA_FILE_PROP)) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroConvertor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroConvertor.java
@@ -45,6 +45,8 @@ public class AvroConvertor implements Serializable {
   private transient Schema schema;
 
   private final String schemaStr;
+  private final String invalidCharMask;
+  private final boolean shouldSanitize;
 
   /**
    * To be lazily inited on executors.
@@ -58,12 +60,24 @@ public class AvroConvertor implements Serializable {
   private transient Injection<GenericRecord, byte[]> recordInjection;
 
   public AvroConvertor(String schemaStr) {
+    this(schemaStr, false, "");
+  }
+
+  public AvroConvertor(String schemaStr, boolean shouldSanitize, String invalidCharMask) {
     this.schemaStr = schemaStr;
+    this.invalidCharMask = invalidCharMask;
+    this.shouldSanitize = shouldSanitize;
   }
 
   public AvroConvertor(Schema schema) {
+    this(schema, false, "");
+  }
+
+  public AvroConvertor(Schema schema, boolean shouldSanitize, String invalidCharMask) {
     this.schemaStr = schema.toString();
     this.schema = schema;
+    this.invalidCharMask = invalidCharMask;
+    this.shouldSanitize = shouldSanitize;
   }
 
   private void initSchema() {
@@ -81,7 +95,7 @@ public class AvroConvertor implements Serializable {
 
   private void initJsonConvertor() {
     if (jsonConverter == null) {
-      jsonConverter = new MercifulJsonConverter();
+      jsonConverter = new MercifulJsonConverter(this.shouldSanitize, this.invalidCharMask);
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroConvertor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroConvertor.java
@@ -32,6 +32,9 @@ import scala.util.Either;
 import scala.util.Left;
 import scala.util.Right;
 
+import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES;
+import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK;
+
 /**
  * Convert a variety of datum into Avro GenericRecords. Has a bunch of lazy fields to circumvent issues around
  * serializing these objects from driver to executors
@@ -60,24 +63,24 @@ public class AvroConvertor implements Serializable {
   private transient Injection<GenericRecord, byte[]> recordInjection;
 
   public AvroConvertor(String schemaStr) {
-    this(schemaStr, false, "");
+    this(schemaStr, SANITIZE_SCHEMA_FIELD_NAMES.defaultValue(), SCHEMA_FIELD_NAME_INVALID_CHAR_MASK.defaultValue());
   }
 
   public AvroConvertor(String schemaStr, boolean shouldSanitize, String invalidCharMask) {
     this.schemaStr = schemaStr;
-    this.invalidCharMask = invalidCharMask;
     this.shouldSanitize = shouldSanitize;
+    this.invalidCharMask = invalidCharMask;
   }
 
   public AvroConvertor(Schema schema) {
-    this(schema, false, "");
+    this(schema, SANITIZE_SCHEMA_FIELD_NAMES.defaultValue(), SCHEMA_FIELD_NAME_INVALID_CHAR_MASK.defaultValue());
   }
 
   public AvroConvertor(Schema schema, boolean shouldSanitize, String invalidCharMask) {
     this.schemaStr = schema.toString();
     this.schema = schema;
-    this.invalidCharMask = invalidCharMask;
     this.shouldSanitize = shouldSanitize;
+    this.invalidCharMask = invalidCharMask;
   }
 
   private void initSchema() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.utilities.sources.InputBatch;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SanitizationUtils {
+
+  private static ObjectMapper OM = new ObjectMapper();
+
+  public static class Config {
+    // sanitizes names of invalid schema fields both in the data read from source and also in the schema.
+    // invalid definition here goes by avro naming convention (https://avro.apache.org/docs/current/spec.html#names).
+    public static final String SANITIZE_SCHEMA_FIELD_NAMES = "hoodie.deltastreamer.source.sanitize.invalid.schema.field.names";
+
+    public static final String SCHEMA_FIELD_NAME_INVALID_CHAR_MASK = "hoodie.deltastreamer.source.sanitize.invalid.char.mask";
+  }
+
+  private static final String AVRO_FIELD_NAME_KEY = "name";
+
+  private static DataType sanitizeDataTypeForAvro(DataType dataType, String invalidCharMask) {
+    if (dataType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) dataType;
+      DataType sanitizedDataType = sanitizeDataTypeForAvro(arrayType.elementType(), invalidCharMask);
+      return new ArrayType(sanitizedDataType, arrayType.containsNull());
+    } else if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      DataType sanitizedKeyDataType = sanitizeDataTypeForAvro(mapType.keyType(), invalidCharMask);
+      DataType sanitizedValueDataType = sanitizeDataTypeForAvro(mapType.valueType(), invalidCharMask);
+      return new MapType(sanitizedKeyDataType, sanitizedValueDataType, mapType.valueContainsNull());
+    } else if (dataType instanceof StructType) {
+      return sanitizeStructTypeForAvro((StructType) dataType, invalidCharMask);
+    }
+    return dataType;
+  }
+
+  // TODO(HUDI-5256): Refactor this to use InternalSchema when it is ready.
+  private static StructType sanitizeStructTypeForAvro(StructType structType, String invalidCharMask) {
+    StructType sanitizedStructType = new StructType();
+    StructField[] structFields = structType.fields();
+    for (StructField s : structFields) {
+      DataType currFieldDataTypeSanitized = sanitizeDataTypeForAvro(s.dataType(), invalidCharMask);
+      StructField structFieldCopy = new StructField(HoodieAvroUtils.sanitizeName(s.name(), invalidCharMask),
+          currFieldDataTypeSanitized, s.nullable(), s.metadata());
+      sanitizedStructType = sanitizedStructType.add(structFieldCopy);
+    }
+    return sanitizedStructType;
+  }
+
+  private static Dataset<Row> sanitizeColumnNamesForAvro(Dataset<Row> inputDataset, String invalidCharMask) {
+    StructField[] inputFields = inputDataset.schema().fields();
+    Dataset<Row> targetDataset = inputDataset;
+    for (StructField sf : inputFields) {
+      DataType sanitizedFieldDataType = sanitizeDataTypeForAvro(sf.dataType(), invalidCharMask);
+      if (!sanitizedFieldDataType.equals(sf.dataType())) {
+        // Sanitizing column names for nested types can be thought of as going from one schema to another
+        // which are structurally similar except for actual column names itself. So casting is safe and sufficient.
+        targetDataset = targetDataset.withColumn(sf.name(), targetDataset.col(sf.name()).cast(sanitizedFieldDataType));
+      }
+      String possibleRename = HoodieAvroUtils.sanitizeName(sf.name(), invalidCharMask);
+      if (!sf.name().equals(possibleRename)) {
+        targetDataset = targetDataset.withColumnRenamed(sf.name(), possibleRename);
+      }
+    }
+    return targetDataset;
+  }
+
+  /**
+   * Sanitize all columns including nested ones as per Avro conventions.
+   * @param srcBatch
+   * @param shouldSanitize
+   * @param invalidCharMask
+   * @return sanitized batch.
+   */
+  public static InputBatch<Dataset<Row>> maybeSanitizeFieldNames(InputBatch<Dataset<Row>> srcBatch,
+                                                                 boolean shouldSanitize,
+                                                                 String invalidCharMask) {
+    if (!shouldSanitize || !srcBatch.getBatch().isPresent()) {
+      return srcBatch;
+    }
+    Dataset<Row> srcDs = srcBatch.getBatch().get();
+    Dataset<Row> targetDs = sanitizeColumnNamesForAvro(srcDs, invalidCharMask);
+    return new InputBatch<>(Option.ofNullable(targetDs), srcBatch.getCheckpointForNextBatch(), srcBatch.getSchemaProvider());
+  }
+
+  /*
+   * We first rely on Avro to parse and then try to rename only for those failed.
+   * This way we can improve our parsing capabilities without breaking existing functionality.
+   * For example, we don't yet support multiple named schemas defined in a file.
+   */
+  public static Schema parseAvroSchema(String schemaStr, boolean shouldSanitize, String invalidCharMask) {
+    try {
+      return new Schema.Parser().parse(schemaStr);
+    } catch (SchemaParseException spe) {
+      // if sanitizing is not enabled rethrow the exception.
+      if (!shouldSanitize) {
+        throw spe;
+      }
+      // Rename avro fields and try parsing once again.
+      Option<Schema> parseResult = parseSanitizedAvroSchemaNoThrow(schemaStr, invalidCharMask);
+      if (!parseResult.isPresent()) {
+        // throw original exception.
+        throw spe;
+      }
+      return parseResult.get();
+    }
+  }
+
+  /**
+   * Parse list for sanitizing
+   * @param src - deserialized schema
+   * @param invalidCharMask - mask to replace invalid characters with
+   */
+  private static List<Object> transformList(List<Object> src, String invalidCharMask) {
+    return src.stream().map(obj -> {
+      if (obj instanceof List) {
+        return transformList((List<Object>) obj, invalidCharMask);
+      } else if (obj instanceof Map) {
+        return transformMap((Map<String, Object>) obj, invalidCharMask);
+      } else {
+        return obj;
+      }
+    }).collect(Collectors.toList());
+  }
+
+  /**
+   * Parse map for sanitizing. If we have a string in the map, and it is an avro field name key, then we sanitize the name.
+   * Otherwise, we keep recursively going through the schema.
+   * @param src - deserialized schema
+   * @param invalidCharMask - mask to replace invalid characters with
+   */
+  private static Map<String, Object> transformMap(Map<String, Object> src, String invalidCharMask) {
+    return src.entrySet().stream()
+        .map(kv -> {
+          if (kv.getValue() instanceof List) {
+            return Pair.of(kv.getKey(), transformList((List<Object>) kv.getValue(), invalidCharMask));
+          } else if (kv.getValue() instanceof Map) {
+            return Pair.of(kv.getKey(), transformMap((Map<String, Object>) kv.getValue(), invalidCharMask));
+          } else if (kv.getValue() instanceof String) {
+            String currentStrValue = (String) kv.getValue();
+            if (kv.getKey().equals(AVRO_FIELD_NAME_KEY)) {
+              return Pair.of(kv.getKey(), HoodieAvroUtils.sanitizeName(currentStrValue, invalidCharMask));
+            }
+            return Pair.of(kv.getKey(), currentStrValue);
+          } else {
+            return Pair.of(kv.getKey(), kv.getValue());
+          }
+        }).collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+  }
+
+  /**
+   * Sanitizes illegal field names in the schema using recursive calls to transformMap and transformList
+   */
+  private static Option<Schema> parseSanitizedAvroSchemaNoThrow(String schemaStr, String invalidCharMask) {
+    try {
+      OM.enable(JsonParser.Feature.ALLOW_COMMENTS);
+      Map<String, Object> objMap = OM.readValue(schemaStr, Map.class);
+      Map<String, Object> modifiedMap = transformMap(objMap, invalidCharMask);
+      return Option.of(new Schema.Parser().parse(OM.writeValueAsString(modifiedMap)));
+    } catch (Exception ex) {
+      return Option.empty();
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
@@ -21,7 +21,6 @@ package org.apache.hudi.utilities.sources.helpers;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.utilities.sources.InputBatch;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -82,8 +81,9 @@ public class SanitizationUtils {
     return sanitizedStructType;
   }
 
-  private static Dataset<Row> sanitizeColumnNamesForAvro(Dataset<Row> inputDataset, String invalidCharMask) {
+  public static Dataset<Row> sanitizeColumnNamesForAvro(Dataset<Row> inputDataset, String invalidCharMask) {
     StructField[] inputFields = inputDataset.schema().fields();
+    String[] fieldNames = inputDataset.schema().fieldNames();
     Dataset<Row> targetDataset = inputDataset;
     for (StructField sf : inputFields) {
       DataType sanitizedFieldDataType = sanitizeDataTypeForAvro(sf.dataType(), invalidCharMask);
@@ -98,24 +98,6 @@ public class SanitizationUtils {
       }
     }
     return targetDataset;
-  }
-
-  /**
-   * Sanitize all columns including nested ones as per Avro conventions.
-   * @param srcBatch
-   * @param shouldSanitize
-   * @param invalidCharMask
-   * @return sanitized batch.
-   */
-  public static InputBatch<Dataset<Row>> maybeSanitizeFieldNames(InputBatch<Dataset<Row>> srcBatch,
-                                                                 boolean shouldSanitize,
-                                                                 String invalidCharMask) {
-    if (!shouldSanitize || !srcBatch.getBatch().isPresent()) {
-      return srcBatch;
-    }
-    Dataset<Row> srcDs = srcBatch.getBatch().get();
-    Dataset<Row> targetDs = sanitizeColumnNamesForAvro(srcDs, invalidCharMask);
-    return new InputBatch<>(Option.ofNullable(targetDs), srcBatch.getCheckpointForNextBatch(), srcBatch.getSchemaProvider());
   }
 
   /*

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 
 public class SanitizationUtils {
 
-  private static ObjectMapper OM = new ObjectMapper();
+  private static final ObjectMapper OM = new ObjectMapper();
 
   public static class Config {
     // sanitizes names of invalid schema fields both in the data read from source and also in the schema.

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSourceFormatAdapter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSourceFormatAdapter.java
@@ -258,8 +258,6 @@ public class TestSourceFormatAdapter {
     assertTrue(inputBatch.getBatch().isPresent());
     Dataset<Row> ds = inputBatch.getBatch().get();
     assertTrue(ds.collectAsList().size() == 2);
-    System.out.println(getSchemaWithBadAvroNamingForArrayType(true));
-    System.out.println(ds.schema());
     assertTrue(getSchemaWithBadAvroNamingForArrayType(true).equals(ds.schema()));
     JavaRDD<String> expectedData = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_nested_array_out.json");
     assertEquals(expectedData.collect(), ds.toJSON().collectAsList());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSourceFormatAdapter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSourceFormatAdapter.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.InputBatch;
+import org.apache.hudi.utilities.sources.Source;
+import org.apache.hudi.utilities.sources.helpers.SanitizationUtils;
+
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.avro.SchemaConverters;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestSourceFormatAdapter {
+  private static final String DUMMY_CHECKPOINT = "dummy_checkpoint";
+
+  private static SparkSession spark;
+  private static JavaSparkContext jsc;
+  private TestRowDataSource testRowDataSource;
+  private TestJsonDataSource testJsonDataSource;
+
+  @BeforeAll
+  public static void start() {
+    spark = SparkSession
+        .builder()
+        .master("local[*]")
+        .appName(TestSourceFormatAdapter.class.getName())
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .getOrCreate();
+    jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    jsc.close();
+    spark.close();
+  }
+
+  // Forces to initialize object before every test.
+  @AfterEach
+  public void teardown() {
+    testRowDataSource = null;
+    testJsonDataSource = null;
+  }
+
+  private String sanitizeIfNeeded(String src, boolean shouldSanitize) {
+    return shouldSanitize ? HoodieAvroUtils.sanitizeName(src, "__") : src;
+  }
+
+  private StructType getSchemaWithProperNaming() {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField("state", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("street", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("zip", DataTypes.LongType, true, Metadata.empty()),
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField("address", addressStruct, true, Metadata.empty()),
+        new StructField("name", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("occupation", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("place", DataTypes.StringType, true, Metadata.empty())
+    });
+    return personStruct;
+  }
+
+  private StructType getSchemaWithBadAvroNamingForStructType(boolean shouldSanitize) {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@state.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@@stree@t@", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("8@_zip", shouldSanitize),
+            DataTypes.LongType, true, Metadata.empty())
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@_addr*$ess", shouldSanitize),
+            addressStruct, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("9name", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("_occu9pation", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@plac.e.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty())
+    });
+    return personStruct;
+  }
+
+  private StructType getSchemaWithBadAvroNamingForArrayType(boolean shouldSanitize) {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@state.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@@stree@t@", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("8@_zip", shouldSanitize),
+            DataTypes.LongType, true, Metadata.empty())
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@name", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@arr@", shouldSanitize),
+            new ArrayType(addressStruct, true), true, Metadata.empty())
+    });
+    return personStruct;
+  }
+
+  private StructType getSchemaWithBadAvroNamingForMapType(boolean shouldSanitize) {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@state.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@@stree@t@", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("8@_zip", shouldSanitize),
+            DataTypes.LongType, true, Metadata.empty())
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@name", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@map9", shouldSanitize),
+            new MapType(DataTypes.StringType, addressStruct, true), true, Metadata.empty()),
+    });
+    return personStruct;
+  }
+
+  private void setupRowSource(Dataset<Row> ds) {
+    SchemaProvider nullSchemaProvider = new InputBatch.NullSchemaProvider();
+    InputBatch<Dataset<Row>> batch = new InputBatch<>(Option.of(ds), DUMMY_CHECKPOINT, nullSchemaProvider);
+    testRowDataSource = new TestRowDataSource(new TypedProperties(), jsc, spark, nullSchemaProvider, batch);
+  }
+
+  private void setupJsonSource(JavaRDD<String> ds, Schema schema) {
+    SchemaProvider basicSchemaProvider = new BasicSchemaProvider(schema);
+    InputBatch<JavaRDD<String>> batch = new InputBatch<>(Option.of(ds), DUMMY_CHECKPOINT, basicSchemaProvider);
+    testJsonDataSource = new TestJsonDataSource(new TypedProperties(), jsc, spark, basicSchemaProvider, batch);
+  }
+
+  private InputBatch<Dataset<Row>> fetchRowData(JavaRDD<String> rdd, StructType inputSchema) {
+    TypedProperties typedProperties = new TypedProperties();
+    typedProperties.put(SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES, true);
+    typedProperties.put(SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK, "__");
+    setupRowSource(spark.read().schema(inputSchema).json(rdd));
+    SourceFormatAdapter sourceFormatAdapter = new SourceFormatAdapter(testRowDataSource, Option.empty(), Option.of(typedProperties));
+    return sourceFormatAdapter.fetchNewDataInRowFormat(Option.of(DUMMY_CHECKPOINT), 10L);
+  }
+
+  private InputBatch<Dataset<Row>> fetchJsonData(JavaRDD<String> rdd, StructType inputSchema) {
+    TypedProperties typedProperties = new TypedProperties();
+    typedProperties.put(SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES, true);
+    typedProperties.put(SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK, "__");
+    setupJsonSource(rdd, SchemaConverters.toAvroType(inputSchema, false, "record", ""));
+    SourceFormatAdapter sourceFormatAdapter = new SourceFormatAdapter(testJsonDataSource, Option.empty(), Option.of(typedProperties));
+    return sourceFormatAdapter.fetchNewDataInRowFormat(Option.of(DUMMY_CHECKPOINT), 10L);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"row", "json"})
+  public void nestedTypeWithProperNaming(String sourceType) {
+    JavaRDD<String> rdd = jsc.textFile("src/test/resources/data/avro_sanitization.json");
+    StructType inputSchema = getSchemaWithProperNaming();
+    InputBatch<Dataset<Row>> inputBatch;
+    switch (sourceType) {
+      case "row":
+        inputBatch = fetchRowData(rdd, inputSchema);
+        break;
+      case "json":
+        inputBatch = fetchJsonData(rdd, inputSchema);
+        break;
+      default:
+        throw new HoodieException("Invalid test source");
+    }
+    assertTrue(inputBatch.getBatch().isPresent());
+    Dataset<Row> ds = inputBatch.getBatch().get();
+    assertTrue(ds.collectAsList().size() == 2);
+    assertTrue(inputSchema.equals(ds.schema()));
+    JavaRDD<String> expectedData = jsc.textFile("src/test/resources/data/avro_sanitization.json");
+    assertEquals(expectedData.collect(), ds.toJSON().collectAsList());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"row", "json"})
+  public void structTypeAndBadNaming(String sourceType) {
+    JavaRDD<String> rdd = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_in.json");
+    InputBatch<Dataset<Row>> inputBatch;
+    switch (sourceType) {
+      case "row":
+        inputBatch = fetchRowData(rdd, getSchemaWithBadAvroNamingForStructType(false));
+        break;
+      case "json":
+        inputBatch = fetchJsonData(rdd, getSchemaWithBadAvroNamingForStructType(true));
+        break;
+      default:
+        throw new HoodieException("Invalid test source");
+    }
+    assertTrue(inputBatch.getBatch().isPresent());
+    Dataset<Row> ds = inputBatch.getBatch().get();
+    assertTrue(ds.collectAsList().size() == 2);
+    assertTrue(getSchemaWithBadAvroNamingForStructType(true).equals(ds.schema()));
+    JavaRDD<String> expectedData = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_out.json");
+    assertEquals(expectedData.collect(), ds.toJSON().collectAsList());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"row", "json"})
+  public void arrayTypeAndBadNaming(String sourceType) {
+    JavaRDD<String> rdd = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_nested_array_in.json");
+    InputBatch<Dataset<Row>> inputBatch;
+    switch (sourceType) {
+      case "row":
+        inputBatch = fetchRowData(rdd, getSchemaWithBadAvroNamingForArrayType(false));
+        break;
+      case "json":
+        inputBatch = fetchJsonData(rdd, getSchemaWithBadAvroNamingForArrayType(true));
+        break;
+      default:
+        throw new HoodieException("Invalid test source");
+    }
+    assertTrue(inputBatch.getBatch().isPresent());
+    Dataset<Row> ds = inputBatch.getBatch().get();
+    assertTrue(ds.collectAsList().size() == 2);
+    System.out.println(getSchemaWithBadAvroNamingForArrayType(true));
+    System.out.println(ds.schema());
+    assertTrue(getSchemaWithBadAvroNamingForArrayType(true).equals(ds.schema()));
+    JavaRDD<String> expectedData = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_nested_array_out.json");
+    assertEquals(expectedData.collect(), ds.toJSON().collectAsList());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"row", "json"})
+  public void mapTypeAndBadNaming(String sourceType) {
+    JavaRDD<String> rdd = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_nested_map_in.json");
+    InputBatch<Dataset<Row>> inputBatch;
+    switch (sourceType) {
+      case "row":
+        inputBatch = fetchRowData(rdd, getSchemaWithBadAvroNamingForMapType(false));
+        break;
+      case "json":
+        inputBatch = fetchJsonData(rdd, getSchemaWithBadAvroNamingForMapType(true));
+        break;
+      default:
+        throw new HoodieException("Invalid test source");
+    }
+    assertTrue(inputBatch.getBatch().isPresent());
+    Dataset<Row> ds = inputBatch.getBatch().get();
+    assertTrue(ds.collectAsList().size() == 2);
+    assertTrue(getSchemaWithBadAvroNamingForMapType(true).equals(ds.schema()));
+    JavaRDD<String> expectedData = jsc.textFile("src/test/resources/data/avro_sanitization_bad_naming_nested_map_out.json");
+    assertEquals(expectedData.collect(), ds.toJSON().collectAsList());
+  }
+
+  public static class TestRowDataSource extends Source<Dataset<Row>> {
+    private final InputBatch<Dataset<Row>> batch;
+
+    public TestRowDataSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
+                             SchemaProvider schemaProvider, InputBatch<Dataset<Row>> batch) {
+      super(props, sparkContext, sparkSession, schemaProvider, SourceType.ROW);
+      this.batch = batch;
+    }
+
+    @Override
+    protected InputBatch<Dataset<Row>> fetchNewData(Option<String> lastCkptStr, long sourceLimit) {
+      return batch;
+    }
+  }
+
+  public static class TestJsonDataSource extends Source<JavaRDD<String>> {
+    private final InputBatch<JavaRDD<String>> batch;
+
+    public TestJsonDataSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
+                             SchemaProvider schemaProvider, InputBatch<JavaRDD<String>> batch) {
+      super(props, sparkContext, sparkSession, schemaProvider, SourceType.JSON);
+      this.batch = batch;
+    }
+
+    @Override
+    protected InputBatch<JavaRDD<String>> fetchNewData(Option<String> lastCkptStr, long sourceLimit) {
+      return batch;
+    }
+  }
+
+  public static class BasicSchemaProvider extends SchemaProvider {
+
+    private final Schema schema;
+
+    public BasicSchemaProvider(Schema schema) {
+      this(null, null, schema);
+    }
+
+    public BasicSchemaProvider(TypedProperties props, JavaSparkContext jssc, Schema schema) {
+      super(props, jssc);
+      this.schema = schema;
+    }
+
+    @Override
+    public Schema getSourceSchema() {
+      return schema;
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestFilebasedSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestFilebasedSchemaProvider.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.schema;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.SchemaParseException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES;
+import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link FilebasedSchemaProvider}.
+ */
+public class TestFilebasedSchemaProvider extends UtilitiesTestBase {
+
+  private FilebasedSchemaProvider schemaProvider;
+
+  @BeforeAll
+  public static void initClass() throws Exception {
+    UtilitiesTestBase.initTestServices(false, false, false);
+  }
+
+  @AfterAll
+  public static void cleanUpUtilitiesTestServices() {
+    UtilitiesTestBase.cleanUpUtilitiesTestServices();
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    super.setup();
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    super.teardown();
+  }
+
+  private Schema generateProperFormattedSchema() {
+    Schema addressSchema = SchemaBuilder.record("Address").fields()
+        .requiredString("streetaddress")
+        .requiredString("city")
+        .endRecord();
+    Schema personSchema = SchemaBuilder.record("Person").fields()
+        .requiredString("firstname")
+        .requiredString("lastname")
+        .name("address").type(addressSchema).noDefault()
+        .endRecord();
+    return personSchema;
+  }
+
+  // replacement mask is "__".
+  private Schema generateRenamedSchemaWithDefaultReplacement() {
+    Schema addressSchema = SchemaBuilder.record("__Address").fields()
+        .nullableString("__stree9add__ress", "@@@any_address")
+        .requiredString("cit__y__")
+        .endRecord();
+    Schema personSchema = SchemaBuilder.record("Person").fields()
+        .requiredString("__firstname")
+        .requiredString("__lastname")
+        .name("address").type(addressSchema).noDefault()
+        .endRecord();
+    return personSchema;
+  }
+
+  // replacement mask is "_".
+  private Schema generateRenamedSchemaWithConfiguredReplacement() {
+    Schema addressSchema = SchemaBuilder.record("_Address").fields()
+        .nullableString("_stree9add_ress", "@@@any_address")
+        .requiredString("cit_y_")
+        .endRecord();
+    Schema personSchema = SchemaBuilder.record("Person").fields()
+        .requiredString("_firstname")
+        .requiredString("_lastname")
+        .name("address").type(addressSchema).noDefault()
+        .endRecord();
+    return personSchema;
+  }
+
+  @Test
+  public void properlyFormattedNestedSchemaTest() throws IOException {
+    this.schemaProvider = new FilebasedSchemaProvider(
+        Helpers.setupSchemaOnDFS("delta-streamer-config", "file_schema_provider_valid.avsc"), jsc);
+    assertEquals(this.schemaProvider.getSourceSchema(), generateProperFormattedSchema());
+  }
+
+  @Test
+  public void renameBadlyFormattedSchemaTest() throws IOException {
+    TypedProperties props = Helpers.setupSchemaOnDFS("delta-streamer-config", "file_schema_provider_invalid.avsc");
+    props.put(SANITIZE_SCHEMA_FIELD_NAMES, "true");
+    this.schemaProvider = new FilebasedSchemaProvider(props, jsc);
+    assertEquals(this.schemaProvider.getSourceSchema(), generateRenamedSchemaWithDefaultReplacement());
+  }
+
+  @Test
+  public void renameBadlyFormattedSchemaWithProperyDisabledTest() {
+    assertThrows(SchemaParseException.class, () -> {
+      new FilebasedSchemaProvider(
+          Helpers.setupSchemaOnDFS("delta-streamer-config", "file_schema_provider_invalid.avsc"), jsc);
+    });
+  }
+
+  @Test
+  public void renameBadlyFormattedSchemaWithInvalidCharMaskConfiguredTest() throws IOException {
+    TypedProperties props = Helpers.setupSchemaOnDFS("delta-streamer-config", "file_schema_provider_invalid.avsc");
+    props.put(SANITIZE_SCHEMA_FIELD_NAMES, "true");
+    props.put(SCHEMA_FIELD_NAME_INVALID_CHAR_MASK, "_");
+    this.schemaProvider = new FilebasedSchemaProvider(props, jsc);
+    assertEquals(this.schemaProvider.getSourceSchema(), generateRenamedSchemaWithConfiguredReplacement());
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestFilebasedSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestFilebasedSchemaProvider.java
@@ -32,9 +32,9 @@ import java.io.IOException;
 
 import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES;
 import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK;
-import static org.apache.hudi.utilities.testutils.SanitizationTestBase.generateProperFormattedSchema;
-import static org.apache.hudi.utilities.testutils.SanitizationTestBase.generateRenamedSchemaWithConfiguredReplacement;
-import static org.apache.hudi.utilities.testutils.SanitizationTestBase.generateRenamedSchemaWithDefaultReplacement;
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.generateProperFormattedSchema;
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.generateRenamedSchemaWithConfiguredReplacement;
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.generateRenamedSchemaWithDefaultReplacement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -75,7 +75,7 @@ public class TestFilebasedSchemaProvider extends UtilitiesTestBase {
   @Test
   public void renameBadlyFormattedSchemaTest() throws IOException {
     TypedProperties props = Helpers.setupSchemaOnDFS("delta-streamer-config", "file_schema_provider_invalid.avsc");
-    props.put(SANITIZE_SCHEMA_FIELD_NAMES, "true");
+    props.put(SANITIZE_SCHEMA_FIELD_NAMES.key(), "true");
     this.schemaProvider = new FilebasedSchemaProvider(props, jsc);
     assertEquals(this.schemaProvider.getSourceSchema(), generateRenamedSchemaWithDefaultReplacement());
   }
@@ -89,10 +89,10 @@ public class TestFilebasedSchemaProvider extends UtilitiesTestBase {
   }
 
   @Test
-  public void renameBadlyFormattedSchemaWithInvalidCharMaskConfiguredTest() throws IOException {
+  public void renameBadlyFormattedSchemaWithAltCharMaskConfiguredTest() throws IOException {
     TypedProperties props = Helpers.setupSchemaOnDFS("delta-streamer-config", "file_schema_provider_invalid.avsc");
-    props.put(SANITIZE_SCHEMA_FIELD_NAMES, "true");
-    props.put(SCHEMA_FIELD_NAME_INVALID_CHAR_MASK, "_");
+    props.put(SANITIZE_SCHEMA_FIELD_NAMES.key(), "true");
+    props.put(SCHEMA_FIELD_NAME_INVALID_CHAR_MASK.key(), "_");
     this.schemaProvider = new FilebasedSchemaProvider(props, jsc);
     assertEquals(this.schemaProvider.getSourceSchema(), generateRenamedSchemaWithConfiguredReplacement());
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestFilebasedSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestFilebasedSchemaProvider.java
@@ -21,8 +21,6 @@ package org.apache.hudi.utilities.schema;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
 import org.apache.avro.SchemaParseException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -34,6 +32,9 @@ import java.io.IOException;
 
 import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SANITIZE_SCHEMA_FIELD_NAMES;
 import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK;
+import static org.apache.hudi.utilities.testutils.SanitizationTestBase.generateProperFormattedSchema;
+import static org.apache.hudi.utilities.testutils.SanitizationTestBase.generateRenamedSchemaWithConfiguredReplacement;
+import static org.apache.hudi.utilities.testutils.SanitizationTestBase.generateRenamedSchemaWithDefaultReplacement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -62,47 +63,6 @@ public class TestFilebasedSchemaProvider extends UtilitiesTestBase {
   @AfterEach
   public void teardown() throws Exception {
     super.teardown();
-  }
-
-  private Schema generateProperFormattedSchema() {
-    Schema addressSchema = SchemaBuilder.record("Address").fields()
-        .requiredString("streetaddress")
-        .requiredString("city")
-        .endRecord();
-    Schema personSchema = SchemaBuilder.record("Person").fields()
-        .requiredString("firstname")
-        .requiredString("lastname")
-        .name("address").type(addressSchema).noDefault()
-        .endRecord();
-    return personSchema;
-  }
-
-  // replacement mask is "__".
-  private Schema generateRenamedSchemaWithDefaultReplacement() {
-    Schema addressSchema = SchemaBuilder.record("__Address").fields()
-        .nullableString("__stree9add__ress", "@@@any_address")
-        .requiredString("cit__y__")
-        .endRecord();
-    Schema personSchema = SchemaBuilder.record("Person").fields()
-        .requiredString("__firstname")
-        .requiredString("__lastname")
-        .name("address").type(addressSchema).noDefault()
-        .endRecord();
-    return personSchema;
-  }
-
-  // replacement mask is "_".
-  private Schema generateRenamedSchemaWithConfiguredReplacement() {
-    Schema addressSchema = SchemaBuilder.record("_Address").fields()
-        .nullableString("_stree9add_ress", "@@@any_address")
-        .requiredString("cit_y_")
-        .endRecord();
-    Schema personSchema = SchemaBuilder.record("Person").fields()
-        .requiredString("_firstname")
-        .requiredString("_lastname")
-        .name("address").type(addressSchema).noDefault()
-        .endRecord();
-    return personSchema;
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -237,7 +237,7 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
     props.put("hoodie.base.path","/tmp/json_kafka_row_events");
     Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
     Option<BaseErrorTableWriter> errorTableWriter = Option.of(getAnonymousErrorTableWriter(props));
-    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, errorTableWriter);
+    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, errorTableWriter, Option.of(props));
     assertEquals(1000, kafkaSource.fetchNewDataInRowFormat(Option.empty(),Long.MAX_VALUE).getBatch().get().count());
     assertEquals(2,((JavaRDD)errorTableWriter.get().getErrorEvents(
         HoodieActiveTimeline.createNewInstantTime(), Option.empty()).get()).count());
@@ -267,7 +267,7 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
 
     Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
     Option<BaseErrorTableWriter> errorTableWriter = Option.of(getAnonymousErrorTableWriter(props));
-    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, errorTableWriter);
+    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, errorTableWriter, Option.of(props));
     InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(),Long.MAX_VALUE);
     assertEquals(1000,fetch1.getBatch().get().count());
     assertEquals(2, ((JavaRDD)errorTableWriter.get().getErrorEvents(

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSanitizaitonUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSanitizaitonUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.util.FileIOUtils;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.utilities.testutils.SanitizationTestBase;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestSanitizaitonUtils extends SanitizationTestBase {
+
+  @ParameterizedTest
+  @MethodSource("provideDataFiles")
+  public void testSanitizeDataset(String unsanitizedDataFile, String sanitizedDataFile, StructType unsanitizedSchema, StructType sanitizedSchema) {
+    Dataset<Row> expectedSantitizedDataset = spark.read().schema(sanitizedSchema).format("json").load(sanitizedDataFile);
+    Dataset<Row> unsanitizedDataset = spark.read().schema(unsanitizedSchema).format("json").load(unsanitizedDataFile);
+    Dataset<Row> sanitizedDataset = SanitizationUtils.sanitizeColumnNamesForAvro(unsanitizedDataset,invalidCharMask);
+    assertEquals(unsanitizedDataset.count(), sanitizedDataset.count());
+    assertEquals(expectedSantitizedDataset.schema(), sanitizedDataset.schema());
+    assertEquals(expectedSantitizedDataset.collectAsList(), sanitizedDataset.collectAsList());
+  }
+
+  private void testSanitizeSchema(String unsanitizedSchema, Schema expectedSanitizedSchema) {
+    Schema sanitizedSchema = SanitizationUtils.parseAvroSchema(unsanitizedSchema, true, invalidCharMask);
+    assertEquals(sanitizedSchema, expectedSanitizedSchema);
+  }
+
+  @Test
+  public void testGoodAvroSchema() {
+    String goodJson = getJson("src/test/resources/delta-streamer-config/file_schema_provider_valid.avsc");
+    testSanitizeSchema(goodJson,generateProperFormattedSchema());
+  }
+
+  @Test
+  public void testBadAvroSchema() {
+    String badJson = getJson("src/test/resources/delta-streamer-config/file_schema_provider_invalid.avsc");
+    testSanitizeSchema(badJson,generateRenamedSchemaWithDefaultReplacement());
+  }
+
+  private String getJson(String path) {
+    FileSystem fs = FSUtils.getFs(path, jsc.hadoopConfiguration(), true);
+    String schemaStr;
+    try (FSDataInputStream in = fs.open(new Path(path))) {
+      schemaStr = FileIOUtils.readAsUTFString(in);
+    } catch (IOException e) {
+      throw new HoodieIOException("can't read schema file", e);
+    }
+    return schemaStr;
+  }
+
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSanitizationUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSanitizationUtils.java
@@ -22,24 +22,57 @@ package org.apache.hudi.utilities.sources.helpers;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.utilities.testutils.SanitizationTestBase;
+import org.apache.hudi.utilities.deltastreamer.TestSourceFormatAdapter;
+import org.apache.hudi.utilities.testutils.SanitizationTestUtils;
 
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.stream.Stream;
 
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.generateProperFormattedSchema;
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.generateRenamedSchemaWithConfiguredReplacement;
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.generateRenamedSchemaWithDefaultReplacement;
+import static org.apache.hudi.utilities.testutils.SanitizationTestUtils.invalidCharMask;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TestSanitizaitonUtils extends SanitizationTestBase {
+public class TestSanitizationUtils {
+
+  protected static SparkSession spark;
+  protected static JavaSparkContext jsc;
+
+  @BeforeAll
+  public static void start() {
+    spark = SparkSession
+        .builder()
+        .master("local[*]")
+        .appName(TestSourceFormatAdapter.class.getName())
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .getOrCreate();
+    jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    jsc.close();
+    spark.close();
+  }
 
   @ParameterizedTest
   @MethodSource("provideDataFiles")
@@ -53,7 +86,15 @@ public class TestSanitizaitonUtils extends SanitizationTestBase {
   }
 
   private void testSanitizeSchema(String unsanitizedSchema, Schema expectedSanitizedSchema) {
-    Schema sanitizedSchema = SanitizationUtils.parseAvroSchema(unsanitizedSchema, true, invalidCharMask);
+    testSanitizeSchema(unsanitizedSchema, expectedSanitizedSchema, true);
+  }
+
+  private void testSanitizeSchema(String unsanitizedSchema, Schema expectedSanitizedSchema, boolean shouldSanitize) {
+    testSanitizeSchema(unsanitizedSchema, expectedSanitizedSchema, shouldSanitize, invalidCharMask);
+  }
+
+  private void testSanitizeSchema(String unsanitizedSchema, Schema expectedSanitizedSchema, boolean shouldSanitize, String charMask) {
+    Schema sanitizedSchema = SanitizationUtils.parseAvroSchema(unsanitizedSchema, shouldSanitize, charMask);
     assertEquals(sanitizedSchema, expectedSanitizedSchema);
   }
 
@@ -69,6 +110,19 @@ public class TestSanitizaitonUtils extends SanitizationTestBase {
     testSanitizeSchema(badJson,generateRenamedSchemaWithDefaultReplacement());
   }
 
+  @Test
+  public void testBadAvroSchemaAltCharMask() {
+    String badJson = getJson("src/test/resources/delta-streamer-config/file_schema_provider_invalid.avsc");
+    testSanitizeSchema(badJson,generateRenamedSchemaWithConfiguredReplacement(),true, "_");
+  }
+
+  @Test
+  public void testBadAvroSchemaDisabledTest() {
+    String badJson = getJson("src/test/resources/delta-streamer-config/file_schema_provider_invalid.avsc");
+    assertThrows(SchemaParseException.class, () -> testSanitizeSchema(badJson,generateRenamedSchemaWithDefaultReplacement(), false));
+  }
+
+  @Test
   private String getJson(String path) {
     FileSystem fs = FSUtils.getFs(path, jsc.hadoopConfiguration(), true);
     String schemaStr;
@@ -78,6 +132,10 @@ public class TestSanitizaitonUtils extends SanitizationTestBase {
       throw new HoodieIOException("can't read schema file", e);
     }
     return schemaStr;
+  }
+
+  private static Stream<Arguments> provideDataFiles() {
+    return SanitizationTestUtils.provideDataFiles();
   }
 
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/SanitizationTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/SanitizationTestBase.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.testutils;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.utilities.deltastreamer.TestSourceFormatAdapter;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.stream.Stream;
+
+public class SanitizationTestBase {
+
+  protected static SparkSession spark;
+  protected static JavaSparkContext jsc;
+
+  protected final String invalidCharMask = "__";
+
+  @BeforeAll
+  public static void start() {
+    spark = SparkSession
+        .builder()
+        .master("local[*]")
+        .appName(TestSourceFormatAdapter.class.getName())
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .getOrCreate();
+    jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    jsc.close();
+    spark.close();
+  }
+
+  private static String sanitizeIfNeeded(String src, boolean shouldSanitize) {
+    return shouldSanitize ? HoodieAvroUtils.sanitizeName(src, "__") : src;
+  }
+
+  protected static StructType getSchemaWithProperNaming() {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField("state", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("street", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("zip", DataTypes.LongType, true, Metadata.empty()),
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField("address", addressStruct, true, Metadata.empty()),
+        new StructField("name", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("occupation", DataTypes.StringType, true, Metadata.empty()),
+        new StructField("place", DataTypes.StringType, true, Metadata.empty())
+    });
+    return personStruct;
+  }
+
+  protected static StructType getSchemaWithBadAvroNamingForStructType(boolean shouldSanitize) {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@state.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@@stree@t@", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("8@_zip", shouldSanitize),
+            DataTypes.LongType, true, Metadata.empty())
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@_addr*$ess", shouldSanitize),
+            addressStruct, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("9name", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("_occu9pation", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@plac.e.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty())
+    });
+    return personStruct;
+  }
+
+  protected static StructType getSchemaWithBadAvroNamingForArrayType(boolean shouldSanitize) {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@state.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@@stree@t@", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("8@_zip", shouldSanitize),
+            DataTypes.LongType, true, Metadata.empty())
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@name", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@arr@", shouldSanitize),
+            new ArrayType(addressStruct, true), true, Metadata.empty())
+    });
+    return personStruct;
+  }
+
+  protected static StructType getSchemaWithBadAvroNamingForMapType(boolean shouldSanitize) {
+    StructType addressStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@state.", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@@stree@t@", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("8@_zip", shouldSanitize),
+            DataTypes.LongType, true, Metadata.empty())
+    });
+
+    StructType personStruct = new StructType(new StructField[] {
+        new StructField(sanitizeIfNeeded("@name", shouldSanitize),
+            DataTypes.StringType, true, Metadata.empty()),
+        new StructField(sanitizeIfNeeded("@map9", shouldSanitize),
+            new MapType(DataTypes.StringType, addressStruct, true), true, Metadata.empty()),
+    });
+    return personStruct;
+  }
+
+  public static Schema generateProperFormattedSchema() {
+    Schema addressSchema = SchemaBuilder.record("Address").fields()
+        .requiredString("streetaddress")
+        .requiredString("city")
+        .endRecord();
+    Schema personSchema = SchemaBuilder.record("Person").fields()
+        .requiredString("firstname")
+        .requiredString("lastname")
+        .name("address").type(addressSchema).noDefault()
+        .endRecord();
+    return personSchema;
+  }
+
+  public static Schema generateRenamedSchemaWithDefaultReplacement() {
+    Schema addressSchema = SchemaBuilder.record("__Address").fields()
+        .nullableString("__stree9add__ress", "@@@any_address")
+        .requiredString("cit__y__")
+        .endRecord();
+    Schema personSchema = SchemaBuilder.record("Person").fields()
+        .requiredString("__firstname")
+        .requiredString("__lastname")
+        .name("address").type(addressSchema).noDefault()
+        .endRecord();
+    return personSchema;
+  }
+
+  public static Schema generateRenamedSchemaWithConfiguredReplacement() {
+    Schema addressSchema = SchemaBuilder.record("_Address").fields()
+        .nullableString("_stree9add_ress", "@@@any_address")
+        .requiredString("cit_y_")
+        .endRecord();
+    Schema personSchema = SchemaBuilder.record("Person").fields()
+        .requiredString("_firstname")
+        .requiredString("_lastname")
+        .name("address").type(addressSchema).noDefault()
+        .endRecord();
+    return personSchema;
+  }
+
+  protected static Stream<Arguments> provideDataFiles() {
+    return Stream.of(
+        Arguments.of("src/test/resources/data/avro_sanitization.json", "src/test/resources/data/avro_sanitization.json",
+            getSchemaWithProperNaming(), getSchemaWithProperNaming()),
+        Arguments.of("src/test/resources/data/avro_sanitization_bad_naming_in.json", "src/test/resources/data/avro_sanitization_bad_naming_out.json",
+            getSchemaWithBadAvroNamingForStructType(false), getSchemaWithBadAvroNamingForStructType(true)),
+        Arguments.of("src/test/resources/data/avro_sanitization_bad_naming_nested_array_in.json", "src/test/resources/data/avro_sanitization_bad_naming_nested_array_out.json",
+            getSchemaWithBadAvroNamingForArrayType(false), getSchemaWithBadAvroNamingForArrayType(true)),
+        Arguments.of("src/test/resources/data/avro_sanitization_bad_naming_nested_map_in.json", "src/test/resources/data/avro_sanitization_bad_naming_nested_map_out.json",
+            getSchemaWithBadAvroNamingForMapType(false), getSchemaWithBadAvroNamingForMapType(true))
+    );
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/SanitizationTestUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/SanitizationTestUtils.java
@@ -20,50 +20,26 @@
 package org.apache.hudi.utilities.testutils;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
-import org.apache.hudi.utilities.deltastreamer.TestSourceFormatAdapter;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
-public class SanitizationTestBase {
+import static org.apache.hudi.utilities.sources.helpers.SanitizationUtils.Config.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK;
 
-  protected static SparkSession spark;
-  protected static JavaSparkContext jsc;
-
-  protected final String invalidCharMask = "__";
-
-  @BeforeAll
-  public static void start() {
-    spark = SparkSession
-        .builder()
-        .master("local[*]")
-        .appName(TestSourceFormatAdapter.class.getName())
-        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-        .getOrCreate();
-    jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-  }
-
-  @AfterAll
-  public static void shutdown() {
-    jsc.close();
-    spark.close();
-  }
+public class SanitizationTestUtils {
+  public static String invalidCharMask = SCHEMA_FIELD_NAME_INVALID_CHAR_MASK.defaultValue();
 
   private static String sanitizeIfNeeded(String src, boolean shouldSanitize) {
-    return shouldSanitize ? HoodieAvroUtils.sanitizeName(src, "__") : src;
+    return shouldSanitize ? HoodieAvroUtils.sanitizeName(src, invalidCharMask) : src;
   }
 
   protected static StructType getSchemaWithProperNaming() {
@@ -182,7 +158,7 @@ public class SanitizationTestBase {
     return personSchema;
   }
 
-  protected static Stream<Arguments> provideDataFiles() {
+  public static Stream<Arguments> provideDataFiles() {
     return Stream.of(
         Arguments.of("src/test/resources/data/avro_sanitization.json", "src/test/resources/data/avro_sanitization.json",
             getSchemaWithProperNaming(), getSchemaWithProperNaming()),

--- a/hudi-utilities/src/test/resources/data/avro_sanitization.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization.json
@@ -1,0 +1,2 @@
+{"address":{"state":"some state","street":"some street","zip":123},"name":"random name","occupation":"some occupation","place":"some place"}
+{"address":{"state":"some state","street":"some street","zip":123},"name":"random name","occupation":"some occupation","place":"some place"}

--- a/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_in.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_in.json
@@ -1,0 +1,2 @@
+{"@_addr*$ess":{"@state.":"some state","@@stree@t@":"some street","8@_zip":123},"9name":"random name","_occu9pation":"some occupation","@plac.e.":"some place"}
+{"@_addr*$ess":{"@state.":"some state","@@stree@t@":"some street","8@_zip":123},"9name":"random name","_occu9pation":"some occupation","@plac.e.":"some place"}

--- a/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_array_in.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_array_in.json
@@ -1,0 +1,2 @@
+{"@name":"somename","@arr@":[{"@state.":"some state","@@stree@t@":"some street","8@_zip":123},{"@state.":"some state","@@stree@t@":"some street","8@_zip":123},{"@state.":"some state","@@stree@t@":"some street","8@_zip":123}]}
+{"@name":"somename","@arr@":[{"@state.":"some state","@@stree@t@":"some street","8@_zip":123},{"@state.":"some state","@@stree@t@":"some street","8@_zip":123},{"@state.":"some state","@@stree@t@":"some street","8@_zip":123}]}

--- a/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_array_out.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_array_out.json
@@ -1,0 +1,2 @@
+{"__name":"somename","__arr__":[{"__state__":"some state","____stree__t__":"some street","_____zip":123},{"__state__":"some state","____stree__t__":"some street","_____zip":123},{"__state__":"some state","____stree__t__":"some street","_____zip":123}]}
+{"__name":"somename","__arr__":[{"__state__":"some state","____stree__t__":"some street","_____zip":123},{"__state__":"some state","____stree__t__":"some street","_____zip":123},{"__state__":"some state","____stree__t__":"some street","_____zip":123}]}

--- a/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_map_in.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_map_in.json
@@ -1,0 +1,2 @@
+{"@name":"somename","@map9":{"address1":{"@state.":"some state","@@stree@t@":"some street","8@_zip":123}}}
+{"@name":"somename","@map9":{"address2":{"@state.":"some state","@@stree@t@":"some street","8@_zip":123}}}

--- a/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_map_out.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_nested_map_out.json
@@ -1,0 +1,2 @@
+{"__name":"somename","__map9":{"address1":{"__state__":"some state","____stree__t__":"some street","_____zip":123}}}
+{"__name":"somename","__map9":{"address2":{"__state__":"some state","____stree__t__":"some street","_____zip":123}}}

--- a/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_out.json
+++ b/hudi-utilities/src/test/resources/data/avro_sanitization_bad_naming_out.json
@@ -1,0 +1,2 @@
+{"___addr____ess":{"__state__":"some state","____stree__t__":"some street","_____zip":123},"__name":"random name","_occu9pation":"some occupation","__plac__e__":"some place"}
+{"___addr____ess":{"__state__":"some state","____stree__t__":"some street","_____zip":123},"__name":"random name","_occu9pation":"some occupation","__plac__e__":"some place"}

--- a/hudi-utilities/src/test/resources/delta-streamer-config/file_schema_provider_invalid.avsc
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/file_schema_provider_invalid.avsc
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+  "type": "record",
+  "name": "Person",
+  "fields": [
+    {
+      "name": "@firstname",
+      "type": "string"
+    },
+    {
+      "name": "9lastname",
+      "type": "string"
+    },
+    {
+      "name": "address",
+      "type": {
+        "type": "record",
+        "name": "@Address",
+        "fields": [
+          {
+            "name": "@stree9add*ress",
+            "type": ["string", "null"],
+            "default": "@@@any_address"
+          },
+          {
+            "name": "cit.y.",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hudi-utilities/src/test/resources/delta-streamer-config/file_schema_provider_valid.avsc
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/file_schema_provider_valid.avsc
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+  "type": "record",
+  "name": "Person",
+  "fields": [
+    {
+      "name": "firstname",
+      "type": "string"
+    },
+    {
+      "name": "lastname",
+      "type": "string"
+    },
+    {
+      "name": "address",
+      "type": {
+        "type": "record",
+        "name": "Address",
+        "fields": [
+          {
+            "name": "streetaddress",
+            "type": "string"
+          },
+          {
+            "name": "city",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Change Logs

Updates the MercifulJsonConverter to have more mercy by:
1. Replaces field names with illegal avro name chars with __
2. Leverages aliases in the avro schema if present

This issue is within the scope of row sources. The actual issue is that if the names of the columns in the row sources contain invalid avro characters ref [here|https://avro.apache.org/docs/1.10.2/spec.html#names] then using configuration set we can sanitize the column names both in the schema and actual data and the data ingestion to hudi isn't failed. The schema provider is scoped out to filebasedschemaregistry as other schema registries might not allow to register invalid schema in the first place.

### Impact

No impact by default because configs are turned off by default. If turned on, data and schema(file based) are repaired, so the dataset contains renamed columns.
Allows users to more easily get their data into hudi even if their json data has field names that are not avro compatible

### Risk level (write none, low medium or high below)

low (as it has to be turned on explicitly).

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
