### PR TITLE
[HUDI-5890] Fix build of asf-site branch

### DIFF
--- a/website/versioned_docs/version-0.13.0/querying_data.md
+++ b/website/versioned_docs/version-0.13.0/querying_data.md
@@ -282,13 +282,13 @@ REFRESH database.table_name
 ```
 
 ## Redshift Spectrum
-To set up Redshift Spectrum for querying Hudi, see the [Query Engine Setup](/docs/next/query_engine_setup#redshift-spectrum) page.
+To set up Redshift Spectrum for querying Hudi, see the [Query Engine Setup](/docs/query_engine_setup#redshift-spectrum) page.
 
 ## Doris 
-To set up Doris for querying Hudi, see the [Query Engine Setup](/docs/next/query_engine_setup#doris) page.
+To set up Doris for querying Hudi, see the [Query Engine Setup](/docs/query_engine_setup#doris) page.
 
 ## StarRocks
-To set up StarRocks for querying Hudi, see the [Query Engine Setup](/docs/next/query_engine_setup#starrocks) page.
+To set up StarRocks for querying Hudi, see the [Query Engine Setup](/docs/query_engine_setup#starrocks) page.
 
 ## Support Matrix
 


### PR DESCRIPTION
### Change Logs

This PR fixes the following build failure of `asf-site` branch:
```
Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /docs/querying_data:
   -> linking to /docs/next/query_engine_setup#redshift-spectrum (resolved as: /docs/next/query_engine_setup)
   -> linking to /docs/next/query_engine_setup#doris (resolved as: /docs/next/query_engine_setup)
   -> linking to /docs/next/query_engine_setup#starrocks (resolved as: /docs/next/query_engine_setup)

    at reportMessage (/home/runner/work/hudi/hudi/website/node_modules/@docusaurus/utils/lib/index.js:306:19)
    at handleBrokenLinks (/home/runner/work/hudi/hudi/website/node_modules/@docusaurus/core/lib/server/brokenLinks.js:138:35)
    at async buildLocale (/home/runner/work/hudi/hudi/website/node_modules/@docusaurus/core/lib/commands/build.js:155:5)
    at async tryToBuildLocale (/home/runner/work/hudi/hudi/website/node_modules/@docusaurus/core/lib/commands/build.js:33:20)
    at async mapAsyncSequencial (/home/runner/work/hudi/hudi/website/node_modules/@docusaurus/utils/lib/index.js:262:24)
    at async build (/home/runner/work/hudi/hudi/website/node_modules/@docusaurus/core/lib/commands/build.js:68:25)
Error: Process completed with exit code 1.
```

### Impact

Fixes the build and unblock the website update from `asf-site` branch.

### Risk level

none

### Documentation Update

As above.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
