### PR TITLE
[HUDI-6122] Unify options in call procedure

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -22,6 +22,7 @@ package org.apache.hudi
 import org.apache.hudi.avro.model.HoodieClusteringGroup
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.util.StringUtils
 import org.apache.spark.SparkException
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SparkSession
@@ -89,5 +90,12 @@ object HoodieCLIUtils {
       case _ =>
         throw new SparkException(s"Unsupported identifier $table")
     }
+  }
+
+  def extractOptions(s: String): Map[String, String] = {
+    StringUtils.split(s, ",").asScala
+      .map(split => StringUtils.split(split, "="))
+      .map(pair => pair.get(0) -> pair.get(1))
+      .toMap
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ArchiveCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ArchiveCommitsProcedure.scala
@@ -30,8 +30,8 @@ class ArchiveCommitsProcedure extends BaseProcedure
   with SparkAdapterSupport
   with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.optional(1, "path", DataTypes.StringType, None),
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType),
     ProcedureParameter.optional(2, "min_commits", DataTypes.IntegerType, 20),
     ProcedureParameter.optional(3, "max_commits", DataTypes.IntegerType, 30),
     ProcedureParameter.optional(4, "retain_commits", DataTypes.IntegerType, 10),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/BaseProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/BaseProcedure.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 
 abstract class BaseProcedure extends Procedure {
-  val INVALID_ARG_INDEX: Int = -1
-
   val spark: SparkSession = SparkSession.active
   val jsc = new JavaSparkContext(spark.sparkContext)
 
@@ -41,41 +39,31 @@ abstract class BaseProcedure extends Procedure {
       .build
   }
 
-  protected def checkArgs(target: Array[ProcedureParameter], args: ProcedureArgs): Unit = {
-    val internalRow = args.internalRow
-    for (i <- target.indices) {
-      if (target(i).required) {
-        var argsIndex: Integer = null
-        if (args.isNamedArgs) {
-          argsIndex = getArgsIndex(target(i).name, args)
-        } else {
-          argsIndex = getArgsIndex(i.toString, args)
-        }
-        assert(-1 != argsIndex && internalRow.get(argsIndex, target(i).dataType) != null,
-          s"Argument: ${target(i).name} is required")
-      }
+  protected def getParamKey(parameter: ProcedureParameter, isNamedArgs: Boolean): String = {
+    if (isNamedArgs) {
+      parameter.name
+    } else {
+      parameter.index.toString
     }
   }
 
-  protected def getArgsIndex(key: String, args: ProcedureArgs): Integer = {
-    args.map.getOrDefault(key, INVALID_ARG_INDEX)
+  protected def checkArgs(parameters: Array[ProcedureParameter], args: ProcedureArgs): Unit = {
+    for (parameter <- parameters) {
+      if (parameter.required) {
+        val paramKey = getParamKey(parameter, args.isNamedArgs)
+        assert(args.map.containsKey(paramKey) &&
+          args.internalRow.get(args.map.get(paramKey), parameter.dataType) != null,
+          s"Argument: ${parameter.name} is required")
+      }
+    }
   }
 
   protected def getArgValueOrDefault(args: ProcedureArgs, parameter: ProcedureParameter): Option[Any] = {
-    var argsIndex: Int = INVALID_ARG_INDEX
-    if (args.isNamedArgs) {
-      argsIndex = getArgsIndex(parameter.name, args)
+    val paramKey = getParamKey(parameter, args.isNamedArgs)
+    if (args.map.containsKey(paramKey)) {
+      Option.apply(getInternalRowValue(args.internalRow, args.map.get(paramKey), parameter.dataType))
     } else {
-      argsIndex = getArgsIndex(parameter.index.toString, args)
-    }
-
-    if (argsIndex.equals(INVALID_ARG_INDEX)) {
-      parameter.default match {
-        case option: Option[Any] => option
-        case _ => Option.apply(parameter.default)
-      }
-    } else {
-      Option.apply(getInternalRowValue(args.internalRow, argsIndex, parameter.dataType))
+      Option.apply(parameter.default)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CommitsCompareProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CommitsCompareProcedure.scala
@@ -30,8 +30,8 @@ import scala.collection.JavaConverters._
 
 class CommitsCompareProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "path", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CopyToTableProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CopyToTableProcedure.scala
@@ -28,9 +28,9 @@ class CopyToTableProcedure extends BaseProcedure with ProcedureBuilder with Logg
 
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "query_type", DataTypes.StringType, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL),
-    ProcedureParameter.required(2, "new_table", DataTypes.StringType, None),
+    ProcedureParameter.required(2, "new_table", DataTypes.StringType),
     ProcedureParameter.optional(3, "begin_instance_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(4, "end_instance_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(5, "as_of_instant", DataTypes.StringType, ""),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CopyToTempView.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CopyToTempView.scala
@@ -27,9 +27,9 @@ import java.util.function.Supplier
 class CopyToTempView extends BaseProcedure with ProcedureBuilder with Logging {
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "query_type", DataTypes.StringType, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL),
-    ProcedureParameter.required(2, "view_name", DataTypes.StringType, None),
+    ProcedureParameter.required(2, "view_name", DataTypes.StringType),
     ProcedureParameter.optional(3, "begin_instance_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(4, "end_instance_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(5, "as_of_instant", DataTypes.StringType, ""),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateMetadataTableProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateMetadataTableProcedure.scala
@@ -31,7 +31,7 @@ import java.util.function.Supplier
 
 class CreateMetadataTableProcedure extends BaseProcedure with ProcedureBuilder with SparkAdapterSupport {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointProcedure.scala
@@ -29,11 +29,11 @@ import java.util.function.Supplier
 
 class CreateSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "commit_time", DataTypes.StringType, None),
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "commit_time", DataTypes.StringType),
     ProcedureParameter.optional(2, "user", DataTypes.StringType, ""),
     ProcedureParameter.optional(3, "comments", DataTypes.StringType, ""),
-    ProcedureParameter.optional(4, "path", DataTypes.StringType, None)
+    ProcedureParameter.optional(4, "path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMarkerProcedure.scala
@@ -30,8 +30,8 @@ import scala.util.{Failure, Success, Try}
 
 class DeleteMarkerProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "instant_time", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMetadataTableProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteMetadataTableProcedure.scala
@@ -29,7 +29,7 @@ import java.util.function.Supplier
 
 class DeleteMetadataTableProcedure extends BaseProcedure with ProcedureBuilder with SparkAdapterSupport {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointProcedure.scala
@@ -29,9 +29,9 @@ import java.util.function.Supplier
 
 class DeleteSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None),
-    ProcedureParameter.optional(2, "path", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "instant_time", DataTypes.StringType),
+    ProcedureParameter.optional(2, "path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ExportInstantsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ExportInstantsProcedure.scala
@@ -47,8 +47,8 @@ class ExportInstantsProcedure extends BaseProcedure with ProcedureBuilder with L
   val defaultActions = "clean,commit,deltacommit,rollback,savepoint,restore"
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "local_folder", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "local_folder", DataTypes.StringType),
     ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, -1),
     ProcedureParameter.optional(3, "actions", DataTypes.StringType, defaultActions),
     ProcedureParameter.optional(4, "desc", DataTypes.BooleanType, false)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HdfsParquetImportProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HdfsParquetImportProcedure.scala
@@ -27,13 +27,13 @@ import scala.language.higherKinds
 
 class HdfsParquetImportProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "table_type", DataTypes.StringType, None),
-    ProcedureParameter.required(2, "src_path", DataTypes.StringType, None),
-    ProcedureParameter.required(3, "target_path", DataTypes.StringType, None),
-    ProcedureParameter.required(4, "row_key", DataTypes.StringType, None),
-    ProcedureParameter.required(5, "partition_key", DataTypes.StringType, None),
-    ProcedureParameter.required(6, "schema_file_path", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "table_type", DataTypes.StringType),
+    ProcedureParameter.required(2, "src_path", DataTypes.StringType),
+    ProcedureParameter.required(3, "target_path", DataTypes.StringType),
+    ProcedureParameter.required(4, "row_key", DataTypes.StringType),
+    ProcedureParameter.required(5, "partition_key", DataTypes.StringType),
+    ProcedureParameter.required(6, "schema_file_path", DataTypes.StringType),
     ProcedureParameter.optional(7, "format", DataTypes.StringType, "parquet"),
     ProcedureParameter.optional(8, "command", DataTypes.StringType, "insert"),
     ProcedureParameter.optional(9, "retry", DataTypes.IntegerType, 0),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HelpProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HelpProcedure.scala
@@ -27,7 +27,7 @@ import java.util.function.Supplier
 class HelpProcedure extends BaseProcedure with ProcedureBuilder with Logging {
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "cmd", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "cmd", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -88,7 +88,7 @@ class HelpProcedure extends BaseProcedure with ProcedureBuilder with Logging {
         result.append(tab)
           .append(lengthFormat(param.name)).append(tab)
           .append(lengthFormat(param.dataType.typeName)).append(tab)
-          .append(lengthFormat(param.default.toString)).append(tab)
+          .append(lengthFormat(String.valueOf(param.default))).append(tab)
           .append(lengthFormat(param.required.toString)).append(line)
       })
       result.append("outputType:").append(line)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HiveSyncProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HiveSyncProcedure.scala
@@ -33,7 +33,7 @@ class HiveSyncProcedure extends BaseProcedure with ProcedureBuilder
   with ProvidesHoodieConfig with Logging {
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "metastore_uri", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "username", DataTypes.StringType, ""),
     ProcedureParameter.optional(3, "password", DataTypes.StringType, ""),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/InitMetadataTableProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/InitMetadataTableProcedure.scala
@@ -32,7 +32,7 @@ import java.util.function.Supplier
 
 class InitMetadataTableProcedure extends BaseProcedure with ProcedureBuilder with SparkAdapterSupport with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "read_only", DataTypes.BooleanType, false)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ProcedureParameter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ProcedureParameter.scala
@@ -54,8 +54,8 @@ object ProcedureParameter {
    * @param dataType the type of the parameter
    * @return the constructed stored procedure parameter
    */
-  def required(index: Int, name: String, dataType: DataType, default: Any): ProcedureParameterImpl = {
-    ProcedureParameterImpl(index, name, dataType, default, required = true)
+  def required(index: Int, name: String, dataType: DataType): ProcedureParameterImpl = {
+    ProcedureParameterImpl(index, name, dataType, null, required = true)
   }
 
   /**
@@ -63,9 +63,10 @@ object ProcedureParameter {
    *
    * @param name     the name of the parameter.
    * @param dataType the type of the parameter.
+   * @param default  the default value of the parameter.
    * @return the constructed optional stored procedure parameter
    */
-  def optional(index: Int, name: String, dataType: DataType, default: Any): ProcedureParameterImpl = {
+  def optional(index: Int, name: String, dataType: DataType, default: Any = null): ProcedureParameterImpl = {
     ProcedureParameterImpl(index, name, dataType, default, required = false)
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairAddpartitionmetaProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairAddpartitionmetaProcedure.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConversions._
 
 class RepairAddpartitionmetaProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "dry_run", DataTypes.BooleanType, true)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairCorruptedCleanFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairCorruptedCleanFilesProcedure.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 
 class RepairCorruptedCleanFilesProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairDeduplicateProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairDeduplicateProcedure.scala
@@ -30,9 +30,9 @@ import scala.util.{Failure, Success, Try}
 
 class RepairDeduplicateProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "duplicated_partition_path", DataTypes.StringType, None),
-    ProcedureParameter.required(2, "repaired_output_path", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "duplicated_partition_path", DataTypes.StringType),
+    ProcedureParameter.required(2, "repaired_output_path", DataTypes.StringType),
     ProcedureParameter.optional(3, "dry_run", DataTypes.BooleanType, true),
     ProcedureParameter.optional(4, "dedupe_type", DataTypes.StringType, "insert_type")
   )

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairMigratePartitionMetaProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairMigratePartitionMetaProcedure.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConversions._
 
 class RepairMigratePartitionMetaProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "dry_run", DataTypes.BooleanType, true)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairOverwriteHoodiePropsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairOverwriteHoodiePropsProcedure.scala
@@ -33,8 +33,8 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 
 class RepairOverwriteHoodiePropsProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "new_props_file_path", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "new_props_file_path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToInstantTimeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToInstantTimeProcedure.scala
@@ -32,8 +32,8 @@ import java.util.function.Supplier
 
 class RollbackToInstantTimeProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None))
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "instant_time", DataTypes.StringType))
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
     StructField("rollback_result", DataTypes.BooleanType, nullable = true, Metadata.empty))

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToSavepointProcedure.scala
@@ -29,9 +29,9 @@ import java.util.function.Supplier
 
 class RollbackToSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType, None),
