### PR TITLE
[HUDI-5859] Adding standalone restore tool

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -953,7 +953,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
       try {
         LOG.info("Deleting metadata table because it is disabled in writer.");
         deleteMetadataTable(config.getBasePath(), context);
-        clearMetadataTablePartitionsConfig(Option.empty(), true);
+        clearMetadataTablePartitionsConfig(Option.empty(), true, metaClient);
       } catch (HoodieMetadataException e) {
         throw new HoodieException("Failed to delete metadata table.", e);
       }
@@ -971,7 +971,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
           if (metadataPartitionExists(metaClient.getBasePath(), context, partitionType)) {
             deleteMetadataPartition(metaClient.getBasePath(), context, partitionType);
           }
-          clearMetadataTablePartitionsConfig(Option.of(partitionType), false);
+          clearMetadataTablePartitionsConfig(Option.of(partitionType), false, metaClient);
         } catch (HoodieMetadataException e) {
           throw new HoodieException("Failed to delete metadata partition: " + partitionType.name(), e);
         }
@@ -1021,7 +1021,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   /**
    * Clears hoodie.table.metadata.partitions in hoodie.properties
    */
-  private void clearMetadataTablePartitionsConfig(Option<MetadataPartitionType> partitionType, boolean clearAll) {
+  public static void clearMetadataTablePartitionsConfig(Option<MetadataPartitionType> partitionType, boolean clearAll, HoodieTableMetaClient metaClient) {
     Set<String> partitions = metaClient.getTableConfig().getMetadataPartitions();
     if (clearAll && partitions.size() > 0) {
       LOG.info("Clear hoodie.table.metadata.partitions in hoodie.properties");

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReader.java
@@ -52,7 +52,7 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
 
   private static final Logger LOG = LogManager.getLogger(HoodieLogFormatReader.class);
 
-  HoodieLogFormatReader(FileSystem fs, List<HoodieLogFile> logFiles, Schema readerSchema, boolean readBlocksLazily,
+  public HoodieLogFormatReader(FileSystem fs, List<HoodieLogFile> logFiles, Schema readerSchema, boolean readBlocksLazily,
                         boolean reverseLogReader, int bufferSize, boolean enableRecordLookups,
                         String recordKeyField, InternalSchema internalSchema) throws IOException {
     this.logFiles = logFiles;

--- a/hudi-tests-common/src/main/resources/log4j2-surefire.properties
+++ b/hudi-tests-common/src/main/resources/log4j2-surefire.properties
@@ -32,6 +32,6 @@ rootLogger.appenderRef.stdout.ref = CONSOLE
 logger.apache.name = org.apache
 logger.apache.level = info
 logger.hudi.name = org.apache.hudi
-logger.hudi.level = debug
+logger.hudi.level = info
 logger.hbase.name = org.apache.hadoop.hbase
 logger.hbase.level = error

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/MORRestoreTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/MORRestoreTool.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.exception.HoodieException;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ *
+ */
+public class MORRestoreTool implements Serializable {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieMetadataTableValidator.class);
+
+  // Spark context
+  private transient JavaSparkContext jsc;
+  // config
+  private Config cfg;
+  // Properties with source, hoodie client, key generator etc.
+  private TypedProperties props;
+
+  private final HoodieTableMetaClient metaClient;
+
+  public MORRestoreTool(HoodieTableMetaClient metaClient) {
+    this.metaClient = metaClient;
+  }
+
+  public MORRestoreTool(JavaSparkContext jsc, Config cfg) {
+    this.jsc = jsc;
+    this.cfg = cfg;
+
+    this.props = cfg.propsFilePath == null
+        ? UtilHelpers.buildProperties(cfg.configs)
+        : readConfigFromFileSystem(jsc, cfg);
+
+    this.metaClient = HoodieTableMetaClient.builder()
+        .setConf(jsc.hadoopConfiguration()).setBasePath(cfg.basePath)
+        .build();
+  }
+
+  /**
+   * Reads config from the file system.
+   *
+   * @param jsc {@link JavaSparkContext} instance.
+   * @param cfg {@link Config} instance.
+   * @return the {@link TypedProperties} instance.
+   */
+  private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {
+    return UtilHelpers.readConfig(jsc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs)
+        .getProps(true);
+  }
+
+  public static class Config implements Serializable {
+    @Parameter(names = {"--base-path", "-sp"}, description = "Base path for the table", required = true)
+    public String basePath = null;
+
+    @Parameter(names = {"--parallelism", "-pl"}, description = "Parallelism for valuation", required = false)
+    public int parallelism = 200;
+
+    @Parameter(names = {"--commitTime", "-c"}, description = "Instant Time to restore to", required = true)
+    public String commitTime = "";
+
+    @Parameter(names = {"--dryRun"}, description = "Dry run without deleting any files", required = false)
+    public boolean dryRun = true;
+
+    @Parameter(names = {"--spark-master", "-ms"}, description = "Spark master", required = false)
+    public String sparkMaster = null;
+
+    @Parameter(names = {"--spark-memory", "-sm"}, description = "spark memory to use", required = false)
+    public String sparkMemory = "1g";
+
+    @Parameter(names = {"--assume-date-partitioning"}, description = "Should HoodieWriteClient assume the data is partitioned by dates, i.e three levels from base path."
+        + "This is a stop-gap to support tables created by versions < 0.3.1. Will be removed eventually", required = false)
+    public Boolean assumeDatePartitioning = false;
+
+    @Parameter(names = {"--props"}, description = "path to properties file on localfs or dfs, with configurations for "
+        + "hoodie client")
+    public String propsFilePath = null;
+
+    @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+        splitter = IdentitySplitter.class)
+    public List<String> configs = new ArrayList<>();
+
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
+
+    @Override
+    public String toString() {
+      return "MetadataTableValidatorConfig {\n"
+          + "   --base-path " + basePath + ", \n"
+          + "   --commitTime " + commitTime + ", \n"
+          + "   --parallelism " + parallelism + ", \n"
+          + "   --spark-master " + sparkMaster + ", \n"
+          + "   --spark-memory " + sparkMemory + ", \n"
+          + "   --assumeDatePartitioning-memory " + assumeDatePartitioning + ", \n"
+          + "   --props " + propsFilePath + ", \n"
+          + "   --hoodie-conf " + configs
+          + "\n}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Config config = (Config) o;
+      return basePath.equals(config.basePath)
+          && Objects.equals(commitTime, config.commitTime)
+          && Objects.equals(parallelism, config.parallelism)
+          && Objects.equals(sparkMaster, config.sparkMaster)
+          && Objects.equals(sparkMemory, config.sparkMemory)
+          && Objects.equals(assumeDatePartitioning, config.assumeDatePartitioning)
+          && Objects.equals(propsFilePath, config.propsFilePath)
+          && Objects.equals(configs, config.configs);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(basePath, commitTime,
+          parallelism, sparkMaster, sparkMemory, assumeDatePartitioning, propsFilePath, configs, help);
+    }
+  }
+
+  public static void main(String[] args) {
+    final Config cfg = new Config();
+    JCommander cmd = new JCommander(cfg, null, args);
+
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+
+    SparkConf sparkConf = UtilHelpers.buildSparkConf("Hoodie-Metadata-Table-Validator", cfg.sparkMaster);
+    sparkConf.set("spark.executor.memory", cfg.sparkMemory);
+    JavaSparkContext jsc = new JavaSparkContext(sparkConf);
+
+    MORRestoreTool validator = new MORRestoreTool(jsc, cfg);
+
+    try {
+      validator.run();
+    } catch (Throwable throwable) {
+      LOG.error("Fail to do hoodie metadata table validation for " + validator.cfg, throwable);
+    } finally {
+      jsc.stop();
+    }
+  }
+
+  public boolean run() {
+    boolean result = false;
+    try {
+      LOG.info(cfg);
+      LOG.info(" ****** Triggering restore to " + cfg.commitTime + " ******");
+      result = doRestore();
+    } catch (Exception e) {
+      throw new HoodieException("Unable to do hoodie metadata table validation in " + cfg.basePath, e);
+    } finally {
+      return result;
+    }
+  }
+
+  public boolean doRestore() {
+    boolean finalResult = true;
+    String basePath = metaClient.getBasePath();
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(false).build();
+    List<String> partitions = FSUtils.getAllPartitionPaths(engineContext, metadataConfig, basePath);
+    Map<String, List<String>> filesToDelete = new HashMap<>();
+
+    HoodieTableFileSystemView fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(engineContext, metaClient, metadataConfig);
+    partitions.forEach(pPath -> {
+      LOG.info("Processing partition " + pPath);
+      filesToDelete.put(pPath, new ArrayList<>());
+      List<FileSlice> fileSlices = fileSystemView.getAllFileSlices(pPath).collect(Collectors.toList());
+      for (FileSlice fileSlice : fileSlices) {
+        LOG.info("File slice commit time " + fileSlice.getBaseInstantTime());
+        if (HoodieTimeline.compareTimestamps(fileSlice.getBaseInstantTime(), HoodieTimeline.GREATER_THAN, cfg.commitTime)) {
+          LOG.info("Deleting entire file slice ");
+          if (fileSlice.getBaseFile().isPresent()) {
+            LOG.info("Base file to delete " + fileSlice.getBaseFile().get().getPath());
+            filesToDelete.get(pPath).add(fileSlice.getBaseFile().get().getPath());
+          }
+          fileSlice.getLogFiles().forEach(logFile -> {
+            LOG.info("   log file to delete " + logFile.getPath().toString());
+            filesToDelete.get(pPath).add(logFile.getPath().toString());
+          });
+        } else if (HoodieTimeline.compareTimestamps(fileSlice.getBaseInstantTime(), HoodieTimeline.EQUALS, cfg.commitTime)) {
+          LOG.info("Deleting all log files except base file");
+          if (fileSlice.getBaseFile().isPresent()) {
+            LOG.info("Not deleting Base file " + fileSlice.getBaseFile().get().getPath());
+          }
+          fileSlice.getLogFiles().forEach(logFile -> {
+            LOG.info("   log file to delete " + logFile.getPath().toString());
+            filesToDelete.get(pPath).add(logFile.getPath().toString());
+          });
+          LOG.info("Not procssing remaining file slices");
+          break;
+        } else {
+          // we need to collect only partial list of log files to be deleted
+          /*TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
+          try {
+            Schema schema = tableSchemaResolver.getTableAvroSchema();
+            HoodieLogFormatReader logFormatReaderWrapper = new HoodieLogFormatReader(metaClient.getFs(),
+                fileSlice.getLogFiles().collect(Collectors.toList()),
+                schema, true, true, HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE.defaultValue(), true, HoodieRecord.RECORD_KEY_METADATA_FIELD,
+                InternalSchema.getEmptyInternalSchema());
+
+            while (logFormatReaderWrapper.hasNext()) {
+              HoodieLogFile logFile = logFormatReaderWrapper.getLogFile();
+              LOG.info("Scanning log file " + logFile);
+              HoodieLogBlock logBlock = logFormatReaderWrapper.next();
+              final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
+              // process until we hit a log block whose instant time is < commit to restore
+              if (instantTime != null && HoodieTimeline.compareTimestamps(instantTime, HoodieTimeline.LESSER_THAN, cfg.commitTime)) {
+                LOG.info("Hit a log block whose commit time is < commit to restore. Skipping rest of log files " + instantTime);
+                break;
+              } else {
+                // collect all log blocks until we hit a block whose time < commit to restore.
+                filesToDelete.get(pPath).add(logFile.getPath().toString());
+              }
+            }
+          } catch (Exception e) {
+            LOG.error("Failed with an exception ", e);
+          } */
+        }
+      }
+    });
+
+    FileSystem fs = metaClient.getFs();
+    LOG.info("\n\n================================================================================");
+    LOG.info("List of files to delete ");
+    filesToDelete.forEach((k, v) -> {
+      LOG.info("For partition " + k);
+      v.forEach(file -> {
+        LOG.info("   File to delete " + file);
+        if (!cfg.dryRun) {
+          try {
+            fs.delete(new Path(file), false);
+          } catch (IOException e) {
+            LOG.error("Failed to delete " + file);
+          }
+        }
+      });
+    });
+
+    if (!cfg.dryRun) {
+      LOG.info("Removing timeline files ");
+      metaClient.reloadActiveTimeline().getReverseOrderedInstants().collect(Collectors.toList())
+          .forEach(instant -> {
+            if (HoodieTimeline.compareTimestamps(instant.getTimestamp(), HoodieTimeline.GREATER_THAN, cfg.commitTime)) {
+              LOG.info("Deleting timeline file for commit " + instant.getTimestamp());
+              try {
+                if (instant.isCompleted()) {
+                  LOG.info("Deleting all 3 timeline files");
+                  fs.delete(new Path(basePath + "/.hoodie/" + instant.getFileName()));
+                  String action = instant.getAction();
+                  if (instant.getAction().equals("commit")) {
+                    action = "compaction";
+                  }
+                  fs.delete(new Path(basePath + "/.hoodie/" + instant.getTimestamp() + "." + action
+                      + HoodieTimeline.INFLIGHT_EXTENSION));
+                  fs.delete(new Path(basePath + "/.hoodie/" + instant.getTimestamp() + "." + action
+                      + HoodieTimeline.REQUESTED_EXTENSION));
+                } else if (instant.isInflight()) {
+                  LOG.info("Deleting requested and inflight timeline files");
+                  fs.delete(new Path(basePath + "/.hoodie/" + instant.getTimestamp() + "." + instant.getAction()
+                      + HoodieTimeline.INFLIGHT_EXTENSION));
+                  fs.delete(new Path(basePath + "/.hoodie/" + instant.getTimestamp() + "." + instant.getAction()
+                      + HoodieTimeline.REQUESTED_EXTENSION));
+                } else {
+                  LOG.info("Deleting only requested timeline files");
+                  fs.delete(new Path(basePath + "/.hoodie/" + instant.getTimestamp() + "." + instant.getAction()
+                      + HoodieTimeline.REQUESTED_EXTENSION));
+                }
+              } catch (IOException e) {
+                LOG.error("Failed to delete timeline file ", e);
+              }
+            }
+          });
+    }
+    return finalResult;
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMorRestoreTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMorRestoreTool.java
@@ -167,7 +167,7 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
       MORRestoreTool.Config restoreToolConfig = new MORRestoreTool.Config();
       restoreToolConfig.basePath = cfg.getBasePath();
       restoreToolConfig.commitTime = toRestoreCommit;
-      restoreToolConfig.dryRun = false;
+      restoreToolConfig.execute = true;
       MORRestoreTool restoreTool = new MORRestoreTool(jsc(), restoreToolConfig);
       restoreTool.run();
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMorRestoreTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMorRestoreTool.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMorRestoreTool extends SparkClientFunctionalTestHarness implements SparkProvider {
 
-  private static final HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0L);
+  private static final HoodieTestDataGenerator DATA_GENERATOR = new HoodieTestDataGenerator(0L);
   private HoodieTableMetaClient metaClient;
 
   @BeforeEach
@@ -69,7 +69,7 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
 
   @AfterAll
   public static void cleanup() {
-    dataGen.close();
+    DATA_GENERATOR.close();
   }
 
   @Test
@@ -91,7 +91,7 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
       String newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
 
-      List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
+      List<HoodieRecord> records = DATA_GENERATOR.generateInserts(newCommitTime, 200);
       upsertToMorTable(client, records, newCommitTime);
 
       /*
@@ -99,12 +99,12 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
        */
       newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
-      records = dataGen.generateUpdates(newCommitTime, 100);
+      records = DATA_GENERATOR.generateUpdates(newCommitTime, 100);
       upsertToMorTable(client, records, newCommitTime);
 
       newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
-      records = dataGen.generateUpdates(newCommitTime, 50);
+      records = DATA_GENERATOR.generateUpdates(newCommitTime, 50);
       upsertToMorTable(client, records, newCommitTime);
       String toRestoreCommit = newCommitTime;
 
@@ -112,7 +112,7 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
       HoodieTable table = HoodieSparkTable.create(cfg, context(), metaClient);
       table.getHoodieView().sync();
       Map<String, List<HoodieLogFile>> beforeRestoreFileSlice = new HashMap<>();
-      for (String partitionPath : dataGen.getPartitionPaths()) {
+      for (String partitionPath : DATA_GENERATOR.getPartitionPaths()) {
         List<FileSlice> groupedLogFiles =
             table.getSliceView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
         beforeRestoreFileSlice.put(partitionPath, new ArrayList<>());
@@ -136,12 +136,12 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
        */
       newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
-      records = dataGen.generateUpdates(newCommitTime, 100);
+      records = DATA_GENERATOR.generateUpdates(newCommitTime, 100);
       upsertToMorTable(client, records, newCommitTime);
 
       newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
-      records = dataGen.generateUpdates(newCommitTime, 50);
+      records = DATA_GENERATOR.generateUpdates(newCommitTime, 50);
       upsertToMorTable(client, records, newCommitTime);
 
       String secondCompactionInstant = client.scheduleCompaction(Option.empty()).get().toString();
@@ -155,12 +155,12 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
 
       newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
-      records = dataGen.generateUpdates(newCommitTime, 100);
+      records = DATA_GENERATOR.generateUpdates(newCommitTime, 100);
       upsertToMorTable(client, records, newCommitTime);
 
       newCommitTime = HoodieActiveTimeline.createNewInstantTime();
       client.startCommitWithTime(newCommitTime);
-      records = dataGen.generateUpdates(newCommitTime, 50);
+      records = DATA_GENERATOR.generateUpdates(newCommitTime, 50);
       upsertToMorTable(client, records, newCommitTime);
 
       // trigger restore
@@ -175,7 +175,7 @@ public class TestMorRestoreTool extends SparkClientFunctionalTestHarness impleme
       table = HoodieSparkTable.create(cfg, context(), metaClient);
       table.getHoodieView().sync();
       Map<String, List<HoodieLogFile>> afterRestoreFileSlice = new HashMap<>();
-      for (String partitionPath : dataGen.getPartitionPaths()) {
+      for (String partitionPath : DATA_GENERATOR.getPartitionPaths()) {
         List<FileSlice> groupedLogFiles =
             table.getSliceView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
         afterRestoreFileSlice.put(partitionPath, new ArrayList<>());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMorRestoreTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMorRestoreTool.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+import org.apache.hudi.testutils.providers.SparkProvider;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestMorRestoreTool extends SparkClientFunctionalTestHarness implements SparkProvider {
+
+  private static final HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0L);
+  private HoodieTableMetaClient metaClient;
+
+  @BeforeEach
+  public void init() throws IOException {
+    this.metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ);
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    dataGen.close();
+  }
+
+  @Test
+  public void testSimpleRestore() throws Exception {
+    HoodieFileFormat fileFormat = HoodieFileFormat.PARQUET;
+
+    Properties properties = new Properties();
+    properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), fileFormat.toString());
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, properties);
+
+    HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder(true)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build());
+    HoodieWriteConfig cfg = cfgBuilder.build();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
+      /*
+       * Write 1 (only inserts)
+       */
+      String newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+
+      List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
+      upsertToMorTable(client, records, newCommitTime);
+
+      /*
+       * Write 2 (updates)
+       */
+      newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 100);
+      upsertToMorTable(client, records, newCommitTime);
+
+      newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 50);
+      upsertToMorTable(client, records, newCommitTime);
+      String toRestoreCommit = newCommitTime;
+
+      // collect file slices to validate later
+      HoodieTable table = HoodieSparkTable.create(cfg, context(), metaClient);
+      table.getHoodieView().sync();
+      Map<String, List<HoodieLogFile>> beforeRestoreFileSlice = new HashMap<>();
+      for (String partitionPath : dataGen.getPartitionPaths()) {
+        List<FileSlice> groupedLogFiles =
+            table.getSliceView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
+        beforeRestoreFileSlice.put(partitionPath, new ArrayList<>());
+        for (FileSlice fileSlice : groupedLogFiles) {
+          beforeRestoreFileSlice.get(partitionPath).addAll(fileSlice.getLogFiles().collect(Collectors.toList()));
+        }
+      }
+
+      String firstCompactionInstant = client.scheduleCompaction(Option.empty()).get().toString();
+      client.compact(firstCompactionInstant);
+
+      // verify that there is a commit
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+      HoodieTimeline timeline = metaClient.getCommitTimeline().filterCompletedInstants();
+      assertEquals(1, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(),
+          "Expecting a single commit.");
+      String latestCompactionCommitTime = timeline.lastInstant().get().getTimestamp();
+      assertTrue(HoodieTimeline.compareTimestamps("000", HoodieTimeline.LESSER_THAN, latestCompactionCommitTime));
+      /*
+       * Write 1 (only inserts)
+       */
+      newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 100);
+      upsertToMorTable(client, records, newCommitTime);
+
+      newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 50);
+      upsertToMorTable(client, records, newCommitTime);
+
+      String secondCompactionInstant = client.scheduleCompaction(Option.empty()).get().toString();
+      client.compact(secondCompactionInstant);
+
+      // verify that there is a commit
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+      timeline = metaClient.getCommitTimeline().filterCompletedInstants();
+      assertEquals(2, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(),
+          "Expecting two commits.");
+
+      newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 100);
+      upsertToMorTable(client, records, newCommitTime);
+
+      newCommitTime = HoodieActiveTimeline.createNewInstantTime();
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 50);
+      upsertToMorTable(client, records, newCommitTime);
+
+      // trigger restore
+      MORRestoreTool.Config restoreToolConfig = new MORRestoreTool.Config();
+      restoreToolConfig.basePath = cfg.getBasePath();
+      restoreToolConfig.commitTime = toRestoreCommit;
+      restoreToolConfig.dryRun = false;
+      MORRestoreTool restoreTool = new MORRestoreTool(jsc(), restoreToolConfig);
+      restoreTool.run();
+
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+      table = HoodieSparkTable.create(cfg, context(), metaClient);
+      table.getHoodieView().sync();
+      Map<String, List<HoodieLogFile>> afterRestoreFileSlice = new HashMap<>();
+      for (String partitionPath : dataGen.getPartitionPaths()) {
+        List<FileSlice> groupedLogFiles =
+            table.getSliceView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
+        afterRestoreFileSlice.put(partitionPath, new ArrayList<>());
+        for (FileSlice fileSlice : groupedLogFiles) {
+          afterRestoreFileSlice.get(partitionPath).addAll(fileSlice.getLogFiles().collect(Collectors.toList()));
+        }
+        // validate
+        List<HoodieLogFile> beforeLogFiles = beforeRestoreFileSlice.get(partitionPath);
+        List<HoodieLogFile> afterLogFiles = afterRestoreFileSlice.get(partitionPath);
+        for (HoodieLogFile beforeLogFile : beforeLogFiles) {
+          assertTrue(afterLogFiles.contains(beforeLogFile));
+        }
+        for (HoodieLogFile afterLogFile : afterLogFiles) {
+          assertTrue(beforeLogFiles.contains(afterLogFile));
+        }
+      }
+    }
+  }
+
+  private void upsertToMorTable(SparkRDDWriteClient client, List<HoodieRecord> records, String commitTime) {
+    JavaRDD<WriteStatus> statusesRdd = client.upsert(jsc().parallelize(records, 1), commitTime);
+    List<WriteStatus> statuses = statusesRdd.collect();
+    // Verify there are no errors
+    assertNoWriteErrors(statuses);
+  }
+}


