### PR TITLE
[HUDI-6004] Allow procedures to operate table which is not in the current session

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
@@ -80,10 +80,13 @@ class RunCleanProcedure extends BaseProcedure with ProcedureBuilder with Logging
       HoodieCleanConfig.CLEAN_TRIGGER_STRATEGY.key() -> getArgValueOrDefault(args, PARAMETERS(7)).get.toString,
       HoodieCleanConfig.CLEAN_MAX_COMMITS.key() -> getArgValueOrDefault(args, PARAMETERS(8)).get.toString
     )
+    val actualTableName = tableName.map(
+      t => Some(t.asInstanceOf[String]))
+      .getOrElse(Option.empty)
 
     var client: SparkRDDWriteClient[_] = null
     try {
-      client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, props)
+      client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, props, actualTableName)
       val hoodieCleanMeta = client.clean(cleanInstantTime, scheduleInLine, skipLocking)
 
       if (hoodieCleanMeta == null) Seq.empty

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -170,8 +170,12 @@ class RunClusteringProcedure extends BaseProcedure
     logInfo(s"Pending clustering instants: ${pendingClustering.mkString(",")}")
 
     var client: SparkRDDWriteClient[_] = null
+    val actualTableName = tableName.map(
+      t => Some(t.asInstanceOf[String]))
+      .getOrElse(Option.empty)
+
     try {
-      client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, conf)
+      client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, conf, actualTableName)
       if (operator.isSchedule) {
         val instantTime = HoodieActiveTimeline.createNewInstantTime
         if (client.scheduleClusteringAtInstant(instantTime, HOption.empty())) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -67,8 +67,12 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     var client: SparkRDDWriteClient[_] = null
+    val actualTableName = tableName.map(
+      t => Some(t.asInstanceOf[String]))
+      .getOrElse(Option.empty)
+
     try {
-      client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, Map.empty)
+      client = HoodieCLIUtils.createHoodieClientFromPath(sparkSession, basePath, Map.empty, actualTableName)
       var willCompactionInstants: Seq[String] = Seq.empty
       operation match {
         case "schedule" =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/HoodieSparkProcedureTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/HoodieSparkProcedureTestBase.scala
@@ -20,7 +20,15 @@ package org.apache.spark.sql.hudi.procedure
 import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase
 
 class HoodieSparkProcedureTestBase extends HoodieSparkSqlTestBase {
+
+  protected var hoodieDatabase = "hoodie_database"
+
   override def generateTableName: String = {
     s"default.${super.generateTableName}"
   }
+
+  def generateNotDefaultTableName: String = {
+    s"${hoodieDatabase}.${super.generateTableName}"
+  }
+
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
@@ -117,4 +117,107 @@ class TestCleanProcedure extends HoodieSparkProcedureTestBase {
       )
     }
   }
+
+  test("Test Call run_clean Procedure by Table not in default database") {
+    withTempDir { tmp =>
+      val tableName = generateNotDefaultTableName
+
+      spark.sql(
+        s"""
+           |create database if not exists ${hoodieDatabase}
+           |""".stripMargin)
+
+      spark.sql(
+        s"""
+           |create table $tableName (
+           | id int,
+           | name string,
+           | price double,
+           | ts long
+           | ) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |   primaryKey = 'id',
+           |   type = 'cow',
+           |   preCombineField = 'ts'
+           | )
+           |""".stripMargin)
+
+      spark.sql("set hoodie.parquet.max.file.size = 10000")
+      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+      spark.sql(s"update $tableName set price = 11 where id = 1")
+      spark.sql(s"update $tableName set price = 12 where id = 1")
+      spark.sql(s"update $tableName set price = 13 where id = 1")
+
+      // KEEP_LATEST_COMMITS
+      val result1 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
+        .collect()
+        .map(row => Seq(row.getString(0), row.getLong(1), row.getInt(2), row.getString(3), row.getString(4), row.getInt(5)))
+
+      assertResult(1)(result1.length)
+      assertResult(2)(result1(0)(2))
+
+      val result11 = spark.sql(
+        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+      assertResult(2)(result11.length)
+
+      checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+        Seq(1, "a1", 13, 1000)
+      )
+
+      val result2 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
+        .collect()
+      assertResult(0)(result2.length)
+
+      // KEEP_LATEST_FILE_VERSIONS
+      spark.sql(s"update $tableName set price = 14 where id = 1")
+
+      val result3 = spark.sql(
+        s"call run_clean(table => '$tableName', clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 3)").collect()
+      assertResult(0)(result3.length)
+
+      val result4 = spark.sql(
+        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+      assertResult(3)(result4.length)
+
+      val result5 = spark.sql(
+        s"call run_clean(table => '$tableName', clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
+      assertResult(1)(result5.length)
+      assertResult(2)(result5(0)(2))
+
+      val result6 = spark.sql(
+        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+      assertResult(1)(result6.length)
+
+      checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+        Seq(1, "a1", 14, 1000)
+      )
+
+      // trigger time
+      spark.sql(s"update $tableName set price = 15 where id = 1")
+
+      // no trigger, only has 1 commit
+      val result7 = spark.sql(
+        s"call run_clean(table => '$tableName', trigger_max_commits => 2, clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
+      assertResult(0)(result7.length)
+
+      val result8 = spark.sql(
+        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+      assertResult(2)(result8.length)
+
+      // trigger
+      val result9 = spark.sql(
+        s"call run_clean(table => '$tableName', trigger_max_commits => 1, clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
+      assertResult(1)(result9.length)
+      assertResult(1)(result9(0)(2))
+
+      val result10 = spark.sql(
+        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+      assertResult(1)(result10.length)
+
+      checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+        Seq(1, "a1", 15, 1000)
+      )
+    }
+  }
 }


### PR DESCRIPTION
### Change Logs

1. Add a new method to `HoodieCLIUtils.scala` so that we could get HoodieCatalogTable which is not in the current session. `hoodie.properties` file only record table name with `hoodie.table.name` property, we will get error message like [HUDI-6004](https://issues.apache.org/jira/browse/HUDI-6004).

3. Add some test cases for this change.

### Impact

expand the ability  of `run_clustering`、`run_clean`、`run_compaction` procedures

### Risk level (write none, low medium or high below)

low 

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
