### PR TITLE
[HUDI-6019] support config minPartitions when reading from kafka

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
@@ -63,6 +63,14 @@ public class KafkaSourceConfig extends HoodieConfig {
       .defaultValue(5000000L)
       .withDocumentation("Maximum number of records obtained in each batch.");
 
+  public static final ConfigProperty<Long> MAX_EVENTS_PER_KAFKA_PARTITION = ConfigProperty
+          .key(PREFIX + "per.partition.maxEvents")
+          .defaultValue(Long.MAX_VALUE)
+          .withDocumentation("Maximum number of records in per kafka partition. For example: set this param to 500000, "
+                  + "in kafka partition 0 offset from 0 to 1000000, "
+                  + "will split to two kafka inputs offset from 0 to 500000 and "
+                  + "offset from 500000 to 1000000");
+
   public static final ConfigProperty<String> KAFKA_TOPIC_NAME = ConfigProperty
       .key(PREFIX + "topic")
       .noDefaultValue()

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
@@ -63,15 +63,15 @@ public class KafkaSourceConfig extends HoodieConfig {
       .defaultValue(5000000L)
       .withDocumentation("Maximum number of records obtained in each batch.");
 
-  // the documentation is copied from the minPartition definition of kafka structured streaming
+  // the documentation is inspired by the minPartition definition of kafka structured streaming
   public static final ConfigProperty<Long> KAFKA_SOURCE_MIN_PARTITIONS = ConfigProperty
           .key(PREFIX + "minPartitions")
           .defaultValue(0L)
           .withDocumentation("Desired minimum number of partitions to read from Kafka. "
-              + "By default, Spark has a 1-1 mapping of topicPartitions to Spark partitions consuming from Kafka. "
+              + "By default, Hudi has a 1-1 mapping of topicPartitions to Hudi partitions consuming from Kafka. "
               + "If set this option to a value greater than topicPartitions, "
-              + "Spark will divvy up large Kafka partitions to smaller pieces. "
-              + "Please note that this configuration is like a hint: the number of Spark tasks will be approximately minPartitions. "
+              + "Hudi will divvy up large Kafka partitions to smaller pieces. "
+              + "Please note that this configuration is like a hint: the number of input tasks will be approximately minPartitions. "
               + "It can be less or more depending on rounding errors or Kafka partitions that didn't receive any new data.");
 
   public static final ConfigProperty<String> KAFKA_TOPIC_NAME = ConfigProperty

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
@@ -63,13 +63,16 @@ public class KafkaSourceConfig extends HoodieConfig {
       .defaultValue(5000000L)
       .withDocumentation("Maximum number of records obtained in each batch.");
 
-  public static final ConfigProperty<Long> MAX_EVENTS_PER_KAFKA_PARTITION = ConfigProperty
-          .key(PREFIX + "per.partition.maxEvents")
-          .defaultValue(Long.MAX_VALUE)
-          .withDocumentation("Maximum number of records in per kafka partition. For example: set this param to 500000, "
-                  + "in kafka partition 0 offset from 0 to 1000000, "
-                  + "will split to two kafka inputs offset from 0 to 500000 and "
-                  + "offset from 500000 to 1000000");
+  // the documentation is copied from the minPartition definition of kafka structured streaming
+  public static final ConfigProperty<Long> KAFKA_SOURCE_MIN_PARTITIONS = ConfigProperty
+          .key(PREFIX + "minPartitions")
+          .defaultValue(0L)
+          .withDocumentation("Desired minimum number of partitions to read from Kafka. "
+              + "By default, Spark has a 1-1 mapping of topicPartitions to Spark partitions consuming from Kafka. "
+              + "If set this option to a value greater than topicPartitions, "
+              + "Spark will divvy up large Kafka partitions to smaller pieces. "
+              + "Please note that this configuration is like a hint: the number of Spark tasks will be approximately minPartitions. "
+              + "It can be less or more depending on rounding errors or Kafka partitions that didn't receive any new data.");
 
   public static final ConfigProperty<String> KAFKA_TOPIC_NAME = ConfigProperty
       .key(PREFIX + "topic")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -134,7 +134,7 @@ public class KafkaOffsetGen {
       long actualNumEvents = Math.min(totalEvents, numEvents);
 
       // keep going until we have events to allocate and partitions still not exhausted.
-      while (allocedEvents < actualNumEvents && exhaustedPartitions.size() < toOffsetMap.size()) {
+      while (allocedEvents < numEvents && exhaustedPartitions.size() < toOffsetMap.size()) {
         // Allocate the remaining events to non-exhausted partitions, in round robin fashion
         Set<Integer> allocatedPartitionsThisLoop = new HashSet<>(exhaustedPartitions);
         for (int i = 0; i < ranges.length; i++) {
@@ -162,10 +162,7 @@ public class KafkaOffsetGen {
             toOffset = Math.min(range.untilOffset(), toOffset + offsetsToAdd);
           }
           OffsetRange thisRange = OffsetRange.create(range.topicPartition(), range.fromOffset(), toOffset);
-          // filter out the empty ranges
-          if (thisRange.count() > 0) {
-            finalRanges.add(thisRange);
-          }
+          finalRanges.add(thisRange);
           ranges[i] = OffsetRange.create(range.topicPartition(), range.fromOffset() + thisRange.count(), range.untilOffset());
           allocatedPartitionsThisLoop.add(range.partition());
         }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -92,6 +92,7 @@ public class KafkaOffsetGen {
      * Format: topic1,0:offset0,1:offset1,2:offset2, .....
      */
     public static String offsetsToStr(OffsetRange[] ranges) {
+      // merge the ranges by partition to maintain one offset range map to one topic partition.
       ranges = mergeRangesByTp(ranges);
       StringBuilder sb = new StringBuilder();
       // at least 1 partition will be present.
@@ -174,6 +175,11 @@ public class KafkaOffsetGen {
       return newRanges.toArray(new OffsetRange[0]);
     }
 
+    /**
+     * Merge ranges by partition, because we need to maintain the checkpoint with one offset range per topic partition.
+     * @param oldRanges to merge
+     * @return ranges merged by partition
+     */
     public static OffsetRange[] mergeRangesByTp(OffsetRange[] oldRanges) {
       List<OffsetRange> newRanges = new ArrayList<>();
       Map<TopicPartition, List<OffsetRange>> tpOffsets = Arrays.stream(oldRanges).collect(Collectors.groupingBy(OffsetRange::topicPartition));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -218,21 +218,6 @@ public class KafkaOffsetGen {
       return newRanges.toArray(new OffsetRange[0]);
     }
 
-    public static List<OffsetRange> splitSingleRange(OffsetRange range, long maxEvents) {
-      List<OffsetRange> newRanges = new ArrayList<>();
-      if (range.count() <= maxEvents) {
-        newRanges.add(range);
-        return newRanges;
-      }
-      long partsNum = (range.count() + maxEvents - 1) / maxEvents;
-      long step = range.count() / partsNum;
-      for (long start = range.fromOffset(); start < range.untilOffset(); start += step) {
-        long end = Math.min(start + step, range.untilOffset());
-        newRanges.add(OffsetRange.create(range.topicPartition(), start, end));
-      }
-      return newRanges;
-    }
-
     public static long totalNewMessages(OffsetRange[] ranges) {
       return Arrays.stream(ranges).mapToLong(OffsetRange::count).sum();
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -60,6 +61,28 @@ public class TestCheckpointUtils {
             CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
                     makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 1000000L);
     assertEquals(TEST_TOPIC_NAME + ",0:300000,1:350000", CheckpointUtils.offsetsToStr(ranges));
+
+    ranges = new OffsetRange[]{
+            OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
+            OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200),
+            OffsetRange.apply(TEST_TOPIC_NAME, 1, 100, 200),
+            OffsetRange.apply(TEST_TOPIC_NAME, 1, 200, 300)};
+    assertEquals(TEST_TOPIC_NAME + ",0:200,1:300", CheckpointUtils.offsetsToStr(ranges));
+  }
+
+  @Test
+  public void testOffsetStringfy() {
+    OffsetRange[] ranges =
+            CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
+                    makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 1000000L);
+    assertEquals(TEST_TOPIC_NAME + ",0:200000->300000,1:250000->350000", CheckpointUtils.offsetsStringfy(ranges));
+
+    ranges = new OffsetRange[]{
+            OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
+            OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200),
+            OffsetRange.apply(TEST_TOPIC_NAME, 1, 100, 200),
+            OffsetRange.apply(TEST_TOPIC_NAME, 1, 200, 300)};
+    assertEquals(TEST_TOPIC_NAME + ",0:0->100,0:100->200,1:100->200,1:200->300", CheckpointUtils.offsetsStringfy(ranges));
   }
 
   @Test
@@ -114,6 +137,38 @@ public class TestCheckpointUtils {
     assertEquals(226, ranges[2].count());
     assertEquals(226, ranges[3].count());
     assertEquals(223, ranges[4].count());
+  }
+
+  @Test
+  public void testSplitAndMergeRanges() {
+    OffsetRange range = OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100);
+    List<OffsetRange> rangeList = CheckpointUtils.splitSingleRange(range, 50);
+    assertEquals(2, rangeList.size());
+    assertEquals(50, rangeList.get(0).count());
+    assertEquals(0, rangeList.get(0).fromOffset());
+    assertEquals(50, rangeList.get(0).untilOffset());
+    assertEquals(50, rangeList.get(1).count());
+    assertEquals(50, rangeList.get(1).fromOffset());
+    assertEquals(100, rangeList.get(1).untilOffset());
+
+    OffsetRange[] mergedRanges = CheckpointUtils.mergeRangesByTp(rangeList.toArray(new OffsetRange[0]));
+    assertEquals(1, mergedRanges.length);
+    assertEquals(0, mergedRanges[0].fromOffset());
+    assertEquals(100, mergedRanges[0].untilOffset());
+
+    rangeList = CheckpointUtils.splitSingleRange(range, 30);
+    assertEquals(4, rangeList.size());
+    assertEquals(25, rangeList.get(0).count());
+    assertEquals(25, rangeList.get(1).count());
+    assertEquals(25, rangeList.get(1).fromOffset());
+    assertEquals(50, rangeList.get(1).untilOffset());
+    assertEquals(25, rangeList.get(2).count());
+    assertEquals(25, rangeList.get(3).count());
+
+    mergedRanges = CheckpointUtils.mergeRangesByTp(rangeList.toArray(new OffsetRange[0]));
+    assertEquals(1, mergedRanges.length);
+    assertEquals(0, mergedRanges[0].fromOffset());
+    assertEquals(100, mergedRanges[0].untilOffset());
   }
 
   private static Map<TopicPartition, Long> makeOffsetMap(int[] partitions, long[] offsets) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
@@ -185,22 +185,31 @@ public class TestCheckpointUtils {
     assertEquals(67, ranges[2].fromOffset());
     assertEquals(100, ranges[2].untilOffset());
 
-    // ignore empty ranges
+    // do not ignore empty ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}),
         makeOffsetMap(new int[] {0, 1}, new long[] {100, 600}), 600, 3);
     assertEquals(3, ranges.length);
-    assertEquals(0, ranges[0].fromOffset());
-    assertEquals(200, ranges[0].untilOffset());
-    assertEquals(200, ranges[1].fromOffset());
-    assertEquals(400, ranges[1].untilOffset());
-    assertEquals(400, ranges[2].fromOffset());
+    assertEquals(0, ranges[0].partition());
+    assertEquals(100, ranges[0].fromOffset());
+    assertEquals(100, ranges[0].untilOffset());
+    assertEquals(1, ranges[1].partition());
+    assertEquals(0, ranges[1].fromOffset());
+    assertEquals(300, ranges[1].untilOffset());
+    assertEquals(1, ranges[2].partition());
+    assertEquals(300, ranges[2].fromOffset());
     assertEquals(600, ranges[2].untilOffset());
 
-    // all empty ranges
+    // all empty ranges, do not ignore empty ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}),
         makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}), 600, 3);
     assertEquals(0, CheckpointUtils.totalNewMessages(ranges));
-    assertEquals(0, ranges.length);
+    assertEquals(2, ranges.length);
+    assertEquals(0, ranges[0].partition());
+    assertEquals(100, ranges[0].fromOffset());
+    assertEquals(100, ranges[0].untilOffset());
+    assertEquals(1, ranges[1].partition());
+    assertEquals(0, ranges[1].fromOffset());
+    assertEquals(0, ranges[1].untilOffset());
 
     // minPartitions more than maxEvents
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
@@ -42,7 +42,7 @@ public class TestCheckpointUtils {
   public void testStringToOffsets() {
     OffsetRange[] ranges =
         CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, 0);
     String checkpointStr = CheckpointUtils.offsetsToStr(ranges);
     Map<TopicPartition, Long> offsetMap = CheckpointUtils.strToOffsets(checkpointStr);
     assertEquals(2, offsetMap.size());
@@ -60,7 +60,7 @@ public class TestCheckpointUtils {
   public void testOffsetToString() {
     OffsetRange[] ranges =
         CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, 0);
     assertEquals(TEST_TOPIC_NAME + ",0:300000,1:350000", CheckpointUtils.offsetsToStr(ranges));
 
     ranges = new OffsetRange[] {
@@ -75,7 +75,7 @@ public class TestCheckpointUtils {
   public void testOffsetStringfy() {
     OffsetRange[] ranges =
         CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, 0);
     assertEquals(TEST_TOPIC_NAME + ",0:200000->300000,1:250000->350000", CheckpointUtils.offsetsStringfy(ranges));
 
     ranges = new OffsetRange[] {
@@ -96,12 +96,12 @@ public class TestCheckpointUtils {
     // should consume all the full data
     OffsetRange[] ranges =
         CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, 0);
     assertEquals(200000, CheckpointUtils.totalNewMessages(ranges));
 
     // should only consume upto limit
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-        makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 10000, Long.MAX_VALUE);
+        makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 10000, 0);
     assertEquals(10000, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(200000, ranges[0].fromOffset());
     assertEquals(205000, ranges[0].untilOffset());
@@ -110,20 +110,20 @@ public class TestCheckpointUtils {
 
     // should also consume from new partitions.
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-        makeOffsetMap(new int[] {0, 1, 2}, new long[] {300000, 350000, 100000}), 1000000L, Long.MAX_VALUE);
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {300000, 350000, 100000}), 1000000L, 0);
     assertEquals(300000, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(3, ranges.length);
 
     // for skewed offsets, does not starve any partition & can catch up
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-        makeOffsetMap(new int[] {0, 1, 2}, new long[] {200010, 350000, 10000}), 100000, Long.MAX_VALUE);
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {200010, 350000, 10000}), 100000, 0);
     assertEquals(100000, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(10, ranges[0].count());
     assertEquals(89990, ranges[1].count());
     assertEquals(10000, ranges[2].count());
 
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
-        makeOffsetMap(new int[] {0, 1, 2}, new long[] {200010, 350000, 10000}), 1000000, Long.MAX_VALUE);
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {200010, 350000, 10000}), 1000000, 0);
     assertEquals(110010, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(10, ranges[0].count());
     assertEquals(100000, ranges[1].count());
@@ -131,17 +131,46 @@ public class TestCheckpointUtils {
 
     // not all partitions consume same entries.
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1, 2, 3, 4}, new long[] {0, 0, 0, 0, 0}),
-        makeOffsetMap(new int[] {0, 1, 2, 3, 4}, new long[] {100, 1000, 1000, 1000, 1000}), 1001, Long.MAX_VALUE);
+        makeOffsetMap(new int[] {0, 1, 2, 3, 4}, new long[] {100, 1000, 1000, 1000, 1000}), 1001, 0);
     assertEquals(1001, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(100, ranges[0].count());
     assertEquals(226, ranges[1].count());
     assertEquals(226, ranges[2].count());
     assertEquals(226, ranges[3].count());
     assertEquals(223, ranges[4].count());
+  }
 