-    ProcedureParameter.optional(2, "path", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "instant_time", DataTypes.StringType),
+    ProcedureParameter.optional(2, "path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunBootstrapProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunBootstrapProcedure.scala
@@ -36,11 +36,11 @@ import java.util.function.Supplier
 import scala.collection.JavaConverters._
 class RunBootstrapProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "table_type", DataTypes.StringType, None),
-    ProcedureParameter.required(2, "bootstrap_path", DataTypes.StringType, None),
-    ProcedureParameter.required(3, "base_path", DataTypes.StringType, None),
-    ProcedureParameter.required(4, "rowKey_field", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "table_type", DataTypes.StringType),
+    ProcedureParameter.required(2, "bootstrap_path", DataTypes.StringType),
+    ProcedureParameter.required(3, "base_path", DataTypes.StringType),
+    ProcedureParameter.required(4, "rowKey_field", DataTypes.StringType),
     ProcedureParameter.optional(5, "base_file_format", DataTypes.StringType, "PARQUET"),
     ProcedureParameter.optional(6, "partition_path_field", DataTypes.StringType, ""),
     ProcedureParameter.optional(7, "bootstrap_index_class", DataTypes.StringType, "org.apache.hudi.common.bootstrap.index.HFileBootstrapIndex"),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
