### PR TITLE
[HUDI-5949] Check the write operation configured by user for better troubleshooting

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -570,6 +570,22 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
           "Insert Overwrite Partition can not use bulk insert."
         )
       }
+
+      withSQLConf("hoodie.datasource.write.operation" -> "upsert") {
+        val tableName4 = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName4 (
+             |  id int,
+             |  name string,
+             |  price double
+             |) using hudi
+             | tblproperties (primaryKey = 'id')
+        """.stripMargin)
+        checkException(s"insert into table $tableName4 values(1, 'a1', 10)")(
+          "Table without preCombineKey can not use upsert operation."
+        )
+      }
     }
   }
 


### PR DESCRIPTION
### Change Logs
Add the insert operation config check for better troubletshooting, especially for the case where upsert to table without preCombineKey.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
