### PR TITLE
[HUDI-5870] Fix some comments about column type change rules

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkInternalSchemaConverter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkInternalSchemaConverter.java
@@ -287,7 +287,7 @@ public class SparkInternalSchemaConverter {
 
   /**
    * Convert Int/long type to other Type.
-   * Now only support int/long -> long/float/double/string
+   * Now only support int/long -> long/float/double/string/Decimal
    * TODO: support more types
    */
   private static boolean convertIntLongType(WritableColumnVector oldV, WritableColumnVector newV, DataType newType, int len) {
@@ -321,7 +321,7 @@ public class SparkInternalSchemaConverter {
 
   /**
    * Convert float type to other Type.
-   * Now only support float -> double/String
+   * Now only support float -> double/String/Decimal
    * TODO: support more types
    */
   private static boolean convertFloatType(WritableColumnVector oldV, WritableColumnVector newV, DataType newType, int len) {

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/SchemaChangeUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/SchemaChangeUtils.java
@@ -38,9 +38,9 @@ public class SchemaChangeUtils {
   /**
    * Whether to allow the column type to be updated.
    * now only support:
-   * int => long/float/double/string
-   * long => float/double/string
-   * float => double/String
+   * int => long/float/double/String/Decimal
+   * long => float/double/String/Decimal
+   * float => double/String/Decimal
    * double => String/Decimal
    * Decimal => Decimal/String
    * String => date/decimal


### PR DESCRIPTION
### Change Logs

This patch didn't change any logic. It just update the comment for schema evolution type change.

### Impact

No

### Risk level (write none, low medium or high below)

No Risk

### Documentation Update

No document update, these rules are listed here: https://hudi.apache.org/docs/schema_evolution/ . 
But in the code, these were wrong.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
