### PR TITLE
[MINOR][DOCS] fix HiveMetastore lock provider package name

### DIFF
--- a/website/docs/concurrency_control.md
+++ b/website/docs/concurrency_control.md
@@ -69,7 +69,7 @@ hoodie.write.lock.zookeeper.base_path
 **`HiveMetastore`** based lock provider
 
 ```
-hoodie.write.lock.provider=org.apache.hudi.hive.HiveMetastoreBasedLockProvider
+hoodie.write.lock.provider=org.apache.hudi.hive.transaction.lock.HiveMetastoreBasedLockProvider
 hoodie.write.lock.hivemetastore.database
 hoodie.write.lock.hivemetastore.table
 ```

--- a/website/versioned_docs/version-0.13.0/concurrency_control.md
+++ b/website/versioned_docs/version-0.13.0/concurrency_control.md
@@ -69,7 +69,7 @@ hoodie.write.lock.zookeeper.base_path
 **`HiveMetastore`** based lock provider
 
 ```
-hoodie.write.lock.provider=org.apache.hudi.hive.HiveMetastoreBasedLockProvider
+hoodie.write.lock.provider=org.apache.hudi.hive.transaction.lock.HiveMetastoreBasedLockProvider
 hoodie.write.lock.hivemetastore.database
 hoodie.write.lock.hivemetastore.table
 ```


### PR DESCRIPTION
### Change Logs

HiveMetastore lock provider full name `org.apache.hudi.hive.HiveMetastoreBasedLockProvider` -> `org.apache.hudi.hive.transaction.lock.HiveMetastoreBasedLockProvider`

According to the code https://github.com/apache/hudi/blob/master/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java

### Impact

NO impact, doc update only.

### Risk level (write none, low medium or high below)

none

### Documentation Update

Update HiveMetastore lock provider full name in concurrency control doc.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
