### PR TITLE
[HUDI-4911] Following the first patch, fix the inefficient code

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -343,7 +342,7 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
             .collect(Collectors.toMap(Pair::getKey, p -> p.getRight().get()));
 
     Set<Path> missingPartitionPaths =
-        CollectionUtils.diffSet(new HashSet<>(partitionPaths), cachedPartitionPaths.keySet());
+        CollectionUtils.diffSet(partitionPaths, cachedPartitionPaths.keySet());
 
     // NOTE: We're constructing a mapping of absolute form of the partition-path into
     //       its relative one, such that we don't need to reconstruct these again later on

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CollectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CollectionUtils.java
@@ -184,9 +184,10 @@ public class CollectionUtils {
   }
 
   /**
-   * Returns difference b/w {@code one} {@link Set} of elements and {@code another}
+   * Returns difference b/w {@code one} {@link Collection} of elements and {@code another}
+   * The elements in collection {@code one} are also duplicated and returned as a {@link Set}.
    */
-  public static <E> Set<E> diffSet(Set<E> one, Set<E> another) {
+  public static <E> Set<E> diffSet(Collection<E> one, Set<E> another) {
     Set<E> diff = new HashSet<>(one);
     diff.removeAll(another);
     return diff;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -43,7 +43,6 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.collection.ClosableIterator;
-import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SpillableMapUtils;
@@ -286,13 +285,6 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
                 .stream()
                 .map(record -> Pair.of(record.getRecordKey(), Option.of(record)))
                 .collect(Collectors.toList());
-
-    // Second, back-fill keys not present in the log-blocks (such that map holds
-    // a record for every key being looked up)
-    List<String> missingKeys = CollectionUtils.diff(keys, logRecords.keySet());
-    for (String key : missingKeys) {
-      logRecords.put(key, Option.empty());
-    }
 
     for (Pair<String, Option<HoodieRecord<HoodieMetadataPayload>>> entry : logRecordsList) {
       logRecords.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
### Change Logs

While I review the HUDI-4911 patch, found 2 code snippet to improve.

### Impact

No impact

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
