### PR TITLE
[HUDI-5934] Remove archival configs for metadata table

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
@@ -80,7 +80,7 @@ public class TestArchivedCommitsCommand extends CLIFunctionalTestHarness {
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath)
         .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
@@ -132,7 +132,7 @@ public class TestArchivedCommitsCommand extends CLIFunctionalTestHarness {
 
     // Generate expected data
     final List<Comparable[]> rows = new ArrayList<>();
-    for (int i = 100; i < 104; i++) {
+    for (int i = 100; i < 102; i++) {
       String instant = String.valueOf(i);
       for (int j = 0; j < 3; j++) {
         Comparable[] defaultComp = new Comparable[] {"commit", instant,
@@ -169,21 +169,20 @@ public class TestArchivedCommitsCommand extends CLIFunctionalTestHarness {
    */
   @Test
   public void testShowCommits() throws Exception {
-    Object cmdResult = shell.evaluate(() -> "show archived commits");
+    Object cmdResult = shell.evaluate(() -> "show archived commits --limit 5");
     assertTrue(ShellEvaluationResultUtil.isSuccess(cmdResult));
     final List<Comparable[]> rows = new ArrayList<>();
 
-    // Test default skipMetadata and limit 10
+    // Test default skipMetadata and limit 5
     TableHeader header = new TableHeader().addTableHeaderField("CommitTime").addTableHeaderField("CommitType");
-    for (int i = 100; i < 103; i++) {
-      String instant = String.valueOf(i);
-      Comparable[] result = new Comparable[] {instant, "commit"};
-      rows.add(result);
-      rows.add(result);
-      rows.add(result);
-    }
-    rows.add(new Comparable[] {"103", "commit"});
-    String expected = HoodiePrintHelper.print(header, new HashMap<>(), "", false, 10, false, rows);
+    Comparable[] result1 = new Comparable[] {"100", "commit"};
+    Comparable[] result2 = new Comparable[] {"101", "commit"};
+    rows.add(result1);
+    rows.add(result1);
+    rows.add(result1);
+    rows.add(result2);
+    rows.add(result2);
+    String expected = HoodiePrintHelper.print(header, new HashMap<>(), "", false, 5, false, rows);
     expected = removeNonWordAndStripSpace(expected);
     String got = removeNonWordAndStripSpace(cmdResult.toString());
     assertEquals(expected, got);
@@ -194,7 +193,7 @@ public class TestArchivedCommitsCommand extends CLIFunctionalTestHarness {
 
     rows.clear();
 
-    for (int i = 100; i < 104; i++) {
+    for (int i = 100; i < 102; i++) {
       String instant = String.valueOf(i);
       // Since HoodiePrintHelper order data by default, need to order commitMetadata
       HoodieCommitMetadata metadata = HoodieTestCommitMetadataGenerator.generateCommitMetadata(tablePath, instant);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -39,6 +39,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.NumericUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -216,11 +217,17 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
 
   private String generateExpectDataWithExtraMetadata(int records, Map<String, Integer[]> data) throws IOException {
     List<Comparable[]> rows = new ArrayList<>();
+    Map<String, Pair<String, String>> expectedNums = new HashMap<>();
+    expectedNums.put("106", Pair.of("50", "30"));
+    expectedNums.put("105", Pair.of("40", "20"));
+    expectedNums.put("104", Pair.of("20", "10"));
+    expectedNums.put("103", Pair.of("15", "15"));
     data.forEach((key, value) -> {
       for (int i = 0; i < records; i++) {
         // there are more than 1 partitions, so need to * partitions
         rows.add(new Comparable[] {HoodieTimeline.COMMIT_ACTION, key, "2015/03/16", HoodieTestCommitMetadataGenerator.DEFAULT_FILEID,
-            HoodieTestCommitMetadataGenerator.DEFAULT_PRE_COMMIT, key.equals("104") ? "20" : "15", "0", "0", key.equals("104") ? "10" : "15",
+            HoodieTestCommitMetadataGenerator.DEFAULT_PRE_COMMIT,
+            expectedNums.get(key).getLeft(), "0", "0", expectedNums.get(key).getRight(),
             "0", HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_LOG_BLOCKS, "0", "0", HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_LOG_RECORDS,
             "0", HoodieTestCommitMetadataGenerator.DEFAULT_TOTAL_WRITE_BYTES});
       }
@@ -247,12 +254,14 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
 
     // archived 101 and 102 instant, generate expect data
-    assertEquals(2, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
-        "There should 2 instants not be archived!");
+    assertEquals(4, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
+        "There should 4 instants not be archived!");
 
     // archived 101 and 102 instants, remove 103 and 104 instant
     data.remove("103");
     data.remove("104");
+    data.remove("105");
+    data.remove("106");
     String expected = generateExpectData(1, data);
     expected = removeNonWordAndStripSpace(expected);
     String got = removeNonWordAndStripSpace(result.toString());
@@ -264,7 +273,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath1)
         .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadataTable).build())
@@ -272,6 +281,8 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
 
     // generate data and metadata
     Map<String, Integer[]> data = new LinkedHashMap<>();
+    data.put("106", new Integer[] {50, 30});
+    data.put("105", new Integer[] {40, 20});
     data.put("104", new Integer[] {20, 10});
     data.put("103", new Integer[] {15, 15});
     data.put("102", new Integer[] {25, 45});
@@ -287,7 +298,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     if (enableMetadataTable) {
       // Simulate a compaction commit in metadata table timeline
       // so the archival in data table can happen
-      createCompactionCommitInMetadataTable(hadoopConf(), metaClient.getFs(), tablePath1, "104");
+      createCompactionCommitInMetadataTable(hadoopConf(), metaClient.getFs(), tablePath1, "106");
     }
 
     // archive
@@ -305,7 +316,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath1)
         .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadataTable).build())
@@ -340,8 +351,8 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
 
     Object result = shell.evaluate(() -> String.format("commits showarchived --startTs %s --endTs %s", "160", "174"));
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
-    assertEquals(3, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
-        "There should 3 instants not be archived!");
+    assertEquals(5, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
+        "There should 5 instants not be archived!");
 
     Map<String, Integer[]> data2 = new LinkedHashMap<>();
     for (int i = 174; i >= 161; i--) {

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -257,7 +257,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     assertEquals(4, metaClient.reloadActiveTimeline().getCommitsTimeline().countInstants(),
         "There should 4 instants not be archived!");
 
-    // archived 101 and 102 instants, remove 103 and 104 instant
+    // archived 101 and 102 instants, remove instant 103 to 106
     data.remove("103");
     data.remove("104");
     data.remove("105");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2359,14 +2359,6 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBooleanOrDefault(HoodieMetadataConfig.ASYNC_INDEX_ENABLE);
   }
 
-  public int getMetadataMaxCommitsToKeep() {
-    return getInt(HoodieMetadataConfig.MAX_COMMITS_TO_KEEP);
-  }
-
-  public int getMetadataMinCommitsToKeep() {
-    return getInt(HoodieMetadataConfig.MIN_COMMITS_TO_KEEP);
-  }
-
   /**
    * Hoodie Client Lock Configs.
    *

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -250,9 +250,6 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       HoodieWriteConfig writeConfig, HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy) {
     int parallelism = writeConfig.getMetadataInsertParallelism();
 
-    int minCommitsToKeep = Math.max(writeConfig.getMetadataMinCommitsToKeep(), writeConfig.getMinCommitsToKeep());
-    int maxCommitsToKeep = Math.max(writeConfig.getMetadataMaxCommitsToKeep(), writeConfig.getMaxCommitsToKeep());
-
     // Create the write config for the metadata table by borrowing options from the main write config.
     HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder()
         .withEngineType(writeConfig.getEngineType())
@@ -284,7 +281,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
             .build())
         // we will trigger archive manually, to ensure only regular writer invokes it
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
-            .archiveCommitsWith(minCommitsToKeep, maxCommitsToKeep)
+            .archiveCommitsWith(
+                writeConfig.getMinCommitsToKeep(), writeConfig.getMaxCommitsToKeep())
             .withAutoArchive(false)
             .build())
         // we will trigger compaction manually, to control the instant times

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnMergeOnReadStorage.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.client.functional;
 
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -49,6 +48,8 @@ import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.testutils.GenericRecordValidationTestUtils;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 import org.apache.hudi.testutils.HoodieSparkWriteableTestTable;
+
+import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -486,7 +487,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
     HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.INMEMORY)
         .withAutoCommit(true).withCompactionConfig(compactionConfig)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(2).build())
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(3, 4).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();
     SparkRDDWriteClient client = new SparkRDDWriteClient(context, config);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
@@ -371,8 +371,8 @@ public class TestHoodieMetadataBase extends HoodieClientTestHarness {
   protected HoodieWriteConfig getMetadataWriteConfig(HoodieWriteConfig writeConfig) {
     int parallelism = writeConfig.getMetadataInsertParallelism();
 
-    int minCommitsToKeep = Math.max(writeConfig.getMetadataMinCommitsToKeep(), writeConfig.getMinCommitsToKeep());
-    int maxCommitsToKeep = Math.max(writeConfig.getMetadataMaxCommitsToKeep(), writeConfig.getMaxCommitsToKeep());
+    int minCommitsToKeep = writeConfig.getMinCommitsToKeep();
+    int maxCommitsToKeep = writeConfig.getMaxCommitsToKeep();
 
     // Create the write config for the metadata table by borrowing options from the main write config.
     HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -847,7 +847,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   public void testArchiveRollbacksTestTable(boolean enableMetadata) throws Exception {
     HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 3, 2);
 
-    for (int i = 1; i < 9; i += 2) {
+    for (int i = 1; i < 13; i += 2) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       testTable.doRollback("0000000" + i, "0000000" + (i + 1));
 
@@ -856,7 +856,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
 
-      if (i != 7) {
+      if (i != 11) {
         assertEquals(originalCommits, commitsAfterArchival);
       } else {
         // only time when archival will kick in

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -263,12 +263,12 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testArchiveTableWithArchival(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 4, 2);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2);
 
-    // min archival commits is 2 and max archival commits is 4. and so, after 5th commit, 3 commits will be archived.
-    // 1,2,3,4,5 : after archival -> 4,5
-    // after 3 more commits, earliest 3 will be archived
-    // 4,5,6,7,8 : after archival -> 7, 8
+    // min archival commits is 4 and max archival commits is 5. and so, after 6th commit, 2 commits will be archived.
+    // 1,2,3,4,5,6 : after archival -> 3,4,5,6
+    // after 2 more commits, earliest 2 will be archived
+    // 3,4,5,6,7,8 : after archival -> 5,6,7,8
     // after 9 no-op wrt archival.
     for (int i = 1; i < 10; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
@@ -276,17 +276,22 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
-      if (i < 5) {
+      if (i < 6) {
         assertEquals(originalCommits, commitsAfterArchival);
-      } else if (i == 5) {
+      } else if (i == 6) {
         // archival should have kicked in.
-        verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003")), getActiveCommitInstants(Arrays.asList("00000004", "00000005")), commitsAfterArchival);
+        verifyArchival(
+            getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002")),
+            getActiveCommitInstants(Arrays.asList("00000003", "00000004", "00000005", "00000006")),
+            commitsAfterArchival);
       } else if (i < 8) {
         assertEquals(originalCommits, commitsAfterArchival);
       } else if (i == 8) {
         // archival should have kicked in.
-        verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006")),
-            getActiveCommitInstants(Arrays.asList("00000007", "00000008")), commitsAfterArchival);
+        verifyArchival(
+            getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004")),
+            getActiveCommitInstants(Arrays.asList("00000005", "00000006", "00000007", "00000008")),
+            commitsAfterArchival);
       } else {
         assertEquals(originalCommits, commitsAfterArchival);
       }
@@ -295,8 +300,8 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
 
   @Test
   public void testArchiveTableWithReplaceCommits() throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 4, 2);
-    for (int i = 1; i < 7; i++) {
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2);
+    for (int i = 1; i < 9; i++) {
       if (i < 3) {
         testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(),
             Arrays.asList("p1", "p2"), 2);
@@ -308,10 +313,10 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
 
-      if (i == 6) {
-        // after all rounds, only 3 should be left in active timeline. 4,5,6
-        assertEquals(originalCommits, commitsAfterArchival);
-        assertEquals(3, originalCommits.size());
+      if (i == 8) {
+        // after all rounds, only 4 should be left in active timeline. 5,6,7,8
+        assertEquals(6, originalCommits.size());
+        assertEquals(4, commitsAfterArchival.size());
       }
     }
   }
@@ -444,10 +449,10 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testMergeSmallArchiveFilesRecoverFromBuildPlanFailed(boolean enableArchiveMerge) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 3, 2, enableArchiveMerge, 3, 209715200);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2, enableArchiveMerge, 3, 209715200);
 
     // do ingestion and trigger archive actions here.
-    for (int i = 1; i < 8; i++) {
+    for (int i = 1; i < 10; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       archiveAndGetCommitsList(writeConfig);
     }
@@ -470,7 +475,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // check that damaged plan file will not block archived timeline loading.
     HoodieActiveTimeline rawActiveTimeline = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine = metaClient.getArchivedTimeline().reload();
-    assertEquals(7 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.countInstants());
+    assertEquals(9 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.countInstants());
 
     // trigger several archive after left damaged merge small archive file plan.
     for (int i = 1; i < 10; i++) {
@@ -483,7 +488,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     HoodieArchivedTimeline archivedTimeLine1 = metaClient.getArchivedTimeline().reload();
 
     // check instant number
-    assertEquals(16 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
+    assertEquals(18 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
 
     // if there are damaged archive files and damaged plan, hoodie need throw ioe while loading archived timeline.
     Path damagedFile = new Path(metaClient.getArchivePath(), ".commits_.archive.300_1-0-1");
@@ -495,10 +500,10 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testMergeSmallArchiveFilesRecoverFromMergeFailed(boolean enableArchiveMerge) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 3, 2, enableArchiveMerge, 3, 209715200);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2, enableArchiveMerge, 3, 209715200);
 
     // do ingestion and trigger archive actions here.
-    for (int i = 1; i < 8; i++) {
+    for (int i = 1; i < 10; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       archiveAndGetCommitsList(writeConfig);
     }
@@ -518,7 +523,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // check loading archived and active timeline success
     HoodieActiveTimeline rawActiveTimeline = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine = metaClient.getArchivedTimeline().reload();
-    assertEquals(7 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.reload().countInstants());
+    assertEquals(9 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.reload().countInstants());
 
     String s = "Dummy Content";
     // stain the current merged archive file.
@@ -535,7 +540,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     HoodieActiveTimeline rawActiveTimeline1 = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine1 = metaClient.getArchivedTimeline().reload();
 
-    assertEquals(16 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
+    assertEquals(18 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
 
     // if there are a damaged merged archive files and other common damaged archive file.
     // hoodie need throw ioe while loading archived timeline because of parsing the damaged archive file.
@@ -548,10 +553,10 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testMergeSmallArchiveFilesRecoverFromDeleteFailed(boolean enableArchiveMerge) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 3, 2, enableArchiveMerge, 3, 209715200);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2, enableArchiveMerge, 3, 209715200);
 
     // do ingestion and trigger archive actions here.
-    for (int i = 1; i < 8; i++) {
+    for (int i = 1; i < 10; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       archiveAndGetCommitsList(writeConfig);
     }
@@ -575,7 +580,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // loading archived timeline and active timeline success
     HoodieActiveTimeline rawActiveTimeline = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine = metaClient.getArchivedTimeline().reload();
-    assertEquals(7 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.countInstants());
+    assertEquals(9 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.countInstants());
 
     // do another archive actions with merge small archive files.
     for (int i = 1; i < 10; i++) {
@@ -587,17 +592,22 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     HoodieActiveTimeline rawActiveTimeline1 = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine1 = metaClient.getArchivedTimeline().reload();
 
-    assertEquals(16 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
+    assertEquals(18 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testLoadArchiveTimelineWithDamagedPlanFile(boolean enableArchiveMerge) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 3, 2, enableArchiveMerge, 3, 209715200);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2, enableArchiveMerge, 3, 209715200);
 
     // do ingestion and trigger archive actions here.
-    for (int i = 1; i < 8; i++) {
-      testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+    int numInstant = 12;
+    for (int i = 1; i < 12; i++) {
+      testTable.doWriteOperation(
+          "000000" + String.format("%02d", i),
+          WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(),
+          Arrays.asList("p1", "p2"),
+          2);
       archiveAndGetCommitsList(writeConfig);
     }
 
@@ -609,7 +619,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // check that damaged plan file will not block archived timeline loading.
     HoodieActiveTimeline rawActiveTimeline = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine = metaClient.getArchivedTimeline().reload();
-    assertEquals(7 * 3, rawActiveTimeline.countInstants() + archivedTimeLine.countInstants());
+    assertEquals((numInstant - 1) * 3, rawActiveTimeline.countInstants() + archivedTimeLine.countInstants());
 
     // if there are damaged archive files and damaged plan, hoodie need throw ioe while loading archived timeline.
     Path damagedFile = new Path(metaClient.getArchivePath(), ".commits_.archive.300_1-0-1");
@@ -621,7 +631,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testArchivalWithMultiWriters(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 4, 5, 2,
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 5, 2,
         HoodieTableType.COPY_ON_WRITE, false, 10, 209715200,
         HoodieFailedWritesCleaningPolicy.LAZY, WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL);
 
@@ -639,7 +649,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
         }
         metaClient.reloadActiveTimeline();
         while (!metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().lastInstant().get().getTimestamp().endsWith("29")
-            || metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().countInstants() > 4) {
+            || metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().countInstants() > 5) {
           try {
             HoodieTimelineArchiver archiver = new HoodieTimelineArchiver(writeConfig, table);
             archiver.archiveIfRequired(context, true);
@@ -662,7 +672,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // do ingestion and trigger archive actions here.
     for (int i = 1; i < 30; i++) {
       testTable.doWriteOperation("0000000" + String.format("%02d", i), WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
-      if (i == 5) {
+      if (i == 6) {
         // start up archival threads only after 4 commits.
         countDownLatch.countDown();
       }
@@ -694,8 +704,8 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testLoadArchiveTimelineWithUncompletedMergeArchiveFile(boolean enableArchiveMerge) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 3, 2, enableArchiveMerge, 3, 209715200);
-    for (int i = 1; i < 8; i++) {
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2, enableArchiveMerge, 3, 209715200);
+    for (int i = 1; i < 10; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       archiveAndGetCommitsList(writeConfig);
     }
@@ -720,7 +730,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     HoodieActiveTimeline rawActiveTimeline1 = new HoodieActiveTimeline(metaClient, false);
     HoodieArchivedTimeline archivedTimeLine1 = metaClient.getArchivedTimeline();
 
-    assertEquals(7 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
+    assertEquals(9 * 3, archivedTimeLine1.countInstants() + rawActiveTimeline1.countInstants());
 
     // if there are a damaged merged archive files and other common damaged archive file.
     // hoodie need throw ioe while loading archived timeline because of parsing the damaged archive file.
@@ -733,7 +743,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testNoArchivalUntilMaxArchiveConfigWithExtraInflightCommits(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 5, 2);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2);
 
     // when max archival commits is set to 5, until 6th commit there should not be any archival.
     for (int i = 1; i < 6; i++) {
@@ -826,7 +836,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testPendingClusteringWillBlockArchival(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 5, 2);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2);
     HoodieTestDataGenerator.createPendingReplaceFile(basePath, "00000000", wrapperFs.getConf());
     for (int i = 1; i < 8; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, Arrays.asList("p1", "p2"), Arrays.asList("p1", "p2"), 2);
@@ -845,11 +855,16 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testArchiveRollbacksTestTable(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 3, 2);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2);
 
     for (int i = 1; i < 13; i += 2) {
-      testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
-      testTable.doRollback("0000000" + i, "0000000" + (i + 1));
+      testTable.doWriteOperation(
+          "000000" + String.format("%02d", i),
+          WriteOperationType.UPSERT,
+          i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"),
+          2);
+      testTable.doRollback(
+          "000000" + String.format("%02d", i), "000000" + String.format("%02d", i + 1));
 
       // trigger archival
       Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
@@ -864,8 +879,10 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
         expectedArchivedInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000003")));
         expectedArchivedInstants.addAll(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000004"), HoodieTimeline.ROLLBACK_ACTION));
         List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
-        expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000005", "00000007")));
-        expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000006", "00000008"), HoodieTimeline.ROLLBACK_ACTION));
+        expectedActiveInstants.addAll(getActiveCommitInstants(
+            Arrays.asList("00000005", "00000007", "00000009", "00000011")));
+        expectedActiveInstants.addAll(getActiveCommitInstants(
+            Arrays.asList("00000006", "00000008", "00000010", "00000012"), HoodieTimeline.ROLLBACK_ACTION));
         verifyArchival(expectedArchivedInstants, expectedActiveInstants, commitsAfterArchival);
       }
     }
@@ -874,10 +891,10 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testNoArchivalWithInflightCompactionInMiddle(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 4, 2, 2,
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2, 2,
         HoodieTableType.MERGE_ON_READ);
 
-    // when max archival commits is set to 4, even after 7 commits, if there is an inflight compaction in the middle, archival should not kick in.
+    // when max archival commits is set to 5, even after 7 commits, if there is an inflight compaction in the middle, archival should not kick in.
     HoodieCommitMetadata inflightCompactionMetadata = null;
     for (int i = 1; i < 8; i++) {
       if (i == 2) {
@@ -891,19 +908,19 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
       if (enableMetadata) {
-        if (i != 6) {
-          assertEquals(originalCommits, commitsAfterArchival);
-        } else {
-          // on 6th commit, archival will kick in. but will archive only one commit since 2nd compaction commit is inflight.
-          assertEquals(originalCommits.size() - commitsAfterArchival.size(), 1);
-        }
-      } else {
-        if (i != 6) {
+        if (i != 7) {
           assertEquals(originalCommits, commitsAfterArchival);
         } else {
           // on 7th commit, archival will kick in. but will archive only one commit since 2nd compaction commit is inflight.
           assertEquals(originalCommits.size() - commitsAfterArchival.size(), 1);
-          for (int j = 1; j <= 6; j++) {
+        }
+      } else {
+        if (i != 7) {
+          assertEquals(originalCommits, commitsAfterArchival);
+        } else {
+          // on 7th commit, archival will kick in. but will archive only one commit since 2nd compaction commit is inflight.
+          assertEquals(originalCommits.size() - commitsAfterArchival.size(), 1);
+          for (int j = 1; j <= 7; j++) {
             if (j == 1) {
               // first commit should be archived
               assertFalse(commitsAfterArchival.contains(new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j)));
@@ -922,17 +939,19 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // move inflight compaction to complete and add one regular write commit. archival should archive more commits.
     // an extra one commit is required, bcoz compaction in data table will not trigger table services in metadata table.
     // before this move, timeline : 2_inflight_compaction, 3,4,5,6,7.
-    // after this move: 6,7,8 (2,3,4,5 will be archived)
+    // after this move: 5,6,7,8 (2,3,4 will be archived)
     testTable.moveInflightCompactionToComplete("00000002", inflightCompactionMetadata);
     testTable.doWriteOperation("00000008", WriteOperationType.UPSERT, Arrays.asList("p1", "p2"), 2);
 
     Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
     List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
 
-    List<HoodieInstant> archivedInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000003", "00000004", "00000005", "00000006"), HoodieTimeline.DELTA_COMMIT_ACTION);
+    List<HoodieInstant> archivedInstants = getAllArchivedCommitInstants(Arrays.asList("00000001", "00000003", "00000004"), HoodieTimeline.DELTA_COMMIT_ACTION);
     archivedInstants.add(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "00000002"));
     archivedInstants.add(new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000002"));
-    verifyArchival(archivedInstants, getActiveCommitInstants(Arrays.asList("00000007", "00000008"), HoodieTimeline.DELTA_COMMIT_ACTION), commitsAfterArchival);
+    verifyArchival(archivedInstants,
+        getActiveCommitInstants(Arrays.asList("00000005", "00000006", "00000007", "00000008"), HoodieTimeline.DELTA_COMMIT_ACTION),
+        commitsAfterArchival);
   }
 
   @ParameterizedTest
@@ -1003,56 +1022,62 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testArchiveTableWithCleanCommits(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 4, 2);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2);
 
-    // min archival commits is 2 and max archival commits is 4
-    // (either clean commits has to be > 4 or commits has to be greater than 4)
-    // and so, after 5th commit, 3 commits will be archived.
-    // 1,2,3,4,5,6 : after archival -> 1,5,6 (because, 2,3,4,5 and 6 are clean commits and are eligible for archival)
-    // after 7th and 8th commit no-op wrt archival.
+    // min archival commits is 4 and max archival commits is 5
+    // (either clean commits has to be > 5 or commits has to be greater than 5)
+    // and so, after 6th instant, 2 instants will be archived.
+    // 1,2,3,4,5,6 : after archival -> 1,3,4,5,6
+    // (because, 2,3,4,5 and 6 are clean instants and are eligible for archival)
+    // after 7th and 9th instant no-op wrt archival.  After 8th instant,
+    // archival kicks in when metadata table is enabled.
     Map<String, Integer> cleanStats = new HashMap<>();
     cleanStats.put("p1", 1);
     cleanStats.put("p2", 2);
-    for (int i = 1; i < 9; i++) {
+    for (int i = 1; i <= 10; i++) {
       if (i == 1) {
-        testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 10);
-      } else if (i < 7) {
+        testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 20);
+      } else if (i <= 7 || i == 9) {
         testTable.doClean("0000000" + i, cleanStats);
       } else {
-        testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+        testTable.doWriteOperation("000000" + String.format("%02d", i), WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       }
       // trigger archival
       Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
-      if (i < 6) {
+      if (i < 7) {
         assertEquals(originalCommits, commitsAfterArchival);
-      } else if (i == 6) {
+      } else if (i == 7) {
         if (!enableMetadata) {
-          // 1,2,3,4,5,6 : after archival -> 1,5,6 (bcoz, 2,3,4,5 and 6 are clean commits and are eligible for archival)
+          // 1,2,3,4,5,6,7 : after archival -> 1,4,5,6,7 (bcoz, 2,3,4,5,6,7 are clean instants and are eligible for archival)
           List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
           expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000001")));
-          expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000005", "00000006"), HoodieTimeline.CLEAN_ACTION));
-          verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003", "00000004"), HoodieTimeline.CLEAN_ACTION), expectedActiveInstants, commitsAfterArchival);
+          expectedActiveInstants.addAll(
+              getActiveCommitInstants(Arrays.asList("00000004", "00000005", "00000006", "00000007"), HoodieTimeline.CLEAN_ACTION));
+          verifyArchival(getAllArchivedCommitInstants(
+              Arrays.asList("00000002", "00000003"), HoodieTimeline.CLEAN_ACTION), expectedActiveInstants, commitsAfterArchival);
         } else {
           // with metadata enabled, archival in data table is fenced based on compaction in metadata table. Clean commits in data table will not trigger compaction in
           // metadata table.
           List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
           expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000001")));
-          expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000002", "00000003", "00000004", "00000005", "00000006"), HoodieTimeline.CLEAN_ACTION));
+          expectedActiveInstants.addAll(getActiveCommitInstants(
+              Arrays.asList("00000002", "00000003", "00000004", "00000005", "00000006", "00000007"), HoodieTimeline.CLEAN_ACTION));
           verifyArchival(getAllArchivedCommitInstants(Collections.emptyList(), HoodieTimeline.CLEAN_ACTION), expectedActiveInstants, commitsAfterArchival);
         }
       } else {
         if (!enableMetadata) {
           assertEquals(originalCommits, commitsAfterArchival);
         } else {
-          if (i == 7) {
-            // when i == 7 compaction in metadata table will be triggered and hence archival in datatable will kick in.
-            // 1,2,3,4,5,6 : after archival -> 1,5,6 (bcoz, 2,3,4,5 and 6 are clean commits and are eligible for archival)
+          if (i == 8) {
+            // when i == 7 compaction in metadata table will be triggered
+            // and afterwards archival in datatable will kick in when i == 8.
+            // 1,2,3,4,5,6,7,8 : after archival -> 1,4,5,6,7,8 (bcoz, 2,3,4,5 and 6 are clean commits and are eligible for archival)
             List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
-            expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000001", "00000007")));
-            expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000005", "00000006"), HoodieTimeline.CLEAN_ACTION));
-            verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003", "00000004"), HoodieTimeline.CLEAN_ACTION), expectedActiveInstants, commitsAfterArchival);
+            expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000001", "00000008")));
+            expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000004", "00000005", "00000006", "00000007"), HoodieTimeline.CLEAN_ACTION));
+            verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003"), HoodieTimeline.CLEAN_ACTION), expectedActiveInstants, commitsAfterArchival);
           } else {
             assertEquals(originalCommits, commitsAfterArchival);
           }
@@ -1063,7 +1088,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
 
   @Test
   public void testArchiveRollbacksAndCleanTestTable() throws Exception {
-    int minArchiveCommits = 2;
+    int minArchiveCommits = 4;
     int maxArchiveCommits = 9;
     HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, minArchiveCommits, maxArchiveCommits, 2);
 
@@ -1089,13 +1114,13 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     List<HoodieInstant> originalCommits = commitsList.getKey();
     List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
 
-    // out of 10 clean commits, 8 will be archived. 2 to 9. 10 and 11 will be active.
+    // out of 10 clean commits, 6 will be archived. 2 to 7. 8 to 11 will be active.
     // wrt regular commits, there aren't 9 commits yet and so all of them will be active.
     List<HoodieInstant> expectedActiveInstants = new ArrayList<>();
-    expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000010", "00000011"), HoodieTimeline.CLEAN_ACTION));
+    expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000008", "00000009", "00000010", "00000011"), HoodieTimeline.CLEAN_ACTION));
     expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000001", "00000012", "00000014", "00000016", "00000018")));
     expectedActiveInstants.addAll(getActiveCommitInstants(Arrays.asList("00000013", "00000015", "00000017", "00000019"), HoodieTimeline.ROLLBACK_ACTION));
-    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003", "00000004", "00000005", "00000006", "00000007", "00000008", "00000009"),
+    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000002", "00000003", "00000004", "00000005", "00000006", "00000007"),
         HoodieTimeline.CLEAN_ACTION), expectedActiveInstants, commitsAfterArchival);
   }
 
@@ -1199,12 +1224,12 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
 
   @Test
   public void testArchiveTableWithMetadataTableCompaction() throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 4, 7);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 7);
 
-    // min archival commits is 2 and max archival commits is 4. and so, after 5th commit, ideally archival should kick in. but max delta commits in metadata table is set to 6. and so
+    // min archival commits is 4 and max archival commits is 5. and so, after 6th commit, ideally archival should kick in. but max delta commits in metadata table is set to 7. and so
     // archival will kick in only by 7th commit in datatable(1 commit for bootstrap + 6 commits from data table).
     // and then 2nd compaction will take place
-    for (int i = 1; i < 6; i++) {
+    for (int i = 1; i < 7; i++) {
       testTable.doWriteOperation("0000000" + i, WriteOperationType.UPSERT, i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
       // trigger archival
       Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
@@ -1213,46 +1238,52 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       assertEquals(originalCommits, commitsAfterArchival);
     }
 
-    // two more commits will trigger compaction in metadata table and will let archival move forward.
-    testTable.doWriteOperation("00000006", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+    // one more commit will trigger compaction in metadata table and will let archival move forward.
     testTable.doWriteOperation("00000007", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
     // trigger archival
     Pair<List<HoodieInstant>, List<HoodieInstant>> commitsList = archiveAndGetCommitsList(writeConfig);
     List<HoodieInstant> originalCommits = commitsList.getKey();
     List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
     // before archival 1,2,3,4,5,6,7
-    // after archival 6,7
-    assertEquals(originalCommits.size() - commitsAfterArchival.size(), 5);
-    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005")),
-        getActiveCommitInstants(Arrays.asList("00000006", "00000007")), commitsAfterArchival);
+    // after archival 4,5,6,7
+    assertEquals(originalCommits.size() - commitsAfterArchival.size(), 3);
+    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003")),
+        getActiveCommitInstants(Arrays.asList("00000004", "00000005", "00000006", "00000007")), commitsAfterArchival);
 
-    // 3 more commits, 6 and 7 will be archived. but will not move after 6 since compaction has to kick in metadata table.
+    // 3 more commits, 4 to 6 will be archived. but will not move after 6 since compaction has to kick in metadata table.
     testTable.doWriteOperation("00000008", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
     testTable.doWriteOperation("00000009", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+    testTable.doWriteOperation("00000010", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+    // trigger archival
+    commitsList = archiveAndGetCommitsList(writeConfig);
+    originalCommits = commitsList.getKey();
+    commitsAfterArchival = commitsList.getValue();
+    assertEquals(originalCommits.size() - commitsAfterArchival.size(), 3);
+    verifyArchival(getAllArchivedCommitInstants(
+            Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006")),
+        getActiveCommitInstants(
+            Arrays.asList("00000007", "00000008", "00000009", "00000010")),
+        commitsAfterArchival);
+
+    // No archival should kick in since compaction has not kicked in metadata table
+    testTable.doWriteOperation("00000011", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+    testTable.doWriteOperation("00000012", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
+    commitsList = archiveAndGetCommitsList(writeConfig);
+    originalCommits = commitsList.getKey();
+    commitsAfterArchival = commitsList.getValue();
+    assertEquals(originalCommits, commitsAfterArchival);
+    verifyArchival(getAllArchivedCommitInstants(
+            Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006")),
+        getActiveCommitInstants(
+            Arrays.asList("00000007", "00000008", "00000009", "00000010", "00000011", "00000012")),
+        commitsAfterArchival);
+
+    testTable.doWriteOperation("00000013", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
     // trigger archival
     commitsList = archiveAndGetCommitsList(writeConfig);
     originalCommits = commitsList.getKey();
     commitsAfterArchival = commitsList.getValue();
     assertEquals(originalCommits, commitsAfterArchival);
-
-    // ideally, this will archive commits 6, 7, 8 but since compaction in metadata is until 6, only 6 will get archived,
-    testTable.doWriteOperation("00000010", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
-    commitsList = archiveAndGetCommitsList(writeConfig);
-    originalCommits = commitsList.getKey();
-    commitsAfterArchival = commitsList.getValue();
-    assertEquals(originalCommits.size() - commitsAfterArchival.size(), 1);
-    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006")),
-        getActiveCommitInstants(Arrays.asList("00000007", "00000008", "00000009", "00000010")), commitsAfterArchival);
-
-    // and then 2nd compaction will take place at 12th commit
-    for (int i = 11; i < 14; i++) {
-      testTable.doWriteOperation("000000" + i, WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
-      // trigger archival
-      commitsList = archiveAndGetCommitsList(writeConfig);
-      originalCommits = commitsList.getKey();
-      commitsAfterArchival = commitsList.getValue();
-      assertEquals(originalCommits, commitsAfterArchival);
-    }
 
     // one more commit will trigger compaction in metadata table and will let archival move forward.
     testTable.doWriteOperation("00000014", WriteOperationType.UPSERT, Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
@@ -1261,15 +1292,19 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     originalCommits = commitsList.getKey();
     commitsAfterArchival = commitsList.getValue();
     // before archival 7,8,9,10,11,12,13,14
-    // after archival 13,14
-    assertEquals(originalCommits.size() - commitsAfterArchival.size(), 6);
-    verifyArchival(getAllArchivedCommitInstants(Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006", "00000007", "00000008",
-        "00000009", "00000010", "00000011", "00000012")), getActiveCommitInstants(Arrays.asList("00000013", "00000014")), commitsAfterArchival);
+    // after archival 11,12,13,14
+    assertEquals(originalCommits.size() - commitsAfterArchival.size(), 4);
+    verifyArchival(getAllArchivedCommitInstants(
+            Arrays.asList("00000001", "00000002", "00000003", "00000004", "00000005", "00000006",
+                "00000007", "00000008", "00000009", "00000010")),
+        getActiveCommitInstants(
+            Arrays.asList("00000011", "00000012", "00000013", "00000014")),
+        commitsAfterArchival);
   }
 
   @Test
   public void testArchiveCommitsWithCompactionCommitInMetadataTableTimeline() throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 2, 4, 20);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 20);
     int startInstantTime = 100;
     int numCommits = 15;
     int numExpectedArchived = 6; // "100" till "105" should be archived in this case
@@ -1300,9 +1335,9 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ValueSource(booleans = {true, false})
   public void testArchivalWithMaxDeltaCommitsGuaranteeForCompaction(boolean enableMetadata) throws Exception {
     HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(
-        enableMetadata, 2, 4, 8, 1, HoodieTableType.MERGE_ON_READ);
+        enableMetadata, 4, 5, 8, 1, HoodieTableType.MERGE_ON_READ);
 
-    // When max archival commits is set to 4, even after 8 delta commits, since the number of delta
+    // When max archival commits is set to 5, even after 8 delta commits, since the number of delta
     // commits is still smaller than 8, the archival should not kick in.
     // The archival should only kick in after the 9th delta commit
     // instant "00000001" to "00000009"
@@ -1337,33 +1372,46 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       List<HoodieInstant> originalCommits = commitsList.getKey();
       List<HoodieInstant> commitsAfterArchival = commitsList.getValue();
 
-      // first 9 delta commits before the completed compaction should be archived
-      IntStream.range(1, 10).forEach(j ->
-          assertFalse(commitsAfterArchival.contains(
-              new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j))));
-
-      if (i == 1) {
-        assertEquals(8, originalCommits.size() - commitsAfterArchival.size());
+      if (i <= 2) {
+        // first 7 delta commits before the completed compaction should be archived in data table
+        IntStream.range(1, 8).forEach(j ->
+            assertFalse(commitsAfterArchival.contains(
+                new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j))));
+        assertEquals(i == 1 ? 6 : 0, originalCommits.size() - commitsAfterArchival.size());
         // instant from "00000011" should be in the active timeline
         assertTrue(commitsAfterArchival.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000010")));
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "00000008")));
         assertTrue(commitsAfterArchival.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "00000011")));
-      } else if (i < 8) {
-        assertEquals(originalCommits, commitsAfterArchival);
-      } else {
-        assertEquals(1, originalCommits.size() - commitsAfterArchival.size());
-        assertFalse(commitsAfterArchival.contains(
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "00000009")));
+        assertTrue(commitsAfterArchival.contains(
             new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000010")));
-        // i == 8 -> ["00000011", "00000018"] should be in the active timeline
-        // i == 9 -> ["00000012", "00000019"] should be in the active timeline
-        if (i == 9) {
-          assertFalse(commitsAfterArchival.contains(
-              new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "00000011")));
+        for (int j = 1; j <= i; j++) {
+          assertTrue(commitsAfterArchival.contains(
+              new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000001" + j)));
         }
-        IntStream.range(i - 7, i + 1).forEach(j ->
-            assertTrue(commitsAfterArchival.contains(
-                new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000001" + j))));
+      } else {
+        // first 9 delta commits before the completed compaction should be archived in data table
+        IntStream.range(1, 10).forEach(j ->
+            assertFalse(commitsAfterArchival.contains(
+                new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j))));
+        if (i == 3) {
+          assertEquals(2, originalCommits.size() - commitsAfterArchival.size());
+        } else if (i < 8) {
+          assertEquals(originalCommits, commitsAfterArchival);
+        } else {
+          assertEquals(1, originalCommits.size() - commitsAfterArchival.size());
+          assertFalse(commitsAfterArchival.contains(
+              new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000010")));
+          // i == 8 -> ["00000011", "00000018"] should be in the active timeline
+          // i == 9 -> ["00000012", "00000019"] should be in the active timeline
+          if (i == 9) {
+            assertFalse(commitsAfterArchival.contains(
+                new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "00000011")));
+          }
+          IntStream.range(i - 7, i + 1).forEach(j ->
+              assertTrue(commitsAfterArchival.contains(
+                  new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000001" + j))));
+        }
       }
     }
   }
@@ -1487,7 +1535,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testPendingClusteringAfterArchiveCommit(boolean enableMetadata) throws Exception {
-    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 2, 5, 2);
+    HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 2);
     // timeline:0000000(completed)->00000001(completed)->00000002(replace&inflight)->00000003(completed)->...->00000007(completed)
     HoodieTestDataGenerator.createPendingReplaceFile(basePath, "00000002", wrapperFs.getConf());
     for (int i = 1; i < 8; i++) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -1374,13 +1374,13 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     // Test configs where metadata table has more aggressive archival configs than the compaction config
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 4).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 6).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withRemoteServerPort(timelineServicePort).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true)
             .withMaxNumDeltaCommitsBeforeCompaction(8)
-            .archiveCommitsWith(4, 5).build())
+            .build())
         .forTable("test-trip-table").build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
 
@@ -1429,13 +1429,13 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j))));
       } else if (i <= 11) {
-        // In the metadata table timeline, the first delta commit is "00000007"
+        // In the metadata table timeline, the first delta commit is "00000005"
         // because it equals with the earliest commit on the dataset timeline, after archival,
-        // delta commits "00000008" till "00000011" are added later on without archival or compaction
-        assertEquals(i - 5, metadataTableInstants.size());
+        // delta commits "00000006" till "00000011" are added later on without archival or compaction
+        assertEquals(i - 3, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
             new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000007001")));
-        IntStream.range(7, i + 1).forEach(j ->
+        IntStream.range(5, i + 1).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
                     "000000" + String.format("%02d", j)))));
@@ -1472,11 +1472,11 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
                     "000000" + String.format("%02d", j)))));
       } else {
         // i == 17
-        // Only commits [00000015, 00000017] and "00000015001" are on the metadata timeline
-        assertEquals(4, metadataTableInstants.size());
+        // Only commits [00000013, 00000017] and "00000015001" are on the metadata timeline
+        assertEquals(6, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
             new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000015001")));
-        IntStream.range(15, 18).forEach(j ->
+        IntStream.range(13, 18).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
                     "000000" + String.format("%02d", j)))));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -1106,7 +1106,7 @@ public class TestCleaner extends HoodieClientTestBase {
                 .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .withArchivalConfig(
             HoodieArchivalConfig.newBuilder()
-                .archiveCommitsWith(3, 4).build())
+                .archiveCommitsWith(4, 5).build())
         .withMarkersType(MarkerType.DIRECT.name())
         .withPath(basePath)
         .build();
@@ -1149,10 +1149,13 @@ public class TestCleaner extends HoodieClientTestBase {
 
     // empty commits
     testTable.addCommit("5");
+    testTable.addCommit("6");
 
     // archive commit 1, 2
     new HoodieTimelineArchiver<>(config, HoodieSparkTable.create(config, context, metaClient))
         .archiveIfRequired(context, false);
+    assertFalse(metaClient.reloadActiveTimeline().containsInstant("1"));
+    assertFalse(metaClient.reloadActiveTimeline().containsInstant("2"));
 
     runCleaner(config);
     assertFalse(testTable.baseFileExists(p1, "1", file1P1), "Clean old FileSlice in p1 by fallback to full clean");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableArchiveWithReplace.java
@@ -56,7 +56,7 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
     HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.COPY_ON_WRITE);
     HoodieWriteConfig writeConfig = getConfigBuilder(true)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
             .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(metadataEnabled).build())
         .build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig);
@@ -81,8 +81,8 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
       client.startCommitWithTime(instantTime4, HoodieActiveTimeline.REPLACE_COMMIT_ACTION);
       client.deletePartitions(Arrays.asList(DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH), instantTime4);
 
-      // 2nd write batch; 4 commits for the 4th partition; the 4th commit to trigger archiving the replace commit
-      for (int i = 5; i < 9; i++) {
+      // 2nd write batch; 6 commits for the 4th partition; the 6th commit to trigger archiving the replace commit
+      for (int i = 5; i < 11; i++) {
         String instantTime = HoodieActiveTimeline.createNewInstantTime(i * 1000);
         client.startCommitWithTime(instantTime);
         client.insert(jsc().parallelize(dataGen.generateInsertsForPartition(instantTime, 1, DEFAULT_THIRD_PARTITION_PATH), 1), instantTime);
@@ -98,8 +98,8 @@ public class TestHoodieSparkCopyOnWriteTableArchiveWithReplace extends SparkClie
 
       // verify records
       final HoodieTimeline timeline2 = metaClient.getCommitTimeline().filterCompletedInstants();
-      assertEquals(5, countRecordsOptionallySince(jsc(), basePath(), sqlContext(), timeline2, Option.empty()),
-          "should only have the 5 records from the 3rd partition.");
+      assertEquals(7, countRecordsOptionallySince(jsc(), basePath(), sqlContext(), timeline2, Option.empty()),
+          "should only have the 7 records from the 3rd partition.");
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -94,25 +94,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Controls how often the metadata table is compacted.");
 
-  // Archival settings
-  public static final ConfigProperty<Integer> MIN_COMMITS_TO_KEEP = ConfigProperty
-      .key(METADATA_PREFIX + ".keep.min.commits")
-      .defaultValue(20)
-      .markAdvanced()
-      .sinceVersion("0.7.0")
-      .withDocumentation("Archiving service moves older entries from metadata table’s timeline "
-          + "into an archived log after each write, to keep the overhead constant, even as the "
-          + "metadata table size grows.  This config controls the minimum number of instants "
-          + "to retain in the active timeline.");
-
-  public static final ConfigProperty<Integer> MAX_COMMITS_TO_KEEP = ConfigProperty
-      .key(METADATA_PREFIX + ".keep.max.commits")
-      .defaultValue(30)
-      .markAdvanced()
-      .sinceVersion("0.7.0")
-      .withDocumentation("Similar to " + MIN_COMMITS_TO_KEEP.key() + ", this config controls "
-          + "the maximum number of instants to retain in the active timeline.");
-
   // Regex to filter out matching directories during bootstrap
   public static final ConfigProperty<String> DIR_FILTER_REGEX = ConfigProperty
       .key(METADATA_PREFIX + ".dir.filter.regex")
@@ -415,12 +396,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder archiveCommitsWith(int minToKeep, int maxToKeep) {
-      metadataConfig.setValue(MIN_COMMITS_TO_KEEP, String.valueOf(minToKeep));
-      metadataConfig.setValue(MAX_COMMITS_TO_KEEP, String.valueOf(maxToKeep));
-      return this;
-    }
-
     public Builder withFileListingParallelism(int parallelism) {
       metadataConfig.setValue(FILE_LISTING_PARALLELISM_VALUE, String.valueOf(parallelism));
       return this;
@@ -519,26 +494,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   @Deprecated
   public static final int DEFAULT_METADATA_COMPACT_NUM_DELTA_COMMITS = COMPACT_NUM_DELTA_COMMITS.defaultValue();
 
-  /**
-   * @deprecated Use {@link #MIN_COMMITS_TO_KEEP} and its methods.
-   */
-  @Deprecated
-  public static final String MIN_COMMITS_TO_KEEP_PROP = MIN_COMMITS_TO_KEEP.key();
-  /**
-   * @deprecated Use {@link #MIN_COMMITS_TO_KEEP} and its methods.
-   */
-  @Deprecated
-  public static final int DEFAULT_MIN_COMMITS_TO_KEEP = MIN_COMMITS_TO_KEEP.defaultValue();
-  /**
-   * @deprecated Use {@link #MAX_COMMITS_TO_KEEP} and its methods.
-   */
-  @Deprecated
-  public static final String MAX_COMMITS_TO_KEEP_PROP = MAX_COMMITS_TO_KEEP.key();
-  /**
-   * @deprecated Use {@link #MAX_COMMITS_TO_KEEP} and its methods.
-   */
-  @Deprecated
-  public static final int DEFAULT_MAX_COMMITS_TO_KEEP = MAX_COMMITS_TO_KEEP.defaultValue();
   /**
    * @deprecated No longer takes any effect.
    */

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
@@ -40,8 +40,10 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
    * Step2: Upsert 50
    * Step3: Delete 20 With Clustering
    * Step4: Insert Overwrite 50
-   * Step5: Upsert 30 With Clean
-   * Step6: Bulk_Insert 20
+   * Step5: Insert 7
+   * Step6: Insert 3
+   * Step7: Upsert 30 With Clean
+   * Step8: Bulk_Insert 20
    */
   @ParameterizedTest
   @EnumSource(classOf[HoodieCDCSupplementalLoggingMode])
@@ -162,52 +164,63 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
     allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
 
-    // Upsert Operation With Clean Operation
-    val records5 = recordsToStrings(dataGen.generateUniqueUpdates("004", 30)).toList
+    val records5 = recordsToStrings(dataGen.generateInserts("005", 7)).toList
     val inputDF5 = spark.read.json(spark.sparkContext.parallelize(records5, 2))
     inputDF5.write.format("org.apache.hudi")
       .options(options)
-      .option("hoodie.clean.automatic", "true")
-      .option("hoodie.keep.min.commits", "2")
-      .option("hoodie.keep.max.commits", "3")
-      .option("hoodie.cleaner.commits.retained", "1")
       .mode(SaveMode.Append)
       .save(basePath)
-    val instant5 = metaClient.reloadActiveTimeline.lastInstant().get()
+
+    val records6 = recordsToStrings(dataGen.generateInserts("006", 3)).toList
+    val inputDF6 = spark.read.json(spark.sparkContext.parallelize(records6, 2))
+    inputDF6.write.format("org.apache.hudi")
+      .options(options)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    // Upsert Operation With Clean Operation
+    val records7 = recordsToStrings(dataGen.generateUniqueUpdates("007", 30)).toList
+    val inputDF7 = spark.read.json(spark.sparkContext.parallelize(records7, 2))
+    inputDF7.write.format("org.apache.hudi")
+      .options(options)
+      .option("hoodie.clean.automatic", "true")
+      .option("hoodie.keep.min.commits", "4")
+      .option("hoodie.keep.max.commits", "5")
+      .option("hoodie.cleaner.commits.retained", "3")
+      .mode(SaveMode.Append)
+      .save(basePath)
+    val instant7 = metaClient.reloadActiveTimeline.getCommitsTimeline.lastInstant().get()
     // part of data are updated, it will write out cdc log files.
-    // But instant5 is the clean instant, not the upsert one. so we omit to test.
-    val commitTime5 = instant5.getTimestamp
-    // here we use `commitTime4` to query the change data in commit 5.
-    // because `commitTime5` is the ts of the clean operation, not the upsert operation.
-    val cdcDataOnly5 = cdcDataFrame(commitTime4)
+    val cdcDataOnly7 = cdcDataFrame((instant7.getTimestamp.toLong - 1).toString)
     val currentData = spark.read.format("hudi").load(basePath)
-    val insertedCnt5 = currentData.count() - 50
-    val updatedCnt5 = 30 - insertedCnt5
-    assertCDCOpCnt(cdcDataOnly5, insertedCnt5, updatedCnt5, 0)
-    // here cause we do the clean operation and just remain the commit4 and commit5, so we need to reset the total cnt.
-    // 50 is the number of inserted records at commit 4.
-    totalInsertedCnt = 50 + insertedCnt5
-    totalUpdatedCnt = updatedCnt5
+    val insertedCnt7 = currentData.count() - 60
+    val updatedCnt7 = 30 - insertedCnt7
+    assertCDCOpCnt(cdcDataOnly7, insertedCnt7, updatedCnt7, 0)
+    // here cause we do the clean operation and just remain the commit4 to commit7,
+    // so we need to reset the total cnt.
+    // 60 is the number of inserted records since commit 4.
+    totalInsertedCnt = 60 + insertedCnt7
+    totalUpdatedCnt = updatedCnt7
     totalDeletedCnt = 0
     allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
 
     // Bulk_Insert Operation With Clean Operation
-    val records6 = recordsToStrings(dataGen.generateInserts("005", 20)).toList
-    val inputDF6 = spark.read.json(spark.sparkContext.parallelize(records6, 2))
-    inputDF6.write.format("org.apache.hudi")
+    val records8 = recordsToStrings(dataGen.generateInserts("008", 20)).toList
+    val inputDF8 = spark.read.json(spark.sparkContext.parallelize(records8, 2))
+    inputDF8.write.format("org.apache.hudi")
       .options(options)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
       .mode(SaveMode.Append)
       .save(basePath)
-    val instant6 = metaClient.reloadActiveTimeline.lastInstant().get()
+    val instant8 = metaClient.reloadActiveTimeline.lastInstant().get()
     // the files which keep all the old data will be replaced directly.
     // and all the new data will write out some new file groups.
     // it will NOT write out cdc log files
-    assertFalse(hasCDCLogFile(instant6))
-    val commitTime6 = instant6.getTimestamp
-    val cdcDataOnly6 = cdcDataFrame((commitTime6.toLong - 1).toString)
-    assertCDCOpCnt(cdcDataOnly6, 20, 0, 0)
+    assertFalse(hasCDCLogFile(instant8))
+    val commitTime8 = instant8.getTimestamp
+    val cdcDataOnly8 = cdcDataFrame((commitTime8.toLong - 1).toString)
+    assertCDCOpCnt(cdcDataOnly8, 20, 0, 0)
     totalInsertedCnt += 20
     allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
@@ -221,7 +234,8 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
    * Step4: Bulk_Insert 100
    * Step5: Upsert 60 With Clustering
    * Step6: Insert Overwrite 70
-   * Step7: Upsert 30 With CLean
+   * Step7,8: Insert 10 in two commits
+   * Step9: Upsert 30 With Clean
    */
   @ParameterizedTest
   @EnumSource(classOf[HoodieCDCSupplementalLoggingMode])
@@ -348,7 +362,7 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
       .save(basePath)
     val instant5 = metaClient.reloadActiveTimeline.lastInstant().get()
     // in cases that there is log files, it will NOT write out cdc log files.
-    // But instant5 is the clustering instant, not the upsert one. so we omit to test.
+    // But instant9 is the clustering instant, not the upsert one. so we omit to test.
     val commitTime5 = instant5.getTimestamp
     // here we use `commitTime4` to query the change data in commit 5.
     // because `commitTime5` is the ts of the clean operation, not the upsert operation.
@@ -389,31 +403,48 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
     allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)
 
-    // 7. Upsert Operation With Clean Operation
-    val records7 = recordsToStrings(dataGen.generateUniqueUpdates("006", 30)).toList
+    // 7,8. insert 10 records
+    val records7 = recordsToStrings(dataGen.generateInserts("006", 7)).toList
     val inputDF7 = spark.read.json(spark.sparkContext.parallelize(records7, 2))
     inputDF7.write.format("org.apache.hudi")
       .options(options)
-      .option("hoodie.clean.automatic", "true")
-      .option("hoodie.keep.min.commits", "2")
-      .option("hoodie.keep.max.commits", "3")
-      .option("hoodie.cleaner.commits.retained", "1")
       .mode(SaveMode.Append)
       .save(basePath)
-    val instant7 = metaClient.reloadActiveTimeline.lastInstant().get()
+
+    val records8 = recordsToStrings(dataGen.generateInserts("007", 3)).toList
+    val inputDF8 = spark.read.json(spark.sparkContext.parallelize(records8, 2))
+    inputDF8.write.format("org.apache.hudi")
+      .options(options)
+      .mode(SaveMode.Append)
+      .save(basePath)
+    val instant8 = metaClient.reloadActiveTimeline.lastInstant().get()
+    val commitTime8 = instant8.getTimestamp
+
+    // 8. Upsert Operation With Clean Operation
+    val records9 = recordsToStrings(dataGen.generateUniqueUpdates("008", 30)).toList
+    val inputDF9 = spark.read.json(spark.sparkContext.parallelize(records9, 2))
+    inputDF9.write.format("org.apache.hudi")
+      .options(options)
+      .option("hoodie.clean.automatic", "true")
+      .option("hoodie.keep.min.commits", "4")
+      .option("hoodie.keep.max.commits", "5")
+      .option("hoodie.cleaner.commits.retained", "3")
+      .mode(SaveMode.Append)
+      .save(basePath)
+    val instant9 = metaClient.reloadActiveTimeline.lastInstant().get()
     // in cases that there is log files, it will NOT write out cdc log files.
-    // But instant7 is the clean instant, not the upsert one. so we omit to test.
-    val commitTime7 = instant7.getTimestamp
-    val cntForInstant7 = spark.read.format("hudi").load(basePath).count()
-    val cdcDataOnly7 = cdcDataFrame(commitTime6)
-    val insertedCnt7 = cntForInstant7 - cntForInstant6
-    val updatedCnt7 = 30 - insertedCnt7
-    assertCDCOpCnt(cdcDataOnly7, insertedCnt7, updatedCnt7, 0)
+    // But instant9 is the clean instant, not the upsert one. so we omit to test.
+    val commitTime9 = instant9.getTimestamp
+    val cntForInstant9 = spark.read.format("hudi").load(basePath).count()
+    val cdcDataOnly9 = cdcDataFrame(commitTime8)
+    val insertedCnt9 = cntForInstant9 - cntForInstant6 - 10
+    val updatedCnt9 = 30 - insertedCnt9
+    assertCDCOpCnt(cdcDataOnly9, insertedCnt9, updatedCnt9, 0)
 
     // here cause we do the clean operation and just remain the commit6 and commit7, so we need to reset the total cnt.
     // 70 is the number of inserted records at commit 6.
-    totalInsertedCnt = 70 + insertedCnt7
-    totalUpdatedCnt = updatedCnt7
+    totalInsertedCnt = 80 + insertedCnt9
+    totalUpdatedCnt = updatedCnt9
     totalDeletedCnt = 0
     allVisibleCDCData = cdcDataFrame((commitTime1.toLong - 1).toString)
     assertCDCOpCnt(allVisibleCDCData, totalInsertedCnt, totalUpdatedCnt, totalDeletedCnt)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCommitsProcedure.scala
@@ -35,13 +35,13 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
            | tblproperties (
            |  primaryKey = 'id',
            |  preCombineField = 'ts',
-           |  hoodie.keep.max.commits = 3,
-           |  hoodie.keep.min.commits = 2,
+           |  hoodie.keep.max.commits = 5,
+           |  hoodie.keep.min.commits = 4,
            |  hoodie.cleaner.commits.retained = 1
            | )
        """.stripMargin)
 
-      // insert data to table, will generate 3 active commits and 4 archived commits
+      // insert data to table, will generate 5 active commits and 2 archived commits
       spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
       spark.sql(s"insert into $tableName select 2, 'a2', 20, 1500")
       spark.sql(s"insert into $tableName select 3, 'a3', 30, 2000")
@@ -56,12 +56,16 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
 
       // collect active commits for table
       val commits = spark.sql(s"""call show_commits(table => '$tableName', limit => 10)""").collect()
-      assertResult(3){commits.length}
+      assertResult(5) {
+        commits.length
+      }
 
       // collect archived commits for table
       val endTs = commits(0).get(0).toString
       val archivedCommits = spark.sql(s"""call show_archived_commits(table => '$tableName', end_ts => '$endTs')""").collect()
-      assertResult(4){archivedCommits.length}
+      assertResult(2) {
+        archivedCommits.length
+      }
     }
   }
 
@@ -81,13 +85,13 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
            | tblproperties (
            |  primaryKey = 'id',
            |  preCombineField = 'ts',
-           |  hoodie.keep.max.commits = 3,
-           |  hoodie.keep.min.commits = 2,
+           |  hoodie.keep.max.commits = 5,
+           |  hoodie.keep.min.commits = 4,
            |  hoodie.cleaner.commits.retained = 1
            | )
        """.stripMargin)
 
-      // insert data to table, will generate 3 active commits and 4 archived commits
+      // insert data to table, will generate 5 active commits and 2 archived commits
       spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
       spark.sql(s"insert into $tableName select 2, 'a2', 20, 1500")
       spark.sql(s"insert into $tableName select 3, 'a3', 30, 2000")
@@ -102,12 +106,16 @@ class TestCommitsProcedure extends HoodieSparkProcedureTestBase {
 
       // collect active commits for table
       val commits = spark.sql(s"""call show_commits(table => '$tableName', limit => 10)""").collect()
-      assertResult(3){commits.length}
+      assertResult(5) {
+        commits.length
+      }
 
       // collect archived commits for table
       val endTs = commits(0).get(0).toString
       val archivedCommits = spark.sql(s"""call show_archived_commits_metadata(table => '$tableName', end_ts => '$endTs')""").collect()
-      assertResult(4){archivedCommits.length}
+      assertResult(2) {
+        archivedCommits.length
+      }
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1088,28 +1088,30 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
     assertFalse(replacedFilePaths.isEmpty());
 
-    // Step 4 : Insert 1 record and trigger sync/async cleaner and archive.
-    List<String> configs = getAsyncServicesConfigs(1, "true", "true", "6", "", "");
-    configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_POLICY.key(), "KEEP_LATEST_COMMITS"));
-    configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "1"));
-    configs.add(String.format("%s=%s", HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "2"));
-    configs.add(String.format("%s=%s", HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "3"));
-    configs.add(String.format("%s=%s", HoodieCleanConfig.ASYNC_CLEAN.key(), asyncClean));
-    configs.add(String.format("%s=%s", HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key(), "1"));
-    configs.add(String.format("%s=%s", HoodieWriteConfig.MARKERS_TYPE.key(), "DIRECT"));
-    if (asyncClean) {
-      configs.add(String.format("%s=%s", HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(),
-          WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()));
-      configs.add(String.format("%s=%s", HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(),
-          HoodieFailedWritesCleaningPolicy.LAZY.name()));
-      configs.add(String.format("%s=%s", HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
-          InProcessLockProvider.class.getName()));
+    // Step 4 : Add commits with insert of 1 record and trigger sync/async cleaner and archive.
+    for (int i = 0; i < 2; i++) {
+      List<String> configs = getAsyncServicesConfigs(1, "true", "true", "6", "", "");
+      configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_POLICY.key(), "KEEP_LATEST_COMMITS"));
+      configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "1"));
+      configs.add(String.format("%s=%s", HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "4"));
+      configs.add(String.format("%s=%s", HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "5"));
+      configs.add(String.format("%s=%s", HoodieCleanConfig.ASYNC_CLEAN.key(), asyncClean));
+      configs.add(String.format("%s=%s", HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key(), "1"));
+      configs.add(String.format("%s=%s", HoodieWriteConfig.MARKERS_TYPE.key(), "DIRECT"));
+      if (asyncClean) {
+        configs.add(String.format("%s=%s", HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(),
+            WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()));
+        configs.add(String.format("%s=%s", HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(),
+            HoodieFailedWritesCleaningPolicy.LAZY.name()));
+        configs.add(String.format("%s=%s", HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
+            InProcessLockProvider.class.getName()));
+      }
+      TestHelpers.addRecordMerger(recordType, configs);
+      cfg.configs = configs;
+      cfg.continuousMode = false;
+      ds = new HoodieDeltaStreamer(cfg, jsc);
+      ds.sync();
     }
