### PR TITLE
[HUDI-5993] Connection leak for lock provider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -111,6 +111,7 @@ public class LockManager implements Serializable, AutoCloseable {
     if (writeConfig.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
       getLockProvider().unlock();
       metrics.updateLockHeldTimerMetrics();
+      close();
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestLockManager.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestLockManager.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.transaction;
+
+import org.apache.hudi.client.transaction.lock.LockManager;
+import org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider;
+import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestLockManager extends HoodieCommonTestHarness {
+
+  private static final Logger LOG = LogManager.getLogger(TestLockManager.class);
+
+  private static TestingServer server;
+  private static String zk_basePath = "/hudi/test/lock";
+  private static String key = "table1";
+
+  HoodieWriteConfig writeConfig;
+  LockManager lockManager;
+
+  @BeforeAll
+  public static void setup() {
+    while (server == null) {
+      try {
+        server = new TestingServer();
+      } catch (Exception e) {
+        LOG.error("Getting bind exception - retrying to allocate server");
+        server = null;
+      }
+    }
+  }
+
+  @AfterAll
+  public static void tearDown() throws IOException {
+    if (server != null) {
+      server.close();
+    }
+  }
+
+  private HoodieWriteConfig getWriteConfig() {
+    return HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
+            .build())
+        .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
+        .withLockConfig(HoodieLockConfig.newBuilder()
+            .withLockProvider(ZookeeperBasedLockProvider.class)
+            .withZkBasePath(zk_basePath)
+            .withZkLockKey(key)
+            .withZkQuorum(server.getConnectString())
+            .build())
+        .build();
+  }
+
+  @BeforeEach
+  private void init() throws IOException {
+    initPath();
+    initMetaClient();
+    this.writeConfig = getWriteConfig();
+    this.lockManager = new LockManager(this.writeConfig, this.metaClient.getFs());
+  }
+
+  @Test
+  public void testLockAndUnlock() throws NoSuchFieldException, IllegalAccessException{
+
+    Field lockProvider = lockManager.getClass().getDeclaredField("lockProvider");
+    lockProvider.setAccessible(true);
+
+    assertDoesNotThrow(() -> {
+      lockManager.lock();
+    });
+
+    assertNotNull(lockProvider.get(lockManager));
+
+    assertDoesNotThrow(() -> {
+      lockManager.unlock();
+    });
+
+    // we set lockProvider = null, when we call close(),
+    // if lockProvider == null, we believe close() has been called.
+    assertNull(lockProvider.get(lockManager));
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestLockManager.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestLockManager.java
@@ -34,13 +34,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestLockManager extends HoodieCommonTestHarness {
 
@@ -97,23 +95,17 @@ public class TestLockManager extends HoodieCommonTestHarness {
   }
 
   @Test
-  public void testLockAndUnlock() throws NoSuchFieldException, IllegalAccessException{
-
-    Field lockProvider = lockManager.getClass().getDeclaredField("lockProvider");
-    lockProvider.setAccessible(true);
+  public void testLockAndUnlock() {
+    LockManager mockLockManager = Mockito.spy(lockManager);
 
     assertDoesNotThrow(() -> {
-      lockManager.lock();
+      mockLockManager.lock();
     });
-
-    assertNotNull(lockProvider.get(lockManager));
 
     assertDoesNotThrow(() -> {
-      lockManager.unlock();
+      mockLockManager.unlock();
     });
 
-    // we set lockProvider = null, when we call close(),
-    // if lockProvider == null, we believe close() has been called.
-    assertNull(lockProvider.get(lockManager));
+    Mockito.verify(mockLockManager).close();
   }
 }


### PR DESCRIPTION
### Change Logs
Enable occ with ZookeeperBasedLockProvider, when the job runs for a while, it throws a CuratorConnectionLossException. And I find `Too many connections` in zk log.

```
23/03/27 11:23:54 ERROR ConnectionState: Connection timed out for connection string (10.19.36.89) and timeout (15000) / elapsed (33970)
org.apache.curator.CuratorConnectionLossException: KeeperErrorCode = ConnectionLoss
	at org.apache.curator.ConnectionState.checkTimeouts(ConnectionState.java:225)
	at org.apache.curator.ConnectionState.getZooKeeper(ConnectionState.java:94)
	at org.apache.curator.CuratorZookeeperClient.getZooKeeper(CuratorZookeeperClient.java:117)
	at org.apache.curator.framework.imps.CuratorFrameworkImpl.getZooKeeper(CuratorFrameworkImpl.java:489)
	at org.apache.curator.framework.imps.CreateBuilderImpl$12.call(CreateBuilderImpl.java:786)
	at org.apache.curator.framework.imps.CreateBuilderImpl$12.call(CreateBuilderImpl.java:778)
	at org.apache.curator.RetryLoop.callWithRetry(RetryLoop.java:109)
	at org.apache.curator.framework.imps.CreateBuilderImpl.findProtectedNodeInForeground(CreateBuilderImpl.java:775)
	at org.apache.curator.framework.imps.CreateBuilderImpl.access$1200(CreateBuilderImpl.java:44)
	at org.apache.curator.framework.imps.CreateBuilderImpl$11.call(CreateBuilderImpl.java:733)
	at org.apache.curator.framework.imps.CreateBuilderImpl$11.call(CreateBuilderImpl.java:723)
	at org.apache.curator.RetryLoop.callWithRetry(RetryLoop.java:109)
	at org.apache.curator.framework.imps.CreateBuilderImpl.pathInForeground(CreateBuilderImpl.java:720)
	at org.apache.curator.framework.imps.CreateBuilderImpl.protectedPathInForeground(CreateBuilderImpl.java:484)
	at org.apache.curator.framework.imps.CreateBuilderImpl.forPath(CreateBuilderImpl.java:474)
	at org.apache.curator.framework.imps.CreateBuilderImpl.forPath(CreateBuilderImpl.java:454)
	at org.apache.curator.framework.imps.CreateBuilderImpl.forPath(CreateBuilderImpl.java:44)
	at org.apache.curator.framework.recipes.locks.StandardLockInternalsDriver.createsTheLock(StandardLockInternalsDriver.java:54)
	at org.apache.curator.framework.recipes.locks.LockInternals.attemptLock(LockInternals.java:217)
	at org.apache.curator.framework.recipes.locks.InterProcessMutex.internalLock(InterProcessMutex.java:232)
	at org.apache.curator.framework.recipes.locks.InterProcessMutex.acquire(InterProcessMutex.java:108)
	at org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider.acquireLock(ZookeeperBasedLockProvider.java:144)
	at org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider.tryLock(ZookeeperBasedLockProvider.java:96)
	at org.apache.hudi.client.transaction.lock.LockManager.lock(LockManager.java:78)
	at org.apache.hudi.client.transaction.TransactionManager.beginTransaction(TransactionManager.java:59)
	at org.apache.hudi.client.HoodieTimelineArchiver.archiveIfRequired(HoodieTimelineArchiver.java:168)
	at org.apache.hudi.client.BaseHoodieTableServiceClient.archive(BaseHoodieTableServiceClient.java:577)
	at org.apache.hudi.client.BaseHoodieWriteClient.archive(BaseHoodieWriteClient.java:784)
	at org.apache.hudi.client.BaseHoodieWriteClient.autoArchiveOnCommit(BaseHoodieWriteClient.java:574)
	at org.apache.hudi.client.BaseHoodieWriteClient.mayBeCleanAndArchive(BaseHoodieWriteClient.java:540)
	at org.apache.hudi.client.BaseHoodieWriteClient.commitStats(BaseHoodieWriteClient.java:247)
	at org.apache.hudi.client.SparkRDDWriteClient.commit(SparkRDDWriteClient.java:103)
	at org.apache.hudi.HoodieSparkSqlWriter$.commitAndPerformPostOperations(HoodieSparkSqlWriter.scala:960)
	at org.apache.hudi.HoodieSparkSqlWriter$.write(HoodieSparkSqlWriter.scala:377)
	at org.apache.hudi.HoodieStreamingSink.$anonfun$addBatch$2(HoodieStreamingSink.scala:122)
	at scala.util.Try$.apply(Try.scala:213)
	at org.apache.hudi.HoodieStreamingSink.$anonfun$addBatch$1(HoodieStreamingSink.scala:120)
	at org.apache.hudi.HoodieStreamingSink.retry(HoodieStreamingSink.scala:244)
	at org.apache.hudi.HoodieStreamingSink.addBatch(HoodieStreamingSink.scala:119)
```



This pr calls TransactionManager.close after endTransaction

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
