### PR TITLE
[HUDI-5879] Extends evaluators to support evaluate based on column values

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestExpressionEvaluators.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestExpressionEvaluators.java
@@ -146,7 +146,11 @@ public class TestExpressionEvaluators {
 
     RowData indexRow6 = intIndexRow(null, null);
     Map<String, ColumnStats> stats6 = convertColumnStats(indexRow6, queryFields(2));
-    assertTrue(notEqualTo.eval(stats6), "12 <> null");
+    assertFalse(notEqualTo.eval(stats6), "12 <> 13 and 12 <> 14");
+
+    RowData indexRow7 = intIndexRow(12, 12);
+    Map<String, ColumnStats> stats7 = convertColumnStats(indexRow7, queryFields(2));
+    assertFalse(notEqualTo.eval(stats7), "12 <> null");
 
     notEqualTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
     assertFalse(notEqualTo.eval(stats1), "It is not possible to test for NULL values with '<>' operator");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestExpressionEvaluators.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestExpressionEvaluators.java
@@ -146,11 +146,11 @@ public class TestExpressionEvaluators {
 
     RowData indexRow6 = intIndexRow(null, null);
     Map<String, ColumnStats> stats6 = convertColumnStats(indexRow6, queryFields(2));
-    assertFalse(notEqualTo.eval(stats6), "12 <> 13 and 12 <> 14");
+    assertFalse(notEqualTo.eval(stats6), "12 <> null");
 
     RowData indexRow7 = intIndexRow(12, 12);
     Map<String, ColumnStats> stats7 = convertColumnStats(indexRow7, queryFields(2));
-    assertFalse(notEqualTo.eval(stats7), "12 <> null");
+    assertFalse(notEqualTo.eval(stats7), "12 == 12 == 12");
 
     notEqualTo.bindVal(new ValueLiteralExpression(null, DataTypes.INT()));
     assertFalse(notEqualTo.eval(stats1), "It is not possible to test for NULL values with '<>' operator");


### PR DESCRIPTION
### Change Logs
The pr aims to extends evaluators to support evaluate based on column value.  It could be wrapped in a `ColumnStats` object, which min is same with max and nullCnt is 0.
We need to refactor `IN` and `NotEquals` evaluators to avoid unnecessary overhead of reading data.

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
