### PR TITLE
[HUDI-6087] Fix flink streaming source savepoint instant

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -242,11 +242,9 @@ public class StreamReadMonitoringFunction
     if (checkpointLock != null) {
       // this is to cover the case where cancel() is called before the run()
       synchronized (checkpointLock) {
-        issuedInstant = null;
         isRunning = false;
       }
     } else {
-      issuedInstant = null;
       isRunning = false;
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestStreamReadMonitoringFunction.java
@@ -252,6 +252,71 @@ public class TestStreamReadMonitoringFunction {
     }
   }
 
+  /**
+   * When stopping with savepoint, these interface methods are called:
+   * <ul>
+   * <li>cancel()</li>
+   * <li>snapshotState()</li>
+   * <li>close()</li>
+   * </ul>
+   * This test ensured that the state is saved properly when these 3 methods are called in the order listed above.
+   */
+  @Test
+  public void testStopWithSavepointAndRestore() throws Exception {
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+    conf.setString(FlinkOptions.READ_START_COMMIT, FlinkOptions.START_COMMIT_EARLIEST);
+    StreamReadMonitoringFunction function = TestUtils.getMonitorFunc(conf);
+    OperatorSubtaskState state;
+    try (AbstractStreamOperatorTestHarness<MergeOnReadInputSplit> harness = createHarness(function)) {
+      harness.setup();
+      harness.open();
+
+      CountDownLatch latch = new CountDownLatch(4);
+      CollectingSourceContext sourceContext = new CollectingSourceContext(latch);
+      runAsync(sourceContext, function);
+
+      assertTrue(latch.await(WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS), "Should finish splits generation");
+      Thread.sleep(1000L);
+
+      // Simulate a stop-with-savepoint
+      function.cancel();
+
+      state = harness.snapshot(1, 1);
+
+      // Stop the stream task.
+      function.close();
+
+      assertTrue(latch.await(WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS), "Should finish splits generation");
+      assertThat("Should produce the expected splits",
+          sourceContext.getPartitionPaths(), is("par1,par2,par3,par4"));
+      assertTrue(sourceContext.splits.stream().noneMatch(split -> split.getInstantRange().isPresent()),
+          "All instants should have range limit");
+
+    }
+
+    TestData.writeData(TestData.DATA_SET_UPDATE_INSERT, conf);
+    StreamReadMonitoringFunction function2 = TestUtils.getMonitorFunc(conf);
+    try (AbstractStreamOperatorTestHarness<MergeOnReadInputSplit> harness = createHarness(function2)) {
+      harness.setup();
+      // Recover to process the remaining snapshots.
+      harness.initializeState(state);
+      harness.open();
+
+      CountDownLatch latch = new CountDownLatch(4);
+      CollectingSourceContext sourceContext = new CollectingSourceContext(latch);
+      runAsync(sourceContext, function2);
+
+      // Stop the stream task.
+      function.close();
+
+      assertTrue(latch.await(WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS), "Should finish splits generation");
+      assertThat("Should produce the expected splits",
+          sourceContext.getPartitionPaths(), is("par1,par2,par3,par4"));
+      assertTrue(sourceContext.splits.stream().allMatch(split -> split.getInstantRange().isPresent()),
+          "All the instants should have range limit");
+    }
+  }
+
   private AbstractStreamOperatorTestHarness<MergeOnReadInputSplit> createHarness(
       StreamReadMonitoringFunction function) throws Exception {
     StreamSource<MergeOnReadInputSplit, StreamReadMonitoringFunction> streamSource = new StreamSource<>(function);


### PR DESCRIPTION
### Change Logs

Hudi streaming-read is not stopping with savepoint correctly. 

Flink supports stopping with savepoint as documented here:

https://nightlies.apache.org/flink/flink-docs-master/docs/ops/state/savepoints/#stopping-a-job-with-savepoint 

Stopping with savepoint will invoke these 3 interface functions Flink functions.

1. cancel()
2. snapshotState()
3. close()

**(1)** and **(3)** alter the value of `issuedInstant`, which is required by `(2) snapshotState`. 
This PR adds a test and fixes `StreamReadMonitoringFunction` when these 3 interface functions are invoked such that `(2) snapshotState` is able to save the correct `issuedInstant` into Flink's  state before closing.


### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
