### PR TITLE
[HUDI-5893] Mark additional advanced configs

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -47,12 +47,14 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> DYNAMODB_LOCK_TABLE_NAME = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "table")
       .defaultValue("hudi_locks")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("For DynamoDB based lock provider, the name of the DynamoDB table acting as lock table");
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_PARTITION_KEY = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "partition_key")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withInferFunction(cfg -> {
         if (cfg.contains(HoodieTableConfig.NAME)) {
@@ -67,6 +69,7 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> DYNAMODB_LOCK_REGION = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "region")
       .defaultValue("us-east-1")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withInferFunction(cfg -> {
         String regionFromEnv = System.getenv("AWS_REGION");
@@ -81,30 +84,35 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> DYNAMODB_LOCK_BILLING_MODE = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "billing_mode")
       .defaultValue(BillingMode.PAY_PER_REQUEST.name())
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("For DynamoDB based lock provider, by default it is `PAY_PER_REQUEST` mode. Alternative is `PROVISIONED`.");
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_READ_CAPACITY = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "read_capacity")
       .defaultValue("20")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("For DynamoDB based lock provider, read capacity units when using PROVISIONED billing mode");
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_WRITE_CAPACITY = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "write_capacity")
       .defaultValue("10")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("For DynamoDB based lock provider, write capacity units when using PROVISIONED billing mode");
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_TABLE_CREATION_TIMEOUT = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "table_creation_timeout")
       .defaultValue(String.valueOf(2 * 60 * 1000))
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("For DynamoDB based lock provider, the maximum number of milliseconds to wait for creating DynamoDB table");
 
   public static final ConfigProperty<String> DYNAMODB_ENDPOINT_URL = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "endpoint_url")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.10.1")
       .withDocumentation("For DynamoDB based lock provider, the url endpoint used for Amazon DynamoDB service."
                          + " Useful for development with a local dynamodb instance.");

--- a/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
@@ -23,11 +23,12 @@ import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
-import javax.annotation.concurrent.Immutable;
 
 import static org.apache.hudi.config.DynamoDbBasedLockConfig.DYNAMODB_LOCK_BILLING_MODE;
 import static org.apache.hudi.config.DynamoDbBasedLockConfig.DYNAMODB_LOCK_PARTITION_KEY;
@@ -46,22 +47,25 @@ import static org.apache.hudi.config.DynamoDbBasedLockConfig.DYNAMODB_LOCK_WRITE
             + " Amazon CloudWatch (metrics).")
 public class HoodieAWSConfig extends HoodieConfig {
   public static final ConfigProperty<String> AWS_ACCESS_KEY = ConfigProperty
-        .key("hoodie.aws.access.key")
-        .noDefaultValue()
-        .sinceVersion("0.10.0")
-        .withDocumentation("AWS access key id");
+      .key("hoodie.aws.access.key")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("0.10.0")
+      .withDocumentation("AWS access key id");
 
   public static final ConfigProperty<String> AWS_SECRET_KEY = ConfigProperty
-        .key("hoodie.aws.secret.key")
-        .noDefaultValue()
-        .sinceVersion("0.10.0")
-        .withDocumentation("AWS secret key");
+      .key("hoodie.aws.secret.key")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("0.10.0")
+      .withDocumentation("AWS secret key");
 
   public static final ConfigProperty<String> AWS_SESSION_TOKEN = ConfigProperty
-        .key("hoodie.aws.session.token")
-        .noDefaultValue()
-        .sinceVersion("0.10.0")
-        .withDocumentation("AWS session token");
+      .key("hoodie.aws.session.token")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("0.10.0")
+      .withDocumentation("AWS session token");
 
   private HoodieAWSConfig() {
     super();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -65,6 +65,7 @@ public class HoodieArchivalConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> DELETE_ARCHIVED_INSTANT_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.archive.delete.parallelism")
       .defaultValue(100)
+      .markAdvanced()
       .withDocumentation("When performing archival operation, Hudi needs to delete the files of "
           + "the archived instants in the active timeline in .hoodie folder. The file deletion "
           + "also happens after merging small archived files into larger ones if enabled. "
@@ -83,28 +84,33 @@ public class HoodieArchivalConfig extends HoodieConfig {
   public static final ConfigProperty<String> COMMITS_ARCHIVAL_BATCH_SIZE = ConfigProperty
       .key("hoodie.commits.archival.batch")
       .defaultValue(String.valueOf(10))
+      .markAdvanced()
       .withDocumentation("Archiving of instants is batched in best-effort manner, to pack more instants into a single"
           + " archive log. This config controls such archival batch size.");
 
   public static final ConfigProperty<Integer> ARCHIVE_MERGE_FILES_BATCH_SIZE = ConfigProperty
       .key("hoodie.archive.merge.files.batch.size")
       .defaultValue(10)
+      .markAdvanced()
       .withDocumentation("The number of small archive files to be merged at once.");
 
   public static final ConfigProperty<Long> ARCHIVE_MERGE_SMALL_FILE_LIMIT_BYTES = ConfigProperty
       .key("hoodie.archive.merge.small.file.limit.bytes")
       .defaultValue(20L * 1024 * 1024)
+      .markAdvanced()
       .withDocumentation("This config sets the archive file size limit below which an archive file becomes a candidate to be selected as such a small file.");
 
   public static final ConfigProperty<Boolean> ARCHIVE_MERGE_ENABLE = ConfigProperty
       .key("hoodie.archive.merge.enable")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("When enable, hoodie will auto merge several small archive files into larger one. It's"
           + " useful when storage scheme doesn't support append operation.");
 
   public static final ConfigProperty<Boolean> ARCHIVE_BEYOND_SAVEPOINT = ConfigProperty
       .key("hoodie.archive.beyond.savepoint")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.12.0")
       .withDocumentation("If enabled, archival will proceed beyond savepoint, skipping savepoint commits."
           + " If disabled, archival will stop at the earliest savepoint commit.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
@@ -56,6 +56,7 @@ public class HoodieBootstrapConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARTITION_SELECTOR_REGEX_MODE = ConfigProperty
       .key("hoodie.bootstrap.mode.selector.regex.mode")
       .defaultValue(METADATA_ONLY.name())
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withValidValues(METADATA_ONLY.name(), FULL_RECORD.name())
       .withDocumentation("Bootstrap mode to apply for partition paths, that match regex above. "
@@ -65,36 +66,42 @@ public class HoodieBootstrapConfig extends HoodieConfig {
   public static final ConfigProperty<String> MODE_SELECTOR_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.mode.selector")
       .defaultValue(MetadataOnlyBootstrapModeSelector.class.getCanonicalName())
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Selects the mode in which each file/partition in the bootstrapped dataset gets bootstrapped");
 
   public static final ConfigProperty<String> FULL_BOOTSTRAP_INPUT_PROVIDER_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.full.input.provider")
       .defaultValue("org.apache.hudi.bootstrap.SparkParquetBootstrapDataProvider")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Class to use for reading the bootstrap dataset partitions/files, for Bootstrap mode FULL_RECORD");
 
   public static final ConfigProperty<String> KEYGEN_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.keygen.class")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Key generator implementation to be used for generating keys from the bootstrapped dataset");
 
   public static final ConfigProperty<String> KEYGEN_TYPE = ConfigProperty
       .key("hoodie.bootstrap.keygen.type")
       .defaultValue(KeyGeneratorType.SIMPLE.name())
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("Type of build-in key generator, currently support SIMPLE, COMPLEX, TIMESTAMP, CUSTOM, NON_PARTITION, GLOBAL_DELETE");
 
   public static final ConfigProperty<String> PARTITION_PATH_TRANSLATOR_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.partitionpath.translator.class")
       .defaultValue(IdentityBootstrapPartitionPathTranslator.class.getName())
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Translates the partition paths from the bootstrapped data into how is laid out as a Hudi table.");
 
   public static final ConfigProperty<String> PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.bootstrap.parallelism")
       .defaultValue("1500")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("For metadata-only bootstrap, Hudi parallelizes the operation so that "
           + "each table partition is handled by one Spark task. This config limits the number "
@@ -109,12 +116,14 @@ public class HoodieBootstrapConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARTITION_SELECTOR_REGEX_PATTERN = ConfigProperty
       .key("hoodie.bootstrap.mode.selector.regex")
       .defaultValue(".*")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Matches each bootstrap dataset partition against this regex and applies the mode below to it.");
 
   public static final ConfigProperty<String> INDEX_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.index.class")
       .defaultValue(HFileBootstrapIndex.class.getName())
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Implementation to use, for mapping a skeleton base file to a bootstrap base file.");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -53,6 +53,7 @@ public class HoodieCleanConfig extends HoodieConfig {
   public static final ConfigProperty<String> AUTO_CLEAN = ConfigProperty
       .key("hoodie.clean.automatic")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("When enabled, the cleaner table service is invoked immediately after each commit,"
           + " to delete older file slices. It's recommended to enable this, to ensure metadata and data storage"
           + " growth is bounded.");
@@ -69,6 +70,7 @@ public class HoodieCleanConfig extends HoodieConfig {
   public static final ConfigProperty<String> CLEANER_POLICY = ConfigProperty
       .key("hoodie.cleaner.policy")
       .defaultValue(HoodieCleaningPolicy.KEEP_LATEST_COMMITS.name())
+      .markAdvanced()
       .withInferFunction(cfg -> {
         boolean isCommitsRetainedConfigured = cfg.contains(CLEANER_COMMITS_RETAINED_KEY);
         boolean isHoursRetainedConfigured = cfg.contains(CLEANER_HOURS_RETAINED_KEY);
@@ -116,6 +118,7 @@ public class HoodieCleanConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> CLEANER_HOURS_RETAINED = ConfigProperty.key(CLEANER_HOURS_RETAINED_KEY)
       .defaultValue("24")
+      .markAdvanced()
       .withDocumentation("Number of hours for which commits need to be retained. This config provides a more flexible option as"
           + "compared to number of commits retained for cleaning service. Setting this property ensures all the files, but the latest in a file group,"
           + " corresponding to commits with commit times older than the configured number of hours to be retained are cleaned.");
@@ -123,23 +126,27 @@ public class HoodieCleanConfig extends HoodieConfig {
   public static final ConfigProperty<String> CLEANER_FILE_VERSIONS_RETAINED = ConfigProperty
       .key(CLEANER_FILE_VERSIONS_RETAINED_KEY)
       .defaultValue("3")
+      .markAdvanced()
       .withDocumentation("When " + HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS.name() + " cleaning policy is used, "
           + " the minimum number of file slices to retain in each file group, during cleaning.");
 
   public static final ConfigProperty<String> CLEAN_TRIGGER_STRATEGY = ConfigProperty
       .key("hoodie.clean.trigger.strategy")
       .defaultValue(CleaningTriggerStrategy.NUM_COMMITS.name())
+      .markAdvanced()
       .withDocumentation("Controls how cleaning is scheduled. Valid options: "
           + Arrays.stream(CleaningTriggerStrategy.values()).map(Enum::name).collect(Collectors.joining(",")));
 
   public static final ConfigProperty<String> CLEAN_MAX_COMMITS = ConfigProperty
       .key("hoodie.clean.max.commits")
       .defaultValue("1")
+      .markAdvanced()
       .withDocumentation("Number of commits after the last clean operation, before scheduling of a new clean is attempted.");
 
   public static final ConfigProperty<String> CLEANER_INCREMENTAL_MODE_ENABLE = ConfigProperty
       .key("hoodie.cleaner.incremental.mode")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("When enabled, the plans for each cleaner service run is computed incrementally off the events "
           + " in the timeline, since the last cleaner run. This is much more efficient than obtaining listings for the full"
           + " table for each planning (even with a metadata table).");
@@ -155,6 +162,7 @@ public class HoodieCleanConfig extends HoodieConfig {
         }
         return Option.of(HoodieFailedWritesCleaningPolicy.LAZY.name());
       })
+      .markAdvanced()
       .withDocumentation("Cleaning policy for failed writes to be used. Hudi will delete any files written by "
           + "failed writes to re-claim space. Choose to perform this rollback of failed writes eagerly before "
           + "every writer starts (only supported for single writer) or lazily by the cleaner (required for multi-writers)");
@@ -162,6 +170,7 @@ public class HoodieCleanConfig extends HoodieConfig {
   public static final ConfigProperty<String> CLEANER_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.cleaner.parallelism")
       .defaultValue("200")
+      .markAdvanced()
       .withDocumentation("This config controls the behavior of both the cleaning plan and "
           + "cleaning execution. Deriving the cleaning plan is parallelized at the table "
           + "partition level, i.e., each table partition is processed by one Spark task to figure "
@@ -177,6 +186,7 @@ public class HoodieCleanConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ALLOW_MULTIPLE_CLEANS = ConfigProperty
       .key("hoodie.clean.allow.multiple")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Allows scheduling/executing multiple cleans by enabling this config. If users prefer to strictly ensure clean requests should be mutually exclusive, "
           + ".i.e. a 2nd clean will not be scheduled if another clean is not yet completed to avoid repeat cleaning of same files, they might want to disable this config.");
@@ -184,6 +194,7 @@ public class HoodieCleanConfig extends HoodieConfig {
   public static final ConfigProperty<String> CLEANER_BOOTSTRAP_BASE_FILE_ENABLE = ConfigProperty
       .key("hoodie.cleaner.delete.bootstrap.base.file")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When set to true, cleaner also deletes the bootstrap base file when it's skeleton base file is "
           + " cleaned. Turn this to true, if you want to ensure the bootstrap dataset storage is reclaimed over time, as the"
           + " table receives updates/deletes. Another reason to turn this on, would be to ensure data residing in bootstrap "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -73,12 +73,14 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> DAYBASED_LOOKBACK_PARTITIONS = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "daybased.lookback.partitions")
       .defaultValue("2")
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Number of partitions to list to create ClusteringPlan");
 
   public static final ConfigProperty<String> PARTITION_FILTER_BEGIN_PARTITION = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "cluster.begin.partition")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Begin partition used to filter partition (inclusive), only effective when the filter mode '"
           + PLAN_PARTITION_FILTER_MODE + "' is " + ClusteringPlanPartitionFilterMode.SELECTED_PARTITIONS.name());
@@ -86,6 +88,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARTITION_FILTER_END_PARTITION = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "cluster.end.partition")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("End partition used to filter partition (inclusive), only effective when the filter mode '"
           + PLAN_PARTITION_FILTER_MODE + "' is " + ClusteringPlanPartitionFilterMode.SELECTED_PARTITIONS.name());
@@ -99,18 +102,21 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARTITION_REGEX_PATTERN = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "partition.regex.pattern")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Filter clustering partitions that matched regex pattern");
 
   public static final ConfigProperty<String> PARTITION_SELECTED = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "partition.selected")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Partitions to run clustering");
 
   public static final ConfigProperty<String> PLAN_STRATEGY_CLASS_NAME = ConfigProperty
       .key("hoodie.clustering.plan.strategy.class")
       .defaultValue(SPARK_SIZED_BASED_CLUSTERING_PLAN_STRATEGY)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Config to provide a strategy class (subclass of ClusteringPlanStrategy) to create clustering plan "
           + "i.e select what file groups are being clustered. Default strategy, looks at the clustering small file size limit (determined by "
@@ -119,6 +125,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> EXECUTION_STRATEGY_CLASS_NAME = ConfigProperty
       .key("hoodie.clustering.execution.strategy.class")
       .defaultValue(SPARK_SORT_AND_SIZE_EXECUTION_STRATEGY)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Config to provide a strategy class (subclass of RunClusteringStrategy) to define how the "
           + " clustering plan is executed. By default, we sort the file groups in th plan by the specified columns, while "
@@ -134,24 +141,28 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> INLINE_CLUSTERING_MAX_COMMITS = ConfigProperty
       .key("hoodie.clustering.inline.max.commits")
       .defaultValue("4")
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Config to control frequency of clustering planning");
 
   public static final ConfigProperty<String> ASYNC_CLUSTERING_MAX_COMMITS = ConfigProperty
       .key("hoodie.clustering.async.max.commits")
       .defaultValue("4")
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("Config to control frequency of async clustering");
 
   public static final ConfigProperty<String> PLAN_STRATEGY_SKIP_PARTITIONS_FROM_LATEST = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "daybased.skipfromlatest.partitions")
       .defaultValue("0")
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("Number of partitions to skip from latest when choosing partitions to create ClusteringPlan");
 
   public static final ConfigProperty<ClusteringPlanPartitionFilterMode> PLAN_PARTITION_FILTER_MODE_NAME = ConfigProperty
       .key(PLAN_PARTITION_FILTER_MODE)
       .defaultValue(ClusteringPlanPartitionFilterMode.NONE)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Partition filter mode used in the creation of clustering plan. Available values are - "
           + "NONE: do not filter table partition and thus the clustering plan will include all partitions that have clustering candidate."
@@ -165,6 +176,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> PLAN_STRATEGY_MAX_BYTES_PER_OUTPUT_FILEGROUP = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "max.bytes.per.group")
       .defaultValue(String.valueOf(2 * 1024 * 1024 * 1024L))
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Each clustering operation can create multiple output file groups. Total amount of data processed by clustering operation"
           + " is defined by below two properties (CLUSTERING_MAX_BYTES_PER_GROUP * CLUSTERING_MAX_NUM_GROUPS)."
@@ -173,6 +185,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> PLAN_STRATEGY_MAX_GROUPS = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "max.num.groups")
       .defaultValue("30")
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Maximum number of groups to create as part of ClusteringPlan. Increasing groups will increase parallelism");
 
@@ -185,18 +198,21 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> PLAN_STRATEGY_SINGLE_GROUP_CLUSTERING_ENABLED = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "single.group.clustering.enabled")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.14.0")
       .withDocumentation("Whether to generate clustering plan when there is only one file group involved, by default true");
 
   public static final ConfigProperty<String> PLAN_STRATEGY_SORT_COLUMNS = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "sort.columns")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Columns to sort the data by when clustering");
 
   public static final ConfigProperty<String> UPDATES_STRATEGY = ConfigProperty
       .key("hoodie.clustering.updates.strategy")
       .defaultValue("org.apache.hudi.client.clustering.update.strategy.SparkRejectUpdateStrategy")
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Determines how to handle updates, deletes to file groups that are under clustering."
           + " Default strategy just rejects the update");
@@ -204,6 +220,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> SCHEDULE_INLINE_CLUSTERING = ConfigProperty
       .key("hoodie.clustering.schedule.inline")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When set to true, clustering service will be attempted for inline scheduling after each write. Users have to ensure "
           + "they have a separate job to run async clustering(execution) for the one scheduled by this writer. Users can choose to set both "
           + "`hoodie.clustering.inline` and `hoodie.clustering.schedule.inline` to false and have both scheduling and execution triggered by any async process, on which "
@@ -225,6 +242,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty LAYOUT_OPTIMIZE_ENABLE = ConfigProperty
       .key(LAYOUT_OPTIMIZE_PARAM_PREFIX + "enable")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .deprecatedAfter("0.11.0")
       .withDocumentation("This setting has no effect. Please refer to clustering configuration, as well as "
@@ -245,6 +263,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> LAYOUT_OPTIMIZE_STRATEGY = ConfigProperty
       .key(LAYOUT_OPTIMIZE_PARAM_PREFIX + "strategy")
       .defaultValue("linear")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Determines ordering strategy used in records layout optimization. "
           + "Currently supported strategies are \"linear\", \"z-order\" and \"hilbert\" values are supported.");
@@ -272,6 +291,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> LAYOUT_OPTIMIZE_SPATIAL_CURVE_BUILD_METHOD = ConfigProperty
       .key(LAYOUT_OPTIMIZE_PARAM_PREFIX + "curve.build.method")
       .defaultValue("direct")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Controls how data is sampled to build the space-filling curves. "
           + "Two methods: \"direct\", \"sample\". The direct method is faster than the sampling, "
@@ -288,6 +308,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<String> LAYOUT_OPTIMIZE_BUILD_CURVE_SAMPLE_SIZE = ConfigProperty
       .key(LAYOUT_OPTIMIZE_PARAM_PREFIX + "build.curve.sample.size")
       .defaultValue("200000")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Determines target sample size used by the Boundary-based Interleaved Index method "
           + "of building space-filling curve. Larger sample size entails better layout optimization outcomes, "
@@ -299,6 +320,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty LAYOUT_OPTIMIZE_DATA_SKIPPING_ENABLE = ConfigProperty
       .key(LAYOUT_OPTIMIZE_PARAM_PREFIX + "data.skipping.enable")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .deprecatedAfter("0.11.0")
       .withDocumentation("Enable data skipping by collecting statistics once layout optimization is complete.");