-    // single partition with maxEventsPerPartition
+  @Test
+  public void testSplitRangeToMinPartitions() {
+    // default(0) minPartitions
+    OffsetRange[] ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
+        makeOffsetMap(new int[] {0}, new long[] {1000}), 300, 0);
+    assertEquals(1, ranges.length);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(300, ranges[0].untilOffset());
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {0, 0}),
+        makeOffsetMap(new int[] {0, 1}, new long[] {1000, 1000}), 300, 0);
+    assertEquals(2, ranges.length);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(150, ranges[0].untilOffset());
+    assertEquals(0, ranges[1].fromOffset());
+    assertEquals(150, ranges[1].untilOffset());
+
+    // N TopicPartitions to N offset ranges
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1, 2}, new long[] {0, 0, 0}),
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {1000, 1000, 1000}), 300, 3);
+    assertEquals(3, ranges.length);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(100, ranges[0].untilOffset());
+    assertEquals(0, ranges[1].fromOffset());
+    assertEquals(100, ranges[1].untilOffset());
+    assertEquals(0, ranges[1].fromOffset());
+    assertEquals(100, ranges[1].untilOffset());
+
+    // 1 TopicPartition to N offset ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
-        makeOffsetMap(new int[] {0}, new long[] {1000}), 300, 100);
+        makeOffsetMap(new int[] {0}, new long[] {1000}), 300, 3);
+    assertEquals(3, ranges.length);
     assertEquals(0, ranges[0].fromOffset());
     assertEquals(100, ranges[0].untilOffset());
     assertEquals(100, ranges[1].fromOffset());
