### PR TITLE
[HUDI-6127]Flink Hudi Write support commit on an empty batch

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -618,7 +618,7 @@ public class FlinkOptions extends HoodieConfig {
       .key("write.allow.commit.on.empty.batch")
       .booleanType()
       .defaultValue(false)
-      .withDescription("Weather to commit the instant when there is no data in current batch");
+      .withDescription("Whether to commit the instant even when there is no data in current batch");
 
 
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -614,6 +614,13 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(ClientIds.INIT_CLIENT_ID)
       .withDescription("Unique identifier used to distinguish different writer pipelines for concurrent mode");
 
+  public static final ConfigOption<Boolean> WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH = ConfigOptions
+      .key("write.allow.commit.on.empty.batch")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Weather to commit the instant when there is no data in current batch");
+
+
   // ------------------------------------------------------------------------
   //  Compaction Options
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -614,13 +614,6 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(ClientIds.INIT_CLIENT_ID)
       .withDescription("Unique identifier used to distinguish different writer pipelines for concurrent mode");
 
-  public static final ConfigOption<Boolean> WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH = ConfigOptions
-      .key("write.allow.commit.on.empty.batch")
-      .booleanType()
-      .defaultValue(false)
-      .withDescription("Whether to commit the instant even when there is no data in current batch");
-
-
   // ------------------------------------------------------------------------
   //  Compaction Options
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -287,6 +287,13 @@ public class OptionsResolver {
         : new SimpleConcurrentFileWritesConflictResolutionStrategy();
   }
 
+  /**
+   * Returns whether to commit even when current batch has no data, for flink defaults false
+   */
+  public static boolean allowCommitOnEmptyBatch(Configuration conf) {
+    return conf.getBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false);
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -522,10 +522,7 @@ public class StreamWriteOperatorCoordinator
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
 
-    // Control whether we can commit on empty batch to start a new instant after each checkpoint
-    boolean allowCommitOnEmptyBatch = conf.get(FlinkOptions.WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH);
-
-    if (writeResults.size() == 0 && !allowCommitOnEmptyBatch) {
+    if (writeResults.size() == 0 && !OptionsResolver.allowCommitOnEmptyBatch(conf)) {
       // No data has written, reset the buffer and returns early
       reset();
       // Send commit ack event to the write function to unblock the flushing

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -522,7 +522,10 @@ public class StreamWriteOperatorCoordinator
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
 
-    if (writeResults.size() == 0) {
+    // Control whether we can commit on empty batch to start a new instant after each checkpoint
+    boolean allowCommitOnEmptyBatch = conf.get(FlinkOptions.WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH);
+
+    if (writeResults.size() == 0 && !allowCommitOnEmptyBatch) {
       // No data has written, reset the buffer and returns early
       reset();
       // Send commit ack event to the write function to unblock the flushing

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -394,7 +394,7 @@ public class TestStreamWriteOperatorCoordinator {
   @Test
   public void testCommitOnEmptyBatch() throws Exception {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
-    conf.setBoolean(FlinkOptions.WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH, true);
+    conf.setBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), true);
     MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(new OperatorID(), 2);
     NonThrownExecutor executor = new MockCoordinatorExecutor(context);
     try (StreamWriteOperatorCoordinator coordinator = new StreamWriteOperatorCoordinator(conf, context)) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -391,6 +391,42 @@ public class TestStreamWriteOperatorCoordinator {
     assertThat(completedTimeline.lastInstant().get().getTimestamp(), is(instant));
   }
 
+  @Test
+  public void testCommitOnEmptyBatch() throws Exception {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.setBoolean(FlinkOptions.WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH, true);
+    MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(new OperatorID(), 2);
+    NonThrownExecutor executor = new MockCoordinatorExecutor(context);
+    try (StreamWriteOperatorCoordinator coordinator = new StreamWriteOperatorCoordinator(conf, context)) {
+      coordinator.start();
+      coordinator.setExecutor(executor);
+      coordinator.handleEventFromOperator(0, WriteMetadataEvent.emptyBootstrap(0));
+      coordinator.handleEventFromOperator(1, WriteMetadataEvent.emptyBootstrap(1));
+
+      // Coordinator start the instant
+      String instant = coordinator.getInstant();
+
+      OperatorEvent event1 = WriteMetadataEvent.builder()
+          .taskID(1)
+          .instantTime(instant)
+          .writeStatus(Collections.emptyList())
+          .build();
+      OperatorEvent event2 = WriteMetadataEvent.builder()
+          .taskID(1)
+          .instantTime(instant)
+          .writeStatus(Collections.emptyList())
+          .build();
+      coordinator.handleEventFromOperator(0, event1);
+      coordinator.handleEventFromOperator(0, event2);
+
+      assertDoesNotThrow(() -> coordinator.notifyCheckpointComplete(1),
+          "Commit the instant");
+      String lastCompleted = TestUtils.getLastCompleteInstant(tempFile.getAbsolutePath());
+      assertThat("Commits the instant with empty batch anyway", lastCompleted, is(instant));
+      assertNull(coordinator.getEventBuffer()[0]);
+    }
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -414,7 +414,6 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
         .end();
   }
 
-
   protected Map<String, String> getMiniBatchExpected() {
     Map<String, String> expected = new HashMap<>();
     // the last 2 lines are merged

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -381,7 +381,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   @Test
   public void testCommitOnEmptyBatch() throws Exception {
     // reset the config option
-    conf.setBoolean(FlinkOptions.WRITE_ALLOW_COMMIT_ON_EMPTY_BATCH, true);
+    conf.setBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), true);
 
     preparePipeline()
         .consume(TestData.DATA_SET_INSERT)

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -516,5 +516,10 @@ public class TestWriteBase {
           ? TestUtils.getLastDeltaCompleteInstant(basePath)
           : TestUtils.getLastCompleteInstant(basePath, HoodieTimeline.COMMIT_ACTION);
     }
+
+    public TestHarness checkCompletedInstantCount(int count) {
+      assertEquals(TestUtils.getCompletedInstantCount(basePath), count);
+      return this;
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -518,7 +518,8 @@ public class TestWriteBase {
     }
 
     public TestHarness checkCompletedInstantCount(int count) {
-      assertEquals(TestUtils.getCompletedInstantCount(basePath), count);
+      boolean isMor = OptionsResolver.isMorTable(conf);
+      assertEquals(count, TestUtils.getCompletedInstantCount(basePath, isMor ? HoodieTimeline.DELTA_COMMIT_ACTION : HoodieTimeline.COMMIT_ACTION));
       return this;
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -25,7 +25,6 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.source.StreamReadMonitoringFunction;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
-import org.apache.hudi.util.FlinkClientUtil;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.Configuration;
@@ -109,10 +108,13 @@ public class TestUtils {
     return new StreamReadMonitoringFunction(conf, new Path(basePath), TestConfigurations.ROW_TYPE, 1024 * 1024L, null);
   }
 
-  public static int getCompletedInstantCount(String basePath) {
+  public static int getCompletedInstantCount(String basePath, String action) {
     final HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
-        .setConf(FlinkClientUtil.getHadoopConf()).setBasePath(basePath).build();
-    return metaClient.getCommitsTimeline().filterCompletedInstants().countInstants();
+        .setConf(HadoopConfigurations.getHadoopConf(new Configuration())).setBasePath(basePath).build();
+    return metaClient.getActiveTimeline()
+        .filterCompletedInstants()
+        .filter(instant -> action.equals(instant.getAction()))
+        .countInstants();
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.source.StreamReadMonitoringFunction;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
+import org.apache.hudi.util.FlinkClientUtil;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.Configuration;
@@ -107,4 +108,11 @@ public class TestUtils {
     final String basePath = conf.getString(FlinkOptions.PATH);
     return new StreamReadMonitoringFunction(conf, new Path(basePath), TestConfigurations.ROW_TYPE, 1024 * 1024L, null);
   }
+
+  public static int getCompletedInstantCount(String basePath) {
+    final HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+        .setConf(FlinkClientUtil.getHadoopConf()).setBasePath(basePath).build();
+    return metaClient.getCommitsTimeline().filterCompletedInstants().countInstants();
+  }
+
 }


### PR DESCRIPTION
### Change Logs

Fix issue #8498

In flink multi-writer scenario, if one of the writers has no data, it will keep its inflight instant in the timeline. But incremental clean and archive will be blocked by the oldest inflight commit in the timeline.

So to make clean and archive can move forward  we should upport starting a new instant even when there is no data in the last batch. 


### Impact

Now we will commit the instant even when there is no data in current batch, thus there maybe some useless commits on the timeline.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
