### PR TITLE
[HUDI-5919] Fix the validation of partition listing in metadata table validator

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -92,6 +92,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.INSTANT_TIME;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.hadoop.CachingPath.getPathWithoutSchemeAndAuthority;
 
 /**
@@ -543,7 +544,8 @@ public class HoodieMetadataTableValidator implements Serializable {
         if (!completedTimeline.containsOrBeforeTimelineStarts(instantTime)) {
           Option<HoodieInstant> lastInstant = completedTimeline.lastInstant();
           return lastInstant.isPresent()
-              && lastInstant.get().getTimestamp().compareTo(instantTime) >= 0;
+              && HoodieTimeline.compareTimestamps(
+              instantTime, LESSER_THAN_OR_EQUALS, lastInstant.get().getTimestamp());
         }
         return true;
       } else {


### PR DESCRIPTION
### Change Logs

In the following scenario, before this fix, the validation job fires a false alarm complaining that the partition list returned by the file system does not match that of the metadata table:
- Commit C1 creates the partition, the partition metadata is written, and C1 fails during writing data files.  Next time, C2 adds new data to the same partition after C1 is rolled back. In this case, the partition metadata still has C1 as the created commit time, since Hudi does not rewrite the partition metadata in C2.  Note that there are other commits in the active timeline before C1, which created existing partitions.

In this case, the validator filters the partition out in the partition list returned by the file system, thinking that the partition is created by a failed commit and should not be included.

```
23/03/11 00:27:18 ERROR HoodieMetadataTableValidator: Compare Partitions Failed! AllPartitionPathsFromFS : [2022/1/24, 2022/1/25, 2022/1/26, 2022/1/29, 2022/2/1, 2022/2/2] and allPartitionPathsMeta : [2022/1/24, 2022/1/25, 2022/1/26, 2022/1/27, 2022/1/28, 2022/1/29, 2022/1/30, 2022/1/31, 2022/2/1, 2022/2/2]
23/03/11 00:27:18 ERROR HoodieMetadataTableValidator: Metadata table validation failed to HoodieValidationException
org.apache.hudi.exception.HoodieValidationException: Compare Partitions Failed! AllPartitionPathsFromFS : [2022/1/24, 2022/1/25, 2022/1/26, 2022/1/29, 2022/2/1, 2022/2/2] and allPartitionPathsMeta : [2022/1/24, 2022/1/25, 2022/1/26, 2022/1/27, 2022/1/28, 2022/1/29, 2022/1/30, 2022/1/31, 2022/2/1, 2022/2/2]
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.validatePartitions(HoodieMetadataTableValidator.java:551)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.doMetadataTableValidation(HoodieMetadataTableValidator.java:441)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.doHoodieMetadataTableValidationOnce(HoodieMetadataTableValidator.java:383)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.run(HoodieMetadataTableValidator.java:368)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.main(HoodieMetadataTableValidator.java:348)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:955)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1043)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1052)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

This PR fixes the validation of partition listing in metadata table validator for this case, by checking if the created commit time is the same as or before the latest completed commit.  The above case does not fire a false alarm anymore.

### Impact

Fixes the false validation failure in the scenario where the commit creating the partitions fails and is rolled back later.  The fix is tested locally for the above scenario and other scenarios and all of them pass.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