### PR DESCRIPTION
### Change Logs

For MOR Table, restoring to a very old delta commit is very time consuming. since internally, we do rollback of 1 commit at a time. This standalone tool takes a stab at improving the performance of restore. You can choose a delta commit just before a compaction commit, and this tool will directly delete files for newer file slices after the delta commit chosen. 

this tool does not yet suport restoring to middle of file slice. 
Restore timestamp has to be latest delta commit before any compaction commit. 

For eg, 
dc1,
dc2
c3,
dc4,
dc5,
c6, 
dc7, 
dc8, 
c9,
dc10,
dc11


Valid commit times to restore w/ this tool:
dc2, or dc5, dc8. 

In other words, this tool can only clean up entire file slices and hence. 

After cleaning up the data files, this toll will also delete the corresponding commit meta files from ".hoodie". 

Caution:
Metadata has to be disbaled. 
And this tool takesn unconventional route of not going via rollback. This tool directly lists the files and deletes them and also deleted the timeline files if necessary. 

Sample command
```
./bin/spark-submit --num-executors 1 --executor-cores 2 --deploy-mode client --driver-memory 8g --executor-memory 8g  --class org.apache.hudi.utilities.MORRestoreTool BUNDLE_LOCATION/hudi-utilities-bundle_2.11-0.14.0-SNAPSHOT.jar --base-path /tmp/hudi_trips_more_restore/ --parallelism 4 --commitTime 20230225091008404 --spark-master local[2] --execute --cleanUpMetadata
```

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
