### PR TITLE
[HUDI-6012] Delete base path when failed to run bootstrap procedure

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -185,8 +185,15 @@ public class BootstrapExecutorUtils implements Serializable {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
       checkpointCommitMetadata.put(CHECKPOINT_KEY, Config.checkpoint);
       bootstrapClient.bootstrap(Option.of(checkpointCommitMetadata));
-      syncHive();
+    } catch (Exception e) {
+      Path basePath = new Path(cfg.basePath);
+      if (fs.exists(basePath)) {
+        LOG.warn("deleted target base path " + cfg.basePath);
+        fs.delete(basePath, true);
+      }
+      throw new HoodieException("Failed to bootstrap table", e);
     }
+    syncHive();
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Deleted the `base_path` we created when bootstrap failed.
`base_path` is always empty when we start bootstrap as we have checked in [BootstrapExecutorUtils](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java)#initializeTable
Though we can still rerun bootstrap procedure and pass `bootstrap_overwrite` parameter, it's better to clean this path that we created after failure.
 

### Impact

`run_bootstrap` spark procedure

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
