### PR TITLE
[MINOR] Fix typo in ValidateMetadataTableFilesProcedure

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateMetadataTableFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateMetadataTableFilesProcedure.scala
@@ -44,7 +44,7 @@ class ValidateMetadataTableFilesProcedure() extends BaseProcedure with Procedure
     StructField("partition", DataTypes.StringType, nullable = true, Metadata.empty),
     StructField("file_name", DataTypes.StringType, nullable = true, Metadata.empty),
     StructField("is_present_in_fs", DataTypes.BooleanType, nullable = true, Metadata.empty),
-    StructField("is_resent_in_metadata", DataTypes.BooleanType, nullable = true, Metadata.empty),
+    StructField("is_present_in_metadata", DataTypes.BooleanType, nullable = true, Metadata.empty),
     StructField("fs_size", DataTypes.LongType, nullable = true, Metadata.empty),
     StructField("metadata_size", DataTypes.LongType, nullable = true, Metadata.empty)
   ))


### PR DESCRIPTION
### Change Logs

Fix typo in ValidateMetadataTableFilesProcedure

### Impact

The program that reads this field directly needs to be modified, but this sql does not exist in the current document and is not commonly used

### Risk level (write none, low medium or high below)

low

### Documentation Update

**https://github.com/apache/hudi/pull/8004**  should be updated if this pr is merged.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
