### PR TITLE
[HUDI-6143] use the startoffset of each logfile when the downstream tasks read the logfile

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -175,7 +175,8 @@ public class HoodieCommitMetadata implements Serializable {
    * @param basePath The base path
    * @return the file full path to file status mapping
    */
-  public Map<String, FileStatus> getFullPathToFileStatus(Configuration hadoopConf, String basePath) {
+  public Map<String, FileStatus> getFullPathToFileStatus(Configuration hadoopConf, String basePath,
+                                                         Map<String, String> fileToPos) {
     Map<String, FileStatus> fullPathToFileStatus = new HashMap<>();
     for (List<HoodieWriteStat> stats : getPartitionToWriteStats().values()) {
       // Iterate through all the written files.
@@ -188,6 +189,7 @@ public class HoodieCommitMetadata implements Serializable {
               0, fullPath);
           fullPathToFileStatus.put(fullPath.getName(), fileStatus);
         }
+        fileToPos.put(relativeFilePath, fullPath.getName());
       }
     }
     return fullPathToFileStatus;
@@ -198,7 +200,7 @@ public class HoodieCommitMetadata implements Serializable {
    * been touched multiple times in the given commits, the return value will keep the one
    * from the latest commit by file group ID.
    *
-   * <p>Note: different with {@link #getFullPathToFileStatus(Configuration, String)},
+   * <p>Note: different with {@link #getFullPathToFileStatus(Configuration, String, Map)},
    * only the latest commit file for a file group is returned,
    * this is an optimization for COPY_ON_WRITE table to eliminate legacy files for filesystem view.
    *

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieDeltaWriteStat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieDeltaWriteStat.java
@@ -35,7 +35,6 @@ import java.util.Map;
 public class HoodieDeltaWriteStat extends HoodieWriteStat {
 
   private int logVersion;
-  private long logOffset;
   private String baseFile;
   private List<String> logFiles = new ArrayList<>();
   private Option<Map<String, HoodieColumnRangeMetadata<Comparable>>> recordsStats = Option.empty();
@@ -46,14 +45,6 @@ public class HoodieDeltaWriteStat extends HoodieWriteStat {
 
   public int getLogVersion() {
     return logVersion;
-  }
-
-  public void setLogOffset(long logOffset) {
-    this.logOffset = logOffset;
-  }
-
-  public long getLogOffset() {
-    return logOffset;
   }
 
   public void setBaseFile(String baseFile) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieWriteStat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieWriteStat.java
@@ -160,6 +160,8 @@ public class HoodieWriteStat implements Serializable {
   @Nullable
   private Long maxEventTime;
 
+  private long offset;
+
   @Nullable
   private RuntimeStats runtimeStats;
 
@@ -366,6 +368,14 @@ public class HoodieWriteStat implements Serializable {
    */
   public void setPath(Path basePath, Path path) {
     this.path = path.toString().replace(basePath + "/", "");
+  }
+
+  public void setLogOffset(long logOffset) {
+    this.offset = logOffset;
+  }
+
+  public long getLogOffset() {
+    return offset;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -48,6 +48,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -98,9 +99,11 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
                                        Option<String> partitionName,
                                        InternalSchema internalSchema,
                                        Option<String> keyFieldOverride,
-                                       boolean enableOptimizedLogBlocksScan, HoodieRecordMerger recordMerger) {
+                                       boolean enableOptimizedLogBlocksScan, HoodieRecordMerger recordMerger,
+                                       Option<List<Long>> logFileStartPos) {
     super(fs, basePath, logFilePaths, readerSchema, latestInstantTime, readBlocksLazily, reverseReader, bufferSize,
-        instantRange, withOperationField, forceFullScan, partitionName, internalSchema, keyFieldOverride, enableOptimizedLogBlocksScan, recordMerger);
+        instantRange, withOperationField, forceFullScan, partitionName, internalSchema, keyFieldOverride,
+        enableOptimizedLogBlocksScan, recordMerger, logFileStartPos);
     try {
       this.maxMemorySizeInBytes = maxMemorySizeInBytes;
       // Store merged records for all versions for this log file, set the in-memory footprint to maxInMemoryMapSize
@@ -335,6 +338,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
     // Use scanV2 method.
     private boolean enableOptimizedLogBlocksScan = false;
     private HoodieRecordMerger recordMerger;
+    private Option<List<Long>> logfilePos = Option.of(Collections.EMPTY_LIST);
 
     @Override
     public Builder withFileSystem(FileSystem fs) {
@@ -418,6 +422,12 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
       return this;
     }
 
+    @Override
+    public Builder withOptimizedLogFilePos(Option<List<Long>> logFilePos) {
+      this.logfilePos = logFilePos;
+      return this;
+    }
+
     public Builder withOperationField(boolean withOperationField) {
       this.withOperationField = withOperationField;
       return this;
@@ -462,7 +472,8 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
           latestInstantTime, maxMemorySizeInBytes, readBlocksLazily, reverseReader,
           bufferSize, spillableMapBasePath, instantRange,
           diskMapType, isBitCaskDiskMapCompressionEnabled, withOperationField, forceFullScan,
-          Option.ofNullable(partitionName), internalSchema, Option.ofNullable(keyFieldOverride), enableOptimizedLogBlocksScan, recordMerger);
+          Option.ofNullable(partitionName), internalSchema, Option.ofNullable(keyFieldOverride),
+          enableOptimizedLogBlocksScan, recordMerger, logfilePos);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -29,6 +29,7 @@ import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,9 +43,9 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
   private HoodieUnMergedLogRecordScanner(FileSystem fs, String basePath, List<String> logFilePaths, Schema readerSchema,
                                          String latestInstantTime, boolean readBlocksLazily, boolean reverseReader, int bufferSize,
                                          LogRecordScannerCallback callback, Option<InstantRange> instantRange, InternalSchema internalSchema,
-                                         boolean enableOptimizedLogBlocksScan, HoodieRecordMerger recordMerger) {
+                                         boolean enableOptimizedLogBlocksScan, HoodieRecordMerger recordMerger, Option<List<Long>> logFilePos) {
     super(fs, basePath, logFilePaths, readerSchema, latestInstantTime, readBlocksLazily, reverseReader, bufferSize, instantRange,
-        false, true, Option.empty(), internalSchema, Option.empty(), enableOptimizedLogBlocksScan, recordMerger);
+        false, true, Option.empty(), internalSchema, Option.empty(), enableOptimizedLogBlocksScan, recordMerger, logFilePos);
     this.callback = callback;
   }
 
@@ -107,6 +108,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
     private LogRecordScannerCallback callback;
     private boolean enableOptimizedLogBlocksScan;
     private HoodieRecordMerger recordMerger;
+    private Option<List<Long>> logfilePos = Option.of(Collections.EMPTY_LIST);
 
     public Builder withFileSystem(FileSystem fs) {
       this.fs = fs;
@@ -173,6 +175,12 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
     }
 
     @Override
+    public Builder withOptimizedLogFilePos(Option<List<Long>> logFilePos) {
+      this.logfilePos = logFilePos;
+      return this;
+    }
+
+    @Override
     public Builder withRecordMerger(HoodieRecordMerger recordMerger) {
       this.recordMerger = recordMerger;
       return this;
@@ -184,7 +192,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
 
       return new HoodieUnMergedLogRecordScanner(fs, basePath, logFilePaths, readerSchema,
           latestInstantTime, readBlocksLazily, reverseReader, bufferSize, callback, instantRange,
-          internalSchema, enableOptimizedLogBlocksScan, recordMerger);
+          internalSchema, enableOptimizedLogBlocksScan, recordMerger, logfilePos);
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.cdc.HoodieCDCExtractor;
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit;
@@ -60,6 +61,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -237,7 +239,7 @@ public class IncrementalInputSplits implements Serializable {
     }
 
     List<MergeOnReadInputSplit> inputSplits = getInputSplits(metaClient, commitTimeline,
-        fileStatuses, readPartitions, endInstant, instantRange, false);
+        fileStatuses, readPartitions, endInstant, instantRange, false, null);
 
     return Result.instance(inputSplits, endInstant);
   }
@@ -296,7 +298,7 @@ public class IncrementalInputSplits implements Serializable {
 
       final String endInstant = instantToIssue.getTimestamp();
       List<MergeOnReadInputSplit> inputSplits = getInputSplits(metaClient, commitTimeline,
-          fileStatuses, readPartitions, endInstant, null, false);
+          fileStatuses, readPartitions, endInstant, null, false, Collections.EMPTY_MAP);
 
       return Result.instance(inputSplits, endInstant);
     } else {
@@ -329,8 +331,10 @@ public class IncrementalInputSplits implements Serializable {
         LOG.warn("No partitions found for reading under path: " + path);
         return Result.EMPTY;
       }
-      fileStatuses = WriteProfiles.getWritePathsOfInstants(path, hadoopConf, metadataList, metaClient.getTableType());
-
+      Map<String, Long> fileToStartPos = new HashMap<>();
+      Map<String, String> relativePathToFullPath = new HashMap<>();
+      fileStatuses = WriteProfiles.getWritePathsOfInstants(path, hadoopConf, metadataList, metaClient.getTableType(), relativePathToFullPath);
+      initFileToStartPos(metadataList, fileToStartPos, relativePathToFullPath);
       if (fileStatuses.length == 0) {
         LOG.warn("No files found for reading under path: " + path);
         return Result.EMPTY;
@@ -338,7 +342,7 @@ public class IncrementalInputSplits implements Serializable {
 
       final String endInstant = instantToIssue.getTimestamp();
       List<MergeOnReadInputSplit> inputSplits = getInputSplits(metaClient, commitTimeline,
-          fileStatuses, readPartitions, endInstant, instantRange, skipCompaction);
+          fileStatuses, readPartitions, endInstant, instantRange, skipCompaction, fileToStartPos);
 
       return Result.instance(inputSplits, endInstant);
     }
@@ -372,7 +376,8 @@ public class IncrementalInputSplits implements Serializable {
       Set<String> readPartitions,
       String endInstant,
       InstantRange instantRange,
-      boolean skipBaseFiles) {
+      boolean skipBaseFiles,
+      Map<String, Long> logFileToStartPos) {
     final HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, commitTimeline, fileStatuses);
     final AtomicInteger cnt = new AtomicInteger(0);
     final String mergeType = this.conf.getString(FlinkOptions.MERGE_TYPE);
@@ -385,9 +390,9 @@ public class IncrementalInputSplits implements Serializable {
                   .filter(logPath -> !logPath.endsWith(HoodieCDCUtils.CDC_LOGFILE_SUFFIX))
                   .collect(Collectors.toList()));
               String basePath = fileSlice.getBaseFile().map(BaseFile::getPath).orElse(null);
-              return new MergeOnReadInputSplit(cnt.getAndAdd(1),
-                  basePath, logPaths, endInstant,
-                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, instantRange, fileSlice.getFileId());
+              return new MergeOnReadInputSplit(cnt.getAndAdd(1), basePath, logPaths,
+                  endInstant, metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType,
+                  instantRange, fileSlice.getFileId(), logFileToStartPos);
             }).collect(Collectors.toList()))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
@@ -593,6 +598,25 @@ public class IncrementalInputSplits implements Serializable {
     public static Result instance(List<MergeOnReadInputSplit> inputSplits, String endInstant) {
       return new Result(inputSplits, endInstant);
     }
+  }
+
+  private void initFileToStartPos(List<HoodieCommitMetadata> metadataList, Map<String, Long> fileToStartPos,
+                                  Map<String, String> relativePathToFullPath) {
+    if (relativePathToFullPath.size() == 0) {
+      return;
+    }
+    metadataList.stream().map(HoodieCommitMetadata::getWriteStats).
+        flatMap(Collection::stream).
+        collect(Collectors.toList()).
+        stream().forEach(writeStat -> {
+          String fullPath = relativePathToFullPath.get(writeStat.getPath());
+          Long aLong = fileToStartPos.get(fullPath);
+          if (aLong != null) {
+            fileToStartPos.put(fullPath, Math.min(aLong, writeStat.getLogOffset()));
+          } else {
+            fileToStartPos.put(fullPath, writeStat.getLogOffset());
+          }
+        });
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -347,7 +347,7 @@ public class HoodieTableSource implements
                   .map(logFile -> logFile.getPath().toString())
                   .collect(Collectors.toList()));
               return new MergeOnReadInputSplit(cnt.getAndAdd(1), basePath, logPaths, latestCommit,
-                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, null, fileSlice.getFileId());
+                  metaClient.getBasePath(), maxCompactionMemoryInBytes, mergeType, null, fileSlice.getFileId(), null);
             }).collect(Collectors.toList()))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
