### PR TITLE
[HUDI-6101] Use UnBoundedCompactionStrategy for MDT compactions.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -71,7 +71,7 @@ import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.hadoop.SerializablePath;
-
+import org.apache.hudi.table.action.compact.strategy.UnBoundedCompactionStrategy;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -292,6 +292,10 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
             .withInlineCompaction(false)
             .withMaxNumDeltaCommitsBeforeCompaction(writeConfig.getMetadataCompactDeltaCommitMax())
             .withEnableOptimizedLogBlocksScan(String.valueOf(writeConfig.enableOptimizedLogBlocksScan()))
+            // Compaction on metadata table is used as a barrier for archiving on main dataset and for validating the
+            // deltacommits having corresponding completed commits. Therefore, we need to compact all fileslices of all
+            // partitions together requiring UnBoundedCompactionStrategy.
+            .withCompactionStrategy(new UnBoundedCompactionStrategy())
             .build())
         .withParallelism(parallelism, parallelism)
         .withDeleteParallelism(parallelism)


### PR DESCRIPTION
[HUDI-6101] Use UnBoundedCompactionStrategy for MDT compactions.

### Change Logs

Changed the MDT compaction strategy to UnBoundedCompactionStrategy.

Compaction on metadata table is used as a barrier for archiving on main dataset and for validating the deltacommits having corresponding completed commits. Therefore, we need to compact all fileslices of all partitions together requiring UnBoundedCompactionStrategy.

### Impact

Corrects compaction on MDT when large amount of log data is to be compacted. Without this change, the current default strategy (LogFileSizeBasedCompactionStrategy) may only compact some file groups.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
