### PR TITLE
[HUDI-5964] fix error info not show in CreateHoodieTableCommand

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -83,7 +83,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
       CreateHoodieTableCommand.createTableInCatalog(sparkSession, hoodieCatalogTable, ignoreIfExists, queryAsProp)
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Failed to create catalog table in metastore: ${e.getMessage}")
+        logWarning(s"Failed to create catalog table in metastore: ${e}")
     }
     Seq.empty[Row]
   }


### PR DESCRIPTION
fix error info not show in CreateHoodieTableCommand

### Change Logs

when we create hudi table with hive async，if not success would not show error detail message，this is confused to user to location error reason.

example:

when not put hudi-hadoop-mr.jar in hive lib，error show only class name org.apache.hudi.hadoop.HoodieParquetInputformat;

after fix，error show:
java.lang.ClassNotFoundException:org.apache.hudi.hadoop.HoodieParquetInputformat

### Impact

NA

### Risk level (write none, low medium or high below)

none

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
