### PR TITLE
[HUDI-6048] Check if partition exists before list partition by path prefix

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -299,7 +299,9 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
       // prefix to try to reduce the scope of the required file-listing
       val relativePartitionPathPrefix = composeRelativePartitionPath(staticPartitionColumnNameValuePairs)
 
-      if (staticPartitionColumnNameValuePairs.length == partitionColumnNames.length) {
+      if (!metaClient.getFs.exists(new Path(getBasePath, relativePartitionPathPrefix))) {
+        Seq()
+      } else if (staticPartitionColumnNameValuePairs.length == partitionColumnNames.length) {
         // In case composed partition path is complete, we can return it directly avoiding extra listing operation
         Seq(new PartitionPath(relativePartitionPathPrefix, staticPartitionColumnNameValuePairs.map(_._2.asInstanceOf[AnyRef]).toArray))
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -520,7 +520,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
         "dt = '2023/01/01' and region_code = '1'",
         enablePartitionPathPrefixAnalysis,
         Seq(("1", "2023/01/01"))),
-      // no partition marched
+      // no partition matched
       (Seq(EqualTo(attribute("region_code"), literal("0"))),
         "region_code = '0'",
         enablePartitionPathPrefixAnalysis,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -519,7 +519,12 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
         EqualTo(attribute("region_code"), literal("1"))),
         "dt = '2023/01/01' and region_code = '1'",
         enablePartitionPathPrefixAnalysis,
-        Seq(("1", "2023/01/01")))
+        Seq(("1", "2023/01/01"))),
+      // no partition marched
+      (Seq(EqualTo(attribute("region_code"), literal("0"))),
+        "region_code = '0'",
+        enablePartitionPathPrefixAnalysis,
+        Seq())
     )
 
     testCases.foreach(testCase => {


### PR DESCRIPTION
### Change Logs

Currently, in `tryListByPartitionPathPrefix`, when the prefix search condition is met, it will directly return or search without judging whether the directory exists. 

When metadata is not used, an exception will be thrown when querying non-existing partitions, for example:

```sql
create table hudi_cow_test_tbl (
  id bigint,
  name string,
  ts bigint,
  dt string,
  hh string
) using hudi
tblproperties (
  type = 'cow',
  primaryKey = 'id',
  preCombineField = 'ts',
  'hoodie.metadata.enable' = 'false'
)
partitioned by (dt, hh);

select * from hudi_cow_test_tbl where dt='xxx';
```

ERROR Executor: Exception in task 0.0 in stage 8.0 (TID 10)
java.io.FileNotFoundException: File file:/hudi_cow_test_tbl/dt=xxx does not exist

### Impact

When metadata is disabled and PartitionPathPrefixAnalysis is enabled, no exception will be thrown when querying non-existing partitions

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