-    TestHelpers.addRecordMerger(recordType, configs);
-    cfg.configs = configs;
-    cfg.continuousMode = false;
-    ds = new HoodieDeltaStreamer(cfg, jsc);
-    ds.sync();
 
     // Step 5 : Make sure that firstReplaceHoodieInstant is archived.
     long count = meta.reloadActiveTimeline().getCompletedReplaceTimeline().getInstantsAsStream().filter(instant -> firstReplaceHoodieInstant.get().equals(instant)).count();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1089,26 +1089,27 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     assertFalse(replacedFilePaths.isEmpty());
 
     // Step 4 : Add commits with insert of 1 record and trigger sync/async cleaner and archive.
+    List<String> configs = getAsyncServicesConfigs(1, "true", "true", "6", "", "");
+    configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_POLICY.key(), "KEEP_LATEST_COMMITS"));
+    configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "1"));
+    configs.add(String.format("%s=%s", HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "4"));
+    configs.add(String.format("%s=%s", HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "5"));
+    configs.add(String.format("%s=%s", HoodieCleanConfig.ASYNC_CLEAN.key(), asyncClean));
+    configs.add(String.format("%s=%s", HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key(), "1"));
+    configs.add(String.format("%s=%s", HoodieWriteConfig.MARKERS_TYPE.key(), "DIRECT"));
+    if (asyncClean) {
+      configs.add(String.format("%s=%s", HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(),
+          WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()));
+      configs.add(String.format("%s=%s", HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(),
+          HoodieFailedWritesCleaningPolicy.LAZY.name()));
+      configs.add(String.format("%s=%s", HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
+          InProcessLockProvider.class.getName()));
+    }
+    TestHelpers.addRecordMerger(recordType, configs);
+    cfg.configs = configs;
+    cfg.continuousMode = false;
+
     for (int i = 0; i < 2; i++) {
-      List<String> configs = getAsyncServicesConfigs(1, "true", "true", "6", "", "");
-      configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_POLICY.key(), "KEEP_LATEST_COMMITS"));
-      configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key(), "1"));
-      configs.add(String.format("%s=%s", HoodieArchivalConfig.MIN_COMMITS_TO_KEEP.key(), "4"));
-      configs.add(String.format("%s=%s", HoodieArchivalConfig.MAX_COMMITS_TO_KEEP.key(), "5"));
-      configs.add(String.format("%s=%s", HoodieCleanConfig.ASYNC_CLEAN.key(), asyncClean));
-      configs.add(String.format("%s=%s", HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key(), "1"));
-      configs.add(String.format("%s=%s", HoodieWriteConfig.MARKERS_TYPE.key(), "DIRECT"));
-      if (asyncClean) {
-        configs.add(String.format("%s=%s", HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(),
-            WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()));
-        configs.add(String.format("%s=%s", HoodieCleanConfig.FAILED_WRITES_CLEANER_POLICY.key(),
-            HoodieFailedWritesCleaningPolicy.LAZY.name()));
-        configs.add(String.format("%s=%s", HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(),
-            InProcessLockProvider.class.getName()));
-      }
-      TestHelpers.addRecordMerger(recordType, configs);
-      cfg.configs = configs;
-      cfg.continuousMode = false;
       ds = new HoodieDeltaStreamer(cfg, jsc);
       ds.sync();
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -215,7 +215,7 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
 
   private HoodieWriteConfig getWriteConfig() {
     return getConfigBuilder(basePath(), metaClient)
-            .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
             .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
             .withMetadataConfig(HoodieMetadataConfig.newBuilder()
                     .withMaxNumDeltaCommitsBeforeCompaction(1).build())

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -96,7 +96,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     this.tableType = tableType;
     metaClient = getHoodieMetaClient(hadoopConf(), basePath());
     HoodieWriteConfig writeConfig = getConfigBuilder(basePath(), metaClient)
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withInlineCompaction(true).withMaxNumDeltaCommitsBeforeCompaction(3).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
@@ -138,7 +138,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     this.tableType = tableType;
     metaClient = getHoodieMetaClient(hadoopConf(), basePath());
     HoodieWriteConfig writeConfig = getConfigBuilder(basePath(), metaClient)
-        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(3, 4).build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(2).build())
         .withCompactionConfig(
             HoodieCompactionConfig.newBuilder()


### PR DESCRIPTION
### Change Logs

This PR removes the archival configs for the metadata table, `hoodie.metadata.keep.min.commits` and `hoodie.metadata.keep.max.commits`, since the metadata table's archival operation is tied to the corresponding data table's timeline and these two configs do not provide much value.  The PR makes the metadata table's archival operation to use the same configs, `hoodie.keep.min.commits` and `hoodie.keep.max.commits`, as the data table.

A few tests are also adjusted since the number of commits to retain in metadata table is 3, so the `hoodie.keep.min.commits` should be larger than 3.

### Impact

Removes `hoodie.metadata.keep.min.commits` and `hoodie.metadata.keep.max.commits`, which users should not tweak anyway.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
