### PR TITLE
[HUDI-5957] Fix table props not being properly propagated for HoodieCLIUtils

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -27,11 +27,11 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
-import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.withSparkConf
+import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 
 import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter}
 
-object HoodieCLIUtils {
+object HoodieCLIUtils extends ProvidesHoodieConfig{
 
   def createHoodieClientFromPath(sparkSession: SparkSession,
                                  basePath: String,
@@ -41,9 +41,7 @@ object HoodieCLIUtils {
     val schemaUtil = new TableSchemaResolver(metaClient)
     val schemaStr = schemaUtil.getTableAvroSchema(false).toString
     val finalParameters = HoodieWriterUtils.parametersWithWriteDefaults(
-      withSparkConf(sparkSession, Map.empty)(
-        conf + (DataSourceWriteOptions.TABLE_TYPE.key() -> metaClient.getTableType.name()))
-    )
+      buildHoodieConfig(getHoodieCatalogTable(sparkSession, metaClient.getTableConfig.getTableName)) ++ conf)
 
     val jsc = new JavaSparkContext(sparkSession.sparkContext)
     DataSourceUtils.createHoodieClient(jsc, schemaStr, basePath,


### PR DESCRIPTION
### Change Logs

At present,  `finalParameters` in `HoodieCLIUtils.createHoodieClientFromPath` not contain table props. 

This causes some problems, such as: 

Run cluster should fail when using bucket index, but it does not, because it didn't use `hoodie.index.type` in table props

```sql
drop table hudi_cow_test_tbl;
create table hudi_cow_test_tbl (
  id bigint,  
  name string,  
  ts bigint,  
  dt string,  
  hh string
) using hudi
tblproperties (
  type = 'cow',
  primaryKey = 'id',
  preCombineField = 'ts',
  hoodie.index.type = 'BUCKET'
)partitioned by (dt, hh);

insert into hudi_cow_test_tbl values (1, 'a1', 1001, '2021-12-09', '10');
insert into hudi_cow_test_tbl values (2, 'a2', 1001, '2021-12-09', '10');

# this operation should fail, otherwise the table will become unavailable
call run_clustering(table => 'hudi_cow_test_tbl');

insert into hudi_cow_test_tbl values (3, 'a3', 1001, '2021-12-09', '10'); 
```

### Impact

Fix `finalParameters` in `HoodieCLIUtils.createHoodieClientFromPath`

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
