### PR TITLE
[HUDI-5876] Remove usage of deprecated TableConfig.

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/sort/SortOperatorGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/sort/SortOperatorGen.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 public class SortOperatorGen {
   private final int[] sortIndices;
   private final RowType rowType;
-  private final TableConfig tableConfig = new TableConfig();
+  private final TableConfig tableConfig = TableConfig.getDefault();
 
   public SortOperatorGen(RowType rowType, String[] sortFields) {
     this.sortIndices = Arrays.stream(sortFields).mapToInt(rowType::getFieldIndex).toArray();


### PR DESCRIPTION
### Change Logs

JIRA: HUDI-5876. Remove usage of deprecated TableConfig.

This is a small change, I found out that SortOperatorGen initializes TableConfig using deprecated method. Use recommended methods to improve.

TableConfig
```
/** Please use {@link TableConfig#getDefault()} instead. */
@Deprecated
public TableConfig() {}
```

### Impact

none.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
