### PR TITLE
[HUDI-5991]  Fix RDDCustomColumnsSortPartitioner's RepartitionRecords

### DIFF
--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaCustomColumnsSortPartitioner.java
@@ -52,13 +52,13 @@ public class JavaCustomColumnsSortPartitioner<T>
   public List<HoodieRecord<T>> repartitionRecords(
       List<HoodieRecord<T>> records, int outputPartitions) {
     return records.stream().sorted((o1, o2) -> {
-      FlatLists.ComparableList<Comparable> cmp1 = FlatLists.ofComparableArray(
+      FlatLists.ComparableList<Comparable> values1 = FlatLists.ofComparableArray(
           HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord) o1, sortColumnNames, schema, consistentLogicalTimestampEnabled)
       );
-      FlatLists.ComparableList<Comparable> cmp2 = FlatLists.ofComparableArray(
+      FlatLists.ComparableList<Comparable> values2 = FlatLists.ofComparableArray(
           HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord) o2, sortColumnNames, schema, consistentLogicalTimestampEnabled)
       );
-      return cmp1.compareTo(cmp2);
+      return values1.compareTo(values2);
     }).collect(Collectors.toList());
   }
 

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaCustomColumnsSortPartitioner.java
@@ -22,6 +22,7 @@ package org.apache.hudi.execution.bulkinsert;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.avro.Schema;
@@ -51,9 +52,13 @@ public class JavaCustomColumnsSortPartitioner<T>
   public List<HoodieRecord<T>> repartitionRecords(
       List<HoodieRecord<T>> records, int outputPartitions) {
     return records.stream().sorted((o1, o2) -> {
-      Object values1 = HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord)o1, sortColumnNames, schema, consistentLogicalTimestampEnabled);
-      Object values2 = HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord)o2, sortColumnNames, schema, consistentLogicalTimestampEnabled);
-      return values1.toString().compareTo(values2.toString());
+      FlatLists.ComparableList<Comparable> cmp1 = FlatLists.ofComparableArray(
+          HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord) o1, sortColumnNames, schema, consistentLogicalTimestampEnabled)
+      );
+      FlatLists.ComparableList<Comparable> cmp2 = FlatLists.ofComparableArray(
+          HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord) o2, sortColumnNames, schema, consistentLogicalTimestampEnabled)
+      );
+      return cmp1.compareTo(cmp2);
     }).collect(Collectors.toList());
   }
 

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestJavaBulkInsertInternalPartitioner.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestJavaBulkInsertInternalPartitioner.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.table.BulkInsertPartitioner;
 import org.apache.hudi.testutils.HoodieJavaClientTestHarness;
 
