### PR TITLE
[HUDI-5992] Fix (de)serialization for avro versions > 1.10.0

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/GenericAvroSerializer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/GenericAvroSerializer.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.avro;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaNormalization;
+import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+
+/**
+ * Custom serializer used for generic Avro containers.
+ * <p>
+ * Heavily adapted from:
+ * <p>
+ * https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+ * <p>
+ * As {@link org.apache.hudi.common.util.SerializationUtils} is not shared between threads and does not concern any
+ * shuffling operations, compression and decompression cache is omitted.
+ *
+ * @param <D> the subtype of [[GenericContainer]] handled by this serializer
+ */
+public class GenericAvroSerializer<D extends GenericContainer> extends Serializer<D> {
+
+  // reuses the same datum reader/writer since the same schema will be used many times
+  private final HashMap<Schema, DatumWriter<D>> writerCache = new HashMap<>();
+  private final HashMap<Schema, DatumReader<D>> readerCache = new HashMap<>();
+
+  // fingerprinting is very expensive so this alleviates most of the work
+  private final HashMap<Schema, Long> fingerprintCache = new HashMap<>();
+  private final HashMap<Long, Schema> schemaCache = new HashMap<>();
+
+  private Long getFingerprint(Schema schema) {
+    if (fingerprintCache.containsKey(schema)) {
+      return fingerprintCache.get(schema);
+    } else {
+      Long fingerprint = SchemaNormalization.parsingFingerprint64(schema);
+      fingerprintCache.put(schema, fingerprint);
+      return fingerprint;
+    }
+  }
+
+  private Schema getSchema(Long fingerprint, byte[] schemaBytes) {
+    if (schemaCache.containsKey(fingerprint)) {
+      return schemaCache.get(fingerprint);
+    } else {
+      String schema = new String(schemaBytes, StandardCharsets.UTF_8);
+      Schema parsedSchema = new Schema.Parser().parse(schema);
+      schemaCache.put(fingerprint, parsedSchema);
+      return parsedSchema;
+    }
+  }
+
+  private DatumWriter<D> getDatumWriter(Schema schema) {
+    DatumWriter<D> writer;
+    if (writerCache.containsKey(schema)) {
+      writer = writerCache.get(schema);
+    } else {
+      writer = new GenericDatumWriter<>(schema);
+      writerCache.put(schema, writer);
+    }
+    return writer;
+  }
+
+  private DatumReader<D> getDatumReader(Schema schema) {
+    DatumReader<D> reader;
+    if (readerCache.containsKey(schema)) {
+      reader = readerCache.get(schema);
+    } else {
+      reader = new GenericDatumReader<>(schema);
+      readerCache.put(schema, reader);
+    }
+    return reader;
+  }
+
+  private void serializeDatum(D datum, Output output) throws IOException {
+    Encoder encoder = EncoderFactory.get().directBinaryEncoder(output, null);
+    Schema schema = datum.getSchema();
+    Long fingerprint = this.getFingerprint(schema);
+    byte[] schemaBytes = schema.toString().getBytes(StandardCharsets.UTF_8);
+    output.writeLong(fingerprint);
+    output.writeInt(schemaBytes.length);
+    output.writeBytes(schemaBytes);
+    getDatumWriter(schema).write(datum, encoder);
+    encoder.flush();
+  }
+
+  private D deserializeDatum(Input input) throws IOException {
+    Long fingerprint = input.readLong();
+    int schemaBytesLen = input.readInt();
+    byte[] schemaBytes = input.readBytes(schemaBytesLen);
+    Schema schema = getSchema(fingerprint, schemaBytes);
+    Decoder decoder = DecoderFactory.get().directBinaryDecoder(input, null);
+    return getDatumReader(schema).read(null, decoder);
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output, D datum) {
+    try {
+      serializeDatum(datum, output);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public D read(Kryo kryo, Input input, Class<D> datumClass) {
+    try {
+      return deserializeDatum(input);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/SerializationUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/SerializationUtils.java
@@ -22,6 +22,8 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import org.apache.avro.generic.GenericData;
+import org.apache.hudi.avro.GenericAvroSerializer;
 import org.apache.avro.util.Utf8;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
@@ -122,6 +124,7 @@ public class SerializationUtils {
 
       // Register serializers
       kryo.register(Utf8.class, new AvroUtf8Serializer());
+      kryo.register(GenericData.Fixed.class, new GenericAvroSerializer<>());
 
       return kryo;
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/compact/TestBitCaskDiskMapFromFlink.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/compact/TestBitCaskDiskMapFromFlink.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.compact;
+
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.hudi.common.model.EventTimeAvroPayload;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.collection.BitCaskDiskMap;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class TestBitCaskDiskMapFromFlink extends HoodieCommonTestHarness {
+
+  @Test
+  public void testPutDecimal() throws IOException {
+    // the avro version used by hudi-flink module is 1.10.0
+    // placing the test here will use avro 1.10.0, allowing the error caused by anonymous classes to be thrown
+    BitCaskDiskMap<String, HoodieRecord> records = new BitCaskDiskMap<>(basePath, true);
+    Schema precombineFieldSchema = LogicalTypes.decimal(20, 0)
+        .addToSchema(Schema.createFixed("fixed", null, "record.precombineField", 9));
+
+    byte[] decimalFieldBytes = new byte[] {0, 0, 0, 1, -122, -16, -116, -90, -32};
+    GenericFixed genericFixed = new GenericData.Fixed(precombineFieldSchema, decimalFieldBytes);
+
+    HoodieRecord avroRecord = new HoodieAvroRecord<>(new HoodieKey("recordKey", "partitionPath"),
+        new EventTimeAvroPayload(null, (Comparable) genericFixed));
+
+    records.put("a", avroRecord);
+    records.get("a");
+  }
+
+}


### PR DESCRIPTION
### Change Logs
Added a custom (de)serializer to handle `GenericData$Fixed` types.

Please refer to [HUDI-5992](https://issues.apache.org/jira/browse/HUDI-5992) for more details.

### Impact

`GenericData$Fixed` types will be ser-de with Hudi's **GenericAvroSerializer**, which is heavily adapted from:

https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
