### PR TITLE
[HUDI-6010] Always write parquets for insert overwrite operation

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkWriteHandleFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkWriteHandleFactory.java
@@ -41,7 +41,11 @@ public class FlinkWriteHandleFactory {
    */
   public static <T, I, K, O> Factory<T, I, K, O> getFactory(
       HoodieTableConfig tableConfig,
-      HoodieWriteConfig writeConfig) {
+      HoodieWriteConfig writeConfig,
+      boolean overwrite) {
+    if (overwrite) {
+      return CommitWriteHandleFactory.getInstance();
+    }
     if (writeConfig.allowDuplicateInserts()) {
       return ClusterWriteHandleFactory.getInstance();
     }


### PR DESCRIPTION
### Change Logs

Always write parquet directly for `INSERT OVERWRITE` and `INSERT OVERWRITE TABLE`.

### Impact

Before the patches, mor table for `INSERT OVERWRITE` operation write avro logs, which is not that effieicnt for backfill scenarios.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
