### PR TITLE
[HUDI-6045] Support append mode by default for MOR table with INSERT operation

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -59,8 +59,8 @@ public class OptionsResolver {
   public static boolean isAppendMode(Configuration conf) {
     // 1. inline clustering is supported for COW table;
     // 2. async clustering is supported for both COW and MOR table
-    return isCowTable(conf) && isInsertOperation(conf) && !conf.getBoolean(FlinkOptions.INSERT_CLUSTER)
-        || needsScheduleClustering(conf);
+    return (isCowTable(conf) && isInsertOperation(conf) && !conf.getBoolean(FlinkOptions.INSERT_CLUSTER))
+        || (isMorTable(conf) && isInsertOperation(conf));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -59,8 +59,7 @@ public class OptionsResolver {
   public static boolean isAppendMode(Configuration conf) {
     // 1. inline clustering is supported for COW table;
     // 2. async clustering is supported for both COW and MOR table
-    return (isCowTable(conf) && isInsertOperation(conf) && !conf.getBoolean(FlinkOptions.INSERT_CLUSTER))
-        || (isMorTable(conf) && isInsertOperation(conf));
+    return isInsertOperation(conf) && ((isCowTable(conf) && !conf.getBoolean(FlinkOptions.INSERT_CLUSTER)) || isMorTable(conf));
   }
 
   /**


### PR DESCRIPTION
### Change Logs
[HUDI-6045](https://issues.apache.org/jira/browse/HUDI-6045)

1. Insert scenario in the COW table, if both online sync-clustering and online async-clustering(plan generate || plan execute) are configured simultaneously, sometimes sync-clustering takes effect, sometimes async-clustering takes effect：

sync-clustering=true & generate async-clustering=true & execute async-clustering=true：sync-clustering takes effect
sync-clustering=true & generate async-clustering=false & execute async-clustering=true: async-clustering takes effect

2. Insert scenario in the MOR table，sometimes generate log files, sometimes generate parquet files.
async-compaction=true & generate async-clustering=false : generate log files
async-compaction=false & generate async-clustering=true: generate parquet files

This will cause confusion for users

After modification:

1. Insert scenario in the COW table,  sync-clustering has higher priority than online async-clusering.
3. Insert scenario in the MOR table will always generate parquet files


### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
