### PR TITLE
[MINOR] hoodie.datasource.write.row.writer.enable should set to be true.

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -113,7 +113,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     Stream<HoodieData<WriteStatus>> writeStatusesStream = FutureUtils.allOf(
             clusteringPlan.getInputGroups().stream()
                 .map(inputGroup -> {
-                  if (getWriteConfig().getBooleanOrDefault("hoodie.datasource.write.row.writer.enable", false)) {
+                  if (getWriteConfig().getBooleanOrDefault("hoodie.datasource.write.row.writer.enable", true)) {
                     return runClusteringForGroupAsyncAsRow(inputGroup,
                         clusteringPlan.getStrategy().getStrategyParams(),
                         shouldPreserveMetadata,


### PR DESCRIPTION
### Change Logs

Fix the mismatch between the value of hoodie.datasource.write.row.writer.enable and the document.

### Impact

If the user does not find this configuration when sorting within the partition, the desired result will not be obtained.

### Risk level

low

### Documentation Update

No documentation update needed.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
