### PR TITLE
[HUDI-5927] Improve parallelism of deleting invalid files

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -94,6 +94,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -660,21 +661,17 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   private void deleteInvalidFilesByPartitions(HoodieEngineContext context, Map<String, List<Pair<String, String>>> invalidFilesByPartition) {
     // Now delete partially written files
     context.setJobStatus(this.getClass().getSimpleName(), "Delete invalid files generated during the write operation: " + config.getTableName());
-    context.map(new ArrayList<>(invalidFilesByPartition.values()), partitionWithFileList -> {
+    context.map(invalidFilesByPartition.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList()), partitionFilePair -> {
       final FileSystem fileSystem = metaClient.getFs();
-      LOG.info("Deleting invalid data files=" + partitionWithFileList);
-      if (partitionWithFileList.isEmpty()) {
-        return true;
-      }
+      LOG.info("Deleting invalid data file=" + partitionFilePair);
       // Delete
-      partitionWithFileList.stream().map(Pair::getValue).forEach(file -> {
-        try {
-          fileSystem.delete(new Path(file), false);
-        } catch (IOException e) {
-          throw new HoodieIOException(e.getMessage(), e);
-        }
-      });
-
+      try {
+        fileSystem.delete(new Path(partitionFilePair.getValue()), false);
+      } catch (IOException e) {
+        throw new HoodieIOException(e.getMessage(), e);
+      }
       return true;
     }, config.getFinalizeWriteParallelism());
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -662,18 +662,19 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     // Now delete partially written files
     context.setJobStatus(this.getClass().getSimpleName(), "Delete invalid files generated during the write operation: " + config.getTableName());
     context.map(invalidFilesByPartition.values().stream()
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList()), partitionFilePair -> {
-      final FileSystem fileSystem = metaClient.getFs();
-      LOG.info("Deleting invalid data file=" + partitionFilePair);
-      // Delete
-      try {
-        fileSystem.delete(new Path(partitionFilePair.getValue()), false);
-      } catch (IOException e) {
-        throw new HoodieIOException(e.getMessage(), e);
-      }
-      return true;
-    }, config.getFinalizeWriteParallelism());
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList()),
+        partitionFilePair -> {
+          final FileSystem fileSystem = metaClient.getFs();
+          LOG.info("Deleting invalid data file=" + partitionFilePair);
+          // Delete
+          try {
+            fileSystem.delete(new Path(partitionFilePair.getValue()), false);
+          } catch (IOException e) {
+            throw new HoodieIOException(e.getMessage(), e);
+          }
+          return true;
+        }, config.getFinalizeWriteParallelism());
   }
 
   /**


### PR DESCRIPTION
### Change Logs

This PR improves the parallelism of deleting invalid files when finalizing the write, so that the file deletion is parallelized at the file level instead of the partition level.

### Impact

Improves the parallelism of deleting invalid files.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