@@ -306,6 +328,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ROLLBACK_PENDING_CLUSTERING_ON_CONFLICT = ConfigProperty
       .key("hoodie.clustering.rollback.pending.replacecommit.on.conflict")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("If updates are allowed to file groups pending clustering, then set this config to rollback failed or pending clustering instants. "
           + "Pending clustering will be rolled back ONLY IF there is conflict between incoming upsert and filegroup to be clustered. "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -55,6 +55,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> SCHEDULE_INLINE_COMPACT = ConfigProperty
       .key("hoodie.compact.schedule.inline")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When set to true, compaction service will be attempted for inline scheduling after each write. Users have to ensure "
           + "they have a separate job to run async compaction(execution) for the one scheduled by this writer. Users can choose to set both "
           + "`hoodie.compact.inline` and `hoodie.compact.schedule.inline` to false and have both scheduling and execution triggered by any async process. "
@@ -65,6 +66,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> INLINE_LOG_COMPACT = ConfigProperty
       .key("hoodie.log.compaction.inline")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("When set to true, logcompaction service is triggered after each write. While being "
           + " simpler operationally, this adds extra latency on the write path.");
@@ -79,6 +81,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> INLINE_COMPACT_TIME_DELTA_SECONDS = ConfigProperty
       .key("hoodie.compact.inline.max.delta.seconds")
       .defaultValue(String.valueOf(60 * 60))
+      .markAdvanced()
       .withDocumentation("Number of elapsed seconds after the last compaction, before scheduling a new one. "
           + "This config takes effect only for the compaction triggering strategy based on the elapsed time, "
           + "i.e., TIME_ELAPSED, NUM_AND_TIME, and NUM_OR_TIME.");
@@ -86,12 +89,14 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> INLINE_COMPACT_TRIGGER_STRATEGY = ConfigProperty
       .key("hoodie.compact.inline.trigger.strategy")
       .defaultValue(CompactionTriggerStrategy.NUM_COMMITS.name())
+      .markAdvanced()
       .withDocumentation("Controls how compaction scheduling is triggered, by time or num delta commits or combination of both. "
           + "Valid options: " + Arrays.stream(CompactionTriggerStrategy.values()).map(Enum::name).collect(Collectors.joining(",")));
 
   public static final ConfigProperty<String> PARQUET_SMALL_FILE_LIMIT = ConfigProperty
       .key("hoodie.parquet.small.file.limit")
       .defaultValue(String.valueOf(104857600))
+      .markAdvanced()
       .withDocumentation("During upsert operation, we opportunistically expand existing small files on storage, instead of writing"
           + " new files, to keep number of files to an optimum. This config sets the file size limit below which a file on storage "
           + " becomes a candidate to be selected as such a `small file`. By default, treat any file <= 100MB as a small file."
@@ -100,6 +105,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> RECORD_SIZE_ESTIMATION_THRESHOLD = ConfigProperty
       .key("hoodie.record.size.estimation.threshold")
       .defaultValue("1.0")
+      .markAdvanced()
       .withDocumentation("We use the previous commits' metadata to calculate the estimated record size and use it "
           + " to bin pack records into partitions. If the previous commit is too small to make an accurate estimation, "
           + " Hudi will search commits in the reverse order, until we find a commit that has totalBytesWritten "
@@ -109,18 +115,21 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> TARGET_IO_PER_COMPACTION_IN_MB = ConfigProperty
       .key("hoodie.compaction.target.io")
       .defaultValue(String.valueOf(500 * 1024))
+      .markAdvanced()
       .withDocumentation("Amount of MBs to spend during compaction run for the LogFileSizeBasedCompactionStrategy. "
           + "This value helps bound ingestion latency while compaction is run inline mode.");
 
   public static final ConfigProperty<Long> COMPACTION_LOG_FILE_SIZE_THRESHOLD = ConfigProperty
       .key("hoodie.compaction.logfile.size.threshold")
       .defaultValue(0L)
+      .markAdvanced()
       .withDocumentation("Only if the log file size is greater than the threshold in bytes,"
           + " the file group will be compacted.");
 
   public static final ConfigProperty<Long> COMPACTION_LOG_FILE_NUM_THRESHOLD = ConfigProperty
       .key("hoodie.compaction.logfile.num.threshold")
       .defaultValue(0L)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Only if the log file num is greater than the threshold,"
           + " the file group will be compacted.");
@@ -128,6 +137,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> COMPACTION_STRATEGY = ConfigProperty
       .key("hoodie.compaction.strategy")
       .defaultValue(LogFileSizeBasedCompactionStrategy.class.getName())
+      .markAdvanced()
       .withDocumentation("Compaction strategy decides which file groups are picked up for "
           + "compaction during each compaction run. By default. Hudi picks the log file "
           + "with most accumulated unmerged data");
@@ -135,6 +145,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> COMPACTION_LAZY_BLOCK_READ_ENABLE = ConfigProperty
       .key("hoodie.compaction.lazy.block.read")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("When merging the delta log files, this config helps to choose whether the log blocks "
           + "should be read lazily or not. Choose true to use lazy block reading (low memory usage, but incurs seeks to each block"
           + " header) or false for immediate block read (higher memory usage)");
@@ -142,12 +153,14 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> COMPACTION_REVERSE_LOG_READ_ENABLE = ConfigProperty
       .key("hoodie.compaction.reverse.log.read")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("HoodieLogFormatReader reads a logfile in the forward direction starting from pos=0 to pos=file_length. "
           + "If this config is set to true, the reader reads the logfile in reverse direction, from pos=file_length to pos=0");
 
   public static final ConfigProperty<String> TARGET_PARTITIONS_PER_DAYBASED_COMPACTION = ConfigProperty
       .key("hoodie.compaction.daybased.target.partitions")
       .defaultValue("10")
+      .markAdvanced()
       .withDocumentation("Used by org.apache.hudi.io.compact.strategy.DayBasedCompactionStrategy to denote the number of "
           + "latest partitions to compact during a compaction run.");
 
@@ -157,6 +170,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> COPY_ON_WRITE_INSERT_SPLIT_SIZE = ConfigProperty
       .key("hoodie.copyonwrite.insert.split.size")
       .defaultValue(String.valueOf(500000))
+      .markAdvanced()
       .withDocumentation("Number of inserts assigned for each partition/bucket for writing. "
           + "We based the default on writing out 100MB files, with at least 1kb records (100K records per file), and "
           + "  over provision to 500K. As long as auto-tuning of splits is turned on, this only affects the first "
@@ -165,6 +179,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> COPY_ON_WRITE_AUTO_SPLIT_INSERTS = ConfigProperty
       .key("hoodie.copyonwrite.insert.auto.split")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Config to control whether we control insert split sizes automatically based on average"
           + " record sizes. It's recommended to keep this turned on, since hand tuning is otherwise extremely"
           + " cumbersome.");
@@ -172,6 +187,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> COPY_ON_WRITE_RECORD_SIZE_ESTIMATE = ConfigProperty
       .key("hoodie.copyonwrite.record.size.estimate")
       .defaultValue(String.valueOf(1024))
+      .markAdvanced()
       .withDocumentation("The average record size. If not explicitly specified, hudi will compute the "
           + "record size estimate compute dynamically based on commit metadata. "
           + " This is critical in computing the insert parallelism and bin-packing inserts into small files.");
@@ -179,6 +195,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> LOG_COMPACTION_BLOCKS_THRESHOLD = ConfigProperty
       .key("hoodie.log.compaction.blocks.threshold")
       .defaultValue("5")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Log compaction can be scheduled if the no. of log blocks crosses this threshold value. "
           + "This is effective only when log compaction is enabled via " + INLINE_LOG_COMPACT.key());
@@ -186,6 +203,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> ENABLE_OPTIMIZED_LOG_BLOCKS_SCAN = ConfigProperty
       .key("hoodie" + HoodieMetadataConfig.OPTIMIZED_LOG_BLOCKS_SCAN)
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("New optimized scan for log blocks that handles all multi-writer use-cases while appending to log files. "
           + "It also differentiates original blocks written by ingestion writers and compacted blocks written log compaction.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieHBaseIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieHBaseIndexConfig.java
@@ -40,51 +40,60 @@ public class HoodieHBaseIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> ZKQUORUM = ConfigProperty
       .key("hoodie.index.hbase.zkquorum")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Only applies if index type is HBASE. HBase ZK Quorum url to connect to");
 
   public static final ConfigProperty<String> ZKPORT = ConfigProperty
       .key("hoodie.index.hbase.zkport")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Only applies if index type is HBASE. HBase ZK Quorum port to connect to");
 
   public static final ConfigProperty<String> TABLENAME = ConfigProperty
       .key("hoodie.index.hbase.table")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Only applies if index type is HBASE. HBase Table name to use as the index. "
           + "Hudi stores the row_key and [partition_path, fileID, commitTime] mapping in the table");
 
   public static final ConfigProperty<Integer> GET_BATCH_SIZE = ConfigProperty
       .key("hoodie.index.hbase.get.batch.size")
       .defaultValue(100)
+      .markAdvanced()
       .withDocumentation("Controls the batch size for performing gets against HBase. "
           + "Batching improves throughput, by saving round trips.");
 
   public static final ConfigProperty<String> ZK_NODE_PATH = ConfigProperty
       .key("hoodie.index.hbase.zknode.path")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Only applies if index type is HBASE. This is the root znode that will contain "
           + "all the znodes created/used by HBase");
 
   public static final ConfigProperty<Integer> PUT_BATCH_SIZE = ConfigProperty
       .key("hoodie.index.hbase.put.batch.size")
       .defaultValue(100)
+      .markAdvanced()
       .withDocumentation("Controls the batch size for performing puts against HBase. "
           + "Batching improves throughput, by saving round trips.");
 
   public static final ConfigProperty<String> QPS_ALLOCATOR_CLASS_NAME = ConfigProperty
       .key("hoodie.index.hbase.qps.allocator.class")
       .defaultValue(DefaultHBaseQPSResourceAllocator.class.getName())
+      .markAdvanced()
       .withDocumentation("Property to set which implementation of HBase QPS resource allocator to be used, which"
           + "controls the batching rate dynamically.");
 
   public static final ConfigProperty<Boolean> PUT_BATCH_SIZE_AUTO_COMPUTE = ConfigProperty
       .key("hoodie.index.hbase.put.batch.size.autocompute")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Property to set to enable auto computation of put batch size");
 
   public static final ConfigProperty<Float> QPS_FRACTION = ConfigProperty
       .key("hoodie.index.hbase.qps.fraction")
       .defaultValue(0.5f)
+      .markAdvanced()
       .withDocumentation("Property to set the fraction of the global share of QPS that should be allocated to this job. Let's say there are 3"
           + " jobs which have input size in terms of number of rows required for HbaseIndexing as x, 2x, 3x respectively. Then"
           + " this fraction for the jobs would be (0.17) 1/6, 0.33 (2/6) and 0.5 (3/6) respectively."
@@ -93,6 +102,7 @@ public class HoodieHBaseIndexConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> MAX_QPS_PER_REGION_SERVER = ConfigProperty
       .key("hoodie.index.hbase.max.qps.per.region.server")
       .defaultValue(1000)
+      .markAdvanced()
       .withDocumentation("Property to set maximum QPS allowed per Region Server. This should be same across various jobs. This is intended to\n"
           + " limit the aggregate QPS generated across various jobs to an Hbase Region Server. It is recommended to set this\n"
           + " value based on global indexing throughput needs and most importantly, how much the HBase installation in use is\n"
@@ -101,52 +111,62 @@ public class HoodieHBaseIndexConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> COMPUTE_QPS_DYNAMICALLY = ConfigProperty
       .key("hoodie.index.hbase.dynamic_qps")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Property to decide if HBASE_QPS_FRACTION_PROP is dynamically calculated based on write volume.");
 
   public static final ConfigProperty<String> MIN_QPS_FRACTION = ConfigProperty
       .key("hoodie.index.hbase.min.qps.fraction")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Minimum for HBASE_QPS_FRACTION_PROP to stabilize skewed write workloads");
 
   public static final ConfigProperty<String> MAX_QPS_FRACTION = ConfigProperty
       .key("hoodie.index.hbase.max.qps.fraction")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Maximum for HBASE_QPS_FRACTION_PROP to stabilize skewed write workloads");
 
   public static final ConfigProperty<Integer> DESIRED_PUTS_TIME_IN_SECONDS = ConfigProperty
       .key("hoodie.index.hbase.desired_puts_time_in_secs")
       .defaultValue(600)
+      .markAdvanced()
       .withDocumentation("");
 
   public static final ConfigProperty<String> SLEEP_MS_FOR_PUT_BATCH = ConfigProperty
       .key("hoodie.index.hbase.sleep.ms.for.put.batch")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("");
 
   public static final ConfigProperty<String> SLEEP_MS_FOR_GET_BATCH = ConfigProperty
       .key("hoodie.index.hbase.sleep.ms.for.get.batch")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("");
 
   public static final ConfigProperty<Integer> ZK_SESSION_TIMEOUT_MS = ConfigProperty
       .key("hoodie.index.hbase.zk.session_timeout_ms")
       .defaultValue(60 * 1000)
+      .markAdvanced()
       .withDocumentation("Session timeout value to use for Zookeeper failure detection, for the HBase client."
           + "Lower this value, if you want to fail faster.");
 
   public static final ConfigProperty<Integer> ZK_CONNECTION_TIMEOUT_MS = ConfigProperty
       .key("hoodie.index.hbase.zk.connection_timeout_ms")
       .defaultValue(15 * 1000)
+      .markAdvanced()
       .withDocumentation("Timeout to use for establishing connection with zookeeper, from HBase client.");
 
   public static final ConfigProperty<String> ZKPATH_QPS_ROOT = ConfigProperty
       .key("hoodie.index.hbase.zkpath.qps_root")
       .defaultValue("/QPS_ROOT")
+      .markAdvanced()
       .withDocumentation("chroot in zookeeper, to use for all qps allocation co-ordination.");
 
   public static final ConfigProperty<Boolean> UPDATE_PARTITION_PATH_ENABLE = ConfigProperty
       .key("hoodie.hbase.index.update.partition.path")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Only applies if index type is HBASE. "
           + "When an already existing record is upserted to a new partition compared to whats in storage, "
           + "this config when set, will delete old record in old partition "
@@ -155,38 +175,45 @@ public class HoodieHBaseIndexConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ROLLBACK_SYNC_ENABLE = ConfigProperty
       .key("hoodie.index.hbase.rollback.sync")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("When set to true, the rollback method will delete the last failed task index. "
           + "The default value is false. Because deleting the index will add extra load on the Hbase cluster for each rollback");
 
   public static final ConfigProperty<String> SECURITY_AUTHENTICATION = ConfigProperty
       .key("hoodie.index.hbase.security.authentication")
       .defaultValue("simple")
+      .markAdvanced()
       .withDocumentation("Property to decide if the hbase cluster secure authentication is enabled or not. "
           + "Possible values are 'simple' (no authentication), and 'kerberos'.");
 
   public static final ConfigProperty<String> KERBEROS_USER_KEYTAB = ConfigProperty
       .key("hoodie.index.hbase.kerberos.user.keytab")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("File name of the kerberos keytab file for connecting to the hbase cluster.");
 
   public static final ConfigProperty<String> KERBEROS_USER_PRINCIPAL = ConfigProperty
       .key("hoodie.index.hbase.kerberos.user.principal")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The kerberos principal name for connecting to the hbase cluster.");
 
   public static final ConfigProperty<String> REGIONSERVER_PRINCIPAL = ConfigProperty
       .key("hoodie.index.hbase.regionserver.kerberos.principal")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The value of hbase.regionserver.kerberos.principal in hbase cluster.");
 
   public static final ConfigProperty<String> MASTER_PRINCIPAL = ConfigProperty
       .key("hoodie.index.hbase.master.kerberos.principal")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The value of hbase.master.kerberos.principal in hbase cluster.");
 
   public static final ConfigProperty<Integer> BUCKET_NUMBER = ConfigProperty
       .key("hoodie.index.hbase.bucket.number")
       .defaultValue(8)
+      .markAdvanced()
       .withDocumentation("Only applicable when using RebalancedSparkHoodieHBaseIndex, same as hbase regions count can get the best performance");
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -84,6 +84,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> INDEX_CLASS_NAME = ConfigProperty
       .key("hoodie.index.class")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("Full path of user-defined index class and must be a subclass of HoodieIndex class. "
           + "It will take precedence over the hoodie.index.type configuration if specified");
 
@@ -91,6 +92,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_FILTER_NUM_ENTRIES_VALUE = ConfigProperty
       .key("hoodie.index.bloom.num_entries")
       .defaultValue("60000")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM. "
           + "This is the number of entries to be stored in the bloom filter. "
           + "The rationale for the default: Assume the maxParquetFileSize is 128MB and averageRecordSize is 1kb and "
@@ -103,6 +105,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_FILTER_FPP_VALUE = ConfigProperty
       .key("hoodie.index.bloom.fpp")
       .defaultValue("0.000000001")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM. "
           + "Error rate allowed given the number of entries. This is used to calculate how many bits should be "
           + "assigned for the bloom filter and the number of hash functions. This is usually set very low (default: 0.000000001), "
@@ -113,6 +116,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.bloom.index.parallelism")
       .defaultValue("0")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM. "
           + "This is the amount of parallelism for index lookup, which involves a shuffle. "
           + "By default, this is auto computed based on input workload characteristics. "
@@ -123,6 +127,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_PRUNE_BY_RANGES = ConfigProperty
       .key("hoodie.bloom.index.prune.by.ranges")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM. "
           + "When true, range information from files to leveraged speed up index lookups. Particularly helpful, "
           + "if the key has a monotonously increasing prefix, such as timestamp. "
@@ -132,6 +137,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_USE_CACHING = ConfigProperty
       .key("hoodie.bloom.index.use.caching")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM."
           + "When true, the input RDD will cached to speed up index lookup by reducing IO "
           + "for computing parallelism or affected partitions");
@@ -139,6 +145,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> BLOOM_INDEX_USE_METADATA = ConfigProperty
       .key("hoodie.bloom.index.use.metadata")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Only applies if index type is BLOOM."
           + "When true, the index lookup uses bloom filters and column stats from metadata "
@@ -147,6 +154,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_TREE_BASED_FILTER = ConfigProperty
       .key("hoodie.bloom.index.use.treebased.filter")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BLOOM. "
           + "When true, interval tree based file pruning optimization is enabled. "
           + "This mode speeds-up file-pruning based on key ranges when compared with the brute-force mode");
@@ -164,6 +172,7 @@ public class HoodieIndexConfig extends HoodieConfig {
       .key("hoodie.bloom.index.filter.type")
       .defaultValue(BloomFilterTypeCode.DYNAMIC_V0.name())
       .withValidValues(BloomFilterTypeCode.SIMPLE.name(), BloomFilterTypeCode.DYNAMIC_V0.name())
+      .markAdvanced()
       .withDocumentation("Filter type used. Default is BloomFilterTypeCode.DYNAMIC_V0. "
           + "Available values are [BloomFilterTypeCode.SIMPLE , BloomFilterTypeCode.DYNAMIC_V0]. "
           + "Dynamic bloom filters auto size themselves based on number of keys.");
@@ -171,12 +180,14 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_FILTER_DYNAMIC_MAX_ENTRIES = ConfigProperty
       .key("hoodie.bloom.index.filter.dynamic.max.entries")
       .defaultValue("100000")
+      .markAdvanced()
       .withDocumentation("The threshold for the maximum number of keys to record in a dynamic Bloom filter row. "
           + "Only applies if filter type is BloomFilterTypeCode.DYNAMIC_V0.");
 
   public static final ConfigProperty<String> SIMPLE_INDEX_USE_CACHING = ConfigProperty
       .key("hoodie.simple.index.use.caching")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is SIMPLE. "
           + "When true, the incoming writes will cached to speed up index lookup by reducing IO "
           + "for computing parallelism or affected partitions");
@@ -184,6 +195,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> SIMPLE_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.simple.index.parallelism")
       .defaultValue("100")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is SIMPLE. "
           + "This limits the parallelism of fetching records from the base files of affected "
           + "partitions. The index picks the configured parallelism if the number of base "
@@ -194,6 +206,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> GLOBAL_SIMPLE_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.global.simple.index.parallelism")
       .defaultValue("100")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is GLOBAL_SIMPLE. "
           + "This limits the parallelism of fetching records from the base files of all table "
           + "partitions. The index picks the configured parallelism if the number of base "
@@ -206,6 +219,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_KEYS_PER_BUCKET = ConfigProperty
       .key("hoodie.bloom.index.keys.per.bucket")
       .defaultValue("10000000")
