### PR TITLE
[HUDI-6082] Mark advanced Flink configs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/AdvancedConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/AdvancedConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for advanced configs which are not defined through {@link ConfigProperty}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdvancedConfig {
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.configuration;
 
 import org.apache.hudi.client.clustering.plan.strategy.FlinkSizeBasedClusteringPlanStrategy;
+import org.apache.hudi.common.config.AdvancedConfig;
 import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.HoodieConfig;
@@ -114,6 +115,7 @@ public class FlinkOptions extends HoodieConfig {
           + "key value, we will pick the one with the largest value for the precombine field,\n"
           + "determined by Object.compareTo(..)");
 
+  @AdvancedConfig
   public static final ConfigOption<String> PAYLOAD_CLASS_NAME = ConfigOptions
       .key("payload.class")
       .stringType()
@@ -122,6 +124,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Payload class used. Override this, if you like to roll your own merge logic, when upserting/inserting.\n"
           + "This will render any value set for the option in-effective");
 
+  @AdvancedConfig
   public static final ConfigOption<String> RECORD_MERGER_IMPLS = ConfigOptions
       .key("record.merger.impls")
       .stringType()
@@ -131,6 +134,7 @@ public class FlinkOptions extends HoodieConfig {
           + "These merger impls will filter by record.merger.strategy. "
           + "Hudi will pick most efficient implementation to perform merging/combining of the records (during update, reading MOR table, etc)");
 
+  @AdvancedConfig
   public static final ConfigOption<String> RECORD_MERGER_STRATEGY = ConfigOptions
       .key("record.merger.strategy")
       .stringType()
