### PR TITLE
[HUDI-5921] Partition path should be considered in BucketIndexConcurrentFileWritesConflictResolutionStrategy

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/BucketIndexConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/BucketIndexConcurrentFileWritesConflictResolutionStrategy.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This class is a basic implementation of a conflict resolution strategy for concurrent writes {@link ConflictResolutionStrategy} using bucket index.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentOperation.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentOperation.java
@@ -18,9 +18,7 @@
 
 package org.apache.hudi.client.transaction;
 
-import org.apache.hudi.avro.model.HoodieCompactionOperation;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
-import org.apache.hudi.avro.model.HoodieSliceInfo;
 import org.apache.hudi.client.utils.MetadataConversionUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieMetadataWrapper;
@@ -29,6 +27,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -40,7 +39,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_AC
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LOG_COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
-import static org.apache.hudi.common.util.CommitUtils.getFileIdWithoutSuffixAndRelativePathsFromSpecificRecord;
+import static org.apache.hudi.common.util.CommitUtils.getPartitionAndFileIdWithoutSuffix;
 
 /**
  * This class is used to hold all information used to identify how to resolve conflicts between instants.
@@ -55,7 +54,7 @@ public class ConcurrentOperation {
   private final String actionState;
   private final String actionType;
   private final String instantTime;
-  private Set<String> mutatedFileIds = Collections.emptySet();
+  private Set<Pair<String, String>> mutatedPartitionAndFileIds = Collections.emptySet();
 
   public ConcurrentOperation(HoodieInstant instant, HoodieTableMetaClient metaClient) throws IOException {
     this.metadataWrapper = new HoodieMetadataWrapper(MetadataConversionUtils.createMetaWrapper(instant, metaClient));
@@ -91,8 +90,8 @@ public class ConcurrentOperation {
     return operationType;
   }
 
-  public Set<String> getMutatedFileIds() {
-    return mutatedFileIds;
+  public Set<Pair<String, String>> getMutatedPartitionAndFileIds() {
+    return mutatedPartitionAndFileIds;
   }
 
   public Option<HoodieCommitMetadata> getCommitMetadataOption() {
@@ -104,21 +103,21 @@ public class ConcurrentOperation {
       switch (getInstantActionType()) {
         case COMPACTION_ACTION:
           this.operationType = WriteOperationType.COMPACT;
-          this.mutatedFileIds = this.metadataWrapper.getMetadataFromTimeline().getHoodieCompactionPlan().getOperations()
+          this.mutatedPartitionAndFileIds = this.metadataWrapper.getMetadataFromTimeline().getHoodieCompactionPlan().getOperations()
               .stream()
-              .map(HoodieCompactionOperation::getFileId)
+              .map(operation -> Pair.of(operation.getPartitionPath(), operation.getFileId()))
               .collect(Collectors.toSet());
           break;
         case COMMIT_ACTION:
         case DELTA_COMMIT_ACTION:
-          this.mutatedFileIds = getFileIdWithoutSuffixAndRelativePathsFromSpecificRecord(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata()
-              .getPartitionToWriteStats()).keySet();
+          this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffix(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata()
+              .getPartitionToWriteStats());
           this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata().getOperationType());
           break;
         case REPLACE_COMMIT_ACTION:
           if (instant.isCompleted()) {
-            this.mutatedFileIds = getFileIdWithoutSuffixAndRelativePathsFromSpecificRecord(
-                this.metadataWrapper.getMetadataFromTimeline().getHoodieReplaceCommitMetadata().getPartitionToWriteStats()).keySet();
+            this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffix(
+                this.metadataWrapper.getMetadataFromTimeline().getHoodieReplaceCommitMetadata().getPartitionToWriteStats());
             this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieReplaceCommitMetadata().getOperationType());
           } else {
             // we need to have different handling for requested and inflight replacecommit because
@@ -129,16 +128,16 @@ public class ConcurrentOperation {
             if (instant.isRequested()) {
               // for insert_overwrite/insert_overwrite_table clusteringPlan will be empty
               if (requestedReplaceMetadata != null && requestedReplaceMetadata.getClusteringPlan() != null) {
-                this.mutatedFileIds = getFileIdsFromRequestedReplaceMetadata(requestedReplaceMetadata);
+                this.mutatedPartitionAndFileIds = getPartitionAndFileIdsFromRequestedReplaceMetadata(requestedReplaceMetadata);
                 this.operationType = WriteOperationType.CLUSTER;
               }
             } else {
               if (inflightCommitMetadata != null) {
-                this.mutatedFileIds = getFileIdWithoutSuffixAndRelativePathsFromSpecificRecord(inflightCommitMetadata.getPartitionToWriteStats()).keySet();
+                this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffix(inflightCommitMetadata.getPartitionToWriteStats());
                 this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieInflightReplaceMetadata().getOperationType());
               } else if (requestedReplaceMetadata != null) {
                 // inflight replacecommit metadata is empty due to clustering, read fileIds from requested replacecommit
-                this.mutatedFileIds = getFileIdsFromRequestedReplaceMetadata(requestedReplaceMetadata);
+                this.mutatedPartitionAndFileIds = getPartitionAndFileIdsFromRequestedReplaceMetadata(requestedReplaceMetadata);
                 this.operationType = WriteOperationType.CLUSTER;
               }
               // NOTE: it cannot be the case that instant is inflight, and both the requested and inflight replacecommit metadata are empty
@@ -157,7 +156,7 @@ public class ConcurrentOperation {
         case DELTA_COMMIT_ACTION:
         case REPLACE_COMMIT_ACTION:
         case LOG_COMPACTION_ACTION:
-          this.mutatedFileIds = CommitUtils.getFileIdWithoutSuffixAndRelativePaths(this.metadataWrapper.getCommitMetadata().getPartitionToWriteStats()).keySet();
+          this.mutatedPartitionAndFileIds = CommitUtils.getPartitionAndFileIdWithoutSuffixAndRelativePaths(this.metadataWrapper.getCommitMetadata().getPartitionToWriteStats());
           this.operationType = this.metadataWrapper.getCommitMetadata().getOperationType();
           break;
         default:
@@ -166,12 +165,12 @@ public class ConcurrentOperation {
     }
   }
 
-  private static Set<String> getFileIdsFromRequestedReplaceMetadata(HoodieRequestedReplaceMetadata requestedReplaceMetadata) {
+  private static Set<Pair<String, String>> getPartitionAndFileIdsFromRequestedReplaceMetadata(HoodieRequestedReplaceMetadata requestedReplaceMetadata) {
     return requestedReplaceMetadata
         .getClusteringPlan().getInputGroups()
         .stream()
         .flatMap(ig -> ig.getSlices().stream())
-        .map(HoodieSliceInfo::getFileId)
+        .map(fileSlice -> Pair.of(fileSlice.getPartitionPath(), fileSlice.getFileId()))
         .collect(Collectors.toSet());
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentOperation.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentOperation.java
@@ -39,7 +39,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_AC
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LOG_COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
-import static org.apache.hudi.common.util.CommitUtils.getPartitionAndFileIdWithoutSuffix;
+import static org.apache.hudi.common.util.CommitUtils.getPartitionAndFileIdWithoutSuffixFromSpecificRecord;
 
 /**
  * This class is used to hold all information used to identify how to resolve conflicts between instants.
@@ -110,13 +110,13 @@ public class ConcurrentOperation {
           break;
         case COMMIT_ACTION:
         case DELTA_COMMIT_ACTION:
-          this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffix(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata()
+          this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffixFromSpecificRecord(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata()
               .getPartitionToWriteStats());
           this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieCommitMetadata().getOperationType());
           break;
         case REPLACE_COMMIT_ACTION:
           if (instant.isCompleted()) {
-            this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffix(
+            this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffixFromSpecificRecord(
                 this.metadataWrapper.getMetadataFromTimeline().getHoodieReplaceCommitMetadata().getPartitionToWriteStats());
             this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieReplaceCommitMetadata().getOperationType());
           } else {
@@ -133,7 +133,7 @@ public class ConcurrentOperation {
               }
             } else {
               if (inflightCommitMetadata != null) {
-                this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffix(inflightCommitMetadata.getPartitionToWriteStats());
+                this.mutatedPartitionAndFileIds = getPartitionAndFileIdWithoutSuffixFromSpecificRecord(inflightCommitMetadata.getPartitionToWriteStats());
                 this.operationType = WriteOperationType.fromValue(this.metadataWrapper.getMetadataFromTimeline().getHoodieInflightReplaceMetadata().getOperationType());
               } else if (requestedReplaceMetadata != null) {
                 // inflight replacecommit metadata is empty due to clustering, read fileIds from requested replacecommit
@@ -156,7 +156,7 @@ public class ConcurrentOperation {
         case DELTA_COMMIT_ACTION:
         case REPLACE_COMMIT_ACTION:
         case LOG_COMPACTION_ACTION:
-          this.mutatedPartitionAndFileIds = CommitUtils.getPartitionAndFileIdWithoutSuffixAndRelativePaths(this.metadataWrapper.getCommitMetadata().getPartitionToWriteStats());
+          this.mutatedPartitionAndFileIds = CommitUtils.getPartitionAndFileIdWithoutSuffix(this.metadataWrapper.getCommitMetadata().getPartitionToWriteStats());
           this.operationType = this.metadataWrapper.getCommitMetadata().getOperationType();
           break;
         default:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieWriteConflictException;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.log4j.LogManager;
@@ -72,10 +73,10 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
   @Override
   public boolean hasConflict(ConcurrentOperation thisOperation, ConcurrentOperation otherOperation) {
     // TODO : UUID's can clash even for insert/insert, handle that case.
-    Set<String> fileIdsSetForFirstInstant = thisOperation.getMutatedFileIds();
-    Set<String> fileIdsSetForSecondInstant = otherOperation.getMutatedFileIds();
-    Set<String> intersection = new HashSet<>(fileIdsSetForFirstInstant);
-    intersection.retainAll(fileIdsSetForSecondInstant);
+    Set<Pair<String, String>> partitionAndFileIdsSetForFirstInstant = thisOperation.getMutatedPartitionAndFileIds();
+    Set<Pair<String, String>> partitionAndFileIdsSetForSecondInstant = otherOperation.getMutatedPartitionAndFileIds();
+    Set<Pair<String, String>> intersection = new HashSet<>(partitionAndFileIdsSetForFirstInstant);
+    intersection.retainAll(partitionAndFileIdsSetForSecondInstant);
     if (!intersection.isEmpty()) {
       LOG.info("Found conflicting writes between first operation = " + thisOperation
           + ", second operation = " + otherOperation + " , intersecting file ids " + intersection);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -78,7 +78,7 @@ public class TransactionUtils {
       final ConcurrentOperation thisOperation = new ConcurrentOperation(currentTxnOwnerInstant.get(), thisCommitMetadata.orElse(new HoodieCommitMetadata()));
       instantStream.forEach(instant -> {
         try {
-          ConcurrentOperation otherOperation = new ConcurrentOperation(instant, TimelineUtils.getCommitMetadata(instant, table.getActiveTimeline()));
+          ConcurrentOperation otherOperation = new ConcurrentOperation(instant, table.getMetaClient());
           if (resolutionStrategy.hasConflict(thisOperation, otherOperation)) {
             LOG.info("Conflict encountered between current instant = " + thisOperation + " and instant = "
                 + otherOperation + ", attempting to resolve it...");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -78,7 +78,8 @@ public class TransactionUtils {
       final ConcurrentOperation thisOperation = new ConcurrentOperation(currentTxnOwnerInstant.get(), thisCommitMetadata.orElse(new HoodieCommitMetadata()));
       instantStream.forEach(instant -> {
         try {
-          ConcurrentOperation otherOperation = new ConcurrentOperation(instant, table.getMetaClient());
+          ConcurrentOperation otherOperation = new ConcurrentOperation(instant, TimelineUtils.getCommitMetadata(instant, reloadActiveTimeline
+              ? table.getMetaClient().reloadActiveTimeline() : table.getActiveTimeline()));
           if (resolutionStrategy.hasConflict(thisOperation, otherOperation)) {
             LOG.info("Conflict encountered between current instant = " + thisOperation + " and instant = "
                 + otherOperation + ", attempting to resolve it...");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -79,13 +79,7 @@ public class TransactionUtils {
       final ConcurrentOperation thisOperation = new ConcurrentOperation(currentTxnOwnerInstant.get(), thisCommitMetadata.orElse(new HoodieCommitMetadata()));
       instantStream.forEach(instant -> {
         try {
-          ConcurrentOperation otherOperation;
-          if (resolutionStrategy.getClass().getName().equals(BucketIndexConcurrentFileWritesConflictResolutionStrategy.class.getName())) {
-            otherOperation = new ConcurrentOperation(instant, TimelineUtils.getCommitMetadata(instant,
-                reloadActiveTimeline ? table.getMetaClient().reloadActiveTimeline() : table.getActiveTimeline()));
-          } else {
-            otherOperation = new ConcurrentOperation(instant, table.getMetaClient());
-          }
+          ConcurrentOperation otherOperation = new ConcurrentOperation(instant, TimelineUtils.getCommitMetadata(instant, table.getActiveTimeline()));
           if (resolutionStrategy.hasConflict(thisOperation, otherOperation)) {
             LOG.info("Conflict encountered between current instant = " + thisOperation + " and instant = "
                 + otherOperation + ", attempting to resolve it...");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.client.utils;
 
-import org.apache.hudi.client.transaction.BucketIndexConcurrentFileWritesConflictResolutionStrategy;
 import org.apache.hudi.client.transaction.ConcurrentOperation;
 import org.apache.hudi.client.transaction.ConflictResolutionStrategy;
 import org.apache.hudi.common.model.HoodieCommitMetadata;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/CompactHelpers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/CompactHelpers.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
@@ -65,6 +66,7 @@ public class CompactHelpers<T, I, K, O> {
       metadata.addWriteStat(stat.getPartitionPath(), stat);
     }
     metadata.addMetadata(org.apache.hudi.common.model.HoodieCommitMetadata.SCHEMA_KEY, schema);
+    metadata.setOperationType(WriteOperationType.COMPACT);
     if (compactionPlan.getExtraMetadata() != null) {
       compactionPlan.getExtraMetadata().forEach(metadata::addMetadata);
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -68,9 +69,9 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
     createCommit(newInstantTime);
     // consider commits before this are all successful
     // writer 1
-    createInflightCommit(HoodieTestTable.makeNewCommitTime());
+    createInflightCommit(HoodieTestTable.makeNewCommitTime(), HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
     // writer 2
-    createInflightCommit(HoodieTestTable.makeNewCommitTime());
+    createInflightCommit(HoodieTestTable.makeNewCommitTime(), HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
     Option<HoodieInstant> lastSuccessfulInstant = metaClient.getCommitsTimeline().filterCompletedInstants().lastInstant();
     newInstantTime = HoodieTestTable.makeNewCommitTime();
     Option<HoodieInstant> currentInstant = Option.of(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, newInstantTime));
@@ -87,20 +88,20 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
     // writer 1 starts
     String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
-    createInflightCommit(currentWriterInstant);
+    createInflightCommit(currentWriterInstant, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
     // writer 2 starts and finishes
     String newInstantTime = HoodieActiveTimeline.createNewInstantTime();
     createCommit(newInstantTime);
 
     Option<HoodieInstant> currentInstant = Option.of(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
     SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new BucketIndexConcurrentFileWritesConflictResolutionStrategy();
-    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
+    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant, HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
     timeline = timeline.reload();
     List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(timeline, currentInstant.get(), lastSuccessfulInstant).collect(
         Collectors.toList());
     // writer 1 conflicts with writer 2
     Assertions.assertEquals(1, candidateInstants.size());
-    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
+    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), TimelineUtils.getCommitMetadata(candidateInstants.get(0), metaClient.getActiveTimeline().reload()));
     ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
     Assertions.assertTrue(strategy.hasConflict(thisCommitOperation, thatCommitOperation));
     try {
@@ -109,6 +110,33 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
     } catch (HoodieWriteConflictException e) {
       // expected
     }
+  }
+
+  @Test
+  public void testConcurrentWritesWithDifferentPartition() throws Exception {
+    createCommit(HoodieActiveTimeline.createNewInstantTime());
+    HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+    // consider commits before this are all successful
+    Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
+    // writer 1 starts
+    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    createInflightCommit(currentWriterInstant, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH);
+    // writer 2 starts and finishes
+    String newInstantTime = HoodieActiveTimeline.createNewInstantTime();
+    createCommit(newInstantTime);
+
+    Option<HoodieInstant> currentInstant = Option.of(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
+    SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new BucketIndexConcurrentFileWritesConflictResolutionStrategy();
+    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH);
+    timeline = timeline.reload();
+    List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(timeline, currentInstant.get(), lastSuccessfulInstant).collect(
+        Collectors.toList());
+
+    // writer 1 conflicts with writer 2
+    Assertions.assertEquals(1, candidateInstants.size());
+    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), TimelineUtils.getCommitMetadata(candidateInstants.get(0), metaClient.getActiveTimeline().reload()));
+    ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
+    Assertions.assertFalse(strategy.hasConflict(thisCommitOperation, thatCommitOperation));
   }
 
   private void createCommit(String instantTime) throws Exception {
@@ -126,25 +154,25 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
         .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
   }
 
-  private HoodieCommitMetadata createCommitMetadata(String instantTime, String writeFileName) {
+  private HoodieCommitMetadata createCommitMetadata(String instantTime, String writeFileName, String partition) {
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     commitMetadata.addMetadata("test", "test");
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId(writeFileName);
-    commitMetadata.addWriteStat(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, writeStat);
+    commitMetadata.addWriteStat(partition, writeStat);
     commitMetadata.setOperationType(WriteOperationType.INSERT);
     return commitMetadata;
   }
 
-  private HoodieCommitMetadata createCommitMetadata(String instantTime) {
-    return createCommitMetadata(instantTime, "00000001-file-" + instantTime + "-1");
+  private HoodieCommitMetadata createCommitMetadata(String instantTime, String partition) {
+    return createCommitMetadata(instantTime, "00000001-file-" + instantTime + "-1", partition);
   }
 
-  private void createInflightCommit(String instantTime) throws Exception {
+  private void createInflightCommit(String instantTime, String partition) throws Exception {
     String fileId1 = "00000001-file-" + instantTime + "-1";
     String fileId2 = "00000002-file-" + instantTime + "-2";
     HoodieTestTable.of(metaClient)
         .addInflightCommit(instantTime)
-        .withBaseFilesInPartition(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, fileId1, fileId2);
+        .withBaseFilesInPartition(partition, fileId1, fileId2);
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
@@ -132,10 +132,11 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
     List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(timeline, currentInstant.get(), lastSuccessfulInstant).collect(
         Collectors.toList());
 
-    // writer 1 conflicts with writer 2
+    // there should be 1 candidate instant
     Assertions.assertEquals(1, candidateInstants.size());
     ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), TimelineUtils.getCommitMetadata(candidateInstants.get(0), metaClient.getActiveTimeline().reload()));
     ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
+    // there should be no conflict between writer 1 and writer 2
     Assertions.assertFalse(strategy.hasConflict(thisCommitOperation, thatCommitOperation));
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestBucketIndexConcurrentFileWritesConflictResolutionStrategy.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -101,7 +100,7 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
         Collectors.toList());
     // writer 1 conflicts with writer 2
     Assertions.assertEquals(1, candidateInstants.size());
-    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), TimelineUtils.getCommitMetadata(candidateInstants.get(0), metaClient.getActiveTimeline().reload()));
+    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
     ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
     Assertions.assertTrue(strategy.hasConflict(thisCommitOperation, thatCommitOperation));
     try {
@@ -134,7 +133,7 @@ public class TestBucketIndexConcurrentFileWritesConflictResolutionStrategy exten
 
     // there should be 1 candidate instant
     Assertions.assertEquals(1, candidateInstants.size());
-    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), TimelineUtils.getCommitMetadata(candidateInstants.get(0), metaClient.getActiveTimeline().reload()));
+    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
     ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
     // there should be no conflict between writer 1 and writer 2
     Assertions.assertFalse(strategy.hasConflict(thisCommitOperation, thatCommitOperation));

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
@@ -119,7 +119,7 @@ public class CommitUtils {
     return commitMetadata;
   }
 
-  public static Set<Pair<String, String>> getPartitionAndFileIdWithoutSuffix(Map<String, List<org.apache.hudi.avro.model.HoodieWriteStat>>
+  public static Set<Pair<String, String>> getPartitionAndFileIdWithoutSuffixFromSpecificRecord(Map<String, List<org.apache.hudi.avro.model.HoodieWriteStat>>
                                                                                                      partitionToWriteStats) {
     Set<Pair<String, String>> partitionToFileId = new HashSet<>();
     // list all partitions paths
@@ -131,7 +131,7 @@ public class CommitUtils {
     return partitionToFileId;
   }
 
-  public static Set<Pair<String, String>> getPartitionAndFileIdWithoutSuffixAndRelativePaths(Map<String, List<HoodieWriteStat>> partitionToWriteStats) {
+  public static Set<Pair<String, String>> getPartitionAndFileIdWithoutSuffix(Map<String, List<HoodieWriteStat>> partitionToWriteStats) {
     Set<Pair<String, String>> partitionTofileId = new HashSet<>();
     // list all partitions paths
     for (Map.Entry<String, List<HoodieWriteStat>> entry : partitionToWriteStats.entrySet()) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 
@@ -33,9 +34,10 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Helper class to generate commit metadata.
@@ -117,28 +119,27 @@ public class CommitUtils {
     return commitMetadata;
   }
 
-  public static HashMap<String, String> getFileIdWithoutSuffixAndRelativePathsFromSpecificRecord(Map<String, List<org.apache.hudi.avro.model.HoodieWriteStat>>
-                                                                                       partitionToWriteStats) {
-    HashMap<String, String> fileIdToPath = new HashMap<>();
+  public static Set<Pair<String, String>> getPartitionAndFileIdWithoutSuffix(Map<String, List<org.apache.hudi.avro.model.HoodieWriteStat>>
+                                                                                                     partitionToWriteStats) {
+    Set<Pair<String, String>> partitionToFileId = new HashSet<>();
     // list all partitions paths
     for (Map.Entry<String, List<org.apache.hudi.avro.model.HoodieWriteStat>> entry : partitionToWriteStats.entrySet()) {
       for (org.apache.hudi.avro.model.HoodieWriteStat stat : entry.getValue()) {
-        fileIdToPath.put(stat.getFileId(), stat.getPath());
+        partitionToFileId.add(Pair.of(entry.getKey(), stat.getFileId()));
       }
     }
-    return fileIdToPath;
+    return partitionToFileId;
   }
 
-  public static HashMap<String, String> getFileIdWithoutSuffixAndRelativePaths(Map<String, List<HoodieWriteStat>>
-      partitionToWriteStats) {
-    HashMap<String, String> fileIdToPath = new HashMap<>();
+  public static Set<Pair<String, String>> getPartitionAndFileIdWithoutSuffixAndRelativePaths(Map<String, List<HoodieWriteStat>> partitionToWriteStats) {
+    Set<Pair<String, String>> partitionTofileId = new HashSet<>();
     // list all partitions paths
     for (Map.Entry<String, List<HoodieWriteStat>> entry : partitionToWriteStats.entrySet()) {
       for (HoodieWriteStat stat : entry.getValue()) {
-        fileIdToPath.put(stat.getFileId(), stat.getPath());
+        partitionTofileId.add(Pair.of(entry.getKey(), stat.getFileId()));
       }
     }
-    return fileIdToPath;
+    return partitionTofileId;
   }
 
   /**


### PR DESCRIPTION

### Change Logs

When we do conflict detecting on BUCKET index table, we check bucketId to see if there is a conflict, for partitioned table, if two client write different partition but same bucketId, there will be a conflict, actually this case should not have conflict.

This pr check partition+bucketId to see if there is a conflict.

### Impact

none

### Risk level (write none, low medium or high below)
low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