+      .markAdvanced()
       .withDocumentation("Only applies if bloomIndexBucketizedChecking is enabled and index type is bloom. "
           + "This configuration controls the “bucket” size which tracks the number of record-key checks made against "
           + "a single file and is the unit of work allocated to each partition performing bloom filter lookup. "
@@ -214,12 +228,14 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_INPUT_STORAGE_LEVEL_VALUE = ConfigProperty
       .key("hoodie.bloom.index.input.storage.level")
       .defaultValue("MEMORY_AND_DISK_SER")
+      .markAdvanced()
       .withDocumentation("Only applies when #bloomIndexUseCaching is set. Determine what level of persistence is used to cache input RDDs. "
           + "Refer to org.apache.spark.storage.StorageLevel for different values");
 
   public static final ConfigProperty<String> SIMPLE_INDEX_INPUT_STORAGE_LEVEL_VALUE = ConfigProperty
       .key("hoodie.simple.index.input.storage.level")
       .defaultValue("MEMORY_AND_DISK_SER")
+      .markAdvanced()
       .withDocumentation("Only applies when #simpleIndexUseCaching is set. Determine what level of persistence is used to cache input RDDs. "
           + "Refer to org.apache.spark.storage.StorageLevel for different values");
 
@@ -234,6 +250,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE = ConfigProperty
       .key("hoodie.bloom.index.update.partition.path")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Only applies if index type is GLOBAL_BLOOM. "
           + "When set to true, an update including the partition path of a record that already exists will result in "
           + "inserting the incoming record into the new partition and deleting the original record in the old partition. "
@@ -242,6 +259,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE = ConfigProperty
       .key("hoodie.simple.index.update.partition.path")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Similar to " + BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE + ", but for simple index.");
 
   /**
@@ -265,6 +283,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BUCKET_INDEX_ENGINE_TYPE = ConfigProperty
       .key("hoodie.index.bucket.engine")
       .defaultValue("SIMPLE")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Type of bucket index engine to use. Default is SIMPLE bucket index, with fixed number of bucket."
           + "Possible options are [SIMPLE | CONSISTENT_HASHING]."
@@ -280,12 +299,14 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> BUCKET_INDEX_NUM_BUCKETS = ConfigProperty
       .key("hoodie.bucket.index.num.buckets")
       .defaultValue(256)
+      .markAdvanced()
       .withDocumentation("Only applies if index type is BUCKET. Determine the number of buckets in the hudi table, "
           + "and each partition is divided to N buckets.");
 
   public static final ConfigProperty<String> BUCKET_INDEX_MAX_NUM_BUCKETS = ConfigProperty
       .key("hoodie.bucket.index.max.num.buckets")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Only applies if bucket index engine is consistent hashing. Determine the upper bound of "
           + "the number of buckets in the hudi table. Bucket resizing cannot be done higher than this max limit.");
@@ -293,6 +314,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BUCKET_INDEX_MIN_NUM_BUCKETS = ConfigProperty
       .key("hoodie.bucket.index.min.num.buckets")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Only applies if bucket index engine is consistent hashing. Determine the lower bound of "
           + "the number of buckets in the hudi table. Bucket resizing cannot be done lower than this min limit.");
@@ -300,12 +322,14 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<String> BUCKET_INDEX_HASH_FIELD = ConfigProperty
       .key("hoodie.bucket.index.hash.field")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Index key. It is used to index the record and find its file group. "
           + "If not set, use record key field as default");
 
   public static final ConfigProperty<Double> BUCKET_SPLIT_THRESHOLD = ConfigProperty
       .key("hoodie.bucket.index.split.threshold")
       .defaultValue(2.0)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Control if the bucket should be split when using consistent hashing bucket index."
           + "Specifically, if a file slice size reaches `hoodie.xxxx.max.file.size` * threshold, then split will be carried out.");
@@ -313,6 +337,7 @@ public class HoodieIndexConfig extends HoodieConfig {
   public static final ConfigProperty<Double> BUCKET_MERGE_THRESHOLD = ConfigProperty
       .key("hoodie.bucket.index.merge.threshold")
       .defaultValue(0.2)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Control if buckets should be merged when using consistent hashing bucket index"
           + "Specifically, if a file slice size is smaller than `hoodie.xxxx.max.file.size` * threshold, then it will be considered"

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieInternalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieInternalConfig.java
@@ -34,6 +34,7 @@ public class HoodieInternalConfig extends HoodieConfig {
   public static final ConfigProperty<String> BULKINSERT_INPUT_DATA_SCHEMA_DDL = ConfigProperty
       .key("hoodie.bulkinsert.schema.ddl")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Schema set for row writer/bulk insert.");
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLayoutConfig.java
@@ -26,6 +26,7 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.storage.HoodieStorageLayout;
 
 import javax.annotation.concurrent.Immutable;
+
 import java.util.Properties;
 
 /**
@@ -41,11 +42,13 @@ public class HoodieLayoutConfig extends HoodieConfig {
   public static final ConfigProperty<String> LAYOUT_TYPE = ConfigProperty
       .key("hoodie.storage.layout.type")
       .defaultValue("DEFAULT")
+      .markAdvanced()
       .withDocumentation("Type of storage layout. Possible options are [DEFAULT | BUCKET]");
 
   public static final ConfigProperty<String> LAYOUT_PARTITIONER_CLASS_NAME = ConfigProperty
       .key("hoodie.storage.layout.partitioner.class")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Partitioner class, it is used to distribute data in a specific way.");
 
   public static final String SIMPLE_BUCKET_LAYOUT_PARTITIONER_CLASS_NAME =

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieLockConfig.java
@@ -70,6 +70,7 @@ public class HoodieLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS = ConfigProperty
       .key(LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY)
       .defaultValue(DEFAULT_LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS)
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Initial amount of time to wait between retries to acquire locks, "
           + " subsequent retries will exponentially backoff.");
@@ -77,6 +78,7 @@ public class HoodieLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> LOCK_ACQUIRE_RETRY_MAX_WAIT_TIME_IN_MILLIS = ConfigProperty
       .key(LOCK_ACQUIRE_RETRY_MAX_WAIT_TIME_IN_MILLIS_PROP_KEY)
       .defaultValue(String.valueOf(16000L))
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Maximum amount of time to wait between retries by lock provider client. This bounds"
           + " the maximum delay from the exponential backoff. Currently used by ZK based lock provider only.");
@@ -84,60 +86,70 @@ public class HoodieLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS = ConfigProperty
       .key(LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY)
       .defaultValue(String.valueOf(5000L))
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Amount of time to wait between retries on the lock provider by the lock manager");
 
   public static final ConfigProperty<String> LOCK_ACQUIRE_NUM_RETRIES = ConfigProperty
       .key(LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY)
       .defaultValue(DEFAULT_LOCK_ACQUIRE_NUM_RETRIES)
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Maximum number of times to retry lock acquire, at each lock provider");
 
   public static final ConfigProperty<String> LOCK_ACQUIRE_CLIENT_NUM_RETRIES = ConfigProperty
       .key(LOCK_ACQUIRE_CLIENT_NUM_RETRIES_PROP_KEY)
       .defaultValue(String.valueOf(50))
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Maximum number of times to retry to acquire lock additionally from the lock manager.");
 
   public static final ConfigProperty<Integer> LOCK_ACQUIRE_WAIT_TIMEOUT_MS = ConfigProperty
       .key(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY)
       .defaultValue(60 * 1000)
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Timeout in ms, to wait on an individual lock acquire() call, at the lock provider.");
 
   public static final ConfigProperty<String> FILESYSTEM_LOCK_PATH = ConfigProperty
       .key(FILESYSTEM_LOCK_PATH_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("For DFS based lock providers, path to store the locks under. use Table's meta path as default");
 
   public static final ConfigProperty<Integer> FILESYSTEM_LOCK_EXPIRE = ConfigProperty
       .key(FILESYSTEM_LOCK_EXPIRE_PROP_KEY)
       .defaultValue(0)
+      .markAdvanced()
       .sinceVersion("0.12.0")
       .withDocumentation("For DFS based lock providers, expire time in minutes, must be a non-negative number, default means no expire");
 
   public static final ConfigProperty<String> HIVE_DATABASE_NAME = ConfigProperty
       .key(HIVE_DATABASE_NAME_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("For Hive based lock provider, the Hive database to acquire lock against");
 
   public static final ConfigProperty<String> HIVE_TABLE_NAME = ConfigProperty
       .key(HIVE_TABLE_NAME_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("For Hive based lock provider, the Hive table to acquire lock against");
 
   public static final ConfigProperty<String> HIVE_METASTORE_URI = ConfigProperty
       .key(HIVE_METASTORE_URI_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("For Hive based lock provider, the Hive metastore URI to acquire locks against.");
 
   public static final ConfigProperty<String> ZK_BASE_PATH = ConfigProperty
       .key(ZK_BASE_PATH_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("The base path on Zookeeper under which to create lock related ZNodes. "
           + "This should be same for all concurrent writers to the same table");
@@ -145,24 +157,28 @@ public class HoodieLockConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> ZK_SESSION_TIMEOUT_MS = ConfigProperty
       .key(ZK_SESSION_TIMEOUT_MS_PROP_KEY)
       .defaultValue(DEFAULT_ZK_SESSION_TIMEOUT_MS)
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Timeout in ms, to wait after losing connection to ZooKeeper, before the session is expired");
 
   public static final ConfigProperty<Integer> ZK_CONNECTION_TIMEOUT_MS = ConfigProperty
       .key(ZK_CONNECTION_TIMEOUT_MS_PROP_KEY)
       .defaultValue(DEFAULT_ZK_CONNECTION_TIMEOUT_MS)
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Timeout in ms, to wait for establishing connection with Zookeeper.");
 
   public static final ConfigProperty<String> ZK_CONNECT_URL = ConfigProperty
       .key(ZK_CONNECT_URL_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Zookeeper URL to connect to.");
 
   public static final ConfigProperty<String> ZK_PORT = ConfigProperty
       .key(ZK_PORT_PROP_KEY)
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Zookeeper port to connect to.");
 
@@ -170,6 +186,7 @@ public class HoodieLockConfig extends HoodieConfig {
       .key(ZK_LOCK_KEY_PROP_KEY)
       .noDefaultValue()
       .withInferFunction(p -> Option.ofNullable(p.getStringOrDefault(HoodieWriteConfig.TBL_NAME, null)))
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Key name under base_path at which to create a ZNode and acquire lock. "
           + "Final path on zk will look like base_path/lock_key. If this parameter is not set, we would "
@@ -179,6 +196,7 @@ public class HoodieLockConfig extends HoodieConfig {
   public static final ConfigProperty<String> LOCK_PROVIDER_CLASS_NAME = ConfigProperty
       .key(LOCK_PREFIX + "provider")
       .defaultValue(ZookeeperBasedLockProvider.class.getName())
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Lock provider class name, user can provide their own implementation of LockProvider "
           + "which should be subclass of org.apache.hudi.common.lock.LockProvider");
@@ -194,6 +212,7 @@ public class HoodieLockConfig extends HoodieConfig {
           return Option.of(SimpleConcurrentFileWritesConflictResolutionStrategy.class.getName());
         }
       })
+      .markAdvanced()
       .sinceVersion("0.8.0")
       .withDocumentation("Lock provider class name, this should be subclass of "
           + "org.apache.hudi.client.transaction.ConflictResolutionStrategy");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieMemoryConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieMemoryConfig.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.util.FileIOUtils;
 
 import javax.annotation.concurrent.Immutable;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -44,6 +45,7 @@ public class HoodieMemoryConfig extends HoodieConfig {
   public static final ConfigProperty<String> MAX_MEMORY_FRACTION_FOR_MERGE = ConfigProperty
       .key("hoodie.memory.merge.fraction")
       .defaultValue(String.valueOf(0.6))
+      .markAdvanced()
       .withDocumentation("This fraction is multiplied with the user memory fraction (1 - spark.memory.fraction) "
           + "to get a final fraction of heap space to use during merge");
 
@@ -51,6 +53,7 @@ public class HoodieMemoryConfig extends HoodieConfig {
   public static final ConfigProperty<String> MAX_MEMORY_FRACTION_FOR_COMPACTION = ConfigProperty
       .key("hoodie.memory.compaction.fraction")
       .defaultValue(String.valueOf(0.6))
+      .markAdvanced()
       .withDocumentation("HoodieCompactedLogScanner reads logblocks, converts records to HoodieRecords and then "
           + "merges these log blocks and records. At any point, the number of entries in a log block can be "
           + "less than or equal to the number of entries in the corresponding parquet file. This can lead to "
@@ -65,26 +68,31 @@ public class HoodieMemoryConfig extends HoodieConfig {
   public static final ConfigProperty<Long> MAX_MEMORY_FOR_MERGE = ConfigProperty
       .key("hoodie.memory.merge.max.size")
       .defaultValue(DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES)
+      .markAdvanced()
       .withDocumentation("Maximum amount of memory used  in bytes for merge operations, before spilling to local storage.");
 
   public static final ConfigProperty<String> MAX_MEMORY_FOR_COMPACTION = ConfigProperty
       .key("hoodie.memory.compaction.max.size")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Maximum amount of memory used  in bytes for compaction operations in bytes , before spilling to local storage.");
 
   public static final ConfigProperty<Integer> MAX_DFS_STREAM_BUFFER_SIZE = ConfigProperty
       .key("hoodie.memory.dfs.buffer.max.size")
       .defaultValue(16 * 1024 * 1024)
+      .markAdvanced()
       .withDocumentation("Property to control the max memory in bytes for dfs input stream buffer size");
 
   public static final ConfigProperty<String> SPILLABLE_MAP_BASE_PATH = ConfigProperty
       .key("hoodie.memory.spillable.map.path")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Default file path for spillable map");
 
   public static final ConfigProperty<Double> WRITESTATUS_FAILURE_FRACTION = ConfigProperty
       .key("hoodie.memory.writestatus.failure.fraction")
       .defaultValue(0.1)
+      .markAdvanced()
       .withDocumentation("Property to control how what fraction of the failed record, exceptions we report back to driver. "
           + "Default is 10%. If set to 100%, with lot of failures, this can cause memory pressure, cause OOMs and "
           + "mask actual data errors.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePayloadConfig.java
@@ -44,18 +44,21 @@ public class HoodiePayloadConfig extends HoodieConfig {
   public static final ConfigProperty<String> ORDERING_FIELD = ConfigProperty
       .key(PAYLOAD_ORDERING_FIELD_PROP_KEY)
       .defaultValue("ts")
+      .markAdvanced()
       .withDocumentation("Table column/field name to order records that have the same key, before "
           + "merging and writing to storage.");
 
   public static final ConfigProperty<String> EVENT_TIME_FIELD = ConfigProperty
       .key(PAYLOAD_EVENT_TIME_FIELD_PROP_KEY)
       .defaultValue("ts")
+      .markAdvanced()
       .withDocumentation("Table column/field name to derive timestamp associated with the records. This can"
           + "be useful for e.g, determining the freshness of the table.");
 
   public static final ConfigProperty<String> PAYLOAD_CLASS_NAME = ConfigProperty
       .key("hoodie.compaction.payload.class")
       .defaultValue(OverwriteWithLatestAvroPayload.class.getName())
+      .markAdvanced()
       .withDocumentation("This needs to be same as class used during insert/upserts. Just like writing, compaction also uses "
         + "the record payload class to merge records in the log against each other, merge again with the base file and "
         + "produce the final record to be written after compaction.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePreCommitValidatorConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodiePreCommitValidatorConfig.java
@@ -42,12 +42,14 @@ public class HoodiePreCommitValidatorConfig extends HoodieConfig {
   public static final ConfigProperty<String> VALIDATOR_CLASS_NAMES = ConfigProperty
       .key("hoodie.precommit.validators")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("Comma separated list of class names that can be invoked to validate commit");
   public static final String VALIDATOR_TABLE_VARIABLE = "<TABLE_NAME>";
 
   public static final ConfigProperty<String> EQUALITY_SQL_QUERIES = ConfigProperty
       .key("hoodie.precommit.validators.equality.sql.queries")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("Spark SQL queries to run on table before committing new data to validate state before and after commit."
           + " Multiple queries separated by ';' delimiter are supported."
           + " Example: \"select count(*) from \\<TABLE_NAME\\>"
@@ -56,6 +58,7 @@ public class HoodiePreCommitValidatorConfig extends HoodieConfig {
   public static final ConfigProperty<String> SINGLE_VALUE_SQL_QUERIES = ConfigProperty
       .key("hoodie.precommit.validators.single.value.sql.queries")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("Spark SQL queries to run on table before committing new data to validate state after commit."
           + "Multiple queries separated by ';' delimiter are supported."
           + "Expected result is included as part of query separated by '#'. Example query: 'query1#result1:query2#result2'"
@@ -70,6 +73,7 @@ public class HoodiePreCommitValidatorConfig extends HoodieConfig {
   public static final ConfigProperty<String> INEQUALITY_SQL_QUERIES = ConfigProperty
       .key("hoodie.precommit.validators.inequality.sql.queries")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("Spark SQL queries to run on table before committing new data to validate state before and after commit."
           + "Multiple queries separated by ';' delimiter are supported."
           + "Example query: 'select count(*) from \\<TABLE_NAME\\> where col=null'"

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteCommitCallbackConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteCommitCallbackConfig.java
@@ -42,12 +42,14 @@ public class HoodieWriteCommitCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> TURN_CALLBACK_ON = ConfigProperty
       .key(CALLBACK_PREFIX + "on")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Turn commit callback on/off. off by default.");
 
   public static final ConfigProperty<String> CALLBACK_CLASS_NAME = ConfigProperty
       .key(CALLBACK_PREFIX + "class")
       .defaultValue("org.apache.hudi.callback.impl.HoodieWriteCommitHttpCallback")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Full path of callback class and must be a subclass of HoodieWriteCommitCallback class, "
           + "org.apache.hudi.callback.impl.HoodieWriteCommitHttpCallback by default");
@@ -56,18 +58,21 @@ public class HoodieWriteCommitCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<String> CALLBACK_HTTP_URL = ConfigProperty
       .key(CALLBACK_PREFIX + "http.url")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Callback host to be sent along with callback messages");
 
   public static final ConfigProperty<String> CALLBACK_HTTP_API_KEY_VALUE = ConfigProperty
       .key(CALLBACK_PREFIX + "http.api.key")
       .defaultValue("hudi_write_commit_http_callback")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Http callback API key. hudi_write_commit_http_callback by default");
 
   public static final ConfigProperty<Integer> CALLBACK_HTTP_TIMEOUT_IN_SECONDS = ConfigProperty
       .key(CALLBACK_PREFIX + "http.timeout.seconds")
       .defaultValue(30)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Callback timeout in seconds.");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -129,9 +129,10 @@ public class HoodieWriteConfig extends HoodieConfig {
       .withDocumentation("Table name that will be used for registering with metastores like HMS. Needs to be same across runs.");
 
   public static final ConfigProperty<String> TAGGED_RECORD_STORAGE_LEVEL_VALUE = ConfigProperty
-       .key("hoodie.write.tagged.record.storage.level")
-       .defaultValue("MEMORY_AND_DISK_SER")
-       .withDocumentation("Determine what level of persistence is used to cache write RDDs. "
+      .key("hoodie.write.tagged.record.storage.level")
+      .defaultValue("MEMORY_AND_DISK_SER")
+      .markAdvanced()
+      .withDocumentation("Determine what level of persistence is used to cache write RDDs. "
           + "Refer to org.apache.spark.storage.StorageLevel for different values");
 
   public static final ConfigProperty<String> PRECOMBINE_FIELD_NAME = ConfigProperty
@@ -143,12 +144,14 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> WRITE_PAYLOAD_CLASS_NAME = ConfigProperty
       .key("hoodie.datasource.write.payload.class")
       .defaultValue(OverwriteWithLatestAvroPayload.class.getName())
+      .markAdvanced()
       .withDocumentation("Payload class used. Override this, if you like to roll your own merge logic, when upserting/inserting. "
           + "This will render any value set for PRECOMBINE_FIELD_OPT_VAL in-effective");
 
   public static final ConfigProperty<String> RECORD_MERGER_IMPLS = ConfigProperty
       .key("hoodie.datasource.write.record.merger.impls")
       .defaultValue(HoodieAvroRecordMerger.class.getName())
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("List of HoodieMerger implementations constituting Hudi's merging strategy -- based on the engine used. "
           + "These merger impls will filter by hoodie.datasource.write.record.merger.strategy "
@@ -157,12 +160,14 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> RECORD_MERGER_STRATEGY = ConfigProperty
       .key("hoodie.datasource.write.record.merger.strategy")
       .defaultValue(HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Id of merger strategy. Hudi will pick HoodieRecordMerger implementations in hoodie.datasource.write.record.merger.impls which has the same merger strategy id");
 
   public static final ConfigProperty<String> KEYGENERATOR_CLASS_NAME = ConfigProperty
       .key("hoodie.datasource.write.keygenerator.class")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Key generator class, that implements `org.apache.hudi.keygen.KeyGenerator` "
           + "extract a key out of incoming records.");
 
@@ -170,6 +175,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key("hoodie.write.executor.type")
       .defaultValue(SIMPLE.name())
       .withValidValues(Arrays.stream(ExecutorType.values()).map(Enum::name).toArray(String[]::new))
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Set executor which orchestrates concurrent producers and consumers communicating through a message queue."
           + "BOUNDED_IN_MEMORY: Use LinkedBlockingQueue as a bounded in-memory queue, this queue will use extra lock to balance producers and consumer"
@@ -181,6 +187,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> KEYGENERATOR_TYPE = ConfigProperty
       .key("hoodie.datasource.write.keygenerator.type")
       .defaultValue(KeyGeneratorType.SIMPLE.name())
+      .markAdvanced()
       .withDocumentation("Easily configure one the built-in key generators, instead of specifying the key generator class."
           + "Currently supports SIMPLE, COMPLEX, TIMESTAMP, CUSTOM, NON_PARTITION, GLOBAL_DELETE. "
           + "**Note** This is being actively worked on. Please use "
@@ -189,12 +196,14 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> ROLLBACK_USING_MARKERS_ENABLE = ConfigProperty
       .key("hoodie.rollback.using.markers")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Enables a more efficient mechanism for rollbacks based on the marker files generated "
           + "during the writes. Turned on by default.");
 
   public static final ConfigProperty<String> TIMELINE_LAYOUT_VERSION_NUM = ConfigProperty
       .key("hoodie.timeline.layout.version")
       .defaultValue(Integer.toString(TimelineLayoutVersion.VERSION_1))
+      .markAdvanced()
       .sinceVersion("0.5.1")
       .withDocumentation("Controls the layout of the timeline. Version 0 relied on renames, Version 1 (default) models "
           + "the timeline as an immutable log relying only on atomic writes for object storage.");
@@ -203,6 +212,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key("hoodie.table.base.file.format")
       .defaultValue(HoodieFileFormat.PARQUET)
       .withAlternatives("hoodie.table.ro.file.format")
+      .markAdvanced()
       .withDocumentation("Base file format to store all the base file data.");
 
   public static final ConfigProperty<String> BASE_PATH = ConfigProperty
@@ -224,22 +234,26 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> INTERNAL_SCHEMA_STRING = ConfigProperty
       .key("hoodie.internal.schema")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Schema string representing the latest schema of the table. Hudi passes this to "
           + "implementations of evolution of schema");
 
   public static final ConfigProperty<Boolean> ENABLE_INTERNAL_SCHEMA_CACHE = ConfigProperty
       .key("hoodie.schema.cache.enable")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("cache query internalSchemas in driver/executor side");
 
   public static final ConfigProperty<String> AVRO_SCHEMA_VALIDATE_ENABLE = ConfigProperty
       .key("hoodie.avro.schema.validate")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Validate the schema used for the write against the latest schema, for backwards compatibility.");
 
   public static final ConfigProperty<String> SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP = ConfigProperty
       .key("hoodie.datasource.write.schema.allow.auto.evolution.column.drop")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Controls whether table's schema is allowed to automatically evolve when "
           + "incoming batch's schema can have any of the columns dropped. By default, Hudi will not "
@@ -249,6 +263,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> INSERT_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.insert.shuffle.parallelism")
       .defaultValue("0")
+      .markAdvanced()
       .withDocumentation("Parallelism for inserting records into the table. Inserts can shuffle "
           + "data before writing to tune file sizes and optimize the storage layout. Before "
           + "0.13.0 release, if users do not configure it, Hudi would use 200 as the default "
@@ -262,6 +277,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> BULKINSERT_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.bulkinsert.shuffle.parallelism")
       .defaultValue("0")
+      .markAdvanced()
       .withDocumentation("For large initial imports using bulk_insert operation, controls the "
           + "parallelism to use for sort modes or custom partitioning done before writing records "
           + "to the table. Before 0.13.0 release, if users do not configure it, Hudi would use "
@@ -276,12 +292,14 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS = ConfigProperty
       .key("hoodie.bulkinsert.user.defined.partitioner.sort.columns")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Columns to sort the data by when use org.apache.hudi.execution.bulkinsert.RDDCustomColumnsSortPartitioner as user defined partitioner during bulk_insert. "
           + "For example 'column1,column2'");
 
   public static final ConfigProperty<String> BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME = ConfigProperty
       .key("hoodie.bulkinsert.user.defined.partitioner.class")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("If specified, this class will be used to re-partition records before they are bulk inserted. This can be used to sort, pack, cluster data"
           + " optimally for common query patterns. For now we support a build-in user defined bulkinsert partitioner org.apache.hudi.execution.bulkinsert.RDDCustomColumnsSortPartitioner"
           + " which can does sorting based on specified column values set by " + BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS.key());
@@ -289,6 +307,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> UPSERT_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.upsert.shuffle.parallelism")
       .defaultValue("0")
+      .markAdvanced()
       .withDocumentation("Parallelism to use for upsert operation on the table. Upserts can "
           + "shuffle data to perform index lookups, file sizing, bin packing records optimally "
           + "into file groups. Before 0.13.0 release, "
@@ -303,6 +322,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> DELETE_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.delete.shuffle.parallelism")
       .defaultValue("0")
+      .markAdvanced()
       .withDocumentation("Parallelism used for delete operation. Delete operations also performs "
           + "shuffles, similar to upsert operation. Before 0.13.0 release, "
           + "if users do not configure it, Hudi would use 200 as the default "
@@ -314,6 +334,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> ROLLBACK_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.rollback.parallelism")
       .defaultValue("100")
+      .markAdvanced()
       .withDocumentation("This config controls the parallelism for rollback of commits. "
           + "Rollbacks perform deletion of files or logging delete blocks to file groups on "
           + "storage in parallel. The configure value limits the parallelism so that the number "
@@ -323,17 +344,21 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> WRITE_BUFFER_LIMIT_BYTES_VALUE = ConfigProperty
       .key("hoodie.write.buffer.limit.bytes")
       .defaultValue(String.valueOf(4 * 1024 * 1024))
+      .markAdvanced()
+      .markAdvanced()
       .withDocumentation("Size of in-memory buffer used for parallelizing network reads and lake storage writes.");
 
   public static final ConfigProperty<String> WRITE_EXECUTOR_DISRUPTOR_BUFFER_LIMIT_BYTES = ConfigProperty
       .key("hoodie.write.executor.disruptor.buffer.limit.bytes")
       .defaultValue(String.valueOf(1024))
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The size of the Disruptor Executor ring buffer, must be power of 2");
 
   public static final ConfigProperty<String> WRITE_EXECUTOR_DISRUPTOR_WAIT_STRATEGY = ConfigProperty
       .key("hoodie.write.executor.disruptor.wait.strategy")
       .defaultValue(DisruptorWaitStrategyType.BLOCKING_WAIT.name())
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Strategy employed for making Disruptor Executor wait on a cursor. Other options are "
           + "SLEEPING_WAIT, it attempts to be conservative with CPU usage by using a simple busy wait loop"
@@ -343,12 +368,14 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> COMBINE_BEFORE_INSERT = ConfigProperty
       .key("hoodie.combine.before.insert")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When inserted records share same key, controls whether they should be first combined (i.e de-duplicated) before"
           + " writing to storage.");
 
   public static final ConfigProperty<String> COMBINE_BEFORE_UPSERT = ConfigProperty
       .key("hoodie.combine.before.upsert")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("When upserted records share same key, controls whether they should be first combined (i.e de-duplicated) before"
           + " writing to storage. This should be turned off only if you are absolutely certain that there are no duplicates incoming, "
           + " otherwise it can lead to duplicate keys and violate the uniqueness guarantees.");
@@ -356,30 +383,35 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> COMBINE_BEFORE_DELETE = ConfigProperty
       .key("hoodie.combine.before.delete")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("During delete operations, controls whether we should combine deletes (and potentially also upserts) before "
           + " writing to storage.");
 
   public static final ConfigProperty<String> WRITE_STATUS_STORAGE_LEVEL_VALUE = ConfigProperty
       .key("hoodie.write.status.storage.level")
       .defaultValue("MEMORY_AND_DISK_SER")
+      .markAdvanced()
       .withDocumentation("Write status objects hold metadata about a write (stats, errors), that is not yet committed to storage. "
           + "This controls the how that information is cached for inspection by clients. We rarely expect this to be changed.");
 
   public static final ConfigProperty<String> AUTO_COMMIT_ENABLE = ConfigProperty
       .key("hoodie.auto.commit")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Controls whether a write operation should auto commit. This can be turned off to perform inspection"
           + " of the uncommitted write before deciding to commit.");
 
   public static final ConfigProperty<String> WRITE_STATUS_CLASS_NAME = ConfigProperty
       .key("hoodie.writestatus.class")
       .defaultValue(WriteStatus.class.getName())
+      .markAdvanced()
       .withDocumentation("Subclass of " + WriteStatus.class.getName() + " to be used to collect information about a write. Can be "
           + "overridden to collection additional metrics/statistics about the data if needed.");
 
   public static final ConfigProperty<String> FINALIZE_WRITE_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.finalize.write.parallelism")
       .defaultValue("200")
+      .markAdvanced()
       .withDocumentation("Parallelism for the write finalization internal operation, which involves removing any partially written "
           + "files from lake storage, before committing the write. Reduce this value, if the high number of tasks incur delays for smaller tables "
           + "or low latency writes.");
@@ -387,6 +419,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> MARKERS_TYPE = ConfigProperty
       .key("hoodie.write.markers.type")
       .defaultValue(MarkerType.TIMELINE_SERVER_BASED.toString())
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("Marker type to use.  Two modes are supported: "
           + "- DIRECT: individual marker file corresponding to each data file is directly "
@@ -401,6 +434,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> MARKERS_TIMELINE_SERVER_BASED_BATCH_NUM_THREADS = ConfigProperty
       .key("hoodie.markers.timeline_server_based.batch.num_threads")
       .defaultValue(20)
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("Number of threads to use for batch processing marker "
           + "creation requests at the timeline server");
@@ -408,18 +442,21 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Long> MARKERS_TIMELINE_SERVER_BASED_BATCH_INTERVAL_MS = ConfigProperty
       .key("hoodie.markers.timeline_server_based.batch.interval_ms")
       .defaultValue(50L)
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("The batch interval in milliseconds for marker creation batch processing");
 
   public static final ConfigProperty<String> MARKERS_DELETE_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.markers.delete.parallelism")
       .defaultValue("100")
+      .markAdvanced()
       .withDocumentation("Determines the parallelism for deleting marker files, which are used to track all files (valid or invalid/partial) written during "
           + "a write operation. Increase this value if delays are observed, with large batch writes.");
 
   public static final ConfigProperty<String> BULK_INSERT_SORT_MODE = ConfigProperty
       .key("hoodie.bulkinsert.sort.mode")
       .defaultValue(BulkInsertSortMode.NONE.toString())
+      .markAdvanced()
       .withDocumentation("Sorting modes to use for sorting records for bulk insert. This is use when user "
           + BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME.key() + "is not configured. Available values are - "
           + "GLOBAL_SORT: this ensures best file sizes, with lowest memory overhead at cost of sorting. "
@@ -441,46 +478,54 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_SERVER_ENABLE = ConfigProperty
       .key("hoodie.embed.timeline.server")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("When true, spins up an instance of the timeline server (meta server that serves cached file listings, statistics),"
           + "running on each writer's driver process, accepting requests during the write from executors.");
 
   public static final ConfigProperty<Boolean> EMBEDDED_TIMELINE_SERVER_REUSE_ENABLED = ConfigProperty
       .key("hoodie.embed.timeline.server.reuse.enabled")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Controls whether the timeline server instance should be cached and reused across the JVM (across task lifecycles)"
           + "to avoid startup costs. This should rarely be changed.");
 
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_SERVER_PORT_NUM = ConfigProperty
       .key("hoodie.embed.timeline.server.port")
       .defaultValue("0")
+      .markAdvanced()
       .withDocumentation("Port at which the timeline server listens for requests. When running embedded in each writer, it picks "
           + "a free port and communicates to all the executors. This should rarely be changed.");
 
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_NUM_SERVER_THREADS = ConfigProperty
       .key("hoodie.embed.timeline.server.threads")
       .defaultValue("-1")
+      .markAdvanced()
       .withDocumentation("Number of threads to serve requests in the timeline server. By default, auto configured based on the number of underlying cores.");
 
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_SERVER_COMPRESS_ENABLE = ConfigProperty
       .key("hoodie.embed.timeline.server.gzip")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Controls whether gzip compression is used, for large responses from the timeline server, to improve latency.");
 
   public static final ConfigProperty<String> EMBEDDED_TIMELINE_SERVER_USE_ASYNC_ENABLE = ConfigProperty
       .key("hoodie.embed.timeline.server.async")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Controls whether or not, the requests to the timeline server are processed in asynchronous fashion, "
           + "potentially improving throughput.");
 
   public static final ConfigProperty<String> FAIL_ON_TIMELINE_ARCHIVING_ENABLE = ConfigProperty
       .key("hoodie.fail.on.timeline.archiving")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Timeline archiving removes older instants from the timeline, after each write operation, to minimize metadata overhead. "
           + "Controls whether or not, the write should be failed as well, if such archiving fails.");
 
   public static final ConfigProperty<String> FAIL_ON_INLINE_TABLE_SERVICE_EXCEPTION = ConfigProperty
       .key("hoodie.fail.writes.on.inline.table.service.exception")
       .defaultValue("true")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Table services such as compaction and clustering can fail and prevent syncing to "
           + "the metaclient. Set this to true to fail writes when table services fail");
@@ -488,45 +533,53 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Long> INITIAL_CONSISTENCY_CHECK_INTERVAL_MS = ConfigProperty
       .key("hoodie.consistency.check.initial_interval_ms")
       .defaultValue(2000L)
+      .markAdvanced()
       .withDocumentation("Initial time between successive attempts to ensure written data's metadata is consistent on storage. Grows with exponential"
           + " backoff after the initial value.");
 
   public static final ConfigProperty<Long> MAX_CONSISTENCY_CHECK_INTERVAL_MS = ConfigProperty
       .key("hoodie.consistency.check.max_interval_ms")
       .defaultValue(300000L)
+      .markAdvanced()
       .withDocumentation("Max time to wait between successive attempts at performing consistency checks");
 
   public static final ConfigProperty<Integer> MAX_CONSISTENCY_CHECKS = ConfigProperty
       .key("hoodie.consistency.check.max_checks")
       .defaultValue(7)
+      .markAdvanced()
       .withDocumentation("Maximum number of checks, for consistency of written data.");
 
   public static final ConfigProperty<String> MERGE_DATA_VALIDATION_CHECK_ENABLE = ConfigProperty
       .key("hoodie.merge.data.validation.enabled")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When enabled, data validation checks are performed during merges to ensure expected "
           + "number of records after merge operation.");
 
   public static final ConfigProperty<String> MERGE_ALLOW_DUPLICATE_ON_INSERTS_ENABLE = ConfigProperty
       .key("hoodie.merge.allow.duplicate.on.inserts")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When enabled, we allow duplicate keys even if inserts are routed to merge with an existing file (for ensuring file sizing)."
           + " This is only relevant for insert operation, since upsert, delete operations will ensure unique key constraints are maintained.");
 
   public static final ConfigProperty<Integer> MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT = ConfigProperty
       .key("hoodie.merge.small.file.group.candidates.limit")
       .defaultValue(1)
+      .markAdvanced()
       .withDocumentation("Limits number of file groups, whose base file satisfies small-file limit, to consider for appending records during upsert operation. "
           + "Only applicable to MOR tables");
 
   public static final ConfigProperty<Integer> CLIENT_HEARTBEAT_INTERVAL_IN_MS = ConfigProperty
       .key("hoodie.client.heartbeat.interval_in_ms")
       .defaultValue(60 * 1000)
+      .markAdvanced()
       .withDocumentation("Writers perform heartbeats to indicate liveness. Controls how often (in ms), such heartbeats are registered to lake storage.");
 
   public static final ConfigProperty<Integer> CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES = ConfigProperty
       .key("hoodie.client.heartbeat.tolerable.misses")
       .defaultValue(2)
+      .markAdvanced()
       .withDocumentation("Number of heartbeat misses, before a writer is deemed not alive and all pending writes are aborted.");
 
   public static final ConfigProperty<String> WRITE_CONCURRENCY_MODE = ConfigProperty
@@ -540,6 +593,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> WRITE_SCHEMA_OVERRIDE = ConfigProperty
       .key("hoodie.write.schema")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Config allowing to override writer's schema. This might be necessary in "
           + "cases when writer's schema derived from the incoming dataset might actually be different from "
           + "the schema we actually want to use when writing. This, for ex, could be the case for"
@@ -560,24 +614,28 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> ALLOW_MULTI_WRITE_ON_SAME_INSTANT_ENABLE = ConfigProperty
       .key("_.hoodie.allow.multi.write.on.same.instant")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("");
 
   public static final ConfigProperty<String> AVRO_EXTERNAL_SCHEMA_TRANSFORMATION_ENABLE = ConfigProperty
       .key(AVRO_SCHEMA_STRING.key() + ".external.transformation")
       .defaultValue("false")
       .withAlternatives(AVRO_SCHEMA_STRING.key() + ".externalTransformation")
+      .markAdvanced()
       .withDocumentation("When enabled, records in older schema are rewritten into newer schema during upsert,delete and background"
           + " compaction,clustering operations.");
 
   public static final ConfigProperty<Boolean> ALLOW_EMPTY_COMMIT = ConfigProperty
       .key("hoodie.allow.empty.commit")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether to allow generation of empty commits, even if no data was written in the commit. "
           + "It's useful in cases where extra metadata needs to be published regardless e.g tracking source offsets when ingesting data");
 
   public static final ConfigProperty<Boolean> ALLOW_OPERATION_METADATA_FIELD = ConfigProperty
       .key("hoodie.allow.operation.metadata.field")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.9.0")
       .withDocumentation("Whether to include '_hoodie_operation' in the metadata fields. "
           + "Once enabled, all the changes of a record are persisted to the delta log directly without merge");
@@ -585,30 +643,35 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> FILEID_PREFIX_PROVIDER_CLASS = ConfigProperty
       .key("hoodie.fileid.prefix.provider.class")
       .defaultValue(RandomFileIdPrefixProvider.class.getName())
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("File Id Prefix provider class, that implements `org.apache.hudi.fileid.FileIdPrefixProvider`");
 
   public static final ConfigProperty<Boolean> TABLE_SERVICES_ENABLED = ConfigProperty
       .key("hoodie.table.services.enabled")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Master control to disable all table services including archive, clean, compact, cluster, etc.");
 
   public static final ConfigProperty<Boolean> RELEASE_RESOURCE_ENABLE = ConfigProperty
       .key("hoodie.release.resource.on.completion.enable")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Control to enable release all persist rdds when the spark job finish.");
 
   public static final ConfigProperty<Boolean> AUTO_ADJUST_LOCK_CONFIGS = ConfigProperty
       .key("hoodie.auto.adjust.lock.configs")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Auto adjust lock configurations when metadata table is enabled and for async table services.");
 
   public static final ConfigProperty<Boolean> SKIP_DEFAULT_PARTITION_VALIDATION = ConfigProperty
       .key("hoodie.skip.default.partition.validation")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.12.0")
       .withDocumentation("When table is upgraded from pre 0.12 to 0.12, we check for \"default\" partition and fail if found one. "
           + "Users are expected to rewrite the data in those partitions. Enabling this config will bypass this validation");
@@ -616,6 +679,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> EARLY_CONFLICT_DETECTION_STRATEGY_CLASS_NAME = ConfigProperty
       .key(CONCURRENCY_PREFIX + "early.conflict.detection.strategy")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withInferFunction(cfg -> {
         MarkerType markerType = MarkerType.valueOf(cfg.getStringOrDefault(MARKERS_TYPE).toUpperCase());
@@ -628,6 +692,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> EARLY_CONFLICT_DETECTION_ENABLE = ConfigProperty
       .key(CONCURRENCY_PREFIX + "early.conflict.detection.enable")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Whether to enable early conflict detection based on markers. "
           + "It eagerly detects writing conflict before create markers and fails fast if a "
@@ -636,6 +701,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Long> ASYNC_CONFLICT_DETECTOR_INITIAL_DELAY_MS = ConfigProperty
       .key(CONCURRENCY_PREFIX + "async.conflict.detector.initial_delay_ms")
       .defaultValue(0L)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Used for timeline-server-based markers with "
           + "`AsyncTimelineServerBasedDetectionStrategy`. "
@@ -644,6 +710,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Long> ASYNC_CONFLICT_DETECTOR_PERIOD_MS = ConfigProperty
       .key(CONCURRENCY_PREFIX + "async.conflict.detector.period_ms")
       .defaultValue(30000L)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Used for timeline-server-based markers with "
           + "`AsyncTimelineServerBasedDetectionStrategy`. "
@@ -652,6 +719,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> EARLY_CONFLICT_DETECTION_CHECK_COMMIT_CONFLICT = ConfigProperty
       .key(CONCURRENCY_PREFIX + "early.conflict.check.commit.conflict")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Whether to enable commit conflict checking or not during early "
           + "conflict detection.");
@@ -659,6 +727,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<String> SENSITIVE_CONFIG_KEYS_FILTER = ConfigProperty
       .key("hoodie.sensitive.config.keys")
       .defaultValue("ssl,tls,sasl,auth,credentials")
+      .markAdvanced()
       .withDocumentation("Comma separated list of filters for sensitive config keys. Delta Streamer "
           + "will not print any configuration which contains the configured filter. For example with "
           + "a configured filter `ssl`, value for config `ssl.trustore.location` would be masked.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsCloudWatchConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsCloudWatchConfig.java
@@ -39,18 +39,21 @@ public class HoodieMetricsCloudWatchConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> REPORT_PERIOD_SECONDS = ConfigProperty
       .key(CLOUDWATCH_PREFIX + ".report.period.seconds")
       .defaultValue(60)
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Reporting interval in seconds");
 
   public static final ConfigProperty<String> METRIC_PREFIX = ConfigProperty
       .key(CLOUDWATCH_PREFIX + ".metric.prefix")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Metric prefix of reporter");
 
   public static final ConfigProperty<String> METRIC_NAMESPACE = ConfigProperty
       .key(CLOUDWATCH_PREFIX + ".namespace")
       .defaultValue("Hudi")
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Namespace of reporter");
   /*
@@ -60,6 +63,7 @@ public class HoodieMetricsCloudWatchConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> MAX_DATUMS_PER_REQUEST =
       ConfigProperty.key(CLOUDWATCH_PREFIX + ".maxDatumsPerRequest")
           .defaultValue(20)
+          .markAdvanced()
           .sinceVersion("0.10.0")
           .withDocumentation("Max number of Datums per request");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -61,6 +61,7 @@ public class HoodieMetricsConfig extends HoodieConfig {
   public static final ConfigProperty<String> METRICS_REPORTER_CLASS_NAME = ConfigProperty
       .key(METRIC_PREFIX + ".reporter.class")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("");
 
@@ -74,12 +75,14 @@ public class HoodieMetricsConfig extends HoodieConfig {
         }
         return Option.empty();
       })
+      .markAdvanced()
       .withDocumentation("The prefix given to the metrics names.");
 
   // Enable metrics collection from executors
   public static final ConfigProperty<String> EXECUTOR_METRICS_ENABLE = ConfigProperty
       .key(METRIC_PREFIX + ".executor.enable")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("");
 
@@ -92,12 +95,14 @@ public class HoodieMetricsConfig extends HoodieConfig {
         }
         return Option.empty();
       })
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Enable metrics for locking infra. Useful when operating in multiwriter mode");
 
   public static final ConfigProperty<String> METRICS_REPORTER_FILE_BASED_CONFIGS_PATH = ConfigProperty
       .key(METRIC_PREFIX + ".configs.properties")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.14.0")
       .withDocumentation("Comma separated list of config file paths for metric exporter configs");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsDatadogConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsDatadogConfig.java
@@ -46,24 +46,28 @@ public class HoodieMetricsDatadogConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> REPORT_PERIOD_IN_SECONDS = ConfigProperty
       .key(DATADOG_PREFIX + ".report.period.seconds")
       .defaultValue(30)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog reporting period in seconds. Default to 30.");
 
   public static final ConfigProperty<String> API_SITE_VALUE = ConfigProperty
       .key(DATADOG_PREFIX + ".api.site")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog API site: EU or US");
 
   public static final ConfigProperty<String> API_KEY = ConfigProperty
       .key(DATADOG_PREFIX + ".api.key")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog API key");
 
   public static final ConfigProperty<Boolean> API_KEY_SKIP_VALIDATION = ConfigProperty
       .key(DATADOG_PREFIX + ".api.key.skip.validation")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Before sending metrics via Datadog API, whether to skip validating Datadog API key or not. "
           + "Default to false.");
@@ -71,6 +75,7 @@ public class HoodieMetricsDatadogConfig extends HoodieConfig {
   public static final ConfigProperty<String> API_KEY_SUPPLIER = ConfigProperty
       .key(DATADOG_PREFIX + ".api.key.supplier")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog API key supplier to supply the API key at runtime. "
           + "This will take effect if hoodie.metrics.datadog.api.key is not set.");
@@ -78,12 +83,14 @@ public class HoodieMetricsDatadogConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> API_TIMEOUT_IN_SECONDS = ConfigProperty
       .key(DATADOG_PREFIX + ".api.timeout.seconds")
       .defaultValue(3)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog API timeout in seconds. Default to 3.");
 
   public static final ConfigProperty<String> METRIC_PREFIX_VALUE = ConfigProperty
       .key(DATADOG_PREFIX + ".metric.prefix")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog metric prefix to be prepended to each metric name with a dot as delimiter. "
           + "For example, if it is set to foo, foo. will be prepended.");
@@ -91,12 +98,14 @@ public class HoodieMetricsDatadogConfig extends HoodieConfig {
   public static final ConfigProperty<String> METRIC_HOST_NAME = ConfigProperty
       .key(DATADOG_PREFIX + ".metric.host")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog metric host to be sent along with metrics data.");
 
   public static final ConfigProperty<String> METRIC_TAG_VALUES = ConfigProperty
       .key(DATADOG_PREFIX + ".metric.tags")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Datadog metric tags (comma-delimited) to be sent along with metrics data.");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsGraphiteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsGraphiteConfig.java
@@ -46,24 +46,28 @@ public class HoodieMetricsGraphiteConfig extends HoodieConfig {
   public static final ConfigProperty<String> GRAPHITE_SERVER_HOST_NAME = ConfigProperty
       .key(GRAPHITE_PREFIX + ".host")
       .defaultValue("localhost")
+      .markAdvanced()
       .sinceVersion("0.5.0")
       .withDocumentation("Graphite host to connect to.");
 
   public static final ConfigProperty<Integer> GRAPHITE_SERVER_PORT_NUM = ConfigProperty
       .key(GRAPHITE_PREFIX + ".port")
       .defaultValue(4756)
+      .markAdvanced()
       .sinceVersion("0.5.0")
       .withDocumentation("Graphite port to connect to.");
 
   public static final ConfigProperty<String> GRAPHITE_METRIC_PREFIX_VALUE = ConfigProperty
       .key(GRAPHITE_PREFIX + ".metric.prefix")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.5.1")
       .withDocumentation("Standard prefix applied to all metrics. This helps to add datacenter, environment information for e.g");
 
   public static final ConfigProperty<Integer> GRAPHITE_REPORT_PERIOD_IN_SECONDS = ConfigProperty
       .key(GRAPHITE_PREFIX + ".report.period.seconds")
       .defaultValue(30)
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("Graphite reporting period in seconds. Default to 30.");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsJmxConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsJmxConfig.java
@@ -46,12 +46,14 @@ public class HoodieMetricsJmxConfig extends HoodieConfig {
   public static final ConfigProperty<String> JMX_HOST_NAME = ConfigProperty
       .key(JMX_PREFIX + ".host")
       .defaultValue("localhost")
+      .markAdvanced()
       .sinceVersion("0.5.1")
       .withDocumentation("Jmx host to connect to");
 
   public static final ConfigProperty<Integer> JMX_PORT_NUM = ConfigProperty
       .key(JMX_PREFIX + ".port")
       .defaultValue(9889)
+      .markAdvanced()
       .sinceVersion("0.5.1")
       .withDocumentation("Jmx port to connect to");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsPrometheusConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsPrometheusConfig.java
@@ -45,42 +45,49 @@ public class HoodieMetricsPrometheusConfig extends HoodieConfig {
   public static final ConfigProperty<String> PUSHGATEWAY_HOST_NAME = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".host")
       .defaultValue("localhost")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Hostname of the prometheus push gateway.");
 
   public static final ConfigProperty<Integer> PUSHGATEWAY_PORT_NUM = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".port")
       .defaultValue(9091)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Port for the push gateway.");
 
   public static final ConfigProperty<Integer> PUSHGATEWAY_REPORT_PERIOD_IN_SECONDS = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".report.period.seconds")
       .defaultValue(30)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Reporting interval in seconds.");
 
   public static final ConfigProperty<Boolean> PUSHGATEWAY_DELETE_ON_SHUTDOWN_ENABLE = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".delete.on.shutdown")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Delete the pushgateway info or not when job shutdown, true by default.");
 
   public static final ConfigProperty<String> PUSHGATEWAY_JOBNAME = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".job.name")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Name of the push gateway job.");
 
   public static final ConfigProperty<String> PUSHGATEWAY_LABELS = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".report.labels")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.14.0")
       .withDocumentation("Label for the metrics emitted to the Pushgateway. Labels can be specified with key:value pairs separated by commas");
 
   public static final ConfigProperty<Boolean> PUSHGATEWAY_RANDOM_JOBNAME_SUFFIX = ConfigProperty
       .key(PUSHGATEWAY_PREFIX + ".random.job.name.suffix")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Whether the pushgateway name need a random suffix , default true.");
 
@@ -90,6 +97,7 @@ public class HoodieMetricsPrometheusConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> PROMETHEUS_PORT_NUM = ConfigProperty
       .key(PROMETHEUS_PREFIX + ".port")
       .defaultValue(9090)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Port for prometheus server.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -37,16 +37,19 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> SCHEMA_EVOLUTION_ENABLE = ConfigProperty
       .key("hoodie.schema.on.read.enable")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Enables support for Schema Evolution feature");
 
   public static final ConfigProperty<String> TIMESTAMP_AS_OF = ConfigProperty
       .key("as.of.instant")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The query instant for time travel. Without specified this option, we query the latest snapshot.");
 
   public static final ConfigProperty<Boolean> RECONCILE_SCHEMA = ConfigProperty
       .key("hoodie.datasource.write.reconcile.schema")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("This config controls how writer's schema will be selected based on the incoming batch's "
           + "schema as well as existing table's one. When schema reconciliation is DISABLED, incoming batch's "
           + "schema will be picked as a writer-schema (therefore updating table's schema). When schema reconciliation "
@@ -58,6 +61,7 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<ExternalSpillableMap.DiskMapType> SPILLABLE_DISK_MAP_TYPE = ConfigProperty
       .key("hoodie.common.spillable.diskmap.type")
       .defaultValue(ExternalSpillableMap.DiskMapType.BITCASK)
+      .markAdvanced()
       .withDocumentation("When handling input data that cannot be held in memory, to merge with a file on storage, a spillable diskmap is employed.  "
           + "By default, we use a persistent hashmap based loosely on bitcask, that offers O(1) inserts, lookups. "
           + "Change this to `ROCKS_DB` to prefer using rocksDB, for handling the spill.");
@@ -65,6 +69,7 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> DISK_MAP_BITCASK_COMPRESSION_ENABLED = ConfigProperty
       .key("hoodie.common.diskmap.compression.enabled")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Turn on compression for BITCASK disk map used by the External Spillable Map");
 
   public ExternalSpillableMap.DiskMapType getSpillableDiskMapType() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -66,6 +66,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> METRICS_ENABLE = ConfigProperty
       .key(METADATA_PREFIX + ".metrics.enable")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Enable publishing of metrics around metadata table.");
 
@@ -73,6 +74,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> INSERT_PARALLELISM_VALUE = ConfigProperty
       .key(METADATA_PREFIX + ".insert.parallelism")
       .defaultValue(1)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Parallelism to use when inserting to the metadata table");
 
@@ -80,6 +82,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ASYNC_INDEX_ENABLE = ConfigProperty
       .key(METADATA_PREFIX + ".index.async")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Enable asynchronous indexing of metadata table.");
 
@@ -87,6 +90,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> COMPACT_NUM_DELTA_COMMITS = ConfigProperty
       .key(METADATA_PREFIX + ".compact.max.delta.commits")
       .defaultValue(10)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Controls how often the metadata table is compacted.");
 
@@ -94,6 +98,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> MIN_COMMITS_TO_KEEP = ConfigProperty
       .key(METADATA_PREFIX + ".keep.min.commits")
       .defaultValue(20)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Archiving service moves older entries from metadata table’s timeline "
           + "into an archived log after each write, to keep the overhead constant, even as the "
@@ -103,6 +108,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> MAX_COMMITS_TO_KEEP = ConfigProperty
       .key(METADATA_PREFIX + ".keep.max.commits")
       .defaultValue(30)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Similar to " + MIN_COMMITS_TO_KEEP.key() + ", this config controls "
           + "the maximum number of instants to retain in the active timeline.");
@@ -111,12 +117,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<String> DIR_FILTER_REGEX = ConfigProperty
       .key(METADATA_PREFIX + ".dir.filter.regex")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Directories matching this regex, will be filtered out when initializing metadata table from lake storage for the first time.");
 
   public static final ConfigProperty<String> ASSUME_DATE_PARTITIONING = ConfigProperty
       .key("hoodie.assume.date.partitioning")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.3.0")
       .withDocumentation("Should HoodieWriteClient assume the data is partitioned by dates, i.e three levels from base path. "
           + "This is a stop-gap to support tables created by versions < 0.3.1. Will be removed eventually");
@@ -124,6 +132,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> FILE_LISTING_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.file.listing.parallelism")
       .defaultValue(200)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Parallelism to use, when listing the table on lake storage.");
 
@@ -138,6 +147,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> METADATA_INDEX_BLOOM_FILTER_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.bloom.filter.file.group.count")
       .defaultValue(4)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Metadata bloom filter index partition file group count. This controls the size of the base and "
           + "log files and read parallelism in the bloom filter index partition. The recommendation is to size the "
@@ -146,6 +156,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> BLOOM_FILTER_INDEX_PARALLELISM = ConfigProperty
       .key(METADATA_PREFIX + ".index.bloom.filter.parallelism")
       .defaultValue(200)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Parallelism to use for generating bloom filter index in metadata table.");
 
@@ -160,20 +171,23 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> METADATA_INDEX_COLUMN_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.file.group.count")
       .defaultValue(2)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Metadata column stats partition file group count. This controls the size of the base and "
           + "log files and read parallelism in the column stats index partition. The recommendation is to size the "
           + "file group count such that the base files are under 1GB.");
 
   public static final ConfigProperty<Integer> COLUMN_STATS_INDEX_PARALLELISM = ConfigProperty
-          .key(METADATA_PREFIX + ".index.column.stats.parallelism")
-          .defaultValue(10)
-          .sinceVersion("0.11.0")
-          .withDocumentation("Parallelism to use, when generating column stats index.");
+      .key(METADATA_PREFIX + ".index.column.stats.parallelism")
+      .defaultValue(10)
+      .markAdvanced()
+      .sinceVersion("0.11.0")
+      .withDocumentation("Parallelism to use, when generating column stats index.");
 
   public static final ConfigProperty<String> COLUMN_STATS_INDEX_FOR_COLUMNS = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.column.list")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Comma-separated list of columns for which column stats index will be built. If not set, all columns will be indexed");
 
@@ -184,6 +198,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".index.column.stats.processing.mode.override")
       .noDefaultValue()
       .withValidValues(COLUMN_STATS_INDEX_PROCESSING_MODE_IN_MEMORY, COLUMN_STATS_INDEX_PROCESSING_MODE_ENGINE)
+      .markAdvanced()
       .sinceVersion("0.12.0")
       .withDocumentation("By default Column Stats Index is automatically determining whether it should be read and processed either"
           + "'in-memory' (w/in executing process) or using Spark (on a cluster), based on some factors like the size of the Index "
@@ -192,6 +207,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> COLUMN_STATS_INDEX_IN_MEMORY_PROJECTION_THRESHOLD = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.inMemory.projection.threshold")
       .defaultValue(100000)
+      .markAdvanced()
       .sinceVersion("0.12.0")
       .withDocumentation("When reading Column Stats Index, if the size of the expected resulting projection is below the in-memory"
           + " threshold (counted by the # of rows), it will be attempted to be loaded \"in-memory\" (ie not using the execution engine"
@@ -200,12 +216,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<String> BLOOM_FILTER_INDEX_FOR_COLUMNS = ConfigProperty
       .key(METADATA_PREFIX + ".index.bloom.filter.column.list")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Comma-separated list of columns for which bloom filter index will be built. If not set, only record key will be indexed.");
 
   public static final ConfigProperty<Integer> METADATA_INDEX_CHECK_TIMEOUT_SECONDS = ConfigProperty
       .key(METADATA_PREFIX + ".index.check.timeout.seconds")
       .defaultValue(900)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("After the async indexer has finished indexing upto the base instant, it will ensure that all inflight writers "
           + "reliably write index updates as well. If this timeout expires, then the indexer will abort itself safely.");
@@ -213,6 +231,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> IGNORE_SPURIOUS_DELETES = ConfigProperty
       .key("_" + METADATA_PREFIX + ".ignore.spurious.deletes")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.10.0")
       .withDocumentation("There are cases when extra files are requested to be deleted from "
           + "metadata table which are never added before. This config determines how to handle "
@@ -221,6 +240,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ENABLE_OPTIMIZED_LOG_BLOCKS_SCAN = ConfigProperty
       .key(METADATA_PREFIX + OPTIMIZED_LOG_BLOCKS_SCAN)
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Optimized log blocks scanner that addresses all the multiwriter use-cases while appending to log files. "
           + "It also differentiates original blocks written by ingestion writers and compacted blocks written by log compaction.");

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetaserverConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetaserverConfig.java
@@ -38,30 +38,36 @@ public class HoodieMetaserverConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> METASERVER_ENABLE = ConfigProperty
       .key(METASERVER_PREFIX + ".enabled")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Enable Hudi metaserver for storing Hudi tables' metadata.");
 
   public static final ConfigProperty<String> DATABASE_NAME = HoodieTableConfig.DATABASE_NAME
+      .markAdvanced()
       .sinceVersion("0.13.0");
 
   public static final ConfigProperty<String> TABLE_NAME = HoodieTableConfig.NAME
+      .markAdvanced()
       .sinceVersion("0.13.0");
 
   public static final ConfigProperty<String> METASERVER_URLS = ConfigProperty
       .key(METASERVER_PREFIX + ".uris")
       .defaultValue("thrift://localhost:9090")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Metastore server uris");
 
   public static final ConfigProperty<Integer> METASERVER_CONNECTION_RETRIES = ConfigProperty
       .key(METASERVER_PREFIX + ".connect.retries")
       .defaultValue(3)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Number of retries while opening a connection to metastore");
 
   public static final ConfigProperty<Integer> METASERVER_CONNECTION_RETRY_DELAY = ConfigProperty
       .key(METASERVER_PREFIX + ".connect.retry.delay")
       .defaultValue(1)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Number of seconds for the client to wait between consecutive connection attempts");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -43,55 +43,65 @@ public class HoodieStorageConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARQUET_BLOCK_SIZE = ConfigProperty
       .key("hoodie.parquet.block.size")
       .defaultValue(String.valueOf(120 * 1024 * 1024))
+      .markAdvanced()
       .withDocumentation("Parquet RowGroup size in bytes. It's recommended to make this large enough that scan costs can be"
           + " amortized by packing enough column values into a single row group.");
 
   public static final ConfigProperty<String> PARQUET_PAGE_SIZE = ConfigProperty
       .key("hoodie.parquet.page.size")
       .defaultValue(String.valueOf(1 * 1024 * 1024))
+      .markAdvanced()
       .withDocumentation("Parquet page size in bytes. Page is the unit of read within a parquet file. "
           + "Within a block, pages are compressed separately.");
 
   public static final ConfigProperty<String> ORC_FILE_MAX_SIZE = ConfigProperty
       .key("hoodie.orc.max.file.size")
       .defaultValue(String.valueOf(120 * 1024 * 1024))
+      .markAdvanced()
       .withDocumentation("Target file size in bytes for ORC base files.");
 
   public static final ConfigProperty<String> ORC_STRIPE_SIZE = ConfigProperty
       .key("hoodie.orc.stripe.size")
       .defaultValue(String.valueOf(64 * 1024 * 1024))
+      .markAdvanced()
       .withDocumentation("Size of the memory buffer in bytes for writing");
 
   public static final ConfigProperty<String> ORC_BLOCK_SIZE = ConfigProperty
       .key("hoodie.orc.block.size")
       .defaultValue(ORC_FILE_MAX_SIZE.defaultValue())
+      .markAdvanced()
       .withDocumentation("ORC block size, recommended to be aligned with the target file size.");
 
   public static final ConfigProperty<String> HFILE_MAX_FILE_SIZE = ConfigProperty
       .key("hoodie.hfile.max.file.size")
       .defaultValue(String.valueOf(120 * 1024 * 1024))
+      .markAdvanced()
       .withDocumentation("Target file size in bytes for HFile base files.");
 
   public static final ConfigProperty<String> HFILE_BLOCK_SIZE = ConfigProperty
       .key("hoodie.hfile.block.size")
       .defaultValue(String.valueOf(1024 * 1024))
+      .markAdvanced()
       .withDocumentation("Lower values increase the size in bytes of metadata tracked within HFile, but can offer potentially "
           + "faster lookup times.");
 
   public static final ConfigProperty<String> LOGFILE_DATA_BLOCK_FORMAT = ConfigProperty
       .key("hoodie.logfile.data.block.format")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Format of the data block within delta logs. Following formats are currently supported \"avro\", \"hfile\", \"parquet\"");
 
   public static final ConfigProperty<String> LOGFILE_MAX_SIZE = ConfigProperty
       .key("hoodie.logfile.max.size")
       .defaultValue(String.valueOf(1024 * 1024 * 1024)) // 1 GB
+      .markAdvanced()
       .withDocumentation("LogFile max size in bytes. This is the maximum size allowed for a log file "
           + "before it is rolled over to the next version.");
 
   public static final ConfigProperty<String> LOGFILE_DATA_BLOCK_MAX_SIZE = ConfigProperty
       .key("hoodie.logfile.data.block.max.size")
       .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
       .withDocumentation("LogFile Data block max size in bytes. This is the maximum size allowed for a single data block "
           + "to be appended to a log file. This helps to make sure the data appended to the log file is broken up "
           + "into sizable blocks to prevent from OOM errors. This size should be greater than the JVM memory.");
@@ -99,6 +109,7 @@ public class HoodieStorageConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARQUET_COMPRESSION_RATIO_FRACTION = ConfigProperty
       .key("hoodie.parquet.compression.ratio")
       .defaultValue(String.valueOf(0.1))
+      .markAdvanced()
       .withDocumentation("Expected compression of parquet data used by Hudi, when it tries to size new parquet files. "
           + "Increase this value, if bulk_insert is producing smaller than expected sized files");
 
@@ -111,11 +122,13 @@ public class HoodieStorageConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> PARQUET_DICTIONARY_ENABLED = ConfigProperty
       .key("hoodie.parquet.dictionary.enabled")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether to use dictionary encoding");
 
   public static final ConfigProperty<String> PARQUET_WRITE_LEGACY_FORMAT_ENABLED = ConfigProperty
       .key("hoodie.parquet.writelegacyformat.enabled")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Sets spark.sql.parquet.writeLegacyFormat. If true, data will be written in a way of Spark 1.4 and earlier. "
           + "For example, decimal values will be written in Parquet's fixed-length byte array format which other systems such as Apache Hive and Apache Impala use. "
           + "If false, the newer format in Parquet will be used. For example, decimals will be written in int-based format.");
@@ -123,6 +136,7 @@ public class HoodieStorageConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARQUET_OUTPUT_TIMESTAMP_TYPE = ConfigProperty
       .key("hoodie.parquet.outputtimestamptype")
       .defaultValue("TIMESTAMP_MICROS")
+      .markAdvanced()
       .withDocumentation("Sets spark.sql.parquet.outputTimestampType. Parquet timestamp type to use when Spark writes data to Parquet files.");
 
   // SPARK-38094 Spark 3.3 checks if this field is enabled. Hudi has to provide this or there would be NPE thrown
@@ -131,6 +145,7 @@ public class HoodieStorageConfig extends HoodieConfig {
   public static final ConfigProperty<String> PARQUET_FIELD_ID_WRITE_ENABLED = ConfigProperty
       .key("hoodie.parquet.field_id.write.enabled")
       .defaultValue("true")
+      .markAdvanced()
       .sinceVersion("0.12.0")
       .withDocumentation("Would only be effective with Spark 3.3+. Sets spark.sql.parquet.fieldId.write.enabled. "
           + "If enabled, Spark will write out parquet native field ids that are stored inside StructField's metadata as parquet.field.id to parquet files.");
@@ -138,17 +153,20 @@ public class HoodieStorageConfig extends HoodieConfig {
   public static final ConfigProperty<String> HFILE_COMPRESSION_ALGORITHM_NAME = ConfigProperty
       .key("hoodie.hfile.compression.algorithm")
       .defaultValue("GZ")
+      .markAdvanced()
       .withDocumentation("Compression codec to use for hfile base files.");
 
   public static final ConfigProperty<String> ORC_COMPRESSION_CODEC_NAME = ConfigProperty
       .key("hoodie.orc.compression.codec")
       .defaultValue("ZLIB")
+      .markAdvanced()
       .withDocumentation("Compression codec to use for ORC base files.");
 
   // Default compression ratio for log file to parquet, general 3x
   public static final ConfigProperty<String> LOGFILE_TO_PARQUET_COMPRESSION_RATIO_FRACTION = ConfigProperty
       .key("hoodie.logfile.to.parquet.compression.ratio")
       .defaultValue(String.valueOf(0.35))
+      .markAdvanced()
       .withDocumentation("Expected additional compression as records move from log files to parquet. Used for merge_on_read "
           + "table to send inserts into log files & control the size of compacted parquet file.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTableServiceManagerConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTableServiceManagerConfig.java
@@ -37,72 +37,84 @@ public class HoodieTableServiceManagerConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> TABLE_SERVICE_MANAGER_ENABLED = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".enabled")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("If true, use table service manager to execute table service");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_URIS = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".uris")
       .defaultValue("http://localhost:9091")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Table service manager URIs (comma-delimited).");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_ACTIONS = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".actions")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The actions deployed on table service manager, such as compaction or clean.");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_DEPLOY_USERNAME = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".deploy.username")
       .defaultValue("default")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The user name for this table to deploy table services.");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_DEPLOY_QUEUE = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".deploy.queue")
       .defaultValue("default")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The queue for this table to deploy table services.");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_DEPLOY_RESOURCES = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".deploy.resources")
       .defaultValue("spark:4g,4g")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The resources for this table to use for deploying table services.");
 
   public static final ConfigProperty<Integer> TABLE_SERVICE_MANAGER_DEPLOY_PARALLELISM = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".deploy.parallelism")
       .defaultValue(100)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The parallelism for this table to deploy table services.");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_DEPLOY_EXECUTION_ENGINE = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".execution.engine")
       .defaultValue("spark")
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The execution engine to deploy for table service of this table, default spark");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_DEPLOY_EXTRA_PARAMS = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".deploy.extra.params")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The extra params to deploy for table service of this table, split by ';'");
 
   public static final ConfigProperty<Integer> TABLE_SERVICE_MANAGER_TIMEOUT_SEC = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".connection.timeout.sec")
       .defaultValue(300)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Timeout in seconds for connections to table service manager.");
 
   public static final ConfigProperty<Integer> TABLE_SERVICE_MANAGER_RETRIES = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".connection.retries")
       .defaultValue(3)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Number of retries while opening a connection to table service manager");
 
   public static final ConfigProperty<Integer> TABLE_SERVICE_MANAGER_RETRY_DELAY_SEC = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".connection.retry.delay.sec")
       .defaultValue(1)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Number of seconds for the client to wait between consecutive connection attempts");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/ConsistencyGuardConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/ConsistencyGuardConfig.java
@@ -40,6 +40,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   public static final ConfigProperty<String> ENABLE = ConfigProperty
       .key("hoodie.consistency.check.enabled")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.5.0")
       .deprecatedAfter("0.7.0")
       .withDocumentation("Enabled to handle S3 eventual consistency issue. This property is no longer required "
@@ -48,6 +49,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   public static final ConfigProperty<Long> INITIAL_CHECK_INTERVAL_MS = ConfigProperty
       .key("hoodie.consistency.check.initial_interval_ms")
       .defaultValue(400L)
+      .markAdvanced()
       .sinceVersion("0.5.0")
       .deprecatedAfter("0.7.0")
       .withDocumentation("Amount of time (in ms) to wait, before checking for consistency after an operation on storage.");
@@ -55,6 +57,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   public static final ConfigProperty<Long> MAX_CHECK_INTERVAL_MS = ConfigProperty
       .key("hoodie.consistency.check.max_interval_ms")
       .defaultValue(20000L)
+      .markAdvanced()
       .sinceVersion("0.5.0")
       .deprecatedAfter("0.7.0")
       .withDocumentation("Maximum amount of time (in ms), to wait for consistency checking.");
@@ -63,6 +66,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> MAX_CHECKS = ConfigProperty
       .key("hoodie.consistency.check.max_checks")
       .defaultValue(6)
+      .markAdvanced()
       .sinceVersion("0.5.0")
       .deprecatedAfter("0.7.0")
       .withDocumentation("Maximum number of consistency checks to perform, with exponential backoff.");
@@ -71,6 +75,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   public static final ConfigProperty<Long> OPTIMISTIC_CONSISTENCY_GUARD_SLEEP_TIME_MS = ConfigProperty
       .key("hoodie.optimistic.consistency.guard.sleep_time_ms")
       .defaultValue(500L)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Amount of time (in ms), to wait after which we assume storage is consistent.");
 
@@ -78,6 +83,7 @@ public class ConsistencyGuardConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> OPTIMISTIC_CONSISTENCY_GUARD_ENABLE = ConfigProperty
       .key("_hoodie.optimistic.consistency.guard.enable")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.6.0")
       .withDocumentation("Enable consistency guard, which optimistically assumes consistency is achieved after a certain time period.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FileSystemRetryConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FileSystemRetryConfig.java
@@ -39,30 +39,35 @@ public class FileSystemRetryConfig  extends HoodieConfig {
   public static final ConfigProperty<String> FILESYSTEM_RETRY_ENABLE = ConfigProperty
       .key("hoodie.filesystem.operation.retry.enable")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Enabled to handle list/get/delete etc file system performance issue.");
 
   public static final ConfigProperty<Long> INITIAL_RETRY_INTERVAL_MS = ConfigProperty
       .key("hoodie.filesystem.operation.retry.initial_interval_ms")
       .defaultValue(100L)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Amount of time (in ms) to wait, before retry to do operations on storage.");
 
   public static final ConfigProperty<Long> MAX_RETRY_INTERVAL_MS = ConfigProperty
       .key("hoodie.filesystem.operation.retry.max_interval_ms")
       .defaultValue(2000L)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Maximum amount of time (in ms), to wait for next retry.");
 
   public static final ConfigProperty<Integer> MAX_RETRY_NUMBERS = ConfigProperty
       .key("hoodie.filesystem.operation.retry.max_numbers")
       .defaultValue(4)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Maximum number of retry actions to perform, with exponential backoff.");
 
   public static final ConfigProperty<String> RETRY_EXCEPTIONS = ConfigProperty
       .key("hoodie.filesystem.operation.retry.exceptions")
       .defaultValue("")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("The class name of the Exception that needs to be re-tryed, separated by commas. "
           + "Default is empty which means retry all the IOException and RuntimeException from FileSystem");

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/FileSystemViewStorageConfig.java
@@ -43,6 +43,7 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
   public static final ConfigProperty<FileSystemViewStorageType> VIEW_TYPE = ConfigProperty
       .key("hoodie.filesystem.view.type")
       .defaultValue(FileSystemViewStorageType.MEMORY)
+      .markAdvanced()
       .withDocumentation("File system view provides APIs for viewing the files on the underlying lake storage, "
           + " as file groups and file slices. This config controls how such a view is held. Options include "
           + Arrays.stream(FileSystemViewStorageType.values()).map(Enum::name).collect(Collectors.joining(","))
@@ -51,105 +52,124 @@ public class FileSystemViewStorageConfig extends HoodieConfig {
   public static final ConfigProperty<String> INCREMENTAL_TIMELINE_SYNC_ENABLE = ConfigProperty
       .key("hoodie.filesystem.view.incr.timeline.sync.enable")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Controls whether or not, the file system view is incrementally updated as "
           + "new actions are performed on the timeline.");
 
   public static final ConfigProperty<FileSystemViewStorageType> SECONDARY_VIEW_TYPE = ConfigProperty
       .key("hoodie.filesystem.view.secondary.type")
       .defaultValue(FileSystemViewStorageType.MEMORY)
+      .markAdvanced()
       .withDocumentation("Specifies the secondary form of storage for file system view, if the primary (e.g timeline server) "
           + " is unavailable.");
 
   public static final ConfigProperty<String> REMOTE_HOST_NAME = ConfigProperty
       .key("hoodie.filesystem.view.remote.host")
       .defaultValue("localhost")
+      .markAdvanced()
       .withDocumentation("We expect this to be rarely hand configured.");
 
   public static final ConfigProperty<Integer> REMOTE_PORT_NUM = ConfigProperty
       .key("hoodie.filesystem.view.remote.port")
       .defaultValue(26754)
+      .markAdvanced()
       .withDocumentation("Port to serve file system view queries, when remote. We expect this to be rarely hand configured.");
 
   public static final ConfigProperty<String> SPILLABLE_DIR = ConfigProperty
       .key("hoodie.filesystem.view.spillable.dir")
       .defaultValue("/tmp/")
+      .markAdvanced()
       .withDocumentation("Path on local storage to use, when file system view is held in a spillable map.");
 
   public static final ConfigProperty<Long> SPILLABLE_MEMORY = ConfigProperty
       .key("hoodie.filesystem.view.spillable.mem")
       .defaultValue(100 * 1024 * 1024L) // 100 MB
+      .markAdvanced()
       .withDocumentation("Amount of memory to be used in bytes for holding file system view, before spilling to disk.");
 
   public static final ConfigProperty<Double> SPILLABLE_COMPACTION_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.compaction.mem.fraction")
       .defaultValue(0.8)
+      .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding compaction related metadata.");
 
   public static final ConfigProperty<Double> SPILLABLE_LOG_COMPACTION_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.log.compaction.mem.fraction")
       .defaultValue(0.8)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Fraction of the file system view memory, to be used for holding log compaction related metadata.");
 
   public static final ConfigProperty<Double> BOOTSTRAP_BASE_FILE_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.bootstrap.base.file.mem.fraction")
       .defaultValue(0.05)
+      .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding mapping to bootstrap base files.");
 
   public static final ConfigProperty<Double> SPILLABLE_REPLACED_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.replaced.mem.fraction")
       .defaultValue(0.01)
+      .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding replace commit related metadata.");
 
   public static final ConfigProperty<Double> SPILLABLE_CLUSTERING_MEM_FRACTION = ConfigProperty
       .key("hoodie.filesystem.view.spillable.clustering.mem.fraction")
       .defaultValue(0.01)
+      .markAdvanced()
       .withDocumentation("Fraction of the file system view memory, to be used for holding clustering related metadata.");
 
   public static final ConfigProperty<String> ROCKSDB_BASE_PATH = ConfigProperty
       .key("hoodie.filesystem.view.rocksdb.base.path")
       .defaultValue("/tmp/hoodie_timeline_rocksdb")
+      .markAdvanced()
       .withDocumentation("Path on local storage to use, when storing file system view in embedded kv store/rocksdb.");
 
   public static final ConfigProperty<Integer> REMOTE_TIMEOUT_SECS = ConfigProperty
       .key("hoodie.filesystem.view.remote.timeout.secs")
       .defaultValue(5 * 60) // 5 min
+      .markAdvanced()
       .withDocumentation("Timeout in seconds, to wait for API requests against a remote file system view. e.g timeline server.");
 
   public static final ConfigProperty<String> REMOTE_RETRY_ENABLE = ConfigProperty
-          .key("hoodie.filesystem.view.remote.retry.enable")
-          .defaultValue("false")
-          .sinceVersion("0.12.1")
-          .withDocumentation("Whether to enable API request retry for remote file system view.");
+      .key("hoodie.filesystem.view.remote.retry.enable")
+      .defaultValue("false")
+      .markAdvanced()
+      .sinceVersion("0.12.1")
+      .withDocumentation("Whether to enable API request retry for remote file system view.");
 
   public static final ConfigProperty<Integer> REMOTE_MAX_RETRY_NUMBERS = ConfigProperty
       .key("hoodie.filesystem.view.remote.retry.max_numbers")
       .defaultValue(3) // 3 times
+      .markAdvanced()
       .sinceVersion("0.12.1")
       .withDocumentation("Maximum number of retry for API requests against a remote file system view. e.g timeline server.");
 
   public static final ConfigProperty<Long> REMOTE_INITIAL_RETRY_INTERVAL_MS = ConfigProperty
       .key("hoodie.filesystem.view.remote.retry.initial_interval_ms")
       .defaultValue(100L)
+      .markAdvanced()
       .sinceVersion("0.12.1")
       .withDocumentation("Amount of time (in ms) to wait, before retry to do operations on storage.");
 
   public static final ConfigProperty<Long> REMOTE_MAX_RETRY_INTERVAL_MS = ConfigProperty
       .key("hoodie.filesystem.view.remote.retry.max_interval_ms")
       .defaultValue(2000L)
+      .markAdvanced()
       .sinceVersion("0.12.1")
       .withDocumentation("Maximum amount of time (in ms), to wait for next retry.");
 
   public static final ConfigProperty<String> RETRY_EXCEPTIONS = ConfigProperty
-          .key("hoodie.filesystem.view.remote.retry.exceptions")
-          .defaultValue("")
-          .sinceVersion("0.12.1")
-          .withDocumentation("The class name of the Exception that needs to be re-tryed, separated by commas. "
-                  + "Default is empty which means retry all the IOException and RuntimeException from Remote Request.");
+      .key("hoodie.filesystem.view.remote.retry.exceptions")
+      .defaultValue("")
+      .markAdvanced()
+      .sinceVersion("0.12.1")
+      .withDocumentation("The class name of the Exception that needs to be re-tryed, separated by commas. "
+          + "Default is empty which means retry all the IOException and RuntimeException from Remote Request.");
 
   public static final ConfigProperty<String> REMOTE_BACKUP_VIEW_ENABLE = ConfigProperty
       .key("hoodie.filesystem.remote.backup.view.enable")
       .defaultValue("true") // Need to be disabled only for tests.
+      .markAdvanced()
       .withDocumentation("Config to control whether backup needs to be configured if clients were not able to reach"
           + " timeline service.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
@@ -37,6 +37,7 @@ public class KeyGeneratorOptions extends HoodieConfig {
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = ConfigProperty
       .key("hoodie.datasource.write.partitionpath.urlencode")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Should we url encode the partition path value, before creating the folder structure.");
 
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = ConfigProperty
@@ -62,6 +63,7 @@ public class KeyGeneratorOptions extends HoodieConfig {
   public static final ConfigProperty<String> KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED = ConfigProperty
       .key("hoodie.datasource.write.keygenerator.consistent.logical.timestamp.enabled")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When set to true, consistent value will be generated for a logical timestamp type column, "
           + "like timestamp-millis and timestamp-micros, irrespective of whether row-writer is enabled. Disabled by default so "
           + "as not to break the pipeline that deploy either fully row-writer path or non row-writer path. For example, "

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
@@ -54,17 +54,20 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
   public static final ConfigProperty<String> BIGQUERY_SYNC_PROJECT_ID = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.project_id")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Name of the target project in BigQuery");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_DATASET_NAME = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.dataset_name")
       .noDefaultValue()
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(DATABASE_NAME)))
+      .markAdvanced()
       .withDocumentation("Name of the target dataset in BigQuery");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_DATASET_LOCATION = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.dataset_location")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Location of the target dataset in BigQuery");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_TABLE_NAME = ConfigProperty
@@ -72,22 +75,26 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       .noDefaultValue()
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HOODIE_TABLE_NAME_KEY))
           .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))
+      .markAdvanced()
       .withDocumentation("Name of the target table in BigQuery");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_SOURCE_URI = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.source_uri")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Name of the source uri gcs path of the table");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_SOURCE_URI_PREFIX = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.source_uri_prefix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Name of the source uri gcs path prefix of the table");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_SYNC_BASE_PATH = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.base_path")
       .noDefaultValue()
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(META_SYNC_BASE_PATH)))
+      .markAdvanced()
       .withDocumentation("Base path of the hoodie table to sync");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_PARTITION_FIELDS = ConfigProperty
@@ -95,18 +102,21 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       .noDefaultValue()
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HoodieTableConfig.PARTITION_FIELDS))
           .or(() -> Option.ofNullable(cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME))))
+      .markAdvanced()
       .withDocumentation("Comma-delimited partition fields. Default to non-partitioned.");
 
   public static final ConfigProperty<Boolean> BIGQUERY_SYNC_USE_FILE_LISTING_FROM_METADATA = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.use_file_listing_from_metadata")
       .defaultValue(DEFAULT_METADATA_ENABLE_FOR_READERS)
       .withInferFunction(cfg -> Option.of(cfg.getBooleanOrDefault(HoodieMetadataConfig.ENABLE, DEFAULT_METADATA_ENABLE_FOR_READERS)))
+      .markAdvanced()
       .withDocumentation("Fetch file listing from Hudi's metadata");
 
   public static final ConfigProperty<String> BIGQUERY_SYNC_ASSUME_DATE_PARTITIONING = ConfigProperty
       .key("hoodie.gcp.bigquery.sync.assume_date_partitioning")
       .defaultValue(HoodieMetadataConfig.ASSUME_DATE_PARTITIONING.defaultValue())
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HoodieMetadataConfig.ASSUME_DATE_PARTITIONING)))
+      .markAdvanced()
       .withDocumentation("Assume standard yyyy/mm/dd partitioning, this"
           + " exists to support backward compatibility. If you use hoodie 0.3.x, do not set this parameter");
 

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectConfigs.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectConfigs.java
@@ -50,12 +50,14 @@ public class KafkaConnectConfigs extends HoodieConfig {
   public static final ConfigProperty<String> CONTROL_TOPIC_NAME = ConfigProperty
       .key("hoodie.kafka.control.topic")
       .defaultValue("hudi-control-topic")
+      .markAdvanced()
       .withDocumentation("Kafka topic name used by the Hudi Sink Connector for "
           + "sending and receiving control messages. Not used for data records.");
 
   public static final ConfigProperty<String> SCHEMA_PROVIDER_CLASS = ConfigProperty
       .key("hoodie.schemaprovider.class")
       .defaultValue(FilebasedSchemaProvider.class.getName())
+      .markAdvanced()
       .withDocumentation("subclass of org.apache.hudi.schema.SchemaProvider "
           + "to attach schemas to input & target table data, built in options: "
           + "org.apache.hudi.schema.FilebasedSchemaProvider.");
@@ -63,12 +65,14 @@ public class KafkaConnectConfigs extends HoodieConfig {
   public static final ConfigProperty<String> COMMIT_INTERVAL_SECS = ConfigProperty
       .key("hoodie.kafka.commit.interval.secs")
       .defaultValue("60")
+      .markAdvanced()
       .withDocumentation("The interval at which Hudi will commit the records written "
           + "to the files, making them consumable on the read-side.");
 
   public static final ConfigProperty<String> COORDINATOR_WRITE_TIMEOUT_SECS = ConfigProperty
       .key("hoodie.kafka.coordinator.write.timeout.secs")
       .defaultValue("300")
+      .markAdvanced()
       .withDocumentation("The timeout after sending an END_COMMIT until when "
           + "the coordinator will wait for the write statuses from all the partitions"
           + "to ignore the current commit and start a new commit.");
@@ -76,33 +80,39 @@ public class KafkaConnectConfigs extends HoodieConfig {
   public static final ConfigProperty<String> ASYNC_COMPACT_ENABLE = ConfigProperty
       .key("hoodie.kafka.compaction.async.enable")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Controls whether async compaction should be turned on for MOR table writing.");
 
   public static final ConfigProperty<String> META_SYNC_ENABLE = ConfigProperty
       .key("hoodie.meta.sync.enable")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Enable Meta Sync such as Hive");
 
   public static final ConfigProperty<String> META_SYNC_CLASSES = ConfigProperty
       .key("hoodie.meta.sync.classes")
       .defaultValue(HiveSyncTool.class.getName())
+      .markAdvanced()
       .withDocumentation("Meta sync client tool, using comma to separate multi tools");
 
   public static final ConfigProperty<Boolean> ALLOW_COMMIT_ON_ERRORS = ConfigProperty
       .key("hoodie.kafka.allow.commit.on.errors")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Commit even when some records failed to be written");
 
   // Reference https://docs.confluent.io/kafka-connect-hdfs/current/configuration_options.html#hdfs
   public static final ConfigProperty<String> HADOOP_CONF_DIR = ConfigProperty
-          .key("hadoop.conf.dir")
-          .noDefaultValue()
-          .withDocumentation("The Hadoop configuration directory.");
+      .key("hadoop.conf.dir")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("The Hadoop configuration directory.");
 
   public static final ConfigProperty<String> HADOOP_HOME = ConfigProperty
-          .key("hadoop.home")
-          .noDefaultValue()
-          .withDocumentation("The Hadoop home directory.");
+      .key("hadoop.home")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("The Hadoop home directory.");
 
   protected KafkaConnectConfigs() {
     super();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -69,6 +69,7 @@ object DataSourceReadOptions {
     .key("hoodie.datasource.query.incremental.format")
     .defaultValue(INCREMENTAL_FORMAT_LATEST_STATE_VAL)
     .withValidValues(INCREMENTAL_FORMAT_LATEST_STATE_VAL, INCREMENTAL_FORMAT_CDC_VAL)
+    .markAdvanced()
     .sinceVersion("0.13.0")
     .withDocumentation("This config is used alone with the 'incremental' query type." +
       "When set to 'latest_state', it returns the latest records' values." +
@@ -80,6 +81,7 @@ object DataSourceReadOptions {
     .key("hoodie.datasource.merge.type")
     .defaultValue(REALTIME_PAYLOAD_COMBINE_OPT_VAL)
     .withValidValues(REALTIME_SKIP_MERGE_OPT_VAL, REALTIME_PAYLOAD_COMBINE_OPT_VAL)
+    .markAdvanced()
     .withDocumentation("For Snapshot query on merge on read table, control whether we invoke the record " +
       s"payload implementation to merge (${REALTIME_PAYLOAD_COMBINE_OPT_VAL}) or skip merging altogether" +
       s"${REALTIME_SKIP_MERGE_OPT_VAL}")
@@ -87,6 +89,7 @@ object DataSourceReadOptions {
   val READ_PATHS: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.paths")
     .noDefaultValue()
+    .markAdvanced()
     .withDocumentation("Comma separated list of file paths to read within a Hudi table.")
 
   val READ_PRE_COMBINE_FIELD = HoodieWriteConfig.PRECOMBINE_FIELD_NAME
@@ -94,6 +97,7 @@ object DataSourceReadOptions {
   val ENABLE_HOODIE_FILE_INDEX: ConfigProperty[Boolean] = ConfigProperty
     .key("hoodie.file.index.enable")
     .defaultValue(true)
+    .markAdvanced()
     .deprecatedAfter("0.11.0")
     .withDocumentation("Enables use of the spark file index implementation for Hudi, "
       + "that speeds up listing of large tables.")
@@ -101,6 +105,7 @@ object DataSourceReadOptions {
   val START_OFFSET: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.streaming.startOffset")
     .defaultValue("earliest")
+    .markAdvanced()
     .sinceVersion("0.13.0")
     .withDocumentation("Start offset to pull data from hoodie streaming source. allow earliest, latest, and " +
       "specified start instant time")
@@ -121,11 +126,13 @@ object DataSourceReadOptions {
   val INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.schema.use.end.instanttime")
     .defaultValue("false")
+    .markAdvanced()
     .withDocumentation("Uses end instant schema when incrementally fetched data to. Default: users latest instant schema.")
 
   val PUSH_DOWN_INCR_FILTERS: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.incr.filters")
     .defaultValue("")
+    .markAdvanced()
     .withDocumentation("For use-cases like DeltaStreamer which reads from Hoodie Incremental table and applies "
       + "opaque map functions, filters appearing late in the sequence of transformations cannot be automatically "
       + "pushed down. This option allows setting filters directly on Hoodie Source.")
@@ -133,6 +140,7 @@ object DataSourceReadOptions {
   val INCR_PATH_GLOB: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.incr.path.glob")
     .defaultValue("")
+    .markAdvanced()
     .withDocumentation("For the use-cases like users only want to incremental pull from certain partitions "
       + "instead of the full table. This option allows using glob pattern to directly filter on path.")
 
@@ -141,6 +149,7 @@ object DataSourceReadOptions {
   val ENABLE_DATA_SKIPPING: ConfigProperty[Boolean] = ConfigProperty
     .key("hoodie.enable.data.skipping")
     .defaultValue(false)
+    .markAdvanced()
     .sinceVersion("0.10.0")
     .withDocumentation("Enables data-skipping allowing queries to leverage indexes to reduce the search space by " +
       "skipping over files")
@@ -148,6 +157,7 @@ object DataSourceReadOptions {
   val EXTRACT_PARTITION_VALUES_FROM_PARTITION_PATH: ConfigProperty[Boolean] =
     ConfigProperty.key("hoodie.datasource.read.extract.partition.values.from.path")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("When set to true, values for partition columns (partition values) will be extracted" +
         " from physical partition path (default Spark behavior). When set to false partition values will be" +
@@ -161,6 +171,7 @@ object DataSourceReadOptions {
     ConfigProperty.key("hoodie.datasource.read.file.index.listing.mode")
       .defaultValue(FILE_INDEX_LISTING_MODE_LAZY)
       .withValidValues(FILE_INDEX_LISTING_MODE_LAZY, FILE_INDEX_LISTING_MODE_EAGER)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Overrides Hudi's file-index implementation's file listing mode: when set to 'eager'," +
         " file-index will list all partition paths and corresponding file slices w/in them eagerly, during initialization," +
@@ -174,6 +185,7 @@ object DataSourceReadOptions {
   val FILE_INDEX_LISTING_PARTITION_PATH_PREFIX_ANALYSIS_ENABLED: ConfigProperty[Boolean] =
     ConfigProperty.key("hoodie.datasource.read.file.index.listing.partition-path-prefix.analysis.enabled")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Controls whether partition-path prefix analysis is enabled w/in the file-index, allowing" +
         " to avoid necessity to recursively list deep folder structures of partitioned tables w/ multiple partition columns," +
@@ -183,6 +195,7 @@ object DataSourceReadOptions {
   val INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN_FOR_NON_EXISTING_FILES: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.incr.fallback.fulltablescan.enable")
     .defaultValue("false")
+    .markAdvanced()
     .withDocumentation("When doing an incremental query whether we should fall back to full table scans if file does not exist.")
 
   val SCHEMA_EVOLUTION_ENABLED: ConfigProperty[Boolean] = HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE
@@ -331,6 +344,7 @@ object DataSourceWriteOptions {
   val TABLE_NAME: ConfigProperty[String] = ConfigProperty
     .key(HoodieTableConfig.HOODIE_WRITE_TABLE_NAME_KEY)
     .noDefaultValue()
+    .markAdvanced()
     .withDocumentation("Table name for the datasource write. Also used to register the table into meta stores.")
 
   /**
@@ -389,6 +403,7 @@ object DataSourceWriteOptions {
     .key("hoodie.datasource.write.keygenerator.class")
     .defaultValue(classOf[SimpleKeyGenerator].getName)
     .withInferFunction(keyGeneratorInferFunc)
+    .markAdvanced()
     .withDocumentation("Key generator class, that implements `org.apache.hudi.keygen.KeyGenerator`")
 
   val KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED: ConfigProperty[String] = KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED
@@ -396,6 +411,7 @@ object DataSourceWriteOptions {
   val ENABLE_ROW_WRITER: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.row.writer.enable")
     .defaultValue("true")
+    .markAdvanced()
     .withDocumentation("When set to true, will perform write operations directly using the spark native " +
       "`Row` representation, avoiding any additional conversion costs.")
 
@@ -405,6 +421,7 @@ object DataSourceWriteOptions {
   val SQL_ENABLE_BULK_INSERT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.sql.bulk.insert.enable")
     .defaultValue("false")
+    .markAdvanced()
     .withDocumentation("When set to true, the sql insert statement will use bulk insert.")
 
   val SQL_INSERT_MODE: ConfigProperty[String] = ConfigProperty
@@ -418,27 +435,32 @@ object DataSourceWriteOptions {
   val COMMIT_METADATA_KEYPREFIX: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.commitmeta.key.prefix")
     .defaultValue("_")
+    .markAdvanced()
     .withDocumentation("Option keys beginning with this prefix, are automatically added to the commit/deltacommit metadata. " +
       "This is useful to store checkpointing information, in a consistent way with the hudi timeline")
 
   val INSERT_DROP_DUPS: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.insert.drop.duplicates")
     .defaultValue("false")
+    .markAdvanced()
     .withDocumentation("If set to true, filters out all duplicate records from incoming dataframe, during insert operations.")
 
   val PARTITIONS_TO_DELETE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.partitions.to.delete")
     .noDefaultValue()
+    .markAdvanced()
     .withDocumentation("Comma separated list of partitions to delete. Allows use of wildcard *")
 
   val STREAMING_RETRY_CNT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.retry.count")
     .defaultValue("3")
+    .markAdvanced()
     .withDocumentation("Config to indicate how many times streaming job should retry for a failed micro batch.")
 
   val STREAMING_RETRY_INTERVAL_MS: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.retry.interval.ms")
     .defaultValue("2000")
+    .markAdvanced()
     .withDocumentation(" Config to indicate how long (by millisecond) before a retry should issued for failed microbatch")
 
   /**
@@ -447,6 +469,7 @@ object DataSourceWriteOptions {
   val STREAMING_IGNORE_FAILED_BATCH: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.ignore.failed.batch")
     .defaultValue("false")
+    .markAdvanced()
     .withDocumentation("Config to indicate whether to ignore any non exception error (e.g. writestatus error)"
       + " within a streaming microbatch. Turning this on, could hide the write status errors while the spark checkpoint moves ahead." +
       "So, would recommend users to use this with caution.")
@@ -454,6 +477,7 @@ object DataSourceWriteOptions {
   val STREAMING_CHECKPOINT_IDENTIFIER: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.checkpoint.identifier")
     .defaultValue("default_single_writer")
+    .markAdvanced()
     .sinceVersion("0.13.0")
     .withDocumentation("A stream identifier used for HUDI to fetch the right checkpoint(`batch id` to be more specific) "
       + "corresponding this writer. Please note that keep the identifier an unique value for different writer "
@@ -464,9 +488,10 @@ object DataSourceWriteOptions {
   val META_SYNC_CLIENT_TOOL_CLASS_NAME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.meta.sync.client.tool.class")
     .defaultValue(classOf[HiveSyncTool].getName)
+    .markAdvanced()
     .withDocumentation("Sync tool class name used to sync to metastore. Defaults to Hive.")
 
-  val RECONCILE_SCHEMA: ConfigProperty[Boolean] = HoodieCommonConfig.RECONCILE_SCHEMA
+  val RECONCILE_SCHEMA: ConfigProperty[Boolean] = HoodieCommonConfig.RECONCILE_SCHEMA.markAdvanced()
 
   // HIVE SYNC SPECIFIC CONFIGS
   // NOTE: DO NOT USE uppercase for the keys as they are internally lower-cased. Using upper-cases causes
@@ -543,6 +568,7 @@ object DataSourceWriteOptions {
   val ASYNC_COMPACT_ENABLE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.compaction.async.enable")
     .defaultValue("true")
+    .markAdvanced()
     .withDocumentation("Controls whether async compaction should be turned on for MOR table writing.")
 
   val INLINE_CLUSTERING_ENABLE = HoodieClusteringConfig.INLINE_CLUSTERING
@@ -552,10 +578,11 @@ object DataSourceWriteOptions {
   val KAFKA_AVRO_VALUE_DESERIALIZER_CLASS: ConfigProperty[String] = ConfigProperty
     .key("hoodie.deltastreamer.source.kafka.value.deserializer.class")
     .defaultValue("io.confluent.kafka.serializers.KafkaAvroDeserializer")
+    .markAdvanced()
     .sinceVersion("0.9.0")
     .withDocumentation("This class is used by kafka client to deserialize the records")
 
-  val DROP_PARTITION_COLUMNS: ConfigProperty[Boolean] = HoodieTableConfig.DROP_PARTITION_COLUMNS
+  val DROP_PARTITION_COLUMNS: ConfigProperty[Boolean] = HoodieTableConfig.DROP_PARTITION_COLUMNS.markAdvanced()
 
   /** @deprecated Use {@link HIVE_ASSUME_DATE_PARTITION} and its methods instead */
   @Deprecated

--- a/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncConfig.java
+++ b/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncConfig.java
@@ -37,76 +37,91 @@ public class AdbSyncConfig extends HiveSyncConfig {
   public static final ConfigProperty<String> ADB_SYNC_USER = ConfigProperty
       .key("hoodie.datasource.adb.sync.username")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("ADB username");
 
   public static final ConfigProperty<String> ADB_SYNC_PASS = ConfigProperty
       .key("hoodie.datasource.adb.sync.password")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("ADB user password");
 
   public static final ConfigProperty<String> ADB_SYNC_JDBC_URL = ConfigProperty
       .key("hoodie.datasource.adb.sync.jdbc_url")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Adb jdbc connect url");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_SKIP_RO_SUFFIX = ConfigProperty
       .key("hoodie.datasource.adb.sync.skip_ro_suffix")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether skip the `_ro` suffix for read optimized table when syncing");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_SKIP_RT_SYNC = ConfigProperty
       .key("hoodie.datasource.adb.sync.skip_rt_sync")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether skip the rt table when syncing");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_USE_HIVE_STYLE_PARTITIONING = ConfigProperty
       .key("hoodie.datasource.adb.sync.hive_style_partitioning")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether use hive style partitioning, true if like the following style: field1=value1/field2=value2");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_SUPPORT_TIMESTAMP = ConfigProperty
       .key("hoodie.datasource.adb.sync.support_timestamp")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("If true, converts int64(timestamp_micros) to timestamp type");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_SYNC_AS_SPARK_DATA_SOURCE_TABLE = ConfigProperty
       .key("hoodie.datasource.adb.sync.sync_as_spark_datasource")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether sync this table as spark data source table");
 
   public static final ConfigProperty<String> ADB_SYNC_TABLE_PROPERTIES = ConfigProperty
       .key("hoodie.datasource.adb.sync.table_properties")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Table properties, to support read hoodie table as datasource table");
 
   public static final ConfigProperty<String> ADB_SYNC_SERDE_PROPERTIES = ConfigProperty
       .key("hoodie.datasource.adb.sync.serde_properties")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Serde properties, to support read hoodie table as datasource table");
 
   public static final ConfigProperty<Integer> ADB_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD = ConfigProperty
       .key("hoodie.datasource.adb.sync.schema_string_length_threshold")
       .defaultValue(4000)
+      .markAdvanced()
       .withDocumentation("The maximum length allowed in a single cell when storing additional schema information in Hive's metastore");
 
   public static final ConfigProperty<String> ADB_SYNC_DB_LOCATION = ConfigProperty
       .key("hoodie.datasource.adb.sync.db_location")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Database location");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_AUTO_CREATE_DATABASE = ConfigProperty
       .key("hoodie.datasource.adb.sync.auto_create_database")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether auto create adb database");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_SKIP_LAST_COMMIT_TIME_SYNC = ConfigProperty
       .key("hoodie.datasource.adb.sync.skip_last_commit_time_sync")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether skip last commit time syncing");
 
   public static final ConfigProperty<Boolean> ADB_SYNC_DROP_TABLE_BEFORE_CREATION = ConfigProperty
       .key("hoodie.datasource.adb.sync.drop_table_before_creation")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether drop table before creation");
 
   public AdbSyncConfig(Properties props) {

--- a/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
+++ b/hudi-sync/hudi-datahub-sync/src/main/java/org/apache/hudi/sync/datahub/config/DataHubSyncConfig.java
@@ -46,32 +46,38 @@ public class DataHubSyncConfig extends HoodieSyncConfig {
   public static final ConfigProperty<String> META_SYNC_DATAHUB_DATASET_IDENTIFIER_CLASS = ConfigProperty
       .key("hoodie.meta.sync.datahub.dataset.identifier.class")
       .defaultValue(HoodieDataHubDatasetIdentifier.class.getName())
+      .markAdvanced()
       .withDocumentation("Pluggable class to help provide info to identify a DataHub Dataset.");
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_EMITTER_SERVER = ConfigProperty
       .key("hoodie.meta.sync.datahub.emitter.server")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Server URL of the DataHub instance.");
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_EMITTER_TOKEN = ConfigProperty
       .key("hoodie.meta.sync.datahub.emitter.token")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Auth token to connect to the DataHub instance.");
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_EMITTER_SUPPLIER_CLASS = ConfigProperty
       .key("hoodie.meta.sync.datahub.emitter.supplier.class")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Pluggable class to supply a DataHub REST emitter to connect to the DataHub instance. This overwrites other emitter configs.");
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_DATAPLATFORM_NAME = ConfigProperty
       .key("hoodie.meta.sync.datahub.dataplatform.name")
       .defaultValue(DEFAULT_HOODIE_DATAHUB_PLATFORM_NAME)
+      .markAdvanced()
       .withDocumentation("String used to represent Hudi when creating its corresponding DataPlatform entity "
           + "within Datahub");
 
   public static final ConfigProperty<String> META_SYNC_DATAHUB_DATASET_ENV = ConfigProperty
       .key("hoodie.meta.sync.datahub.dataset.env")
       .defaultValue(DEFAULT_DATAHUB_ENV.name())
+      .markAdvanced()
       .withDocumentation("Environment to use when pushing entities to Datahub");
 
   public final HoodieDataHubDatasetIdentifier datasetIdentifier;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -77,11 +77,13 @@ public class HiveSyncConfig extends HoodieSyncConfig {
   public static final ConfigProperty<Boolean> HIVE_SYNC_FILTER_PUSHDOWN_ENABLED = ConfigProperty
       .key("hoodie.datasource.hive_sync.filter_pushdown_enabled")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether to enable push down partitions by filter");
 
   public static final ConfigProperty<Integer> HIVE_SYNC_FILTER_PUSHDOWN_MAX_SIZE = ConfigProperty
       .key("hoodie.datasource.hive_sync.filter_pushdown_max_size")
       .defaultValue(1000)
+      .markAdvanced()
       .withDocumentation("Max size limit to push down partition filters, if the estimate push down "
           + "filters exceed this size, will directly try to fetch all partitions");
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -38,10 +38,12 @@ public class HiveSyncConfigHolder {
   public static final ConfigProperty<String> HIVE_USER = ConfigProperty
       .key("hoodie.datasource.hive_sync.username")
       .defaultValue("hive")
+      .markAdvanced()
       .withDocumentation("hive user name to use");
   public static final ConfigProperty<String> HIVE_PASS = ConfigProperty
       .key("hoodie.datasource.hive_sync.password")
       .defaultValue("hive")
+      .markAdvanced()
       .withDocumentation("hive password to use");
   public static final ConfigProperty<String> HIVE_URL = ConfigProperty
       .key("hoodie.datasource.hive_sync.jdbcurl")
@@ -50,6 +52,7 @@ public class HiveSyncConfigHolder {
   public static final ConfigProperty<String> HIVE_USE_PRE_APACHE_INPUT_FORMAT = ConfigProperty
       .key("hoodie.datasource.hive_sync.use_pre_apache_input_format")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Flag to choose InputFormat under com.uber.hoodie package instead of org.apache.hudi package. "
           + "Use this when you are in the process of migrating from "
           + "com.uber.hoodie to org.apache.hudi. Stop using this after you migrated the table definition to org.apache.hudi input format");
@@ -60,6 +63,7 @@ public class HiveSyncConfigHolder {
   public static final ConfigProperty<String> HIVE_USE_JDBC = ConfigProperty
       .key("hoodie.datasource.hive_sync.use_jdbc")
       .defaultValue("true")
+      .markAdvanced()
       .deprecatedAfter("0.9.0")
       .withDocumentation("Use JDBC when hive synchronization is enabled");
   public static final ConfigProperty<String> METASTORE_URIS = ConfigProperty
@@ -69,49 +73,60 @@ public class HiveSyncConfigHolder {
   public static final ConfigProperty<String> HIVE_AUTO_CREATE_DATABASE = ConfigProperty
       .key("hoodie.datasource.hive_sync.auto_create_database")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("Auto create hive database if does not exists");
   public static final ConfigProperty<String> HIVE_IGNORE_EXCEPTIONS = ConfigProperty
       .key("hoodie.datasource.hive_sync.ignore_exceptions")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Ignore exceptions when syncing with Hive.");
   public static final ConfigProperty<String> HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE = ConfigProperty
       .key("hoodie.datasource.hive_sync.skip_ro_suffix")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Skip the _ro suffix for Read optimized table, when registering");
   public static final ConfigProperty<String> HIVE_SUPPORT_TIMESTAMP_TYPE = ConfigProperty
       .key("hoodie.datasource.hive_sync.support_timestamp")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("‘INT64’ with original type TIMESTAMP_MICROS is converted to hive ‘timestamp’ type. "
           + "Disabled by default for backward compatibility.");
   public static final ConfigProperty<String> HIVE_TABLE_PROPERTIES = ConfigProperty
       .key("hoodie.datasource.hive_sync.table_properties")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Additional properties to store with table.");
   public static final ConfigProperty<String> HIVE_TABLE_SERDE_PROPERTIES = ConfigProperty
       .key("hoodie.datasource.hive_sync.serde_properties")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Serde properties to hive table.");
   public static final ConfigProperty<String> HIVE_SYNC_AS_DATA_SOURCE_TABLE = ConfigProperty
       .key("hoodie.datasource.hive_sync.sync_as_datasource")
       .defaultValue("true")
+      .markAdvanced()
       .withDocumentation("");
   public static final ConfigProperty<Integer> HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD = ConfigProperty
       .key("hoodie.datasource.hive_sync.schema_string_length_thresh")
       .defaultValue(4000)
+      .markAdvanced()
       .withDocumentation("");
   // Create table as managed table
   public static final ConfigProperty<Boolean> HIVE_CREATE_MANAGED_TABLE = ConfigProperty
       .key("hoodie.datasource.hive_sync.create_managed_table")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether to sync the table as managed table.");
   public static final ConfigProperty<Boolean> HIVE_SYNC_OMIT_METADATA_FIELDS = ConfigProperty
       .key("hoodie.datasource.hive_sync.omit_metadata_fields")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Whether to omit the hoodie metadata fields in the target table.");
   public static final ConfigProperty<Integer> HIVE_BATCH_SYNC_PARTITION_NUM = ConfigProperty
       .key("hoodie.datasource.hive_sync.batch_num")
       .defaultValue(1000)
+      .markAdvanced()
       .withDocumentation("The number of partitions one batch when synchronous partitions to hive.");
   public static final ConfigProperty<String> HIVE_SYNC_MODE = ConfigProperty
       .key("hoodie.datasource.hive_sync.mode")
@@ -120,21 +135,25 @@ public class HiveSyncConfigHolder {
   public static final ConfigProperty<Boolean> HIVE_SYNC_BUCKET_SYNC = ConfigProperty
       .key("hoodie.datasource.hive_sync.bucket_sync")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether sync hive metastore bucket specification when using bucket index."
           + "The specification is 'CLUSTERED BY (trace_id) SORTED BY (trace_id ASC) INTO 65536 BUCKETS'");
   public static final ConfigProperty<String> HIVE_SYNC_BUCKET_SYNC_SPEC = ConfigProperty
       .key("hoodie.datasource.hive_sync.bucket_sync_spec")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("The hive metastore bucket specification when using bucket index."
           + "The specification is 'CLUSTERED BY (trace_id) SORTED BY (trace_id ASC) INTO 65536 BUCKETS'");
   public static final ConfigProperty<String> HIVE_SYNC_COMMENT = ConfigProperty
       .key("hoodie.datasource.hive_sync.sync_comment")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("Whether to sync the table column comments while syncing the table.");
 
   public static final ConfigProperty<String> HIVE_SYNC_TABLE_STRATEGY = ConfigProperty
       .key("hoodie.datasource.hive_sync.table.strategy")
       .defaultValue(HoodieSyncTableStrategy.ALL.name())
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("Hive table synchronization strategy. Available option: ONLY_RO, ONLY_RT, ALL.");
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/replication/GlobalHiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/replication/GlobalHiveSyncConfig.java
@@ -41,6 +41,7 @@ public class GlobalHiveSyncConfig extends HiveSyncConfig {
   public static final ConfigProperty<String> META_SYNC_GLOBAL_REPLICATE_TIMESTAMP = ConfigProperty
       .key("hoodie.meta_sync.global.replicate.timestamp")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("");
 
   public GlobalHiveSyncConfig(Properties props, Configuration hadoopConf) {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -67,6 +67,7 @@ public class HoodieSyncConfig extends HoodieConfig {
   public static final ConfigProperty<String> META_SYNC_BASE_PATH = ConfigProperty
       .key("hoodie.datasource.meta.sync.base.path")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("Base path of the hoodie table to sync");
 
   public static final ConfigProperty<String> META_SYNC_ENABLED = ConfigProperty
@@ -79,6 +80,7 @@ public class HoodieSyncConfig extends HoodieConfig {
       .key("hoodie.datasource.hive_sync.database")
       .defaultValue("default")
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(DATABASE_NAME)))
+      .markAdvanced()
       .withDocumentation("The name of the destination database that we should sync the hudi table to.");
 
   public static final ConfigProperty<String> META_SYNC_TABLE_NAME = ConfigProperty
@@ -86,12 +88,14 @@ public class HoodieSyncConfig extends HoodieConfig {
       .defaultValue("unknown")
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HOODIE_TABLE_NAME_KEY))
           .or(() -> Option.ofNullable(cfg.getString(HOODIE_WRITE_TABLE_NAME_KEY))))
+      .markAdvanced()
       .withDocumentation("The name of the destination table that we should sync the hudi table to.");
 
   public static final ConfigProperty<String> META_SYNC_BASE_FILE_FORMAT = ConfigProperty
       .key("hoodie.datasource.hive_sync.base_file_format")
       .defaultValue("PARQUET")
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(BASE_FILE_FORMAT)))
+      .markAdvanced()
       .withDocumentation("Base file format for the sync.");
 
   public static final ConfigProperty<String> META_SYNC_PARTITION_FIELDS = ConfigProperty
@@ -99,6 +103,7 @@ public class HoodieSyncConfig extends HoodieConfig {
       .defaultValue("")
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HoodieTableConfig.PARTITION_FIELDS))
           .or(() -> Option.ofNullable(cfg.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME))))
+      .markAdvanced()
       .withDocumentation("Field in the table to use for determining hive partition columns.");
 
   public static final ConfigProperty<String> META_SYNC_PARTITION_EXTRACTOR_CLASS = ConfigProperty
@@ -132,6 +137,7 @@ public class HoodieSyncConfig extends HoodieConfig {
           return Option.of("org.apache.hudi.hive.NonPartitionedExtractor");
         }
       })
+      .markAdvanced()
       .withDocumentation("Class which implements PartitionValueExtractor to extract the partition values, "
           + "default 'org.apache.hudi.hive.MultiPartKeysValueExtractor'.");
 
@@ -139,28 +145,33 @@ public class HoodieSyncConfig extends HoodieConfig {
       .key("hoodie.datasource.hive_sync.assume_date_partitioning")
       .defaultValue(HoodieMetadataConfig.ASSUME_DATE_PARTITIONING.defaultValue())
       .withInferFunction(cfg -> Option.ofNullable(cfg.getString(HoodieMetadataConfig.ASSUME_DATE_PARTITIONING)))
+      .markAdvanced()
       .withDocumentation("Assume partitioning is yyyy/MM/dd");
 
   public static final ConfigProperty<Boolean> META_SYNC_DECODE_PARTITION = ConfigProperty
       .key("hoodie.meta.sync.decode_partition")
       .defaultValue(false)
       .withInferFunction(cfg -> Option.ofNullable(cfg.getBoolean(URL_ENCODE_PARTITIONING)))
+      .markAdvanced()
       .withDocumentation("If true, meta sync will url-decode the partition path, as it is deemed as url-encoded. Default to false.");
 
   public static final ConfigProperty<Boolean> META_SYNC_USE_FILE_LISTING_FROM_METADATA = ConfigProperty
       .key("hoodie.meta.sync.metadata_file_listing")
       .defaultValue(DEFAULT_METADATA_ENABLE_FOR_READERS)
       .withInferFunction(cfg -> Option.of(cfg.getBooleanOrDefault(HoodieMetadataConfig.ENABLE, DEFAULT_METADATA_ENABLE_FOR_READERS)))
+      .markAdvanced()
       .withDocumentation("Enable the internal metadata table for file listing for syncing with metastores");
 
   public static final ConfigProperty<String> META_SYNC_CONDITIONAL_SYNC = ConfigProperty
       .key("hoodie.datasource.meta_sync.condition.sync")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("If true, only sync on conditions like schema change or partition change.");
 
   public static final ConfigProperty<String> META_SYNC_SPARK_VERSION = ConfigProperty
       .key("hoodie.meta_sync.spark.version")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("The spark version used when syncing with a metastore.");
 
   private Configuration hadoopConf;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallbackConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallbackConfig.java
@@ -36,18 +36,21 @@ public class HoodieWriteCommitKafkaCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<String> BOOTSTRAP_SERVERS = ConfigProperty
       .key(CALLBACK_PREFIX + "kafka.bootstrap.servers")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Bootstrap servers of kafka cluster, to be used for publishing commit metadata.");
 
   public static final ConfigProperty<String> TOPIC = ConfigProperty
       .key(CALLBACK_PREFIX + "kafka.topic")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Kafka topic name to publish timeline activity into.");
 
   public static final ConfigProperty<String> PARTITION = ConfigProperty
       .key(CALLBACK_PREFIX + "kafka.partition")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("It may be desirable to serialize all changes into a single Kafka partition "
           + " for providing strict ordering. By default, Kafka messages are keyed by table name, which "
@@ -56,12 +59,14 @@ public class HoodieWriteCommitKafkaCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<String> ACKS = ConfigProperty
       .key(CALLBACK_PREFIX + "kafka.acks")
       .defaultValue("all")
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("kafka acks level, all by default to ensure strong durability.");
 
   public static final ConfigProperty<Integer> RETRIES = ConfigProperty
       .key(CALLBACK_PREFIX + "kafka.retries")
       .defaultValue(3)
+      .markAdvanced()
       .sinceVersion("0.7.0")
       .withDocumentation("Times to retry the produce. 3 by default");
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/pulsar/HoodieWriteCommitPulsarCallbackConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/pulsar/HoodieWriteCommitPulsarCallbackConfig.java
@@ -36,36 +36,42 @@ public class HoodieWriteCommitPulsarCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<String> BROKER_SERVICE_URL = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.broker.service.url")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Server's url of pulsar cluster, to be used for publishing commit metadata.");
 
   public static final ConfigProperty<String> TOPIC = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.topic")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("pulsar topic name to publish timeline activity into.");
 
   public static final ConfigProperty<String> PRODUCER_ROUTE_MODE = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.producer.route-mode")
       .defaultValue("RoundRobinPartition")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Message routing logic for producers on partitioned topics.");
 
   public static final ConfigProperty<Integer> PRODUCER_PENDING_QUEUE_SIZE = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.producer.pending-queue-size")
       .defaultValue(1000)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("The maximum size of a queue holding pending messages.");
 
   public static final ConfigProperty<Integer> PRODUCER_PENDING_SIZE = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.producer.pending-total-size")
       .defaultValue(50000)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("The maximum number of pending messages across partitions.");
 
   public static final ConfigProperty<Boolean> PRODUCER_BLOCK_QUEUE_FULL = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.producer.block-if-queue-full")
       .defaultValue(true)
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("When the queue is full, the method is blocked "
           + "instead of an exception is thrown.");
@@ -73,18 +79,21 @@ public class HoodieWriteCommitPulsarCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<String> PRODUCER_SEND_TIMEOUT = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.producer.send-timeout")
       .defaultValue("30s")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("The timeout in each sending to pulsar.");
 
   public static final ConfigProperty<String> OPERATION_TIMEOUT = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.operation-timeout")
       .defaultValue("30s")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Duration of waiting for completing an operation.");
 
   public static final ConfigProperty<String> CONNECTION_TIMEOUT = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.connection-timeout")
       .defaultValue("10s")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Duration of waiting for a connection to a "
           + "broker to be established.");
@@ -92,12 +101,14 @@ public class HoodieWriteCommitPulsarCallbackConfig extends HoodieConfig {
   public static final ConfigProperty<String> REQUEST_TIMEOUT = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.request-timeout")
       .defaultValue("60s")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Duration of waiting for completing a request.");
 
   public static final ConfigProperty<String> KEEPALIVE_INTERVAL = ConfigProperty
       .key(CALLBACK_PREFIX + "pulsar.keepalive-interval")
       .defaultValue("30s")
+      .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Duration of keeping alive interval for each "
           + "client broker connection.");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -48,47 +48,56 @@ public class CloudSourceConfig extends HoodieConfig {
        *      which is 512KB as per Google's docs. See: https://cloud.google.com/pubsub/quotas#resource_limits
        */
       .defaultValue(10)
+      .markAdvanced()
       .withDocumentation("Number of metadata messages to pull at a time");
 
   public static final ConfigProperty<Boolean> ACK_MESSAGES = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.meta.ack")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("Whether to acknowledge Metadata messages during Cloud Ingestion or not. This is useful during dev and testing.\n "
           + "In Prod this should always be true. In case of Cloud Pubsub, not acknowledging means Pubsub will keep redelivering the same messages.");
 
   public static final ConfigProperty<Boolean> ENABLE_EXISTS_CHECK = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.check.file.exists")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("If true, checks whether file exists before attempting to pull it");
 
   public static final ConfigProperty<String> SELECT_RELATIVE_PATH_PREFIX = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.select.relpath.prefix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Only selects objects in the bucket whose relative path matches this prefix");
 
   public static final ConfigProperty<String> IGNORE_RELATIVE_PATH_PREFIX = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.ignore.relpath.prefix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Ignore objects in the bucket whose relative path matches this prefix");
 
   public static final ConfigProperty<String> IGNORE_RELATIVE_PATH_SUBSTR = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.ignore.relpath.substring")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Ignore objects in the bucket whose relative path contains this substring");
 
   public static final ConfigProperty<String> SPARK_DATASOURCE_OPTIONS = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.datasource.options")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("A JSON string passed to the Spark DataFrameReader while loading the dataset. "
           + "Example: hoodie.deltastreamer.gcp.spark.datasource.options={\"header\":\"true\",\"encoding\":\"UTF-8\"}\n");
 
   public static final ConfigProperty<String> CLOUD_DATAFILE_EXTENSION = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.select.file.extension")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Only match files with this extension. By default, this is the same as hoodie.deltastreamer.source.hoodieincr.file.format");
 
   public static final ConfigProperty<String> DATAFILE_FORMAT = ConfigProperty
       .key("hoodie.deltastreamer.source.cloud.data.datafile.format")
       .defaultValue("parquet")
