### PR TITLE
[MINOR] Add another bootstrap method to improve the documentation

### DIFF
--- a/website/versioned_docs/version-0.13.0/migration_guide.md
+++ b/website/versioned_docs/version-0.13.0/migration_guide.md
@@ -78,3 +78,11 @@ fired by via `cd hudi-cli && ./hudi-cli.sh`.
 hudi->bootstrap run --srcPath /tmp/source_table --targetPath /tmp/hoodie/bootstrap_table --tableName bootstrap_table --tableType COPY_ON_WRITE --rowKeyField ${KEY_FIELD} --partitionPathField ${PARTITION_FIELD} --sparkMaster local --hoodieConfigs hoodie.datasource.write.hive_style_partitioning=true --selectorClass org.apache.hudi.client.bootstrap.selector.FullRecordBootstrapModeSelector
 ```
 Unlike deltaStream, FULL_RECORD or METADATA_ONLY is set with --selectorClass, see detalis with help "bootstrap run".
+
+**Option 4**
+You can load an existing table into a Hudi managed one only through SQL.
+Here is an example of using the `spark-sql` script to execute bootstrap through the SQL of `call run_bootstrap`
+
+```
+spark-sql> call run_bootstrap(table => 'bootstrap_table',table_type => 'COPY_ON_WRITE',bootstrap_path => '/tmp/source_table',base_path => '/tmp/hoodie/bootstrap_table', rowKey_field => '${KEY_FIELD}',partition_path_field => '${PARTITION_FIELD}',selector_class => 'org.apache.hudi.client.bootstrap.selector.FullRecordBootstrapModeSelector', bootstrap_overwrite => true);
+```


### PR DESCRIPTION
### Change Logs

Currently, the Call run_bootstrap Produce method is supported to load existing data to hudi.
### Impact

No

### Risk level (write none, low medium or high below)

none
### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
