### PR TITLE
[HUDI-5960] Allow bootstrap procedure to throw an exception when execution fails

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunBootstrapProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunBootstrapProcedure.scala
@@ -120,13 +120,7 @@ class RunBootstrapProcedure extends BaseProcedure with ProcedureBuilder with Log
 
     // add session bootstrap conf
     properties.putAll(spark.sqlContext.conf.getAllConfs.asJava)
-    try {
-      new BootstrapExecutorUtils(cfg, jsc, fs, jsc.hadoopConfiguration, properties).execute()
-    } catch {
-      case e: Exception =>
-        logWarning(s"Run bootstrap failed due to", e)
-        Seq(Row(-1))
-    }
+    new BootstrapExecutorUtils(cfg, jsc, fs, jsc.hadoopConfiguration, properties).execute()
     Seq(Row(0))
   }
 


### PR DESCRIPTION
### Change Logs

No exception is thrown when the bootstrap procedure fails. It is necessary to throw out the exception information during the execution process to facilitate the user to locate the problem.

### Impact

No

### Risk level (write none, low medium or high below)

none
### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
