### PR TITLE
[HUDI-5173] Fix new config naming around single file group clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -183,7 +183,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .withDocumentation("Each group can produce 'N' (CLUSTERING_MAX_GROUP_SIZE/CLUSTERING_TARGET_FILE_SIZE) output file groups");
 
   public static final ConfigProperty<Boolean> PLAN_STRATEGY_SINGLE_GROUP_CLUSTERING_ENABLED = ConfigProperty
-      .key(CLUSTERING_STRATEGY_PARAM_PREFIX + ".single.group.clustering.enabled")
+      .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "single.group.clustering.enabled")
       .defaultValue(true)
       .sinceVersion("0.14.0")
       .withDocumentation("Whether to generate clustering plan when there is only one file group involved, by default true");


### PR DESCRIPTION
### Change Logs

This PR fixes the naming of the new config, from
`hoodie.clustering.plan.strategy..single.group.clustering.enabled` 
to
`hoodie.clustering.plan.strategy.single.group.clustering.enabled`.

### Impact

Corrects the config naming.

### Risk level

none.  The config is not in any release yet.

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
