### PR TITLE
[HUDI-6000] Fix RunClusteringProcedure when no partition matched

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -93,17 +93,20 @@ class RunClusteringProcedure extends BaseProcedure
     val selectedPartitions: String = (parts, predicate) match {
       case (_, Some(p)) => prunePartition(metaClient, p.asInstanceOf[String])
       case (Some(o), _) => o.asInstanceOf[String]
-      case _ => ""
+      case _ => null
     }
 
-    if (selectedPartitions.nonEmpty) {
+    if (selectedPartitions == null) {
+      logInfo("No partition selected")
+    } else if (selectedPartitions.isEmpty) {
+      logInfo("No partition matched")
+      return Seq()
+    } else {
       conf = conf ++ Map(
         HoodieClusteringConfig.PLAN_PARTITION_FILTER_MODE_NAME.key() -> "SELECTED_PARTITIONS",
         HoodieClusteringConfig.PARTITION_SELECTED.key() -> selectedPartitions
       )
       logInfo(s"Partition selected: $selectedPartitions")
-    } else {
-      logInfo("No partition selected")
     }
 
     // Construct sort column info

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
@@ -28,7 +28,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieActiveTimeline, HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.collection.Pair
-import org.apache.hudi.config.HoodieClusteringConfig
 import org.apache.hudi.{DataSourceReadOptions, HoodieCLIUtils, HoodieDataSourceHelpers, HoodieFileIndex}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal}
 import org.apache.spark.sql.types.{DataTypes, Metadata, StringType, StructField, StructType}
@@ -392,6 +391,14 @@ class TestClusteringProcedure extends HoodieSparkProcedureTestBase {
             Seq(9, "a9", 10.0, 1008),
             Seq(10, "a10", 10.0, 1009)
           )
+        }
+
+        // Test partition pruning with invalid predicates
+        {
+          val resultD = spark.sql(s"call run_clustering(table => '$tableName', predicate => 'ts > 1111L', order => 'ts', show_involved_partition => true)")
+            .collect()
+            .map(row => Seq(row.getString(0), row.getInt(1), row.getString(2), row.getString(3)))
+          assertResult(0)(resultD.length)
         }
       }
     }


### PR DESCRIPTION
### Change Logs

There are two ways to specify the partitions to be clustered in run_clustering:

`predicate => xxx` and `selected_partitions => xxx`

But cluster is still scheduled when `predicate` does not match any partitions or `selected_partitions` = "" currently

### Impact

Cluster will not be scheduled when no partition matched

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
