### PR TITLE
[HUDI-5816] List all partitions as the fallback mechanism in Hive and Glue Sync

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,7 @@ stages:
       - job: UT_FT_1
         displayName: UT FT common & flink & UT client/spark-client
         timeoutInMinutes: '150'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -138,6 +139,7 @@ stages:
       - job: UT_FT_2
         displayName: FT client/spark-client
         timeoutInMinutes: '150'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -162,6 +164,7 @@ stages:
       - job: UT_FT_3
         displayName: UT spark-datasource
         timeoutInMinutes: '180'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -200,7 +203,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB4_UT_MODULES)
+              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB4_UT_MODULES) -DfailIfNoTests=false -DwildcardSuites="abc" -Dtest=TestHoodieDeltaStreamer#testForceEmptyMetaSync
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
@@ -219,6 +222,7 @@ stages:
       - job: IT
         displayName: IT modules
         timeoutInMinutes: '150'
+        condition: false
         steps:
           - task: Maven@4
             displayName: maven install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,6 @@ stages:
       - job: UT_FT_1
         displayName: UT FT common & flink & UT client/spark-client
         timeoutInMinutes: '150'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -139,7 +138,6 @@ stages:
       - job: UT_FT_2
         displayName: FT client/spark-client
         timeoutInMinutes: '150'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -164,7 +162,6 @@ stages:
       - job: UT_FT_3
         displayName: UT spark-datasource
         timeoutInMinutes: '180'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install
@@ -203,7 +200,7 @@ stages:
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB4_UT_MODULES) -DfailIfNoTests=false -DwildcardSuites="abc" -Dtest=TestHoodieDeltaStreamer#testForceEmptyMetaSync
+              options: $(MVN_OPTS_TEST) -Punit-tests -pl $(JOB4_UT_MODULES)
               publishJUnitResults: false
               jdkVersionOption: '1.8'
               mavenOptions: '-Xmx4g'
@@ -222,7 +219,6 @@ stages:
       - job: IT
         displayName: IT modules
         timeoutInMinutes: '150'
