### PR TITLE
[HUDI-6058] Bump Curator referred in spark3 to 2.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2208,6 +2208,7 @@
         <orc.spark.version>1.7.8</orc.spark.version>
         <avro.version>1.11.1</avro.version>
         <antlr.version>4.8</antlr.version>
+        <zk-curator.version>2.13.0</zk-curator.version>
         <fasterxml.spark3.version>2.13.3</fasterxml.spark3.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
@@ -2249,6 +2250,7 @@
         <orc.spark.version>1.5.13</orc.spark.version>
         <avro.version>1.8.2</avro.version>
         <antlr.version>4.8-1</antlr.version>
+        <zk-curator.version>2.13.0</zk-curator.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
@@ -2290,6 +2292,7 @@
         <orc.spark.version>1.6.12</orc.spark.version>
         <avro.version>1.10.2</avro.version>
         <antlr.version>4.8</antlr.version>
+        <zk-curator.version>2.13.0</zk-curator.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
@@ -2332,6 +2335,7 @@
         <orc.spark.version>1.7.8</orc.spark.version>
         <avro.version>1.11.1</avro.version>
         <antlr.version>4.8</antlr.version>
+        <zk-curator.version>2.13.0</zk-curator.version>
         <fasterxml.spark3.version>2.13.3</fasterxml.spark3.version>
         <fasterxml.version>${fasterxml.spark3.version}</fasterxml.version>
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>


### PR DESCRIPTION
### Change Logs

Currently curator-client in hudi is 2.7.1, while the version is 2.13.0 in spark3.

There will be a NoSuchMethodError if we user ZookeeperBasedLockProvider with spark3.
```
Caused by: java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;
        at org.apache.curator.framework.listen.ListenerContainer.addListener(ListenerContainer.java:40)
        at org.apache.curator.framework.imps.CuratorFrameworkImpl.start(CuratorFrameworkImpl.java:246)
        at org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider.<init>(ZookeeperBasedLockProvider.java:76) 
```


### Impact

none
### Risk level (write none, low medium or high below)

low
### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
