### PR TITLE
[HUDI-5994] Spark bulk insert with bucket index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -91,6 +91,10 @@ public class BucketIdentifier implements Serializable {
     return newBucketFileIdPrefix(bucketIdStr(bucketId));
   }
 
+  public static String newBucketFileIdPrefix(String fileId, int bucketId) {
+    return fileId.replaceFirst(".{8}", bucketIdStr(bucketId));
+  }
+
   public static String newBucketFileIdPrefix(String bucketId) {
     return FSUtils.createNewFileIdPfx().replaceFirst(".{8}", bucketId);
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketPartitionerWithRows.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.execution.bulkinsert;
+
+import org.apache.hudi.table.BulkInsertPartitioner;
+import org.apache.spark.sql.BucketPartitionUtils$;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+public class BucketPartitionerWithRows implements BulkInsertPartitioner<Dataset<Row>> {
+
+  private String indexKeyFields;
+  private int bucketNum;
+
+  public BucketPartitionerWithRows(String indexKeyFields, int bucketNum) {
+    this.indexKeyFields = indexKeyFields;
+    this.bucketNum = bucketNum;
+  }
+
+  @Override
+  public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputSparkPartitions) {
+    return BucketPartitionUtils$.MODULE$.createDataFrame(rows, indexKeyFields, bucketNum, outputSparkPartitions);
+  }
+
+  @Override
+  public boolean arePartitionRecordsSorted() {
+    return false;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BulkInsertBucketInternalWriterHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BulkInsertBucketInternalWriterHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+import org.apache.hudi.io.storage.row.HoodieRowCreateHandle;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BulkInsertBucketInternalWriterHelper extends BulkInsertDataInternalWriterHelper {
+
+  private static final Logger LOG = LogManager.getLogger(BulkInsertBucketInternalWriterHelper.class);
+
+  private int lastKnownBucketNum = -1;
+  // p -> (bucketNum -> handle)
+  private Map<String, Map<Integer, HoodieRowCreateHandle>> bucketHandles = new HashMap<>();
+  private String indexKeyFields;
+  private int bucketNum = -1;
+
+  public BulkInsertBucketInternalWriterHelper(HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
+      String instantTime, int taskPartitionId, long taskId, long taskEpochId, StructType structType,
+      boolean populateMetaFields, boolean arePartitionRecordsSorted) {
+    super(hoodieTable, writeConfig, instantTime, taskPartitionId, taskId, taskEpochId, structType, populateMetaFields, arePartitionRecordsSorted);
+    indexKeyFields = writeConfig.getStringOrDefault(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD, writeConfig.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()));
+    bucketNum = writeConfig.getInt(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS);
+  }
+
+  @Override
+  protected void tryCreateNewHandle(UTF8String partitionPath, UTF8String recordKey) throws IOException {
+    int bucketId = BucketIdentifier.getBucketId(String.valueOf(recordKey), indexKeyFields, bucketNum);
+    if ((lastKnownPartitionPath == null) || !lastKnownPartitionPath.equals(partitionPath) || !handle.canWrite() || bucketId != lastKnownBucketNum) {
+      handle = getBucketRowCreateHandle(String.valueOf(partitionPath), bucketId);
+      lastKnownPartitionPath = partitionPath;
+      lastKnownBucketNum = bucketId;
+    }
+  }
+
+  protected HoodieRowCreateHandle getBucketRowCreateHandle(String partitionPath, int bucketId) throws IOException {
+    Map<Integer, HoodieRowCreateHandle> bucketHandleMap = bucketHandles.getOrDefault(partitionPath, new HashMap<>());
+    if (!bucketHandleMap.isEmpty() && bucketHandleMap.containsKey(bucketId)) {
+      return bucketHandleMap.get(bucketId);
+    }
+    LOG.info("Creating new file for partition path " + partitionPath);
+    HoodieRowCreateHandle rowCreateHandle = new HoodieRowCreateHandle(hoodieTable, writeConfig, partitionPath, getNextBucketFileId(bucketId),
+        instantTime, taskPartitionId, taskId, taskEpochId, structType, shouldPreserveHoodieMetadata);
+    bucketHandleMap.put(bucketId, rowCreateHandle);
+    bucketHandles.put(partitionPath, bucketHandleMap);
+    return rowCreateHandle;
+  }
+
+  @Override
+  public void close() throws IOException {
+    for (Map<Integer, HoodieRowCreateHandle> entry : bucketHandles.values()) {
+      for (HoodieRowCreateHandle rowCreateHandle : entry.values()) {
+        LOG.info("Closing bulk insert file " + rowCreateHandle.getFileName());
+        writeStatusList.add(rowCreateHandle.close());
+      }
+      entry.clear();
+    }
+    bucketHandles.clear();
+  }
+
+  protected String getNextBucketFileId(int bucketInt) {
+    return BucketIdentifier.newBucketFileIdPrefix(getNextFileId(), bucketInt);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/BucketPartitionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/BucketPartitionUtils.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.index.bucket.BucketIdentifier
+import org.apache.spark.Partitioner
+import org.apache.spark.sql.catalyst.InternalRow
+
+object BucketPartitionUtils {
+  def createDataFrame(df: DataFrame, indexKeyFields: String, bucketNum: Int, partitionNum: Int): DataFrame = {
+    def getPartitionKeyExtractor(): InternalRow => Int = row => {
+      val kb = BucketIdentifier
+        .getBucketId(row.getString(HoodieRecord.HOODIE_META_COLUMNS.indexOf(HoodieRecord.RECORD_KEY_METADATA_FIELD)), indexKeyFields, bucketNum)
+      val partition = row.getString(HoodieRecord.HOODIE_META_COLUMNS.indexOf(HoodieRecord.PARTITION_PATH_METADATA_FIELD))
+      if (partition == null || partition.trim.isEmpty) {
+        kb
+      } else {
+        val pw = (partition.hashCode & Int.MaxValue) % partitionNum
+        BucketIdentifier.mod(kb + pw, partitionNum)
+      }
+    }
+
+    // use internalRow to avoid extra convert.
+    val reRdd = df.queryExecution.toRdd.mapPartitions { iter => {
+      val getPartitionKey = getPartitionKeyExtractor()
+      iter.map { row => (getPartitionKey(row), row) }
+    }
+    }.partitionBy(new Partitioner {
+      override def numPartitions: Int = partitionNum
+
+      override def getPartition(key: Any): Int = {
+        key.asInstanceOf[Int]
+      }
+    }).values
+    df.sparkSession.internalCreateDataFrame(reRdd, df.schema)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -1058,6 +1058,62 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test Bulk Insert Into Bucket Index Table") {
+    withSQLConf("hoodie.sql.bulk.insert.enable" -> "true") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        // Create a partitioned table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  dt string,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             | primaryKey = 'id,name',
+             | preCombineField = 'ts',
+             | hoodie.index.type = 'BUCKET',
+             | hoodie.bucket.index.hash.field = 'id,name')
+             | partitioned by (dt)
+             | location '${tmp.getCanonicalPath}'
+       """.stripMargin)
+
+        // Note: Do not write the field alias, the partition field must be placed last.
+        spark.sql(
+          s"""
+             | insert into $tableName values
+             | (1, 'a1,1', 10, 1000, "2021-01-05"),
+             | (2, 'a2', 20, 2000, "2021-01-06"),
+             | (3, 'a3,3', 30, 3000, "2021-01-07")
+              """.stripMargin)
+
+        checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+          Seq(1, "a1,1", 10.0, 1000, "2021-01-05"),
+          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+          Seq(3, "a3,3", 30.0, 3000, "2021-01-07")
+        )
+
+        spark.sql(
+          s"""
+             | insert into $tableName values
+             | (1, 'a1', 10, 1000, "2021-01-05"),
+             | (3, "a3", 30, 3000, "2021-01-07")
+              """.stripMargin)
+
+        checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+          Seq(1, "a1,1", 10.0, 1000, "2021-01-05"),
+          Seq(1, "a1", 10.0, 1000, "2021-01-05"),
+          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
+          Seq(3, "a3,3", 30.0, 3000, "2021-01-07"),
+          Seq(3, "a3", 30.0, 3000, "2021-01-07")
+        )
+      }
+    }
+  }
+
   /**
    * This test is to make sure that bulk insert doesn't create a bunch of tiny files if
    * hoodie.bulkinsert.user.defined.partitioner.sort.columns doesn't start with the partition columns

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/java/org/apache/hudi/spark3/internal/HoodieBulkInsertDataInternalWriter.java
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/java/org/apache/hudi/spark3/internal/HoodieBulkInsertDataInternalWriter.java
@@ -21,6 +21,8 @@ package org.apache.hudi.spark3.internal;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.commit.BulkInsertDataInternalWriterHelper;
+import org.apache.hudi.table.action.commit.BulkInsertBucketInternalWriterHelper;
+import org.apache.hudi.index.HoodieIndex;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
@@ -39,7 +41,11 @@ public class HoodieBulkInsertDataInternalWriter implements DataWriter<InternalRo
   public HoodieBulkInsertDataInternalWriter(HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
                                             String instantTime, int taskPartitionId, long taskId, StructType structType, boolean populateMetaFields,
                                             boolean arePartitionRecordsSorted) {
-    this.bulkInsertWriterHelper = new BulkInsertDataInternalWriterHelper(hoodieTable,
+    boolean bucketEnable = writeConfig.getIndexType() == HoodieIndex.IndexType.BUCKET;
+    this.bulkInsertWriterHelper = bucketEnable
+      ? new BulkInsertBucketInternalWriterHelper(hoodieTable,
+        writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted)
+      : new BulkInsertDataInternalWriterHelper(hoodieTable,
         writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted);
   }
 


### PR DESCRIPTION
### Change Logs

Bucket index supports bulk insert mode.

### Impact

you can set hoodie.sql.bulk.insert.enable=true when using bucket index.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
