### PR TITLE
[HUDI-5861] fix table can not read data after overwrite table with bu…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieBucketIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieBucketIndex.java
@@ -92,7 +92,6 @@ public abstract class HoodieBucketIndex extends HoodieIndex<Object, Object> {
   public boolean requiresTagging(WriteOperationType operationType) {
     switch (operationType) {
       case INSERT:
-      case INSERT_OVERWRITE:
       case UPSERT:
       case DELETE:
         return true;


### PR DESCRIPTION
a table with bucket index, if `insert overwrite` the same partition twice, can not get any data will `query sql`

reason: insert overwrite in bucket index will tagLocation, the new file version will use the same fgId, so the lastest file slice will be filtered by `replacecommit` file with the same fileGroupId.

### Change Logs

if op is `insert_overwrite`, ignore tagLocation.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
