### PR TITLE
[MINOR] Fixed the hudi-cli export command.

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ExportCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ExportCommand.java
@@ -44,6 +44,8 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.exception.HoodieException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
@@ -67,6 +69,8 @@ import java.util.stream.Collectors;
 @ShellComponent
 public class ExportCommand {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ExportCommand.class);
+
   @ShellMethod(key = "export instants", value = "Export Instants and their metadata from the Timeline")
   public String exportInstants(
       @ShellOption(value = {"--limit"}, help = "Limit Instants", defaultValue = "-1") final Integer limit,
@@ -77,7 +81,7 @@ public class ExportCommand {
       throws Exception {
 
     final String basePath = HoodieCLI.getTableMetaClient().getBasePath();
-    final Path archivePath = new Path(basePath + "/.hoodie/.commits_.archive*");
+    final Path archivePath = new Path(HoodieCLI.getTableMetaClient().getArchivePath());
     final Set<String> actionSet = new HashSet<String>(Arrays.asList(filter.split(",")));
     int numExports = limit == -1 ? Integer.MAX_VALUE : limit;
     int numCopied = 0;
@@ -121,7 +125,7 @@ public class ExportCommand {
       Reader reader = HoodieLogFormat.newReader(fileSystem, new HoodieLogFile(fs.getPath()), HoodieArchivedMetaEntry.getClassSchema());
 
       // read the avro blocks
-      while (reader.hasNext() && copyCount < limit) {
+      while (reader.hasNext() && copyCount++ < limit) {
         HoodieAvroDataBlock blk = (HoodieAvroDataBlock) reader.next();
         try (ClosableIterator<HoodieRecord<IndexedRecord>> recordItr = blk.getRecordIterator(HoodieRecordType.AVRO)) {
           while (recordItr.hasNext()) {
@@ -158,11 +162,12 @@ public class ExportCommand {
             }
 
             final String instantTime = archiveEntryRecord.get("commitTime").toString();
+            if (metadata == null) {
+              LOG.error("Could not load metadata for action " + action + " at instant time " + instantTime);
+              continue;
+            }
             final String outPath = localFolder + Path.SEPARATOR + instantTime + "." + action;
             writeToFile(outPath, HoodieAvroUtils.avroToJson(metadata, true));
-            if (++copyCount == limit) {
-              break;
-            }
           }
         }
       }


### PR DESCRIPTION
[MINOR] Fixed the hudi-cli export command.

### Change Logs

1. Removed the hardcoded location of archives
2. Handle the case where the metadata from an archive entry may be null (seen in very old archives)
3. Corrected the return value from copyNonArchivedInstants

### Impact

Exporting of instants from very old archives works now.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
