### PR TITLE
[HUDI-6069] Fix record key range fetching from the metadata table in Bloom Index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -239,8 +239,8 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
           new BloomIndexFileInfo(
               partitionAndFileNameToFileId.get(entry.getKey()),
               // NOTE: Here we assume that the type of the primary key field is string
-              (String) unwrapAvroValueWrapper(entry.getValue().getMinValue()),
-              (String) unwrapAvroValueWrapper(entry.getValue().getMaxValue())
+              unwrapAvroValueWrapper(entry.getValue().getMinValue()).toString(),
+              unwrapAvroValueWrapper(entry.getValue().getMaxValue()).toString()
           )));
     }
 


### PR DESCRIPTION
### Change Logs

Change the way metadata table obtains minValue string strong-aroundmethod

Fixing If the primary key is a non-string type, and metastore table is used for filtering, taking minValue to forcibly convert to String will error

### Impact
metadata table skip data

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
