### PR TITLE
[HUDI-5944] Added the ability to fix partitiion missing in hudi synctool

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -234,6 +234,25 @@ public class TimelineUtils {
     return timeline.getCommitsTimeline()
         .findInstantsAfter(exclusiveStartInstantTime, Integer.MAX_VALUE);
   }
+
+  /**
+   * Returns a Hudi timeline with commits after the given instant time (include).
+   *
+   * @param metaClient                {@link HoodieTableMetaClient} instance.
+   * @param includeStartInstantTime Start instant time (include).
+   * @return Hudi timeline.
+   */
+  public static HoodieTimeline getCommitsTimelineAfterOrEquals(
+      HoodieTableMetaClient metaClient, String includeStartInstantTime) {
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+    HoodieDefaultTimeline timeline =
+        activeTimeline.isBeforeTimelineStarts(includeStartInstantTime)
+            ? metaClient.getArchivedTimeline(includeStartInstantTime)
+            .mergeTimeline(activeTimeline)
+            : activeTimeline;
+    return timeline.getCommitsTimeline()
+        .findInstantsAfterOrEquals(includeStartInstantTime, Integer.MAX_VALUE);
+  }
   
   /**
    * Returns the commit metadata of the given instant.

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -602,7 +602,7 @@ public class TestHiveSyncTool {
     // Lets do the sync
     reSyncHiveTable();
     List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(commitTime1));
-    assertEquals(1, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
+    assertEquals(6, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
     List<org.apache.hudi.sync.common.model.Partition> hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
     assertEquals(1, partitionEvents.size(), "There should be only one partition event");
@@ -934,7 +934,7 @@ public class TestHiveSyncTool {
 
     reInitHiveSyncClient();
     List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(instantTime));
-    assertEquals(1, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
+    assertEquals(6, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
     List<org.apache.hudi.sync.common.model.Partition> hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
     assertEquals(1, partitionEvents.size(), "There should be only one partition event");
@@ -963,7 +963,7 @@ public class TestHiveSyncTool {
         "Table partitions should match the number of partitions we wrote");
     assertEquals(commitTime3, hiveClient.getLastCommitTimeSynced(HiveTestUtil.TABLE_NAME).get(),
         "The last commit that was synced should be updated in the TBLPROPERTIES");
-    assertEquals(1, hiveClient.getWrittenPartitionsSince(Option.of(commitTime2)).size());
+    assertEquals(2, hiveClient.getWrittenPartitionsSince(Option.of(commitTime2)).size());
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -125,7 +125,7 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
     } else {
       LOG.info("Last commit time synced is " + lastCommitTimeSynced.get() + ", Getting commits since then");
       return TimelineUtils.getWrittenPartitions(
-          TimelineUtils.getCommitsTimelineAfter(metaClient, lastCommitTimeSynced.get()));
+          TimelineUtils.getCommitsTimelineAfterOrEquals(metaClient, lastCommitTimeSynced.get()));
     }
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -163,6 +163,11 @@ public class HoodieSyncConfig extends HoodieConfig {
       .defaultValue("")
       .withDocumentation("The spark version used when syncing with a metastore.");
 
+  public static final ConfigProperty<String> META_SYNC_CURRENT_INSTANT_TS = ConfigProperty
+      .key("hoodie.datasource.hive_sync.current_instant_ts")
+      .defaultValue("")
+      .withDocumentation("Sync current instant ts");
+
   private Configuration hadoopConf;
 
   public HoodieSyncConfig(Properties props) {
@@ -230,6 +235,8 @@ public class HoodieSyncConfig extends HoodieConfig {
     @Parameter(names = {"--help", "-h"}, help = true)
     public boolean help = false;
 
+    public String currentInstantTs;
+
     public boolean isHelp() {
       return help;
     }
@@ -247,6 +254,7 @@ public class HoodieSyncConfig extends HoodieConfig {
       props.setPropertyIfNonNull(META_SYNC_USE_FILE_LISTING_FROM_METADATA.key(), useFileListingFromMetadata);
       props.setPropertyIfNonNull(META_SYNC_CONDITIONAL_SYNC.key(), isConditionalSync);
       props.setPropertyIfNonNull(META_SYNC_SPARK_VERSION.key(), sparkVersion);
+      props.setPropertyIfNonNull(META_SYNC_CURRENT_INSTANT_TS.key(), currentInstantTs);
       return props;
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <joda.version>2.9.9</joda.version>
     <hadoop.version>2.10.1</hadoop.version>
     <hive.groupid>org.apache.hive</hive.groupid>
-    <hive.version>2.3.1</hive.version>
+    <hive.version>2.3.4</hive.version>
     <hive.parquet.version>1.10.1</hive.parquet.version>
     <hive.avro.version>1.8.2</hive.avro.version>
     <presto.version>0.273</presto.version>


### PR DESCRIPTION
### Change Logs

When occ is enabled, hivesynctool causes partiton metadata to be lost. We added some repair logic.

### Impact

Resolve the problem that partition metadata is lost when occ is enabled.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