-        condition: false
         steps:
           - task: Maven@4
             displayName: maven install

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -235,7 +235,8 @@ public class FSUtils {
     String fullPartitionPathStr = fullPartitionPath.toString();
 
     if (!fullPartitionPathStr.startsWith(basePath.toString())) {
-      throw new IllegalArgumentException("Partition path does not belong to base-path");
+      throw new IllegalArgumentException("Partition path \"" + fullPartitionPathStr
+          + "\" does not belong to base-path \"" + basePath + "\"");
     }
 
     int partitionStartIndex = fullPartitionPathStr.indexOf(basePath.getName(),

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieSyncTableStrategy;
@@ -71,6 +72,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.fs.FSUtils.getRelativePartitionPath;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.hive.HiveSyncConfig.HIVE_SYNC_FILTER_PUSHDOWN_ENABLED;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_AUTO_CREATE_DATABASE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
@@ -282,7 +285,8 @@ public class TestHiveSyncTool {
     // Manually change a hive partition location to check if the sync will detect
     // it and generate a partition update event for it.
     ddlExecutor.runSQL("ALTER TABLE `" + HiveTestUtil.TABLE_NAME
-        + "` PARTITION (`datestr`='2050-01-01') SET LOCATION '/some/new/location'");
+        + "` PARTITION (`datestr`='2050-01-01') SET LOCATION '"
+        + FSUtils.getPartitionPath(basePath, "2050/1/1").toString() + "'");
 
     hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.empty());
@@ -299,6 +303,48 @@ public class TestHiveSyncTool {
     assertEquals(7, tablePartitions.size(), "The one partition we wrote should be added to hive");
     assertEquals(instantTime, hiveClient.getLastCommitTimeSynced(HiveTestUtil.TABLE_NAME).get(),
         "The last commit that was synced should be 100");
+
+    // Verify that there is one ADD, UPDATE, and DROP event for each type
+    hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
+    List<String> allPartitionPathsOnStorage = hiveClient.getAllPartitionPathsOnStorage()
+        .stream().sorted().collect(Collectors.toList());
+    String dropPartition = allPartitionPathsOnStorage.remove(0);
+    allPartitionPathsOnStorage.add("2050/01/02");
+    partitionEvents = hiveClient.getPartitionEvents(hivePartitions, allPartitionPathsOnStorage);
+    assertEquals(3, partitionEvents.size(), "There should be only one partition event");
+    assertEquals(
+        "2050/01/02",
+        partitionEvents.stream().filter(e -> e.eventType == PartitionEventType.ADD)
+            .findFirst().get().storagePartition,
+        "There should be only one partition event of type ADD");
+    assertEquals(
+        "2050/01/01",
+        partitionEvents.stream().filter(e -> e.eventType == PartitionEventType.UPDATE)
+            .findFirst().get().storagePartition,
+        "There should be only one partition event of type UPDATE");
+    assertEquals(
+        dropPartition,
+        partitionEvents.stream().filter(e -> e.eventType == PartitionEventType.DROP)
+            .findFirst().get().storagePartition,
+        "There should be only one partition event of type DROP");
+
+    // Simulate the case where the last sync timestamp is before the start of the active timeline,
+    // by overwriting the same table with some partitions deleted and new partitions added
+    HiveTestUtil.createCOWTable("200", 6, useSchemaFromCommitMetadata);
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+    tablePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
+    assertEquals(Option.of("200"), hiveClient.getLastCommitTimeSynced(HiveTestUtil.TABLE_NAME));
+    assertEquals(6, tablePartitions.size());
+
+    // Trigger the fallback of listing all partitions again.  There is no partition change.
+    HiveTestUtil.commitToTable("300", 1, useSchemaFromCommitMetadata);
+    HiveTestUtil.removeCommitFromActiveTimeline("200", COMMIT_ACTION);
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+    tablePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
+    assertEquals(Option.of("300"), hiveClient.getLastCommitTimeSynced(HiveTestUtil.TABLE_NAME));
+    assertEquals(6, tablePartitions.size());
   }
 
   @ParameterizedTest
@@ -1336,6 +1382,9 @@ public class TestHiveSyncTool {
     String commitTime0 = "100";
     String commitTime1 = "101";
     String commitTime2 = "102";
+    String commitTime3 = "103";
+    String commitTime4 = "104";
+    String commitTime5 = "105";
     HiveTestUtil.createMORTable(commitTime0, commitTime1, 2, true, true);
 
     reInitHiveSyncClient();
@@ -1344,8 +1393,20 @@ public class TestHiveSyncTool {
     assertTrue(hiveClient.tableExists(tableName));
     assertEquals(commitTime1, hiveClient.getLastCommitTimeSynced(tableName).get());
 
-    HiveTestUtil.addMORPartitions(0, true, true, true, ZonedDateTime.now().plusDays(2), commitTime1, commitTime2);
+    HiveTestUtil.addMORPartitions(0, true, true, true, ZonedDateTime.now().plusDays(2), commitTime2, commitTime3);
 
+    reSyncHiveTable();
+    assertEquals(commitTime1, hiveClient.getLastCommitTimeSynced(tableName).get());
+
+    // Let the last commit time synced to be before the start of the active timeline,
+    // to trigger the fallback of listing all partitions. There is no partition change
+    // and the last commit time synced should still be the same.
+    HiveTestUtil.addMORPartitions(0, true, true, true, ZonedDateTime.now().plusDays(2), commitTime4, commitTime5);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime0, COMMIT_ACTION);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime1, DELTA_COMMIT_ACTION);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime2, COMMIT_ACTION);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime3, DELTA_COMMIT_ACTION);
+    reInitHiveSyncClient();
     reSyncHiveTable();
     assertEquals(commitTime1, hiveClient.getLastCommitTimeSynced(tableName).get());
   }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -68,6 +68,7 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.junit.platform.commons.JUnitException;
+import org.mortbay.log.Log;
 
 import java.io.File;
 import java.io.IOException;
