### PR TITLE
[HUDI-5987] Fix clustering on bootstrap table with row writer disabled

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkBootstrapFileReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkBootstrapFileReader.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+
+public class HoodieSparkBootstrapFileReader extends HoodieBootstrapFileReader<InternalRow> {
+
+  public HoodieSparkBootstrapFileReader(HoodieFileReader<InternalRow> skeletonFileReader, HoodieFileReader<InternalRow> dataFileReader, Option<String[]> partitionFields, Object[] partitionValues) {
+    super(skeletonFileReader, dataFileReader, partitionFields, partitionValues);
+  }
+
+  @Override
+  protected void setPartitionField(int position, Object fieldValue, InternalRow row) {
+    if (row.isNullAt(position)) {
+      row.update(position, fieldValue);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
@@ -18,20 +18,20 @@
 
 package org.apache.hudi.io.storage;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieIOException;
 
-import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.internal.SQLConf;
 
-public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory  {
+import java.io.IOException;
+
+public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory {
 
   protected HoodieFileReader newParquetFileReader(Configuration conf, Path path) {
-    conf.setIfUnset(SQLConf.PARQUET_BINARY_AS_STRING().key(),
-        SQLConf.PARQUET_BINARY_AS_STRING().defaultValueString());
-    conf.setIfUnset(SQLConf.PARQUET_INT96_AS_TIMESTAMP().key(),
-        SQLConf.PARQUET_INT96_AS_TIMESTAMP().defaultValueString());
+    conf.setIfUnset(SQLConf.PARQUET_BINARY_AS_STRING().key(), SQLConf.PARQUET_BINARY_AS_STRING().defaultValueString());
+    conf.setIfUnset(SQLConf.PARQUET_INT96_AS_TIMESTAMP().key(), SQLConf.PARQUET_INT96_AS_TIMESTAMP().defaultValueString());
     conf.setIfUnset(SQLConf.CASE_SENSITIVE().key(), SQLConf.CASE_SENSITIVE().defaultValueString());
     return new HoodieSparkParquetReader(conf, path);
   }
@@ -42,5 +42,10 @@ public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory  {
 
   protected HoodieFileReader newOrcFileReader(Configuration conf, Path path) {
     throw new HoodieIOException("Not support read orc file");
+  }
+
+  @Override
+  public HoodieFileReader newBootstrapFileReader(HoodieFileReader skeletonFileReader, HoodieFileReader dataFileReader, Option<String[]> partitionFields, Object[] partitionValues) {
+    return new HoodieSparkBootstrapFileReader(skeletonFileReader, dataFileReader, partitionFields, partitionValues);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -20,17 +20,23 @@ package org.apache.hudi
 
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
+import org.apache.hadoop.fs.Path
 import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.avro.{AvroSchemaUtils, HoodieAvroUtils}
 import org.apache.hudi.client.utils.SparkRowSerDe
 import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.hadoop.CachingPath
 import org.apache.spark.SPARK_VERSION
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.getTimeZone
 import org.apache.spark.sql.execution.SQLConfInjectingRDD
+import org.apache.spark.sql.execution.datasources.SparkParsePartitionUtil
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -54,7 +60,7 @@ private[hudi] trait SparkVersionsSupport {
   def gteqSpark3_3: Boolean = getSparkVersion >= "3.3"
 }
 
-object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport {
+object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport with Logging {
 
   override def getSparkVersion: String = SPARK_VERSION
 
@@ -190,5 +196,79 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport {
 
   def getCatalystRowSerDe(structType: StructType): SparkRowSerDe = {
     sparkAdapter.createSparkRowSerDe(structType)
+  }
+
+  def parsePartitionColumnValues(partitionColumns: Array[String],
+                                 partitionPath: String,
+                                 basePath: Path,
+                                 schema: StructType,
+                                 timeZoneId: String,
+                                 sparkParsePartitionUtil: SparkParsePartitionUtil,
+                                 shouldValidatePartitionCols: Boolean): Array[Object] = {
+    if (partitionColumns.length == 0) {
+      // This is a non-partitioned table
+      Array.empty
+    } else {
+      val partitionFragments = partitionPath.split("/")
+      if (partitionFragments.length != partitionColumns.length) {
+        if (partitionColumns.length == 1) {
+          // If the partition column size is not equal to the partition fragment size
+          // and the partition column size is 1, we map the whole partition path
+          // to the partition column which can benefit from the partition prune.
+          val prefix = s"${partitionColumns.head}="
+          val partitionValue = if (partitionPath.startsWith(prefix)) {
+            // support hive style partition path
+            partitionPath.substring(prefix.length)
+          } else {
+            partitionPath
+          }
+          Array(UTF8String.fromString(partitionValue))
+        } else {
+          // If the partition column size is not equal to the partition fragments size
+          // and the partition column size > 1, we do not know how to map the partition
+          // fragments to the partition columns and therefore return an empty tuple. We don't
+          // fail outright so that in some cases we can fallback to reading the table as non-partitioned
+          // one
+          logWarning(s"Failed to parse partition values: found partition fragments" +
+            s" (${partitionFragments.mkString(",")}) are not aligned with expected partition columns" +
+            s" (${partitionColumns.mkString(",")})")
+          Array.empty
+        }
+      } else {
+        // If partitionSeqs.length == partitionSchema.fields.length
+        // Append partition name to the partition value if the
+        // HIVE_STYLE_PARTITIONING is disable.
+        // e.g. convert "/xx/xx/2021/02" to "/xx/xx/year=2021/month=02"
+        val partitionWithName =
+        partitionFragments.zip(partitionColumns).map {
+          case (partition, columnName) =>
+            if (partition.indexOf("=") == -1) {
+              s"${columnName}=$partition"
+            } else {
+              partition
+            }
+        }.mkString("/")
+
+        val pathWithPartitionName = new CachingPath(basePath, CachingPath.createRelativePathUnsafe(partitionWithName))
+        val partitionSchema = StructType(schema.fields.filter(f => partitionColumns.contains(f.name)))
+        val partitionValues = parsePartitionPath(pathWithPartitionName, partitionSchema, timeZoneId,
+          sparkParsePartitionUtil, basePath, shouldValidatePartitionCols)
+        partitionValues.map(_.asInstanceOf[Object]).toArray
+      }
+    }
+  }
+
+  private def parsePartitionPath(partitionPath: Path, partitionSchema: StructType, timeZoneId: String,
+                                 sparkParsePartitionUtil: SparkParsePartitionUtil, basePath: Path,
+                                 shouldValidatePartitionCols: Boolean): Seq[Any] = {
+    val partitionDataTypes = partitionSchema.map(f => f.name -> f.dataType).toMap
+    sparkParsePartitionUtil.parsePartition(
+      partitionPath,
+      typeInference = false,
+      Set(basePath),
+      partitionDataTypes,
+      getTimeZone(timeZoneId),
+      validatePartitionValues = shouldValidatePartitionCols
+    ).toSeq(partitionSchema)
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroBootstrapFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroBootstrapFileReader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.generic.IndexedRecord;
+
+import java.util.Objects;
+
+public class HoodieAvroBootstrapFileReader extends HoodieBootstrapFileReader<IndexedRecord> {
+
+  public HoodieAvroBootstrapFileReader(HoodieFileReader<IndexedRecord> skeletonFileReader, HoodieFileReader<IndexedRecord> dataFileReader, Option<String[]> partitionFields, Object[] partitionValues) {
+    super(skeletonFileReader, dataFileReader, partitionFields, partitionValues);
+  }
+
+  @Override
+  protected void setPartitionField(int position, Object fieldValue, IndexedRecord row) {
+    if (Objects.isNull(row.get(position))) {
+      row.put(position, String.valueOf(fieldValue));
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroFileReaderFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.hudi.common.util.Option;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
@@ -38,5 +40,10 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
   @Override
   protected HoodieFileReader newOrcFileReader(Configuration conf, Path path) {
     return new HoodieAvroOrcReader(conf, path);
+  }
+
+  @Override
+  public HoodieFileReader newBootstrapFileReader(HoodieFileReader skeletonFileReader, HoodieFileReader dataFileReader, Option<String[]> partitionFields, Object[] partitionValues) {
+    return new HoodieAvroBootstrapFileReader(skeletonFileReader, dataFileReader, partitionFields, partitionValues);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieBootstrapFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieBootstrapFileReader.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.MetadataValues;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+
+import org.apache.avro.Schema;
+
+import java.io.IOException;
+import java.util.Set;
+
+public abstract class HoodieBootstrapFileReader<T> implements HoodieFileReader<T> {
+
+  private final HoodieFileReader<T> skeletonFileReader;
+  private final HoodieFileReader<T> dataFileReader;
+
+  private final Option<String[]> partitionFields;
+  private final Object[] partitionValues;
+
+  public HoodieBootstrapFileReader(HoodieFileReader<T> skeletonFileReader, HoodieFileReader<T> dataFileReader, Option<String[]> partitionFields, Object[] partitionValues) {
+    this.skeletonFileReader = skeletonFileReader;
+    this.dataFileReader = dataFileReader;
+    this.partitionFields = partitionFields;
+    this.partitionValues = partitionValues;
+  }
+
+  @Override
+  public String[] readMinMaxRecordKeys() {
+    return skeletonFileReader.readMinMaxRecordKeys();
+  }
+
+  @Override
+  public BloomFilter readBloomFilter() {
+    return skeletonFileReader.readBloomFilter();
+  }
+
+  @Override
+  public Set<String> filterRowKeys(Set<String> candidateRowKeys) {
+    return skeletonFileReader.filterRowKeys(candidateRowKeys);
+  }
+
+  @Override
+  public ClosableIterator<HoodieRecord<T>> getRecordIterator(Schema readerSchema, Schema requestedSchema) throws IOException {
+    ClosableIterator<HoodieRecord<T>> skeletonIterator = skeletonFileReader.getRecordIterator(readerSchema, requestedSchema);
+    ClosableIterator<HoodieRecord<T>> dataFileIterator = dataFileReader.getRecordIterator(HoodieAvroUtils.removeMetadataFields(readerSchema), requestedSchema);
+    return new ClosableIterator<HoodieRecord<T>>() {
+      @Override
+      public void close() {
+        skeletonIterator.close();
+        dataFileIterator.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return skeletonIterator.hasNext() && dataFileIterator.hasNext();
+      }
+
+      @Override
+      public HoodieRecord<T> next() {
+        HoodieRecord<T> dataRecord = dataFileIterator.next();
+        HoodieRecord<T> skeletonRecord = skeletonIterator.next();
+        HoodieRecord<T> ret = dataRecord.prependMetaFields(readerSchema, readerSchema,
+            new MetadataValues().setCommitTime(skeletonRecord.getRecordKey(readerSchema, HoodieRecord.COMMIT_TIME_METADATA_FIELD))
+                .setCommitSeqno(skeletonRecord.getRecordKey(readerSchema, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD))
+                .setRecordKey(skeletonRecord.getRecordKey(readerSchema, HoodieRecord.RECORD_KEY_METADATA_FIELD))
+                .setPartitionPath(skeletonRecord.getRecordKey(readerSchema, HoodieRecord.PARTITION_PATH_METADATA_FIELD))
+                .setFileName(skeletonRecord.getRecordKey(readerSchema, HoodieRecord.FILENAME_METADATA_FIELD)), null);
+        if (partitionFields.isPresent()) {
+          for (int i = 0; i < partitionValues.length; i++) {
+            int position = readerSchema.getField(partitionFields.get()[i]).pos();
+            setPartitionField(position, partitionValues[i], ret.getData());
+          }
+        }
+        return ret;
+      }
+    };
+  }
+
+  protected abstract void setPartitionField(int position, Object fieldValue, T row);
+
+  @Override
+  public Schema getSchema() {
+    return skeletonFileReader.getSchema();
+  }
+
+  @Override
+  public void close() {
+    skeletonFileReader.close();
+    dataFileReader.close();
+  }
+
+  @Override
+  public long getTotalRecords() {
+    return Math.min(skeletonFileReader.getTotalRecords(), dataFileReader.getTotalRecords());
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieBootstrapFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieBootstrapFileReader.java
@@ -101,7 +101,8 @@ public abstract class HoodieBootstrapFileReader<T> implements HoodieFileReader<T
 
   @Override
   public Schema getSchema() {
-    return skeletonFileReader.getSchema();
+    // return merged schema (meta fields + data file schema)
+    return HoodieAvroUtils.addMetadataFields(dataFileReader.getSchema());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
@@ -18,14 +18,15 @@
 
 package org.apache.hudi.io.storage;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.exception.HoodieException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 
@@ -81,6 +82,10 @@ public class HoodieFileReaderFactory {
   }
 
   protected HoodieFileReader newOrcFileReader(Configuration conf, Path path) {
+    throw new UnsupportedOperationException();
+  }
+
+  public HoodieFileReader newBootstrapFileReader(HoodieFileReader skeletonFileReader, HoodieFileReader dataFileReader, Option<String[]> partitionFields, Object[] partitionValues) {
     throw new UnsupportedOperationException();
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{CsvSource, EnumSource}
+import org.junit.jupiter.params.provider.{CsvSource, EnumSource, ValueSource}
 
 import java.time.Instant
 import java.util.Collections
@@ -328,8 +328,9 @@ class TestDataSourceForBootstrap {
     verifyIncrementalViewResult(commitInstantTime1, commitInstantTime3, isPartitioned = true, isHiveStylePartitioned = true)
   }
 
-  @Test
-  def testMetadataBootstrapMORPartitionedInlineClustering(): Unit = {
+  @ParameterizedTest
+  @ValueSource(booleans = Array(true, false))
+  def testMetadataBootstrapMORPartitionedInlineClustering(enableRowWriter: Boolean): Unit = {
     val timestamp = Instant.now.toEpochMilli
     val jsc = JavaSparkContext.fromSparkContext(spark.sparkContext)
     // Prepare source data
@@ -366,6 +367,7 @@ class TestDataSourceForBootstrap {
       .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+      .option(DataSourceWriteOptions.ENABLE_ROW_WRITER.key, enableRowWriter.toString)
       .option(HoodieClusteringConfig.INLINE_CLUSTERING.key, "true")
       .option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key, "1")
       .option(HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS.key, "datestr")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
@@ -138,6 +138,13 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
       spark.sql(s"delete from $tableName where _row_key = 'trip_0'")
       val afterDeleteCount = spark.sql(s"select count(*) from $tableName").collect()(0).getLong(0)
       assert(originCount != afterDeleteCount)
+
+      // cluster with row writer disabled and assert that records match with that before clustering
+      // NOTE: the row writer path is already tested in TestDataSourceForBootstrap
+      val beforeClusterDf = spark.sql(s"select * from $tableName")
+      spark.sql("set hoodie.datasource.write.row.writer.enable = false")
+      spark.sql(s"""call run_clustering(table => '$tableName')""".stripMargin)
+      assertResult(0)(spark.sql(s"select * from $tableName").except(beforeClusterDf).count())
     }
   }
 


### PR DESCRIPTION
### Change Logs

Clustering on a bootstrap table (`METADATA_ONLY` bootstrap mode) with row writer disabled did not show correct results. Only meta-fields were populated, while data columns were null. This PR fixes the bug. It adds a separate `HoodieBootstrapFileReader` that stitches the meta columns with the data columns.

Before this fix, snapshot query after clustering on the bootstrap table (check data columns):
```
+-------------------+--------------------+------------------+----------------------+------------------------------------------------------------------------+---------+--------+--------------+-----+------+---------+---------+-------+-------+----+-----------+------------------+-------+
|_hoodie_commit_time|_hoodie_commit_seqno|_hoodie_record_key|_hoodie_partition_path|_hoodie_file_name                                                       |timestamp|_row_key|partition_path|rider|driver|begin_lat|begin_lon|end_lat|end_lon|fare|tip_history|_hoodie_is_deleted|datestr|
+-------------------+--------------------+------------------+----------------------+------------------------------------------------------------------------+---------+--------+--------------+-----+------+---------+---------+-------+-------+----+-----------+------------------+-------+
|00000000000001     |00000000000001_7_0  |trip_25           |datestr=2018          |57b0b650-582e-46be-97c1-24942abf9291-0_0-25-68_20230331123135604.parquet|null     |null    |null          |null |null  |null     |null     |null   |null   |null|null       |null              |null   |
|00000000000001     |00000000000001_7_1  |trip_26           |datestr=2018          |57b0b650-582e-46be-97c1-24942abf9291-0_0-25-68_20230331123135604.parquet|null     |null    |null          |null |null  |null     |null     |null   |null   |null|null       |null              |null   |
|00000000000001     |00000000000001_7_2  |trip_27           |datestr=2018          |57b0b650-582e-46be-97c1-24942abf9291-0_0-25-68_20230331123135604.parquet|null     |null    |null          |null |null  |null     |null     |null   |null   |null|null       |null              |null   |
|00000000000001     |00000000000001_7_3  |trip_28           |datestr=2018          |57b0b650-582e-46be-97c1-24942abf9291-0_0-25-68_20230331123135604.parquet|null     |null    |null          |null |null  |null     |null     |null   |null   |null|null       |null              |null   |
|00000000000001     |00000000000001_7_4  |trip_29           |datestr=2018          |57b0b650-582e-46be-97c1-24942abf9291-0_0-25-68_20230331123135604.parquet|null     |null    |null          |null |null  |null     |null     |null   |null   |null|null       |null              |null   |
+-------------------+--------------------+------------------+----------------------+------------------------------------------------------------------------+---------+--------+--------------+-----+------+---------+---------+-------+-------+----+-----------+------------------+-------+
only showing top 5 rows
```
After this fix:
```
+-------------------+--------------------+------------------+----------------------+------------------------------------------------------------------------+-------------+--------+--------------+--------+---------+------------------+-------------------+-------------------+-------------------+-------------------------+---------------------------+------------------+-------+
|_hoodie_commit_time|_hoodie_commit_seqno|_hoodie_record_key|_hoodie_partition_path|_hoodie_file_name                                                       |timestamp    |_row_key|partition_path|rider   |driver   |begin_lat         |begin_lon          |end_lat            |end_lon            |fare                     |tip_history                |_hoodie_is_deleted|datestr|
+-------------------+--------------------+------------------+----------------------+------------------------------------------------------------------------+-------------+--------+--------------+--------+---------+------------------+-------------------+-------------------+-------------------+-------------------------+---------------------------+------------------+-------+
|00000000000001     |00000000000001_6_0  |trip_25           |datestr=2018          |d1ff344c-5f84-41a5-9005-118dca129b30-0_0-25-68_20230331123355809.parquet|1680265998688|trip_25 |1680265998688 |rider_25|driver_25|0.5533512237148628|0.5681057293830623 |0.07047592205107045|0.48492180271084273|[50.64985395541603, USD] |[[13.994074573153537, USD]]|false             |2018   |
|00000000000001     |00000000000001_6_1  |trip_26           |datestr=2018          |d1ff344c-5f84-41a5-9005-118dca129b30-0_0-25-68_20230331123355809.parquet|1680265998688|trip_26 |1680265998688 |rider_26|driver_26|0.5483446057519853|0.4787499068864025 |0.3438732794172973 |0.23687569228870997|[7.205379512650445, USD] |[[35.07044590983842, USD]] |false             |2018   |
|00000000000001     |00000000000001_6_2  |trip_27           |datestr=2018          |d1ff344c-5f84-41a5-9005-118dca129b30-0_0-25-68_20230331123355809.parquet|1680265998688|trip_27 |1680265998688 |rider_27|driver_27|0.537233960307539 |0.40689621626018646|0.9996340618547656 |0.5136491330606007 |[36.44767181591008, USD] |[[41.64897840565314, USD]] |false             |2018   |
|00000000000001     |00000000000001_6_3  |trip_28           |datestr=2018          |d1ff344c-5f84-41a5-9005-118dca129b30-0_0-25-68_20230331123355809.parquet|1680265998688|trip_28 |1680265998688 |rider_28|driver_28|0.1564015159732266|0.939421953589519  |0.5996707207519414 |0.6017343270411845 |[28.086841928072538, USD]|[[73.75301394035617, USD]] |false             |2018   |
|00000000000001     |00000000000001_6_4  |trip_29           |datestr=2018          |d1ff344c-5f84-41a5-9005-118dca129b30-0_0-25-68_20230331123355809.parquet|1680265998688|trip_29 |1680265998688 |rider_29|driver_29|0.8958509615328525|0.3775097084776675 |0.18696411628776888|0.2629518404213518 |[22.826042892060862, USD]|[[62.964192832973396, USD]]|false             |2018   |
+-------------------+--------------------+------------------+----------------------+------------------------------------------------------------------------+-------------+--------+--------------+--------+---------+------------------+-------------------+-------------------+-------------------+-------------------------+---------------------------+------------------+-------+
only showing top 5 rows
```

### Impact

A bug fix for bootstrap tables.

### Risk level (write none, low medium or high below)

low

Only when the base file has a bootstrap path in clustering then only the `HoodieBootstrapFileReader` will be used.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
