### PR TITLE
[HUDI-5977] Fix Date to String column schema evolution

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -734,43 +734,43 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         }
       }
     }
+  }
 
-    test("Test DATE to STRING conversions when vectorized reading is not enabled") {
-      val tableName = generateTableName
-      // adding a struct column to force reads to use non-vectorized readers
-      spark.sql(
-        s"""
-           | create table $tableName (
-           |  id int,
-           |  name string,
-           |  price double,
-           |  struct_col struct<f0: int, f1: string>,
-           |  ts long
-           |) using hudi
-           | partitioned by (ts)
-           |tblproperties (
-           |  primaryKey = 'id'
-           )
-         """.stripMargin)
-      spark.sql(
-        s"""
-           | insert into $tableName
-           | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
-          """.stripMargin)
-      spark.sql(s"select * from $tableName")
+  test("Test DATE to STRING conversions when vectorized reading is not enabled") {
+    val tableName = generateTableName
+    // adding a struct column to force reads to use non-vectorized readers
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  struct_col struct<f0: int, f1: string>,
+         |  ts long
+         |) using hudi
+         | partitioned by (ts)
+         |tblproperties (
+         |  primaryKey = 'id'
+         )
+       """.stripMargin)
+    spark.sql(
+      s"""
+         | insert into $tableName
+         | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
+        """.stripMargin)
+    spark.sql(s"select * from $tableName")
 
-      spark.sql("set hoodie.schema.on.read.enable=true")
-      spark.sql(s"alter table $tableName add column (`date_to_string_col` date)")
-      spark.sql(
-        s"""
-           | insert into $tableName
-           | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
-          """.stripMargin)
-      spark.sql(s"alter table $tableName alter column `date_to_string_col` type string")
+    spark.sql("set hoodie.schema.on.read.enable=true")
+    spark.sql(s"alter table $tableName add column (`date_to_string_col` date)")
+    spark.sql(
+      s"""
+         | insert into $tableName
+         | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
+        """.stripMargin)
+    spark.sql(s"alter table $tableName alter column `date_to_string_col` type string")
 
-      // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
-      // not checking results as we just need to ensure that the table can be read without any errors thrown
-      spark.sql(s"select * from $tableName")
-    }
+    // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
+    // not checking results as we just need to ensure that the table can be read without any errors thrown
+    spark.sql(s"select * from $tableName")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -761,7 +761,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
     spark.sql(s"select * from $tableName")
 
     spark.sql("set hoodie.schema.on.read.enable=true")
-    spark.sql(s"alter table $tableName add column (`date_to_string_col` date)")
+    spark.sql(s"alter table $tableName add columns(`date_to_string_col` date)")
     spark.sql(
       s"""
          | insert into $tableName

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -741,43 +741,45 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
       Seq("COPY_ON_WRITE", "MERGE_ON_READ").foreach { tableType =>
         val tableName = generateTableName
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
-        // adding a struct column to force reads to use non-vectorized readers
-        spark.sql(
-          s"""
-             | create table $tableName (
-             |  id int,
-             |  name string,
-             |  price double,
-             |  struct_col struct<f0: int, f1: string>,
-             |  ts long
-             |) using hudi
-             | location '$tablePath'
-             | options (
-             |  type = '$tableType',
-             |  primaryKey = 'id',
-             |  preCombineField = 'ts'
-             | )
-             | partitioned by (ts)
-           """.stripMargin)
-        spark.sql(
-          s"""
-             | insert into $tableName
-             | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
-            """.stripMargin)
-        spark.sql(s"select * from $tableName")
+        if (HoodieSparkUtils.gteqSpark3_1) {
+          // adding a struct column to force reads to use non-vectorized readers
+          spark.sql(
+            s"""
+               | create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  struct_col struct<f0: int, f1: string>,
+               |  ts long
+               |) using hudi
+               | location '$tablePath'
+               | options (
+               |  type = '$tableType',
+               |  primaryKey = 'id',
+               |  preCombineField = 'ts'
+               | )
+               | partitioned by (ts)
+             """.stripMargin)
+          spark.sql(
+            s"""
+               | insert into $tableName
+               | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
+              """.stripMargin)
+          spark.sql(s"select * from $tableName")
 
-        spark.sql("set hoodie.schema.on.read.enable=true")
-        spark.sql(s"alter table $tableName add columns(date_to_string_col date)")
-        spark.sql(
-          s"""
-             | insert into $tableName
-             | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
-            """.stripMargin)
-        spark.sql(s"alter table $tableName alter column date_to_string_col type string")
+          spark.sql("set hoodie.schema.on.read.enable=true")
+          spark.sql(s"alter table $tableName add columns(date_to_string_col date)")
+          spark.sql(
+            s"""
+               | insert into $tableName
+               | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
+              """.stripMargin)
+          spark.sql(s"alter table $tableName alter column date_to_string_col type string")
 
-        // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
-        // not checking results as we just need to ensure that the table can be read without any errors thrown
-        spark.sql(s"select * from $tableName")
+          // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
+          // not checking results as we just need to ensure that the table can be read without any errors thrown
+          spark.sql(s"select * from $tableName")
+        }
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -737,40 +737,48 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
   }
 
   test("Test DATE to STRING conversions when vectorized reading is not enabled") {
-    val tableName = generateTableName
-    // adding a struct column to force reads to use non-vectorized readers
-    spark.sql(
-      s"""
-         | create table $tableName (
-         |  id int,
-         |  name string,
-         |  price double,
-         |  struct_col struct<f0: int, f1: string>,
-         |  ts long
-         |) using hudi
-         | partitioned by (ts)
-         |tblproperties (
-         |  primaryKey = 'id'
-         )
-       """.stripMargin)
-    spark.sql(
-      s"""
-         | insert into $tableName
-         | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
-        """.stripMargin)
-    spark.sql(s"select * from $tableName")
+    withTempDir { tmp =>
+      Seq("COPY_ON_WRITE", "MERGE_ON_READ").foreach { tableType =>
+        val tableName = generateTableName
+        val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
+        // adding a struct column to force reads to use non-vectorized readers
+        spark.sql(
+          s"""
+             | create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  struct_col struct<f0: int, f1: string>,
+             |  ts long
+             |) using hudi
+             | location '$tablePath'
+             | options (
+             |  type = '$tableType',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by (ts)
+           """.stripMargin)
+        spark.sql(
+          s"""
+             | insert into $tableName
+             | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
+            """.stripMargin)
+        spark.sql(s"select * from $tableName")
 
-    spark.sql("set hoodie.schema.on.read.enable=true")
-    spark.sql(s"alter table $tableName add columns(`date_to_string_col` date)")
-    spark.sql(
-      s"""
-         | insert into $tableName
-         | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
-        """.stripMargin)
-    spark.sql(s"alter table $tableName alter column `date_to_string_col` type string")
+        spark.sql("set hoodie.schema.on.read.enable=true")
+        spark.sql(s"alter table $tableName add columns(date_to_string_col date)")
+        spark.sql(
+          s"""
+             | insert into $tableName
+             | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
+            """.stripMargin)
+        spark.sql(s"alter table $tableName alter column date_to_string_col type string")
 
-    // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
-    // not checking results as we just need to ensure that the table can be read without any errors thrown
-    spark.sql(s"select * from $tableName")
+        // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
+        // not checking results as we just need to ensure that the table can be read without any errors thrown
+        spark.sql(s"select * from $tableName")
+      }
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -734,5 +734,43 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         }
       }
     }
