### PR TITLE
[HUDI-5979] Add dependencies to hudi-trino-bundle needed for Trino connector

### DIFF
--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -68,6 +68,8 @@
               <artifactSet>
                 <includes combine.children="append">
                   <include>org.apache.hudi:hudi-common</include>
+                  <include>org.apache.hudi:hudi-client-common</include>
+                  <include>org.apache.hudi:hudi-java-client</include>
                   <include>org.apache.hudi:hudi-hadoop-mr</include>
 
                   <!-- Kryo -->
@@ -173,6 +175,22 @@
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-hadoop-mr-bundle</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-client-common</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-java-client</artifactId>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
### Change Logs

Add `hudi-client-common` and `hudi-java-client` to `hudi-trino-bundle`. Trino-Hudi connector makes use of the write client for some tests. Eventually, we want to add write capabilities as well. Have tested the bundle in [Trino](https://github.com/codope/trino/blob/upgrade-hudi-0.13.0/plugin/trino-hudi/pom.xml).

### Impact

The bundle size grows by 1mb from 39.5 to 40.5mb.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
