### PR TITLE
[MINOR] When a clean operation fails do not continue and throw the exception.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -247,7 +247,8 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         // we should not affect original clean logic. Swallow exception and log warn.
         LOG.warn("failed to clean old history schema");
       }
-      pendingCleanInstants.forEach(hoodieInstant -> {
+
+      for (HoodieInstant hoodieInstant : pendingCleanInstants) {
         if (table.getCleanTimeline().isEmpty(hoodieInstant)) {
           table.getActiveTimeline().deleteEmptyInstantIfExists(hoodieInstant);
         } else {
@@ -256,13 +257,14 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
             cleanMetadataList.add(runPendingClean(table, hoodieInstant));
           } catch (Exception e) {
             LOG.warn("Failed to perform previous clean operation, instant: " + hoodieInstant, e);
+            throw e;
           }
         }
         table.getMetaClient().reloadActiveTimeline();
         if (config.isMetadataTableEnabled()) {
           table.getHoodieView().sync();
         }
-      });
+      }
     }
 
     // return the last clean metadata for now


### PR DESCRIPTION
[MINOR] When a clean operation fails do not continue and throw the exception.

### Change Logs

Throws an exception when clean operation fails.

### Impact

If we catch and consume the exception, the clean may still be leftover in an inflight condition. A new clean can then get scheduled which may contain the same files as the previous clean.
By throwing this exception we prevent any future cleans from being scheduled.


### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
