### PR TITLE
[MINOR] Propagate failed cleaner status

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
@@ -108,12 +108,23 @@ public class HoodieCleaner {
 
     String dirName = new Path(cfg.basePath).getName();
     JavaSparkContext jssc = UtilHelpers.buildSparkContext("hoodie-cleaner-" + dirName, cfg.sparkMaster);
+    boolean success = true;
+
     try {
       new HoodieCleaner(cfg, jssc).run();
     } catch (Throwable throwable) {
-      LOG.error("Fail to run cleaning for " + cfg.basePath, throwable);
+      success = false;
+      LOG.error("Failed to run cleaning for " + cfg.basePath, throwable);
     } finally {
       jssc.stop();
     }
+
+    if (!success) {
+      // Return a non-zero exit code to properly notify any resource manager
+      // that cleaning was not successful
+      System.exit(1);
+    }
+
+    LOG.info("Cleaner ran successfully");
   }
 }


### PR DESCRIPTION
### Change Logs
PR Cloned from: https://github.com/apache/hudi/pull/5965

This PR changes the `HoodieCleaner` utility so that errors will propagate to spark + YARN (or whatever RM you are using). 

Currently, if the cleaner fails for any reason the application status (in YARN) is not set to `FAILED`. When running the cleaner outside of the write process (such as DeltaStreamer) this result in a job that cannot be tracked by the coordinating system. We are using Apache Airflow to run the cleaner in parallel on our tables. If the cleaner fails, we need the application status to be set to `FAILED` so that the airflow sensor for the job can alert us. 

There was an [old issue and PR](https://issues.apache.org/jira/browse/HUDI-1749) created to catch all cleaner errors and log them. According to the ticket, the change was done because the cleaner process was hanging during certain scenarios. I have not been able to reproduce this behavior. There is no information about the environment on the ticket (possibly only occurred under spark 2.x?)

### Impact

Minor impact. This would only negatively impact users who currently rely on failures in the async cleaner to return SUCCESS in resource managers like YARN. 

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
