### PR TITLE
[minor] avoid synchronized block in ReflectionUtils if key is present in cache

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -48,13 +48,15 @@ public class ReflectionUtils {
   private static final Map<String, Class<?>> CLAZZ_CACHE = new HashMap<>();
 
   public static Class<?> getClass(String clazzName) {
-    synchronized (CLAZZ_CACHE) {
-      if (!CLAZZ_CACHE.containsKey(clazzName)) {
-        try {
-          Class<?> clazz = Class.forName(clazzName);
-          CLAZZ_CACHE.put(clazzName, clazz);
-        } catch (ClassNotFoundException e) {
-          throw new HoodieException("Unable to load class", e);
+    if (!CLAZZ_CACHE.containsKey(clazzName)) {
+      synchronized (CLAZZ_CACHE) {
+        if (!CLAZZ_CACHE.containsKey(clazzName)) {
+          try {
+            Class<?> clazz = Class.forName(clazzName);
+            CLAZZ_CACHE.put(clazzName, clazz);
+          } catch (ClassNotFoundException e) {
+            throw new HoodieException("Unable to load class", e);
+          }
         }
       }
     }


### PR DESCRIPTION
### Change Logs

Avoids acquiring a lock to check whether a value is present in a cache to allow better performance when the value is already in the cache.

### Impact

This method is invoked on all rows in the DeltaStreamer when building the payload class. This should provide a minor improvement in execution time.

### Risk level (write none, low medium or high below)

none

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
