### PR TITLE
[MINOR] Fix misleading permitted write operation value

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -284,8 +284,8 @@ object DataSourceWriteOptions {
       WriteOperationType.COMPACT.value,
       WriteOperationType.ALTER_SCHEMA.value
     )
-    .withDocumentation("Whether to do upsert, insert or bulkinsert for the write operation. " +
-      "Use bulkinsert to load new data into a table, and there on use upsert/insert. " +
+    .withDocumentation("Whether to do upsert, insert or bulk_insert for the write operation. " +
+      "Use bulk_insert to load new data into a table, and there on use upsert/insert. " +
       "bulk insert uses a disk based write path to scale to load large inputs without need to cache it.")
 
 


### PR DESCRIPTION
### Change Logs

Permitted write operation values do not align with what is actually described in configuration value. 

This PR fixes this so that the permitted write operations aligns with the description. This change is required as Hudi's documentation page is generated from the description of each configuration key.

### Impact
None

### Risk level (write none, low medium or high below)
Low

### Documentation Update

No functionality changes, documentation description update to change ~~bulkinsert~~ to bulk_insert.

This change will "hopefully" prevent NEW users from doing this when they are performing a bulk insert operation in their batch SQL jobs.

**WRONG:**

```sql
set hoodie.datasource.write.operation=bulkinsert;
```

**CORRECT:**

```sql
set hoodie.datasource.write.operation=bulk_insert;
```

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