@@ -210,7 +210,8 @@ public class FormatUtils {
               flinkConf.getInteger(HoodieRealtimeConfig.MAX_DFS_STREAM_BUFFER_SIZE_PROP,
                   HoodieRealtimeConfig.DEFAULT_MAX_DFS_STREAM_BUFFER_SIZE))
           .withInstantRange(split.getInstantRange())
-          .withRecordMerger(merger);
+          .withRecordMerger(merger)
+          .withOptimizedLogFilePos(split.getLogPath2Pos());
 
       this.executor = new BoundedInMemoryExecutor<>(
           StreamerUtil.getMaxCompactionMemoryInBytes(flinkConf),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
@@ -733,6 +733,6 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
     String basePath = fileSlice.getBaseFile().map(BaseFile::getPath).orElse(null);
     return new MergeOnReadInputSplit(0, basePath, logPaths,
         fileSlice.getBaseInstantTime(), tablePath, maxCompactionMemoryInBytes,
-        FlinkOptions.REALTIME_PAYLOAD_COMBINE, null, fileSlice.getFileId());
+        FlinkOptions.REALTIME_PAYLOAD_COMBINE, null, fileSlice.getFileId(), null);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputSplit.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Represents an input split of source, actually a data bucket.
@@ -39,7 +40,7 @@ public class CdcInputSplit extends MergeOnReadInputSplit {
       String fileId,
       HoodieCDCFileSplit[] changes) {
     super(splitNum, null, Option.empty(), "", tablePath,
-        maxCompactionMemoryInBytes, "", null, fileId);
+        maxCompactionMemoryInBytes, "", null, fileId, Collections.emptyMap());
     this.changes = changes;
   }
 

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -480,7 +480,7 @@ public class HoodieInputFormatUtils {
     HashMap<String, FileStatus> fullPathToFileStatus = new HashMap<>();
     // Iterate through the given commits.
     for (HoodieCommitMetadata metadata: metadataList) {
-      fullPathToFileStatus.putAll(metadata.getFullPathToFileStatus(hadoopConf, basePath.toString()));
+      fullPathToFileStatus.putAll(metadata.getFullPathToFileStatus(hadoopConf, basePath.toString(), new HashMap<>()));
     }
     return fullPathToFileStatus.values().toArray(new FileStatus[0]);
   }


### PR DESCRIPTION
…ffset of each logfile recorded in the deltacommit metadata

### Change Logs

When the downstream tasks read the logfile, use the startoffset of each logfile recorded in the deltacommit metadata

### Impact
stream read 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
