### PR TITLE
[HUDI-6158] Strengthen Flink clustering commit and rollback strategy

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitEvent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitEvent.java
@@ -34,6 +34,10 @@ public class ClusteringCommitEvent implements Serializable {
    */
   private String instant;
   /**
+   * The file IDs.
+   */
+  private String fileIds;
+  /**
    * The write statuses.
    */
   private List<WriteStatus> writeStatuses;
@@ -45,14 +49,15 @@ public class ClusteringCommitEvent implements Serializable {
   public ClusteringCommitEvent() {
   }
 
-  public ClusteringCommitEvent(String instant, List<WriteStatus> writeStatuses, int taskID) {
-    this.instant = instant;
-    this.writeStatuses = writeStatuses;
-    this.taskID = taskID;
+  public ClusteringCommitEvent(String instant, String fileIds, int taskID) {
+    this(instant, fileIds, null, taskID);
   }
 
-  public ClusteringCommitEvent(String instant, int taskID) {
-    this(instant, null, taskID);
+  public ClusteringCommitEvent(String instant, String filedIds, List<WriteStatus> writeStatuses, int taskID) {
+    this.instant = instant;
+    this.fileIds = filedIds;
+    this.writeStatuses = writeStatuses;
+    this.taskID = taskID;
   }
 
   public void setInstant(String instant) {
@@ -69,6 +74,10 @@ public class ClusteringCommitEvent implements Serializable {
 
   public String getInstant() {
     return instant;
+  }
+
+  public String getFileIds() {
+    return fileIds;
   }
 
   public List<WriteStatus> getWriteStatuses() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -33,18 +33,17 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieClusteringException;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.util.ClusteringUtil;
 import org.apache.hudi.util.FlinkWriteClients;
-import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -75,9 +74,18 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
 
   /**
    * Buffer to collect the event from each clustering task {@code ClusteringFunction}.
-   * The key is the instant time.
+   *
+   * <p>Stores the mapping of instant_time -> file_ids -> event. Use a map to collect the
+   * events because the rolling back of intermediate clustering tasks generates corrupt
+   * events.
    */
-  private transient Map<String, List<ClusteringCommitEvent>> commitBuffer;
+  private transient Map<String, Map<String, ClusteringCommitEvent>> commitBuffer;
+
+  /**
+   * Cache to store clustering plan for each instant.
+   * Stores the mapping of instant_time -> clusteringPlan.
+   */
+  private transient Map<String, HoodieClusteringPlan> clusteringPlanCache;
 
   public ClusteringCommitSink(Configuration conf) {
     super(conf);
@@ -91,15 +99,16 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
       this.writeClient = FlinkWriteClients.createWriteClient(conf, getRuntimeContext());
     }
     this.commitBuffer = new HashMap<>();
+    this.clusteringPlanCache = new HashMap<>();
     this.table = writeClient.getHoodieTable();
   }
 
   @Override
   public void invoke(ClusteringCommitEvent event, Context context) throws Exception {
     final String instant = event.getInstant();
-    commitBuffer.computeIfAbsent(instant, k -> new ArrayList<>())
-        .add(event);
-    commitIfNecessary(instant, commitBuffer.get(instant));
+    commitBuffer.computeIfAbsent(instant, k -> new HashMap<>())
+        .put(event.getFileIds(), event);
+    commitIfNecessary(instant, commitBuffer.get(instant).values());
   }
 
   /**
@@ -109,11 +118,17 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
    * @param instant Clustering commit instant time
    * @param events  Commit events ever received for the instant
    */
-  private void commitIfNecessary(String instant, List<ClusteringCommitEvent> events) {
-    HoodieInstant clusteringInstant = HoodieTimeline.getReplaceCommitInflightInstant(instant);
-    Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
-        StreamerUtil.createMetaClient(this.conf), clusteringInstant);
-    HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
+  private void commitIfNecessary(String instant, Collection<ClusteringCommitEvent> events) {
+    HoodieClusteringPlan clusteringPlan = clusteringPlanCache.computeIfAbsent(instant, k -> {
+      try {
+        Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
+            this.writeClient.getHoodieTable().getMetaClient(), HoodieTimeline.getReplaceCommitInflightInstant(instant));
+        return clusteringPlanOption.get().getRight();
+      } catch (Exception e) {
+        throw new HoodieException(e);
+      }
+    });
+
     boolean isReady = clusteringPlan.getInputGroups().size() == events.size();
     if (!isReady) {
       return;
@@ -141,7 +156,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
     }
   }
 
-  private void doCommit(String instant, HoodieClusteringPlan clusteringPlan, List<ClusteringCommitEvent> events) {
+  private void doCommit(String instant, HoodieClusteringPlan clusteringPlan, Collection<ClusteringCommitEvent> events) {
     List<WriteStatus> statuses = events.stream()
         .map(ClusteringCommitEvent::getWriteStatuses)
         .flatMap(Collection::stream)
@@ -187,6 +202,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
 
   private void reset(String instant) {
     this.commitBuffer.remove(instant);
+    this.clusteringPlanCache.remove(instant);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -25,12 +25,12 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.utils.ConcatenatingIterator;
 import org.apache.hudi.common.config.HoodieStorageConfig;
-import org.apache.hudi.common.model.ClusteringGroupInfo;
 import org.apache.hudi.common.model.ClusteringOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.log.HoodieFileSliceReader;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
@@ -173,18 +173,19 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
 
   @Override
   public void processElement(StreamRecord<ClusteringPlanEvent> element) throws Exception {
-    ClusteringPlanEvent event = element.getValue();
+    final ClusteringPlanEvent event = element.getValue();
     final String instantTime = event.getClusteringInstantTime();
+    final List<ClusteringOperation> clusteringOperations = event.getClusteringGroupInfo().getOperations();
     if (this.asyncClustering) {
       // executes the compaction task asynchronously to not block the checkpoint barrier propagate.
       executor.execute(
-          () -> doClustering(instantTime, event),
-          (errMsg, t) -> collector.collect(new ClusteringCommitEvent(instantTime, taskID)),
+          () -> doClustering(instantTime, clusteringOperations),
+          (errMsg, t) -> collector.collect(new ClusteringCommitEvent(instantTime, getFileIds(clusteringOperations), taskID)),
           "Execute clustering for instant %s from task %d", instantTime, taskID);
     } else {
       // executes the clustering task synchronously for batch mode.
       LOG.info("Execute clustering for instant {} from task {}", instantTime, taskID);
-      doClustering(instantTime, event);
+      doClustering(instantTime, clusteringOperations);
     }
   }
 
@@ -210,28 +211,22 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
   //  Utilities
   // -------------------------------------------------------------------------
 
-  private void doClustering(String instantTime, ClusteringPlanEvent event) throws Exception {
-    final ClusteringGroupInfo clusteringGroupInfo = event.getClusteringGroupInfo();
-
+  private void doClustering(String instantTime, List<ClusteringOperation> clusteringOperations) throws Exception {
     BulkInsertWriterHelper writerHelper = new BulkInsertWriterHelper(this.conf, this.table, this.writeConfig,
         instantTime, this.taskID, getRuntimeContext().getNumberOfParallelSubtasks(), getRuntimeContext().getAttemptNumber(),
         this.rowType, true);
 
-    List<ClusteringOperation> clusteringOps = clusteringGroupInfo.getOperations();
-    boolean hasLogFiles = clusteringOps.stream().anyMatch(op -> op.getDeltaFilePaths().size() > 0);
-
     Iterator<RowData> iterator;
-    if (hasLogFiles) {
+    if (clusteringOperations.stream().anyMatch(operation -> CollectionUtils.nonEmpty(operation.getDeltaFilePaths()))) {
       // if there are log files, we read all records into memory for a file group and apply updates.
-      iterator = readRecordsForGroupWithLogs(clusteringOps, instantTime);
+      iterator = readRecordsForGroupWithLogs(clusteringOperations, instantTime);
     } else {
       // We want to optimize reading records for case there are no log files.
-      iterator = readRecordsForGroupBaseFiles(clusteringOps);
+      iterator = readRecordsForGroupBaseFiles(clusteringOperations);
     }
 
-    RowDataSerializer rowDataSerializer = new RowDataSerializer(rowType);
-
     if (this.sortClusteringEnabled) {
+      RowDataSerializer rowDataSerializer = new RowDataSerializer(rowType);
       BinaryExternalSorter sorter = initSorter();
       while (iterator.hasNext()) {
         RowData rowData = iterator.next();
@@ -251,7 +246,7 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
     }
 
     List<WriteStatus> writeStatuses = writerHelper.getWriteStatuses(this.taskID);
-    collector.collect(new ClusteringCommitEvent(instantTime, writeStatuses, this.taskID));
+    collector.collect(new ClusteringCommitEvent(instantTime, getFileIds(clusteringOperations), writeStatuses, this.taskID));
     writerHelper.close();
   }
 
@@ -376,6 +371,10 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
     SortOperatorGen sortOperatorGen = new SortOperatorGen(rowType,
         conf.getString(FlinkOptions.CLUSTERING_SORT_COLUMNS).split(","));
     return sortOperatorGen.createSortCodeGenerator();
+  }
+
+  private String getFileIds(List<ClusteringOperation> clusteringOperations) {
+    return clusteringOperations.stream().map(ClusteringOperation::getFileId).collect(Collectors.joining(","));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### Change Logs

`ClusteringCommitSink` could strengthen commit and rollback strategy from two solutions:

- Commit: Introduces `clusteringPlanCache` that caches to store clustering plan for each instant. `clusteringPlanCache` stores the mapping of instant_time -> clusteringPlan.
- Rolback: Updates `commitBuffer` that stores the mapping of instant_time -> file_ids -> event. Use a map to collect the events because the rolling back of intermediate clustering tasks generates corrupt events.

### Impact

Clustering commit and rollback strategy are improved. When the number of filegroups contained in the clustering plan is relatively large, it will be very expensive to read the clustering plan for each event received. Meanwhile, the rolling back of intermediate clustering tasks could generate corrupt events and collects the events via the map.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed