### PR TITLE
[HUDI-5917] Fix HoodieRetryWrapperFileSystem getDefaultReplication

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieRetryWrapperFileSystem.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieRetryWrapperFileSystem.java
@@ -270,4 +270,15 @@ public class HoodieRetryWrapperFileSystem extends FileSystem {
   public String getScheme() {
     return fileSystem.getScheme();
   }
+
+  @Override
+  public short getDefaultReplication() {
+    return fileSystem.getDefaultReplication();
+  }
+
+  @Override
+  public short getDefaultReplication(Path path) {
+    return fileSystem.getDefaultReplication(path);
+  }
+
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
@@ -93,8 +93,8 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     FakeRemoteFileSystem fakeFs = new FakeRemoteFileSystem(FSUtils.getFs(metaClient.getMetaPath(), metaClient.getHadoopConf()), 100);
     FileSystem fileSystem = new HoodieRetryWrapperFileSystem(fakeFs, maxRetryIntervalMs, maxRetryNumbers, initialRetryIntervalMs, "");
     HoodieWrapperFileSystem fs = new HoodieWrapperFileSystem(fileSystem, new NoOpConsistencyGuard());
-    assertEquals(fs.getDefaultReplication(),3);
-    assertEquals(fs.getDefaultReplication(new Path(basePath)),3);
+    assertEquals(fs.getDefaultReplication(), 3);
+    assertEquals(fs.getDefaultReplication(new Path(basePath)), 3);
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -87,6 +88,15 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     assertDoesNotThrow(fs::getScheme, "Method #getSchema does not implement correctly");
   }
 
+  @Test
+  public void testGetDefaultReplication() {
+    FakeRemoteFileSystem fakeFs = new FakeRemoteFileSystem(FSUtils.getFs(metaClient.getMetaPath(), metaClient.getHadoopConf()), 100);
+    FileSystem fileSystem = new HoodieRetryWrapperFileSystem(fakeFs, maxRetryIntervalMs, maxRetryNumbers, initialRetryIntervalMs, "");
+    HoodieWrapperFileSystem fs = new HoodieWrapperFileSystem(fileSystem, new NoOpConsistencyGuard());
+    assertEquals(fs.getDefaultReplication(),3);
+    assertEquals(fs.getDefaultReplication(new Path(basePath)),3);
+  }
+
   /**
    * Fake remote FileSystem which will throw RuntimeException something like AmazonS3Exception 503.
    */
@@ -95,6 +105,7 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     private FileSystem fs;
     private int count = 1;
     private int loop;
+    private short defaultReplication = 3;
 
     public FakeRemoteFileSystem(FileSystem fs, int retryLoop) {
       this.fs = fs;
@@ -218,5 +229,16 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     public String getScheme() {
       return fs.getScheme();
     }
+
+    @Override
+    public short getDefaultReplication() {
+      return  defaultReplication;
+    }
+
+    @Override
+    public short getDefaultReplication(Path path) {
+      return defaultReplication;
+    }
+
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
@@ -37,8 +37,8 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**


### PR DESCRIPTION
### Change Logs

When mor table enable  HoodieRetryWrapperFileSystem through the configuration  `hoodie.filesystem.operation.retry.enable=true` ，log file in hdfs only has one replication.

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
