### PR TITLE
[MINOR] Remove unnecessary KryoSerializable interface in HoodieSparkRecord class signature

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.common.model;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.avro.Schema;
@@ -68,7 +67,7 @@ import static org.apache.spark.sql.types.DataTypes.StringType;
  * </ul>
  *
  */
-public class HoodieSparkRecord extends HoodieRecord<InternalRow> implements KryoSerializable {
+public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
 
   /**
    * Record copy operation to avoid double copying. InternalRow do not need to copy twice.


### PR DESCRIPTION
### Change Logs

`HoodieRecord` implement `KryoSerializable` interface, so we do not need to implement it again in `HoodieSparkRecord` class.
https://github.com/apache/hudi/blob/4b995a8c5d36c08744f08f218ddab84b1c6317bd/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java#L46
### Impact

No

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
