### PR TITLE
[HUDI-5867] Force to use commons-io v2.7+

### DIFF
--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -258,7 +258,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
@@ -284,6 +284,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+<!-- Force to use 2.11.0 since hbase-server requires 2.7+ -->
+   <dependency>
+     <groupId>commons-io</groupId>
+     <artifactId>commons-io</artifactId>
+     <version>${commons.io.version}</version>
+   </dependency>
 
     <!-- LZ4 Hash Utils -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
     <hudi.spark.common.modules.2/>
     <avro.version>1.8.2</avro.version>
     <caffeine.version>2.9.1</caffeine.version>
+    <commons.io.version>2.11.0</commons.io.version>
     <scala11.version>2.11.12</scala11.version>
     <scala12.version>2.12.10</scala12.version>
     <scala.version>${scala11.version}</scala.version>


### PR DESCRIPTION
### Change Logs

Fix the commons-io version since hbase-server requires v2.7+

This fixes #8074 

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update

N.A.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
