### PR TITLE
[HUDI-6080] Use hoodie.properties to determine if the table exists

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -236,7 +236,8 @@ public class StreamerUtil {
     // Hadoop FileSystem
     FileSystem fs = FSUtils.getFs(basePath, hadoopConf);
     try {
-      return fs.exists(new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME));
+      return fs.exists(new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME))
+          && fs.exists(new Path(new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME), HoodieTableConfig.HOODIE_PROPERTIES_FILE));
     } catch (IOException e) {
       throw new HoodieException("Error while checking whether table exists under path:" + basePath, e);
     }


### PR DESCRIPTION
### Change Logs

After [HUDI-6005](https://issues.apache.org/jira/browse/HUDI-6005), if OCC is enabled and WRITE_CLIENT_ID is not set, flink will create .hoodie dir before init table. But we check if table exists with .hoodie, we will get an exception when we write to hudi.

This pr use hoodie.properties to determine if the table exists.
### Impact

none
### Risk level (write none, low medium or high below)

low
### Documentation Update

none
- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