@@ -31,15 +31,16 @@ import java.util.function.Supplier
 class RunCleanProcedure extends BaseProcedure with ProcedureBuilder with Logging {
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "skip_locking", DataTypes.BooleanType, false),
     ProcedureParameter.optional(2, "schedule_in_line", DataTypes.BooleanType, true),
-    ProcedureParameter.optional(3, "clean_policy", DataTypes.StringType, HoodieCleanConfig.CLEANER_POLICY.defaultValue()),
-    ProcedureParameter.optional(4, "retain_commits", DataTypes.IntegerType, HoodieCleanConfig.CLEANER_COMMITS_RETAINED.defaultValue().toInt),
-    ProcedureParameter.optional(5, "hours_retained", DataTypes.IntegerType, HoodieCleanConfig.CLEANER_HOURS_RETAINED.defaultValue().toInt),
-    ProcedureParameter.optional(6, "file_versions_retained", DataTypes.IntegerType, HoodieCleanConfig.CLEANER_FILE_VERSIONS_RETAINED.defaultValue().toInt),
-    ProcedureParameter.optional(7, "trigger_strategy", DataTypes.StringType, HoodieCleanConfig.CLEAN_TRIGGER_STRATEGY.defaultValue()),
-    ProcedureParameter.optional(8, "trigger_max_commits", DataTypes.IntegerType, HoodieCleanConfig.CLEAN_MAX_COMMITS.defaultValue().toInt)
+    ProcedureParameter.optional(3, "clean_policy", DataTypes.StringType),
+    ProcedureParameter.optional(4, "retain_commits", DataTypes.IntegerType),
+    ProcedureParameter.optional(5, "hours_retained", DataTypes.IntegerType),
+    ProcedureParameter.optional(6, "file_versions_retained", DataTypes.IntegerType),
+    ProcedureParameter.optional(7, "trigger_strategy", DataTypes.StringType),
+    ProcedureParameter.optional(8, "trigger_max_commits", DataTypes.IntegerType),
+    ProcedureParameter.optional(9, "options", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -69,20 +70,35 @@ class RunCleanProcedure extends BaseProcedure with ProcedureBuilder with Logging
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
     val skipLocking = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[Boolean]
     val scheduleInLine = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[Boolean]
+    var confs: Map[String, String] = Map.empty
+    if (getArgValueOrDefault(args, PARAMETERS(3)).isDefined) {
+      confs += HoodieCleanConfig.CLEANER_POLICY.key() -> getArgValueOrDefault(args, PARAMETERS(3)).get.toString
+    }
+    if (getArgValueOrDefault(args, PARAMETERS(4)).isDefined) {
+      confs += HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> getArgValueOrDefault(args, PARAMETERS(4)).get.toString
+    }
+    if (getArgValueOrDefault(args, PARAMETERS(5)).isDefined) {
+      confs += HoodieCleanConfig.CLEANER_HOURS_RETAINED.key() -> getArgValueOrDefault(args, PARAMETERS(5)).get.toString
+    }
+    if (getArgValueOrDefault(args, PARAMETERS(6)).isDefined) {
+      confs += HoodieCleanConfig.CLEANER_FILE_VERSIONS_RETAINED.key() -> getArgValueOrDefault(args, PARAMETERS(6)).get.toString
+    }
+    if (getArgValueOrDefault(args, PARAMETERS(7)).isDefined) {
+      confs += HoodieCleanConfig.CLEAN_TRIGGER_STRATEGY.key() -> getArgValueOrDefault(args, PARAMETERS(7)).get.toString
+    }
+    if (getArgValueOrDefault(args, PARAMETERS(8)).isDefined) {
+      confs += HoodieCleanConfig.CLEAN_MAX_COMMITS.key() -> getArgValueOrDefault(args, PARAMETERS(8)).get.toString
+    }
+    if (getArgValueOrDefault(args, PARAMETERS(9)).isDefined) {
+      confs ++= HoodieCLIUtils.extractOptions(getArgValueOrDefault(args, PARAMETERS(9)).get.asInstanceOf[String])
+    }
+
     val basePath = getBasePath(tableName, Option.empty)
     val cleanInstantTime = HoodieActiveTimeline.createNewInstantTime()
-    val props: Map[String, String] = Map(
-      HoodieCleanConfig.CLEANER_POLICY.key() -> getArgValueOrDefault(args, PARAMETERS(3)).get.toString,
-      HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> getArgValueOrDefault(args, PARAMETERS(4)).get.toString,
-      HoodieCleanConfig.CLEANER_HOURS_RETAINED.key() -> getArgValueOrDefault(args, PARAMETERS(5)).get.toString,
-      HoodieCleanConfig.CLEANER_FILE_VERSIONS_RETAINED.key() -> getArgValueOrDefault(args, PARAMETERS(6)).get.toString,
-      HoodieCleanConfig.CLEAN_TRIGGER_STRATEGY.key() -> getArgValueOrDefault(args, PARAMETERS(7)).get.toString,
-      HoodieCleanConfig.CLEAN_MAX_COMMITS.key() -> getArgValueOrDefault(args, PARAMETERS(8)).get.toString
-    )
 
     var client: SparkRDDWriteClient[_] = null
     try {
-      client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, props,
+      client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs,
         tableName.asInstanceOf[Option[String]])
       val hoodieCleanMeta = client.clean(cleanInstantTime, scheduleInLine, skipLocking)
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -39,10 +39,11 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
    * operation = (RUN | SCHEDULE) COMPACTION  ON path = STRING   (AT instantTimestamp = INTEGER_VALUE)?
    */
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "op", DataTypes.StringType, None),
-    ProcedureParameter.optional(1, "table", DataTypes.StringType, None),
-    ProcedureParameter.optional(2, "path", DataTypes.StringType, None),
-    ProcedureParameter.optional(3, "timestamp", DataTypes.LongType, None)
+    ProcedureParameter.required(0, "op", DataTypes.StringType),
+    ProcedureParameter.optional(1, "table", DataTypes.StringType),
+    ProcedureParameter.optional(2, "path", DataTypes.StringType),
+    ProcedureParameter.optional(3, "timestamp", DataTypes.LongType),
+    ProcedureParameter.optional(4, "options", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -62,13 +63,17 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
     val tableName = getArgValueOrDefault(args, PARAMETERS(1))
     val tablePath = getArgValueOrDefault(args, PARAMETERS(2))
     val instantTimestamp = getArgValueOrDefault(args, PARAMETERS(3))
+    var confs: Map[String, String] = Map.empty
+    if (getArgValueOrDefault(args, PARAMETERS(4)).isDefined) {
+      confs = confs ++ HoodieCLIUtils.extractOptions(getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[String])
+    }
 
     val basePath = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     var client: SparkRDDWriteClient[_] = null
     try {
-      client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, Map.empty,
+      client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs,
         tableName.asInstanceOf[Option[String]])
       var willCompactionInstants: Seq[String] = Seq.empty
       operation match {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowArchivedCommitsProcedure.scala
@@ -35,7 +35,7 @@ import scala.collection.JavaConverters._
 
 class ShowArchivedCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10),
     ProcedureParameter.optional(2, "start_ts", DataTypes.StringType, ""),
     ProcedureParameter.optional(3, "end_ts", DataTypes.StringType, "")

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowBootstrapMappingProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowBootstrapMappingProcedure.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 
 class ShowBootstrapMappingProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "partition_path", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "file_ids", DataTypes.StringType, ""),
     ProcedureParameter.optional(3, "limit", DataTypes.IntegerType, 10),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowBootstrapPartitionsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowBootstrapPartitionsProcedure.scala
