### PR TITLE
[HUDI-5855] Release resource actively for Flink hive meta sync

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AwsGlueCatalogSyncTool.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AwsGlueCatalogSyncTool.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.aws.sync;
 
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HiveSyncTool;
 
@@ -25,6 +27,8 @@ import com.beust.jcommander.JCommander;
 import org.apache.hadoop.conf.Configuration;
 
 import java.util.Properties;
+
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 
 /**
  * Currently Experimental. Utility class that implements syncing a Hudi Table with the
@@ -56,6 +60,9 @@ public class AwsGlueCatalogSyncTool extends HiveSyncTool {
       cmd.usage();
       System.exit(0);
     }
-    new AwsGlueCatalogSyncTool(params.toProps(), new Configuration()).syncHoodieTable();
+    // HiveConf needs to load fs conf to allow instantiation via AWSGlueClientFactory
+    TypedProperties props = params.toProps();
+    Configuration hadoopConf = FSUtils.getFs(props.getString(META_SYNC_BASE_PATH.key()), new Configuration()).getConf();
+    new AwsGlueCatalogSyncTool(props, hadoopConf).syncHoodieTable();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -33,6 +33,7 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.hive.HiveSyncTool;
 import org.apache.hudi.sink.event.CommitAckEvent;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
 import org.apache.hudi.sink.meta.CkpMetadata;
@@ -334,7 +335,9 @@ public class StreamWriteOperatorCoordinator
    * Sync hoodie table metadata to Hive metastore.
    */
   public void doSyncHive() {
-    hiveSyncContext.hiveSyncTool().syncHoodieTable();
+    try (HiveSyncTool syncTool = hiveSyncContext.hiveSyncTool()) {
+      syncTool.syncHoodieTable();
+    }
   }
 
   private static void initMetadataTable(HoodieFlinkWriteClient<?> writeClient) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -98,8 +98,6 @@ public class HiveSyncConfig extends HoodieSyncConfig {
     super(props, hadoopConf);
     HiveConf hiveConf = hadoopConf instanceof HiveConf
         ? (HiveConf) hadoopConf : new HiveConf(hadoopConf, HiveConf.class);
-    // HiveConf needs to load fs conf to allow instantiation via AWSGlueClientFactory
-    hiveConf.addResource(getHadoopFileSystem().getConf());
     setHadoopConf(hiveConf);
     validateParameters();
   }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -88,14 +88,15 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
   public static final String SUFFIX_SNAPSHOT_TABLE = "_rt";
   public static final String SUFFIX_READ_OPTIMIZED_TABLE = "_ro";
 
-  protected final HiveSyncConfig config;
-  protected final String databaseName;
-  protected final String tableName;
+  private HiveSyncConfig config;
+  private final String databaseName;
+  private final String tableName;
+
   protected HoodieSyncClient syncClient;
   protected String snapshotTableName;
   protected Option<String> roTableName;
 
-  protected String hiveSyncTableStrategy;
+  private String hiveSyncTableStrategy;
 
   public HiveSyncTool(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf);
@@ -203,6 +204,9 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       } catch (Exception e) {
         throw new HoodieHiveSyncException("Fail to close sync client.", e);
       }
+    }
+    if (config != null) {
+      config = null;
     }
   }
 


### PR DESCRIPTION
Fix oom caused by addResource in flink jm building HiveSyncConfig multiple times
<img width="933" alt="image" src="https://user-images.githubusercontent.com/10494131/221454471-d4fc7a27-d130-49bf-96c3-674a9ca43aaa.png">
![image](https://user-images.githubusercontent.com/10494131/221454481-c875a6ff-ef84-48a1-aa0e-f7badbceacb2.png)


### Change Logs

`HiveSyncContext` and `StreamWriteOperatorCoordinator`

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
