### PR TITLE
[HUDI-5925] Improve bootstrap parallelism

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
@@ -96,7 +96,15 @@ public class HoodieBootstrapConfig extends HoodieConfig {
       .key("hoodie.bootstrap.parallelism")
       .defaultValue("1500")
       .sinceVersion("0.6.0")
-      .withDocumentation("Parallelism value to be used to bootstrap data into hudi");
+      .withDocumentation("For metadata-only bootstrap, Hudi parallelizes the operation so that "
+          + "each table partition is handled by one Spark task. This config limits the number "
+          + "of parallelism. We pick the configured parallelism if the number of table partitions "
+          + "is larger than this configured value. The parallelism is assigned to the number of "
+          + "table partitions if it is smaller than the configured value. For full-record "
+          + "bootstrap, i.e., BULK_INSERT operation of the records, this configured value is "
+          + "passed as the BULK_INSERT shuffle parallelism (`hoodie.bulkinsert.shuffle.parallelism`), "
+          + "determining the BULK_INSERT write behavior. If you see that the bootstrap is slow "
+          + "due to the limited parallelism, you can increase this.");
 
   public static final ConfigProperty<String> PARTITION_SELECTOR_REGEX_PATTERN = ConfigProperty
       .key("hoodie.bootstrap.mode.selector.regex")

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
@@ -368,9 +368,10 @@ public class SparkBootstrapCommitActionExecutor<T>
         .collect(Collectors.toList());
 
     context.setJobStatus(this.getClass().getSimpleName(), "Run metadata-only bootstrap operation: " + config.getTableName());
-    return context.parallelize(bootstrapPaths, config.getBootstrapParallelism())
+    return context.parallelize(
+            bootstrapPaths, Math.min(bootstrapPaths.size(), config.getBootstrapParallelism()))
         .map(partitionFsPair -> getMetadataHandler(config, table, partitionFsPair.getRight().getRight()).runMetadataBootstrap(partitionFsPair.getLeft(),
-                partitionFsPair.getRight().getLeft(), keyGenerator));
+            partitionFsPair.getRight().getLeft(), keyGenerator));
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

This PR improves the bootstrap parallelism to take the minimum of number of bootstrap paths and the configured parallelism.

### Impact

Limits the bootstrap parallelism when necessary.

### Risk level

none

### Documentation Update

The description of `hoodie.bootstrap.parallelism` config is updated.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