@@ -88,6 +89,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
@@ -190,20 +192,54 @@ public class HiveTestUtil {
   public static void createCOWTable(String instantTime, int numberOfPartitions, boolean useSchemaFromCommitMetadata,
                                     String basePath, String databaseName, String tableName) throws IOException, URISyntaxException {
     Path path = new Path(basePath);
-    FileIOUtils.deleteDirectory(new File(basePath));
+    if (fileSystem.exists(path)) {
+      fileSystem.delete(path, true);
+    }
     HoodieTableMetaClient.withPropertyBuilder()
-            .setTableType(HoodieTableType.COPY_ON_WRITE)
-            .setTableName(tableName)
-            .setPayloadClass(HoodieAvroPayload.class)
-            .initTable(configuration, basePath);
+        .setTableType(HoodieTableType.COPY_ON_WRITE)
+        .setTableName(tableName)
+        .setPayloadClass(HoodieAvroPayload.class)
+        .initTable(configuration, basePath);
 
     boolean result = fileSystem.mkdirs(path);
     checkResult(result);
+    commitToTable(instantTime, numberOfPartitions, useSchemaFromCommitMetadata,
+        basePath, databaseName, tableName);
+  }
+
+  public static void commitToTable(
+      String instantTime, int numberOfPartitions, boolean useSchemaFromCommitMetadata)
+      throws IOException, URISyntaxException {
+    commitToTable(instantTime, numberOfPartitions, useSchemaFromCommitMetadata,
+        basePath, DB_NAME, TABLE_NAME);
+  }
+
+  public static void commitToTable(
+      String instantTime, int numberOfPartitions, boolean useSchemaFromCommitMetadata,
+      String basePath, String databaseName, String tableName) throws IOException, URISyntaxException {
     ZonedDateTime dateTime = ZonedDateTime.now();
     HoodieCommitMetadata commitMetadata = createPartitions(numberOfPartitions, true,
-            useSchemaFromCommitMetadata, dateTime, instantTime, basePath);
+        useSchemaFromCommitMetadata, dateTime, instantTime, basePath);
     createdTablesSet.add(databaseName + "." + tableName);
     createCommitFile(commitMetadata, instantTime, basePath);
+  }
+
+  public static void removeCommitFromActiveTimeline(String instantTime, String actionType) {
+    List<Path> pathsToDelete = new ArrayList<>();
+    Path metaFolderPath = new Path(basePath, METAFOLDER_NAME);
+    String actionSuffix = "." + actionType;
+    pathsToDelete.add(new Path(metaFolderPath, instantTime + actionSuffix));
+    pathsToDelete.add(new Path(metaFolderPath, instantTime + actionSuffix + ".requested"));
+    pathsToDelete.add(new Path(metaFolderPath, instantTime + actionSuffix + ".inflight"));
+    pathsToDelete.forEach(path -> {
+      try {
+        if (fileSystem.exists(path)) {
+          fileSystem.delete(path, false);
+        }
+      } catch (IOException e) {
+        Log.warn("Error deleting file: ", e);
+      }
+    });
   }
 
   public static void createCOWTable(String instantTime, int numberOfPartitions, boolean useSchemaFromCommitMetadata)
@@ -481,7 +517,7 @@ public class HiveTestUtil {
 
   public static void createCommitFile(HoodieCommitMetadata commitMetadata, String instantTime, String basePath) throws IOException {
     byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
         + HoodieTimeline.makeCommitFileName(instantTime));
     FSDataOutputStream fsout = fileSystem.create(fullPath, true);
     fsout.write(bytes);
@@ -490,7 +526,7 @@ public class HiveTestUtil {
 
   public static void createReplaceCommitFile(HoodieReplaceCommitMetadata commitMetadata, String instantTime) throws IOException {
     byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
         + HoodieTimeline.makeReplaceFileName(instantTime));
     FSDataOutputStream fsout = fileSystem.create(fullPath, true);
     fsout.write(bytes);
@@ -505,7 +541,7 @@ public class HiveTestUtil {
   private static void createCompactionCommitFile(HoodieCommitMetadata commitMetadata, String instantTime)
       throws IOException {
     byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
         + HoodieTimeline.makeCommitFileName(instantTime));
     FSDataOutputStream fsout = fileSystem.create(fullPath, true);
     fsout.write(bytes);
@@ -515,7 +551,7 @@ public class HiveTestUtil {
   private static void createDeltaCommitFile(HoodieCommitMetadata deltaCommitMetadata, String deltaCommitTime)
       throws IOException {
     byte[] bytes = deltaCommitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
         + HoodieTimeline.makeDeltaFileName(deltaCommitTime));
     FSDataOutputStream fsout = fileSystem.create(fullPath, true);
     fsout.write(bytes);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -68,7 +68,8 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.junit.platform.commons.JUnitException;
-import org.mortbay.log.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,6 +106,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("SameParameterValue")
 public class HiveTestUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveTestUtil.class);
 
   public static final String DB_NAME = "testdb";
   public static final String TABLE_NAME = "test1";
@@ -237,7 +239,7 @@ public class HiveTestUtil {
           fileSystem.delete(path, false);
         }
       } catch (IOException e) {
-        Log.warn("Error deleting file: ", e);
+        LOG.warn("Error deleting file: ", e);
       }
     });
   }

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.sync.common.model.Partition;
 import org.apache.hudi.sync.common.model.PartitionEvent;
 import org.apache.hudi.sync.common.model.PartitionValueExtractor;
