### PR TITLE
[HUDI-5903]: Introduce Glue sync configs

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -18,9 +18,12 @@
 
 package org.apache.hudi.aws.sync;
 
+import com.amazonaws.ClientConfiguration;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.GlueSyncConfig;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.sync.common.HoodieSyncClient;
 import org.apache.hudi.sync.common.model.Partition;
@@ -92,7 +95,13 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   public AWSGlueCatalogSyncClient(HiveSyncConfig config) {
     super(config);
-    this.awsGlue = AWSGlueClientBuilder.standard().build();
+    String regionValue = config.getString(GlueSyncConfig.GLUE_AWS_REGION);
+    ClientConfiguration configuration = new ClientConfiguration().withMaxConnections(config.getIntOrDefault(GlueSyncConfig.GLUE_MAX_CONNECTIONS));
+    AWSGlueClientBuilder builder = AWSGlueClientBuilder.standard().withClientConfiguration(configuration);
+    if (!StringUtils.isNullOrEmpty(regionValue)) {
+      builder.withRegion(regionValue);
+    }
+    this.awsGlue = builder.build();
     this.databaseName = config.getStringOrDefault(META_SYNC_DATABASE_NAME);
   }
 

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AwsGlueCatalogSyncTool.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AwsGlueCatalogSyncTool.java
@@ -20,6 +20,7 @@ package org.apache.hudi.aws.sync;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.config.GlueSyncConfig;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HiveSyncTool;
 
@@ -53,7 +54,7 @@ public class AwsGlueCatalogSyncTool extends HiveSyncTool {
   }
 
   public static void main(String[] args) {
-    final HiveSyncConfig.HiveSyncConfigParams params = new HiveSyncConfig.HiveSyncConfigParams();
+    final GlueSyncConfig.GlueSyncConfigParams params = new GlueSyncConfig.GlueSyncConfigParams();
     JCommander cmd = JCommander.newBuilder().addObject(params).build();
     cmd.parse(args);
     if (params.isHelp()) {

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueSyncConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueSyncConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.config;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.hive.HiveSyncConfig;
+
+import java.util.Properties;
+
+public class GlueSyncConfig extends HiveSyncConfig {
+
+  public static final ConfigProperty<String> GLUE_AWS_REGION = HoodieAWSConfig.AWS_REGION;
+
+  public static final ConfigProperty<Integer> GLUE_MAX_CONNECTIONS = ConfigProperty
+          .key("hoodie.glue.sync.maxConnections")
+          .defaultValue(50)
+          .withDocumentation("Maximum number of open HTTP connections to glue at any given point in time. AWS allows 50 connections by default."
+                  + "The maximum quota of such connections by default is set as 1000. Please refer the link for more - https://docs.aws.amazon.com/general/latest/gr/glue.html");
+
+  public GlueSyncConfig(Properties properties) {
+    super(properties);
+  }
+
+  public static class GlueSyncConfigParams {
+    @ParametersDelegate
+    public final HiveSyncConfigParams hiveSyncConfigParams = new HiveSyncConfigParams();
+
+    @Parameter(names = {"--region"}, description = "AWS region")
+    public String glueRegion;
+
+    @Parameter(names = {"--max-connections"}, description = "Max connections to glue for concurrent access")
+    public String maxConnections;
+
+    public boolean isHelp() {
+      return hiveSyncConfigParams.isHelp();
+    }
+
+    public TypedProperties toProps() {
+      final TypedProperties props = hiveSyncConfigParams.toProps();
+      props.setPropertyIfNonNull(GLUE_AWS_REGION.key(), glueRegion);
+      props.setPropertyIfNonNull(GLUE_MAX_CONNECTIONS.key(), maxConnections);
+      return props;
+    }
+  }
+}

--- a/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
@@ -63,6 +63,11 @@ public class HoodieAWSConfig extends HoodieConfig {
         .sinceVersion("0.10.0")
         .withDocumentation("AWS session token");
 
+  public static final ConfigProperty<String> AWS_REGION = ConfigProperty
+          .key("hoodie.aws.region")
+          .noDefaultValue()
+          .withDocumentation("AWS region");
+
   private HoodieAWSConfig() {
     super();
   }


### PR DESCRIPTION
This PR is a good starting point for introducing glue sync specific configs. By default, AWS chooses the same region where other services like EMR or EC2 are running. There was no provision for selecting the AWS region so far. Please find more info here - https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html.

### Change Logs

 - Introduce glue sync specific configs

### Impact

 - Users will be able to specifically set AWS region for syncing to glue metastore.
 - Enable users to configure the number of concurrent glue connections.

### Risk level (write none, low medium or high below)

None

### Documentation Update

New configs need to be added. Tracking jira - https://issues.apache.org/jira/browse/HUDI-5946

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
