### PR TITLE
[HUDI-5958] Replace deprecated TableSchema with ResolvedSchema

### DIFF
--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
@@ -30,11 +30,13 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.types.Row;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -187,7 +189,10 @@ public final class HoodieFlinkQuickstart {
     if (sourceTable != null) {
       // use the source table schema as the sink schema if the source table was specified, .
       ObjectPath objectPath = new ObjectPath(tEnv.getCurrentDatabase(), sourceTable);
-      TableSchema schema = tEnv.getCatalog(tEnv.getCurrentCatalog()).get().getTable(objectPath).getSchema();
+      String currentCatalog = tEnv.getCurrentCatalog();
+      Catalog catalog = tEnv.getCatalog(currentCatalog).get();
+      ResolvedCatalogTable table = (ResolvedCatalogTable) catalog.getTable(objectPath);
+      ResolvedSchema schema = table.getResolvedSchema();
       sinkDDL = QuickstartConfigurations.getCollectSinkDDL("sink", schema);
     } else {
       sinkDDL = QuickstartConfigurations.getCollectSinkDDL("sink");

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/factory/CollectSinkTableFactory.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/factory/CollectSinkTableFactory.java
@@ -95,7 +95,7 @@ public class CollectSinkTableFactory implements DynamicTableSinkFactory {
     private final String tableName;
 
     private CollectTableSink(
-            ResolvedSchema schema,
+        ResolvedSchema schema,
         String tableName) {
       this.schema = schema;
       this.tableName = tableName;

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/factory/CollectSinkTableFactory.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/factory/CollectSinkTableFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
@@ -62,7 +62,7 @@ public class CollectSinkTableFactory implements DynamicTableSinkFactory {
     FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
     helper.validate();
 
-    TableSchema schema = context.getCatalogTable().getSchema();
+    ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
     RESULT.clear();
     return new CollectTableSink(schema, context.getObjectIdentifier().getObjectName());
   }
@@ -91,11 +91,11 @@ public class CollectSinkTableFactory implements DynamicTableSinkFactory {
    */
   private static class CollectTableSink implements DynamicTableSink {
 
-    private final TableSchema schema;
+    private final ResolvedSchema schema;
     private final String tableName;
 
     private CollectTableSink(
-        TableSchema schema,
+            ResolvedSchema schema,
         String tableName) {
       this.schema = schema;
       this.tableName = tableName;

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/utils/QuickstartConfigurations.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/utils/QuickstartConfigurations.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.DataType;
@@ -159,16 +159,16 @@ public class QuickstartConfigurations {
         + ")";
   }
 
-  public static String getCollectSinkDDL(String tableName, TableSchema tableSchema) {
+  public static String getCollectSinkDDL(String tableName, ResolvedSchema tableSchema) {
     final StringBuilder builder = new StringBuilder("create table " + tableName + "(\n");
-    String[] fieldNames = tableSchema.getFieldNames();
-    DataType[] fieldTypes = tableSchema.getFieldDataTypes();
-    for (int i = 0; i < fieldNames.length; i++) {
+    List<Column> columns = tableSchema.getColumns();
+    for (int i = 0; i < columns.size(); i++) {
+      Column column = columns.get(i);
       builder.append("  `")
-          .append(fieldNames[i])
+          .append(column.getName())
           .append("` ")
-          .append(fieldTypes[i].toString());
-      if (i != fieldNames.length - 1) {
+          .append(column.getDataType());
+      if (i != columns.size() - 1) {
         builder.append(",");
       }
       builder.append("\n");


### PR DESCRIPTION
### Change Logs

JIRA:HUDI-5958. Improve ResolvedSchema Instead of TableSchema.

When reading the code, I found that there is a case of using TableSchema in the flink-example project, TableSchema has been Deprecated, We can use resolvedSchema instead.

### Impact

none.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
