### PR TITLE
[HUDI-5928] Fixing graceful shut down of deltastreamer with post write termination strategy

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -725,10 +725,13 @@ public class HoodieDeltaStreamer implements Serializable {
               Option<HoodieData<WriteStatus>> lastWriteStatuses = Option.ofNullable(
                   scheduledCompactionInstantAndRDD.isPresent() ? HoodieJavaRDD.of(scheduledCompactionInstantAndRDD.get().getRight()) : null);
               if (requestShutdownIfNeeded(lastWriteStatuses)) {
+                LOG.warn("Closing and shutting down ingestion service");
                 error = true;
-                shutdown(false);
+                onIngestionCompletes(false);
+                shutdown(true);
+              } else {
+                sleepBeforeNextIngestion(start);
               }
-              sleepBeforeNextIngestion(start);
             } catch (HoodieUpsertException ue) {
               handleUpsertException(ue);
             } catch (Exception e) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -827,9 +827,9 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(value = HoodieRecordType.class, names = {"AVRO", "SPARK"})
-  public void testUpsertsCOWContinuousModeShutdownGracefully(HoodieRecordType recordType) throws Exception {
-    testUpsertsContinuousMode(HoodieTableType.COPY_ON_WRITE, "continuous_cow", true, recordType);
+  @EnumSource(value = HoodieRecordType.class, names = {"AVRO"})
+  public void testUpsertsMORContinuousModeShutdownGracefully(HoodieRecordType recordType) throws Exception {
+    testUpsertsContinuousMode(HoodieTableType.MERGE_ON_READ, "continuous_cow", true, recordType);
   }
 
   @Disabled("HUDI-5815 for investigation")


### PR DESCRIPTION
### Change Logs

Looks like table services are not propoerly shut down when post write termination kicks in. This patch fixes the flow, where in regular ingestion and any table services are shutdown properly when post write termination is enabled and condition is met. 

### Impact

Improves the usability of post write termination strategy for deltastreamer in continuous mode. 

Test:
Also tested w/ a manual deltastremaer execution. w/o the fix, spark job just hangs, and w/ the fix, it shutsdown gracefully. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
