### PR TITLE
[HUDI-5849] Sync hudi configs to catalogs

### DIFF
--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncClient.java
@@ -59,8 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singletonMap;
-
 public class DataHubSyncClient extends HoodieSyncClient {
 
   protected final DataHubSyncConfig config;
@@ -76,12 +74,6 @@ public class DataHubSyncClient extends HoodieSyncClient {
   @Override
   public Option<String> getLastCommitTimeSynced(String tableName) {
     throw new UnsupportedOperationException("Not supported: `getLastCommitTimeSynced`");
-  }
-
-  @Override
-  public void updateLastCommitTimeSynced(String tableName) {
-    Option<String> latestCommitTime = getActiveTimeline().lastInstant().map(HoodieInstant::getTimestamp);
-    latestCommitTime.ifPresent(s -> updateTableProperties(tableName, singletonMap(HOODIE_LAST_COMMIT_TIME_SYNC, s)));
   }
 
   @Override

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/DataHubSyncTool.java
@@ -53,7 +53,7 @@ public class DataHubSyncTool extends HoodieSyncTool {
   public void syncHoodieTable() {
     try (DataHubSyncClient syncClient = new DataHubSyncClient(config)) {
       syncClient.updateTableSchema(config.getString(META_SYNC_TABLE_NAME), null);
-      syncClient.updateLastCommitTimeSynced(config.getString(META_SYNC_TABLE_NAME));
+      syncClient.updateHoodieConfigs(config.getString(META_SYNC_TABLE_NAME));
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -263,7 +263,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
     boolean partitionsChanged = syncPartitions(tableName, writtenPartitionsSince, droppedPartitions);
     boolean meetSyncConditions = schemaChanged || partitionsChanged;
     if (!config.getBoolean(META_SYNC_CONDITIONAL_SYNC) || meetSyncConditions) {
-      syncClient.updateLastCommitTimeSynced(tableName);
+      syncClient.updateHoodieConfigs(tableName);
     }
     LOG.info("Sync complete for " + tableName);
   }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -308,26 +308,6 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
   }
 
   @Override
-  public void updateLastCommitTimeSynced(String tableName) {
-    // Set the last commit time from the TBLproperties
-    Option<String> lastCommitSynced = getActiveTimeline().lastInstant().map(HoodieInstant::getTimestamp);
-    if (lastCommitSynced.isPresent()) {
-      try {
-        Table table = client.getTable(databaseName, tableName);
-        String basePath = config.getString(META_SYNC_BASE_PATH);
-        StorageDescriptor sd = table.getSd();
-        sd.setLocation(basePath);
-        SerDeInfo serdeInfo = sd.getSerdeInfo();
-        serdeInfo.putToParameters(ConfigUtils.TABLE_SERDE_PATH, basePath);
-        table.putToParameters(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitSynced.get());
-        client.alter_table(databaseName, tableName, table);
-      } catch (Exception e) {
-        throw new HoodieHiveSyncException("Failed to get update last commit time synced to " + lastCommitSynced, e);
-      }
-    }
-  }
-
-  @Override
   public void updateHoodieConfigs(String tableName) {
     Map<String, String> syncConfigs = new HashMap<>(config.toMap());
     Option<String> latestCommitTime = getActiveTimeline().lastInstant().map(HoodieInstant::getTimestamp);

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
@@ -179,8 +179,18 @@ public interface HoodieMetaSyncOperations {
 
   /**
    * Update the timestamp of last sync.
+   *
+   * @deprecated Use {@link #updateHoodieConfigs(String)} instead.
    */
+  @Deprecated
   default void updateLastCommitTimeSynced(String tableName) {
+
+  }
+
+  /**
+   * Update Hudi configs.
+   */
+  default void updateHoodieConfigs(String tableName) {
 
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -41,6 +41,8 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -199,6 +201,13 @@ public class HoodieSyncConfig extends HoodieConfig {
   @Override
   public String toString() {
     return props.toString();
+  }
+
+  public Map<String, String> toMap() {
+    return props.entrySet().stream()
+        .collect(Collectors.toMap(
+            e -> e.getKey().toString(),
+            e -> Objects.toString(e.getValue(), "")));
   }
 
   public static class HoodieSyncConfigParams {


### PR DESCRIPTION
### Change Logs

In addition to last commit time, meta sync also add hudi configs to sync with catalogs like Glue catalog, HMS and DataHub.

### Impact

More properties to be sync'ed to catalogs.

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
