### PR TITLE
[SUPPORT] deltastreamer support migrate COW table to MOR

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
@@ -78,7 +78,7 @@ public class HoodieDeltaStreamerWrapper extends HoodieDeltaStreamer {
   public Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> fetchSource() throws Exception {
     DeltaSync service = getDeltaSync();
     service.refreshTimeline();
-    return service.readFromSource(service.getCommitTimelineOpt());
+    return service.readFromSource(service.getCommitTimelineOpt(), service.getDeltaCommitTimelineOpt());
   }
 
   public DeltaSync getDeltaSync() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -1182,6 +1182,10 @@ public class DeltaSync implements Serializable, Closeable {
     return commitTimelineOpt;
   }
 
+  public Option<HoodieTimeline> getDeltaCommitTimelineOpt() {
+    return deltaCommitTimelineOpt;
+  }
+
   public HoodieIngestionMetrics getMetrics() {
     return metrics;
   }


### PR DESCRIPTION
**_Tips before filing an issue_**

- Have you gone through our [FAQs](https://hudi.apache.org/learn/faq/)?  yes

- Join the mailing list to engage in conversations and get faster support at dev-subscribe@hudi.apache.org. sent email please help involve me in

- If you have triaged this as a bug, then file an [issue](https://issues.apache.org/jira/projects/HUDI/issues) directly.

**Describe the problem you faced**

My company is using deltastreamer to ingestion data from kafka to hdfs, the old hudi table type is COW. But the write latency of the COW table is much higher than MOR table. So we are going to migrate the COW tables to MOR.
According to the [FAQ](https://hudi.apache.org/docs/faq/#how-to-convert-an-existing-cow-table-to-mor), we can change the existing COW table to MOR by just changing the `hoodity.table.type` property.
But there is one issue for continuing deltastreamer of MOR table on the existing path, the checkpoint from old COW table will lost, so there may be dataloss in such cases.

I find the cause of the checkpoint loss.
In the refreshTimeline method, when table is MOR only get checkpoint from deltacommits, that's why the checkpoint loss when migrating COW to MOR https://github.com/apache/hudi/blob/ce21873f332f1728ad46aeb066777e49456ef522/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java#L325

Simply put, I want the deltastreamer to support migrate hudi table directly by a parameter


**Expected behavior**

deltastreamer offer a parameter `--migration-type` to support migrate existing COW table to MOR, 
the value of the param `--migration-type` can be: 
1. NONE (default no migration)
2. COW_TO_MOR
3. MOR_TO_COW (TODO)





