### PR TITLE
[MINOR][DOCS] Remove preCombineField which is not in table

### DIFF
--- a/website/docs/table_management.md
+++ b/website/docs/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.10.0/table_management.md
+++ b/website/versioned_docs/version-0.10.0/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.10.1/table_management.md
+++ b/website/versioned_docs/version-0.10.1/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.11.0/table_management.md
+++ b/website/versioned_docs/version-0.11.0/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.11.1/table_management.md
+++ b/website/versioned_docs/version-0.11.1/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.12.0/table_management.md
+++ b/website/versioned_docs/version-0.12.0/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.12.1/table_management.md
+++ b/website/versioned_docs/version-0.12.1/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.12.2/table_management.md
+++ b/website/versioned_docs/version-0.12.2/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```

--- a/website/versioned_docs/version-0.13.0/table_management.md
+++ b/website/versioned_docs/version-0.13.0/table_management.md
@@ -87,8 +87,7 @@ hh string
 ) using hudi
 options (
   type = 'cow',
-  primaryKey = 'id',
-  preCombineField = 'ts'
+  primaryKey = 'id'
  ) 
 partitioned by (dt, hh);
 ```


### PR DESCRIPTION
### Change Logs

`ts` is not a column of `hudi_table_p0`, and don't need to set preCombineField for cow table.

error message:
```
java.lang.IllegalArgumentException: Can't find preCombineKey `ts` in root
 |-- _hoodie_commit_time: string (nullable = true)
 |-- _hoodie_commit_seqno: string (nullable = true)
 |-- _hoodie_record_key: string (nullable = true)
 |-- _hoodie_partition_path: string (nullable = true)
 |-- _hoodie_file_name: string (nullable = true)
 |-- id: long (nullable = true)
 |-- name: string (nullable = true)
 |-- dt: string (nullable = true)
 |-- hh: string (nullable = true)
.
        at org.apache.hudi.common.util.ValidationUtils.checkArgument(ValidationUtils.java:42)
        at org.apache.spark.sql.hudi.HoodieOptionConfig$.validateTable(HoodieOptionConfig.scala:209)
        at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.parseSchemaAndConfigs(HoodieCatalogTable.scala:260)
        at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.initHoodieTable(HoodieCatalogTable.scala:173)
        at org.apache.spark.sql.hudi.command.CreateHoodieTableCommand.run(CreateHoodieTableCommand.scala:71)

```  

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

[table_management.md](https://hudi.apache.org/docs/table_management#partitioned-table) in version after 0.10.0

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