@@ -149,21 +178,49 @@ public class TestCheckpointUtils {
     assertEquals(200, ranges[2].fromOffset());
     assertEquals(300, ranges[2].untilOffset());
 
-    // multi partitions with maxEventsPerPartition
+    // N skewed TopicPartitions to M offset ranges
     ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {0, 0}),
-        makeOffsetMap(new int[] {0, 1}, new long[] {1000, 1000}), 300, 100);
-    assertEquals(0, ranges[0].partition());
+        makeOffsetMap(new int[] {0, 1}, new long[] {100, 500}), 600, 3);
+    assertEquals(4, ranges.length);
     assertEquals(0, ranges[0].fromOffset());
-    assertEquals(75, ranges[0].untilOffset());
-    assertEquals(0, ranges[1].partition());
-    assertEquals(75, ranges[1].fromOffset());
-    assertEquals(150, ranges[1].untilOffset());
-    assertEquals(1, ranges[2].partition());
-    assertEquals(0, ranges[2].fromOffset());
-    assertEquals(75, ranges[2].untilOffset());
-    assertEquals(1, ranges[3].partition());
-    assertEquals(75, ranges[3].fromOffset());
-    assertEquals(150, ranges[3].untilOffset());
+    assertEquals(100, ranges[0].untilOffset());
+    assertEquals(0, ranges[1].fromOffset());
+    assertEquals(166, ranges[1].untilOffset());
+    assertEquals(166, ranges[2].fromOffset());
+    assertEquals(333, ranges[2].untilOffset());
+    assertEquals(333, ranges[3].fromOffset());
+    assertEquals(500, ranges[3].untilOffset());
+
+    // range inexact multiple of minPartitions
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
+        makeOffsetMap(new int[] {0}, new long[] {100}), 600, 3);
+    assertEquals(3, ranges.length);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(33, ranges[0].untilOffset());
+    assertEquals(33, ranges[1].fromOffset());
+    assertEquals(66, ranges[1].untilOffset());
+    assertEquals(66, ranges[2].fromOffset());
+    assertEquals(100, ranges[2].untilOffset());
+
+    // ignore empty ranges
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {100, 0}),
+        makeOffsetMap(new int[] {0, 1}, new long[] {100, 600}), 600, 3);
+    assertEquals(3, ranges.length);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(200, ranges[0].untilOffset());
+    assertEquals(200, ranges[1].fromOffset());
+    assertEquals(400, ranges[1].untilOffset());
+    assertEquals(400, ranges[2].fromOffset());
+    assertEquals(600, ranges[2].untilOffset());
+
+    // minPartitions more than maxEvents
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
+        makeOffsetMap(new int[] {0}, new long[] {2}), 600, 3);
+    assertEquals(2, ranges.length);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(1, ranges[0].untilOffset());
+    assertEquals(1, ranges[1].fromOffset());
+    assertEquals(2, ranges[1].untilOffset());
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCheckpointUtils.java
@@ -18,10 +18,11 @@
 
 package org.apache.hudi.utilities.sources.helpers;
 
