### PR TITLE
[HUDI-6047] Clustering operation on consistent hashing index resulting in duplicate data

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bucket/HoodieSparkConsistentBucketIndex.java
@@ -40,6 +40,7 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.table.HoodieTable;
 
@@ -56,10 +57,15 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import scala.Tuple2;
+
+import static org.apache.hudi.common.model.HoodieConsistentHashingMetadata.HASHING_METADATA_COMMIT_FILE_SUFFIX;
+import static org.apache.hudi.common.model.HoodieConsistentHashingMetadata.HASHING_METADATA_FILE_SUFFIX;
+import static org.apache.hudi.common.model.HoodieConsistentHashingMetadata.getTimestampFromFile;
 
 /**
  * Consistent hashing bucket index implementation, with auto-adjust bucket number.
@@ -189,29 +195,64 @@ public class HoodieSparkConsistentBucketIndex extends HoodieBucketIndex {
    */
   public static Option<HoodieConsistentHashingMetadata> loadMetadata(HoodieTable table, String partition) {
     Path metadataPath = FSUtils.getPartitionPath(table.getMetaClient().getHashingMetadataPath(), partition);
-
+    Path partitionPath = FSUtils.getPartitionPath(table.getMetaClient().getBasePathV2(), partition);
     try {
-      FileStatus[] metaFiles = table.getMetaClient().getFs().listStatus(metadataPath);
-      final HoodieTimeline completedCommits = table.getMetaClient().getActiveTimeline().getCommitTimeline().filterCompletedInstants();
-      Predicate<FileStatus> metaFilePredicate = fileStatus -> {
+      Predicate<FileStatus> hashingMetaCommitFilePredicate = fileStatus -> {
         String filename = fileStatus.getPath().getName();
-        if (!filename.contains(HoodieConsistentHashingMetadata.HASHING_METADATA_FILE_SUFFIX)) {
-          return false;
-        }
-        String timestamp = HoodieConsistentHashingMetadata.getTimestampFromFile(filename);
-        return completedCommits.containsInstant(timestamp) || timestamp.equals(HoodieTimeline.INIT_INSTANT_TS);
+        return filename.contains(HoodieConsistentHashingMetadata.HASHING_METADATA_COMMIT_FILE_SUFFIX);
       };
-
-      // Get a valid hashing metadata with the largest (latest) timestamp
-      FileStatus metaFile = Arrays.stream(metaFiles).filter(metaFilePredicate)
-          .max(Comparator.comparing(a -> a.getPath().getName())).orElse(null);
-
-      if (metaFile == null) {
-        return Option.empty();
+      Predicate<FileStatus> hashingMetadataFilePredicate = fileStatus -> {
+        String filename = fileStatus.getPath().getName();
+        return filename.contains(HASHING_METADATA_FILE_SUFFIX);
+      };
+      final FileStatus[] metaFiles = table.getMetaClient().getFs().listStatus(metadataPath);
+      final TreeSet<String> commitMetaTss = Arrays.stream(metaFiles).filter(hashingMetaCommitFilePredicate)
+          .map(commitFile -> HoodieConsistentHashingMetadata.getTimestampFromFile(commitFile.getPath().getName()))
+          .sorted()
+          .collect(Collectors.toCollection(TreeSet::new));
+      final FileStatus[] hashingMetaFiles = Arrays.stream(metaFiles).filter(hashingMetadataFilePredicate)
+          .sorted(Comparator.comparing(f -> f.getPath().getName()))
+              .toArray(FileStatus[]::new);
+      // max committed metadata file
+      final String maxCommitMetaFileTs = commitMetaTss.isEmpty() ? null : commitMetaTss.last();
+      // max updated metadata file
+      FileStatus maxMetadataFile = hashingMetaFiles.length > 0 ? hashingMetaFiles[hashingMetaFiles.length - 1] : null;
+      // If single file present in metadata and if its default file return it
+      if (maxMetadataFile != null && HoodieConsistentHashingMetadata.getTimestampFromFile(maxMetadataFile.getPath().getName()).equals(HoodieTimeline.INIT_INSTANT_TS)) {
+        return loadMetadataFromGivenFile(table, maxMetadataFile);
       }
+      // if max updated metadata file and committed metadata file are same then return
+      if (maxCommitMetaFileTs != null && maxMetadataFile != null
+              && maxCommitMetaFileTs.equals(HoodieConsistentHashingMetadata.getTimestampFromFile(maxMetadataFile.getPath().getName()))) {
+        return loadMetadataFromGivenFile(table, maxMetadataFile);
+      }
+      HoodieTimeline completedCommits = table.getMetaClient().getActiveTimeline().getCommitTimeline().filterCompletedInstants();
 
-      byte[] content = FileIOUtils.readAsByteArray(table.getMetaClient().getFs().open(metaFile.getPath()));
-      return Option.of(HoodieConsistentHashingMetadata.fromBytes(content));
+      // fix the in-consistency between un-committed and committed hashing metadata files.
+      List<FileStatus> fixed = new ArrayList<>();
+      Arrays.stream(hashingMetaFiles).forEach(hashingMetaFile -> {
+        Path path = hashingMetaFile.getPath();
+        String timestamp = HoodieConsistentHashingMetadata.getTimestampFromFile(path.getName());
+        if (maxCommitMetaFileTs != null && timestamp.compareTo(maxCommitMetaFileTs) <= 0) {
+          // only fix the metadata with greater timestamp than max committed timestamp
+          return;
+        }
+        boolean isRehashingCommitted = completedCommits.containsInstant(timestamp) || timestamp.equals(HoodieTimeline.INIT_INSTANT_TS);
+        if (isRehashingCommitted) {
+          if (!commitMetaTss.contains(timestamp)) {
+            try {
+              createCommitMarker(table, path, partitionPath);
+            } catch (IOException e) {
+              throw new HoodieIOException("Exception while creating marker file " + path.getName() + " for partition " + partition, e);
+            }
+          }
+          fixed.add(hashingMetaFile);
+        } else if (recommitMetadataFile(table, hashingMetaFile, partition)) {
+          fixed.add(hashingMetaFile);
+        }
+      });
+
+      return fixed.isEmpty() ? Option.empty() : loadMetadataFromGivenFile(table, fixed.get(fixed.size() - 1));
     } catch (FileNotFoundException e) {
       return Option.empty();
     } catch (IOException e) {
@@ -271,8 +312,83 @@ public class HoodieSparkConsistentBucketIndex extends HoodieBucketIndex {
       }
 
       LOG.error("Consistent hashing node has no file group, partition: " + partitionPath + ", meta: "
-          + partitionToIdentifier.get(partitionPath).getMetadata().getFilename() + ", record_key: " + key.toString());
+              + partitionToIdentifier.get(partitionPath).getMetadata().getFilename() + ", record_key: " + key.toString());
       throw new HoodieIndexException("Failed to getBucket as hashing node has no file group");
     }
+  }
+
+  /***
+   * Creates commit marker corresponding to hashing metadata file after post commit clustering operation.
+   * @param table hoodie table
+   * @param fileStatus file for which commit marker should be created
+   * @param partitionPath partition path the file belongs to
+   * @throws IOException
+   */
+  private static void createCommitMarker(HoodieTable table, Path fileStatus, Path partitionPath) throws IOException {
+    HoodieWrapperFileSystem fs = table.getMetaClient().getFs();
+    Path fullPath = new Path(partitionPath, getTimestampFromFile(fileStatus.getName()) + HASHING_METADATA_COMMIT_FILE_SUFFIX);
+    if (fs.exists(fullPath)) {
+      return;
+    }
+    FileIOUtils.createFileInPath(fs, fullPath, Option.of(StringUtils.EMPTY_STRING.getBytes()));
+  }
+
+  /***
+   * Loads consistent hashing metadata of table from the given meta file
+   * @param table hoodie table
+   * @param metaFile hashing metadata file
+   * @return HoodieConsistentHashingMetadata object
+   */
+  private static Option<HoodieConsistentHashingMetadata> loadMetadataFromGivenFile(HoodieTable table, FileStatus metaFile) {
+    try {
+      if (metaFile == null) {
+        return Option.empty();
+      }
+      byte[] content = FileIOUtils.readAsByteArray(table.getMetaClient().getFs().open(metaFile.getPath()));
+      return Option.of(HoodieConsistentHashingMetadata.fromBytes(content));
+    } catch (FileNotFoundException e) {
+      return Option.empty();
+    } catch (IOException e) {
+      LOG.error("Error when loading hashing metadata, for path: " + metaFile.getPath().getName(), e);
+      throw new HoodieIndexException("Error while loading hashing metadata", e);
+    }
+  }
+
+  /***
+   * COMMIT MARKER RECOVERY JOB.
+   * If particular hashing metadta file doesn't have commit marker then there could be a case where clustering is done but post commit marker
+   * creation operation failed. In this case this method will check file group id from consistent hashing metadata against storage base file group ids.
+   * if one of the file group matches then we can conclude that this is the latest metadata file.
+   * Note : we will end up calling this method if there is no marker file and no replace commit on active timeline, if replace commit is not present on
+   * active timeline that means old file group id's before clustering operation got cleaned and only new file group id's  of current clustering operation
+   * are present on the disk.
+   * @param table hoodie table
+   * @param metaFile metadata file on which sync check needs to be performed
+   * @param partition partition metadata file belongs to
+   * @return true if hashing metadata file is latest else false
+   */
+  private static boolean recommitMetadataFile(HoodieTable table, FileStatus metaFile, String partition) {
+    Path partitionPath = FSUtils.getPartitionPath(table.getMetaClient().getBasePathV2(), partition);
+    String timestamp = getTimestampFromFile(metaFile.getPath().getName());
+    if (table.getPendingCommitTimeline().containsInstant(timestamp)) {
+      return false;
+    }
+    Option<HoodieConsistentHashingMetadata> hoodieConsistentHashingMetadataOption = loadMetadataFromGivenFile(table, metaFile);
+    if (!hoodieConsistentHashingMetadataOption.isPresent()) {
+      return false;
+    }
+    HoodieConsistentHashingMetadata hoodieConsistentHashingMetadata = hoodieConsistentHashingMetadataOption.get();
+
+    Predicate<String> hoodieFileGroupIdPredicate = hoodieBaseFile -> hoodieConsistentHashingMetadata.getNodes().stream().anyMatch(node -> node.getFileIdPrefix().equals(hoodieBaseFile));
+    if (table.getBaseFileOnlyView().getLatestBaseFiles(partition)
+            .map(fileIdPrefix -> FSUtils.getFileIdPfxFromFileId(fileIdPrefix.getFileId())).anyMatch(hoodieFileGroupIdPredicate)) {
+      try {
+        createCommitMarker(table, metaFile.getPath(), partitionPath);
+        return true;
+      } catch (IOException e) {
+        throw new HoodieIOException("Exception while creating marker file " + metaFile.getPath().getName() + " for partition " + partition, e);
+      }
+    }
+    return false;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieConsistentHashingMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieConsistentHashingMetadata.java
@@ -49,6 +49,7 @@ public class HoodieConsistentHashingMetadata implements Serializable {
    */
   public static final int HASH_VALUE_MASK = Integer.MAX_VALUE;
   public static final String HASHING_METADATA_FILE_SUFFIX = ".hashing_meta";
+  public static final String HASHING_METADATA_COMMIT_FILE_SUFFIX = ".commit";
 
   private final short version;
   private final String partitionPath;


### PR DESCRIPTION
### Change Logs

Following changes added

- Hudi loads consistent hashing committed bucket metadata file on the basis of replace commit present on active timeline, but when replaced commit gets archived it falls back to default metadata file which result in data duplication.
- Create commit marker for committed index metadata in cluster operation to indicate reader the latest metadata to use
- Added patch for this bug https://issues.apache.org/jira/browse/HUDI-6047


### Impact

None

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
