### PR TITLE
[MINOR] Prevent nullptr exception if enum config class has extra fields

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigProperty.java
@@ -171,7 +171,7 @@ public class ConfigProperty<T> implements Serializable {
     Objects.requireNonNull(description);
     sb.append(description.value());
     for (Field f: e.getFields()) {
-      if (isValid(f.getName())) {
+      if (f.isEnumConstant() && isValid(f.getName())) {
         EnumFieldDescription fieldDescription = f.getAnnotation(EnumFieldDescription.class);
         Objects.requireNonNull(fieldDescription);
         sb.append("\n    ");


### PR DESCRIPTION
### Change Logs

If there are additional fields that aren't enum constants, an exception will occur. This should be allowed.

### Impact

Prevent future aggravation. 

### Risk level (write none, low medium or high below)

None

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