+import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
+
 import org.apache.kafka.common.TopicPartition;
 import org.apache.spark.streaming.kafka010.OffsetRange;
 import org.junit.jupiter.api.Test;
-import org.apache.hudi.utilities.sources.helpers.KafkaOffsetGen.CheckpointUtils;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,8 +41,8 @@ public class TestCheckpointUtils {
   @Test
   public void testStringToOffsets() {
     OffsetRange[] ranges =
-            CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-                    makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 1000000L);
+        CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
     String checkpointStr = CheckpointUtils.offsetsToStr(ranges);
     Map<TopicPartition, Long> offsetMap = CheckpointUtils.strToOffsets(checkpointStr);
     assertEquals(2, offsetMap.size());
@@ -58,49 +59,49 @@ public class TestCheckpointUtils {
   @Test
   public void testOffsetToString() {
     OffsetRange[] ranges =
-            CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-                    makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 1000000L);
+        CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
     assertEquals(TEST_TOPIC_NAME + ",0:300000,1:350000", CheckpointUtils.offsetsToStr(ranges));
 
-    ranges = new OffsetRange[]{
-            OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
-            OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200),
-            OffsetRange.apply(TEST_TOPIC_NAME, 1, 100, 200),
-            OffsetRange.apply(TEST_TOPIC_NAME, 1, 200, 300)};
+    ranges = new OffsetRange[] {
+        OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
+        OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200),
+        OffsetRange.apply(TEST_TOPIC_NAME, 1, 100, 200),
+        OffsetRange.apply(TEST_TOPIC_NAME, 1, 200, 300)};
     assertEquals(TEST_TOPIC_NAME + ",0:200,1:300", CheckpointUtils.offsetsToStr(ranges));
   }
 
   @Test
   public void testOffsetStringfy() {
     OffsetRange[] ranges =
-            CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-                    makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 1000000L);
+        CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
     assertEquals(TEST_TOPIC_NAME + ",0:200000->300000,1:250000->350000", CheckpointUtils.offsetsStringfy(ranges));
 