+      .markAdvanced()
       .withDocumentation("Format of the data file. By default, this will be the same as hoodie.deltastreamer.source.hoodieincr.file.format");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DFSPathSelectorConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DFSPathSelectorConfig.java
@@ -39,6 +39,7 @@ public class DFSPathSelectorConfig extends HoodieConfig {
   public static final ConfigProperty<String> SOURCE_INPUT_SELECTOR = ConfigProperty
       .key("hoodie.deltastreamer.source.input.selector")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Source input selector");
 
   public static final ConfigProperty<String> ROOT_INPUT_PATH = ConfigProperty

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DatePartitionPathSelectorConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DatePartitionPathSelectorConfig.java
@@ -40,25 +40,30 @@ public class DatePartitionPathSelectorConfig extends HoodieConfig {
   public static final ConfigProperty<String> DATE_FORMAT = ConfigProperty
       .key("hoodie.deltastreamer.source.dfs.datepartitioned.date.format")
       .defaultValue("yyyy-MM-dd")
+      .markAdvanced()
       .withDocumentation("Date format.");
 
   public static final ConfigProperty<Integer> DATE_PARTITION_DEPTH = ConfigProperty
       .key("hoodie.deltastreamer.source.dfs.datepartitioned.selector.depth")
       .defaultValue(0)
+      .markAdvanced()
       .withDocumentation("Depth of the files to scan. 0 implies no (date) partition.");
 
   public static final ConfigProperty<Integer> LOOKBACK_DAYS = ConfigProperty
       .key("hoodie.deltastreamer.source.dfs.datepartitioned.selector.lookback.days")
       .defaultValue(2)
+      .markAdvanced()
       .withDocumentation("The maximum look-back days for scanning.");
 
   public static final ConfigProperty<String> CURRENT_DATE = ConfigProperty
       .key("hoodie.deltastreamer.source.dfs.datepartitioned.selector.currentdate")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Current date.");
 
   public static final ConfigProperty<Integer> PARTITIONS_LIST_PARALLELISM = ConfigProperty
       .key("hoodie.deltastreamer.source.dfs.datepartitioned.selector.parallelism")
       .defaultValue(20)
+      .markAdvanced()
       .withDocumentation("Parallelism for listing partitions.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/GCSEventsSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/GCSEventsSourceConfig.java
@@ -39,10 +39,12 @@ public class GCSEventsSourceConfig extends HoodieConfig {
   public static final ConfigProperty<String> GOOGLE_PROJECT_ID = ConfigProperty
       .key("hoodie.deltastreamer.source.gcs.project.id")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The GCP Project Id where the Pubsub Subscription to ingest from resides. Needed to connect to the Pubsub subscription");
 
   public static final ConfigProperty<String> PUBSUB_SUBSCRIPTION_ID = ConfigProperty
       .key("hoodie.deltastreamer.source.gcs.subscription.id")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The GCP Pubsub subscription id for the GCS Notifications. Needed to connect to the Pubsub subscription");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HiveIncrPullSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HiveIncrPullSourceConfig.java
@@ -40,5 +40,6 @@ public class HiveIncrPullSourceConfig extends HoodieConfig {
   public static final ConfigProperty<String> ROOT_INPUT_PATH = ConfigProperty
       .key("hoodie.deltastreamer.source.incrpull.root")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The root path of Hive incremental pulling source.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HiveSchemaProviderConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HiveSchemaProviderConfig.java
@@ -40,20 +40,24 @@ public class HiveSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<String> SOURCE_SCHEMA_DATABASE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.hive.database")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Hive database from where source schema can be fetched");
 
   public static final ConfigProperty<String> SOURCE_SCHEMA_TABLE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.hive.table")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Hive table from where source schema can be fetched");
 
   public static final ConfigProperty<String> TARGET_SCHEMA_DATABASE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "target.schema.hive.database")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Hive database from where target schema can be fetched");
 
   public static final ConfigProperty<String> TARGET_SCHEMA_TABLE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "target.schema.hive.table")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Hive table from where target schema can be fetched");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieDeltaStreamerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieDeltaStreamerConfig.java
@@ -41,6 +41,7 @@ public class HoodieDeltaStreamerConfig extends HoodieConfig {
   public static final ConfigProperty<String> CHECKPOINT_PROVIDER_PATH = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "checkpoint.provider.path")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The path for providing the checkpoints.");
 
   public static final ConfigProperty<String> KAFKA_TOPIC = ConfigProperty
@@ -51,6 +52,7 @@ public class HoodieDeltaStreamerConfig extends HoodieConfig {
   public static final ConfigProperty<String> KAFKA_APPEND_OFFSETS = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "source.kafka.append.offsets")
       .defaultValue("false")
+      .markAdvanced()
       .withDocumentation("When enabled, appends kafka offset info like source offset(_hoodie_kafka_source_offset), "
           + "partition (_hoodie_kafka_source_partition) and timestamp (_hoodie_kafka_source_timestamp) to the records. "
           + "By default its disabled and no kafka offsets are added");
@@ -58,6 +60,7 @@ public class HoodieDeltaStreamerConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> SANITIZE_SCHEMA_FIELD_NAMES = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "source.sanitize.invalid.schema.field.names")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Sanitizes names of invalid schema fields both in the data read from source and also in the schema "
           + "Replaces invalid characters with hoodie.deltastreamer.source.sanitize.invalid.char.mask. Invalid characters are by "
           + "goes by avro naming convention (https://avro.apache.org/docs/current/spec.html#names).");
