### PR TITLE
[HUDI-5996] Verify the consistency of bucket num at job sta…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -949,6 +949,8 @@ public class HoodieTableMetaClient implements Serializable {
 
     private String indexDefinitionPath;
 
+    private Properties hoodieIndexConf = new Properties();
+
     /**
      * Persist the configs that is written at the first time, and should not be changed.
      * Like KeyGenerator's configs.
@@ -1134,6 +1136,11 @@ public class HoodieTableMetaClient implements Serializable {
       return this;
     }
 
+    public PropertyBuilder setHoodieIndexConf(Properties hoodieIndexConf) {
+      this.hoodieIndexConf = hoodieIndexConf;
+      return this;
+    }
+
     public PropertyBuilder fromMetaClient(HoodieTableMetaClient metaClient) {
       return setTableType(metaClient.getTableType())
           .setTableName(metaClient.getTableConfig().getTableName())
@@ -1262,6 +1269,8 @@ public class HoodieTableMetaClient implements Serializable {
       HoodieTableConfig tableConfig = new HoodieTableConfig();
 
       tableConfig.setAll(others);
+
+      tableConfig.setAll(hoodieIndexConf);
 
       if (databaseName != null) {
         tableConfig.setValue(HoodieTableConfig.DATABASE_NAME, databaseName);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.apache.hudi.common.config.HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT;
 
@@ -133,6 +134,16 @@ public class OptionsResolver {
   public static String getPreCombineField(Configuration conf) {
     final String preCombineField = conf.getString(FlinkOptions.PRECOMBINE_FIELD);
     return preCombineField.equals(FlinkOptions.NO_PRE_COMBINE) ? null : preCombineField;
+  }
+
+  public static Properties getHoodieIndexConf(Configuration conf) {
+    Properties pro = new Properties();
+    String indexType = conf.getString(FlinkOptions.INDEX_TYPE);
+    pro.put(FlinkOptions.INDEX_TYPE.key(), indexType);
+    if (indexType.equalsIgnoreCase(HoodieIndex.IndexType.BUCKET.name())) {
+      pro.put(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS).toString());
+    }
+    return pro;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -113,6 +113,17 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   private void setupTableOptions(String basePath, Configuration conf) {
     StreamerUtil.getTableConfig(basePath, HadoopConfigurations.getHadoopConf(conf))
         .ifPresent(tableConfig -> {
+          if (!conf.contains(FlinkOptions.INDEX_TYPE)) {
+            if (tableConfig.contains(FlinkOptions.INDEX_TYPE.key())) {
+              conf.set(FlinkOptions.INDEX_TYPE, tableConfig.getString(FlinkOptions.INDEX_TYPE.key()));
+            } else if (tableConfig.contains(HoodieIndexConfig.INDEX_TYPE)) {
+              conf.set(FlinkOptions.INDEX_TYPE, tableConfig.getString(HoodieIndexConfig.INDEX_TYPE));
+            }
+          }
+          if (tableConfig.contains(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS)
+                  && !conf.contains(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS)) {
+            conf.set(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, tableConfig.getInt(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS));
+          }
           if (tableConfig.contains(HoodieTableConfig.RECORDKEY_FIELDS)
               && !conf.contains(FlinkOptions.RECORD_KEY_FIELD)) {
             conf.setString(FlinkOptions.RECORD_KEY_FIELD, tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));


### PR DESCRIPTION
…rtup.

### Change Logs
Users may sometimes modify the bucket num, and the inconsistency of the bucket num will lead to data duplication and make it unavailability. Maybe there are some other parameters that should also be checked before the job starts

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
none
_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
