### PR TITLE
[HUDI-6035] Make simple index parallelism auto inferred

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -189,15 +189,15 @@ public class HoodieIndexConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> SIMPLE_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.simple.index.parallelism")
-      .defaultValue("100")
+      .defaultValue("0")
       .markAdvanced()
       .withDocumentation("Only applies if index type is SIMPLE. "
           + "This limits the parallelism of fetching records from the base files of affected "
-          + "partitions. The index picks the configured parallelism if the number of base "
-          + "files is larger than this configured value; otherwise, the number of base files "
-          + "is used as the parallelism. If the indexing stage is slow due to the limited "
-          + "parallelism, you can increase this to tune the performance.");
-
+          + "partitions. By default, this is auto computed based on input workload characteristics. "
+          + "If the parallelism is explicitly configured by the user, The index picks the configured "
+          + "parallelism if the number of base files is larger than this configured value; otherwise, "
+          + "the number of base files is used as the parallelism. If the indexing stage is slow due to "
+          + "the limited parallelism, you can increase this to tune the performance.");
   public static final ConfigProperty<String> GLOBAL_SIMPLE_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.global.simple.index.parallelism")
       .defaultValue("100")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -194,10 +194,10 @@ public class HoodieIndexConfig extends HoodieConfig {
       .withDocumentation("Only applies if index type is SIMPLE. "
           + "This limits the parallelism of fetching records from the base files of affected "
           + "partitions. By default, this is auto computed based on input workload characteristics. "
-          + "If the parallelism is explicitly configured by the user, The index picks the configured "
-          + "parallelism if the number of base files is larger than this configured value; otherwise, "
-          + "the number of base files is used as the parallelism. If the indexing stage is slow due to "
-          + "the limited parallelism, you can increase this to tune the performance.");
+          + "If the parallelism is explicitly configured by the user, the user-configured "
+          + "value is used in defining the actual parallelism. If the indexing stage is slow "
+          + "due to the limited parallelism, you can increase this to tune the performance.");
+
   public static final ConfigProperty<String> GLOBAL_SIMPLE_INDEX_PARALLELISM = ConfigProperty
       .key("hoodie.global.simple.index.parallelism")
       .defaultValue("100")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieSimpleIndex.java
@@ -108,10 +108,10 @@ public class HoodieSimpleIndex
     }
 
     int inputParallelism = inputRecords.getNumPartitions();
-    int configuredSampleIndexParallelism = config.getSimpleIndexParallelism();
+    int configuredSimpleIndexParallelism = config.getSimpleIndexParallelism();
     // NOTE: Target parallelism could be overridden by the config
     int targetParallelism =
-        configuredSampleIndexParallelism > 0 ? configuredSampleIndexParallelism : inputParallelism;
+        configuredSimpleIndexParallelism > 0 ? configuredSimpleIndexParallelism : inputParallelism;
     HoodiePairData<HoodieKey, HoodieRecord<R>> keyedInputRecords =
         inputRecords.mapToPair(record -> new ImmutablePair<>(record.getKey(), record));
     HoodiePairData<HoodieKey, HoodieRecordLocation> existingLocationsOnTable =


### PR DESCRIPTION
### Change Logs

Make simple index parallelism auto inferred

### Impact

Simple index parallelism still default to 100, while like bloom index parallelism is auto inferred from input partitions (default 0). we should fix simple index parallelism for this, as it's the default index type.
### Risk level (write none, low medium or high below)

low
### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
