### PR TITLE
[HUDI-5317] Fix insert overwrite table for partitioned table

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -145,13 +145,14 @@ trait ProvidesHoodieConfig extends Logging {
       (enableBulkInsert, isOverwritePartition, isOverwriteTable, dropDuplicate, isNonStrictMode, isPartitionedTable) match {
         case (true, _, _, _, false, _) =>
           throw new IllegalArgumentException(s"Table with primaryKey can not use bulk insert in ${insertMode.value()} mode.")
-        case (true, true, _, _, _, true) =>
-          throw new IllegalArgumentException(s"Insert Overwrite Partition can not use bulk insert.")
+        // if enableBulkInsert is true, use bulk insert for the insert overwrite non-partitioned table.
+        case (true, _, true, _, _, _) =>
+          throw new IllegalArgumentException(s"Insert Overwrite can not use bulk insert.")
+        case (true, true, _, _, _, _) =>
+          throw new IllegalArgumentException(s"Insert Overwrite can not use bulk insert.")
         case (true, _, _, true, _, _) =>
           throw new IllegalArgumentException(s"Bulk insert cannot support drop duplication." +
             s" Please disable $INSERT_DROP_DUPS and try again.")
-        // if enableBulkInsert is true, use bulk insert for the insert overwrite non-partitioned table.
-        case (true, false, true, _, _, false) => BULK_INSERT_OPERATION_OPT_VAL
         // insert overwrite table
         case (false, false, true, _, _, _) => INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL
         // insert overwrite partition

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hudi
 
-import org.apache.hudi.DataSourceReadOptions.SCHEMA_EVOLUTION_ENABLED
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
@@ -568,7 +567,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
              | tblproperties (primaryKey = 'id')
              | partitioned by (dt)
        """.stripMargin)
-        checkException(s"insert overwrite table $tableName3 partition(dt = '2021-07-18') values(1, 'a1', 10, '2021-07-18')")(
+        checkException(s"insert overwrite table $tableName3 partition(dt = '2021-07-18') values(1, 'a1', 10)")(
           "Insert Overwrite Partition can not use bulk insert."
         )
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -1125,4 +1125,39 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       }
     }
   }
+
+  test("Test bulk insert non-partition table") {
+    withSQLConf("hoodie.sql.insert.mode" -> "non-strict", "hoodie.schema.on.read.enable" -> "true") {
+      withTempDir { tmp =>
+        Seq("cow", "mor").foreach { tableType =>
+          // Test bulk insert for non-partitioned table
+          val nonPartitionedTable = generateTableName
+          spark.sql(
+            s"""
+               |create table $nonPartitionedTable (
+               |  id int,
+               |  name string,
+               |  price double
+               |) using hudi
+               | tblproperties (
+               |  type = '$tableType',
+               |  primaryKey = 'id'
+               | )
+               | location '${tmp.getCanonicalPath}/$nonPartitionedTable'
+    """.stripMargin)
+          spark.sql("set hoodie.sql.bulk.insert.enable = true")
+          spark.sql(s"insert into $nonPartitionedTable values(1, 'a1', 10)")
+          checkAnswer(s"select id, name, price from $nonPartitionedTable")(
+            Seq(1, "a1", 10.0)
+          )
+          spark.sql(s"insert overwrite table $nonPartitionedTable values(2, 'a2', 10)")
+          checkAnswer(s"select id, name, price from $nonPartitionedTable")(
+            Seq(2, "a2", 10.0)
+          )
+          spark.sql("set hoodie.sql.bulk.insert.enable = false")
+        }
+      }
+    }
+  }
+
 }

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
@@ -104,10 +104,17 @@ private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
 
   override def build(): V1Write = new V1Write {
     override def toInsertableRelation: InsertableRelation = {
+      val mode = if (overwriteTable) {
+        // insert overwrite non-partition table
+        SaveMode.Overwrite
+      } else {
+        // for insert into or insert overwrite partition we use append mode.
+        SaveMode.Append
+      }
       new InsertableRelation {
         override def insert(data: DataFrame, overwrite: Boolean): Unit = {
           alignOutputColumns(data).write.format("org.apache.hudi")
-            .mode(SaveMode.Append)
+            .mode(mode)
             .options(buildHoodieConfig(hoodieCatalogTable) ++
               buildHoodieInsertConfig(hoodieCatalogTable, spark, overwritePartition, overwriteTable, Map.empty, Map.empty))
             .save()

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
@@ -104,17 +104,10 @@ private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
 
   override def build(): V1Write = new V1Write {
     override def toInsertableRelation: InsertableRelation = {
-      val mode = if (overwriteTable) {
-        // insert overwrite non-partition table
-        SaveMode.Overwrite
-      } else {
-        // for insert into or insert overwrite partition we use append mode.
-        SaveMode.Append
-      }
       new InsertableRelation {
         override def insert(data: DataFrame, overwrite: Boolean): Unit = {
           alignOutputColumns(data).write.format("org.apache.hudi")
-            .mode(mode)
+            .mode(SaveMode.Append)
             .options(buildHoodieConfig(hoodieCatalogTable) ++
               buildHoodieInsertConfig(hoodieCatalogTable, spark, overwritePartition, overwriteTable, Map.empty, Map.empty))
             .save()


### PR DESCRIPTION
### Change Logs

fix https://github.com/apache/hudi/pull/7365,  when hoodie.sql.bulk.insert.enable = true and hoodie.schema.on.read.enable=true, insert overwrite on non-partition table will fail because the save mode is set Append not Overwrite.  

After this pr both insert overwrite table and insert overwrite partition can not use bulk insert 

### Impact

both insert overwrite table and insert overwrite partition can not use bulk insert 

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
