### PR TITLE
[HUDI-6094] make utilities kafka send call from async to sync

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallback.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/callback/kafka/HoodieWriteCommitKafkaCallback.java
@@ -65,7 +65,7 @@ public class HoodieWriteCommitKafkaCallback implements HoodieWriteCommitCallback
     String callbackMsg = HoodieWriteCommitCallbackUtil.convertToJsonString(callbackMessage);
     try (KafkaProducer<String, String> producer = createProducer(hoodieConfig)) {
       ProducerRecord<String, String> record = buildProducerRecord(hoodieConfig, callbackMsg);
-      producer.send(record);
+      producer.send(record).get();
       LOG.info("Send callback message succeed");
     } catch (Exception e) {
       LOG.error("Send kafka callback msg failed : ", e);


### PR DESCRIPTION
### Change Logs

In call method from HoodieWriteCommitKafkaCallback in hudi-utilities module, the kafka send is async, how about to make the send to sync to ensure the kafka send call complete. No performance degradation, because the send call is in a try-with-resource.
### Impact

Wait for the kafka send call response

### Risk level (write none, low medium or high below)

None

### Documentation Update

None
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