@@ -112,16 +113,25 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
     }
   }
 
+  /**
+   * Gets all relative partitions paths in the Hudi table on storage.
+   *
+   * @return All relative partitions paths.
+   */
+  public List<String> getAllPartitionPathsOnStorage() {
+    HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getHadoopConf());
+    return FSUtils.getAllPartitionPaths(engineContext,
+        config.getString(META_SYNC_BASE_PATH),
+        config.getBoolean(META_SYNC_USE_FILE_LISTING_FROM_METADATA),
+        config.getBoolean(META_SYNC_ASSUME_DATE_PARTITION));
+  }
+
   public List<String> getWrittenPartitionsSince(Option<String> lastCommitTimeSynced) {
     if (!lastCommitTimeSynced.isPresent()) {
       LOG.info("Last commit time synced is not known, listing all partitions in "
           + config.getString(META_SYNC_BASE_PATH)
           + ",FS :" + config.getHadoopFileSystem());
-      HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getHadoopConf());
-      return FSUtils.getAllPartitionPaths(engineContext,
-          config.getString(META_SYNC_BASE_PATH),
-          config.getBoolean(META_SYNC_USE_FILE_LISTING_FROM_METADATA),
-          config.getBoolean(META_SYNC_ASSUME_DATE_PARTITION));
+      return getAllPartitionPathsOnStorage();
     } else {
       LOG.info("Last commit time synced is " + lastCommitTimeSynced.get() + ", Getting commits since then");
       return TimelineUtils.getWrittenPartitions(
@@ -130,26 +140,67 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
   }
 
   /**
-   * Iterate over the storage partitions and find if there are any new partitions that need to be added or updated.
-   * Generate a list of PartitionEvent based on the changes required.
+   * Gets the partition events for changed partitions.
+   * <p>
+   * This compares the list of all partitions of a table stored in the metastore and
+   * on the storage:
+   * (1) Partitions exist in the metastore, but NOT the storage: drops them in the metastore;
+   * (2) Partitions exist on the storage, but NOT the metastore: adds them to the metastore;
+   * (3) Partitions exist in both, but the partition path is different: update them in the metastore.
+   *
+   * @param allPartitionsInMetastore All partitions of a table stored in the metastore.
+   * @param allPartitionsOnStorage   All partitions of a table stored on the storage.
+   * @return partition events for changed partitions.
    */
-  public List<PartitionEvent> getPartitionEvents(List<Partition> tablePartitions, List<String> partitionStoragePartitions, Set<String> droppedPartitions) {
-    Map<String, String> paths = new HashMap<>();
-    for (Partition tablePartition : tablePartitions) {
-      List<String> hivePartitionValues = tablePartition.getValues();
-      String fullTablePartitionPath =
-          Path.getPathWithoutSchemeAndAuthority(new Path(tablePartition.getStorageLocation())).toUri().getPath();
-      paths.put(String.join(", ", hivePartitionValues), fullTablePartitionPath);
-    }
+  public List<PartitionEvent> getPartitionEvents(List<Partition> allPartitionsInMetastore,
+                                                 List<String> allPartitionsOnStorage) {
+    Map<String, String> paths = getPartitionValuesToPathMapping(allPartitionsInMetastore);
+    Set<String> partitionsToDrop = new HashSet<>(paths.keySet());
 
     List<PartitionEvent> events = new ArrayList<>();
-    for (String storagePartition : partitionStoragePartitions) {
+    for (String storagePartition : allPartitionsOnStorage) {
       Path storagePartitionPath = FSUtils.getPartitionPath(config.getString(META_SYNC_BASE_PATH), storagePartition);
       String fullStoragePartitionPath = Path.getPathWithoutSchemeAndAuthority(storagePartitionPath).toUri().getPath();
       // Check if the partition values or if hdfs path is the same
       List<String> storagePartitionValues = partitionValueExtractor.extractPartitionValuesInPath(storagePartition);
 
-      if (droppedPartitions.contains(storagePartition)) {
+      if (!storagePartitionValues.isEmpty()) {
+        String storageValue = String.join(", ", storagePartitionValues);
+        // Remove partitions that exist on storage from the `partitionsToDrop` set,
+        // so the remaining partitions that exist in the metastore should be dropped
+        partitionsToDrop.remove(storageValue);
+        if (!paths.containsKey(storageValue)) {
+          events.add(PartitionEvent.newPartitionAddEvent(storagePartition));
+        } else if (!paths.get(storageValue).equals(fullStoragePartitionPath)) {
+          events.add(PartitionEvent.newPartitionUpdateEvent(storagePartition));
+        }
+      }
+    }
+
+    partitionsToDrop.forEach(storageValue ->
+        events.add(PartitionEvent.newPartitionDropEvent(
+            FSUtils.getRelativePartitionPath(
+                metaClient.getBasePathV2(), new CachingPath(paths.get(storageValue))))));
+    return events;
+  }
+
+  /**
+   * Iterate over the storage partitions and find if there are any new partitions that need to be added or updated.
+   * Generate a list of PartitionEvent based on the changes required.
+   */
+  public List<PartitionEvent> getPartitionEvents(List<Partition> partitionsInMetastore,
+                                                 List<String> writtenPartitionsOnStorage,
+                                                 Set<String> droppedPartitionsOnStorage) {
+    Map<String, String> paths = getPartitionValuesToPathMapping(partitionsInMetastore);
+
+    List<PartitionEvent> events = new ArrayList<>();
+    for (String storagePartition : writtenPartitionsOnStorage) {
+      Path storagePartitionPath = FSUtils.getPartitionPath(config.getString(META_SYNC_BASE_PATH), storagePartition);
+      String fullStoragePartitionPath = Path.getPathWithoutSchemeAndAuthority(storagePartitionPath).toUri().getPath();
+      // Check if the partition values or if hdfs path is the same
+      List<String> storagePartitionValues = partitionValueExtractor.extractPartitionValuesInPath(storagePartition);
+
+      if (droppedPartitionsOnStorage.contains(storagePartition)) {
         events.add(PartitionEvent.newPartitionDropEvent(storagePartition));
       } else {
         if (!storagePartitionValues.isEmpty()) {
@@ -163,5 +214,23 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
       }
     }
     return events;
+  }
+
+  /**
+   * Gets the partition values to the absolute path mapping based on the
+   * partition information from the metastore.
+   *
+   * @param partitionsInMetastore Partitions in the metastore.
+   * @return The partition values to the absolute path mapping.
+   */
+  private Map<String, String> getPartitionValuesToPathMapping(List<Partition> partitionsInMetastore) {
+    Map<String, String> paths = new HashMap<>();
+    for (Partition tablePartition : partitionsInMetastore) {
+      List<String> hivePartitionValues = tablePartition.getValues();
+      String fullTablePartitionPath =
+          Path.getPathWithoutSchemeAndAuthority(new Path(tablePartition.getStorageLocation())).toUri().getPath();
+      paths.put(String.join(", ", hivePartitionValues), fullTablePartitionPath);
+    }
+    return paths;
   }
 }


### PR DESCRIPTION
### Change Logs

This PR adds the fallback mechanism in Hive and Glue catalog sync so that if the last commit time synced falls behind to be before the start of the active timeline of Hudi table, the sync gets all partition paths on storage and resolves the difference compared to what's in the metastore, instead of reading archived timeline which can be expensive in I/O.  The PR also enhances the tests to cover the new logic.

Note that, the last commit time synced CAN fall behind, especially for Glue catalog, where `hoodie.datasource.meta_sync.condition.sync` is recommended to be set to `true` so that the last commit time synced is only updated upon partition changes, to limit the number of versions of data in Glue catalog.

### Impact

Avoids loading archived timeline during Hive and Glue Sync.

### Risk level

low

### Documentation Update

No documentation update needed.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
