### PR TITLE
[MINOR] Fixed hadoop configuration not being applied by FileIndex

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
@@ -66,15 +66,19 @@ public class FileIndex {
   private final RowType rowType;
   private final boolean tableExists;
   private final HoodieMetadataConfig metadataConfig;
+  private final HoodieFlinkEngineContext hoodieFlinkEngineContext;
   private final PartitionPruners.PartitionPruner partitionPruner; // for partition pruning
   private final DataPruner dataPruner;                            // for data skipping
   private final int dataBucket;                                   // for bucket pruning
   private List<String> partitionPaths;                            // cache of partition paths
 
   private FileIndex(Path path, Configuration conf, RowType rowType, DataPruner dataPruner, PartitionPruners.PartitionPruner partitionPruner, int dataBucket) {
+    org.apache.hadoop.conf.Configuration hadoopConf = HadoopConfigurations.getHadoopConf(conf);
+
     this.path = path;
     this.rowType = rowType;
-    this.tableExists = StreamerUtil.tableExists(path.toString(), HadoopConfigurations.getHadoopConf(conf));
+    this.tableExists = StreamerUtil.tableExists(path.toString(), hadoopConf);
+    this.hoodieFlinkEngineContext = new HoodieFlinkEngineContext(hadoopConf);
     this.metadataConfig = metadataConfig(conf);
     this.dataPruner = isDataSkippingFeasible(conf.getBoolean(FlinkOptions.READ_DATA_SKIPPING_ENABLED)) ? dataPruner : null;
     this.partitionPruner = partitionPruner;
@@ -145,7 +149,7 @@ public class FileIndex {
       return new FileStatus[0];
     }
     String[] partitions = getOrBuildPartitionPaths().stream().map(p -> fullPartitionPath(path, p)).toArray(String[]::new);
-    FileStatus[] allFiles = FSUtils.getFilesInPartitions(HoodieFlinkEngineContext.DEFAULT, metadataConfig, path.toString(), partitions)
+    FileStatus[] allFiles = FSUtils.getFilesInPartitions(hoodieFlinkEngineContext, metadataConfig, path.toString(), partitions)
         .values().stream()
         .flatMap(Arrays::stream)
         .toArray(FileStatus[]::new);
@@ -271,7 +275,7 @@ public class FileIndex {
       return this.partitionPaths;
     }
     List<String> allPartitionPaths = this.tableExists
-        ? FSUtils.getAllPartitionPaths(HoodieFlinkEngineContext.DEFAULT, metadataConfig, path.toString())
+        ? FSUtils.getAllPartitionPaths(hoodieFlinkEngineContext, metadataConfig, path.toString())
         : Collections.emptyList();
     if (this.partitionPruner == null) {
       this.partitionPaths = allPartitionPaths;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/FileIndex.java
@@ -66,6 +66,7 @@ public class FileIndex {
   private final RowType rowType;
   private final boolean tableExists;
   private final HoodieMetadataConfig metadataConfig;
+  private final org.apache.hadoop.conf.Configuration hadoopConf;
   private final HoodieFlinkEngineContext hoodieFlinkEngineContext;
   private final PartitionPruners.PartitionPruner partitionPruner; // for partition pruning
   private final DataPruner dataPruner;                            // for data skipping
@@ -73,10 +74,9 @@ public class FileIndex {
   private List<String> partitionPaths;                            // cache of partition paths
 
   private FileIndex(Path path, Configuration conf, RowType rowType, DataPruner dataPruner, PartitionPruners.PartitionPruner partitionPruner, int dataBucket) {
-    org.apache.hadoop.conf.Configuration hadoopConf = HadoopConfigurations.getHadoopConf(conf);
-
     this.path = path;
     this.rowType = rowType;
+    this.hadoopConf = HadoopConfigurations.getHadoopConf(conf);
     this.tableExists = StreamerUtil.tableExists(path.toString(), hadoopConf);
     this.hoodieFlinkEngineContext = new HoodieFlinkEngineContext(hadoopConf);
     this.metadataConfig = metadataConfig(conf);


### PR DESCRIPTION
### Change Logs

Fixed hadoop configuration not being applied by org.apache.hudi.source.FileIndex

### Impact
FileIndex uses the DEFAULT HoodieFlinkEngineContext to get the partitionPath without using the information in the configuration.
<img width="981" alt="image" src="https://user-images.githubusercontent.com/46181516/235086491-257b22ab-3b7c-4a09-8b5b-983ec2ffccfc.png">
Since I was connecting to a remote hadoop, I subsequently got the following error due to missing configuration
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/46181516/235085666-3a0b19f9-7432-480e-9c75-6ad76d8df1c2.png">
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/46181516/235085696-b021fe53-9d93-4f53-9098-bb720ec97369.png">


### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
