### PR TITLE
[HUDI-6057]Fixing shutting down deltastreamer properly when post writ…

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -742,8 +742,8 @@ public class HoodieDeltaStreamer implements Serializable {
                   scheduledCompactionInstantAndRDD.isPresent() ? HoodieJavaRDD.of(scheduledCompactionInstantAndRDD.get().getRight()) : null);
               if (requestShutdownIfNeeded(lastWriteStatuses)) {
                 LOG.warn("Closing and shutting down ingestion service");
-                error = true;
                 onIngestionCompletes(false);
+                waitAsyncServicesFinishAndStop();
                 shutdown(true);
               } else {
                 sleepBeforeNextIngestion(start);
@@ -762,6 +762,33 @@ public class HoodieDeltaStreamer implements Serializable {
         }
         return true;
       }, executor), executor);
+    }
+
+    /**
+     * Wait till outstanding pending compaction/clustering
+     */
+    private void waitAsyncServicesFinishAndStop() {
+      LOG.info("wait all async services finish ...");
+      if (asyncCompactService.isPresent()) {
+        LOG.info("wait all async compact service finish ...");
+        try {
+          asyncCompactService.get().waitTillPendingAsyncServiceInstantsReducesTo(0);
+        } catch (InterruptedException e) {
+          LOG.error("Interrupted while waiting for async compact service finish ", e);
+        } finally {
+          asyncCompactService.get().shutdown(true);
+        }
+      }
+      if (asyncClusteringService.isPresent()) {
+        LOG.info("wait all async cluster service finish ...");
+        try {
+          asyncClusteringService.get().waitTillPendingAsyncServiceInstantsReducesTo(0);
+        } catch (InterruptedException e) {
+          LOG.error("Interrupted while waiting for async cluster service finish ", e);
+        } finally {
+          asyncClusteringService.get().shutdown(true);
+        }
+      }
     }
 
     private void handleUpsertException(HoodieUpsertException ue) {


### PR DESCRIPTION
…e termination strategy is enabled

### Change Logs

Looks like table services are not propoerly shut down when post write termination kicks in. This patch fixes the flow, and in regular ingestion, any table service will shut down correctly when it is terminated after enabling write and meets the conditions (including compaction/clustering).

### Impact

Improves the usability of post write termination strategy for deltastreamer in continuous mode.

Also tested w/ a manual deltastremaer execution. w/o the fix, spark job just hangs, and w/ the fix, it shutsdown gracefully,including compaction/clustering.

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
