### PR TITLE
[HUDI-6064] Improve JDBCExecutor#getTableSchema Use ColName.

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
@@ -129,10 +129,11 @@ public class JDBCExecutor extends QueryBasedDDLExecutor {
     ResultSet result = null;
     try {
       DatabaseMetaData databaseMetaData = connection.getMetaData();
-      result = databaseMetaData.getColumns(null, databaseName, tableName, null);
+      String catalog = connection.getCatalog();
+      result = databaseMetaData.getColumns(catalog, databaseName, tableName, "%");
       while (result.next()) {
-        String columnName = result.getString(4);
-        String columnType = result.getString(6);
+        String columnName = result.getString("COLUMN_NAME");
+        String columnType = result.getString("TYPE_NAME");
         if ("DECIMAL".equals(columnType)) {
           int columnSize = result.getInt("COLUMN_SIZE");
           int decimalDigits = result.getInt("DECIMAL_DIGITS");


### PR DESCRIPTION
### Change Logs

JDBCExecutor#getTableSchema Use ColIndex, which is not conducive to code reading, use ColName instead of ColIndex.

### Impact

none.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
