### PR TITLE
[HUDI-5835] After performing the update operation, the hoodie table cannot be read normally by spark

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBootstrapRelation.scala
@@ -21,6 +21,7 @@ package org.apache.hudi
 import org.apache.hadoop.fs.Path
 import org.apache.hudi.HoodieBaseRelation.{BaseFileReader, projectReader}
 import org.apache.hudi.HoodieBootstrapRelation.validate
+import org.apache.hudi.HoodieBaseRelation.convertToAvroSchema
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.spark.rdd.RDD
@@ -119,9 +120,9 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
 
     val bootstrapDataFileReader = createBaseFileReader(
       spark = sqlContext.sparkSession,
-      dataSchema = new HoodieTableSchema(bootstrapDataFileSchema),
+      dataSchema = new HoodieTableSchema(bootstrapDataFileSchema, convertToAvroSchema(bootstrapDataFileSchema, tableName).toString),
       partitionSchema = partitionSchema,
-      requiredDataSchema = new HoodieTableSchema(requiredBootstrapDataFileSchema),
+      requiredDataSchema = new HoodieTableSchema(requiredBootstrapDataFileSchema, convertToAvroSchema(requiredBootstrapDataFileSchema, tableName).toString),
       // NOTE: For bootstrapped files we can't apply any filtering in case we'd need to merge it with
       //       a skeleton-file as we rely on matching ordering of the records across bootstrap- and skeleton-files
       filters = if (requiredSkeletonFileSchema.isEmpty) filters else Seq(),
@@ -136,11 +137,11 @@ case class HoodieBootstrapRelation(override val sqlContext: SQLContext,
 
     val boostrapSkeletonFileReader = createBaseFileReader(
       spark = sqlContext.sparkSession,
-      dataSchema = new HoodieTableSchema(skeletonSchema),
+      dataSchema = new HoodieTableSchema(skeletonSchema, convertToAvroSchema(skeletonSchema, tableName).toString),
       // NOTE: Here we specify partition-schema as empty since we don't need Spark to inject partition-values
       //       parsed from the partition-path
       partitionSchema = StructType(Seq.empty),
-      requiredDataSchema = new HoodieTableSchema(requiredSkeletonFileSchema),
+      requiredDataSchema = new HoodieTableSchema(requiredSkeletonFileSchema, convertToAvroSchema(requiredSkeletonFileSchema, tableName).toString),
       // NOTE: For bootstrapped files we can't apply any filtering in case we'd need to merge it with
       //       a skeleton-file as we rely on matching ordering of the records across bootstrap- and skeleton-files
       filters = if (requiredBootstrapDataFileSchema.isEmpty) filters else Seq(),

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -190,7 +190,7 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
           StructType(requiredDataSchema.structTypeSchema.fields
             .filterNot(f => unusedMandatoryColumnNames.contains(f.name)))
 
-        new HoodieTableSchema(prunedStructSchema)
+        HoodieTableSchema(prunedStructSchema, convertToAvroSchema(prunedStructSchema, tableName).toString)
       }
 
       val requiredSchemaReaderSkipMerging = createBaseFileReader(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
@@ -205,7 +205,7 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
     })
   }
 
-  test("Test Add Column and Update Table") {
+  test("Test decimal type") {
     withTempDir { tmp =>
       val tableName = generateTableName
       // create table
@@ -235,18 +235,6 @@ class TestUpdateTable extends HoodieSparkSqlTestBase {
       spark.sql(s"update $tableName set price = 22 where id = 1")
       checkAnswer(s"select id, name, price, ts from $tableName")(
         Seq(1, "a1", 22.0, 1000)
-      )
-
-      spark.sql(s"alter table $tableName add column new_col1 int")
-
-      checkAnswer(s"select id, name, price, ts, new_col1 from $tableName")(
-        Seq(1, "a1", 22.0, 1000, null)
-      )
-
-      // update and check
-      spark.sql(s"update $tableName set price = price * 2 where id = 1")
-      checkAnswer(s"select id, name, price, ts, new_col1 from $tableName")(
-        Seq(1, "a1", 44.0, 1000, null)
       )
     }
   }


### PR DESCRIPTION
### Change Logs

Fix the bug: After performing the update operation, the hodie table cannot be read normally by spark

### Impact

if user create table with decimal type,   
after performing the update operation, the hodie table cannot be read normally by spark

### Risk level (write none, low medium or high below)

high

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
