### PR TITLE
[HUDI-6196] Keep compatibility for old version archival instants without ACTION_STATE field

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieArchivedTimeline.java
@@ -143,7 +143,11 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
 
   public void loadCompletedInstantDetailsInMemory() {
     loadInstants(null, true,
-        record -> HoodieInstant.State.COMPLETED.toString().equals(record.get(ACTION_STATE).toString()));
+        record -> {
+          // Very old archived instants don't have action state set.
+          Object action = record.get(ACTION_STATE);
+          return action == null || HoodieInstant.State.COMPLETED.toString().equals(action.toString());
+        });
   }
 
   public void loadCompactionDetailsInMemory(String compactionInstantTime) {
@@ -152,9 +156,13 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
 
   public void loadCompactionDetailsInMemory(String startTs, String endTs) {
     // load compactionPlan
-    loadInstants(new TimeRangeFilter(startTs, endTs), true, record ->
-        record.get(ACTION_TYPE_KEY).toString().equals(HoodieTimeline.COMPACTION_ACTION)
-            && HoodieInstant.State.INFLIGHT.toString().equals(record.get(ACTION_STATE).toString())
+    loadInstants(new TimeRangeFilter(startTs, endTs), true,
+        record -> {
+          // Older files don't have action state set.
+          Object action = record.get(ACTION_STATE);
+          return record.get(ACTION_TYPE_KEY).toString().equals(HoodieTimeline.COMPACTION_ACTION)
+            && (action == null || HoodieInstant.State.INFLIGHT.toString().equals(action.toString()));
+      }
     );
   }
 


### PR DESCRIPTION
[MINOR] Fixed the reading of instants from very old archive files where ACTION_STATE is not present in instants.

### Change Logs

Ensure that ACTION_STATE exists in the record before performing the equals comparison.

### Impact

Very old archive files can be read.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