+
+    test("Test DATE to STRING conversions when vectorized reading is not enabled") {
+      val tableName = generateTableName
+      // adding a struct column to force reads to use non-vectorized readers
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  struct_col struct<f0: int, f1: string>,
+           |  ts long
+           |) using hudi
+           | partitioned by (ts)
+           |tblproperties (
+           |  primaryKey = 'id'
+           )
+         """.stripMargin)
+      spark.sql(
+        s"""
+           | insert into $tableName
+           | values (1, 'a1', 10, struct(1, 'f_1'), 1000)
+          """.stripMargin)
+      spark.sql(s"select * from $tableName")
+
+      spark.sql("set hoodie.schema.on.read.enable=true")
+      spark.sql(s"alter table $tableName add column (`date_to_string_col` date)")
+      spark.sql(
+        s"""
+           | insert into $tableName
+           | values (2, 'a2', 20, struct(2, 'f_2'), date '2023-03-22', 1001)
+          """.stripMargin)
+      spark.sql(s"alter table $tableName alter column `date_to_string_col` type string")
+
+      // struct and string (converted from date) column must be read to ensure that non-vectorized reader is used
+      // not checking results as we just need to ensure that the table can be read without any errors thrown
+      spark.sql(s"select * from $tableName")
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark24HoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark24HoodieParquetFileFormat.scala
@@ -107,6 +107,7 @@ class Spark24HoodieParquetFileFormat(private val shouldAppendPartitionValues: Bo
     val pushDownStringStartWith = sqlConf.parquetFilterPushDownStringStartWith
     val pushDownInFilterThreshold = sqlConf.parquetFilterPushDownInFilterThreshold
     val isCaseSensitive = sqlConf.caseSensitiveAnalysis
+    val timeZoneId = Option(sqlConf.sessionLocalTimeZone)
 
     (file: PartitionedFile) => {
       assert(!shouldAppendPartitionValues || file.partitionValues.numFields == partitionSchema.size)
@@ -238,7 +239,10 @@ class Spark24HoodieParquetFileFormat(private val shouldAppendPartitionValues: Bo
           }).toAttributes ++ partitionSchema.toAttributes
           val castSchema = newFullSchema.zipWithIndex.map { case (attr, i) =>
             if (implicitTypeChangeInfos.containsKey(i)) {
-              Cast(attr, implicitTypeChangeInfos.get(i).getLeft)
+              val srcType = typeChangeInfos.get(i).getRight
+              val dstType = typeChangeInfos.get(i).getLeft
+              val needTimeZone = Cast.needsTimeZone(srcType, dstType)
+              Cast(attr, dstType, if (needTimeZone) timeZoneId else None)
             } else attr
           }
           GenerateUnsafeProjection.generate(castSchema, newFullSchema)

--- a/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark24HoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark2/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark24HoodieParquetFileFormat.scala
@@ -239,8 +239,8 @@ class Spark24HoodieParquetFileFormat(private val shouldAppendPartitionValues: Bo
           }).toAttributes ++ partitionSchema.toAttributes
           val castSchema = newFullSchema.zipWithIndex.map { case (attr, i) =>
             if (implicitTypeChangeInfos.containsKey(i)) {
-              val srcType = typeChangeInfos.get(i).getRight
-              val dstType = typeChangeInfos.get(i).getLeft
+              val srcType = implicitTypeChangeInfos.get(i).getRight
+              val dstType = implicitTypeChangeInfos.get(i).getLeft
               val needTimeZone = Cast.needsTimeZone(srcType, dstType)
               Cast(attr, dstType, if (needTimeZone) timeZoneId else None)
             } else attr


### PR DESCRIPTION
### Change Logs

Fix date to string schema evolution when vectorized readers are not used.

Issue and stacktrace can be found here:
https://issues.apache.org/jira/browse/HUDI-5977

### Impact

Tables can be read after a date -> string schema evolution is performed and when vectorized readers are not used.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