-    ranges = new OffsetRange[]{
-            OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
-            OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200),
-            OffsetRange.apply(TEST_TOPIC_NAME, 1, 100, 200),
-            OffsetRange.apply(TEST_TOPIC_NAME, 1, 200, 300)};
+    ranges = new OffsetRange[] {
+        OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
+        OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200),
+        OffsetRange.apply(TEST_TOPIC_NAME, 1, 100, 200),
+        OffsetRange.apply(TEST_TOPIC_NAME, 1, 200, 300)};
     assertEquals(TEST_TOPIC_NAME + ",0:0->100,0:100->200,1:100->200,1:200->300", CheckpointUtils.offsetsStringfy(ranges));
   }
 
   @Test
   public void testComputeOffsetRanges() {
     // test totalNewMessages()
-    long totalMsgs = CheckpointUtils.totalNewMessages(new OffsetRange[]{OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
-            OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200)});
+    long totalMsgs = CheckpointUtils.totalNewMessages(new OffsetRange[] {OffsetRange.apply(TEST_TOPIC_NAME, 0, 0, 100),
+        OffsetRange.apply(TEST_TOPIC_NAME, 0, 100, 200)});
     assertEquals(200, totalMsgs);
 
     // should consume all the full data
     OffsetRange[] ranges =
-            CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-                    makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 1000000L);
+        CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+            makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 1000000L, Long.MAX_VALUE);
     assertEquals(200000, CheckpointUtils.totalNewMessages(ranges));
 
     // should only consume upto limit