@@ -138,6 +142,7 @@ public class FlinkOptions extends HoodieConfig {
       .withFallbackKeys(HoodieWriteConfig.RECORD_MERGER_STRATEGY.key())
       .withDescription("Id of merger strategy. Hudi will pick HoodieRecordMerger implementations in record.merger.impls which has the same merger strategy id");
 
+  @AdvancedConfig
   public static final ConfigOption<String> PARTITION_DEFAULT_NAME = ConfigOptions
       .key("partition.default_name")
       .stringType()
@@ -204,18 +209,21 @@ public class FlinkOptions extends HoodieConfig {
       .withFallbackKeys(HoodieIndexConfig.INDEX_TYPE.key())
       .withDescription("Index type of Flink write job, default is using state backed index.");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> INDEX_BOOTSTRAP_ENABLED = ConfigOptions
       .key("index.bootstrap.enabled")
       .booleanType()
       .defaultValue(false)
       .withDescription("Whether to bootstrap the index state from existing hoodie table, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Double> INDEX_STATE_TTL = ConfigOptions
       .key("index.state.ttl")
       .doubleType()
       .defaultValue(0D)
       .withDescription("Index state ttl in days, default stores the index permanently");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> INDEX_GLOBAL_ENABLED = ConfigOptions
       .key("index.global.enabled")
       .booleanType()
@@ -223,6 +231,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Whether to update index for the old partition path\n"
           + "if same key record with different partition path came in, default true");
 
+  @AdvancedConfig
   public static final ConfigOption<String> INDEX_PARTITION_REGEX = ConfigOptions
       .key("index.partition.regex")
       .stringType()
@@ -233,18 +242,21 @@ public class FlinkOptions extends HoodieConfig {
   //  Read Options
   // ------------------------------------------------------------------------
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> READ_TASKS = ConfigOptions
       .key("read.tasks")
       .intType()
       .noDefaultValue()
       .withDescription("Parallelism of tasks that do actual read, default is the parallelism of the execution environment");
 
+  @AdvancedConfig
   public static final ConfigOption<String> SOURCE_AVRO_SCHEMA_PATH = ConfigOptions
       .key("source.avro-schema.path")
       .stringType()
       .noDefaultValue()
       .withDescription("Source avro schema file path, the parsed schema is used for deserialization");
 
+  @AdvancedConfig
   public static final ConfigOption<String> SOURCE_AVRO_SCHEMA = ConfigOptions
       .key("source.avro-schema")
       .stringType()
@@ -266,6 +278,7 @@ public class FlinkOptions extends HoodieConfig {
 
   public static final String REALTIME_SKIP_MERGE = "skip_merge";
   public static final String REALTIME_PAYLOAD_COMBINE = "payload_combine";
+  @AdvancedConfig
   public static final ConfigOption<String> MERGE_TYPE = ConfigOptions
       .key("hoodie.datasource.merge.type")
       .stringType()
@@ -275,6 +288,7 @@ public class FlinkOptions extends HoodieConfig {
           + "2) payload_combine: read the base file records first, for each record in base file, checks whether the key is in the\n"
           + "   log file records(combines the two records with same key for base and log file records), then read the left log file records");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> UTC_TIMEZONE = ConfigOptions
       .key("read.utc-timezone")
       .booleanType()
@@ -289,12 +303,14 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(false)// default read as batch
       .withDescription("Whether to read as streaming source, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> READ_STREAMING_CHECK_INTERVAL = ConfigOptions
       .key("read.streaming.check-interval")
       .intType()
       .defaultValue(60)// default 1 minute
       .withDescription("Check interval for streaming read of SECOND, default 1 minute");
 
+  @AdvancedConfig
   // this option is experimental
   public static final ConfigOption<Boolean> READ_STREAMING_SKIP_COMPACT = ConfigOptions
       .key("read.streaming.skip_compaction")
@@ -303,13 +319,14 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Whether to skip compaction instants and avoid reading compacted base files for streaming read to improve read performance.\n"
           + "This option can be used to avoid reading duplicates when changelog mode is enabled, it is a solution to keep data integrity\n");
 
+  @AdvancedConfig
   // this option is experimental
   public static final ConfigOption<Boolean> READ_STREAMING_SKIP_CLUSTERING = ConfigOptions
-          .key("read.streaming.skip_clustering")
-          .booleanType()
-          .defaultValue(false)
-          .withDescription("Whether to skip clustering instants to avoid reading base files of clustering operations for streaming read "
-              + "to improve read performance.");
+      .key("read.streaming.skip_clustering")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Whether to skip clustering instants to avoid reading base files of clustering operations for streaming read "
+          + "to improve read performance.");
 
   public static final String START_COMMIT_EARLIEST = "earliest";
   public static final ConfigOption<String> READ_START_COMMIT = ConfigOptions
@@ -325,6 +342,7 @@ public class FlinkOptions extends HoodieConfig {
       .noDefaultValue()
       .withDescription("End commit instant for reading, the commit time format should be 'yyyyMMddHHmmss'");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> READ_DATA_SKIPPING_ENABLED = ConfigOptions
       .key("read.data.skipping.enabled")
       .booleanType()
@@ -336,6 +354,7 @@ public class FlinkOptions extends HoodieConfig {
   //  Write Options
   // ------------------------------------------------------------------------
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> INSERT_CLUSTER = ConfigOptions
       .key("write.insert.cluster")
       .booleanType()
@@ -354,6 +373,7 @@ public class FlinkOptions extends HoodieConfig {
    * Flag to indicate whether to drop duplicates before insert/upsert.
    * By default false to gain extra performance.
    */
+  @AdvancedConfig
   public static final ConfigOption<Boolean> PRE_COMBINE = ConfigOptions
       .key("write.precombine")
       .booleanType()
@@ -363,6 +383,7 @@ public class FlinkOptions extends HoodieConfig {
           + "1) insert operation;\n"
           + "2) upsert for MOR table, the MOR table deduplicate on reading");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> RETRY_TIMES = ConfigOptions
       .key("write.retry.times")
       .intType()
@@ -370,6 +391,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Flag to indicate how many times streaming job should retry for a failed checkpoint batch.\n"
           + "By default 3");
 
+  @AdvancedConfig
   public static final ConfigOption<Long> RETRY_INTERVAL_MS = ConfigOptions
       .key("write.retry.interval.ms")
       .longType()
@@ -377,6 +399,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Flag to indicate how long (by millisecond) before a retry should issued for failed checkpoint batch.\n"
           + "By default 2000 and it will be doubled by every retry");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> IGNORE_FAILED = ConfigOptions
       .key("write.ignore.failed")
       .booleanType()
@@ -393,6 +416,7 @@ public class FlinkOptions extends HoodieConfig {
           + "Actual value will be obtained by invoking .toString() on the field value. Nested fields can be specified using "
           + "the dot notation eg: `a.b.c`");
 
+  @AdvancedConfig
   public static final ConfigOption<String> INDEX_KEY_FIELD = ConfigOptions
       .key(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key())
       .stringType()
@@ -401,6 +425,7 @@ public class FlinkOptions extends HoodieConfig {
           + "Actual value will be obtained by invoking .toString() on the field value. Nested fields can be specified using "
           + "the dot notation eg: `a.b.c`");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> BUCKET_INDEX_NUM_BUCKETS = ConfigOptions
       .key(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key())
       .intType()
@@ -414,6 +439,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Partition path field. Value to be used at the `partitionPath` component of `HoodieKey`.\n"
           + "Actual value obtained by invoking .toString(), default ''");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> URL_ENCODE_PARTITIONING = ConfigOptions
       .key(KeyGeneratorOptions.URL_ENCODE_PARTITIONING.key())
       .booleanType()
@@ -428,12 +454,14 @@ public class FlinkOptions extends HoodieConfig {
           + "If set true, the names of partition folders follow <partition_column_name>=<partition_value> format.\n"
           + "By default false (the names of partition folders are only partition values)");
 
+  @AdvancedConfig
   public static final ConfigOption<String> KEYGEN_CLASS_NAME = ConfigOptions
       .key(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key())
       .stringType()
       .noDefaultValue()
       .withDescription("Key generator class, that implements will extract the key out of incoming record");
 
+  @AdvancedConfig
   public static final ConfigOption<String> KEYGEN_TYPE = ConfigOptions
       .key(HoodieWriteConfig.KEYGENERATOR_TYPE.key())
       .stringType()
@@ -445,6 +473,7 @@ public class FlinkOptions extends HoodieConfig {
   public static final String PARTITION_FORMAT_HOUR = "yyyyMMddHH";
   public static final String PARTITION_FORMAT_DAY = "yyyyMMdd";
   public static final String PARTITION_FORMAT_DASHED_DAY = "yyyy-MM-dd";
+  @AdvancedConfig
   public static final ConfigOption<String> PARTITION_FORMAT = ConfigOptions
       .key("write.partition.format")
       .stringType()
@@ -453,24 +482,28 @@ public class FlinkOptions extends HoodieConfig {
           + "1) 'yyyyMMddHH' for timestamp(3) WITHOUT TIME ZONE, LONG, FLOAT, DOUBLE, DECIMAL;\n"
           + "2) 'yyyyMMdd' for DATE and INT.");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> INDEX_BOOTSTRAP_TASKS = ConfigOptions
       .key("write.index_bootstrap.tasks")
       .intType()
       .noDefaultValue()
       .withDescription("Parallelism of tasks that do index bootstrap, default same as the write task parallelism");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> BUCKET_ASSIGN_TASKS = ConfigOptions
       .key("write.bucket_assign.tasks")
       .intType()
       .noDefaultValue()
       .withDescription("Parallelism of tasks that do bucket assign, default same as the write task parallelism");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_TASKS = ConfigOptions
       .key("write.tasks")
       .intType()
       .noDefaultValue()
       .withDescription("Parallelism of tasks that do actual write, default is the parallelism of the execution environment");
 
+  @AdvancedConfig
   public static final ConfigOption<Double> WRITE_TASK_MAX_SIZE = ConfigOptions
       .key("write.task.max.size")
       .doubleType()
@@ -478,30 +511,35 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Maximum memory in MB for a write task, when the threshold hits,\n"
           + "it flushes the max size data bucket to avoid OOM, default 1GB");
 
+  @AdvancedConfig
   public static final ConfigOption<Long> WRITE_RATE_LIMIT = ConfigOptions
       .key("write.rate.limit")
       .longType()
       .defaultValue(0L) // default no limit
       .withDescription("Write record rate limit per second to prevent traffic jitter and improve stability, default 0 (no limit)");
 
+  @AdvancedConfig
   public static final ConfigOption<Double> WRITE_BATCH_SIZE = ConfigOptions
       .key("write.batch.size")
       .doubleType()
       .defaultValue(256D) // 256MB
       .withDescription("Batch buffer size in MB to flush data into the underneath filesystem, default 256MB");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_LOG_BLOCK_SIZE = ConfigOptions
       .key("write.log_block.size")
       .intType()
       .defaultValue(128)
       .withDescription("Max log block size in MB for log file, default 128MB");
 
+  @AdvancedConfig
   public static final ConfigOption<Long> WRITE_LOG_MAX_SIZE = ConfigOptions
       .key("write.log.max.size")
       .longType()
       .defaultValue(1024L)
       .withDescription("Maximum size allowed in MB for a log file before it is rolled over to the next version, default 1GB");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_PARQUET_BLOCK_SIZE = ConfigOptions
       .key("write.parquet.block.size")
       .intType()
@@ -516,6 +554,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Target size for parquet files produced by Hudi write phases. "
           + "For DFS, this needs to be aligned with the underlying filesystem block size for optimal performance.");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_PARQUET_PAGE_SIZE = ConfigOptions
       .key("write.parquet.page.size")
       .intType()
@@ -523,6 +562,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Parquet page size. Page is the unit of read within a parquet file. "
           + "Within a block, pages are compressed separately.");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_MERGE_MAX_MEMORY = ConfigOptions
       .key("write.merge.max_memory")
       .intType()
@@ -530,6 +570,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Max memory in MB for merge, default 100MB");
 
   // this is only for internal use
+  @AdvancedConfig
   public static final ConfigOption<Long> WRITE_COMMIT_ACK_TIMEOUT = ConfigOptions
       .key("write.commit.ack.timeout")
       .longType()
@@ -537,24 +578,28 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Timeout limit for a writer task after it finishes a checkpoint and\n"
           + "waits for the instant commit success, only for internal use");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> WRITE_BULK_INSERT_SHUFFLE_INPUT = ConfigOptions
       .key("write.bulk_insert.shuffle_input")
       .booleanType()
       .defaultValue(true)
       .withDescription("Whether to shuffle the inputs by specific fields for bulk insert tasks, default true");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> WRITE_BULK_INSERT_SORT_INPUT = ConfigOptions
       .key("write.bulk_insert.sort_input")
       .booleanType()
       .defaultValue(true)
       .withDescription("Whether to sort the inputs by specific fields for bulk insert tasks, default true");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> WRITE_BULK_INSERT_SORT_INPUT_BY_RECORD_KEY = ConfigOptions
