### PR TITLE
[HUDI-6063] Modify logging errors In JDBCExecutor.

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
@@ -154,7 +154,7 @@ public class JDBCExecutor extends QueryBasedDDLExecutor {
       LOG.info("No partitions to add for " + tableName);
       return;
     }
-    LOG.info("Adding partitions " + partitionsToDrop.size() + " to table " + tableName);
+    LOG.info("Drop partitions " + partitionsToDrop.size() + " to table " + tableName);
     List<String> sqls = constructDropPartitions(tableName, partitionsToDrop);
     sqls.stream().forEach(sql -> runSQL(sql));
   }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
@@ -154,7 +154,7 @@ public class JDBCExecutor extends QueryBasedDDLExecutor {
       LOG.info("No partitions to add for " + tableName);
       return;
     }
-    LOG.info("Drop partitions " + partitionsToDrop.size() + " to table " + tableName);
+    LOG.info("Dropping partitions " + partitionsToDrop.size() + " from table " + tableName);
     List<String> sqls = constructDropPartitions(tableName, partitionsToDrop);
     sqls.stream().forEach(sql -> runSQL(sql));
   }


### PR DESCRIPTION
### Change Logs

There is a logging error in JDBCExecutor. During the process of drop partitions, the log prints add partitions.

### Impact

none.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
