### PR TITLE
[HUDI-5863] Fix HoodieMetadataFileSystemView serving stale view at the timeline server

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.functional;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.FileSystemViewStorageType;
+import org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTestDelayedTableMetadata;
+import org.apache.hudi.metadata.HoodieMetadataFileSystemView;
+import org.apache.hudi.testutils.HoodieClientTestHarness;
+import org.apache.hudi.timeline.service.TimelineService;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@link RemoteHoodieTableFileSystemView} with metadata table enabled, using
+ * {@link HoodieMetadataFileSystemView} on the timeline server.
+ */
+public class TestRemoteFileSystemViewWithMetadataTable extends HoodieClientTestHarness {
+  private static final Logger LOG = LogManager.getLogger(TestRemoteFileSystemViewWithMetadataTable.class);
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    initPath();
+    initSparkContexts();
+    initFileSystem();
+    initMetaClient();
+    initTimelineService();
+    dataGen = new HoodieTestDataGenerator(0x1f86);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    cleanupTimelineService();
+    cleanupClients();
+    cleanupSparkContexts();
+    cleanupFileSystem();
+    cleanupExecutorService();
+    dataGen = null;
+    System.gc();
+  }
+
+  @Override
+  public void initTimelineService() {
+    // Start a timeline server that are running across multiple commits
+    HoodieLocalEngineContext localEngineContext = new HoodieLocalEngineContext(metaClient.getHadoopConf());
+
+    try {
+      HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+          .withPath(basePath)
+          .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+              .withRemoteServerPort(incrementTimelineServicePortToUse()).build())
+          .build();
+      timelineService = new TimelineService(localEngineContext, new Configuration(),
+          TimelineService.Config.builder().enableMarkerRequests(true)
+              .serverPort(config.getViewStorageConfig().getRemoteViewServerPort()).build(),
+          FileSystem.get(new Configuration()),
+          FileSystemViewManager.createViewManager(
+              context, config.getMetadataConfig(), config.getViewStorageConfig(),
+              config.getCommonConfig(),
+              () -> new HoodieBackedTestDelayedTableMetadata(
+                  context, config.getMetadataConfig(), basePath,
+                  config.getViewStorageConfig().getSpillableDir(), true)));
+      timelineService.startService();
+      timelineServicePort = timelineService.getServerPort();
+      LOG.info("Started timeline server on port: " + timelineServicePort);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Test
+  public void testMORGetLatestFileSliceWithMetadataTable() throws IOException {
+    // This test utilizes the `HoodieBackedTestDelayedTableMetadata` to make sure the
+    // synced file system view is always served.
+    for (int i = 0; i < 3; i++) {
+      writeToTable(i, timelineService);
+    }
+
+    // At this point, there are three deltacommits and one compaction commit in the Hudi timeline,
+    // and the file system view of timeline server is not yet synced
+    HoodieTableMetaClient newMetaClient = HoodieTableMetaClient.builder()
+        .setConf(metaClient.getHadoopConf())
+        .setBasePath(basePath)
+        .build();
+    HoodieActiveTimeline timeline = newMetaClient.getActiveTimeline();
+    HoodieInstant compactionCommit = timeline.lastInstant().get();
+    assertTrue(timeline.lastInstant().get().getAction().equals(COMMIT_ACTION));
+
+    // For all the file groups compacted by the compaction commit, the file system view
+    // should return the latest file slices which is written by the latest commit
+    HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
+        timeline.getInstantDetails(compactionCommit).get(), HoodieCommitMetadata.class);
+    List<Pair<String, String>> partitionFileIdPairList =
+        commitMetadata.getPartitionToWriteStats().entrySet().stream().flatMap(
+            entry -> {
+              String partitionPath = entry.getKey();
+              return entry.getValue().stream().map(
+                  writeStat -> Pair.of(partitionPath, writeStat.getFileId()));
+            }
+        ).collect(Collectors.toList());
+    List<Pair<String, String>> lookupList = new ArrayList<>();
+    // Accumulate enough threads to test read-write concurrency while syncing the file system
+    // view at the timeline server
+    while (lookupList.size() < 128) {
+      lookupList.addAll(partitionFileIdPairList);
+    }
+
+    LOG.info("Connecting to Timeline Server: " + timelineService.getServerPort());
+    RemoteHoodieTableFileSystemView view = new RemoteHoodieTableFileSystemView(
+        "localhost", timelineService.getServerPort(), metaClient);
+
+    List<TestViewLookUpCallable> callableList = lookupList.stream()
+        .map(pair -> new TestViewLookUpCallable(view, pair, compactionCommit.getTimestamp()))
+        .collect(Collectors.toList());
+    List<Future<Boolean>> resultList = new ArrayList<>();
+
+    ExecutorService pool = Executors.newCachedThreadPool();
+    callableList.forEach(callable -> {
+      resultList.add(pool.submit(callable));
+    });
+
+    assertTrue(resultList.stream().map(future -> {
+      try {
+        return future.get();
+      } catch (Exception e) {
+        LOG.error(e);
+        return false;
+      }
+    }).reduce((a, b) -> a && b).get());
+  }
+
+  @Override
+  protected HoodieTableType getTableType() {
+    return HoodieTableType.MERGE_ON_READ;
+  }
+
+  private void writeToTable(int round, TimelineService timelineService) throws IOException {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withParallelism(2, 2)
+        .withBulkInsertParallelism(2)
+        .withFinalizeWriteParallelism(2)
+        .withDeleteParallelism(2)
+        .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
+        .withMergeSmallFileGroupCandidatesLimit(0)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withMaxNumDeltaCommitsBeforeCompaction(3)
+            .build())
+        .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+            .withStorageType(FileSystemViewStorageType.REMOTE_ONLY)
+            .withRemoteServerPort(timelineService.getServerPort())
+            .build())
+        .withAutoCommit(false)
+        .forTable("test_mor_table")
+        .build();
+    SparkRDDWriteClient writeClient =
+        new SparkRDDWriteClient(context, writeConfig, Option.of(timelineService));
+    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+    writeClient.startCommitWithTime(instantTime);
+    List<HoodieRecord> records = round == 0
+        ? dataGen.generateInserts(instantTime, 100)
+        : dataGen.generateUpdates(instantTime, 100);
+
+    JavaRDD<WriteStatus> writeStatusRDD = writeClient.upsert(jsc.parallelize(records, 1), instantTime);
+    writeClient.commit(instantTime, writeStatusRDD, Option.empty(), DELTA_COMMIT_ACTION, Collections.emptyMap());
+    // Triggers compaction
+    writeClient.scheduleCompaction(Option.empty());
+    writeClient.runAnyPendingCompactions();
+  }
+
+  /**
+   * Test callable to send lookup request to the timeline server for the latest file slice
+   * based on the partition path and file ID.
+   */
+  class TestViewLookUpCallable implements Callable<Boolean> {
+    private final RemoteHoodieTableFileSystemView view;
+    private final Pair<String, String> partitionFileIdPair;
+    private final String expectedCommitTime;
+
+    public TestViewLookUpCallable(
+        RemoteHoodieTableFileSystemView view,
+        Pair<String, String> partitionFileIdPair,
+        String expectedCommitTime) {
+      this.view = view;
+      this.partitionFileIdPair = partitionFileIdPair;
+      this.expectedCommitTime = expectedCommitTime;
+    }
+
+    @Override
+    public Boolean call() throws Exception {
+      Option<FileSlice> latestFileSlice = view.getLatestFileSlice(
+          partitionFileIdPair.getLeft(), partitionFileIdPair.getRight());
+      boolean result = latestFileSlice.isPresent() && expectedCommitTime.equals(
+          FSUtils.getCommitTime(new Path(latestFileSlice.get().getBaseFile().get().getPath()).getName()));
+      if (!result) {
+        LOG.error("The timeline server does not return the correct result: latestFileSliceReturned="
+            + latestFileSlice + " expectedCommitTime=" + expectedCommitTime);
+      }
+      return result;
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -278,9 +278,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   public void reset() {
     try {
       writeLock.lock();
-      clear();
-      // Initialize with new Hoodie timeline.
-      init(metaClient, getTimeline());
+      runReset();
     } finally {
       writeLock.unlock();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -1389,7 +1389,10 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   }
 
   /**
-   * Syncs the file system view from storage to memory.
+   * Syncs the file system view from storage to memory.  Performs complete reset of file-system
+   * view. Subsequent partition view calls will load file slices against the latest timeline.
+   * <p>
+   * NOTE: The logic MUST BE guarded by the write lock.
    */
   @Override
   public void sync() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -269,10 +269,6 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   /**
    * Clears the partition Map and reset view states.
-   * <p>
-   * NOTE: This method SHOULD NOT BE OVERRIDDEN which may cause stale file system view
-   * to be served.  Instead, override {@link AbstractTableFileSystemView#runReset} to
-   * add custom logic.
    */
   @Override
   public void reset() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -269,6 +269,8 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   /**
    * Clears the partition Map and reset view states.
+   * <p>
+   * NOTE: The logic MUST BE guarded by the write lock.
    */
   @Override
   public void reset() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -287,15 +287,6 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   }
 
   /**
-   * Resets the view states, which can be overridden by subclasses.  This reset logic is guarded
-   * by the write lock.
-   * <p>
-   * NOTE: This method SHOULD BE OVERRIDDEN for any custom logic.  DO NOT OVERRIDE
-   * {@link AbstractTableFileSystemView#reset} directly, which may cause stale file system view
-   * to be served.
-   */
-
-  /**
    * Clear the resource.
    */
   protected void clear() {
@@ -1403,10 +1394,6 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   /**
    * Syncs the file system view from storage to memory.
-   * <p>
-   * NOTE: This method SHOULD NOT BE OVERRIDDEN which may cause stale file system view
-   * to be served.  Instead, override {@link AbstractTableFileSystemView#runSync} to
-   * add custom logic.
    */
   @Override
   public void sync() {
@@ -1419,23 +1406,6 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
     } finally {
       writeLock.unlock();
     }
-  }
-
-  /**
-   * Performs complete reset of file-system view. Subsequent partition view calls will load file
-   * slices against the latest timeline.  This sync logic is guarded by the write lock.
-   * <p>
-   * NOTE: This method SHOULD BE OVERRIDDEN for any custom logic.  DO NOT OVERRIDE
-   * {@link AbstractTableFileSystemView#sync} directly, which may cause stale file system view
-   * to be served.
-   *
-   * @param oldTimeline Old Hudi Timeline
-   * @param newTimeline New Hudi Timeline
-   */
-  protected void runSync(HoodieTimeline oldTimeline, HoodieTimeline newTimeline) {
-    clear();
-    // Initialize with new Hoodie timeline.
-    init(metaClient, newTimeline);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
@@ -106,10 +106,7 @@ public class HoodieMetadataFileSystemView extends HoodieTableFileSystemView {
   public void sync() {
     try {
       writeLock.lock();
-      HoodieTimeline newTimeline = metaClient.reloadActiveTimeline().filterCompletedOrMajorOrMinorCompactionInstants();
-      clear();
-      // Initialize with new Hoodie timeline.
-      init(metaClient, newTimeline);
+      maySyncIncrementally();
       tableMetadata.reset();
     } finally {
       writeLock.unlock();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileSystemView.java
@@ -90,14 +90,14 @@ public class HoodieMetadataFileSystemView extends HoodieTableFileSystemView {
   }
 
   @Override
-  public void reset() {
-    super.reset();
+  public void runReset() {
+    super.runReset();
     tableMetadata.reset();
   }
 
   @Override
-  public void sync() {
-    super.sync();
+  protected void runSync(HoodieTimeline oldTimeline, HoodieTimeline newTimeline) {
+    super.runSync(oldTimeline, newTimeline);
     tableMetadata.reset();
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/HoodieBackedTestDelayedTableMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/HoodieBackedTestDelayedTableMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+/**
+ * Table metadata provided by an internal DFS backed Hudi metadata table,
+ * with an intentional delay in `reset()` to test concurrent reads and writes.
+ */
+public class HoodieBackedTestDelayedTableMetadata extends HoodieBackedTableMetadata {
+  private static final Logger LOG = LogManager.getLogger(HoodieBackedTestDelayedTableMetadata.class);
+
+  public HoodieBackedTestDelayedTableMetadata(HoodieEngineContext engineContext,
+                                              HoodieMetadataConfig metadataConfig,
+                                              String datasetBasePath,
+                                              String spillableMapDirectory,
+                                              boolean reuse) {
+    super(engineContext, metadataConfig, datasetBasePath, spillableMapDirectory, reuse);
+  }
+
+  @Override
+  public void reset() {
+    LOG.info("Sleeping for 5 seconds in reset() to simulate processing ...");
+    try {
+      Thread.sleep(5000);
+    } catch (InterruptedException e) {
+      LOG.warn("Sleep is interrupted", e);
+    }
+    LOG.info("Sleep in reset() is finished.");
+    super.reset();
+  }
+}

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -151,30 +151,30 @@ public class RequestHandler {
    * Determines if local view of table's timeline is behind that of client's view.
    */
   private boolean isLocalViewBehind(Context ctx) {
-      String basePath = ctx.queryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM);
-      String lastKnownInstantFromClient =
-          ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.LAST_INSTANT_TS, String.class).getOrDefault(HoodieTimeline.INVALID_INSTANT_TS);
-      String timelineHashFromClient = ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.TIMELINE_HASH, String.class).getOrDefault("");
-      HoodieTimeline localTimeline =
-          viewManager.getFileSystemView(basePath).getTimeline().filterCompletedOrMajorOrMinorCompactionInstants();
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient
-            + "], localTimeline=" + localTimeline.getInstants());
-      }
+    String basePath = ctx.queryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM);
+    String lastKnownInstantFromClient =
+        ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.LAST_INSTANT_TS, String.class).getOrDefault(HoodieTimeline.INVALID_INSTANT_TS);
+    String timelineHashFromClient = ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.TIMELINE_HASH, String.class).getOrDefault("");
+    HoodieTimeline localTimeline =
+        viewManager.getFileSystemView(basePath).getTimeline().filterCompletedOrMajorOrMinorCompactionInstants();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient
+          + "], localTimeline=" + localTimeline.getInstants());
+    }
 
-      if ((!localTimeline.getInstantsAsStream().findAny().isPresent())
-          && HoodieTimeline.INVALID_INSTANT_TS.equals(lastKnownInstantFromClient)) {
-        return false;
-      }
+    if ((!localTimeline.getInstantsAsStream().findAny().isPresent())
+        && HoodieTimeline.INVALID_INSTANT_TS.equals(lastKnownInstantFromClient)) {
+      return false;
+    }
 
-      String localTimelineHash = localTimeline.getTimelineHash();
-      // refresh if timeline hash mismatches
-      if (!localTimelineHash.equals(timelineHashFromClient)) {
-        return true;
-      }
+    String localTimelineHash = localTimeline.getTimelineHash();
+    // refresh if timeline hash mismatches
+    if (!localTimelineHash.equals(timelineHashFromClient)) {
+      return true;
+    }
 
-      // As a safety check, even if hash is same, ensure instant is present
-      return !localTimeline.containsOrBeforeTimelineStarts(lastKnownInstantFromClient);
+    // As a safety check, even if hash is same, ensure instant is present
+    return !localTimeline.containsOrBeforeTimelineStarts(lastKnownInstantFromClient);
   }
 
   /**

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -181,7 +181,6 @@ public class RequestHandler {
    * Syncs data-set view if local view is behind.
    */
   private boolean syncIfLocalViewBehind(Context ctx) {
-    boolean result = false;
     String basePath = ctx.queryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM);
     SyncableFileSystemView view = viewManager.getFileSystemView(basePath);
     synchronized (view) {
@@ -195,10 +194,10 @@ public class RequestHandler {
             + " as last known instant but server has the following last instant on timeline :"
             + localTimeline.lastInstant());
         view.sync();
-        result = true;
+        return true;
       }
     }
