### PR TITLE
[HUDI-5983] Improve loading data via cloud store incr source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -23,9 +23,10 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.helpers.CloudObjectMetadata;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy;
-import org.apache.hudi.utilities.sources.helpers.gcs.FileDataFetcher;
-import org.apache.hudi.utilities.sources.helpers.gcs.FilePathsFetcher;
+import org.apache.hudi.utilities.sources.helpers.gcs.GcsObjectDataFetcher;
+import org.apache.hudi.utilities.sources.helpers.gcs.GcsObjectMetadataFetcher;
 import org.apache.hudi.utilities.sources.helpers.gcs.QueryInfo;
 
 import org.apache.spark.api.java.JavaSparkContext;
@@ -37,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.DATAFILE_FORMAT;
@@ -101,8 +101,8 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
   private final int numInstantsPerFetch;
 
   private final MissingCheckpointStrategy missingCheckpointStrategy;
-  private final FilePathsFetcher filePathsFetcher;
-  private final FileDataFetcher fileDataFetcher;
+  private final GcsObjectMetadataFetcher gcsObjectMetadataFetcher;
+  private final GcsObjectDataFetcher gcsObjectDataFetcher;
 
   private static final Logger LOG = LoggerFactory.getLogger(GcsEventsHoodieIncrSource.class);
 
@@ -110,13 +110,13 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
                                    SchemaProvider schemaProvider) {
 
     this(props, jsc, spark, schemaProvider,
-            new FilePathsFetcher(props, getSourceFileFormat(props)),
-        new FileDataFetcher(props, props.getString(DATAFILE_FORMAT.key(), DATAFILE_FORMAT.defaultValue()))
+        new GcsObjectMetadataFetcher(props, getSourceFileFormat(props)),
+        new GcsObjectDataFetcher(props, props.getString(DATAFILE_FORMAT.key(), DATAFILE_FORMAT.defaultValue()))
     );
   }
 
   GcsEventsHoodieIncrSource(TypedProperties props, JavaSparkContext jsc, SparkSession spark,
-                            SchemaProvider schemaProvider, FilePathsFetcher filePathsFetcher, FileDataFetcher fileDataFetcher) {
+                            SchemaProvider schemaProvider, GcsObjectMetadataFetcher gcsObjectMetadataFetcher, GcsObjectDataFetcher gcsObjectDataFetcher) {
     super(props, jsc, spark, schemaProvider);
 
     DataSourceUtils.checkRequiredProperties(props, Collections.singletonList(HOODIE_SRC_BASE_PATH.key()));
@@ -125,8 +125,8 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
     numInstantsPerFetch = props.getInteger(NUM_INSTANTS_PER_FETCH.key(), NUM_INSTANTS_PER_FETCH.defaultValue());
     checkIfFileExists = props.getBoolean(ENABLE_EXISTS_CHECK.key(), ENABLE_EXISTS_CHECK.defaultValue());
 
-    this.filePathsFetcher = filePathsFetcher;
-    this.fileDataFetcher = fileDataFetcher;
+    this.gcsObjectMetadataFetcher = gcsObjectMetadataFetcher;
+    this.gcsObjectDataFetcher = gcsObjectDataFetcher;
 
     LOG.info("srcPath: " + srcPath);
     LOG.info("missingCheckpointStrategy: " + missingCheckpointStrategy);
@@ -143,24 +143,20 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
       return Pair.of(Option.empty(), queryInfo.getStartInstant());
     }
 
-    Dataset<Row> sourceForFilenames = queryInfo.initializeSourceForFilenames(srcPath, sparkSession);
+    Dataset<Row> sourceCloudObjects = queryInfo.initializeSourceForFilenames(srcPath, sparkSession);
 
-    if (sourceForFilenames.isEmpty()) {
+    if (sourceCloudObjects.isEmpty()) {
       LOG.info("Source of file names is empty. Returning empty result and endInstant: "
               + queryInfo.getEndInstant());
       return Pair.of(Option.empty(), queryInfo.getEndInstant());
     }
 
-    return extractData(queryInfo, sourceForFilenames);
+    return extractData(queryInfo, sourceCloudObjects);
   }
 
