### PR TITLE
[HUDI-6131] Refactor getWritePathsOfInstants in Flink WriteProfiles

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -170,7 +170,6 @@ public class HoodieCommitMetadata implements Serializable {
    * been touched multiple times in the given commits, the return value will keep the one
    * from the latest commit.
    *
-   *
    * @param hadoopConf
    * @param basePath The base path
    * @return the file full path to file status mapping
@@ -201,7 +200,6 @@ public class HoodieCommitMetadata implements Serializable {
    * <p>Note: different with {@link #getFullPathToFileStatus(Configuration, String)},
    * only the latest commit file for a file group is returned,
    * this is an optimization for COPY_ON_WRITE table to eliminate legacy files for filesystem view.
-   *
    *
    * @param hadoopConf
    * @param basePath The base path

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfiles.java
@@ -28,21 +28,21 @@ import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.core.fs.Path;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hudi.util.StreamerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Factory for {@link WriteProfile}.
@@ -83,95 +83,38 @@ public class WriteProfiles {
   }
 
   /**
-   * Returns all the incremental write file statuses with the given commits metadata.
+   * Returns all exist incremental write file statuses from the given commit metadata list.
    *
-   * <p> Different with {@link #getWritePathsOfInstants}, the files are not filtered by
-   * existence.
-   *
-   * @param basePath     Table base path
-   * @param hadoopConf   The hadoop conf
-   * @param metadataList The commits metadata
-   * @param tableType    The table type
+   * @param basePath         Table base path
+   * @param hadoopConf       The hadoop conf
+   * @param metadataList     The commit metadata list (should in ascending order)
+   * @param tableType        The table type
+   * @param tolerateNonExist Whether to tolerate non-exist file, when is false and have non-exist file return null
    * @return the file status array
    */
-  public static FileStatus[] getRawWritePathsOfInstants(
+  @Nullable
+  public static FileStatus[] getExistFileFromMetadata(
       Path basePath,
       Configuration hadoopConf,
       List<HoodieCommitMetadata> metadataList,
-      HoodieTableType tableType) {
-    Map<String, FileStatus> uniqueIdToFileStatus = new HashMap<>();
-    metadataList.forEach(metadata ->
-        uniqueIdToFileStatus.putAll(getFilesToReadOfInstant(basePath, metadata, hadoopConf, tableType)));
-    return uniqueIdToFileStatus.values().toArray(new FileStatus[0]);
-  }
-
-  /**
-   * Returns all the incremental write file statuses with the given commits metadata.
-   *
-   * @param basePath     Table base path
-   * @param hadoopConf   The hadoop conf
-   * @param metadataList The commits metadata
-   * @param tableType    The table type
-   * @return the file status array
-   */
-  public static FileStatus[] getWritePathsOfInstants(
-      Path basePath,
-      Configuration hadoopConf,
-      List<HoodieCommitMetadata> metadataList,
-      HoodieTableType tableType) {
+      HoodieTableType tableType,
+      boolean tolerateNonExist) {
     FileSystem fs = FSUtils.getFs(basePath.toString(), hadoopConf);
     Map<String, FileStatus> uniqueIdToFileStatus = new HashMap<>();
-    metadataList.forEach(metadata ->
-        uniqueIdToFileStatus.putAll(getFilesToReadOfInstant(basePath, metadata, fs, tableType)));
-    return uniqueIdToFileStatus.values().toArray(new FileStatus[0]);
-  }
-
-  /**
-   * Returns the commit file status info with given metadata.
-   *
-   * @param basePath   Table base path
-   * @param metadata   The metadata
-   * @param hadoopConf The filesystem
-   * @param tableType  The table type
-   * @return the commit file status info grouping by specific ID
-   */
-  private static Map<String, FileStatus> getFilesToReadOfInstant(
-      Path basePath,
-      HoodieCommitMetadata metadata,
-      Configuration hadoopConf,
-      HoodieTableType tableType) {
-    return getFilesToRead(hadoopConf, metadata, basePath.toString(), tableType).entrySet().stream()
-        .filter(entry -> StreamerUtil.isValidFile(entry.getValue()))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-  }
-
-  /**
-   * Returns the commit file status info with given metadata.
-   *
-   * @param basePath  Table base path
-   * @param metadata  The metadata
-   * @param fs        The filesystem
-   * @param tableType The table type
-   * @return the commit file status info grouping by specific ID
-   */
-  private static Map<String, FileStatus> getFilesToReadOfInstant(
-      Path basePath,
-      HoodieCommitMetadata metadata,
-      FileSystem fs,
-      HoodieTableType tableType) {
-    return getFilesToRead(fs.getConf(), metadata, basePath.toString(), tableType).entrySet().stream()
-        // filter out the file paths that does not exist, some files may be cleaned by
-        // the cleaner.
-        .filter(entry -> {
-          try {
-            return fs.exists(entry.getValue().getPath());
-          } catch (IOException e) {
-            LOG.error("Checking exists of path: {} error", entry.getValue().getPath());
-            throw new HoodieException(e);
+    // If a file has been touched multiple times in the given commits, the return value should keep the one
+    // from the latest commit, so here we traverse in reverse order
+    for (int i = metadataList.size() - 1; i >= 0; i--) {
+      for (Map.Entry<String, FileStatus> entry : getFilesToRead(hadoopConf, metadataList.get(i), basePath.toString(), tableType).entrySet()) {
+        if (!uniqueIdToFileStatus.containsKey(entry.getKey())) {
+          if (StreamerUtil.fileExists(fs, entry.getValue().getPath())) {
+            uniqueIdToFileStatus.put(entry.getKey(), entry.getValue());
+          } else if (!tolerateNonExist){
+            return null;
           }
-        })
-        .filter(entry -> StreamerUtil.isValidFile(entry.getValue()))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+      }
+    }
+    return uniqueIdToFileStatus.values().toArray(new FileStatus[0]);
   }
 
   private static Map<String, FileStatus> getFilesToRead(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.source;
 
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -42,14 +41,12 @@ import org.apache.hudi.source.prune.PartitionPruners;
 import org.apache.hudi.table.format.cdc.CdcInputSplit;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 import org.apache.hudi.util.ClusteringUtil;
-import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +54,6 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -213,9 +209,8 @@ public class IncrementalInputSplits implements Serializable {
         LOG.warn("No partitions found for reading in user provided path.");
         return Result.EMPTY;
       }
-      FileStatus[] files = WriteProfiles.getRawWritePathsOfInstants(path, hadoopConf, metadataList, metaClient.getTableType());
-      FileSystem fs = FSUtils.getFs(path.toString(), hadoopConf);
-      if (Arrays.stream(files).anyMatch(fileStatus -> !StreamerUtil.fileExists(fs, fileStatus.getPath()))) {
+      FileStatus[] files = WriteProfiles.getExistFileFromMetadata(path, hadoopConf, metadataList, metaClient.getTableType(), false);
+      if (files == null) {
         LOG.warn("Found deleted files in metadata, fall back to full table scan.");
         // fallback to full table scan
         // reading from the earliest, scans the partitions and files directly.
@@ -329,7 +324,7 @@ public class IncrementalInputSplits implements Serializable {
         LOG.warn("No partitions found for reading under path: " + path);
         return Result.EMPTY;
       }
-      fileStatuses = WriteProfiles.getWritePathsOfInstants(path, hadoopConf, metadataList, metaClient.getTableType());
+      fileStatuses = WriteProfiles.getExistFileFromMetadata(path, hadoopConf, metadataList, metaClient.getTableType(), true);
 
       if (fileStatuses.length == 0) {
         LOG.warn("No files found for reading under path: " + path);
@@ -515,11 +510,7 @@ public class IncrementalInputSplits implements Serializable {
 
     if (OptionsResolver.hasNoSpecificReadCommits(this.conf)) {
       // by default read from the latest commit
-      List<HoodieInstant> instants = completedTimeline.getInstants();
-      if (instants.size() > 1) {
-        return Collections.singletonList(instants.get(instants.size() - 1));
-      }
-      return instants;
+      return completedTimeline.lastInstant().map(Collections::singletonList).orElseGet(Collections::emptyList);
     }
 
     if (OptionsResolver.isSpecificStartCommit(this.conf)) {


### PR DESCRIPTION
### Change Logs

Refactor `getWritePathsOfInstants` and `getRawWritePathsOfInstants` in Flink WriteProfiles, combine them into one function and return early when file doesn't exist to reduce the cost of `fs.exist`

### Impact

May reduce the cost of `getWritePathsOfInstants`

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
