### PR TITLE
[HUDI-5989] Fix date conversion issue when performing partition pruning on Spark

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan, SubqueryAlias}
+import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.parser.HoodieExtendedParserInterface
@@ -42,7 +43,7 @@ import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.{DataType, Metadata, StructType}
 import org.apache.spark.storage.StorageLevel
 
-import java.util.Locale
+import java.util.{Locale, TimeZone}
 
 /**
  * Interface adapting discrepancies and incompatibilities between different Spark versions
@@ -114,6 +115,11 @@ trait SparkAdapter extends Serializable {
    * Create the SparkParsePartitionUtil.
    */
   def getSparkParsePartitionUtil: SparkParsePartitionUtil
+
+  /**
+   * Get the [[DateFormatter]].
+   */
+  def getDateFormatter(tz: TimeZone): DateFormatter
 
   /**
    * Combine [[PartitionedFile]] to [[FilePartition]] according to `maxSplitBytes`.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestLazyPartitionPathFetching.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestLazyPartitionPathFetching.scala
@@ -46,6 +46,12 @@ class TestLazyPartitionPathFetching extends HoodieSparkSqlTestBase {
       checkAnswer(s"select id, name, price, ts from $tableName where date_par='2023-03-01' order by id")(
         Seq(3, "a3", 10.0, 1000)
       )
+
+      withSQLConf("spark.sql.session.timeZone" -> "UTC+2") {
+        checkAnswer(s"select id, name, price, ts from $tableName where date_par='2023-03-01' order by id")(
+          Seq(3, "a3", 10.0, 1000)
+        )
+      }
     }
   }
 
@@ -79,6 +85,13 @@ class TestLazyPartitionPathFetching extends HoodieSparkSqlTestBase {
         s"where date_par='2023-03-01' and country='ID' order by id")(
         Seq(3, "a3", 10.0, 1000)
       )
+
+      withSQLConf("spark.sql.session.timeZone" -> "UTC+2") {
+        checkAnswer(s"select id, name, price, ts from $tableName " +
+          s"where date_par='2023-03-01' and country='ID' order by id")(
+          Seq(3, "a3", 10.0, 1000)
+        )
+      }
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestLazyPartitionPathFetching.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestLazyPartitionPathFetching.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+class TestLazyPartitionPathFetching extends HoodieSparkSqlTestBase {
+
+  test("Test querying with string column + partition pruning") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  grass_date string
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey ='id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+           | PARTITIONED BY (grass_date)
+       """.stripMargin)
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, date('2023-02-27'))")
+      spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, date('2023-02-28'))")
+      spark.sql(s"insert into $tableName values(3, 'a3', 10, 1000, date('2023-03-01'))")
+
+      checkAnswer(s"select id, name, price, ts from $tableName where grass_date = '2023-03-01' order by id")(
+        Seq(3, "a3", 10.0, 1000)
+      )
+    }
+  }
+
+  test("Test querying with date column + partition pruning") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  grass_date date
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey ='id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+           | PARTITIONED BY (grass_date)
+       """.stripMargin)
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, date('2023-02-27'))")
+      spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, date('2023-02-28'))")
+      spark.sql(s"insert into $tableName values(3, 'a3', 10, 1000, date('2023-03-01'))")
+
+      checkAnswer(s"select id, name, price, ts from $tableName where grass_date = date'2023-03-01' order by id")(
+        Seq(3, "a3", 10.0, 1000)
+      )
+    }
+  }
+
+  test("Test querying with date column + partition pruning (multi-level partitioning)") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long,
+           |  grass_region string,
+           |  grass_date date
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey ='id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+           | PARTITIONED BY (grass_region, grass_date)
+         """.stripMargin)
+      spark.sql(s"set schema.on.read.enable=true")
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, 'ID', date('2023-02-27'))")
+      spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, 'ID', date('2023-02-28'))")
+      spark.sql(s"insert into $tableName values(3, 'a3', 10, 1000, 'ID', date('2023-03-01'))")
+
+      // test (A) that is expected to fail
+      // must execute this first to prevent caching
+      // steps into prunePartition, causing partitionPath to be incorrectly constructed
+      checkAnswer(s"select id, name, price, ts from $tableName " +
+        s"where grass_date = date'2023-03-01' and grass_region='ID' order by id")(
+        Seq(3, "a3", 10.0, 1000)
+      )
+
+      // test (B) that is expected to pass
+      // if we execute the test (B) first, cached listings will be used, test (A) will pass
+      // no error
+      checkAnswer(s"select id, name, price, ts from $tableName where grass_date = date'2023-03-01' order by id")(
+        Seq(3, "a3", 10.0, 1000)
+      )
+
+      // TLDR:
+      // execution order of [B] = pass
+      // execution order of [B, A] = pass
+      // execution order of [A] = fail
+      // execution order of [A, B] = fail
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -21,6 +21,7 @@ import org.apache.avro.Schema
 import org.apache.hadoop.fs.Path
 import org.apache.hudi.client.utils.SparkRowSerDe
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.spark3.internal.ReflectUtil
 import org.apache.hudi.{AvroConversionUtils, DefaultSource, Spark3RowSerDe}
 import org.apache.hudi.{AvroConversionUtils, DefaultSource, HoodieBaseRelation, Spark3RowSerDe}
 import org.apache.spark.internal.Logging
@@ -32,6 +33,7 @@ import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.{Expression, InterpretedPredicate, Predicate}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -42,12 +44,19 @@ import org.apache.spark.sql.{HoodieSpark3CatalogUtils, SQLContext, SparkSession}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
 
+import java.time.ZoneId
+import java.util.TimeZone
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters.mapAsScalaMapConverter
+import scala.collection.convert.Wrappers.JConcurrentMapWrapper
 
 /**
  * Base implementation of [[SparkAdapter]] for Spark 3.x branch
  */
 abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
+
+  private val cache = JConcurrentMapWrapper(
+    new ConcurrentHashMap[ZoneId, DateFormatter](1))
 
   def getCatalogUtils: HoodieSpark3CatalogUtils
 
@@ -73,6 +82,10 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
   override def getAvroSchemaConverters: HoodieAvroSchemaConverters = HoodieSparkAvroSchemaConverters
 
   override def getSparkParsePartitionUtil: SparkParsePartitionUtil = Spark3ParsePartitionUtil
+
+  override def getDateFormatter(tz: TimeZone): DateFormatter = {
+    cache.getOrElseUpdate(tz.toZoneId, ReflectUtil.getDateFormatter(tz.toZoneId))
+  }
 
   /**
    * Combine [[PartitionedFile]] to [[FilePartition]] according to `maxSplitBytes`.


### PR DESCRIPTION
### Change Logs

When lazy fetching partition path & file slice for HoodieFileIndex is used, date cannot be converted to the correct string representation. 

This is the case as Spark store dates as an integer value representing the number of days that has past since 1970-01-01.

When rebuilding the partition path, this FS path could be rebuilt wrongly causing a partition to be empty, and hence, the query result to be empty/incorrect.

```
INFO DataSourceStrategy: Pruning directories with: isnotnull(country#80), isnotnull(par_date#81),(country#80 = ID),(par_date#81=19415)

...

INFO AbstractTableFileSystemView: Building file system view for partition (country=ID/par_date=19415) 
```

### Impact
None

### Risk level (write none, low medium or high below)
None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
