### PR TITLE
[HUDI-6033] Fix rounding exception when to decimal casting

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.HoodieUnsafeRowUtils.{NestedFieldPath, composeNested
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, GenericArrayData, MapData}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
-import org.apache.spark.sql.types.Decimal.ROUND_HALF_EVEN
+import org.apache.spark.sql.types.Decimal.ROUND_HALF_UP
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -286,7 +286,7 @@ object HoodieInternalRowUtils {
             (fieldUpdater, ordinal, value) =>
               val scale = newDecimal.scale
               // TODO this has to be revisited to avoid loss of precision (for fps)
-              fieldUpdater.setDecimal(ordinal, Decimal.fromDecimal(BigDecimal(value.toString).setScale(scale, ROUND_HALF_EVEN)))
+              fieldUpdater.setDecimal(ordinal, Decimal.fromDecimal(BigDecimal(value.toString).setScale(scale, ROUND_HALF_UP)))
 
           case _: DecimalType =>
             (fieldUpdater, ordinal, value) =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -845,8 +845,6 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           spark.sql(s"alter table $tableName alter column price type decimal(4, 2)")
 
           // Not checking answer as this is an unsafe casting operation, just need to make sure that error is not thrown
-          // Floating point errors can cause a difference between COW (uses Spark's rounding scheme)
-          // and MOR (uses Hudi defined HALF_EVEN rounding) tables
           spark.sql(s"select id, name, cast(price as string), ts from $tableName")
         }
       }


### PR DESCRIPTION
### Change Logs

Fix rounding exception when there's a loss in precision while performing a XXX to DECIMAL(p, s) unsafe casting where a loss in scale is used. 

For stacktrace and detailed explanation of why **HALF_EVEN** and special cases where **HALF_UP** rounding scheme was used, please refer to the JIRA ticket here: [HUDI-6033](https://issues.apache.org/jira/browse/HUDI-6033)


TLDR:
Add rounding mode to to fix rounding exceptions being thrown.

float -> decimal: HALF_EVEN
double -> decimal: HALF_UP,

### Impact
None

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
None

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
