### PR TITLE
[HUDI-6053] Fix integration test run for M1 mac

### DIFF
--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -52,6 +52,21 @@
     </dependency>
 
     <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-common</artifactId>
+      <version>2.6.2</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-native-common</artifactId>
+      <version>2.6.2</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <exclusions>
@@ -554,4 +569,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>m1-mac</id>
+      <properties>
+        <dockerCompose.file>${project.basedir}/../docker/compose/docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml</dockerCompose.file>
+      </properties>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <genjavadoc-plugin.version>0.15</genjavadoc-plugin.version>
     <build-helper-maven-plugin.version>1.7</build-helper-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-    <maven-docker-plugin.version>0.37.0</maven-docker-plugin.version>
+    <maven-docker-plugin.version>0.42.1</maven-docker-plugin.version>
 
     <java.version>1.8</java.version>
     <kryo.shaded.version>4.0.2</kryo.shaded.version>


### PR DESCRIPTION
### Change Logs

Its difficult to get an integration test run on M1 mac. The Jira aims to fix the issues so that integration tests can be run using command line.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

Would create a corresponding jira for updating developer setup documentation.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
