### PR TITLE
[MINOR] Update colstats parallelism default to 200

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -160,7 +160,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Integer> COLUMN_STATS_INDEX_PARALLELISM = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.parallelism")
-      .defaultValue(10)
+      .defaultValue(200)
       .markAdvanced()
       .sinceVersion("0.11.0")
       .withDocumentation("Parallelism to use, when generating column stats index.");


### PR DESCRIPTION
### Change Logs

Make colstats parallelism default to 200.

### Impact

Improve perf when updating colstats for many new created files.

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
