### PR TITLE
[HUDI-5973] Add cachedSchema per batch, fix idempotency with getSourceSchema calls

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -428,6 +428,8 @@ public class DeltaSync implements Serializable, Closeable {
 
       result = writeToSink(srcRecordsWithCkpt.getRight().getRight(),
           srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
+
+      schemaProvider.refresh();
     }
 
     metrics.updateDeltaStreamerSyncMetrics(System.currentTimeMillis());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -429,6 +429,8 @@ public class DeltaSync implements Serializable, Closeable {
       result = writeToSink(srcRecordsWithCkpt.getRight().getRight(),
           srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
 
+      // Should this be at the beginning or the end, will its placement potentially affect the commit
+      // TODO: write tests for this
       schemaProvider.refresh();
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -89,4 +89,10 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     }
     return SanitizationUtils.parseAvroSchema(schemaStr, sanitizeSchema, invalidCharMask);
   }
+
+  // Per write batch, refresh the schema from the file
+  @Override
+  public void refresh() {
+    this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -59,7 +59,8 @@ public abstract class SchemaProvider implements Serializable {
     return getSourceSchema();
   }
 
-  public void clearCaches() {
-    cachedSchema = null;
+  //every schema provider has the ability to refresh itself, which will mean something different per provider.
+  public void refresh() {
+
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -39,6 +39,8 @@ public abstract class SchemaProvider implements Serializable {
 
   protected JavaSparkContext jssc;
 
+  protected Schema cachedSchema;
+
   public SchemaProvider(TypedProperties props) {
     this(props, null);
   }
@@ -55,5 +57,9 @@ public abstract class SchemaProvider implements Serializable {
   public Schema getTargetSchema() {
     // by default, use source schema as target for hoodie table as well
     return getSourceSchema();
+  }
+
+  public void clearCaches() {
+    cachedSchema = null;
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -176,7 +176,10 @@ public class SchemaRegistryProvider extends SchemaProvider {
   public Schema getSourceSchema() {
     String registryUrl = config.getString(Config.SRC_SCHEMA_REGISTRY_URL_PROP);
     try {
-      return parseSchemaFromRegistry(registryUrl);
+      if (cachedSchema == null) {
+        cachedSchema = parseSchemaFromRegistry(registryUrl);
+      }
+      return cachedSchema;
     } catch (IOException ioe) {
       throw new HoodieIOException("Error reading source schema from registry :" + registryUrl, ioe);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -73,6 +73,8 @@ public class SchemaRegistryProvider extends SchemaProvider {
     public static final String SSL_KEY_PASSWORD_PROP = "schema.registry.ssl.key.password";
   }
 
+  protected Schema cachedSchema;
+
   @FunctionalInterface
   public interface SchemaConverter {
     /**
@@ -194,5 +196,12 @@ public class SchemaRegistryProvider extends SchemaProvider {
     } catch (IOException ioe) {
       throw new HoodieIOException("Error reading target schema from registry :" + registryUrl, ioe);
     }
+  }
+  // Per SyncOnce call, the cachedschema for the provider is dropped and SourceSchema re-attained
+  // Subsequent calls to getSourceSchema within the write batch should be cached.
+  @Override
+  public void refresh() {
+    cachedSchema = null;
+    getSourceSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -55,6 +55,10 @@ abstract class KafkaSource<T> extends Source<JavaRDD<T>> {
 
   @Override
   protected InputBatch<JavaRDD<T>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
+    
+    //Clear any cached Schemas if using a SchemaProvider, currently only SchemaRegistryProvider.
+    this.schemaProvider.clearCaches();
+    
     try {
       OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -56,9 +56,6 @@ abstract class KafkaSource<T> extends Source<JavaRDD<T>> {
   @Override
   protected InputBatch<JavaRDD<T>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
     
-    //Clear any cached Schemas if using a SchemaProvider, currently only SchemaRegistryProvider.
-    this.schemaProvider.clearCaches();
-    
     try {
       OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/KafkaSource.java
@@ -55,7 +55,6 @@ abstract class KafkaSource<T> extends Source<JavaRDD<T>> {
 
   @Override
   protected InputBatch<JavaRDD<T>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
-    
     try {
       OffsetRange[] offsetRanges = offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, metrics);
       long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -125,4 +125,24 @@ class TestSchemaRegistryProvider {
           .toString();
     }
   }
+
+  // The SR is checked when cachedSchema is empty, when not empty, the cachedSchema is used.
+  @Test
+  public void testGetSourceSchemaUsesCachedSchema() throws IOException {
+    TypedProperties props = getProps();
+    SchemaRegistryProvider spyUnderTest = getUnderTest(props);
+
+    // Call when cachedSchema is empty
+    Schema actual = spyUnderTest.getSourceSchema();
+    assertNotNull(actual);
+    verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
+
+    assert spyUnderTest.cachedSchema != null;
+
+    Schema actualTwo = spyUnderTest.getSourceSchema();
+    
+    // cachedSchema should now be set, a subsequent call should not call parseSchemaFromRegistry
+    // Assuming this verify() has the scope of the whole test? so it should still be 1 from previous call?
+    verify(spyUnderTest, times(1)).parseSchemaFromRegistry(Mockito.any());
+  }
 }


### PR DESCRIPTION
### Change Logs

Addressing the issues discussed in https://github.com/apache/hudi/issues/8065

JIRA Ticket: https://issues.apache.org/jira/browse/HUDI-5973

@nsivabalan's thinking:

The issue is. getSourceScheme in case of SchemaRegistry provider is not idempotent. even within a single batch of write, if we call getSourceSchema multiple times, it could return latest schema from the schema registry. ideally we want it to return one schema for one batch of write.
so, the fix is to add a new api to Source abstract class called "clearCaches" or "cleanupResources". also add similar apis to SchemaProvider. and so within source.clearCaches, we will call schemaProvider.clearCaches.
Incase of SchemaRegistryProvider, for every batch, we will fetch from remote schema registry and cache is locally. for subsequent calls to getsourceSchema, we will be returning the same value. before moving onto next batch of consume, we will have to call clearCaches which will invalidate the local cache of source schema.

------------

- Now, when a `SchemaRegistryProvider` calls `getSourceSchema`, it will cache its first schema called, and then re-use the cache on subsequent calls, to maintain that schema per batch.
- Also added a clearCarches method to the KafkaSource as per @nsivabalan's recommendation, to "invalidate the local cache of source schema."
- This should ensure that when the Source is instantiated and (KafkaSource and it's children) call `fetchNewData()`, any existing cache from the `SchemaProvider` (Currently only `SchemaRegistryProvider`) will be dropped.
- Added tests for new functionality -- passing locally


### Impact

Deltastreamer jobs running in --continuous mode sometimes fail to gracefully evolve their schemas if the schema registry schema's change mid-way through a batch (presents itself as transient failures, as discussed in the above GH Issue)

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
