### PR TITLE
[HUDI-5272][SPARK] No PreCombineField mode - make COMBINE_BEFORE_UPSERT=false automatically

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -135,7 +135,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> PRECOMBINE_FIELD_NAME = ConfigProperty
       .key("hoodie.datasource.write.precombine.field")
-      .defaultValue("ts")
+      .defaultValue("")
       .withDocumentation("Field used in preCombining before actual write. When two records have the same key value, "
           + "we will pick the one with the largest value for the precombine field, determined by Object.compareTo(..)");
 
@@ -1126,7 +1126,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean isPrecombineFieldSet() {
     // TODO(HUDI-3456) cleanup
-    return getPreCombineField().isEmpty() ? false : true;
+    return getPreCombineField().isEmpty() || getPreCombineField() == null ? false : true;
   }
 
   public String getWritePayloadClass() {
@@ -2989,7 +2989,7 @@ public class HoodieWriteConfig extends HoodieConfig {
     }
 
     private void autoAdjustConfigsForNoPreCombineMode(boolean isPreCombineFieldNameSet) {
-      if (writeConfig.getTableType() == HoodieTableType.COPY_ON_WRITE && isPreCombineFieldNameSet) {
+      if (writeConfig.getTableType() == HoodieTableType.COPY_ON_WRITE && !isPreCombineFieldNameSet) {
         LOG.info(String.format("Automatically set %s=%s since use has not disabled combine before upsert "
                 + "in absence of precombine field", COMBINE_BEFORE_UPSERT.key(), "false"));
         writeConfig.setValue(COMBINE_BEFORE_UPSERT.key(), "false");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1121,6 +1121,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public String getPreCombineField() {
+    // passing "" for now as it's done in other places, to be revisited in:
     // TODO(HUDI-3456) cleanup
     String preCombineField = getString(PRECOMBINE_FIELD_NAME);
     return preCombineField == null ? "" : preCombineField;
@@ -1128,7 +1129,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean isPrecombineFieldSet() {
     // TODO(HUDI-3456) cleanup
-    return getPreCombineField().isEmpty() || getPreCombineField() == null ? false : true;
+    return getPreCombineField().isEmpty() ? false : true;
   }
 
   public String getWritePayloadClass() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2945,8 +2945,6 @@ public class HoodieWriteConfig extends HoodieConfig {
       autoAdjustConfigsForNoPreCombineMode(isPreCombineFieldNameSet);
     }
 
-
-
     private void autoAdjustConfigsForConcurrencyMode(boolean isLockProviderPropertySet) {
       if (writeConfig.isAutoAdjustLockConfigs()) {
         // auto adjustment is required only for deltastreamer and spark streaming where async table services can be executed in the same JVM.
@@ -2990,8 +2988,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       }
     }
 
-    private void autoAdjustConfigsForNoPreCombineMode(boolean isPreCombineFieldNameSet){
-      // TODO implement auto adjust when no precombine mode is set
+    private void autoAdjustConfigsForNoPreCombineMode(boolean isPreCombineFieldNameSet) {
       if (writeConfig.getTableType() == HoodieTableType.COPY_ON_WRITE && isPreCombineFieldNameSet) {
         LOG.info(String.format("Automatically set %s=%s since use has not disabled combine before upsert "
                 + "in absence of precombine field", COMBINE_BEFORE_UPSERT.key(), "false"));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -135,7 +135,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> PRECOMBINE_FIELD_NAME = ConfigProperty
       .key("hoodie.datasource.write.precombine.field")
-      .defaultValue("")
+      .noDefaultValue()
       .withDocumentation("Field used in preCombining before actual write. When two records have the same key value, "
           + "we will pick the one with the largest value for the precombine field, determined by Object.compareTo(..)");
 
@@ -1121,7 +1121,9 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public String getPreCombineField() {
-    return getString(PRECOMBINE_FIELD_NAME);
+    // TODO(HUDI-3456) cleanup
+    String preCombineField = getString(PRECOMBINE_FIELD_NAME);
+    return preCombineField == null ? "" : preCombineField;
   }
 
   public boolean isPrecombineFieldSet() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -58,6 +58,7 @@ import static org.apache.hudi.config.HoodieWriteConfig.WRITE_CONCURRENCY_MODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestHoodieWriteConfig {
 
@@ -383,12 +384,12 @@ public class TestHoodieWriteConfig {
             .withProperties(properties)
             .build();
     // assume PreCombine field is not set by default
-    assertEquals(writeConfig.isPrecombineFieldSet(), false);
+    assertFalse(writeConfig.isPrecombineFieldSet());
     if (writeConfig.getTableType() == HoodieTableType.COPY_ON_WRITE) {
-      assertEquals(writeConfig.shouldCombineBeforeUpsert(), false);
+      assertFalse(writeConfig.shouldCombineBeforeUpsert());
     } else {
       // for MoR PreCombine field is required
-      assertEquals(writeConfig.shouldCombineBeforeUpsert(), true);
+      assertTrue(writeConfig.shouldCombineBeforeUpsert());
     }
 
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -373,6 +373,27 @@ public class TestHoodieWriteConfig {
         HoodieFailedWritesCleaningPolicy.LAZY, FileSystemBasedLockProviderTestClass.class.getName());
   }
 
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testAutoAdjustConfigsForNoPreCombineMode(HoodieTableType tableType) {
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(HoodieTableConfig.TYPE.key(), tableType.name());
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+            .withPath("/tmp")
+            .withProperties(properties)
+            .build();
+    // assume PreCombine field is not set by default
+    assertEquals(writeConfig.isPrecombineFieldSet(), false);
+    if (writeConfig.getTableType() == HoodieTableType.COPY_ON_WRITE) {
+      assertEquals(writeConfig.shouldCombineBeforeUpsert(), false);
+    } else {
+      // for MoR PreCombine field is required
+      assertEquals(writeConfig.shouldCombineBeforeUpsert(), true);
+    }
+
+
+  }
+
   @Test
   public void testConsistentBucketIndexDefaultClusteringConfig() {
     Properties props = new Properties();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -937,7 +937,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   public void testDeletesForInsertsInSameBatch(boolean populateMetaFields) throws Exception {
     HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY);
     addConfigsForPopulateMetaFields(cfgBuilder, populateMetaFields);
-    SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.build());
+    SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.withPreCombineField("ts").build());
     /**
      * Write 200 inserts and issue deletes to a subset(50) of inserts.
      */
@@ -989,7 +989,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     // instantiate client
 
     HoodieWriteConfig hoodieWriteConfig = getConfigBuilder()
-        .withProps(config.getProps())
+        .withProps(config.getProps()).withPreCombineField("ts")
         .withCompactionConfig(
             HoodieCompactionConfig.newBuilder().compactionSmallFileSize(10000).build())
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(indexType)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
@@ -90,7 +90,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
     HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder(true);
     addConfigsForPopulateMetaFields(cfgBuilder, populateMetaFields);
-    HoodieWriteConfig cfg = cfgBuilder.build();
+    HoodieWriteConfig cfg = cfgBuilder.withPreCombineField("ts").build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
 
       HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
@@ -245,7 +245,7 @@ public class TestHoodieSparkMergeOnReadTableInsertUpdateDelete extends SparkClie
 
     HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder(true);
     addConfigsForPopulateMetaFields(cfgBuilder, populateMetaFields);
-    HoodieWriteConfig cfg = cfgBuilder.build();
+    HoodieWriteConfig cfg = cfgBuilder.withPreCombineField("ts").build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
 
       HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -679,7 +679,7 @@ object DataSourceWriteOptions {
   val PRECOMBINE_FIELD_OPT_KEY = HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key()
   /** @deprecated Use {@link PRECOMBINE_FIELD} and its methods instead */
   @Deprecated
-  val DEFAULT_PRECOMBINE_FIELD_OPT_VAL = PRECOMBINE_FIELD.defaultValue()
+  val DEFAULT_PRECOMBINE_FIELD_OPT_VAL = PRECOMBINE_FIELD // .defaultValue()
 
   /** @deprecated Use {@link HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME} and its methods instead */
   @Deprecated

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -302,13 +302,13 @@ class TestHoodieSparkSqlWriter {
   def testValidateTableConfigWithOverwriteSaveMode(): Unit = {
     //create a new table
     val tableModifier1 = Map("path" -> tempBasePath, HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
-      "hoodie.datasource.write.recordkey.field" -> "uuid")
+      "hoodie.datasource.write.recordkey.field" -> "uuid", "hoodie.datasource.write.precombine.field" -> "ts")
     val dataFrame = spark.createDataFrame(Seq(StringLongTest(UUID.randomUUID().toString, new Date().getTime)))
     HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, tableModifier1, dataFrame)
 
     //on same path try write with different RECORDKEY_FIELD_NAME and Append SaveMode should throw an exception
     val tableModifier2 = Map("path" -> tempBasePath, HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
-      "hoodie.datasource.write.recordkey.field" -> "ts")
+      "hoodie.datasource.write.recordkey.field" -> "ts", "hoodie.datasource.write.precombine.field" -> "ts")
     val dataFrame2 = spark.createDataFrame(Seq(StringLongTest(UUID.randomUUID().toString, new Date().getTime)))
     val hoodieException = intercept[HoodieException](HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, tableModifier2, dataFrame2))
     assert(hoodieException.getMessage.contains("Config conflict"))
@@ -568,6 +568,7 @@ class TestHoodieSparkSqlWriter {
       HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key -> "4",
       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
       HoodieTableConfig.POPULATE_META_FIELDS.key() -> String.valueOf(populateMetaFields),
       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[SimpleKeyGenerator].getCanonicalName)
@@ -633,6 +634,7 @@ class TestHoodieSparkSqlWriter {
         HoodieBootstrapConfig.PARALLELISM_VALUE.key -> "4",
         DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL,
         DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+        DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
         DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
         HoodieBootstrapConfig.KEYGEN_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getCanonicalName)
       val fooTableParams = HoodieWriterUtils.parametersWithWriteDefaults(fooTableModifier)

--- a/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3.2plus-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterTableCommand.scala
@@ -336,7 +336,6 @@ object AlterTableCommand extends Logging {
   def parametersWithWriteDefaults(parameters: Map[String, String]): Map[String, String] = {
     Map(OPERATION.key -> OPERATION.defaultValue,
       TABLE_TYPE.key -> TABLE_TYPE.defaultValue,
-      PRECOMBINE_FIELD.key -> PRECOMBINE_FIELD.defaultValue,
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key -> HoodieWriteConfig.DEFAULT_WRITE_PAYLOAD_CLASS,
       INSERT_DROP_DUPS.key -> INSERT_DROP_DUPS.defaultValue,
       ASYNC_COMPACT_ENABLE.key -> ASYNC_COMPACT_ENABLE.defaultValue,

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -880,6 +880,7 @@ public class DeltaSync implements Serializable, Closeable {
     HoodieWriteConfig.Builder builder =
         HoodieWriteConfig.newBuilder()
             .withPath(cfg.targetBasePath)
+            .withPreCombineField(cfg.sourceOrderingField)
             .combineInput(cfg.filterDupes, combineBeforeUpsert)
             .withCompactionConfig(
                 HoodieCompactionConfig.newBuilder()

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -2355,6 +2355,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
     TypedProperties properties = new TypedProperties();
     properties.setProperty("hoodie.datasource.write.recordkey.field","key");
+    properties.setProperty("hoodie.datasource.write.precombine.field", "ts");
     properties.setProperty("hoodie.datasource.write.partitionpath.field","pp");
     TestDeltaSync testDeltaSync = new TestDeltaSync(cfg, sparkSession, null, properties,
         jsc, fs, jsc.hadoopConfiguration(), null);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -308,6 +308,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends SparkClientFunctiona
     props.setProperty("include", "sql-transformer.properties");
     props.setProperty("hoodie.datasource.write.keygenerator.class", TestHoodieDeltaStreamer.TestGenerator.class.getName());
     props.setProperty("hoodie.datasource.write.recordkey.field", "_row_key");
+    props.setProperty("hoodie.datasource.write.precombine.field", "ts");
     props.setProperty("hoodie.datasource.write.partitionpath.field", "partition_path");
     props.setProperty("hoodie.deltastreamer.schemaprovider.source.schema.file", basePath + "/source.avsc");
     props.setProperty("hoodie.deltastreamer.schemaprovider.target.schema.file", basePath + "/target.avsc");


### PR DESCRIPTION
### Change Logs

Align with Flink behaviour, since precombine is now optional in Spark let users do updates on Hudi table where precombine field is not defined.
resolves #7282

This PR can be merged after #7998 is done as it depends on this fix to work.

### Impact

No API change.
User-facing feature change - SQL UPDATE and upsert in Spark are allowed on CoW table with no PreCombine field specified.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

Spark quick start guide should be updated, sql updates/ ds upserts are possible now on CoW (only) without PreCombine filed out of the box with no additional configuration provided by the user.
Users should be informed that UPSERT/ UPDATE without PreCombine field will not deduplicate the dataset.
We should make it clear that users will need to handle duplicated with DELETE and INSERT statements on their own and make sure to deduplicate incoming data if using Spark Hudi data source.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