@@ -65,12 +68,14 @@ public class HoodieDeltaStreamerConfig extends HoodieConfig {
   public static final ConfigProperty<String> SCHEMA_FIELD_NAME_INVALID_CHAR_MASK = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "source.sanitize.invalid.char.mask")
       .defaultValue("__")
+      .markAdvanced()
       .withDocumentation("Defines the character sequence that replaces invalid characters in schema field names if "
           + "hoodie.deltastreamer.source.sanitize.invalid.schema.field.names is enabled.");
 
   public static final ConfigProperty<String> MUTLI_WRITER_SOURCE_CHECKPOINT_ID = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "multiwriter.source.checkpoint.id")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Unique Id to be used for multiwriter deltastreamer scenario. This is the "
           + "scenario when multiple deltastreamers are used to write to the same target table. If you are just using "
           + "a single deltastreamer for a table then you do not need to set this config.");
@@ -78,11 +83,13 @@ public class HoodieDeltaStreamerConfig extends HoodieConfig {
   public static final ConfigProperty<String> TABLES_TO_BE_INGESTED = ConfigProperty
       .key(INGESTION_PREFIX + "tablesToBeIngested")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Comma separated names of tables to be ingested in the format <database>.<table>, for example db1.table1,db1.table2");
 
   public static final ConfigProperty<String> TARGET_BASE_PATH = ConfigProperty
       .key(INGESTION_PREFIX + "targetBasePath")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The path to which a particular table is ingested. The config is specific to HoodieMultiTableDeltaStreamer"
           + " and overrides path determined using option `--base-path-prefix` for a table. This config is ignored for a single"
           + " table deltastreamer");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieIncrSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieIncrSourceConfig.java
