### PR TITLE
[HUDI-5941] Support savepoint call procedure with base path in Spark SQL

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointProcedure.scala
@@ -28,10 +28,11 @@ import java.util.function.Supplier
 
 class CreateSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
     ProcedureParameter.required(1, "commit_time", DataTypes.StringType, None),
     ProcedureParameter.optional(2, "user", DataTypes.StringType, ""),
-    ProcedureParameter.optional(3, "comments", DataTypes.StringType, "")
+    ProcedureParameter.optional(3, "comments", DataTypes.StringType, ""),
+    ProcedureParameter.optional(4, "path", DataTypes.StringType, None)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -46,11 +47,12 @@ class CreateSavepointProcedure extends BaseProcedure with ProcedureBuilder with 
     super.checkArgs(PARAMETERS, args)
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val tablePath = getArgValueOrDefault(args, PARAMETERS(4))
     val commitTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
     val user = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[String]
     val comments = getArgValueOrDefault(args, PARAMETERS(3)).get.asInstanceOf[String]
 
-    val basePath: String = getBasePath(tableName)
+    val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     val activeTimeline: HoodieActiveTimeline = metaClient.getActiveTimeline

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointProcedure.scala
@@ -28,8 +28,9 @@ import java.util.function.Supplier
 
 class DeleteSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None),
+    ProcedureParameter.optional(2, "path", DataTypes.StringType, None)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -44,9 +45,10 @@ class DeleteSavepointProcedure extends BaseProcedure with ProcedureBuilder with 
     super.checkArgs(PARAMETERS, args)
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val tablePath = getArgValueOrDefault(args, PARAMETERS(2))
     val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
 
-    val basePath: String = getBasePath(tableName)
+    val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     val completedInstants = metaClient.getActiveTimeline.getSavePointTimeline.filterCompletedInstants

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToSavepointProcedure.scala
@@ -28,8 +28,9 @@ import java.util.function.Supplier
 
 class RollbackToSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None),
+    ProcedureParameter.optional(2, "path", DataTypes.StringType, None)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -44,9 +45,10 @@ class RollbackToSavepointProcedure extends BaseProcedure with ProcedureBuilder w
     super.checkArgs(PARAMETERS, args)
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val tablePath = getArgValueOrDefault(args, PARAMETERS(2))
     val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
 
-    val basePath: String = getBasePath(tableName)
+    val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     val completedInstants = metaClient.getActiveTimeline.getSavePointTimeline.filterCompletedInstants

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowSavepointsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowSavepointsProcedure.scala
@@ -28,7 +28,8 @@ import java.util.stream.Collectors
 
 class ShowSavepointsProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType, None)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -43,8 +44,9 @@ class ShowSavepointsProcedure extends BaseProcedure with ProcedureBuilder {
     super.checkArgs(PARAMETERS, args)
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val tablePath = getArgValueOrDefault(args, PARAMETERS(1))
 
-    val basePath: String = getBasePath(tableName)
+    val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     val activeTimeline: HoodieActiveTimeline = metaClient.getActiveTimeline


### PR DESCRIPTION
### Change Logs

Before this PR, the savepoint-related call procedure can only take the table name stored in the catalog in Spark SQL.  This does not work with the temporary view (`df. createOrReplaceTempView(name)`).  See #7589 .  Relevant call procedure are:

```
call create_savepoint(table => 'table_name', commit_time => 'commit_time')
call show_savepoints(table => 'table_name')
call delete_savepoint(table => 'table_name', instant_time => 'commit_time')
call rollback_to_savepoint(table => 'table_name', instant_time => 'commit_time')
```

This PR adds the support of using the base path of a Hudi table (with `path` parameter) for savepoint call procedure in Spark SQL.  Users can now run the following new call procedure:
```
call create_savepoint(path => '/table/path', commit_time => 'commit_time')
call show_savepoints(path => '/table/path')
call delete_savepoint(path => '/table/path', instant_time => 'commit_time')
call rollback_to_savepoint(path => '/table/path', instant_time => 'commit_time')
```

### Impact

Improves the usability of savepoint call procedure in Spark SQL.  New unit tests are added to make sure the call procedure works.  The new call procedure parameter is also tested in local spark-shell.

### Risk level

none

### Documentation Update

See HUDI-5974.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