@@ -27,7 +27,7 @@ import java.util.function.Supplier
 
 class ShowBootstrapPartitionsProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowClusteringProcedure.scala
@@ -31,8 +31,8 @@ import scala.collection.JavaConverters._
 
 class ShowClusteringProcedure extends BaseProcedure with ProcedureBuilder with SparkAdapterSupport with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.optional(1, "path", DataTypes.StringType, None),
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType),
     ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, 20),
     ProcedureParameter.optional(3, "show_involved_partition", DataTypes.BooleanType, false)
   )

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitExtraMetadataProcedure.scala
@@ -31,10 +31,10 @@ import scala.collection.JavaConversions._
 
 class ShowCommitExtraMetadataProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 100),
-    ProcedureParameter.optional(2, "instant_time", DataTypes.StringType, None),
-    ProcedureParameter.optional(3, "metadata_key", DataTypes.StringType, None)
+    ProcedureParameter.optional(2, "instant_time", DataTypes.StringType),
+    ProcedureParameter.optional(3, "metadata_key", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitFilesProcedure.scala
@@ -34,9 +34,9 @@ import scala.collection.JavaConversions._
 
 class ShowCommitFilesProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10),
-    ProcedureParameter.required(2, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.required(2, "instant_time", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitPartitionsProcedure.scala
@@ -34,9 +34,9 @@ import scala.collection.JavaConversions._
 
 class ShowCommitPartitionsProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10),
-    ProcedureParameter.required(2, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.required(2, "instant_time", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitWriteStatsProcedure.scala
@@ -33,9 +33,9 @@ import scala.collection.JavaConversions._
 
 class ShowCommitWriteStatsProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10),
-    ProcedureParameter.required(2, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.required(2, "instant_time", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCommitsProcedure.scala
@@ -33,7 +33,7 @@ class ShowCommitsProcedure(includeExtraMetadata: Boolean) extends BaseProcedure 
   var sortByFieldParameter: ProcedureParameter = _
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowCompactionProcedure.scala
@@ -37,8 +37,8 @@ class ShowCompactionProcedure extends BaseProcedure with ProcedureBuilder with S
    * SHOW COMPACTION  ON path = STRING (LIMIT limit = INTEGER_VALUE)?
    */
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.optional(1, "path", DataTypes.StringType, None),
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType),
     ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, 20)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFileSystemViewProcedure.scala
@@ -34,7 +34,7 @@ import scala.collection.JavaConverters.{asJavaIterableConverter, asJavaIteratorC
 
 class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS_ALL: Array[ProcedureParameter] = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "max_instant", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "include_max", DataTypes.BooleanType, false),
     ProcedureParameter.optional(3, "include_in_flight", DataTypes.BooleanType, false),
@@ -55,13 +55,13 @@ class ShowFileSystemViewProcedure(showLatest: Boolean) extends BaseProcedure wit
   ))
 
   private val PARAMETERS_LATEST: Array[ProcedureParameter] = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "max_instant", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "include_max", DataTypes.BooleanType, false),
     ProcedureParameter.optional(3, "include_inflight", DataTypes.BooleanType, false),
     ProcedureParameter.optional(4, "exclude_compaction", DataTypes.BooleanType, false),
     ProcedureParameter.optional(5, "limit", DataTypes.IntegerType, 10),