@@ -49,38 +49,45 @@ public class HoodieIncrSourceConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> NUM_INSTANTS_PER_FETCH = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.num_instants")
       .defaultValue(5)
+      .markAdvanced()
       .withDocumentation("Max number of instants whose changes can be incrementally fetched");
 
   @Deprecated
   public static final ConfigProperty<Boolean> READ_LATEST_INSTANT_ON_MISSING_CKPT = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.read_latest_on_missing_ckpt")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("If true, allows delta-streamer to incrementally fetch from latest committed instant when checkpoint is not provided. "
           + "This config is deprecated. Please refer to hoodie.deltastreamer.source.hoodieincr.missing.checkpoint.strategy");
 
   public static final ConfigProperty<String> MISSING_CHECKPOINT_STRATEGY = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.missing.checkpoint.strategy")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Allows delta-streamer to decide the instant to consume from when checkpoint is not set.\n"
           + " Possible values: " + Arrays.toString(IncrSourceHelper.MissingCheckpointStrategy.values()));
 
   public static final ConfigProperty<String> SOURCE_FILE_FORMAT = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.file.format")
       .defaultValue("parquet")
+      .markAdvanced()
       .withDocumentation("This config is passed to the reader while loading dataset. Default value is parquet.");
 
   public static final ConfigProperty<Boolean> HOODIE_DROP_ALL_META_FIELDS_FROM_SOURCE = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.drop.all.meta.fields.from.source")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Drops all meta fields from the source hudi table while ingesting into sink hudi table.");
 
   public static final ConfigProperty<String> HOODIE_SRC_PARTITION_FIELDS = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.partition.fields")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Specifies partition fields that needs to be added to source table after parsing _hoodie_partition_path.");
 
   public static final ConfigProperty<String> HOODIE_SRC_PARTITION_EXTRACTORCLASS = ConfigProperty
       .key("hoodie.deltastreamer.source.hoodieincr.partition.extractor.class")
       .noDefaultValue(SlashEncodedDayPartitionValueExtractor.class.getCanonicalName())
