### PR TITLE
[MINOR][DOCS] HMS mode with Spark datasource is already supported.

### DIFF
--- a/website/docs/syncing_metastore.md
+++ b/website/docs/syncing_metastore.md
@@ -62,7 +62,6 @@ HMS mode uses the hive metastore client to sync Hudi table using thrift APIs dir
 To use this mode, pass `--sync-mode=hms` to `run_sync_tool` and set `--use-jdbc=false`. 
 Additionally, if you are using remote metastore, then `hive.metastore.uris` need to be set in hive-site.xml configuration file.
 Otherwise, the tool assumes that metastore is running locally on port 9083 by default. 
-Support for HMS mode with Spark datasource will be [enabled soon](https://issues.apache.org/jira/browse/HUDI-2491).
 
 #### HIVEQL
 


### PR DESCRIPTION
### Change Logs

The document says HMS mode with Spark datasource will be supported soon, but it's already supported. This change removes the outdated sentence.

### Impact

N/A

### Risk level (write none, low medium or high below)

none

### Documentation Update

Remove the outdated sentence.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
