### PR TITLE
[HUDI-6030] Cleans the ckp meta while the JM restarts

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.exception.HoodieException;
@@ -94,14 +95,13 @@ public class CkpMetadata implements Serializable, AutoCloseable {
   // -------------------------------------------------------------------------
 
   /**
-   * Initialize the message bus, would keep all the messages.
+   * Initialize the message bus, would clean all the messages
    *
    * <p>This expects to be called by the driver.
    */
   public void bootstrap() throws IOException {
-    if (!fs.exists(path)) {
-      fs.mkdirs(path);
-    }
+    fs.delete(path, true);
+    fs.mkdirs(path);
   }
 
   public void startInstant(String instant) {
@@ -201,6 +201,11 @@ public class CkpMetadata implements Serializable, AutoCloseable {
   public boolean isAborted(String instant) {
     ValidationUtils.checkState(this.messages != null, "The checkpoint metadata should #load first");
     return this.messages.stream().anyMatch(ckpMsg -> instant.equals(ckpMsg.getInstant()) && ckpMsg.isAborted());
+  }
+
+  @VisibleForTesting
+  public List<String> getInstantCache() {
+    return this.instantCache;
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
### Change Logs

We received several bug reports since #7620, for example: https://github.com/apache/hudi/issues/8060, this patch revert the changes of `CkpMetadata` and always report the write metadata events for write task, the coordinator would decide whether to re-commit these metadata stats.

### Impact

Fix the problem introduced by #7620.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
