### PR TITLE
[HUDI-6163] Add PR size labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Label PR
+
+on: [ pull_request ]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@54ef367
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size-xs'
+          xs_max_size: '10'
+          s_label: 'size-s'
+          s_max_size: '100'
+          m_label: 'size-m'
+          m_max_size: '500'
+          l_label: 'size-l'
+          l_max_size: '1000'
+          xl_label: 'size-xl'
+          fail_if_xl: 'false'
+          github_api_url: 'api.github.com'
+          files_to_ignore: ''


### PR DESCRIPTION
### Change Logs

This PR adds the GH action of PR size labeler to label the PRs automatically based on the size.  Labels are: `size-xs`, `size-s`, `size-m`, `size-l`, and `size-xl`.

### Impact

Helps reviewers filter PRs of a particular size for review. 

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