+      .markAdvanced()
       .withDocumentation("PartitionValueExtractor class to extract partition fields from _hoodie_partition_path");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieSchemaProviderConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieSchemaProviderConfig.java
@@ -53,30 +53,36 @@ public class HoodieSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<String> SCHEMA_CONVERTER = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "registry.schemaconverter")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The class name of the custom schema converter to use.");
 
   public static final ConfigProperty<Boolean> SPARK_AVRO_POST_PROCESSOR_ENABLE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "spark_avro_post_processor.enable")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Whether to enable Spark Avro post processor.");
 
   public static final ConfigProperty<String> SCHEMA_REGISTRY_BASE_URL = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "registry.baseUrl")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The base URL of the schema registry.");
 
   public static final ConfigProperty<String> SCHEMA_REGISTRY_URL_SUFFIX = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "registry.urlSuffix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The suffix of the URL for the schema registry.");
 
   public static final ConfigProperty<String> SCHEMA_REGISTRY_SOURCE_URL_SUFFIX = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "registry.sourceUrlSuffix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The source URL suffix.");
 
   public static final ConfigProperty<String> SCHEMA_REGISTRY_TARGET_URL_SUFFIX = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "registry.targetUrlSuffix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The target URL suffix.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/JdbcSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/JdbcSourceConfig.java