-    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-            makeOffsetMap(new int[]{0, 1}, new long[]{300000, 350000}), 10000);
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+        makeOffsetMap(new int[] {0, 1}, new long[] {300000, 350000}), 10000, Long.MAX_VALUE);
     assertEquals(10000, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(200000, ranges[0].fromOffset());
     assertEquals(205000, ranges[0].untilOffset());
@@ -108,35 +109,61 @@ public class TestCheckpointUtils {
     assertEquals(255000, ranges[1].untilOffset());
 
     // should also consume from new partitions.
-    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-            makeOffsetMap(new int[]{0, 1, 2}, new long[]{300000, 350000, 100000}), 1000000L);
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {300000, 350000, 100000}), 1000000L, Long.MAX_VALUE);
     assertEquals(300000, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(3, ranges.length);
 
     // for skewed offsets, does not starve any partition & can catch up
-    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-            makeOffsetMap(new int[]{0, 1, 2}, new long[]{200010, 350000, 10000}), 100000);
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {200010, 350000, 10000}), 100000, Long.MAX_VALUE);
     assertEquals(100000, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(10, ranges[0].count());
     assertEquals(89990, ranges[1].count());
     assertEquals(10000, ranges[2].count());
 
-    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1}, new long[]{200000, 250000}),
-            makeOffsetMap(new int[]{0, 1, 2}, new long[]{200010, 350000, 10000}), 1000000);
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {200000, 250000}),
+        makeOffsetMap(new int[] {0, 1, 2}, new long[] {200010, 350000, 10000}), 1000000, Long.MAX_VALUE);
     assertEquals(110010, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(10, ranges[0].count());
     assertEquals(100000, ranges[1].count());
     assertEquals(10000, ranges[2].count());
 
     // not all partitions consume same entries.
-    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[]{0, 1, 2, 3, 4}, new long[]{0, 0, 0, 0, 0}),
-            makeOffsetMap(new int[]{0, 1, 2, 3, 4}, new long[]{100, 1000, 1000, 1000, 1000}), 1001);
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1, 2, 3, 4}, new long[] {0, 0, 0, 0, 0}),
+        makeOffsetMap(new int[] {0, 1, 2, 3, 4}, new long[] {100, 1000, 1000, 1000, 1000}), 1001, Long.MAX_VALUE);
     assertEquals(1001, CheckpointUtils.totalNewMessages(ranges));
     assertEquals(100, ranges[0].count());
     assertEquals(226, ranges[1].count());
     assertEquals(226, ranges[2].count());
     assertEquals(226, ranges[3].count());
     assertEquals(223, ranges[4].count());
+
+    // single partition with maxEventsPerPartition
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0}, new long[] {0}),
+        makeOffsetMap(new int[] {0}, new long[] {1000}), 300, 100);
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(100, ranges[0].untilOffset());
+    assertEquals(100, ranges[1].fromOffset());
+    assertEquals(200, ranges[1].untilOffset());
+    assertEquals(200, ranges[2].fromOffset());
+    assertEquals(300, ranges[2].untilOffset());
+
+    // multi partitions with maxEventsPerPartition
+    ranges = CheckpointUtils.computeOffsetRanges(makeOffsetMap(new int[] {0, 1}, new long[] {0, 0}),
+        makeOffsetMap(new int[] {0, 1}, new long[] {1000, 1000}), 300, 100);
+    assertEquals(0, ranges[0].partition());
+    assertEquals(0, ranges[0].fromOffset());
+    assertEquals(75, ranges[0].untilOffset());
+    assertEquals(0, ranges[1].partition());
+    assertEquals(75, ranges[1].fromOffset());
+    assertEquals(150, ranges[1].untilOffset());
+    assertEquals(1, ranges[2].partition());
+    assertEquals(0, ranges[2].fromOffset());
+    assertEquals(75, ranges[2].untilOffset());
+    assertEquals(1, ranges[3].partition());
+    assertEquals(75, ranges[3].fromOffset());
+    assertEquals(150, ranges[3].untilOffset());
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -172,40 +172,61 @@ public class TestKafkaOffsetGen {
   }
 
   @Test