-    ProcedureParameter.required(6, "partition_path", DataTypes.StringType, None),
+    ProcedureParameter.required(6, "partition_path", DataTypes.StringType),
     ProcedureParameter.optional(7, "merge", DataTypes.BooleanType, true)
 
   )

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFsPathDetailProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowFsPathDetailProcedure.scala
@@ -27,7 +27,7 @@ import java.util.function.Supplier
 
 class ShowFsPathDetailProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "path", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "path", DataTypes.StringType),
     ProcedureParameter.optional(1, "is_sub", DataTypes.BooleanType, false),
     ProcedureParameter.optional(2, "sort", DataTypes.BooleanType, true)
   )

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileMetadataProcedure.scala
@@ -36,8 +36,8 @@ import scala.collection.JavaConverters.{asScalaBufferConverter, asScalaIteratorC
 
 class ShowHoodieLogFileMetadataProcedure extends BaseProcedure with ProcedureBuilder {
   override def parameters: Array[ProcedureParameter] = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "log_file_path_pattern", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "log_file_path_pattern", DataTypes.StringType),
     ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, 10)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileRecordsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileRecordsProcedure.scala
@@ -37,8 +37,8 @@ import scala.collection.JavaConverters._
 
 class ShowHoodieLogFileRecordsProcedure extends BaseProcedure with ProcedureBuilder {
   override def parameters: Array[ProcedureParameter] = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "log_file_path_pattern", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "log_file_path_pattern", DataTypes.StringType),
     ProcedureParameter.optional(2, "merge", DataTypes.BooleanType, false),
     ProcedureParameter.optional(3, "limit", DataTypes.IntegerType, 10)
   )

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowInvalidParquetProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowInvalidParquetProcedure.scala
@@ -31,7 +31,7 @@ import java.util.function.Supplier
 
 class ShowInvalidParquetProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "path", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableFilesProcedure.scala