-  private Pair<Option<Dataset<Row>>, String> extractData(QueryInfo queryInfo, Dataset<Row> sourceForFilenames) {
-    List<String> filepaths = filePathsFetcher.getGcsFilePaths(sparkContext, sourceForFilenames, checkIfFileExists);
-
-    LOG.debug("Extracted " + filepaths.size() + " distinct files."
-            + " Some samples " + filepaths.stream().limit(10).collect(Collectors.toList()));
-
-    Option<Dataset<Row>> fileDataRows = fileDataFetcher.fetchFileData(sparkSession, filepaths, props);
+  private Pair<Option<Dataset<Row>>, String> extractData(QueryInfo queryInfo, Dataset<Row> sourceCloudObjects) {
+    List<CloudObjectMetadata> cloudObjectMetadata = gcsObjectMetadataFetcher.getGcsObjects(sparkContext, sourceCloudObjects, checkIfFileExists);
+    Option<Dataset<Row>> fileDataRows = gcsObjectDataFetcher.fetchCloudObjectData(sparkSession, cloudObjectMetadata, props);
     return Pair.of(fileDataRows, queryInfo.getEndInstant());
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -143,20 +143,20 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
       return Pair.of(Option.empty(), queryInfo.getStartInstant());
     }
 
-    Dataset<Row> sourceCloudObjects = queryInfo.initializeSourceForFilenames(srcPath, sparkSession);
+    Dataset<Row> cloudObjectMetadataDF = queryInfo.initCloudObjectMetadata(srcPath, sparkSession);
 
-    if (sourceCloudObjects.isEmpty()) {
+    if (cloudObjectMetadataDF.isEmpty()) {
       LOG.info("Source of file names is empty. Returning empty result and endInstant: "
               + queryInfo.getEndInstant());
       return Pair.of(Option.empty(), queryInfo.getEndInstant());
     }
 
-    return extractData(queryInfo, sourceCloudObjects);
+    return extractData(queryInfo, cloudObjectMetadataDF);
   }
 
-  private Pair<Option<Dataset<Row>>, String> extractData(QueryInfo queryInfo, Dataset<Row> sourceCloudObjects) {
-    List<CloudObjectMetadata> cloudObjectMetadata = gcsObjectMetadataFetcher.getGcsObjects(sparkContext, sourceCloudObjects, checkIfFileExists);
-    Option<Dataset<Row>> fileDataRows = gcsObjectDataFetcher.fetchCloudObjectData(sparkSession, cloudObjectMetadata, props);
+  private Pair<Option<Dataset<Row>>, String> extractData(QueryInfo queryInfo, Dataset<Row> cloudObjectMetadataDF) {
+    List<CloudObjectMetadata> cloudObjectMetadata = gcsObjectMetadataFetcher.getGcsObjectMetadata(sparkContext, cloudObjectMetadataDF, checkIfFileExists);
+    Option<Dataset<Row>> fileDataRows = gcsObjectDataFetcher.getCloudObjectDataDF(sparkSession, cloudObjectMetadata, props);
     return Pair.of(fileDataRows, queryInfo.getEndInstant());
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectMetadata.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import java.io.Serializable;
+
+public class CloudObjectMetadata implements Serializable {
+  private final String path;
+  private final long size;
+
+  public CloudObjectMetadata(String path, long size) {
+    this.path = path;
+    this.size = size;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public long getSize() {
+    return size;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -19,16 +19,24 @@
 package org.apache.hudi.utilities.sources.helpers;
 
 import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.utilities.config.CloudSourceConfig;
+import org.apache.hudi.utilities.config.S3EventsHoodieIncrSourceConfig;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +44,12 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_MAX_FILE_SIZE;
+import static org.apache.hudi.common.util.CollectionUtils.isNullOrEmpty;
 
 /**
  * Generic helper methods to fetch from Cloud Storage during incremental fetch from cloud storage buckets.
@@ -50,26 +62,36 @@ public class CloudObjectsSelectorCommon {
 
   /**
    * Return a function that extracts filepaths from a list of Rows.
-   * Here Row is assumed to have the schema [bucket_name, filepath_relative_to_bucket]
-   * @param storageUrlSchemePrefix Eg: s3:// or gs://. The storage-provider-specific prefix to use within the URL.
+   * Here Row is assumed to have the schema [bucket_name, filepath_relative_to_bucket, object_size]
+   * @param storageUrlSchemePrefix    Eg: s3:// or gs://. The storage-provider-specific prefix to use within the URL.
    * @param serializableConfiguration
-   * @param checkIfExists check if each file exists, before adding it to the returned list
+   * @param checkIfExists             check if each file exists, before adding it to the returned list
    * @return
    */
-  public static FlatMapFunction<Iterator<Row>, String> getCloudFilesPerPartition(
-          String storageUrlSchemePrefix, SerializableConfiguration serializableConfiguration, boolean checkIfExists) {
+  public static MapPartitionsFunction<Row, CloudObjectMetadata> getCloudObjectsPerPartition(
+      String storageUrlSchemePrefix, SerializableConfiguration serializableConfiguration, boolean checkIfExists) {
     return rows -> {
-      List<String> cloudFilesPerPartition = new ArrayList<>();
+      List<CloudObjectMetadata> cloudObjectMetadata = new ArrayList<>();
       rows.forEachRemaining(row -> {
-        Option<String> filePathUrl = getUrlForFile(row, storageUrlSchemePrefix, serializableConfiguration,
-                checkIfExists);
+        Option<String> filePathUrl = getUrlForFile(row, storageUrlSchemePrefix, serializableConfiguration, checkIfExists);
         filePathUrl.ifPresent(url -> {
           LOG.info("Adding file: " + url);
-          cloudFilesPerPartition.add(url);
+          long size;
+          Object obj = row.get(2);
+          if (obj instanceof String) {
+            size = Long.parseLong((String) obj);
+          } else if (obj instanceof Integer) {
+            size = ((Integer) obj).longValue();
+          } else if (obj instanceof Long) {
+            size = (long) obj;
+          } else {
+            throw new HoodieIOException("unexpected object size's type in Cloud storage events: " + obj.getClass());
+          }
+          cloudObjectMetadata.add(new CloudObjectMetadata(url, size));
         });
       });
 
-      return cloudFilesPerPartition.iterator();
+      return cloudObjectMetadata.iterator();
     };
   }
 
@@ -78,6 +100,7 @@ public class CloudObjectsSelectorCommon {
    * Here Row is assumed to have the schema [bucket_name, filepath_relative_to_bucket].
    * The checkIfExists logic assumes that the relevant impl classes for the storageUrlSchemePrefix are already present
    * on the classpath!
+   *
    * @param storageUrlSchemePrefix Eg: s3:// or gs://. The storage-provider-specific prefix to use within the URL.
    */
   private static Option<String> getUrlForFile(Row row, String storageUrlSchemePrefix,
@@ -115,5 +138,44 @@ public class CloudObjectsSelectorCommon {
       LOG.error(errMsg, ioe);
       throw new HoodieIOException(errMsg, ioe);
     }
+  }
+
+  public static Option<Dataset<Row>> loadAsDataset(SparkSession spark, List<CloudObjectMetadata> cloudObjectMetadata, TypedProperties props, String fileFormat) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Extracted distinct files " + cloudObjectMetadata.size()
+          + " and some samples " + cloudObjectMetadata.stream().map(CloudObjectMetadata::getPath).limit(10).collect(Collectors.toList()));
+    }
+
+    if (isNullOrEmpty(cloudObjectMetadata)) {
+      return Option.empty();
+    }
+    DataFrameReader reader = spark.read().format(fileFormat);
+    String datasourceOpts = props.getString(CloudSourceConfig.SPARK_DATASOURCE_OPTIONS.key(), null);
+    if (StringUtils.isNullOrEmpty(datasourceOpts)) {
+      // fall back to legacy config for BWC. TODO consolidate in HUDI-6020
+      datasourceOpts = props.getString(S3EventsHoodieIncrSourceConfig.SPARK_DATASOURCE_OPTIONS.key(), null);
+    }
+    if (StringUtils.nonEmpty(datasourceOpts)) {
+      final ObjectMapper mapper = new ObjectMapper();
+      Map<String, String> sparkOptionsMap = null;
+      try {
+        sparkOptionsMap = mapper.readValue(datasourceOpts, Map.class);
+      } catch (IOException e) {
+        throw new HoodieException(String.format("Failed to parse sparkOptions: %s", datasourceOpts), e);
+      }
+      LOG.info(String.format("sparkOptions loaded: %s", sparkOptionsMap));
+      reader = reader.options(sparkOptionsMap);
+    }
+    List<String> paths = new ArrayList<>();
+    long totalSize = 0;
+    for (CloudObjectMetadata o : cloudObjectMetadata) {
+      paths.add(o.getPath());
+      totalSize += o.getSize();
+    }
+    // inflate 10% for potential hoodie meta fields
+    totalSize *= 1.1;
+    long parquetMaxFileSize = props.getLong(PARQUET_MAX_FILE_SIZE.key(), Long.parseLong(PARQUET_MAX_FILE_SIZE.defaultValue()));
+    int numPartitions = (int) Math.max(totalSize / parquetMaxFileSize, 1);
+    return Option.of(reader.load(paths.toArray(new String[cloudObjectMetadata.size()])).coalesce(numPartitions));
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/GcsObjectDataFetcher.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/GcsObjectDataFetcher.java
@@ -20,7 +20,7 @@ package org.apache.hudi.utilities.sources.helpers.gcs;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.utilities.sources.helpers.IncrSourceCloudStorageHelper;
+import org.apache.hudi.utilities.sources.helpers.CloudObjectMetadata;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -31,26 +31,28 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.util.List;
 
+import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon.loadAsDataset;
+
 /**
  * Connects to GCS from Spark and downloads data from a given list of files.
  * Assumes SparkContext is already configured with GCS options through GcsEventsHoodieIncrSource.addGcsAccessConfs().
  */
-public class FileDataFetcher implements Serializable {
+public class GcsObjectDataFetcher implements Serializable {
 
   private final String fileFormat;
   private TypedProperties props;
 
-  private static final Logger LOG = LoggerFactory.getLogger(FileDataFetcher.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GcsObjectDataFetcher.class);
 
   private static final long serialVersionUID = 1L;
 
-  public FileDataFetcher(TypedProperties props, String fileFormat) {
+  public GcsObjectDataFetcher(TypedProperties props, String fileFormat) {
     this.fileFormat = fileFormat;
     this.props = props;
   }
 
-  public Option<Dataset<Row>> fetchFileData(SparkSession spark, List<String> filepaths, TypedProperties props) {
-    return IncrSourceCloudStorageHelper.fetchFileData(spark, filepaths, props, fileFormat);
+  public Option<Dataset<Row>> fetchCloudObjectData(SparkSession spark, List<CloudObjectMetadata> cloudObjectMetadata, TypedProperties props) {
+    return loadAsDataset(spark, cloudObjectMetadata, props, fileFormat);
   }
 
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/GcsObjectDataFetcher.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/GcsObjectDataFetcher.java
@@ -51,7 +51,7 @@ public class GcsObjectDataFetcher implements Serializable {
     this.props = props;
   }
 
-  public Option<Dataset<Row>> fetchCloudObjectData(SparkSession spark, List<CloudObjectMetadata> cloudObjectMetadata, TypedProperties props) {
+  public Option<Dataset<Row>> getCloudObjectDataDF(SparkSession spark, List<CloudObjectMetadata> cloudObjectMetadata, TypedProperties props) {
     return loadAsDataset(spark, cloudObjectMetadata, props, fileFormat);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/QueryInfo.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/QueryInfo.java
@@ -51,7 +51,7 @@ public class QueryInfo {
     this.endInstant = endInstant;
   }
 
-  public Dataset<Row> initializeSourceForFilenames(String srcPath, SparkSession sparkSession) {
+  public Dataset<Row> initCloudObjectMetadata(String srcPath, SparkSession sparkSession) {
     if (isIncremental()) {
       return incrementalQuery(sparkSession).load(srcPath);
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -121,28 +121,28 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
     String commitTimeForReads = "1";
 
     Pair<String, List<HoodieRecord>> inserts = writeGcsMetadataRecords(commitTimeForWrites);
-    List<CloudObjectMetadata> dataFiles = Arrays.asList(
+    List<CloudObjectMetadata> cloudObjectMetadataList = Arrays.asList(
         new CloudObjectMetadata("data-file-1.json", 1),
         new CloudObjectMetadata("data-file-2.json", 1));
-    when(gcsObjectMetadataFetcher.getGcsObjectMetadata(Mockito.any(), Mockito.any(), anyBoolean())).thenReturn(dataFiles);
+    when(gcsObjectMetadataFetcher.getGcsObjectMetadata(Mockito.any(), Mockito.any(), anyBoolean())).thenReturn(cloudObjectMetadataList);
 
-    List<GcsDataRecord> recs = Arrays.asList(
-            new GcsDataRecord("1", "Hello 1"),
-            new GcsDataRecord("2", "Hello 2"),
-            new GcsDataRecord("3", "Hello 3"),
-            new GcsDataRecord("4", "Hello 4")
+    List<GcsExampleDataRecord> recs = Arrays.asList(
+        new GcsExampleDataRecord("1", "Hello 1"),
+        new GcsExampleDataRecord("2", "Hello 2"),
+        new GcsExampleDataRecord("3", "Hello 3"),
+        new GcsExampleDataRecord("4", "Hello 4")
     );
 
-    Dataset<Row> rows = spark().createDataFrame(recs, GcsDataRecord.class);
+    Dataset<Row> rows = spark().createDataFrame(recs, GcsExampleDataRecord.class);
 
-    when(gcsObjectDataFetcher.getCloudObjectDataDF(Mockito.any(), eq(dataFiles), Mockito.any())).thenReturn(Option.of(rows));
+    when(gcsObjectDataFetcher.getCloudObjectDataDF(Mockito.any(), eq(cloudObjectMetadataList), Mockito.any())).thenReturn(Option.of(rows));
 
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of(commitTimeForReads), 4, inserts.getKey());
 
     verify(gcsObjectMetadataFetcher, times(1)).getGcsObjectMetadata(Mockito.any(), Mockito.any(),
             anyBoolean());
     verify(gcsObjectDataFetcher, times(1)).getCloudObjectDataDF(Mockito.any(),
-            eq(dataFiles), Mockito.any());
+            eq(cloudObjectMetadataList), Mockito.any());
   }
 
   private void readAndAssert(IncrSourceHelper.MissingCheckpointStrategy missingCheckpointStrategy,
@@ -272,11 +272,11 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
     }
   }
 
-  public static class GcsDataRecord {
+  private static class GcsExampleDataRecord {
     public String id;
     public String text;
 
-    public GcsDataRecord(String id, String text) {
+    public GcsExampleDataRecord(String id, String text) {
       this.id = id;
       this.text = text;
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -109,9 +109,9 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
 
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of(commitTimeForReads), 0, inserts.getKey());
 
-    verify(gcsObjectMetadataFetcher, times(0)).getGcsObjects(Mockito.any(), Mockito.any(),
+    verify(gcsObjectMetadataFetcher, times(0)).getGcsObjectMetadata(Mockito.any(), Mockito.any(),
             anyBoolean());
-    verify(gcsObjectDataFetcher, times(0)).fetchCloudObjectData(
+    verify(gcsObjectDataFetcher, times(0)).getCloudObjectDataDF(
             Mockito.any(), Mockito.any(), Mockito.any());
   }
 
@@ -124,7 +124,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
     List<CloudObjectMetadata> dataFiles = Arrays.asList(
         new CloudObjectMetadata("data-file-1.json", 1),
         new CloudObjectMetadata("data-file-2.json", 1));
-    when(gcsObjectMetadataFetcher.getGcsObjects(Mockito.any(), Mockito.any(), anyBoolean())).thenReturn(dataFiles);
+    when(gcsObjectMetadataFetcher.getGcsObjectMetadata(Mockito.any(), Mockito.any(), anyBoolean())).thenReturn(dataFiles);
 
     List<GcsDataRecord> recs = Arrays.asList(
             new GcsDataRecord("1", "Hello 1"),
@@ -135,13 +135,13 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
 
     Dataset<Row> rows = spark().createDataFrame(recs, GcsDataRecord.class);
 
-    when(gcsObjectDataFetcher.fetchCloudObjectData(Mockito.any(), eq(dataFiles), Mockito.any())).thenReturn(Option.of(rows));
+    when(gcsObjectDataFetcher.getCloudObjectDataDF(Mockito.any(), eq(dataFiles), Mockito.any())).thenReturn(Option.of(rows));
 
     readAndAssert(READ_UPTO_LATEST_COMMIT, Option.of(commitTimeForReads), 4, inserts.getKey());
 
-    verify(gcsObjectMetadataFetcher, times(1)).getGcsObjects(Mockito.any(), Mockito.any(),
+    verify(gcsObjectMetadataFetcher, times(1)).getGcsObjectMetadata(Mockito.any(), Mockito.any(),
             anyBoolean());
-    verify(gcsObjectDataFetcher, times(1)).fetchCloudObjectData(Mockito.any(),
+    verify(gcsObjectDataFetcher, times(1)).getCloudObjectDataDF(Mockito.any(),
             eq(dataFiles), Mockito.any());
   }
 


### PR DESCRIPTION
### Change Logs

Create proper spark partitions for cloud incr source to load data.

Make use of size info of cloud objects and estimate the desired num of spark partitions for writing to cloud storage. This mitigate small file issues when a lot of cloud objects are to be loaded via spark.

### Impact

DeltaStreamer using S3EventsHoodieIncrSource and GcsEventsHoodieIncrSource

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
