### PR TITLE
[HUDI-6062] Fix irregular enum config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -269,11 +269,10 @@ public class HoodieClusteringConfig extends HoodieConfig {
    */
   public static final ConfigProperty<String> LAYOUT_OPTIMIZE_STRATEGY = ConfigProperty
       .key(LAYOUT_OPTIMIZE_PARAM_PREFIX + "strategy")
-      .defaultValue("linear")
+      .defaultValue(LayoutOptimizationStrategy.LINEAR.name())
       .markAdvanced()
       .sinceVersion("0.10.0")
-      .withDocumentation("Determines ordering strategy used in records layout optimization. "
-          + "Currently supported strategies are \"linear\", \"z-order\" and \"hilbert\" values are supported.");
+      .withDocumentation(LayoutOptimizationStrategy.class);
 
   /**
    * NOTE: This setting only has effect if {@link #LAYOUT_OPTIMIZE_STRATEGY} value is set to
@@ -693,7 +692,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
   }
 
   /**
-   * Type of a strategy for building Z-order/Hilbert space-filling curves.
+   * Type of strategy for building Z-order/Hilbert space-filling curves.
    */
   @EnumDescription("This configuration only has effect if `hoodie.layout.optimize.strategy` is "
       + "set to either \"z-order\" or \"hilbert\" (i.e. leveraging space-filling curves). This "
@@ -723,32 +722,22 @@ public class HoodieClusteringConfig extends HoodieConfig {
   /**
    * Layout optimization strategies such as Z-order/Hilbert space-curves, etc
    */
+  @EnumDescription("Determines ordering strategy for records layout optimization.")
   public enum LayoutOptimizationStrategy {
-    LINEAR("linear"),
-    ZORDER("z-order"),
-    HILBERT("hilbert");
+    @EnumFieldDescription("Orders records lexicographically")
+    LINEAR,
 
-    private static final Map<String, LayoutOptimizationStrategy> VALUE_TO_ENUM_MAP =
-        TypeUtils.getValueToEnumMap(LayoutOptimizationStrategy.class, e -> e.value);
+    @EnumFieldDescription("Orders records along Z-order spatial-curve.")
+    ZORDER,
 
-    private final String value;
+    @EnumFieldDescription("Orders records along Hilbert's spatial-curve.")
+    HILBERT
+  }
 
-    LayoutOptimizationStrategy(String value) {
-      this.value = value;
+  public static LayoutOptimizationStrategy resolveLayoutOptimizationStrategy(String cfgVal) {
+    if (cfgVal.equalsIgnoreCase("z-order")) {
+      return LayoutOptimizationStrategy.ZORDER;
     }
-
-    @Nonnull
-    public static LayoutOptimizationStrategy fromValue(String value) {
-      LayoutOptimizationStrategy enumValue = VALUE_TO_ENUM_MAP.get(value);
-      if (enumValue == null) {
-        throw new HoodieException(String.format("Invalid value (%s)", value));
-      }
-
-      return enumValue;
-    }
-
-    public String getValue() {
-      return value;
-    }
+    return LayoutOptimizationStrategy.valueOf(cfgVal.toUpperCase());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -26,19 +26,14 @@ import org.apache.hudi.common.config.EnumFieldDescription;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineType;
-import org.apache.hudi.common.util.TypeUtils;
 import org.apache.hudi.common.util.ValidationUtils;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.action.cluster.ClusteringPlanPartitionFilterMode;
 
-import javax.annotation.Nonnull;
-
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Properties;
 
 /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1736,8 +1736,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public HoodieClusteringConfig.LayoutOptimizationStrategy getLayoutOptimizationStrategy() {
-    return HoodieClusteringConfig.LayoutOptimizationStrategy.fromValue(
-        getStringOrDefault(HoodieClusteringConfig.LAYOUT_OPTIMIZE_STRATEGY));
+    return HoodieClusteringConfig.resolveLayoutOptimizationStrategy(getStringOrDefault(HoodieClusteringConfig.LAYOUT_OPTIMIZE_STRATEGY));
   }
 
   public HoodieClusteringConfig.SpatialCurveCompositionStrategyType getLayoutOptimizationCurveBuildMethod() {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -23,11 +23,9 @@ import org.apache.hudi.common.table.timeline.{HoodieActiveTimeline, HoodieTimeli
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
 import org.apache.hudi.common.util.{ClusteringUtils, HoodieTimer, Option => HOption}
-import org.apache.hudi.config.HoodieClusteringConfig.LayoutOptimizationStrategy
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieLockConfig}
 import org.apache.hudi.exception.HoodieClusteringException
 import org.apache.hudi.{AvroConversionUtils, HoodieCLIUtils, HoodieFileIndex}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.{resolveExpr, splitPartitionAndDataPredicates}
 import org.apache.spark.sql.Row
@@ -125,9 +123,9 @@ class RunClusteringProcedure extends BaseProcedure
 
     orderStrategy match {
       case Some(o) =>
-        val strategy = LayoutOptimizationStrategy.fromValue(o.asInstanceOf[String])
+        val strategy = HoodieClusteringConfig.resolveLayoutOptimizationStrategy(o.asInstanceOf[String])
         confs = confs ++ Map(
-          HoodieClusteringConfig.LAYOUT_OPTIMIZE_STRATEGY.key() -> strategy.getValue
+          HoodieClusteringConfig.LAYOUT_OPTIMIZE_STRATEGY.key() -> strategy.name()
         )
       case _ =>
         logInfo("No order strategy")


### PR DESCRIPTION
### Change Logs

LayoutOptimizationStrategy config values are not snake case like all the other enum configs. This patch fixes that. Additionally, it is backwards compatible.

### Impact

Less config confusion

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