@@ -33,7 +33,7 @@ import java.util.function.Supplier
 
 class ShowMetadataTableFilesProcedure() extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "partition", DataTypes.StringType, "")
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTablePartitionsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTablePartitionsProcedure.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 
 class ShowMetadataTablePartitionsProcedure() extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowMetadataTableStatsProcedure.scala
@@ -30,7 +30,7 @@ import scala.collection.JavaConversions._
 
 class ShowMetadataTableStatsProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowRollbacksProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowRollbacksProcedure.scala
@@ -35,14 +35,14 @@ import scala.collection.JavaConverters._
 
 class ShowRollbacksProcedure(showDetails: Boolean) extends BaseProcedure with ProcedureBuilder {
   private val ROLLBACKS_PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10)
   )
 
   private val ROLLBACK_PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10),
-    ProcedureParameter.required(2, "instant_time", DataTypes.StringType, None)
+    ProcedureParameter.required(2, "instant_time", DataTypes.StringType)
   )
 
   private val ROLLBACKS_OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowSavepointsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowSavepointsProcedure.scala
@@ -28,8 +28,8 @@ import java.util.stream.Collectors
 
 class ShowSavepointsProcedure extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.optional(1, "path", DataTypes.StringType, None)
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowTablePropertiesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowTablePropertiesProcedure.scala
@@ -27,8 +27,8 @@ import scala.collection.JavaConversions._
 
 class ShowTablePropertiesProcedure() extends BaseProcedure with ProcedureBuilder {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.optional(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.optional(1, "path", DataTypes.StringType, None),
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType),
     ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, 10)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsFileSizeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsFileSizeProcedure.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters.{asScalaBufferConverter, mapAsScalaMapCon
 class StatsFileSizeProcedure extends BaseProcedure with ProcedureBuilder {
 
   override def parameters: Array[ProcedureParameter] = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "partition_path", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "limit", DataTypes.IntegerType, 10)
   )

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsWriteAmplificationProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsWriteAmplificationProcedure.scala
@@ -28,7 +28,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 
 class StatsWriteAmplificationProcedure extends BaseProcedure with ProcedureBuilder {
   override def parameters: Array[ProcedureParameter] = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "limit", DataTypes.IntegerType, 10)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/UpgradeOrDowngradeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/UpgradeOrDowngradeProcedure.scala
@@ -34,8 +34,8 @@ import scala.util.{Failure, Success, Try}
 
 class UpgradeOrDowngradeProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "to_version", DataTypes.StringType, None)
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
+    ProcedureParameter.required(1, "to_version", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateHoodieSyncProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateHoodieSyncProcedure.scala
@@ -35,11 +35,11 @@ import scala.collection.JavaConverters._
 class ValidateHoodieSyncProcedure extends BaseProcedure with ProcedureBuilder with Logging {
 
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "src_table", DataTypes.StringType, None),
-    ProcedureParameter.required(1, "dst_table", DataTypes.StringType, None),
-    ProcedureParameter.required(2, "mode", DataTypes.StringType, "complete"),
-    ProcedureParameter.required(3, "hive_server_url", DataTypes.StringType, None),
-    ProcedureParameter.required(4, "hive_pass", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "src_table", DataTypes.StringType),
+    ProcedureParameter.required(1, "dst_table", DataTypes.StringType),
+    ProcedureParameter.required(2, "mode", DataTypes.StringType),
+    ProcedureParameter.required(3, "hive_server_url", DataTypes.StringType),
+    ProcedureParameter.required(4, "hive_pass", DataTypes.StringType),
     ProcedureParameter.optional(5, "src_db", DataTypes.StringType, "rawdata"),
     ProcedureParameter.optional(6, "target_db", DataTypes.StringType, "dwh_hoodie"),
     ProcedureParameter.optional(7, "partition_cnt", DataTypes.IntegerType, 5),

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateMetadataTableFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ValidateMetadataTableFilesProcedure.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 
 class ValidateMetadataTableFilesProcedure() extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
-    ProcedureParameter.required(0, "table", DataTypes.StringType, None),
+    ProcedureParameter.required(0, "table", DataTypes.StringType),
     ProcedureParameter.optional(1, "verbose", DataTypes.BooleanType, false)
   )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCleanProcedure.scala
