### PR TITLE
[HUDI-5955] fix incremental clean not work caused by archive

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieAvroPayload;
@@ -548,6 +549,24 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     Path commitFile = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
         + HoodieTimeline.makeRequestedCleanerFileName(instantTime));
     createEmptyFile(basePath, commitFile, configuration);
+  }
+
+  public static void createCleanFile(String basePath, String instantTime, String earliestInstant, Configuration configuration)
+          throws IOException {
+    HoodieCleanMetadata metadata = HoodieCleanMetadata.newBuilder()
+        .setEarliestCommitToRetain(earliestInstant)
+        .setStartCleanTime(instantTime)
+        .setTimeTakenInMillis(1)
+        .setTotalFilesDeleted(1)
+        .setPartitionMetadata(Collections.emptyMap())
+        .setBootstrapPartitionMetadata(Collections.emptyMap())
+        .build();
+    Path filePath = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+        + HoodieTimeline.makeCleanerFileName(instantTime));
+    FileSystem fs = FSUtils.getFs(basePath, configuration);
+    FSDataOutputStream os = fs.create(filePath, true);
+    os.write(TimelineMetadataUtils.serializeCleanMetadata(metadata).get());
+    os.close();
   }
 
   private static void createEmptyFile(String basePath, Path filePath, Configuration configuration) throws IOException {


### PR DESCRIPTION
### Change Logs

Current incremental clean action may miss data files that should be cleaned, if the commit instants of those data files were archived.

This pr make sure when incremental clean enabled, `HoodieTimelineArchiver` won't archive commit instants later than or equals to the `earliestCommitToRetain` of last complete clean instant, so that clean executor can find those file in active timeline.

### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

no

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