@@ -70,8 +71,9 @@ public class TestJavaBulkInsertInternalPartitioner extends HoodieJavaClientTestH
   }
 
   private Comparator<HoodieRecord> getCustomColumnComparator(Schema schema, String[] sortColumns) {
-    return Comparator.comparing(
-        record -> HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord)record, sortColumns, schema, false).toString());
+    return Comparator.comparing(record ->
+        FlatLists.ofComparableArray(
+            HoodieAvroUtils.getRecordColumnValues((HoodieAvroRecord)record, sortColumns, schema, false)));
   }
 
   private void verifyRecordAscendingOrder(List<HoodieRecord> records,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
@@ -20,14 +20,17 @@ package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.config.SerializableSchema;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaRDD;
+import scala.Tuple2;
 
+import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Comparator;
 
 /**
  * A partitioner that does sorting based on specified column values for each RDD partition.
@@ -59,17 +62,17 @@ public class RDDCustomColumnsSortPartitioner<T>
     final String[] sortColumns = this.sortColumnNames;
     final SerializableSchema schema = this.serializableSchema;
     final boolean consistentLogicalTimestampEnabled = this.consistentLogicalTimestampEnabled;
-    return records.sortBy(
-        record -> {
-          Object recordValue = record.getColumnValues(schema.get(), sortColumns, consistentLogicalTimestampEnabled);
-          // null values are replaced with empty string for null_first order
-          if (recordValue == null) {
-            return StringUtils.EMPTY_STRING;
-          } else {
-            return StringUtils.objToString(recordValue);
-          }
-        },
-        true, outputSparkPartitions);
+
+    Comparator<HoodieRecord<T>> comparator = (Comparator<HoodieRecord<T>> & Serializable) (t1, t2) -> {
+      FlatLists.ComparableList obj1 = FlatLists.ofComparableArray(t1.getColumnValues(schema.get(), sortColumns, consistentLogicalTimestampEnabled));
+      FlatLists.ComparableList obj2 = FlatLists.ofComparableArray(t2.getColumnValues(schema.get(), sortColumns, consistentLogicalTimestampEnabled));
+      return obj1.compareTo(obj2);
+    };
+
+    return records
+        .mapToPair(record -> new Tuple2<>(record, record))
+        .sortByKey(comparator, true, outputSparkPartitions)
+        .map(Tuple2::_2);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.SerializableSchema;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.avro.Schema;
@@ -62,6 +63,11 @@ public class RDDCustomColumnsSortPartitioner<T>
     return records.sortBy(
         record -> {
           Object[] columnValues = record.getColumnValues(schema.get(), sortColumns, consistentLogicalTimestampEnabled);
+          for (int i = 0; i < columnValues.length; i++) {
+            if (columnValues[i] == null) {
+              throw new HoodieValidationException("There is a null value from " + sortColumns[i]);
+            }
+          }
           return FlatLists.ofComparableArray(columnValues);
         },
         true, outputSparkPartitions);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
@@ -22,7 +22,6 @@ import org.apache.hudi.common.config.SerializableSchema;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.avro.Schema;
@@ -63,11 +62,6 @@ public class RDDCustomColumnsSortPartitioner<T>
     return records.sortBy(
         record -> {
           Object[] columnValues = record.getColumnValues(schema.get(), sortColumns, consistentLogicalTimestampEnabled);
-          for (int i = 0; i < columnValues.length; i++) {
-            if (columnValues[i] == null) {
-              throw new HoodieValidationException("There is a null value from " + sortColumns[i]);
-            }
-          }
           return FlatLists.ofComparableArray(columnValues);
         },
         true, outputSparkPartitions);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -210,7 +211,7 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
 
   @Test
   public void testCustomColumnSortPartitioner() {
-    String sortColumnString = "rider";
+    String sortColumnString = "begin_lat";
     String[] sortColumns = sortColumnString.split(",");
     Comparator<HoodieRecord<? extends HoodieRecordPayload>> columnComparator = getCustomColumnComparator(HoodieTestDataGenerator.AVRO_SCHEMA, sortColumns);
 
@@ -238,15 +239,18 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
     Comparator<HoodieRecord<? extends HoodieRecordPayload>> comparator = Comparator.comparing(record -> {
       try {
         GenericRecord genericRecord = (GenericRecord) record.getData().getInsertValue(schema).get();
-        StringBuilder sb = new StringBuilder();
+        List<Object> keys = new ArrayList<>();
         for (String col : sortColumns) {
-          sb.append(genericRecord.get(col));
+          keys.add(genericRecord.get(col));
         }
-
-        return sb.toString();
+        return keys;
       } catch (IOException e) {
         throw new HoodieIOException("unable to read value for " + sortColumns);
       }
+    }, (o1, o2) -> {
+      FlatLists.ComparableList obj11 = FlatLists.ofComparableArray(o1.toArray());
+      FlatLists.ComparableList obj21 = FlatLists.ofComparableArray(o2.toArray());
+      return obj11.compareTo(obj21);
     });
 
     return comparator;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -248,10 +248,10 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
         throw new HoodieIOException("unable to read value for " + sortColumns);
       }
     }, (o1, o2) -> {
-      FlatLists.ComparableList obj11 = FlatLists.ofComparableArray(o1.toArray());
-      FlatLists.ComparableList obj21 = FlatLists.ofComparableArray(o2.toArray());
-      return obj11.compareTo(obj21);
-    });
+        FlatLists.ComparableList obj1 = FlatLists.ofComparableArray(o1.toArray());
+        FlatLists.ComparableList obj2 = FlatLists.ofComparableArray(o2.toArray());
+        return obj1.compareTo(obj2);
+      });
 
     return comparator;
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -248,9 +248,9 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
         throw new HoodieIOException("unable to read value for " + sortColumns);
       }
     }, (o1, o2) -> {
-        FlatLists.ComparableList obj1 = FlatLists.ofComparableArray(o1.toArray());
-        FlatLists.ComparableList obj2 = FlatLists.ofComparableArray(o2.toArray());
-        return obj1.compareTo(obj2);
+        FlatLists.ComparableList values1 = FlatLists.ofComparableArray(o1.toArray());
+        FlatLists.ComparableList values2 = FlatLists.ofComparableArray(o2.toArray());
+        return values1.compareTo(values2);
       });
 
     return comparator;

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -741,29 +741,24 @@ public class HoodieAvroUtils {
   }
 
   /**
-   * Gets record column values into one object.
+   * Gets record column values into object array.
    *
    * @param record  Hoodie record.
    * @param columns Names of the columns to get values.
    * @param schema  {@link Schema} instance.
-   * @return Column value if a single column, or concatenated String values by comma.
+   * @return Column value.
    */
-  public static Object getRecordColumnValues(HoodieAvroRecord record,
-                                             String[] columns,
-                                             Schema schema, boolean consistentLogicalTimestampEnabled) {
+  public static Object[] getRecordColumnValues(HoodieAvroRecord record,
+                                               String[] columns,
+                                               Schema schema,
+                                               boolean consistentLogicalTimestampEnabled) {
     try {
       GenericRecord genericRecord = (GenericRecord) ((HoodieAvroIndexedRecord) record.toIndexedRecord(schema, new Properties()).get()).getData();
-      if (columns.length == 1) {
-        return HoodieAvroUtils.getNestedFieldVal(genericRecord, columns[0], true, consistentLogicalTimestampEnabled);
-      } else {
-        // TODO this is inefficient, instead we can simply return array of Comparable
-        StringBuilder sb = new StringBuilder();
-        for (String col : columns) {
-          sb.append(HoodieAvroUtils.getNestedFieldValAsString(genericRecord, col, true, consistentLogicalTimestampEnabled));
-        }
-
-        return sb.toString();
+      List<Object> list = new ArrayList<>();
+      for (String col : columns) {
+        list.add(HoodieAvroUtils.getNestedFieldVal(genericRecord, col, true, consistentLogicalTimestampEnabled));
       }
+      return list.toArray();
     } catch (IOException e) {
       throw new HoodieIOException("Unable to read record with key:" + record.getKey(), e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -117,7 +117,7 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
 
   @Override
   public Object[] getColumnValues(Schema recordSchema, String[] columns, boolean consistentLogicalTimestampEnabled) {
-    return new Object[]{HoodieAvroUtils.getRecordColumnValues(this, columns, recordSchema, consistentLogicalTimestampEnabled)};
+    return HoodieAvroUtils.getRecordColumnValues(this, columns, recordSchema, consistentLogicalTimestampEnabled);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

When obtaining multiple specified fields, the return value is actually an array, but here it is directly obtained as an object: 
``` Object recordValue = record.getColumnValues(...)```

So it is converted into a string later: ```StringUtils.objToString(recordValue)```, 
in fact, the address of the previous array is obtained, resulting in a sorting error.

### Impact

Modify the sort function.

### Risk level (write none, low medium or high below)

low.

### Documentation Update

none


### Contributor's checklist

- [ x ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ x ] Change Logs and Impact were stated clearly
- [ x ] Adequate tests were added if applicable
- [ x ] CI passed
