### PR TITLE
[HUDI-6090] Optimise payload size for list of FileGroupDTO

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/DTOUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/DTOUtils.java
@@ -21,7 +21,6 @@ package org.apache.hudi.common.table.timeline.dto;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.util.Option;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,8 +55,8 @@ public class DTOUtils {
     }
 
     // Timeline exists only in the first file group DTO. Optimisation to reduce payload size.
-    HoodieTimeline timeline = FileGroupDTO.toFileGroup(dtos.get(0), metaClient).getTimeline();
-    checkState(timeline != null, "Timeline is expected to be set for FileGroupDTO : " + dtos.get(0).toString());
-    return dtos.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient, Option.of(timeline)));
+    checkState(dtos.get(0).timeline != null, "Timeline is expected to be set for the first FileGroupDTO");
+    HoodieTimeline timeline = TimelineDTO.toTimeline(dtos.get(0).timeline, metaClient);
+    return dtos.stream().map(dto -> FileGroupDTO.toFileGroup(dto, timeline));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/DTOUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/DTOUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.dto;
+
+import org.apache.hudi.common.model.HoodieFileGroup;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
+/**
+ * DTO utils to hold batch apis.
+ */
+public class DTOUtils {
+
+  public static List<FileGroupDTO> fileGroupDTOsfromFileGroups(List<HoodieFileGroup> fileGroups) {
+    if (fileGroups.isEmpty()) {
+      return Collections.emptyList();
+    } else if (fileGroups.size() == 1) {
+      return Collections.singletonList(FileGroupDTO.fromFileGroup(fileGroups.get(0), true));
+    } else {
+      List<FileGroupDTO> fileGroupDTOS = new ArrayList<>();
+      fileGroupDTOS.add(FileGroupDTO.fromFileGroup(fileGroups.get(0), true));
+      fileGroupDTOS.addAll(fileGroups.subList(1, fileGroups.size()).stream()
+          .map(fg -> FileGroupDTO.fromFileGroup(fg, false)).collect(Collectors.toList()));
+      return fileGroupDTOS;
+    }
+  }
+
+  public static Stream<HoodieFileGroup> fileGroupDTOsToFileGroups(List<FileGroupDTO> dtos, HoodieTableMetaClient metaClient) {
+    if (dtos.isEmpty()) {
+      return Stream.empty();
+    }
+
+    // Timeline exists only in the first file group DTO. Optimisation to reduce payload size.
+    HoodieTimeline timeline = FileGroupDTO.toFileGroup(dtos.get(0), metaClient).getTimeline();
+    checkState(timeline != null, "Timeline is expected to be set for FileGroupDTO : " + dtos.get(0).toString());
+    return dtos.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient, Option.of(timeline)));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
@@ -20,12 +20,15 @@ package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The data transfer object of file group.
@@ -46,17 +49,50 @@ public class FileGroupDTO {
   TimelineDTO timeline;
 
   public static FileGroupDTO fromFileGroup(HoodieFileGroup fileGroup) {
+    return fromFileGroup(fileGroup, true);
+  }
+
+  public static List<FileGroupDTO> fromFileGroup(List<HoodieFileGroup> fileGroups) {
+    if (fileGroups.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<FileGroupDTO> fileGroupDTOs = fileGroups.stream()
+        .map(fg -> FileGroupDTO.fromFileGroup(fg, false)).collect(Collectors.toList());
+    // Timeline exists only in the first file group. Optimisation to reduce payload size.
+    fileGroupDTOs.set(0, FileGroupDTO.fromFileGroup(fileGroups.get(0), true));
+    return fileGroupDTOs;
+  }
+
+  public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient) {
+    return toFileGroup(dto, metaClient, null);
+  }
+
+  public static Stream<HoodieFileGroup> toFileGroup(List<FileGroupDTO> dtos, HoodieTableMetaClient metaClient) {
+    if (dtos.isEmpty()) {
+      return Stream.empty();
+    }
+
+    // Timeline exists only in the first file group. Optimisation to reduce payload size.
+    HoodieTimeline timeline = toFileGroup(dtos.get(0), metaClient).getTimeline();
+    return dtos.stream().map(dto -> toFileGroup(dto, metaClient, timeline));
+  }
+
+  private static FileGroupDTO fromFileGroup(HoodieFileGroup fileGroup, boolean includeTimeline) {
     FileGroupDTO dto = new FileGroupDTO();
     dto.partition = fileGroup.getPartitionPath();
     dto.id = fileGroup.getFileGroupId().getFileId();
     dto.slices = fileGroup.getAllRawFileSlices().map(FileSliceDTO::fromFileSlice).collect(Collectors.toList());
-    dto.timeline = TimelineDTO.fromTimeline(fileGroup.getTimeline());
+    if (includeTimeline) {
+      dto.timeline = TimelineDTO.fromTimeline(fileGroup.getTimeline());
+    }
     return dto;
   }
 
-  public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient) {
+  private static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient, HoodieTimeline inputTimeline) {
+    HoodieTimeline fgTimeline = inputTimeline == null ? TimelineDTO.toTimeline(dto.timeline, metaClient) : inputTimeline;
     HoodieFileGroup fileGroup =
-        new HoodieFileGroup(dto.partition, dto.id, TimelineDTO.toTimeline(dto.timeline, metaClient));
+        new HoodieFileGroup(dto.partition, dto.id, fgTimeline);
     dto.slices.stream().map(FileSliceDTO::toFileSlice).forEach(fileSlice -> fileGroup.addFileSlice(fileSlice));
     return fileGroup;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
@@ -59,7 +59,7 @@ public class FileGroupDTO {
 
     List<FileGroupDTO> fileGroupDTOs = fileGroups.stream()
         .map(fg -> FileGroupDTO.fromFileGroup(fg, false)).collect(Collectors.toList());
-    // Timeline exists only in the first file group. Optimisation to reduce payload size.
+    // Timeline exists only in the first file group DTO. Optimisation to reduce payload size.
     fileGroupDTOs.set(0, FileGroupDTO.fromFileGroup(fileGroups.get(0), true));
     return fileGroupDTOs;
   }
@@ -73,7 +73,7 @@ public class FileGroupDTO {
       return Stream.empty();
     }
 
-    // Timeline exists only in the first file group. Optimisation to reduce payload size.
+    // Timeline exists only in the first file group DTO. Optimisation to reduce payload size.
     HoodieTimeline timeline = toFileGroup(dtos.get(0), metaClient).getTimeline();
     return dtos.stream().map(dto -> toFileGroup(dto, metaClient, timeline));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/FileGroupDTO.java
@@ -19,9 +19,7 @@
 package org.apache.hudi.common.table.timeline.dto;
 
 import org.apache.hudi.common.model.HoodieFileGroup;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.util.Option;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,14 +45,6 @@ public class FileGroupDTO {
   @JsonProperty("timeline")
   TimelineDTO timeline;
 
-  public static FileGroupDTO fromFileGroup(HoodieFileGroup fileGroup) {
-    return fromFileGroup(fileGroup, true);
-  }
-
-  public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient) {
-    return toFileGroup(dto, metaClient, Option.empty());
-  }
-
   public static FileGroupDTO fromFileGroup(HoodieFileGroup fileGroup, boolean includeTimeline) {
     FileGroupDTO dto = new FileGroupDTO();
     dto.partition = fileGroup.getPartitionPath();
@@ -66,11 +56,9 @@ public class FileGroupDTO {
     return dto;
   }
 
-  public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTableMetaClient metaClient, Option<HoodieTimeline> inputTimeline) {
-    HoodieTimeline fgTimeline = inputTimeline.isPresent() ? inputTimeline.get() : TimelineDTO.toTimeline(dto.timeline, metaClient);
-    HoodieFileGroup fileGroup =
-        new HoodieFileGroup(dto.partition, dto.id, fgTimeline);
-    dto.slices.stream().map(FileSliceDTO::toFileSlice).forEach(fileSlice -> fileGroup.addFileSlice(fileSlice));
+  public static HoodieFileGroup toFileGroup(FileGroupDTO dto, HoodieTimeline fgTimeline) {
+    HoodieFileGroup fileGroup = new HoodieFileGroup(dto.partition, dto.id, fgTimeline);
+    dto.slices.stream().map(FileSliceDTO::toFileSlice).forEach(fileGroup::addFileSlice);
     return fileGroup;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -422,7 +422,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_BEFORE, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return fileGroups.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient));
+      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.dto.BaseFileDTO;
 import org.apache.hudi.common.table.timeline.dto.ClusteringOpDTO;
 import org.apache.hudi.common.table.timeline.dto.CompactionOpDTO;
+import org.apache.hudi.common.table.timeline.dto.DTOUtils;
 import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
 import org.apache.hudi.common.table.timeline.dto.FileSliceDTO;
 import org.apache.hudi.common.table.timeline.dto.InstantDTO;
@@ -398,7 +399,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_FILEGROUPS_FOR_PARTITION_URL, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
+      return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
@@ -410,7 +411,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_BEFORE_OR_ON, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
+      return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
@@ -422,7 +423,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_BEFORE, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
+      return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
@@ -434,7 +435,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_PARTITION, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
+      return DTOUtils.fileGroupDTOsToFileGroups(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RemoteHoodieTableFileSystemView.java
@@ -398,7 +398,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_FILEGROUPS_FOR_PARTITION_URL, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return fileGroups.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient));
+      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
@@ -410,7 +410,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_BEFORE_OR_ON, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return fileGroups.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient));
+      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }
@@ -434,7 +434,7 @@ public class RemoteHoodieTableFileSystemView implements SyncableFileSystemView, 
     try {
       List<FileGroupDTO> fileGroups = executeRequest(ALL_REPLACED_FILEGROUPS_PARTITION, paramsMap,
           new TypeReference<List<FileGroupDTO>>() {}, RequestMethod.GET);
-      return fileGroups.stream().map(dto -> FileGroupDTO.toFileGroup(dto, metaClient));
+      return FileGroupDTO.toFileGroup(fileGroups, metaClient);
     } catch (IOException e) {
       throw new HoodieRemoteException(e);
     }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -160,6 +160,8 @@ public class RequestHandler {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient
           + "], localTimeline=" + localTimeline.getInstants());
