### PR TITLE
[MINOR] Fix flaky flink test ITTestHoodieDataSource.testAppendWriteWi…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -374,6 +374,7 @@ public class ITTestHoodieDataSource {
         .option(FlinkOptions.CLUSTERING_DELTA_COMMITS,2)
         .option(FlinkOptions.CLUSTERING_TASKS, 1)
         .option(FlinkOptions.CLEAN_RETAIN_COMMITS, 1)
+        .option(FlinkOptions.METADATA_ENABLED, false)
         .end();
     streamTableEnv.executeSql(hoodieTableDDL);
     String insertInto = "insert into t1 select * from source";


### PR DESCRIPTION
…thClusteringBatchRead.

### Change Logs

Disable MDT for test ITTestHoodieDataSource.testAppendWriteWithClusteringBatchRead.

This test is flaky after enable MDT as default for Flink.  

Firstly is due to OCC is not enable so concurrent write to MDT table have conflict, but when I tried enable OCC for MDT, another error occurred `Caused by: java.util.ConcurrentModificationException: Cannot resolve conflicts for overlapping writes`, so I think we disable MDT for this test to pass stably until we fix the MDT problem.

### Impact

no

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
