### PR TITLE
[HUDI-6070] Files pruning for bucket index table pk filtering queries

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -38,18 +38,18 @@ public class BucketIdentifier implements Serializable {
   }
 
   public static int getBucketId(HoodieKey hoodieKey, String indexKeyFields, int numBuckets) {
-    return (getHashKeys(hoodieKey, indexKeyFields).hashCode() & Integer.MAX_VALUE) % numBuckets;
+    return getBucketId(getHashKeys(hoodieKey, indexKeyFields), numBuckets);
   }
 
   public static int getBucketId(HoodieKey hoodieKey, List<String> indexKeyFields, int numBuckets) {
-    return (getHashKeys(hoodieKey.getRecordKey(), indexKeyFields).hashCode() & Integer.MAX_VALUE) % numBuckets;
+    return getBucketId(getHashKeys(hoodieKey.getRecordKey(), indexKeyFields), numBuckets);
   }
 
   public static int getBucketId(String recordKey, String indexKeyFields, int numBuckets) {
     return getBucketId(getHashKeys(recordKey, indexKeyFields), numBuckets);
   }
 
-  public  static int getBucketId(List<String> hashKeyFields, int numBuckets) {
+  public static int getBucketId(List<String> hashKeyFields, int numBuckets) {
     return (hashKeyFields.hashCode() & Integer.MAX_VALUE) % numBuckets;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -272,6 +272,13 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns the index key field values.
+   */
+  public static String[] getIndexKeys(Configuration conf) {
+    return getIndexKeyField(conf).split(",");
+  }
+
+  /**
    * Returns the conflict resolution strategy.
    */
   public static ConflictResolutionStrategy getConflictResolutionStrategy(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -84,7 +84,7 @@ public class BucketStreamWriteFunction<I> extends StreamWriteFunction<I> {
   public void open(Configuration parameters) throws IOException {
     super.open(parameters);
     this.bucketNum = config.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS);
-    this.indexKeyFields = config.getString(FlinkOptions.INDEX_KEY_FIELD);
+    this.indexKeyFields = OptionsResolver.getIndexKeyField(config);
     this.taskID = getRuntimeContext().getIndexOfThisSubtask();
     this.parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
     this.bucketIndex = new HashMap<>();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -102,7 +102,7 @@ public class Pipelines {
   public static DataStreamSink<Object> bulkInsert(Configuration conf, RowType rowType, DataStream<RowData> dataStream) {
     WriteOperatorFactory<RowData> operatorFactory = BulkInsertWriteOperator.getFactory(conf, rowType);
     if (OptionsResolver.isBucketIndexType(conf)) {
-      String indexKeys = conf.getString(FlinkOptions.INDEX_KEY_FIELD);
+      String indexKeys = OptionsResolver.getIndexKeyField(conf);
       int numBuckets = conf.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS);
 
       BucketIndexPartitioner<HoodieKey> partitioner = new BucketIndexPartitioner<>(numBuckets, indexKeys);
@@ -328,7 +328,7 @@ public class Pipelines {
     if (OptionsResolver.isBucketIndexType(conf)) {
       WriteOperatorFactory<HoodieRecord> operatorFactory = BucketStreamWriteOperator.getFactory(conf);
       int bucketNum = conf.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS);
-      String indexKeyFields = conf.getString(FlinkOptions.INDEX_KEY_FIELD);
+      String indexKeyFields = OptionsResolver.getIndexKeyField(conf);
       BucketIndexPartitioner<HoodieKey> partitioner = new BucketIndexPartitioner<>(bucketNum, indexKeyFields);
       return dataStream.partitionCustom(partitioner, HoodieRecord::getKey)
           .transform(opName("bucket_write", conf), TypeInformation.of(Object.class), operatorFactory)

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -422,7 +422,12 @@ public class IncrementalInputSplits implements Serializable {
   }
 
   private FileIndex getFileIndex() {
-    return FileIndex.instance(new org.apache.hadoop.fs.Path(path.toUri()), conf, rowType, null, partitionPruner);
+    return FileIndex.builder()
+        .path(new org.apache.hadoop.fs.Path(path.toUri()))
+        .conf(conf)
+        .rowType(rowType)
+        .partitionPruner(partitionPruner)
+        .build();
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/PrimaryKeyPruners.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/PrimaryKeyPruners.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.prune;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+import org.apache.hudi.util.ExpressionUtils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for primary key based file pruning.
+ */
+public class PrimaryKeyPruners {
+  private static final Logger LOG = LoggerFactory.getLogger(PrimaryKeyPruners.class);
+
+  public static final int BUCKET_ID_NO_PRUNING = -1;
+
+  public static int getBucketId(List<ResolvedExpression> hashKeyFilters, Configuration conf) {
+    List<String> pkFields = Arrays.asList(conf.getString(FlinkOptions.RECORD_KEY_FIELD).split(","));
+    // step1: resolve the hash key values
+    final boolean logicalTimestamp = OptionsResolver.isConsistentLogicalTimestampEnabled(conf);
+    List<String> values = hashKeyFilters.stream()
+        .map(filter -> {
+          Pair<FieldReferenceExpression, ValueLiteralExpression> children = castChildAs(filter.getChildren());
+          return Pair.of(pkFields.indexOf(children.getLeft().getName()), StringUtils.objToString(ExpressionUtils.getKeyFromLiteral(children.getRight(), logicalTimestamp)));
+        })
+        // IMPORTANT: follows KeyGenUtils#extractRecordKeysByFields,
+        // the hash keys must be evaluated in the record key field sequence.
+        .sorted(java.util.Map.Entry.comparingByKey())
+        .map(Pair::getValue)
+        .collect(Collectors.toList());
+    // step2: generate bucket id
+    return BucketIdentifier.getBucketId(values, conf.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
+  }
+
+  private static Pair<FieldReferenceExpression, ValueLiteralExpression> castChildAs(List<Expression> children) {
+    Expression lExpr = children.get(0);
+    Expression rExpr = children.get(1);
+    if (lExpr instanceof FieldReferenceExpression) {
+      return Pair.of((FieldReferenceExpression) lExpr, (ValueLiteralExpression) rExpr);
+    } else {
+      return Pair.of((FieldReferenceExpression) rExpr, (ValueLiteralExpression) lExpr);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ExpressionUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ExpressionUtils.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.RowType;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -39,6 +40,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -182,6 +184,73 @@ public class ExpressionUtils {
       default:
         throw new UnsupportedOperationException("Unsupported type: " + logicalType);
     }
+  }
+
+  /**
+   * Returns the field as part of a hoodie key with given value literal expression.
+   *
+   * <p>CAUTION: the data type and value parsing should follow the impl of {@link #getValueFromLiteral(ValueLiteralExpression)}.
+   *
+   * <p>CAUTION: the data and timestamp conversion should follow the impl if {@code HoodieAvroUtils.convertValueForAvroLogicalTypes}.
+   *
+   * <p>Returns null if the value can not parse as the output data type correctly,
+   * should call {@code ValueLiteralExpression.isNull} first to decide whether
+   * the literal is NULL.
+   */
+  @Nullable
+  public static Object getKeyFromLiteral(ValueLiteralExpression expr, boolean logicalTimestamp) {
+    Object val = getValueFromLiteral(expr);
+    if (val == null) {
+      return null;
+    }
+    LogicalType logicalType = expr.getOutputDataType().getLogicalType();
+    switch (logicalType.getTypeRoot()) {
+      case TIMESTAMP_WITHOUT_TIME_ZONE:
+        return logicalTimestamp ? new Timestamp((long) val) : val;
+      case DATE:
+        return LocalDate.ofEpochDay((long) val);
+      default:
+        return val;
+    }
+  }
+
+  /**
+   * Returns whether all the fields {@code fields} are involved in the filtering predicates.
+   *
+   * @param exprs  The filters
+   * @param fields The field set
+   */
+  public static boolean isFilteringByAllFields(List<ResolvedExpression> exprs, Set<String> fields) {
+    if (exprs.size() != fields.size()) {
+      return false;
+    }
+    Set<String> referencedPks = exprs.stream()
+        .map(ResolvedExpression::getChildren)
+        .flatMap(Collection::stream)
+        .filter(expr -> expr instanceof FieldReferenceExpression)
+        .map(rExpr -> ((FieldReferenceExpression) rExpr).getName())
+        .collect(Collectors.toSet());
+    return referencedPks.size() == fields.size();
+  }
+
+  /**
+   * Returns whether the given expression {@code resolvedExpr} is a
+   * literal equivalence predicate within the fields {@code fields}.
+   */
+  public static boolean isEqualsLitExpr(ResolvedExpression resolvedExpr, Set<String> fields) {
+    CallExpression callExpr = (CallExpression) resolvedExpr;
+    FunctionDefinition funcDef = callExpr.getFunctionDefinition();
+    if (funcDef != BuiltInFunctionDefinitions.EQUALS) {
+      return false;
+    }
+
+    if (!isFieldReferenceAndLiteral(callExpr.getChildren())) {
+      return false;
+    }
+
+    return callExpr.getChildren().stream()
+        .filter(expr -> expr instanceof FieldReferenceExpression)
+        .anyMatch(expr -> fields.contains(((FieldReferenceExpression) expr).getName()));
   }
 
   public static List<ResolvedExpression> filterSimpleCallExpression(List<ResolvedExpression> exprs) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BucketStreamWriteFunctionWrapper.java
@@ -26,6 +26,8 @@ import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.bucket.BucketStreamWriteFunction;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
 import org.apache.hudi.sink.transform.RowDataToHoodieFunction;
+import org.apache.hudi.util.AvroSchemaConverter;
+import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
 
 import org.apache.flink.api.common.ExecutionConfig;
@@ -45,6 +47,7 @@ import org.apache.flink.streaming.api.operators.collect.utils.MockOperatorEventG
 import org.apache.flink.streaming.util.MockStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.util.List;
 import java.util.Map;
@@ -114,7 +117,8 @@ public class BucketStreamWriteFunctionWrapper<I> implements TestFunctionWrapper<
   public void openFunction() throws Exception {
     this.coordinator.start();
     this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
-    toHoodieFunction = new RowDataToHoodieFunction<>(TestConfigurations.ROW_TYPE, conf);
+    RowType rowType = (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
+    toHoodieFunction = new RowDataToHoodieFunction<>(rowType, conf);
     toHoodieFunction.setRuntimeContext(runtimeContext);
     toHoodieFunction.open(conf);
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
@@ -128,6 +128,11 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     stateInitializationContext.getOperatorStateStore().checkpointBegin(checkpointId);
   }
 
+  @Override
+  public void endInput() {
+    writeFunction.endInput();
+  }
+
   public void checkpointComplete(long checkpointId) {
     stateInitializationContext.getOperatorStateStore().checkpointSuccess(checkpointId);
     coordinator.notifyCheckpointComplete(checkpointId);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestFunctionWrapper.java
@@ -59,6 +59,11 @@ public interface TestFunctionWrapper<I> {
   void checkpointFunction(long checkpointId) throws Exception;
 
   /**
+   * End inputs for all the operators in the wrapper.
+   */
+  void endInput();
+
+  /**
    * Mark checkpoint with id {code checkpointId} as success.
    */
   void checkpointComplete(long checkpointId);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -141,13 +141,7 @@ public class TestWriteBase {
       this.baseFile = basePath;
       this.basePath = this.baseFile.getAbsolutePath();
       this.conf = conf;
-      if (OptionsResolver.isAppendMode(conf)) {
-        this.pipeline = new InsertFunctionWrapper<>(this.basePath, conf);
-      } else if (OptionsResolver.isBucketIndexType(conf)) {
-        this.pipeline = new BucketStreamWriteFunctionWrapper<>(this.basePath, conf);
-      } else {
-        this.pipeline = new StreamWriteFunctionWrapper<>(this.basePath, conf);
-      }
+      this.pipeline = TestData.getWritePipeline(this.basePath, conf);
       // open the function and ingest data
       this.pipeline.openFunction();
       this.ckpMetadata = CkpMetadata.getInstance(conf);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestFileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestFileIndex.java
@@ -62,7 +62,7 @@ public class TestFileIndex {
     conf.setBoolean(METADATA_ENABLED, true);
     conf.setBoolean(HIVE_STYLE_PARTITIONING, hiveStylePartitioning);
     TestData.writeData(TestData.DATA_SET_INSERT, conf);
-    FileIndex fileIndex = FileIndex.instance(new Path(tempFile.getAbsolutePath()), conf, TestConfigurations.ROW_TYPE);
+    FileIndex fileIndex = FileIndex.builder().path(new Path(tempFile.getAbsolutePath())).conf(conf).rowType(TestConfigurations.ROW_TYPE).build();
     List<String> partitionKeys = Collections.singletonList("partition");
     List<Map<String, String>> partitions = fileIndex.getPartitions(partitionKeys, PARTITION_DEFAULT_NAME.defaultValue(), hiveStylePartitioning);
     assertTrue(partitions.stream().allMatch(m -> m.size() == 1));
@@ -83,7 +83,7 @@ public class TestFileIndex {
     conf.setString(KEYGEN_CLASS_NAME, NonpartitionedAvroKeyGenerator.class.getName());
     conf.setBoolean(METADATA_ENABLED, true);
     TestData.writeData(TestData.DATA_SET_INSERT, conf);
-    FileIndex fileIndex = FileIndex.instance(new Path(tempFile.getAbsolutePath()), conf, TestConfigurations.ROW_TYPE);
+    FileIndex fileIndex = FileIndex.builder().path(new Path(tempFile.getAbsolutePath())).conf(conf).rowType(TestConfigurations.ROW_TYPE).build();
     List<String> partitionKeys = Collections.singletonList("");
     List<Map<String, String>> partitions = fileIndex.getPartitions(partitionKeys, PARTITION_DEFAULT_NAME.defaultValue(), false);
     assertThat(partitions.size(), is(0));
@@ -98,7 +98,7 @@ public class TestFileIndex {
   void testFileListingEmptyTable(boolean enableMetadata) {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     conf.setBoolean(METADATA_ENABLED, enableMetadata);
-    FileIndex fileIndex = FileIndex.instance(new Path(tempFile.getAbsolutePath()), conf, TestConfigurations.ROW_TYPE);
+    FileIndex fileIndex = FileIndex.builder().path(new Path(tempFile.getAbsolutePath())).conf(conf).rowType(TestConfigurations.ROW_TYPE).build();
     List<String> partitionKeys = Collections.singletonList("partition");
     List<Map<String, String>> partitions = fileIndex.getPartitions(partitionKeys, PARTITION_DEFAULT_NAME.defaultValue(), false);
     assertThat(partitions.size(), is(0));

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.source.prune.DataPruner;
+import org.apache.hudi.source.prune.PrimaryKeyPruners;
 import org.apache.hudi.table.format.mor.MergeOnReadInputFormat;
 import org.apache.hudi.utils.TestConfigurations;
 import org.apache.hudi.utils.TestData;
@@ -36,20 +37,30 @@ import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -151,6 +162,127 @@ public class TestHoodieTableSource {
     assertNotNull(dataPruner);
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testBucketPruning(boolean hiveStylePartitioning) throws Exception {
+    String tablePath1 = new Path(tempFile.getAbsolutePath(), "tbl1").toString();
+    Configuration conf1 = TestConfigurations.getDefaultConf(tablePath1);
+    conf1.setString(FlinkOptions.INDEX_TYPE, "BUCKET");
+    conf1.setBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING, hiveStylePartitioning);
+
+    // test single primary key filtering
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT, conf1);
+    HoodieTableSource tableSource1 = createHoodieTableSource(conf1);
+    tableSource1.applyFilters(Collections.singletonList(createLitEquivalenceExpr("uuid", 0, DataTypes.STRING().notNull(), "id1")));
+
+    assertThat(tableSource1.getDataBucket(), is(1));
+    FileStatus[] fileStatuses = tableSource1.getReadFiles();
+    assertThat("Files should be pruned by bucket id 1", fileStatuses.length, CoreMatchers.is(2));
+
+    // test multiple primary keys filtering
+    Configuration conf2 = conf1.clone();
+    String tablePath2 = new Path(tempFile.getAbsolutePath(), "tbl2").toString();
+    conf2.setString(FlinkOptions.PATH, tablePath2);
+    conf2.setString(FlinkOptions.RECORD_KEY_FIELD, "uuid,name");
+    conf2.setString(FlinkOptions.KEYGEN_TYPE, "COMPLEX");
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT, conf2);
+    HoodieTableSource tableSource2 = createHoodieTableSource(conf2);
+    tableSource2.applyFilters(Arrays.asList(
+        createLitEquivalenceExpr("uuid", 0, DataTypes.STRING().notNull(), "id1"),
+        createLitEquivalenceExpr("name", 1, DataTypes.STRING().notNull(), "Danny")));
+    assertThat(tableSource2.getDataBucket(), is(3));
+    FileStatus[] fileStatuses2 = tableSource2.getReadFiles();
+    assertThat("Files should be pruned by bucket id 3", fileStatuses2.length, CoreMatchers.is(3));
+
+    // apply the filters in different order and test again.
+    tableSource2.reset();
+    tableSource2.applyFilters(Arrays.asList(
+        createLitEquivalenceExpr("name", 1, DataTypes.STRING().notNull(), "Danny"),
+        createLitEquivalenceExpr("uuid", 0, DataTypes.STRING().notNull(), "id1")));
+    assertThat(tableSource2.getDataBucket(), is(3));
+    assertThat("Files should be pruned by bucket id 3", tableSource2.getReadFiles().length, CoreMatchers.is(3));
+
+    // test partial primary keys filtering
+    Configuration conf3 = conf1.clone();
+    String tablePath3 = new Path(tempFile.getAbsolutePath(), "tbl3").toString();
+    conf3.setString(FlinkOptions.PATH, tablePath3);
+    conf3.setString(FlinkOptions.RECORD_KEY_FIELD, "uuid,name");
+    conf3.setString(FlinkOptions.KEYGEN_TYPE, "COMPLEX");
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT, conf3);
+    HoodieTableSource tableSource3 = createHoodieTableSource(conf3);
+    tableSource3.applyFilters(Collections.singletonList(createLitEquivalenceExpr("uuid", 0, DataTypes.STRING().notNull(), "id1")));
+
+    assertThat(tableSource3.getDataBucket(), is(PrimaryKeyPruners.BUCKET_ID_NO_PRUNING));
+    FileStatus[] fileStatuses3 = tableSource3.getReadFiles();
+    assertThat("Partial pk filtering does not prune any files", fileStatuses3.length, CoreMatchers.is(7));
+
+    // test single primary keys filtering together with non-primary key predicate
+    Configuration conf4 = conf1.clone();
+    String tablePath4 = new Path(tempFile.getAbsolutePath(), "tbl4").toString();
+    conf4.setString(FlinkOptions.PATH, tablePath4);
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT, conf4);
+    HoodieTableSource tableSource4 = createHoodieTableSource(conf4);
+    tableSource4.applyFilters(Arrays.asList(
+        createLitEquivalenceExpr("uuid", 0, DataTypes.STRING().notNull(), "id1"),
+        createLitEquivalenceExpr("name", 1, DataTypes.STRING().notNull(), "Danny")));
+
+    assertThat(tableSource4.getDataBucket(), is(1));
+    FileStatus[] fileStatuses4 = tableSource4.getReadFiles();
+    assertThat("Files should be pruned by bucket id 1", fileStatuses4.length, CoreMatchers.is(2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Exception {
+    String tablePath1 = new Path(tempFile.getAbsolutePath(), "tbl1").toString();
+    Configuration conf1 = TestConfigurations.getDefaultConf(tablePath1, TestConfigurations.ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE);
+    final String f1 = "f_timestamp";
+    conf1.setString(FlinkOptions.INDEX_TYPE, "BUCKET");
+    conf1.setString(FlinkOptions.RECORD_KEY_FIELD, f1);
+    conf1.setString(FlinkOptions.PRECOMBINE_FIELD, f1);
+    conf1.removeConfig(FlinkOptions.PARTITION_PATH_FIELD);
+    conf1.setBoolean(KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(), logicalTimestamp);
+
+    // test timestamp filtering
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf1);
+    HoodieTableSource tableSource1 = createHoodieTableSource(conf1);
+    tableSource1.applyFilters(Collections.singletonList(createLitEquivalenceExpr(f1, 0, DataTypes.TIMESTAMP(3).notNull(), LocalDateTime.ofInstant(Instant.ofEpochMilli(1), ZoneId.of("UTC")))));
+
+    assertThat(tableSource1.getDataBucket(), is(logicalTimestamp ? 1 : 0));
+    FileStatus[] fileStatuses = tableSource1.getReadFiles();
+    assertThat("Files should be pruned", fileStatuses.length, CoreMatchers.is(1));
+
+    // test date filtering
+    Configuration conf2 = conf1.clone();
+    final String f2 = "f_date";
+    String tablePath2 = new Path(tempFile.getAbsolutePath(), "tbl2").toString();
+    conf2.setString(FlinkOptions.PATH, tablePath2);
+    conf2.setString(FlinkOptions.RECORD_KEY_FIELD, f2);
+    conf2.setString(FlinkOptions.PRECOMBINE_FIELD, f2);
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf2);
+    HoodieTableSource tableSource2 = createHoodieTableSource(conf2);
+    tableSource2.applyFilters(Collections.singletonList(createLitEquivalenceExpr(f2, 1, DataTypes.DATE().notNull(), LocalDate.ofEpochDay(1))));
+
+    assertThat(tableSource2.getDataBucket(), is(1));
+    FileStatus[] fileStatuses2 = tableSource2.getReadFiles();
+    assertThat("Files should be pruned", fileStatuses2.length, CoreMatchers.is(1));
+
+    // test decimal filtering
+    Configuration conf3 = conf1.clone();
+    final String f3 = "f_decimal";
+    String tablePath3 = new Path(tempFile.getAbsolutePath(), "tbl3").toString();
+    conf3.setString(FlinkOptions.PATH, tablePath3);
+    conf3.setString(FlinkOptions.RECORD_KEY_FIELD, f3);
+    conf3.setString(FlinkOptions.PRECOMBINE_FIELD, f3);
+    TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf3);
+    HoodieTableSource tableSource3 = createHoodieTableSource(conf3);
+    tableSource3.applyFilters(Collections.singletonList(createLitEquivalenceExpr(f3, 1, DataTypes.DECIMAL(3, 2).notNull(), new BigDecimal("1.11"))));
+
+    assertThat(tableSource3.getDataBucket(), is(0));
+    FileStatus[] fileStatuses3 = tableSource3.getReadFiles();
+    assertThat("Files should be pruned", fileStatuses3.length, CoreMatchers.is(1));
+  }
+
   @Test
   void testHoodieSourceCachedMetaClient() {
     HoodieTableSource tableSource = getEmptyStreamingSource();
@@ -165,11 +297,24 @@ public class TestHoodieTableSource {
     conf.setBoolean(FlinkOptions.READ_AS_STREAMING, true);
     conf.setBoolean(FlinkOptions.READ_DATA_SKIPPING_ENABLED, true);
 
+    return createHoodieTableSource(conf);
+  }
+
+  private HoodieTableSource createHoodieTableSource(Configuration conf) {
     return new HoodieTableSource(
         TestConfigurations.TABLE_SCHEMA,
-        new Path(tempFile.getPath()),
+        new Path(conf.getString(FlinkOptions.PATH)),
         Arrays.asList(conf.getString(FlinkOptions.PARTITION_PATH_FIELD).split(",")),
         "default-par",
         conf);
+  }
+
+  private ResolvedExpression createLitEquivalenceExpr(String fieldName, int fieldIdx, DataType dataType, Object val) {
+    FieldReferenceExpression ref = new FieldReferenceExpression(fieldName, dataType, fieldIdx, fieldIdx);
+    ValueLiteralExpression literal = new ValueLiteralExpression(val, dataType);
+    return new CallExpression(
+        BuiltInFunctionDefinitions.EQUALS,
+        Arrays.asList(ref, literal),
+        DataTypes.BOOLEAN());
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -105,6 +105,14 @@ public class TestConfigurations {
           DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
       .notNull();
 
+  public static final DataType ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = DataTypes.ROW(
+          DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3)),
+          DataTypes.FIELD("f_date", DataTypes.DATE()),
+          DataTypes.FIELD("f_decimal", DataTypes.DECIMAL(3, 2)))
+      .notNull();
+
+  public static final RowType ROW_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE = (RowType) ROW_DATA_TYPE_HOODIE_KEY_SPECIAL_DATA_TYPE.getLogicalType();
+
   public static final RowType ROW_TYPE_EVOLUTION_AFTER = (RowType) ROW_DATA_TYPE_EVOLUTION_AFTER.getLogicalType();
 
   public static String getCreateHoodieTableDDL(String tableName, Map<String, String> options) {


### PR DESCRIPTION
### Change Logs

Prunes the files efficienly when the table is with BUCKET index type, and the queries have primary key as the filtering predicates.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