+    } else {
+      LOG.info("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient + "]");
     }
 
     if ((!localTimeline.getInstantsAsStream().findAny().isPresent())

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -160,9 +160,7 @@ public class RequestHandler {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient
           + "], localTimeline=" + localTimeline.getInstants());
-    } else {
-      LOG.info("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient + "]");
-    }
+    } 
 
     if ((!localTimeline.getInstantsAsStream().findAny().isPresent())
         && HoodieTimeline.INVALID_INSTANT_TS.equals(lastKnownInstantFromClient)) {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.timeline.dto.ClusteringOpDTO;
 import org.apache.hudi.common.table.timeline.dto.CompactionOpDTO;
+import org.apache.hudi.common.table.timeline.dto.DTOUtils;
 import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
 import org.apache.hudi.common.table.timeline.dto.FileSliceDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
@@ -98,25 +99,25 @@ public class FileSliceHandler extends Handler {
   public List<FileGroupDTO> getAllFileGroups(String basePath, String partitionPath) {
     List<HoodieFileGroup> fileGroups =  viewManager.getFileSystemView(basePath).getAllFileGroups(partitionPath)
         .collect(Collectors.toList());
-    return FileGroupDTO.fromFileGroup(fileGroups);
+    return DTOUtils.fileGroupDTOsfromFileGroups(fileGroups);
   }
 
   public List<FileGroupDTO> getReplacedFileGroupsBeforeOrOn(String basePath, String maxCommitTime, String partitionPath) {
     List<HoodieFileGroup> fileGroups =  viewManager.getFileSystemView(basePath).getReplacedFileGroupsBeforeOrOn(maxCommitTime, partitionPath)
         .collect(Collectors.toList());
-    return FileGroupDTO.fromFileGroup(fileGroups);
+    return DTOUtils.fileGroupDTOsfromFileGroups(fileGroups);
   }
 
   public List<FileGroupDTO> getReplacedFileGroupsBefore(String basePath, String maxCommitTime, String partitionPath) {
     List<HoodieFileGroup> fileGroups = viewManager.getFileSystemView(basePath).getReplacedFileGroupsBefore(maxCommitTime, partitionPath)
         .collect(Collectors.toList());
-    return FileGroupDTO.fromFileGroup(fileGroups);
+    return DTOUtils.fileGroupDTOsfromFileGroups(fileGroups);
   }
   
   public List<FileGroupDTO> getAllReplacedFileGroups(String basePath, String partitionPath) {
     List<HoodieFileGroup> fileGroups =  viewManager.getFileSystemView(basePath).getAllReplacedFileGroups(partitionPath)
         .collect(Collectors.toList());
-    return FileGroupDTO.fromFileGroup(fileGroups);
+    return DTOUtils.fileGroupDTOsfromFileGroups(fileGroups);
   }
 
   public List<ClusteringOpDTO> getFileGroupsInPendingClustering(String basePath) {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
@@ -96,13 +96,15 @@ public class FileSliceHandler extends Handler {
   }
 
   public List<FileGroupDTO> getAllFileGroups(String basePath, String partitionPath) {
-    return viewManager.getFileSystemView(basePath).getAllFileGroups(partitionPath).map(FileGroupDTO::fromFileGroup)
+    List<HoodieFileGroup> fileGroups =  viewManager.getFileSystemView(basePath).getAllFileGroups(partitionPath)
         .collect(Collectors.toList());
+    return FileGroupDTO.fromFileGroup(fileGroups);
   }
 
   public List<FileGroupDTO> getReplacedFileGroupsBeforeOrOn(String basePath, String maxCommitTime, String partitionPath) {
-    return viewManager.getFileSystemView(basePath).getReplacedFileGroupsBeforeOrOn(maxCommitTime, partitionPath).map(FileGroupDTO::fromFileGroup)
+    List<HoodieFileGroup> fileGroups =  viewManager.getFileSystemView(basePath).getReplacedFileGroupsBeforeOrOn(maxCommitTime, partitionPath)
         .collect(Collectors.toList());
+    return FileGroupDTO.fromFileGroup(fileGroups);
   }
 
   public List<FileGroupDTO> getReplacedFileGroupsBefore(String basePath, String maxCommitTime, String partitionPath) {
@@ -112,8 +114,9 @@ public class FileSliceHandler extends Handler {
   }
   
   public List<FileGroupDTO> getAllReplacedFileGroups(String basePath, String partitionPath) {
-    return viewManager.getFileSystemView(basePath).getAllReplacedFileGroups(partitionPath).map(FileGroupDTO::fromFileGroup)
+    List<HoodieFileGroup> fileGroups =  viewManager.getFileSystemView(basePath).getAllReplacedFileGroups(partitionPath)
         .collect(Collectors.toList());
+    return FileGroupDTO.fromFileGroup(fileGroups);
   }
 
   public List<ClusteringOpDTO> getFileGroupsInPendingClustering(String basePath) {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/FileSliceHandler.java
@@ -21,6 +21,7 @@ package org.apache.hudi.timeline.service.handlers;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
+import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.timeline.dto.ClusteringOpDTO;
 import org.apache.hudi.common.table.timeline.dto.CompactionOpDTO;
 import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
@@ -105,8 +106,9 @@ public class FileSliceHandler extends Handler {
   }
 
   public List<FileGroupDTO> getReplacedFileGroupsBefore(String basePath, String maxCommitTime, String partitionPath) {
-    return viewManager.getFileSystemView(basePath).getReplacedFileGroupsBefore(maxCommitTime, partitionPath).map(FileGroupDTO::fromFileGroup)
+    List<HoodieFileGroup> fileGroups = viewManager.getFileSystemView(basePath).getReplacedFileGroupsBefore(maxCommitTime, partitionPath)
         .collect(Collectors.toList());
+    return FileGroupDTO.fromFileGroup(fileGroups);
   }
   
   public List<FileGroupDTO> getAllReplacedFileGroups(String basePath, String partitionPath) {

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -21,23 +21,36 @@ package org.apache.hudi.timeline.service.functional;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.table.view.RemoteHoodieTableFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.table.view.TestHoodieTableFileSystemView;
+import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.exception.HoodieRemoteException;
 import org.apache.hudi.timeline.service.TimelineService;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -123,5 +136,45 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
             || t.getName().startsWith("TimelineService-JettyScheduler"))
         .forEach(t -> assertTrue(t.isDaemon()));
     server.close();
+  }
+
+  @Test
+  public void testListFileGroupDTOPayload() throws IOException, NoSuchFieldException, IllegalAccessException {
+    ObjectMapper mapper = new ObjectMapper();
+    List<HoodieFileGroup> fileGroups = new ArrayList<>();
+    fileGroups.add(createHoodieFileGroup());
+    fileGroups.add(createHoodieFileGroup());
+    fileGroups.add(createHoodieFileGroup());
+
+    // Timeline exists only in the first file group DTO. Optimisation to reduce payload size.
+    Field timelineDTOField = FileGroupDTO.class.getDeclaredField("timeline");
+    timelineDTOField.setAccessible(true);
+    List<FileGroupDTO> fileGroupDTOs = FileGroupDTO.fromFileGroup(fileGroups);
+    assertNotNull(timelineDTOField.get(fileGroupDTOs.get(0)));
+    // Verify other DTO objects do not contain timeline
+    assertNull(timelineDTOField.get(fileGroupDTOs.get(1)));
+    assertNull(timelineDTOField.get(fileGroupDTOs.get(2)));
+
+    String prettyResult = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(fileGroupDTOs);
+    String normalResult = mapper.writeValueAsString(fileGroupDTOs);
+
+    Stream<HoodieFileGroup> prettyFileGroups = readFileGroupStream(prettyResult, mapper);
+    Stream<HoodieFileGroup> normalFileGroups = readFileGroupStream(normalResult, mapper);
+    // FileGroupDTO.toFileGroup should make sure Timeline is repopulated to all the FileGroups
+    prettyFileGroups.forEach(g -> assertNotNull(g.getTimeline()));
+    normalFileGroups.forEach(g -> assertNotNull(g.getTimeline()));
+  }
+
+  private Stream<HoodieFileGroup> readFileGroupStream(String result, ObjectMapper mapper) throws IOException {
+    return FileGroupDTO.toFileGroup((List<FileGroupDTO>) mapper.readValue(result, new TypeReference<List<FileGroupDTO>>() {}),
+        metaClient);
+  }
+
+  private HoodieFileGroup createHoodieFileGroup() {
+    Stream<String> completed = Stream.of("001");
+    Stream<String> inflight = Stream.of("002");
+    MockHoodieTimeline activeTimeline = new MockHoodieTimeline(completed, inflight);
+    return new HoodieFileGroup("", "data",
+        activeTimeline.getCommitsTimeline().filterCompletedInstants());
   }
 }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.dto.DTOUtils;
 import org.apache.hudi.common.table.timeline.dto.FileGroupDTO;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
@@ -149,7 +150,7 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
     // Timeline exists only in the first file group DTO. Optimisation to reduce payload size.
     Field timelineDTOField = FileGroupDTO.class.getDeclaredField("timeline");
     timelineDTOField.setAccessible(true);
-    List<FileGroupDTO> fileGroupDTOs = FileGroupDTO.fromFileGroup(fileGroups);
+    List<FileGroupDTO> fileGroupDTOs = DTOUtils.fileGroupDTOsfromFileGroups(fileGroups);
     assertNotNull(timelineDTOField.get(fileGroupDTOs.get(0)));
     // Verify other DTO objects do not contain timeline
     assertNull(timelineDTOField.get(fileGroupDTOs.get(1)));
@@ -166,7 +167,7 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
   }
 
   private Stream<HoodieFileGroup> readFileGroupStream(String result, ObjectMapper mapper) throws IOException {
-    return FileGroupDTO.toFileGroup((List<FileGroupDTO>) mapper.readValue(result, new TypeReference<List<FileGroupDTO>>() {}),
+    return DTOUtils.fileGroupDTOsToFileGroups((List<FileGroupDTO>) mapper.readValue(result, new TypeReference<List<FileGroupDTO>>() {}),
         metaClient);
   }
 


### PR DESCRIPTION
### Change Logs

FileGroupDTO has TimelineDTO as field. The timeline can be large and have significant size. For a list of FileGroupDTOs, the same timeline is repeated for every FileGroupDTO. The Jira aims to add an optimisation where for a list of FileGroupDTOs, the timeline is sent only in the first FileGroupDTOs. On the client side, FileGroup can be constructed using the TimelineDTO from the first DTO.


### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