-  public void testGetNextOffsetRangesBySplitPartitionSinglePartition() {
+  public void testGetNextOffsetRangesWithMinPartitionsForSinglePartition() {
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
     testUtils.createTopic(testTopicName, 1);
     testUtils.sendMessages(testTopicName, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
     TypedProperties props = getConsumerConfigs("earliest", "string");
-    props.put(KafkaSourceConfig.MAX_EVENTS_PER_KAFKA_PARTITION.key(), 100L);
-    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(props);
 
+    // default no minPartition set
+    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(props);
     OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
     assertEquals(0, nextOffsetRanges[0].fromOffset());
-    assertEquals(100, nextOffsetRanges[0].untilOffset());
-    assertEquals(100, nextOffsetRanges[1].fromOffset());
-    assertEquals(200, nextOffsetRanges[1].untilOffset());
-    assertEquals(200, nextOffsetRanges[2].fromOffset());
-    assertEquals(300, nextOffsetRanges[2].untilOffset());
+    assertEquals(300, nextOffsetRanges[0].untilOffset());
 
+    props.put(KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS.key(), 2L);
     kafkaOffsetGen = new KafkaOffsetGen(props);
-    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 150, metrics);
+    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
     assertEquals(0, nextOffsetRanges[0].fromOffset());
-    assertEquals(75, nextOffsetRanges[0].untilOffset());
-    assertEquals(75, nextOffsetRanges[1].fromOffset());
-    assertEquals(150, nextOffsetRanges[1].untilOffset());
+    assertEquals(150, nextOffsetRanges[0].untilOffset());
+    assertEquals(150, nextOffsetRanges[1].fromOffset());
+    assertEquals(300, nextOffsetRanges[1].untilOffset());
   }
 
   @Test
-  public void testGetNextOffsetRangesBySplitPartitionMultiPartition() {
+  public void testGetNextOffsetRangesWithMinPartitionsForMultiPartition() {
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
     testUtils.createTopic(testTopicName, 2);
     testUtils.sendMessages(testTopicName, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
     TypedProperties props = getConsumerConfigs("earliest", "string");
-    props.put(KafkaSourceConfig.MAX_EVENTS_PER_KAFKA_PARTITION.key(), 100L);
-    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(props);
 
+    // default no minPartition or minPartition less than TopicPartitions
+    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(props);
     OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
+    assertEquals(2, nextOffsetRanges.length);
+    assertEquals(0, nextOffsetRanges[0].partition());
+    assertEquals(0, nextOffsetRanges[0].fromOffset());
+    assertEquals(150, nextOffsetRanges[0].untilOffset());
+    assertEquals(1, nextOffsetRanges[1].partition());
+    assertEquals(0, nextOffsetRanges[1].fromOffset());
+    assertEquals(150, nextOffsetRanges[1].untilOffset());
+
+    props.put(KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS.key(), 1L);
+    kafkaOffsetGen = new KafkaOffsetGen(props);
+    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
+    assertEquals(2, nextOffsetRanges.length);
+    assertEquals(0, nextOffsetRanges[0].partition());
+    assertEquals(0, nextOffsetRanges[0].fromOffset());
+    assertEquals(150, nextOffsetRanges[0].untilOffset());
+    assertEquals(1, nextOffsetRanges[1].partition());
+    assertEquals(0, nextOffsetRanges[1].fromOffset());
+    assertEquals(150, nextOffsetRanges[1].untilOffset());
+
+    // minPartition more than TopicPartitions
+    props.put(KafkaSourceConfig.KAFKA_SOURCE_MIN_PARTITIONS.key(), 4L);
+    kafkaOffsetGen = new KafkaOffsetGen(props);
+    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
+    assertEquals(4, nextOffsetRanges.length);
     assertEquals(0, nextOffsetRanges[0].partition());
     assertEquals(0, nextOffsetRanges[0].fromOffset());
     assertEquals(75, nextOffsetRanges[0].untilOffset());
@@ -218,15 +239,6 @@ public class TestKafkaOffsetGen {
     assertEquals(1, nextOffsetRanges[3].partition());
     assertEquals(75, nextOffsetRanges[3].fromOffset());
     assertEquals(150, nextOffsetRanges[3].untilOffset());
-
-    kafkaOffsetGen = new KafkaOffsetGen(props);
-    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 150, metrics);
-    assertEquals(0, nextOffsetRanges[0].partition());
-    assertEquals(0, nextOffsetRanges[0].fromOffset());
-    assertEquals(75, nextOffsetRanges[0].untilOffset());
-    assertEquals(1, nextOffsetRanges[1].partition());
-    assertEquals(0, nextOffsetRanges[1].fromOffset());
-    assertEquals(75, nextOffsetRanges[1].untilOffset());
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.utilities.config.KafkaSourceConfig;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase.Helpers;
 
@@ -168,6 +169,64 @@ public class TestKafkaOffsetGen {
     assertEquals(500, nextOffsetRanges[0].untilOffset());
     assertEquals(500, nextOffsetRanges[1].fromOffset());
     assertEquals(500, nextOffsetRanges[1].untilOffset());
+  }
+
+  @Test
+  public void testGetNextOffsetRangesBySplitPartitionSinglePartition() {
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+    testUtils.createTopic(testTopicName, 1);
+    testUtils.sendMessages(testTopicName, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
+    TypedProperties props = getConsumerConfigs("earliest", "string");
+    props.put(KafkaSourceConfig.MAX_EVENTS_PER_KAFKA_PARTITION.key(), 100L);
+    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(props);
+
+    OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
+    assertEquals(0, nextOffsetRanges[0].fromOffset());
+    assertEquals(100, nextOffsetRanges[0].untilOffset());
+    assertEquals(100, nextOffsetRanges[1].fromOffset());
+    assertEquals(200, nextOffsetRanges[1].untilOffset());
+    assertEquals(200, nextOffsetRanges[2].fromOffset());
+    assertEquals(300, nextOffsetRanges[2].untilOffset());
+
+    kafkaOffsetGen = new KafkaOffsetGen(props);
+    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 150, metrics);
+    assertEquals(0, nextOffsetRanges[0].fromOffset());
+    assertEquals(75, nextOffsetRanges[0].untilOffset());
+    assertEquals(75, nextOffsetRanges[1].fromOffset());
+    assertEquals(150, nextOffsetRanges[1].untilOffset());
+  }
+
+  @Test
+  public void testGetNextOffsetRangesBySplitPartitionMultiPartition() {
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+    testUtils.createTopic(testTopicName, 2);
+    testUtils.sendMessages(testTopicName, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
+    TypedProperties props = getConsumerConfigs("earliest", "string");
+    props.put(KafkaSourceConfig.MAX_EVENTS_PER_KAFKA_PARTITION.key(), 100L);
+    KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(props);
+
+    OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
+    assertEquals(0, nextOffsetRanges[0].partition());
+    assertEquals(0, nextOffsetRanges[0].fromOffset());
+    assertEquals(75, nextOffsetRanges[0].untilOffset());
+    assertEquals(0, nextOffsetRanges[1].partition());
+    assertEquals(75, nextOffsetRanges[1].fromOffset());
+    assertEquals(150, nextOffsetRanges[1].untilOffset());
+    assertEquals(1, nextOffsetRanges[2].partition());
+    assertEquals(0, nextOffsetRanges[2].fromOffset());
+    assertEquals(75, nextOffsetRanges[2].untilOffset());
+    assertEquals(1, nextOffsetRanges[3].partition());
+    assertEquals(75, nextOffsetRanges[3].fromOffset());
+    assertEquals(150, nextOffsetRanges[3].untilOffset());
+
+    kafkaOffsetGen = new KafkaOffsetGen(props);
+    nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 150, metrics);
+    assertEquals(0, nextOffsetRanges[0].partition());
+    assertEquals(0, nextOffsetRanges[0].fromOffset());
+    assertEquals(75, nextOffsetRanges[0].untilOffset());
+    assertEquals(1, nextOffsetRanges[1].partition());
+    assertEquals(0, nextOffsetRanges[1].fromOffset());
+    assertEquals(75, nextOffsetRanges[1].untilOffset());
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -100,8 +100,9 @@ public class TestKafkaOffsetGen {
     testUtils.sendMessages(testTopicName, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
     KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("latest", "string"));
     OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 500, metrics);
-    // from latest, should be empty ranges
-    assertEquals(0, nextOffsetRanges.length);
+    assertEquals(1, nextOffsetRanges.length);
+    assertEquals(1000, nextOffsetRanges[0].fromOffset());
+    assertEquals(1000, nextOffsetRanges[0].untilOffset());
   }
 
   @Test
@@ -164,8 +165,10 @@ public class TestKafkaOffsetGen {
     // committed offsets are not present for the consumer group
     kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("group", "string"));
     nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
-    // there are all empty ranges which are all filtered
-    assertEquals(0, nextOffsetRanges.length);
+    assertEquals(500, nextOffsetRanges[0].fromOffset());
+    assertEquals(500, nextOffsetRanges[0].untilOffset());
+    assertEquals(500, nextOffsetRanges[1].fromOffset());
+    assertEquals(500, nextOffsetRanges[1].untilOffset());
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestKafkaOffsetGen.java
@@ -100,9 +100,8 @@ public class TestKafkaOffsetGen {
     testUtils.sendMessages(testTopicName, Helpers.jsonifyRecords(dataGenerator.generateInserts("000", 1000)));
     KafkaOffsetGen kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("latest", "string"));
     OffsetRange[] nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 500, metrics);
-    assertEquals(1, nextOffsetRanges.length);
-    assertEquals(1000, nextOffsetRanges[0].fromOffset());
-    assertEquals(1000, nextOffsetRanges[0].untilOffset());
+    // from latest, should be empty ranges
+    assertEquals(0, nextOffsetRanges.length);
   }
 
   @Test
@@ -165,10 +164,8 @@ public class TestKafkaOffsetGen {
     // committed offsets are not present for the consumer group
     kafkaOffsetGen = new KafkaOffsetGen(getConsumerConfigs("group", "string"));
     nextOffsetRanges = kafkaOffsetGen.getNextOffsetRanges(Option.empty(), 300, metrics);
-    assertEquals(500, nextOffsetRanges[0].fromOffset());
-    assertEquals(500, nextOffsetRanges[0].untilOffset());
-    assertEquals(500, nextOffsetRanges[1].fromOffset());
-    assertEquals(500, nextOffsetRanges[1].untilOffset());
+    // there are all empty ranges which are all filtered
+    assertEquals(0, nextOffsetRanges.length);
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

For the kafka source, when pulling data from kafka, the default parallelism is the number of kafka partitions.
There are cases: 
1. Pulling large amount of data from kafka (eg. maxEvents=100000000), but the # of kafka partition is not enough, the procedure of the pulling will cost too much of time
2. There is huge data skew between kafka partitions, the procedure of the pulling will be blocked by the slowest partition

to solve those cases, I add a parameter `hoodie.deltastreamer.source.kafka.minPartitions` to control the maxEvents in one kafka partition input, default 0 means not trun this feature on.

Here is the comparison of this feature:
max executor core is 128.
before: 
<img width="1370" alt="image" src="https://user-images.githubusercontent.com/19326824/228461120-033f0e98-b170-46f4-8380-c0da33f4ad58.png">

after:
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/19326824/228461364-2d6932cd-66bf-4bd8-806c-a669520af255.png">

performance improvement  is about 3 times (can improve more if given more cores).

### Impact

_Default should be no impact._

### Risk level (write none, low medium or high below)

_none._

### Documentation Update

- `hoodie.deltastreamer.source.kafka.minPartitions` the config controls the desired partitions when reading from kafka 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
