### PR TITLE
[HUDI-5893] Mark advanced configs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -42,6 +42,7 @@ public class HoodieArchivalConfig extends HoodieConfig {
   public static final ConfigProperty<String> AUTO_ARCHIVE = ConfigProperty
       .key("hoodie.archive.automatic")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("When enabled, the archival table service is invoked immediately after each commit,"
           + " to archive commits if we cross a maximum value of commits."
           + " It's recommended to enable this, to ensure number of active commits is bounded.");
@@ -49,6 +50,7 @@ public class HoodieArchivalConfig extends HoodieConfig {
   public static final ConfigProperty<String> ASYNC_ARCHIVE = ConfigProperty
       .key("hoodie.archive.async")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Only applies when " + AUTO_ARCHIVE.key() + " is turned on. "
           + "When turned on runs archiver async with writing, which can speed up overall write performance.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -155,6 +155,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_BUCKETIZED_CHECKING = ConfigProperty
       .key("hoodie.bloom.index.bucketized.checking")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM. "
           + "When true, bucketized bloom filtering is enabled. "
           + "This reduces skew seen in sort based bloom index lookup");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -216,6 +216,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> AVRO_SCHEMA_STRING = ConfigProperty
       .key("hoodie.avro.schema")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Schema string representing the current write schema of the table. Hudi passes this to "
           + "implementations of HoodieRecordPayload to convert incoming records to avro. This is also used as the write schema "
           + "evolving records during an update.");


### PR DESCRIPTION
### Change Logs

Some of configs should be marked advanced (https://github.com/apache/hudi/pull/7912). This PR mark the configs:
- hoodie.archive.automatic
- hoodie.archive.async
- hoodie.bloom.index.bucketized.checking
- hoodie.avro.schema



### Impact

makes it easier to use Hudi, especially as a beginner
### Risk level (write none, low medium or high below)

none
### Documentation Update

This will be used for grouping configs on the website, Documentation Need to make changes to the website to show advanced configs.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
