### PR TITLE
[HUDI-6156] Prevent leaving tmp file in timeline when multi process t…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieWrapperFileSystem.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/HoodieWrapperFileSystem.java
@@ -1039,7 +1039,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
         fsout.write(content.get());
       }
     } catch (IOException e) {
-      String errorMsg = "Failed to create file" + (tmpPath != null ? tmpPath : fullPath);
+      String errorMsg = "Failed to create file " + (tmpPath != null ? tmpPath : fullPath);
       throw new HoodieIOException(errorMsg, e);
     } finally {
       try {
@@ -1047,13 +1047,17 @@ public class HoodieWrapperFileSystem extends FileSystem {
           fsout.close();
         }
       } catch (IOException e) {
-        String errorMsg = "Failed to close file" + (needTempFile ? tmpPath : fullPath);
+        String errorMsg = "Failed to close file " + (needTempFile ? tmpPath : fullPath);
         throw new HoodieIOException(errorMsg, e);
       }
 
       try {
         if (null != tmpPath) {
-          fileSystem.rename(tmpPath, fullPath);
+          boolean renameSuccess = fileSystem.rename(tmpPath, fullPath);
+          if (!renameSuccess) {
+            fileSystem.delete(tmpPath, false);
+            LOG.warn("Fail to rename " + tmpPath + " to " + fullPath + ", target file exists: " + fileSystem.exists(fullPath));
+          }
         }
       } catch (IOException e) {
         throw new HoodieIOException("Failed to rename " + tmpPath + " to the target " + fullPath, e);

--- a/hudi-common/src/test/java/org/apache/hudi/common/fs/TestHoodieWrapperFileSystem.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/fs/TestHoodieWrapperFileSystem.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.fs;
+
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.minicluster.HdfsTestService;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestHoodieWrapperFileSystem {
+  private static String basePath;
+  private static FileSystem fs;
+  private static HdfsTestService hdfsTestService;
+  private static MiniDFSCluster dfsCluster;
+
+  @BeforeAll
+  public static void prepareFs() throws IOException {
+    hdfsTestService = new HdfsTestService(HoodieTestUtils.getDefaultHadoopConf());
+    dfsCluster = hdfsTestService.start(true);
+    fs = dfsCluster.getFileSystem();
+    basePath = fs.getWorkingDirectory().toString();
+  }
+
+  @Test
+  public void testCreateImmutableFileInPath() throws IOException {
+    HoodieWrapperFileSystem fs = new HoodieWrapperFileSystem(FSUtils.getFs(basePath, new Configuration()), new NoOpConsistencyGuard());
+    String testContent = "test content";
+    Path testFile = new Path(basePath + Path.SEPARATOR + "clean.00000001");
+
+    // create same commit twice
+    fs.createImmutableFileInPath(testFile, Option.of(testContent.getBytes()));
+    fs.createImmutableFileInPath(testFile, Option.of(testContent.getBytes()));
+
+    assertEquals(1, fs.listStatus(new Path(basePath)).length,
+        "create same file twice should only have on file exists");
+  }
+}


### PR DESCRIPTION
…ry to complete the same instant

### Change Logs

Now if to task try to complete the same instant, a "xxx.tmp" file will leave in the .hoodie dir.

For example a flink ingestion job with offline compaction, the ingestion job and offline compaction could both trigger clean task, and there are chances 2 clean task running the same clean instant, and the slow one will fail to rename tmp file(e.g. 20230429171948763.clean.tmp) to final file name (e.g. 20230429171948763.clean), leaving tmp file in timeline.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