-          .key("write.bulk_insert.sort_input.by_record_key")
-          .booleanType()
-          .defaultValue(false)
-          .withDescription("Whether to sort the inputs by record keys for bulk insert tasks, default false");
+      .key("write.bulk_insert.sort_input.by_record_key")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Whether to sort the inputs by record keys for bulk insert tasks, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_SORT_MEMORY = ConfigOptions
       .key("write.sort.memory")
       .intType()
@@ -562,6 +607,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Sort memory in MB, default 128MB");
 
   // this is only for internal use
+  @AdvancedConfig
   public static final ConfigOption<String> WRITE_CLIENT_ID = ConfigOptions
       .key("write.client.id")
       .stringType()
@@ -572,6 +618,7 @@ public class FlinkOptions extends HoodieConfig {
   //  Compaction Options
   // ------------------------------------------------------------------------
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> COMPACTION_SCHEDULE_ENABLED = ConfigOptions
       .key("compaction.schedule.enabled")
       .booleanType()
@@ -584,6 +631,7 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(true) // default true for MOR write
       .withDescription("Async Compaction, enabled by default for MOR");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> COMPACTION_TASKS = ConfigOptions
       .key("compaction.tasks")
       .intType()
@@ -594,6 +642,7 @@ public class FlinkOptions extends HoodieConfig {
   public static final String TIME_ELAPSED = "time_elapsed";
   public static final String NUM_AND_TIME = "num_and_time";
   public static final String NUM_OR_TIME = "num_or_time";
+  @AdvancedConfig
   public static final ConfigOption<String> COMPACTION_TRIGGER_STRATEGY = ConfigOptions
       .key("compaction.trigger.strategy")
       .stringType()
@@ -610,24 +659,28 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(5)
       .withDescription("Max delta commits needed to trigger compaction, default 5 commits");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> COMPACTION_DELTA_SECONDS = ConfigOptions
       .key("compaction.delta_seconds")
       .intType()
       .defaultValue(3600) // default 1 hour
       .withDescription("Max delta seconds time needed to trigger compaction, default 1 hour");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> COMPACTION_TIMEOUT_SECONDS = ConfigOptions
       .key("compaction.timeout.seconds")
       .intType()
       .defaultValue(1200) // default 20 minutes
       .withDescription("Max timeout time in seconds for online compaction to rollback, default 20 minutes");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> COMPACTION_MAX_MEMORY = ConfigOptions
       .key("compaction.max_memory")
       .intType()
       .defaultValue(100) // default 100 MB
       .withDescription("Max memory in MB for compaction spillable map, default 100MB");
 
+  @AdvancedConfig
   public static final ConfigOption<Long> COMPACTION_TARGET_IO = ConfigOptions
       .key("compaction.target_io")
       .longType()
@@ -640,6 +693,7 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(true)
       .withDescription("Whether to cleanup the old commits immediately on new commits, enabled by default");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLEAN_POLICY = ConfigOptions
       .key("clean.policy")
       .stringType()
@@ -654,6 +708,7 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Number of commits to retain. So data will be retained for num_of_commits * time_between_commits (scheduled).\n"
           + "This also directly translates into how much you can incrementally pull on this table, default 30");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLEAN_RETAIN_HOURS = ConfigOptions
       .key("clean.retain_hours")
       .intType()
@@ -662,6 +717,7 @@ public class FlinkOptions extends HoodieConfig {
           + "compared to number of commits retained for cleaning service. Setting this property ensures all the files, but the latest in a file group,"
           + " corresponding to commits with commit times older than the configured number of hours to be retained are cleaned.");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLEAN_RETAIN_FILE_VERSIONS = ConfigOptions
       .key("clean.retain_file_versions")
       .intType()
@@ -684,6 +740,7 @@ public class FlinkOptions extends HoodieConfig {
   //  Clustering Options
   // ------------------------------------------------------------------------
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> CLUSTERING_SCHEDULE_ENABLED = ConfigOptions
       .key("clustering.schedule.enabled")
       .booleanType()
@@ -696,54 +753,63 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(false) // default false for pipeline
       .withDescription("Async Clustering, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLUSTERING_DELTA_COMMITS = ConfigOptions
       .key("clustering.delta_commits")
       .intType()
       .defaultValue(4)
       .withDescription("Max delta commits needed to trigger clustering, default 4 commits");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLUSTERING_TASKS = ConfigOptions
       .key("clustering.tasks")
       .intType()
       .noDefaultValue()
       .withDescription("Parallelism of tasks that do actual clustering, default same as the write task parallelism");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLUSTERING_TARGET_PARTITIONS = ConfigOptions
       .key("clustering.plan.strategy.daybased.lookback.partitions")
       .intType()
       .defaultValue(2)
       .withDescription("Number of partitions to list to create ClusteringPlan, default is 2");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLUSTERING_PLAN_STRATEGY_SKIP_PARTITIONS_FROM_LATEST = ConfigOptions
       .key("clustering.plan.strategy.daybased.skipfromlatest.partitions")
       .intType()
       .defaultValue(0)
       .withDescription("Number of partitions to skip from latest when choosing partitions to create ClusteringPlan");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_PLAN_STRATEGY_CLUSTER_BEGIN_PARTITION = ConfigOptions
       .key("clustering.plan.strategy.cluster.begin.partition")
       .stringType()
       .defaultValue("")
       .withDescription("Begin partition used to filter partition (inclusive)");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_PLAN_STRATEGY_CLUSTER_END_PARTITION = ConfigOptions
       .key("clustering.plan.strategy.cluster.end.partition")
       .stringType()
       .defaultValue("")
       .withDescription("End partition used to filter partition (inclusive)");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_PLAN_STRATEGY_PARTITION_REGEX_PATTERN = ConfigOptions
       .key("clustering.plan.strategy.partition.regex.pattern")
       .stringType()
       .defaultValue("")
       .withDescription("Filter clustering partitions that matched regex pattern");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_PLAN_STRATEGY_PARTITION_SELECTED = ConfigOptions
       .key("clustering.plan.strategy.partition.selected")
       .stringType()
       .defaultValue("")
       .withDescription("Partitions to run clustering");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_PLAN_STRATEGY_CLASS = ConfigOptions
       .key("clustering.plan.strategy.class")
       .stringType()
@@ -752,6 +818,7 @@ public class FlinkOptions extends HoodieConfig {
           + "i.e select what file groups are being clustered. Default strategy, looks at the last N (determined by "
           + CLUSTERING_TARGET_PARTITIONS.key() + ") day based partitions picks the small file slices within those partitions.");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_PLAN_PARTITION_FILTER_MODE_NAME = ConfigOptions
       .key("clustering.plan.partition.filter.mode")
       .stringType()
@@ -777,12 +844,14 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(600L) // default 600 MB
       .withDescription("Files smaller than the size specified here are candidates for clustering, default 600 MB");
 
+  @AdvancedConfig
   public static final ConfigOption<String> CLUSTERING_SORT_COLUMNS = ConfigOptions
       .key("clustering.plan.strategy.sort.columns")
       .stringType()
       .defaultValue("")
       .withDescription("Columns to sort the data by when clustering");
 
+  @AdvancedConfig
   public static final ConfigOption<Integer> CLUSTERING_MAX_NUM_GROUPS = ConfigOptions
       .key("clustering.plan.strategy.max.num.groups")
       .intType()
@@ -800,18 +869,21 @@ public class FlinkOptions extends HoodieConfig {
       .withFallbackKeys("hive_sync.enable")
       .withDescription("Asynchronously sync Hive meta to HMS, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_DB = ConfigOptions
       .key("hive_sync.db")
       .stringType()
       .defaultValue("default")
       .withDescription("Database name for hive sync, default 'default'");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_TABLE = ConfigOptions
       .key("hive_sync.table")
       .stringType()
       .defaultValue("unknown")
       .withDescription("Table name for hive sync, default 'unknown'");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_FILE_FORMAT = ConfigOptions
       .key("hive_sync.file_format")
       .stringType()
@@ -824,12 +896,14 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(HiveSyncMode.HMS.name())
       .withDescription("Mode to choose for Hive ops. Valid values are hms, jdbc and hiveql, default 'hms'");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_USERNAME = ConfigOptions
       .key("hive_sync.username")
       .stringType()
       .defaultValue("hive")
       .withDescription("Username for hive sync, default 'hive'");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_PASSWORD = ConfigOptions
       .key("hive_sync.password")
       .stringType()
@@ -848,12 +922,14 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue("")
       .withDescription("Metastore uris for hive sync, default ''");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_PARTITION_FIELDS = ConfigOptions
       .key("hive_sync.partition_fields")
       .stringType()
       .defaultValue("")
       .withDescription("Partition fields for hive sync, default ''");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_PARTITION_EXTRACTOR_CLASS_NAME = ConfigOptions
       .key("hive_sync.partition_extractor_class")
       .stringType()
@@ -861,36 +937,42 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Tool to extract the partition value from HDFS path, "
           + "default 'MultiPartKeysValueExtractor'");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> HIVE_SYNC_ASSUME_DATE_PARTITION = ConfigOptions
       .key("hive_sync.assume_date_partitioning")
       .booleanType()
       .defaultValue(false)
       .withDescription("Assume partitioning is yyyy/mm/dd, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> HIVE_SYNC_USE_JDBC = ConfigOptions
       .key("hive_sync.use_jdbc")
       .booleanType()
       .defaultValue(true)
       .withDescription("Use JDBC when hive synchronization is enabled, default true");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> HIVE_SYNC_AUTO_CREATE_DB = ConfigOptions
       .key("hive_sync.auto_create_db")
       .booleanType()
       .defaultValue(true)
       .withDescription("Auto create hive database if it does not exists, default true");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> HIVE_SYNC_IGNORE_EXCEPTIONS = ConfigOptions
       .key("hive_sync.ignore_exceptions")
       .booleanType()
       .defaultValue(false)
       .withDescription("Ignore exceptions during hive synchronization, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> HIVE_SYNC_SKIP_RO_SUFFIX = ConfigOptions
       .key("hive_sync.skip_ro_suffix")
       .booleanType()
       .defaultValue(false)
       .withDescription("Skip the _ro suffix for Read optimized table when registering, default false");
 
+  @AdvancedConfig
   public static final ConfigOption<Boolean> HIVE_SYNC_SUPPORT_TIMESTAMP = ConfigOptions
       .key("hive_sync.support_timestamp")
       .booleanType()
@@ -898,29 +980,33 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("INT64 with original type TIMESTAMP_MICROS is converted to hive timestamp type.\n"
           + "Disabled by default for backward compatibility.");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_TABLE_PROPERTIES = ConfigOptions
       .key("hive_sync.table_properties")
       .stringType()
       .noDefaultValue()
       .withDescription("Additional properties to store with table, the data format is k1=v1\nk2=v2");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_TABLE_SERDE_PROPERTIES = ConfigOptions
       .key("hive_sync.serde_properties")
       .stringType()
       .noDefaultValue()
       .withDescription("Serde properties to hive table, the data format is k1=v1\nk2=v2");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_CONF_DIR = ConfigOptions
       .key("hive_sync.conf.dir")
       .stringType()
       .noDefaultValue()
       .withDescription("The hive configuration directory, where the hive-site.xml lies in, the file should be put on the client machine");
 
+  @AdvancedConfig
   public static final ConfigOption<String> HIVE_SYNC_TABLE_STRATEGY = ConfigOptions
-          .key("hive_sync.table.strategy")
-          .stringType()
-          .defaultValue(HoodieSyncTableStrategy.ALL.name())
-          .withDescription("Hive table synchronization strategy. Available option: RO, RT, ALL.");
+      .key("hive_sync.table.strategy")
+      .stringType()
+      .defaultValue(HoodieSyncTableStrategy.ALL.name())
+      .withDescription("Hive table synchronization strategy. Available option: RO, RT, ALL.");
 
   // -------------------------------------------------------------------------
   //  Utilities


### PR DESCRIPTION
### Change Logs

This PR marks 85 advanced Flink configs. After this PR, we have 33 basic configs and 85 advanced configs for Hudi on Flink.  The criteria of marking advanced configs for Hudi on Flink is the same as #8329.

Here are the configs that are going to show up in the ["Basic Configuration - Flink Options"](http://localhost:3000/docs/next/basic_configurations#Flink-Options) section (other configs are marked advanced by this PR):

```
hoodie.database.name
hoodie.table.name
path
read.end-commit
read.start-commit
archive.max_commits
archive.min_commits
cdc.enabled
cdc.supplemental.logging.mode
changelog.enabled
clean.async.enabled
clean.retain_commits
clustering.async.enabled
clustering.plan.strategy.small.file.limit
clustering.plan.strategy.target.file.max.bytes
compaction.async.enabled
compaction.delta_commits
hive_sync.enabled
hive_sync.jdbc_url
hive_sync.metastore.uris
hive_sync.mode
hoodie.datasource.query.type
hoodie.datasource.write.hive_style_partitioning
hoodie.datasource.write.partitionpath.field
hoodie.datasource.write.recordkey.field
index.type
metadata.compaction.delta_commits
metadata.enabled
precombine.field
read.streaming.enabled
table.type
write.operation
write.parquet.max.file.size
```

### Impact

Advanced Flink configs are not shown in the "Basic Configuration" page in our docs for simplicity.

### Risk level

none

### Documentation Update

[HUDI-5783](https://issues.apache.org/jira/browse/HUDI-5783) for docs update.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
