### PR TITLE
[HUDI-6038] Fix async compact/clustering serdes conflicts caused by WatermarkStatus in multi versions Flink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink.clustering;
 
+import org.apache.hudi.adapter.MaskingOutputAdapter;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
@@ -57,12 +58,12 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
@@ -143,6 +144,11 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
   }
 
   @Override
+  public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<ClusteringCommitEvent>> output) {
+    super.setup(containingTask, config, new MaskingOutputAdapter<>(output));
+  }
+
+  @Override
   public void open() throws Exception {
     super.open();
 
@@ -163,16 +169,6 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
     }
 
     this.collector = new StreamRecordCollector<>(output);
-  }
-
-  @Override
-  public void processWatermark(Watermark mark) {
-    // no need to propagate the watermark
-  }
-
-  @Override
-  public void processLatencyMarker(LatencyMarker latencyMarker) {
-    // no need to propagate the latencyMarker
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+
+/** Adapter class for {@code Output} to handle async compaction/clustering service thread safe issues */
+public class MaskingOutputAdapter<OUT> implements Output<StreamRecord<OUT>> {
+
+  private final Output<StreamRecord<OUT>> output;
+
+  public MaskingOutputAdapter(Output<StreamRecord<OUT>> output) {
+    this.output = output;
+  }
+
+  @Override
+  public void emitWatermark(Watermark watermark) {
+    // For thread safe, not to propagate the watermark
+  }
+
+  @Override
+  public void emitLatencyMarker(LatencyMarker latencyMarker) {
+    // For thread safe, not to propagate latency marker
+  }
+
+  @Override
+  public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> streamRecord) {
+    this.output.collect(outputTag, streamRecord);
+  }
+
+  @Override
+  public void collect(StreamRecord<OUT> outStreamRecord) {
+    this.output.collect(outStreamRecord);
+  }
+
+  @Override
+  public void close() {
+    this.output.close();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.util.OutputTag;
+
+/** Adapter class for {@code Output} to handle async compaction/clustering service thread safe issues */
+public class MaskingOutputAdapter<OUT> implements Output<StreamRecord<OUT>> {
+
+  private final Output<StreamRecord<OUT>> output;
+
+  public MaskingOutputAdapter(Output<StreamRecord<OUT>> output) {
+    this.output = output;
+  }
+
+  @Override
+  public void emitWatermark(Watermark watermark) {
+    // For thread safe, not to propagate the watermark
+  }
+
+  @Override
+  public void emitLatencyMarker(LatencyMarker latencyMarker) {
+    // For thread safe, not to propagate latency marker
+  }
+
+  @Override
+  public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {
+    // For thread safe, not to propagate watermark status
+  }
+
+  @Override
+  public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> streamRecord) {
+    this.output.collect(outputTag, streamRecord);
+  }
+
+  @Override
+  public void collect(StreamRecord<OUT> outStreamRecord) {
+    this.output.collect(outStreamRecord);
+  }
+
+  @Override
+  public void close() {
+    this.output.close();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.util.OutputTag;
+
+/** Adapter class for {@code Output} to handle async compaction/clustering service thread safe issues */
+public class MaskingOutputAdapter<OUT> implements Output<StreamRecord<OUT>> {
+
+  private final Output<StreamRecord<OUT>> output;
+
+  public MaskingOutputAdapter(Output<StreamRecord<OUT>> output) {
+    this.output = output;
+  }
+
+  @Override
+  public void emitWatermark(Watermark watermark) {
+    // For thread safe, not to propagate the watermark
+  }
+
+  @Override
+  public void emitLatencyMarker(LatencyMarker latencyMarker) {
+    // For thread safe, not to propagate latency marker
+  }
+
+  @Override
+  public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {
+    // For thread safe, not to propagate watermark status
+  }
+
+  @Override
+  public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> streamRecord) {
+    this.output.collect(outputTag, streamRecord);
+  }
+
+  @Override
+  public void collect(StreamRecord<OUT> outStreamRecord) {
+    this.output.collect(outStreamRecord);
+  }
+
+  @Override
+  public void close() {
+    this.output.close();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/adapter/MaskingOutputAdapter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.util.OutputTag;
+
+/** Adapter class for {@code Output} to handle async compaction/clustering service thread safe issues */
+public class MaskingOutputAdapter<OUT> implements Output<StreamRecord<OUT>> {
+
+  private final Output<StreamRecord<OUT>> output;
+
+  public MaskingOutputAdapter(Output<StreamRecord<OUT>> output) {
+    this.output = output;
+  }
+
+  @Override
+  public void emitWatermark(Watermark watermark) {
+    // For thread safe, not to propagate the watermark
+  }
+
+  @Override
+  public void emitLatencyMarker(LatencyMarker latencyMarker) {
+    // For thread safe, not to propagate latency marker
+  }
+
+  @Override
+  public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {
+    // For thread safe, not to propagate watermark status
+  }
+
+  @Override
+  public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> streamRecord) {
+    this.output.collect(outputTag, streamRecord);
+  }
+
+  @Override
+  public void collect(StreamRecord<OUT> outStreamRecord) {
+    this.output.collect(outStreamRecord);
+  }
+
+  @Override
+  public void close() {
+    this.output.close();
+  }
+}


### PR DESCRIPTION
### Change Logs

Fix remained ser/des concurrency conflicts when aysnc compaction/clustering enabled.

#### 1.  fix conflicts caused by ```WatermarkStatus```

Conflicts will result from ```Watermark```, ```LatencyMarker``` and ```WatermarkStatus```, the community has fix other issues except ```WatermarkStatus```. We will fix it in this PR.
    
flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java

```
    private void processElement(StreamElement recordOrMark, DataOutput<T> output) throws Exception {
        if (recordOrMark.isRecord()) {
            output.emitRecord(recordOrMark.asRecord());
        } else if (recordOrMark.isWatermark()) {
            statusWatermarkValve.inputWatermark(
                    recordOrMark.asWatermark(), flattenedChannelIndices.get(lastChannel), output);
        } else if (recordOrMark.isLatencyMarker()) {
            output.emitLatencyMarker(recordOrMark.asLatencyMarker());
        } else if (recordOrMark.isWatermarkStatus()) {
            statusWatermarkValve.inputWatermarkStatus(
                    recordOrMark.asWatermarkStatus(),
                    flattenedChannelIndices.get(lastChannel),
                    output);
        } else {
            throw new UnsupportedOperationException("Unknown type of StreamElement");
        }
    }
```

####  2. Since the ```WatermarkStatus```  is introduced since Flink1.14, this PR will add ```SafeAsyncOutputAdapter``` in multi modules, to coordinate Flink1.13 and Flink1.14 above

The ```Output```  is actually the root cause of concurrency conflicts, so let's just refactor it but not the compact/cluster operator to minimize the impacts.

### Impact

none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

fix bugs in multi Flink versions.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
