### PR TITLE
[HUDI-6096] Update table name in hoodie.properties from the write config when it is changed.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -506,6 +506,10 @@ public class HoodieTableConfig extends HoodieConfig {
     setValue(VERSION, Integer.toString(tableVersion.versionCode()));
   }
 
+  public void setTableName(String name) {
+    setValue(NAME, name);
+  }
+
   /**
    * Read the payload class for HoodieRecords from the table properties.
    */


### PR DESCRIPTION
[HUDI-6096] Update table name in hoodie.properties from the write config when it is changed.

### Change Logs

1. Check for table name change within initTable
2. If table name is changed, hoodie.properties is updated 
3. Added a unit test

### Impact

Makes it easy to update table name of a dataset

### Risk level (write none, low medium or high below)

No known risk

### Documentation Update

None required

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