@@ -22,99 +22,182 @@ package org.apache.spark.sql.hudi.procedure
 class TestCleanProcedure extends HoodieSparkProcedureTestBase {
 
   test("Test Call run_clean Procedure by Table") {
-    withTempDir { tmp =>
-      val tableName = generateTableName
-      spark.sql(
-        s"""
-          |create table $tableName (
-          | id int,
-          | name string,
-          | price double,
-          | ts long
-          | ) using hudi
-          | location '${tmp.getCanonicalPath}'
-          | tblproperties (
-          |   primaryKey = 'id',
-          |   type = 'cow',
-          |   preCombineField = 'ts'
-          | )
-          |""".stripMargin)
+    withSQLConf("hoodie.clean.automatic" -> "false", "hoodie.parquet.max.file.size" -> "10000") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName (
+             | id int,
+             | name string,
+             | price double,
+             | ts long
+             | ) using hudi
+             | location '${tmp.getCanonicalPath}'
+             | tblproperties (
+             |   primaryKey = 'id',
+             |   type = 'cow',
+             |   preCombineField = 'ts'
+             | )
+             |""".stripMargin)
 
-      spark.sql("set hoodie.parquet.max.file.size = 10000")
-      spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
-      spark.sql(s"update $tableName set price = 11 where id = 1")
-      spark.sql(s"update $tableName set price = 12 where id = 1")
-      spark.sql(s"update $tableName set price = 13 where id = 1")
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"update $tableName set price = 11 where id = 1")
+        spark.sql(s"update $tableName set price = 12 where id = 1")
+        spark.sql(s"update $tableName set price = 13 where id = 1")
 
-      // KEEP_LATEST_COMMITS
-      val result1 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
-        .collect()
-        .map(row => Seq(row.getString(0), row.getLong(1), row.getInt(2), row.getString(3), row.getString(4), row.getInt(5)))
+        // KEEP_LATEST_COMMITS
+        val result1 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
+          .collect()
+          .map(row => Seq(row.getString(0), row.getLong(1), row.getInt(2), row.getString(3), row.getString(4), row.getInt(5)))
 
-      assertResult(1)(result1.length)
-      assertResult(2)(result1(0)(2))
+        assertResult(1)(result1.length)
+        assertResult(2)(result1(0)(2))
 
-      val result11 = spark.sql(
-        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
-      assertResult(2)(result11.length)
+        val result11 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(2)(result11.length)
 
-      checkAnswer(s"select id, name, price, ts from $tableName order by id") (
-        Seq(1, "a1", 13, 1000)
-      )
+        checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+          Seq(1, "a1", 13, 1000)
+        )
 
-      val result2 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
-        .collect()
-      assertResult(0)(result2.length)
+        val result2 = spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
+          .collect()
+        assertResult(0)(result2.length)
 
-      // KEEP_LATEST_FILE_VERSIONS
-      spark.sql(s"update $tableName set price = 14 where id = 1")
+        // KEEP_LATEST_FILE_VERSIONS
+        spark.sql(s"update $tableName set price = 14 where id = 1")
 
-      val result3 = spark.sql(
-        s"call run_clean(table => '$tableName', clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 3)").collect()
-      assertResult(0)(result3.length)
+        val result3 = spark.sql(
+          s"call run_clean(table => '$tableName', clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 3)").collect()
+        assertResult(0)(result3.length)
 
-      val result4 = spark.sql(
-        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
-      assertResult(3)(result4.length)
+        val result4 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(3)(result4.length)
 
-      val result5 = spark.sql(
-        s"call run_clean(table => '$tableName', clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
-      assertResult(1)(result5.length)
-      assertResult(2)(result5(0)(2))
+        val result5 = spark.sql(
+          s"call run_clean(table => '$tableName', clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
+        assertResult(1)(result5.length)
+        assertResult(2)(result5(0)(2))
 
-      val result6 = spark.sql(
-        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
-      assertResult(1)(result6.length)
+        val result6 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(1)(result6.length)
 
-      checkAnswer(s"select id, name, price, ts from $tableName order by id") (
-        Seq(1, "a1", 14, 1000)
-      )
+        checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+          Seq(1, "a1", 14, 1000)
+        )
 
-      // trigger time
-      spark.sql(s"update $tableName set price = 15 where id = 1")
+        // trigger time
+        spark.sql(s"update $tableName set price = 15 where id = 1")
 
-      // no trigger, only has 1 commit
-      val result7 = spark.sql(
-        s"call run_clean(table => '$tableName', trigger_max_commits => 2, clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
-      assertResult(0)(result7.length)
+        // no trigger, only has 1 commit
+        val result7 = spark.sql(
+          s"call run_clean(table => '$tableName', trigger_max_commits => 2, clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
+        assertResult(0)(result7.length)
 
-      val result8 = spark.sql(
-        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
-      assertResult(2)(result8.length)
+        val result8 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(2)(result8.length)
 
-      // trigger
-      val result9 = spark.sql(
-        s"call run_clean(table => '$tableName', trigger_max_commits => 1, clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
-      assertResult(1)(result9.length)
-      assertResult(1)(result9(0)(2))
+        // trigger
+        val result9 = spark.sql(
+          s"call run_clean(table => '$tableName', trigger_max_commits => 1, clean_policy => 'KEEP_LATEST_FILE_VERSIONS', file_versions_retained => 1)").collect()
+        assertResult(1)(result9.length)
+        assertResult(1)(result9(0)(2))
 
-      val result10 = spark.sql(
-        s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
-      assertResult(1)(result10.length)
+        val result10 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(1)(result10.length)
 
-      checkAnswer(s"select id, name, price, ts from $tableName order by id") (
-        Seq(1, "a1", 15, 1000)
-      )
+        checkAnswer(s"select id, name, price, ts from $tableName order by id")(
+          Seq(1, "a1", 15, 1000)
+        )
+      }
+    }
+  }
+
+  test("Test Call run_clean Procedure with table props") {
+    withSQLConf("hoodie.clean.automatic" -> "false") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName (
+             | id int,
+             | name string,
+             | price double,
+             | ts long
+             | ) using hudi
+             | location '${tmp.getCanonicalPath}'
+             | tblproperties (
+             |   primaryKey = 'id',
+             |   type = 'cow',
+             |   preCombineField = 'ts',
+             |   hoodie.cleaner.policy = 'KEEP_LATEST_COMMITS',
+             |   hoodie.cleaner.commits.retained = '2'
+             | )
+             |""".stripMargin)
+
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1001)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1002)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1003)")
+        spark.sql(s"insert into $tableName values(4, 'a4', 10, 1004)")
+
+        val result1 = spark.sql(s"call run_clean(table => '$tableName')")
+          .collect()
+          .map(row => Seq(row.getString(0), row.getLong(1), row.getInt(2), row.getString(3), row.getString(4), row.getInt(5)))
+        assertResult(1)(result1.length)
+        assertResult(1)(result1(0)(2))
+
+        val result2 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(3)(result2.length)
+      }
+    }
+  }
+
+  test("Test Call run_clean Procedure with options") {
+    withSQLConf("hoodie.clean.automatic" -> "false") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName (
+             | id int,
+             | name string,
+             | price double,
+             | ts long
+             | ) using hudi
+             | location '${tmp.getCanonicalPath}'
+             | tblproperties (
+             |   primaryKey = 'id',
+             |   type = 'cow',
+             |   preCombineField = 'ts'
+             | )
+             |""".stripMargin)
+
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1001)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1002)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1003)")
+        spark.sql(s"insert into $tableName values(4, 'a4', 10, 1004)")
+
+        val result1 = spark.sql(
+          s"""call run_clean(table => '$tableName', options => "
+             | hoodie.cleaner.policy=KEEP_LATEST_COMMITS,
+             | hoodie.cleaner.commits.retained=2
+             |")""".stripMargin)
+          .collect()
+          .map(row => Seq(row.getString(0), row.getLong(1), row.getInt(2), row.getString(3), row.getString(4), row.getInt(5)))
+        assertResult(1)(result1.length)
+        assertResult(1)(result1(0)(2))
+
+        val result2 = spark.sql(
+          s"call show_fsview_all(table => '$tableName', path_regex => '', limit => 10)").collect()
+        assertResult(3)(result2.length)
+      }
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCompactionProcedure.scala
@@ -174,6 +174,7 @@ class TestCompactionProcedure extends HoodieSparkProcedureTestBase {
       )
     }
   }
