### PR TITLE
[HUDI-6017] Sort the results of Call help Procedure with no params

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HelpProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HelpProcedure.scala
@@ -34,7 +34,6 @@ class HelpProcedure extends BaseProcedure with ProcedureBuilder with Logging {
     StructField("result", DataTypes.StringType, nullable = true, Metadata.empty)
   ))
 
-
   /**
    * Returns the description of this procedure.
    */
@@ -54,8 +53,9 @@ class HelpProcedure extends BaseProcedure with ProcedureBuilder with Logging {
       result.append("synopsis").append(line)
         .append(tab).append("call [command]([key1]=>[value1],[key2]=>[value2])").append(line)
       result.append("commands and description").append(line)
-      procedures.keySet.foreach(name => {
-        val builderSupplier: Option[Supplier[ProcedureBuilder]] = procedures.get(name)
+      procedures.toSeq.sortBy(_._1).foreach(procedure => {
+        val name = procedure._1
+        val builderSupplier: Option[Supplier[ProcedureBuilder]] = Option.apply(procedure._2)
         if (builderSupplier.isDefined) {
           val procedure: Procedure = builderSupplier.get.get().build
           result.append(tab)


### PR DESCRIPTION
### Change Logs

Sort the results of Call help Procedure with no params.
The original output is unordered:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/35296098/229341147-6bcb69e1-ef88-441b-931c-900b66b74c92.png">


The sorted output:
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/35296098/229341160-db9e08c6-34b9-44f9-b7f2-45cb7b152be6.png">

### Impact
Increased user experience

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
