### PR TITLE
[MINOR] Add log in flink compact/cluster commit sink for troubleshoot…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -112,16 +112,24 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
   @Override
   public void invoke(ClusteringCommitEvent event, Context context) throws Exception {
     final String instant = event.getInstant();
-    if (event.isFailed() || event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0)) {
+    if (event.isFailed()
+        || (event.getWriteStatuses() != null
+        && event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0))) {
       LOG.warn("Receive abnormal ClusteringCommitEvent of instant {}, task ID is {},"
               + " is failed: {}, error record count: {}",
-          instant, event.getTaskID(), event.isFailed(),
-          event.getWriteStatuses().stream()
-              .map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
+          instant, event.getTaskID(), event.isFailed(), getNumErrorRecords(event));
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
         .put(event.getFileIds(), event);
     commitIfNecessary(instant, commitBuffer.get(instant).values());
+  }
+
+  private long getNumErrorRecords(ClusteringCommitEvent event) {
+    if (event.getWriteStatuses() == null) {
+      return -1L;
+    }
+    return event.getWriteStatuses().stream()
+        .map(WriteStatus::getTotalErrorRecords).reduce(Long::sum).orElse(0L);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -113,9 +113,11 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
   public void invoke(ClusteringCommitEvent event, Context context) throws Exception {
     final String instant = event.getInstant();
     if (event.isFailed() || event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0)) {
-      LOG.warn("Receive abnormal ClusteringCommitEvent of instant " + instant + ", task ID is " + event.getTaskID()
-          + ", is failed: " + event.isFailed() + ", error record count: "
-          + event.getWriteStatuses().stream().map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
+      LOG.warn("Receive abnormal ClusteringCommitEvent of instant {}, task ID is {},"
+              + " is failed: {}, error record count: {}",
+          instant, event.getTaskID(), event.isFailed(),
+          event.getWriteStatuses().stream()
+              .map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
         .put(event.getFileIds(), event);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -112,6 +112,11 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
   @Override
   public void invoke(ClusteringCommitEvent event, Context context) throws Exception {
     final String instant = event.getInstant();
+    if (event.isFailed() || event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0)) {
+      LOG.warn("Receive abnormal ClusteringCommitEvent of instant " + instant + ", task ID is " + event.getTaskID()
+          + ", is failed: " + event.isFailed() + ", error record count: "
+          + event.getWriteStatuses().stream().map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
+    }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
         .put(event.getFileIds(), event);
     commitIfNecessary(instant, commitBuffer.get(instant).values());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -110,9 +110,11 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
   public void invoke(CompactionCommitEvent event, Context context) throws Exception {
     final String instant = event.getInstant();
     if (event.isFailed() || event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0)) {
-      LOG.warn("Receive abnormal CompactionCommitEvent of instant " + instant + ", task ID is " + event.getTaskID()
-              + ", is failed: " + event.isFailed() + ", error record count: "
-              + event.getWriteStatuses().stream().map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
+      LOG.warn("Receive abnormal CompactionCommitEvent of instant {}, task ID is {},"
+              + " is failed: {}, error record count: {}",
+          instant, event.getTaskID(), event.isFailed(),
+          event.getWriteStatuses().stream()
+              .map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
         .put(event.getFileId(), event);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -109,16 +109,24 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
   @Override
   public void invoke(CompactionCommitEvent event, Context context) throws Exception {
     final String instant = event.getInstant();
-    if (event.isFailed() || event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0)) {
+    if (event.isFailed()
+        || (event.getWriteStatuses() != null
+        && event.getWriteStatuses().stream().anyMatch(writeStatus -> writeStatus.getTotalErrorRecords() > 0))) {
       LOG.warn("Receive abnormal CompactionCommitEvent of instant {}, task ID is {},"
               + " is failed: {}, error record count: {}",
-          instant, event.getTaskID(), event.isFailed(),
-          event.getWriteStatuses().stream()
-              .map(WriteStatus::getTotalErrorRecords).reduce(Long::sum));
+          instant, event.getTaskID(), event.isFailed(), getNumErrorRecords(event));
     }
     commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
         .put(event.getFileId(), event);
     commitIfNecessary(instant, commitBuffer.get(instant).values());
+  }
+
+  private long getNumErrorRecords(CompactionCommitEvent event) {
+    if (event.getWriteStatuses() == null) {
+      return -1L;
+    }
+    return event.getWriteStatuses().stream()
+        .map(WriteStatus::getTotalErrorRecords).reduce(Long::sum).orElse(0L);
   }
 
   /**


### PR DESCRIPTION
…ing.

### Change Logs

If online compaction or clustering of flink pipeline failed, it's hard locate which taskmanager contain error log for troubleshooting.
In this pr add warning log with task id of failed compaction/clustering event, so we know which tm log to check.

### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

no

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
