### PR TITLE
[HUDI-5865] Fix table service client to instantiate with timeline server

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -26,6 +26,7 @@ import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackPlan;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.heartbeat.HeartbeatUtils;
 import org.apache.hudi.common.HoodiePendingRollbackInfo;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -87,8 +88,10 @@ public abstract class BaseHoodieTableServiceClient<O> extends BaseHoodieClient i
 
   protected Set<String> pendingInflightAndRequestedInstants;
 
-  protected BaseHoodieTableServiceClient(HoodieEngineContext context, HoodieWriteConfig clientConfig) {
-    super(context, clientConfig, Option.empty());
+  protected BaseHoodieTableServiceClient(HoodieEngineContext context,
+                                         HoodieWriteConfig clientConfig,
+                                         Option<EmbeddedTimelineService> timelineService) {
+    super(context, clientConfig, timelineService);
   }
 
   protected void startAsyncCleanerService(BaseHoodieWriteClient writeClient) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.client;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieKey;
@@ -62,8 +63,10 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
    */
   private HoodieBackedTableMetadataWriter metadataWriter;
 
-  protected HoodieFlinkTableServiceClient(HoodieEngineContext context, HoodieWriteConfig clientConfig) {
-    super(context, clientConfig);
+  protected HoodieFlinkTableServiceClient(HoodieEngineContext context,
+                                          HoodieWriteConfig clientConfig,
+                                          Option<EmbeddedTimelineService> timelineService) {
+    super(context, clientConfig, timelineService);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -87,7 +87,7 @@ public class HoodieFlinkWriteClient<T> extends
   public HoodieFlinkWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
     super(context, writeConfig, FlinkUpgradeDowngradeHelper.getInstance());
     this.bucketToHandles = new HashMap<>();
-    this.tableServiceClient = new HoodieFlinkTableServiceClient<>(context, writeConfig);
+    this.tableServiceClient = new HoodieFlinkTableServiceClient<>(context, writeConfig, getTimelineServer());
   }
 
   /**

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestFlinkWriteClient.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.testutils.HoodieFlinkClientTestHarness;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TestFlinkWriteClient extends HoodieFlinkClientTestHarness {
+
+  @BeforeEach
+  private void setup() throws IOException {
+    initPath();
+    initFileSystem();
+    initMetaClient();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testWriteClientAndTableServiceClientWithTimelineServer(
+      boolean enableEmbeddedTimelineServer) throws IOException {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(metaClient.getBasePathV2().toString())
+        .withEmbeddedTimelineServerEnabled(enableEmbeddedTimelineServer)
+        .build();
+
+    HoodieFlinkWriteClient writeClient = new HoodieFlinkWriteClient(context, writeConfig);
+    // Only one timeline server should be instantiated, and the same timeline server
+    // should be used by both the write client and the table service client.
+    assertEquals(
+        writeClient.getTimelineServer(),
+        writeClient.getTableServiceClient().getTimelineServer());
+    if (!enableEmbeddedTimelineServer) {
+      assertFalse(writeClient.getTimelineServer().isPresent());
+    }
+
+    writeClient.close();
+  }
+}

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaTableServiceClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaTableServiceClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.util.Option;
@@ -34,8 +35,10 @@ import java.util.Map;
 
 public class HoodieJavaTableServiceClient extends BaseHoodieTableServiceClient<List<WriteStatus>> {
 
-  protected HoodieJavaTableServiceClient(HoodieEngineContext context, HoodieWriteConfig clientConfig) {
-    super(context, clientConfig);
+  protected HoodieJavaTableServiceClient(HoodieEngineContext context,
+                                         HoodieWriteConfig clientConfig,
+                                         Option<EmbeddedTimelineService> timelineService) {
+    super(context, clientConfig, timelineService);
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/HoodieJavaWriteClient.java
@@ -53,7 +53,7 @@ public class HoodieJavaWriteClient<T> extends
 
   public HoodieJavaWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig) {
     super(context, writeConfig, JavaUpgradeDowngradeHelper.getInstance());
-    this.tableServiceClient = new HoodieJavaTableServiceClient(context, writeConfig);
+    this.tableServiceClient = new HoodieJavaTableServiceClient(context, writeConfig, getTimelineServer());
   }
 
   public HoodieJavaWriteClient(HoodieEngineContext context,
@@ -61,7 +61,7 @@ public class HoodieJavaWriteClient<T> extends
                                boolean rollbackPending,
                                Option<EmbeddedTimelineService> timelineService) {
     super(context, writeConfig, timelineService, JavaUpgradeDowngradeHelper.getInstance());
-    this.tableServiceClient = new HoodieJavaTableServiceClient(context, writeConfig);
+    this.tableServiceClient = new HoodieJavaTableServiceClient(context, writeConfig, getTimelineServer());
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -20,6 +20,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.avro.model.HoodieClusteringGroup;
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -58,8 +59,10 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkRDDTableServiceClient.class);
 
-  protected SparkRDDTableServiceClient(HoodieEngineContext context, HoodieWriteConfig clientConfig) {
-    super(context, clientConfig);
+  protected SparkRDDTableServiceClient(HoodieEngineContext context,
+                                       HoodieWriteConfig clientConfig,
+                                       Option<EmbeddedTimelineService> timelineService) {
+    super(context, clientConfig, timelineService);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -83,7 +83,7 @@ public class SparkRDDWriteClient<T> extends
   public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig,
                              Option<EmbeddedTimelineService> timelineService) {
     super(context, writeConfig, timelineService, SparkUpgradeDowngradeHelper.getInstance());
-    this.tableServiceClient = new SparkRDDTableServiceClient<>(context, writeConfig);
+    this.tableServiceClient = new SparkRDDTableServiceClient<>(context, writeConfig, getTimelineServer());
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

In 0.13.0 and latest master, the table service client `BaseHoodieTableServiceClient` is instantiated without any timeline server instance, even if the regular write client has one.  This causes the table service client to start a new embedded timeline server and overwrite the write config passed in from the constructor so that the write config points to the newly started timeline server.  The issue is introduced by #6732, adding the Hudi table service manager.

As the regular write client such as `SparkRDDWriteClient` directly passes in the same writeConfig instance, the regular write client's write config is also affected, causing the regular write client to use the newly started embedded timeline server always, instead of the timeline server instance passed in from the constructor or the one instantiated by the regular write client itself.

This means that the Deltastreamer's long-lived timeline server is never going to be used because of this issue.

Note that, this issue does not cause a correctness issue; nevertheless, at least one additional timeline server is instantiated because of the issue, which is never used during the write transaction, wasting compute and memory resources.

This PR fixes the issue by properly initiating the table service client with the timeline server from the regular write client.

Three new tests are added to make sure the timeline server used by the write client and the table service client is expected:
- `TestSparkRDDWriteClient#testWriteClientAndTableServiceClientWithTimelineServer`
- `TestFlinkWriteClient#testWriteClientAndTableServiceClientWithTimelineServer`
- `TestHoodieJavaWriteClientInsert#testWriteClientAndTableServiceClientWithTimelineServer`

### Impact

This makes sure that the timeline server instance passed to the regular write client is used by the write transaction.

The new tests added guard the behavior:
- `TestSparkRDDWriteClient#testWriteClientAndTableServiceClientWithTimelineServer`
- `TestFlinkWriteClient#testWriteClientAndTableServiceClientWithTimelineServer`
- `TestHoodieJavaWriteClientInsert#testWriteClientAndTableServiceClientWithTimelineServer`

Before this fix, these tests fail:
<img width="728" alt="Screenshot 2023-03-17 at 23 11 05" src="https://user-images.githubusercontent.com/2497195/226090585-2082a864-d22f-4f4d-ace5-4308c0e88d89.png">
<img width="726" alt="Screenshot 2023-03-17 at 23 35 14" src="https://user-images.githubusercontent.com/2497195/226090597-762d1e6a-22a8-4c90-b2b1-1e16a138e5f4.png">
<img width="726" alt="Screenshot 2023-03-17 at 23 49 26" src="https://user-images.githubusercontent.com/2497195/226090614-783b9293-0733-413d-ae18-0670a41d1d62.png">

With this fix, all tests pass:
<img width="727" alt="Screenshot 2023-03-17 at 23 11 43" src="https://user-images.githubusercontent.com/2497195/226090591-c9b053c5-8748-4bd8-9c7a-5fbc237ed33e.png">
<img width="727" alt="Screenshot 2023-03-17 at 23 35 34" src="https://user-images.githubusercontent.com/2497195/226090601-107154eb-0463-4402-a304-db07cfc14dfb.png">
<img width="724" alt="Screenshot 2023-03-17 at 23 49 02" src="https://user-images.githubusercontent.com/2497195/226090612-6b13f1fd-f0e4-4334-9a60-3ffc41df7798.png">

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
