### PR TITLE
[HUDI-6120] Filter base file when there is only one file slice fetched

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -1305,6 +1305,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
 
   /**
    * Returns the file slice with all the file slice log files merged.
+   * <p> CAUTION: the method requires that all the file slices must only contain log files.
    *
    * @param fileGroup File Group for which the file slice belongs to
    * @param maxInstantTime The max instant time


### PR DESCRIPTION
### Change Logs
if we only fetch one file slice, we will return the file slice with basefile, and then hudi-flink will create a SkipMergeIterator/MergeIterator which both reads basefile and logfiles for the split.

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
medium
_If medium or high, explain what verification was done to mitigate the risks._
streaming read will read basefile even if skipBaseFiles is set to true.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