+
   test("Test show_compaction Procedure by Path") {
     withTempDir { tmp =>
       val tableName1 = generateTableName
@@ -203,6 +204,50 @@ class TestCompactionProcedure extends HoodieSparkProcedureTestBase {
       spark.sql(s"insert into $tableName1 values(1, 'a4', 10, 1000)")
 
       assertResult(2)(spark.sql(s"call show_compaction(path => '${tmp.getCanonicalPath}/$tableName1')").collect().length)
+    }
+  }
+
+  test("Test run_compaction Procedure with options") {
+    withSQLConf("hoodie.compact.inline" -> "false", "hoodie.compact.inline.max.delta.commits" -> "1") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'mor',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(1, 'a2', 10, 1000)")
+        spark.sql(s"insert into $tableName values(1, 'a3', 10, 1000)")
+
+        val result1 = spark.sql(
+          s"""call run_compaction(table => '$tableName', op => 'run', options => "
+             | hoodie.compaction.strategy=org.apache.hudi.table.action.compact.strategy.LogFileNumBasedCompactionStrategy,
+             | hoodie.compaction.logfile.num.threshold=3
+             |")""".stripMargin)
+          .collect()
+        assertResult(0)(result1.length)
+
+        spark.sql(s"insert into $tableName values(1, 'a4', 10, 1000)")
+        val result2 = spark.sql(
+          s"""call run_compaction(table => '$tableName', op => 'run', options => "
+             | hoodie.compaction.strategy=org.apache.hudi.table.action.compact.strategy.LogFileNumBasedCompactionStrategy,
+             | hoodie.compaction.logfile.num.threshold=3
+             |")""".stripMargin)
+          .collect()
+        assertResult(1)(result2.length)
+      }
     }
   }
 }


### PR DESCRIPTION
### Change Logs

- Don't explicitly set default values for hoodie confs in the call procedure, this is because **hudi should build the value of hoodie confs itself** according to its rules (for example, build from table props, hudi globle conf and so on) **when user does not specify**. 

```scala
// before
ProcedureParameter.optional(4, "retain_commits", DataTypes.IntegerType, HoodieCleanConfig.CLEANER_COMMITS_RETAINED.defaultValue().toInt)

// after
ProcedureParameter.optional(4, "retain_commits", DataTypes.IntegerType)
```

- Add options in run_clean/compacion for use to specifie the running configs of the table service

```scala
call run_compaction(table => "tbl", op => "run", options => "x=a,y=b")
```

-  Format code: `default` in the `ProcedureParameter` needn't to be added when no default value is specified. And when the `ProcedureParameter` is require, `default` should not be exposed in constructor.

### Impact

Above

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
