### PR TITLE
[HUDI-6027] Remove unnecessary scala-maven-plugin

### DIFF
--- a/hudi-client/hudi-client-common/pom.xml
+++ b/hudi-client/hudi-client-common/pom.xml
@@ -259,27 +259,6 @@
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>net.alchim31.maven</groupId>
-        <artifactId>scala-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>scala-compile-first</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>add-source</goal>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>scala-test-compile</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>

--- a/hudi-client/hudi-flink-client/pom.xml
+++ b/hudi-client/hudi-flink-client/pom.xml
@@ -262,27 +262,6 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>scala-compile-first</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>scala-test-compile</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
`hudi-client-common` and `hudi-flink-client` don't have any scala files yet have `scala-maven-plugin` specified in their pom files. It would fail when building `hudi-trino-bundle` with JDK 17 due the the failure below:

> [ERROR] error: error while loading Object, Missing dependency 'object scala.native in compiler mirror', required by /modules/java.base/java/lang/Object.class
> [ERROR] error: scala.reflect.internal.MissingRequirementError: object scala in compiler mirror not found.
> [ERROR]         at scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:24)
> [ERROR]         at scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:25)
> [ERROR]         at scala.reflect.internal.Mirrors$RootsBase.$anonfun$getModuleOrClass$6(Mirrors.scala:65)
> [ERROR]         at scala.reflect.internal.Mirrors$RootsBase.getPackage(Mirrors.scala:65)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackage$lzycompute(Definitions.scala:197)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackage(Definitions.scala:197)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackageClass$lzycompute(Definitions.scala:198)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackageClass(Definitions.scala:198)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.AnyClass$lzycompute(Definitions.scala:293)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.AnyClass(Definitions.scala:293)
> [ERROR]         at scala.tools.nsc.symtab.classfile.ClassfileParser$ClassTypeCompleter.complete(ClassfileParser.scala:1266)
> [ERROR]         at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1542)
> [ERROR]         at scala.reflect.internal.Symbols$Symbol.initialize(Symbols.scala:1690)
> [ERROR]         at scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1480)
> [ERROR]         at scala.tools.nsc.Global$Run.<init>(Global.scala:1199)
> [ERROR]         at scala.tools.nsc.Driver.doCompile(Driver.scala:46)
> [ERROR]         at scala.tools.nsc.MainClass.doCompile(Main.scala:32)
> [ERROR]         at scala.tools.nsc.Driver.process(Driver.scala:67)
> [ERROR]         at scala.tools.nsc.Driver.main(Driver.scala:80)
> [ERROR]         at scala.tools.nsc.Main.main(Main.scala)
> [ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> [ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> [ERROR]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> [ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:568)
> [ERROR]         at scala_maven_executions.MainHelper.runMain(MainHelper.java:164)
> [ERROR]         at scala_maven_executions.MainWithArgsInFile.main(MainWithArgsInFile.java:26)



### Change Logs

Remove `scala-maven-plugin` from `hudi-client-common` and `hudi-flink-client`

### Impact

None

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
