### PR TITLE
[HUDI-5985] Fix orc version for spark 3.3

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/OrcBootstrapMetadataHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/OrcBootstrapMetadataHandler.java
@@ -72,7 +72,7 @@ class OrcBootstrapMetadataHandler extends BaseBootstrapMetadataHandler {
     }
     HoodieExecutor<Void> wrapper = null;
     Reader orcReader = OrcFile.createReader(sourceFilePath, OrcFile.readerOptions(table.getHadoopConf()));
-    TypeDescription orcSchema = orcReader.getSchema();
+    TypeDescription orcSchema = AvroOrcUtils.createOrcSchema(avroSchema);
     try (RecordReader reader = orcReader.rows(new Reader.Options(table.getHadoopConf()).schema(orcSchema))) {
       wrapper = ExecutorFactory.create(config, new OrcReaderIterator<GenericRecord>(reader, avroSchema, orcSchema),
           new BootstrapRecordConsumer(bootstrapHandle), inp -> {

--- a/pom.xml
+++ b/pom.xml
@@ -2205,7 +2205,7 @@
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
                    synchronized to avoid classpath ambiguity -->
         <parquet.version>1.12.2</parquet.version>
-        <orc.spark.version>1.7.4</orc.spark.version>
+        <orc.spark.version>1.7.8</orc.spark.version>
         <avro.version>1.11.1</avro.version>
         <antlr.version>4.8</antlr.version>
         <fasterxml.spark3.version>2.13.3</fasterxml.spark3.version>
@@ -2329,7 +2329,7 @@
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
                    synchronized to avoid classpath ambiguity -->
         <parquet.version>1.12.2</parquet.version>
-        <orc.spark.version>1.7.4</orc.spark.version>
+        <orc.spark.version>1.7.8</orc.spark.version>
         <avro.version>1.11.1</avro.version>
         <antlr.version>4.8</antlr.version>
         <fasterxml.spark3.version>2.13.3</fasterxml.spark3.version>


### PR DESCRIPTION
### Change Logs

Fix orc version based on spark 3.x latest orc version.

Note:
- spark 3.3.0 uses orc 1.7.4 https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/pom.xml#L135
- spark 3.3.1 uses orc 1.7.6 https://github.com/apache/spark/blob/fbbcf9434ac070dd4ced4fb9efe32899c6db12a9/pom.xml#L135
- spark 3.3.2 uses orc 1.7.8 https://github.com/apache/spark/blob/5103e00c4ce5fcc4264ca9c4df12295d42557af6/pom.xml#L136

original change was made as part of https://github.com/apache/hudi/pull/7885

### Impact

orc patch version upgrade may affect orc compatibility.

### Risk level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
