### PR TITLE
The predicate pushdown misses the where filter condition

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodiePruneFileSourcePartitions.scala
@@ -46,12 +46,12 @@ case class HoodiePruneFileSourcePartitions(spark: SparkSession) extends Rule[Log
       val deterministicFilters = filters.filter(f => f.deterministic && !SubqueryExpression.hasSubquery(f))
       val normalizedFilters = exprUtils.normalizeExprs(deterministicFilters, lr.output)
 
-      val (partitionPruningFilters, _) =
+      val (partitionPruningFilters, dataPruningFilters) =
         getPartitionFiltersAndDataFilters(fileIndex.partitionSchema, normalizedFilters)
 
       // [[HudiFileIndex]] is a caching one, therefore we don't need to reconstruct new relation,
       // instead we simply just refresh the index and update the stats
-      fileIndex.listFiles(partitionPruningFilters, Seq())
+      fileIndex.listFiles(partitionPruningFilters, dataPruningFilters)
 
       if (partitionPruningFilters.nonEmpty) {
         // Change table stats based on the sizeInBytes of pruned files


### PR DESCRIPTION
### Change Logs

Data file pruning adds filter conditions

### Impact

If pruning doesn't work, many useless files will be loaded.

### Risk level (write none, low medium or high below)

NA

### Documentation Update
NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
