### PR TITLE
[MINOR] Check the return value from delete during rollback and finalize to ensure the files actually got deleted.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -669,7 +669,10 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
           LOG.info("Deleting invalid data file=" + partitionFilePair);
           // Delete
           try {
-            fileSystem.delete(new Path(partitionFilePair.getValue()), false);
+            Path pathToBeDeleted = new Path(partitionFilePair.getValue());
+            if (!fileSystem.delete(pathToBeDeleted, false) && fileSystem.exists(pathToBeDeleted)) {
+              throw new HoodieException("Failed to delete the invalid data file " + pathToBeDeleted);
+            }
           } catch (IOException e) {
             throw new HoodieIOException(e.getMessage(), e);
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackHelper.java
@@ -197,14 +197,21 @@ public class BaseRollbackHelper implements Serializable {
             // if first rollback attempt failed and retried again, chances that some files are already deleted.
             isDeleted = true;
           }
+
+          if (!isDeleted) {
+            // ensure the file does not exist
+            if (metaClient.getFs().exists(fullDeletePath)) {
+              throw new HoodieRollbackException("Failed to delete file " + fullDeletePath);
+            }
+            isDeleted = true;
+          }
         }
         return HoodieRollbackStat.newBuilder()
             .withPartitionPath(partitionPath)
             .withDeletedFileResult(fullDeletePath.toString(), isDeleted)
             .build();
       } catch (IOException e) {
-        LOG.error("Fetching file status for ");
-        throw new HoodieIOException("Fetching file status for " + fileToDelete + " failed ", e);
+        throw new HoodieIOException("Deleting file " + fileToDelete + " failed ", e);
       }
     }).collect(Collectors.toList());
   }


### PR DESCRIPTION
[MINOR] Check the return value from delete during rollback and finalize to ensure the files actually got deleted.

### Change Logs

Return value from FileSystem.delete call is checked. It should be true in case delete was successful. If the return value is false, we check if the file exists.

### Impact

Improves the guarantee that files are deleted when required. We have seen cases where the call returns false and the file is left over. This causes data inconsistency issues (duplicate data, incomplete rollback) in HUDI dataset.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
