### PR TITLE
[HUDI-6148] Recreate StreamWriteOperatorCoordinator for global failovers

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink;
 
+import org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator;
 import org.apache.hudi.adapter.OperatorCoordinatorAdapter;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
@@ -610,11 +611,12 @@ public class StreamWriteOperatorCoordinator
   /**
    * Provider for {@link StreamWriteOperatorCoordinator}.
    */
-  public static class Provider implements OperatorCoordinator.Provider {
+  public static class Provider extends RecreateOnResetOperatorCoordinator.Provider {
     private final OperatorID operatorId;
     private final Configuration conf;
 
     public Provider(OperatorID operatorId, Configuration conf) {
+      super(operatorId);
       this.operatorId = operatorId;
       this.conf = conf;
     }
@@ -625,7 +627,7 @@ public class StreamWriteOperatorCoordinator
     }
 
     @Override
-    public OperatorCoordinator create(Context context) {
+    protected OperatorCoordinator getCoordinator(Context context) throws Exception {
       return new StreamWriteOperatorCoordinator(this.conf, context);
     }
   }


### PR DESCRIPTION
### Change Logs

When a global failover for a Flink job is triggered, it's safer to recreate a new `StreamWriteOperatorCoordinator`. Otherwise, all exceptions caused by the coordinator itself will not auto-heal. 

Flink offers a `RecreateOnResetOperatorCoordinator` that can be used to restart the coordinator when resetting to a checkpoint (a global failover is triggered).

This should fix #8554.

### Impact

No

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