@@ -39,55 +39,66 @@ public class JdbcSourceConfig extends HoodieConfig {
   public static final ConfigProperty<String> URL = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.url")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("JDBC url for the Hoodie datasource.");
 
   public static final ConfigProperty<String> USER = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.user")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Username used for JDBC connection");
 
   public static final ConfigProperty<String> PASSWORD = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.password")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Password used for JDBC connection");
 
   public static final ConfigProperty<String> PASSWORD_FILE = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.password.file")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Base-path for the JDBC password file.");
 
   public static final ConfigProperty<String> DRIVER_CLASS = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.driver.class")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Driver class used for JDBC connection");
 
   public static final ConfigProperty<String> RDBMS_TABLE_NAME = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.table.name")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("RDBMS table to pull");
 
   public static final ConfigProperty<String> INCREMENTAL_COLUMN = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.table.incr.column.name")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("If run in incremental mode, this field is to pull new data incrementally");
 
   public static final ConfigProperty<String> IS_INCREMENTAL = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.incr.pull")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Will the JDBC source do an incremental pull?");
 
   public static final ConfigProperty<String> EXTRA_OPTIONS = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.extra.options.")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Used to set any extra options the user specifies for jdbc");
 
   public static final ConfigProperty<String> STORAGE_LEVEL = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.storage.level")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Used to control the persistence level. Default value: MEMORY_AND_DISK_SER");
 
   public static final ConfigProperty<String> FALLBACK_TO_FULL_FETCH = ConfigProperty
       .key("hoodie.deltastreamer.jdbc.incr.fallback.to.full.fetch")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("If set true, makes incremental fetch to fallback to full fetch in case of any error");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/JdbcbasedSchemaProviderConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/JdbcbasedSchemaProviderConfig.java
@@ -40,32 +40,38 @@ public class JdbcbasedSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_CONNECTION_URL = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.connection.url")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The JDBC URL to connect to. The source-specific connection properties may be specified in the URL."
           + " e.g., jdbc:postgresql://localhost/test?user=fred&password=secret");
 
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_DRIVER_TYPE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.driver.type")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The class name of the JDBC driver to use to connect to this URL. e.g. org.h2.Driver");
 
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_USERNAME = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.username")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Username for the connection e.g. fred");
 
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_PASSWORD = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.password")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Password for the connection e.g. secret");
 
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_DBTABLE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.dbtable")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The table with the schema to reference e.g. test_database.test1_table or test1_table");
 
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_TIMEOUT = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.timeout")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The number of seconds the driver will wait for a Statement object to execute. Zero means there is no limit. "
           + "In the write path, this option depends on how JDBC drivers implement the API setQueryTimeout, e.g., the h2 JDBC driver "
           + "checks the timeout of each query instead of an entire JDBC batch. It defaults to 0.");
@@ -73,5 +79,6 @@ public class JdbcbasedSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<String> SOURCE_SCHEMA_JDBC_NULLABLE = ConfigProperty
       .key(SCHEMAPROVIDER_CONFIG_PREFIX + "source.schema.jdbc.nullable")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("If true, all the columns are nullable.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/JsonKafkaPostProcessorConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/JsonKafkaPostProcessorConfig.java
@@ -41,28 +41,33 @@ public class JsonKafkaPostProcessorConfig extends HoodieConfig {
   public static final ConfigProperty<String> JSON_KAFKA_PROCESSOR_CLASS = ConfigProperty
       .key("hoodie.deltastreamer.source.json.kafka.processor.class")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Json kafka source post processor class name, post process data after consuming from"
           + "source and before giving it to deltastreamer.");
 
   public static final ConfigProperty<String> DATABASE_NAME_REGEX = ConfigProperty
       .key("hoodie.deltastreamer.source.json.kafka.post.processor.maxwell.database.regex")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Database name regex");
 
   public static final ConfigProperty<String> TABLE_NAME_REGEX = ConfigProperty
       .key("hoodie.deltastreamer.source.json.kafka.post.processor.maxwell.table.regex")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Table name regex");
 
   public static final ConfigProperty<String> PRECOMBINE_FIELD_TYPE = ConfigProperty
       .key("hoodie.deltastreamer.source.json.kafka.post.processor.maxwell.precombine.field.type")
       .defaultValue(DATE_STRING.toString())
+      .markAdvanced()
       .withDocumentation("Data type of the preCombine field. could be NON_TIMESTAMP, DATE_STRING,"
           + "UNIX_TIMESTAMP or EPOCHMILLISECONDS. DATE_STRING by default");
 
   public static final ConfigProperty<String> PRECOMBINE_FIELD_FORMAT = ConfigProperty
       .key("hoodie.deltastreamer.source.json.kafka.post.processor.maxwell.precombine.field.format")
       .defaultValue("yyyy-MM-dd HH:mm:ss")
+      .markAdvanced()
       .withDocumentation("When the preCombine filed is in DATE_STRING format, use should tell hoodie"
           + "what format it is. 'yyyy-MM-dd HH:mm:ss' by default");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
@@ -41,26 +41,31 @@ public class KafkaSourceConfig extends HoodieConfig {
   public static final ConfigProperty<String> KAFKA_CHECKPOINT_TYPE = ConfigProperty
       .key(PREFIX + "checkpoint.type")
       .defaultValue("string")
+      .markAdvanced()
       .withDocumentation("Kafka checkpoint type.");
 
   public static final ConfigProperty<Long> KAFKA_FETCH_PARTITION_TIME_OUT = ConfigProperty
       .key(PREFIX + "fetch_partition.time.out")
       .defaultValue(300 * 1000L)
+      .markAdvanced()
       .withDocumentation("Time out for fetching partitions. 5min by default");
 
   public static final ConfigProperty<Boolean> ENABLE_KAFKA_COMMIT_OFFSET = ConfigProperty
       .key(PREFIX + "enable.commit.offset")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Automatically submits offset to kafka.");
 
   public static final ConfigProperty<Boolean> ENABLE_FAIL_ON_DATA_LOSS = ConfigProperty
       .key(PREFIX + "enable.failOnDataLoss")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Fail when checkpoint goes out of bounds instead of seeking to earliest offsets.");
 
   public static final ConfigProperty<Long> MAX_EVENTS_FROM_KAFKA_SOURCE = ConfigProperty
       .key("hoodie.deltastreamer.kafka.source.maxEvents")
       .defaultValue(5000000L)
+      .markAdvanced()
       .withDocumentation("Maximum number of records obtained in each batch.");
 
   public static final ConfigProperty<String> KAFKA_TOPIC_NAME = ConfigProperty
@@ -72,7 +77,8 @@ public class KafkaSourceConfig extends HoodieConfig {
   public static final ConfigProperty<KafkaResetOffsetStrategies> KAFKA_AUTO_OFFSET_RESET = ConfigProperty
       .key("auto.offset.reset")
       .defaultValue(KafkaResetOffsetStrategies.LATEST)
-          .withDocumentation("Kafka consumer strategy for reading data.");
+      .markAdvanced()
+      .withDocumentation("Kafka consumer strategy for reading data.");
 
   /**
    * Kafka reset offset strategies.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ProtoClassBasedSchemaProviderConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ProtoClassBasedSchemaProviderConfig.java
@@ -42,12 +42,14 @@ public class ProtoClassBasedSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<String> PROTO_SCHEMA_CLASS_NAME = ConfigProperty
       .key(PROTO_SCHEMA_PROVIDER_PREFIX + "class.name")
       .noDefaultValue()
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The Protobuf Message class used as the source for the schema.");
 
   public static final ConfigProperty<Boolean> PROTO_SCHEMA_WRAPPED_PRIMITIVES_AS_RECORDS = ConfigProperty
       .key(PROTO_SCHEMA_PROVIDER_PREFIX + "flatten.wrappers")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("When set to true wrapped primitives like Int64Value are translated to a record with a single 'value' field. By default, the value is false and the wrapped primitives are "
           + "treated as a nullable value");
@@ -55,6 +57,7 @@ public class ProtoClassBasedSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> PROTO_SCHEMA_TIMESTAMPS_AS_RECORDS = ConfigProperty
       .key(PROTO_SCHEMA_PROVIDER_PREFIX + "timestamps.as.records")
       .defaultValue(false)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("When set to true Timestamp fields are translated to a record with a seconds and nanos field. By default, the value is false and the timestamp is converted to a long with "
           + "the timestamp-micros logical type");
@@ -62,6 +65,7 @@ public class ProtoClassBasedSchemaProviderConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> PROTO_SCHEMA_MAX_RECURSION_DEPTH = ConfigProperty
       .key(PROTO_SCHEMA_PROVIDER_PREFIX + "max.recursion.depth")
       .defaultValue(5)
+      .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The max depth to unravel the Proto schema when translating into an Avro schema. Setting this depth allows the user to convert a schema that is recursive in proto into "
           + "something that can be represented in their lake format like Parquet. After a given class has been seen N times within a single branch, the schema provider will create a record with a "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/PulsarSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/PulsarSourceConfig.java
@@ -39,6 +39,7 @@ public class PulsarSourceConfig extends HoodieConfig {
   public static final ConfigProperty<Long> PULSAR_SOURCE_MAX_RECORDS_PER_BATCH_THRESHOLD = ConfigProperty
       .key("hoodie.deltastreamer.source.pulsar.maxRecords")
       .defaultValue(5_000_000L)
+      .markAdvanced()
       .withDocumentation("Max number of records obtained in a single each batch");
 
   public static final ConfigProperty<String> PULSAR_SOURCE_TOPIC_NAME = ConfigProperty
@@ -59,6 +60,7 @@ public class PulsarSourceConfig extends HoodieConfig {
   public static final ConfigProperty<OffsetAutoResetStrategy> PULSAR_SOURCE_OFFSET_AUTO_RESET_STRATEGY = ConfigProperty
       .key("hoodie.deltastreamer.source.pulsar.offset.autoResetStrategy")
       .defaultValue(OffsetAutoResetStrategy.LATEST)
+      .markAdvanced()
       .withDocumentation("Policy determining how offsets shall be automatically reset in case there's "
           + "no checkpoint information present");
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3EventsHoodieIncrSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3EventsHoodieIncrSourceConfig.java
@@ -40,31 +40,37 @@ public class S3EventsHoodieIncrSourceConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> S3_INCR_ENABLE_EXISTS_CHECK = ConfigProperty
       .key("hoodie.deltastreamer.source.s3incr.check.file.exists")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Control whether we do existence check for files before consuming them");
 
   public static final ConfigProperty<String> S3_KEY_PREFIX = ConfigProperty
       .key("hoodie.deltastreamer.source.s3incr.key.prefix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Control whether to filter the s3 objects starting with this prefix");
 
   public static final ConfigProperty<String> S3_FS_PREFIX = ConfigProperty
       .key("hoodie.deltastreamer.source.s3incr.fs.prefix")
       .defaultValue("s3")
+      .markAdvanced()
       .withDocumentation("The file system prefix.");
 
   public static final ConfigProperty<String> S3_IGNORE_KEY_PREFIX = ConfigProperty
       .key("hoodie.deltastreamer.source.s3incr.ignore.key.prefix")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Control whether to ignore the s3 objects starting with this prefix");
 
   public static final ConfigProperty<String> S3_IGNORE_KEY_SUBSTRING = ConfigProperty
       .key("hoodie.deltastreamer.source.s3incr.ignore.key.substring")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Control whether to ignore the s3 objects with this substring");
 
   public static final ConfigProperty<String> SPARK_DATASOURCE_OPTIONS = ConfigProperty
       .key("hoodie.deltastreamer.source.s3incr.spark.datasource.options")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Json string, passed to the reader while loading dataset. Example delta streamer conf \n"
           + " --hoodie-conf hoodie.deltastreamer.source.s3incr.spark.datasource.options={\"header\":\"true\",\"encoding\":\"UTF-8\"}");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3SourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3SourceConfig.java
@@ -46,31 +46,37 @@ public class S3SourceConfig extends HoodieConfig {
   public static final ConfigProperty<String> S3_SOURCE_QUEUE_REGION = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.region")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Case-sensitive region name of the cloud provider for the queue. For example, \"us-east-1\".");
 
   public static final ConfigProperty<String> S3_SOURCE_QUEUE_FS = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.fs")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("File system corresponding to queue. For example, for AWS SQS it is s3/s3a.");
 
   public static final ConfigProperty<String> S3_QUEUE_LONG_POLL_WAIT = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.long.poll.wait")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Long poll wait time in seconds, If set as 0 then client will fetch on short poll basis.");
 
   public static final ConfigProperty<String> S3_SOURCE_QUEUE_MAX_MESSAGES_PER_BATCH = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.max.messages.per.batch")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Max messages for each batch of delta streamer run. Source will process these maximum number of message at a time.");
 
   public static final ConfigProperty<String> S3_SOURCE_QUEUE_MAX_MESSAGES_PER_REQUEST = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.max.messages.per.request")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Max messages for each request");
 
   public static final ConfigProperty<String> S3_SOURCE_QUEUE_VISIBILITY_TIMEOUT = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.visibility.timeout")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Visibility timeout for messages in queue. After we consume the message, queue will move the consumed "
           + "messages to in-flight state, these messages can't be consumed again by source for this timeout period.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/SchemaProviderPostProcessorConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/SchemaProviderPostProcessorConfig.java
@@ -41,36 +41,43 @@ public class SchemaProviderPostProcessorConfig extends HoodieConfig {
   public static final ConfigProperty<String> SCHEMA_POST_PROCESSOR = ConfigProperty
       .key(HoodieSchemaProviderConfig.SCHEMAPROVIDER_CONFIG_PREFIX + "schema_post_processor")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("The class name of the schema post processor.");
 
   public static final ConfigProperty<String> DELETE_COLUMN_POST_PROCESSOR_COLUMN = ConfigProperty
       .key(PREFIX + "delete.columns")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Columns to delete in the schema post processor.");
 
   public static final ConfigProperty<String> SCHEMA_POST_PROCESSOR_ADD_COLUMN_NAME_PROP = ConfigProperty
       .key(PREFIX + "add.column.name")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("New column's name");
 
   public static final ConfigProperty<String> SCHEMA_POST_PROCESSOR_ADD_COLUMN_TYPE_PROP = ConfigProperty
       .key(PREFIX + "add.column.type")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("New column's type");
 
   public static final ConfigProperty<Boolean> SCHEMA_POST_PROCESSOR_ADD_COLUMN_NULLABLE_PROP = ConfigProperty
       .key(PREFIX + "add.column.nullable")
       .defaultValue(true)
+      .markAdvanced()
       .withDocumentation("New column's nullable");
 
   public static final ConfigProperty<String> SCHEMA_POST_PROCESSOR_ADD_COLUMN_DEFAULT_PROP = ConfigProperty
       .key(PREFIX + "add.column.default")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("New column's default value");
 
   public static final ConfigProperty<String> SCHEMA_POST_PROCESSOR_ADD_COLUMN_DOC_PROP = ConfigProperty
       .key(PREFIX + "add.column.doc")
       .noDefaultValue()
+      .markAdvanced()
       .withDocumentation("Docs about new column");
 
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionService.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/ingestion/HoodieIngestionService.java
@@ -151,11 +151,13 @@ public abstract class HoodieIngestionService extends HoodieAsyncService {
     public static final ConfigProperty<Boolean> INGESTION_IS_CONTINUOUS = ConfigProperty
         .key("hoodie.utilities.ingestion.is.continuous")
         .defaultValue(false)
+        .markAdvanced()
         .withDocumentation("Indicate if the ingestion runs in a continuous loop.");
 
     public static final ConfigProperty<Integer> INGESTION_MIN_SYNC_INTERNAL_SECONDS = ConfigProperty
         .key("hoodie.utilities.ingestion.min.sync.internal.seconds")
         .defaultValue(0)
+        .markAdvanced()
         .withDocumentation("the minimum sync interval of each ingestion in continuous mode");
 
     public static Builder newBuilder() {


### PR DESCRIPTION
### Change Logs

This PR marks 582 additional advanced configs.  After this PR, we have 52 basic configs (8%) and 586 advanced configs (excluding Flink specific options).

Here are the configs that are going to show up in the ["Basic Configuration"](https://hudi.apache.org/docs/basic_configurations) page (other configs are marked advanced by this PR):

***Spark configs (in total, 6)***
- Spark Read Configs (3)

```
hoodie.datasource.read.begin.instanttime
hoodie.datasource.read.end.instanttime
hoodie.datasource.query.type
```
- Spark Write Configs (3)
```
hoodie.datasource.write.operation
hoodie.datasource.write.table.type
hoodie.sql.insert.mode
```

***General write and table service configs (in total, 32)***
- Clean Configs (2)
```
hoodie.clean.async
hoodie.cleaner.commits.retained
```
- Archival Configs (2)
```
hoodie.keep.max.commits
hoodie.keep.min.commits
```
- Key Generator Options (3)
```
hoodie.datasource.write.partitionpath.field
hoodie.datasource.write.recordkey.field
hoodie.datasource.write.hive_style_partitioning
```
- Storage Configs (2)
```
hoodie.parquet.compression.codec
hoodie.parquet.max.file.size
```
- Metadata Configs (3)
```
hoodie.metadata.enable
hoodie.metadata.index.bloom.filter.enable
hoodie.metadata.index.column.stats.enable
```
- Write Configurations (4)
```
hoodie.base.path 
hoodie.table.name
hoodie.datasource.write.precombine.field
hoodie.write.concurrency.mode
```
- Compaction Configs (2)
```
hoodie.compact.inline 
hoodie.compact.inline.max.delta.commits
```
- Clustering Configs (4)
```
hoodie.clustering.async.enabled
hoodie.clustering.inline
hoodie.clustering.plan.strategy.small.file.limit
hoodie.clustering.plan.strategy.target.file.max.bytes
```
- Bootstrap Configs (1)
```
hoodie.bootstrap.base.path
```
- Index Configs (1)
```
hoodie.index.type
```
- Common Metadata Sync Configs (1)
```
hoodie.datasource.meta.sync.enable
```
- Hive Sync Configs (4)
```
hoodie.datasource.hive_sync.mode
hoodie.datasource.hive_sync.enable
hoodie.datasource.hive_sync.jdbcurl
hoodie.datasource.hive_sync.metastore.uris
```
- Metrics Configurations (2)
```
hoodie.metrics.on
hoodie.metrics.reporter.type
```
- Kafka Sink Connect Configurations (1)
```
bootstrap.servers
```

***Deltastreamer configs (in total, 14)***
- DeltaStreamer SQL Transformer Configs (2)
```
hoodie.deltastreamer.transformer.sql
hoodie.deltastreamer.transformer.sql.file
```
- SQL Source Configs (1)
```
hoodie.deltastreamer.source.sql.sql.query
```
- Hudi Incremental Source Configs (1)
```
hoodie.deltastreamer.source.hoodieincr.path
```
- Pulsar Source Configs (3)
```
hoodie.deltastreamer.source.pulsar.topic
hoodie.deltastreamer.source.pulsar.endpoint.admin.url
hoodie.deltastreamer.source.pulsar.endpoint.service.url
```
- Kafka Source Configs (1)
```
hoodie.deltastreamer.source.kafka.topic
```
- S3 Source Configs (1)
```
hoodie.deltastreamer.s3.source.queue.url
```
- DFS Path Selector Configs (1)
```
hoodie.deltastreamer.source.dfs.root
```
- DeltaStreamer Schema Provider Configs (2)
```
hoodie.deltastreamer.schemaprovider.registry.targetUrl
hoodie.deltastreamer.schemaprovider.registry.url
```
- File-based Schema Provider Configs (2)
```
hoodie.deltastreamer.schemaprovider.source.schema.file
hoodie.deltastreamer.schemaprovider.target.schema.file
```

### Impact

Advanced configs are not shown in the "Basic Configuration" page in our docs for simplicity.

### Risk level

none

### Documentation Update

HUDI-5783 for docs update.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