-    return result;
+    return false;
   }
 
   private void writeValueAsString(Context ctx, Object obj) throws JsonProcessingException {


### PR DESCRIPTION
### Change Logs

We observe that for MOR table, occasionally (<10% for large tables with frequent updates and compactions), the deltacommit after the compaction commit may add a new log file to the old file slice, not the latest file slice, in the corresponding file group.  This happens when both the metadata table and timeline server are enabled.  If either is disabled, the problem does not show up.  This means that any data written to the log file is lost, i.e., data loss issue.

Deeper analysis of the code surfaces that the file system view at the timeline server may serve the stale view, causing the issue.  This is because the sync of `HoodieMetadataFileSystemView` is not atomic when the metadata table is enabled.

Here's a concrete walkthrough of how this problem can happen.  When the timeline server is long-running and passed to the write client for reusing (like Deltastreamer), the timeline server internally needs to refresh and sync the outdated file system view if it is behind what the client (which sends the request to the timeline server) sees.  This is based on whether the latest instant seen by the client matches what timeline server's file system view has.  The sync logic is implemented in `RequestHandler`:
```
[L1]  private boolean syncIfLocalViewBehind(Context ctx) {
[L2]    if (isLocalViewBehind(ctx)) {
[L3]      String basePath = ctx.queryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM);
[L4]      String lastKnownInstantFromClient = ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.LAST_INSTANT_TS, String.class).getOrDefault(HoodieTimeline.INVALID_INSTANT_TS);
[L5]      SyncableFileSystemView view = viewManager.getFileSystemView(basePath);
[L6]      synchronized (view) {
[L7]        if (isLocalViewBehind(ctx)) {
[L7]          HoodieTimeline localTimeline = viewManager.getFileSystemView(basePath).getTimeline();
[L8]          LOG.info("Syncing view as client passed last known instant " + lastKnownInstantFromClient
[L9]              + " as last known instant but server has the following last instant on timeline :"
[L10]              + localTimeline.lastInstant());
[L11]          view.sync();
[L12]          return true;
[L13]        }
[L14]      }
[L15]    }
[L16]    return false;
[L17]  }
```
```
  private boolean isLocalViewBehind(Context ctx) {
    String basePath = ctx.queryParam(RemoteHoodieTableFileSystemView.BASEPATH_PARAM);
    String lastKnownInstantFromClient =
        ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.LAST_INSTANT_TS, String.class).getOrDefault(HoodieTimeline.INVALID_INSTANT_TS);
    String timelineHashFromClient = ctx.queryParamAsClass(RemoteHoodieTableFileSystemView.TIMELINE_HASH, String.class).getOrDefault("");
    HoodieTimeline localTimeline =
        viewManager.getFileSystemView(basePath).getTimeline().filterCompletedOrMajorOrMinorCompactionInstants();
    if (LOG.isDebugEnabled()) {
      LOG.debug("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient
          + "], localTimeline=" + localTimeline.getInstants());
    }

    if ((!localTimeline.getInstantsAsStream().findAny().isPresent())
        && HoodieTimeline.INVALID_INSTANT_TS.equals(lastKnownInstantFromClient)) {
      return false;
    }

    String localTimelineHash = localTimeline.getTimelineHash();
    // refresh if timeline hash mismatches
    if (!localTimelineHash.equals(timelineHashFromClient)) {
      return true;
    }

    // As a safety check, even if hash is same, ensure instant is present
    return !localTimeline.containsOrBeforeTimelineStarts(lastKnownInstantFromClient);
  }
```

Here's the implementation of `sync()` of the file system view based on the metadata table (`HoodieMetadataFileSystemView`):
```
  @Override
  public void sync() {
    super.sync();
    tableMetadata.reset();
  }
```
The `super.sync()` calls the `sync()` in `AbstractTableFileSystemView`:
```
  @Override
  public void sync() {
    HoodieTimeline oldTimeline = getTimeline();
    HoodieTimeline newTimeline = metaClient.reloadActiveTimeline().filterCompletedOrMajorOrMinorCompactionInstants();
    try {
      writeLock.lock();
      runSync(oldTimeline, newTimeline);
    } finally {
      writeLock.unlock();
    }
  }
```
Note that, the file system view logic should be guarded by the read-write lock, i.e., any read of the cached file system info should be blocked before updates to the cache in the file system are fully done, which is guarded by the write lock.  However, we can see that for `HoodieMetadataFileSystemView`, the write lock covers the sync logic partially, and `tableMetadata.reset()` is not guarded by the write lock, meaning that it can create race condition that the metadata table content can be stale when being read.
- When metadata table is enabled using `HoodieBackedTableMetadata`, `tableMetadata.reset()` has logic to execute.
- When metadata table is disabled, with `FileSystemBackedTableMetadata`, `tableMetadata.reset()` is a no-op, so there is no issue.

Let's now look at concurrent requests are handled in `RequestHandler` to cause the stale view to be read.  Consider two concurrent requests to the timeline server, REQ1 and REQ2:
- Thread1 for REQ1: L2 with `syncIfLocalViewBehind()` returns `true`. Then enters synchronized block from L6 to sync the file system view.  In the middle, the timeline has already been updated, yet the metadata and file system view has not been refreshed.
- Thread2 for REQ2: This comes after the timeline has been updated because of REQ1 at the timeline server, but metadata and the file system view is still in progress.  At this moment, L2 with `syncIfLocalViewBehind()` returns `false`, skipping the synchronized block and continue for getting the information from the file system view.  As mentioned above, given that the sync logic is not fully guarded by the write lock, the read lock thinks that the info is fully updated, thus allowing the file system view to return the info, which is stale.

To easily reproduce this race condition problem consistently, a new test `TestRemoteFileSystemViewWithMetadataTable` is added with `HoodieBackedTestDelayedTableMetadata` to delay the `reset()` process.  By applying the same change to the `HoodieBackedTableMetadata`, we can also reproduce the same problem with the Deltastreamer.

The fix is the following:
- Makes sure all logic in `sync()` and `reset()` are guarded by the write lock.  This is done by implementing the logic with the write lock in each file system view, instead of overriding indect method (e.g., `runSync()`).
- Simplifies the implementation of `syncIfLocalViewBehind()` to be more readable.

**History and Impact of the problem:**

The problematic implementation of `sync()` and `reset()` in `HoodieMetadataFileSystemView` class is introduced by #4307 to properly sync and reset the file system view based on the metadata table.  This did not have an impact at that moment, as Hudi refreshes/synces the file system view explicitly while initializing the `HoodieTable` instance for each write, masking the issue.  Only when the file system view based on the metadata table is synced because of new requests at the timeline server, there's a chance of the `HoodieMetadataFileSystemView` serving a stale view, which is not hit when #4307 is landed.  Subsequently, two more optimization PRs, #5617 and #5716, are landed to remove "unnecessary" refreshes/syncs of the file system view when initializing the `HoodieTable` instance.  It turns out that without this PR properly fixing the `sync()` and `reset()` in `HoodieMetadataFileSystemView`, such refreshes and syncs are necessary to avoid potential stale and inconsistent views.  As the probability of hitting this issue is very low, it is not uncovered during manual testing or CI runs.

After running the same tests added in this PR, it is found that the following Hudi releases are affected: `0.11.1`, `0.12.0`, `0.12.1`, `0.12.2`, `0.13.0`.  This also aligns with the findings around the offending PRs mentioned above.  Although the tests pass for `0.13.0`, there's still an impact on `0.13.0` with a smaller scope, because of another bug #8080 introduced in `0.13.0` release (timeline server instance passed to the write client is ignored due to this bug).

### Impact

This PR fixes the data loss issue and makes sure that the timeline server with the metadata table enabled (using `HoodieMetadataFileSystemView`) always serves the correct information.

This has been tested with deltastreamer writing MOR table with inline compaction in continuous mode, with intentional delay in `HoodieBackedTableMetadata` just like `HoodieBackedTestDelayedTableMetadata` to ensure the problem happens consistently before the fix.  After the fix, the problem goes away.

### Risk level

medium

### Documentation Update

We need to update the release notes regarding this severe regression that can cause data loss: HUDI-5864.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
