### PR TITLE
[HUDI-4630] Add transformer capability to individual feeds in MultiTableDeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -134,6 +134,7 @@ public class HoodieMultiTableDeltaStreamer {
       if (cfg.enableMetaSync && StringUtils.isNullOrEmpty(tableProperties.getString(HoodieSyncConfig.META_SYNC_TABLE_NAME.key(), ""))) {
         throw new HoodieException("Meta sync table field not provided!");
       }
+      populateTransformerProps(cfg, tableProperties);
       populateSchemaProviderProps(cfg, tableProperties);
       executionContext = new TableExecutionContext();
       executionContext.setProperties(tableProperties);
@@ -141,6 +142,13 @@ public class HoodieMultiTableDeltaStreamer {
       executionContext.setDatabase(database);
       executionContext.setTableName(currentTable);
       this.tableExecutionContexts.add(executionContext);
+    }
+  }
+
+  private void populateTransformerProps(HoodieDeltaStreamer.Config cfg, TypedProperties typedProperties) {
+    String transformerClassNameOverride = typedProperties.getString(Constants.TRANSFORMER_CLASS, null);
+    if (not StringUtils.isNullOrEmpty(transformerClassNameOverride)) {
+      cfg.transformerClassNames = transformerClassNameOverride;
     }
   }
 
@@ -453,6 +461,7 @@ public class HoodieMultiTableDeltaStreamer {
     private static final String DELIMITER = ".";
     private static final String UNDERSCORE = "_";
     private static final String COMMA_SEPARATOR = ",";
+    private static final String TRANSFORMER_CLASS = "hoodie.deltastreamer.transformer.class";
   }
 
   public Set<String> getSuccessTables() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -146,8 +146,9 @@ public class HoodieMultiTableDeltaStreamer {
   }
 
   private void populateTransformerProps(HoodieDeltaStreamer.Config cfg, TypedProperties typedProperties) {
-    List<String> transformerClassNameOverride = Arrays.asList(typedProperties.getString(Constants.TRANSFORMER_CLASS, null).split(","));
-    if (! transformerClassNameOverride.isEmpty()) {
+    String transformerClass = typedProperties.getString(Constants.TRANSFORMER_CLASS, null);
+    if (transformerClass != null && !transformerClass.trim().isEmpty()) {
+      List<String> transformerClassNameOverride = Arrays.asList(transformerClass.split(","));
       cfg.transformerClassNames = transformerClassNameOverride;
     }
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -146,8 +146,8 @@ public class HoodieMultiTableDeltaStreamer {
   }
 
   private void populateTransformerProps(HoodieDeltaStreamer.Config cfg, TypedProperties typedProperties) {
-    String transformerClassNameOverride = typedProperties.getString(Constants.TRANSFORMER_CLASS, null);
-    if (not StringUtils.isNullOrEmpty(transformerClassNameOverride)) {
+    List<String> transformerClassNameOverride = Arrays.asList(typedProperties.getString(Constants.TRANSFORMER_CLASS, null).split(","));
+    if (! transformerClassNameOverride.isEmpty()) {
       cfg.transformerClassNames = transformerClassNameOverride;
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -84,7 +84,6 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
     HoodieDeltaStreamer.Config dsConfig = new HoodieDeltaStreamer.Config();
     TypedProperties tblProperties = new TypedProperties();
     HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
-    streamer.populateTransformerProps(dsConfig, tblProperties);
     assertNull(cfg.transformerClassNames);
   }
   

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -244,10 +245,13 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
         case "dummy_table_short_trip":
           String tableLevelKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestTableLevelGenerator.class.getName(), tableLevelKeyGeneratorClass);
+          List<String> transformerClass = tableExecutionContext.getConfig().transformerClassNames;
+          assertEquals("org.apache.hudi.utilities.transform.SqlFileBasedTransformer", transformerClass.get(0));
           break;
         default:
           String defaultKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestGenerator.class.getName(), defaultKeyGeneratorClass);
+          assertNull(tableExecutionContext.getConfig().transformerClassNames);
       }
     });
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -79,7 +79,7 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
 
   @Test
   public void testEmptyTransformerProps() throws IOException {
-//    HUDI-4630: If there is no transformer props passed through, don't populate the transformerClassNames
+    // HUDI-4630: If there is no transformer props passed through, don't populate the transformerClassNames
     HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, basePath + "/config", TestDataSource.class.getName(), false, false, null);
     HoodieDeltaStreamer.Config dsConfig = new HoodieDeltaStreamer.Config();
     TypedProperties tblProperties = new TypedProperties();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -78,6 +78,17 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
   }
 
   @Test
+  public void testEmptyTransformerProps() throws IOException {
+//    HUDI-4630: If there is no transformer props passed through, don't populate the transformerClassNames
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, basePath + "/config", TestDataSource.class.getName(), false, false, null);
+    HoodieDeltaStreamer.Config dsConfig = new HoodieDeltaStreamer.Config();
+    TypedProperties tblProperties = new TypedProperties();
+    HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
+    streamer.populateTransformerProps(dsConfig, tblProperties);
+    assertNull(cfg.transformerClassNames);
+  }
+  
+  @Test
   public void testMetaSyncConfig() throws IOException {
     HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, basePath + "/config", TestDataSource.class.getName(), true, true, null);
     HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
@@ -246,12 +257,12 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
           String tableLevelKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestTableLevelGenerator.class.getName(), tableLevelKeyGeneratorClass);
           List<String> transformerClass = tableExecutionContext.getConfig().transformerClassNames;
-          assertEquals("org.apache.hudi.utilities.transform.SqlFileBasedTransformer", transformerClass.get(0));
+          assertEquals("org.apache.hudi.utilities.transform.SqlFileBasedTransformer", transformerClass.get(0)); // HUDI-4630
           break;
         default:
           String defaultKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestGenerator.class.getName(), defaultKeyGeneratorClass);
-          assertNull(tableExecutionContext.getConfig().transformerClassNames);
+          assertNull(tableExecutionContext.getConfig().transformerClassNames);  //HUDI-4630
       }
     });
   }

--- a/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
@@ -25,3 +25,4 @@ hoodie.datasource.hive_sync.table=short_trip_uber_hive_dummy_table
 hoodie.datasource.write.keygenerator.class=org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamer$TestTableLevelGenerator
 hoodie.deltastreamer.schemaprovider.registry.baseUrl=http://localhost:8081/subjects/
 hoodie.deltastreamer.schemaprovider.registry.urlSuffix=-value/versions/latest
+hoodie.deltastreamer.transformer.class=org.apache.hudi.utilities.transform.SqlFileBasedTransformer


### PR DESCRIPTION
### Change Logs

Follow up of https://github.com/apache/hudi/pull/6726

### Impact

No Impact on existing users of MultitableDeltastreamer as this is a new optional feature.

### Risk level (write none, low medium or high below)

None

### Documentation Update

Adds a feature to have separate and optional transformer logic for individual tables in MultiTableDeltaStreamer. For tables requiring a transformer to be incorporated, `hoodie.deltastreamer.transformer.class` is the property through which the transformer class has to be specified. The config has to be added in the tablewise properties file from `hoodie.deltastreamer.ingestion.<db>.<table>.configFile`.

### Contributor's checklist

- [X ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ X] Change Logs and Impact were stated clearly
- [ X] Adequate tests were added if applicable
- [ ] CI passed
