### PR TITLE
[HUDI-6170] Use correct zone id while calculating earliestTimeToRetain

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -45,6 +45,7 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
@@ -77,7 +78,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -491,7 +491,7 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
         String latestCommitToArchive = instantsToArchive.get(instantsToArchive.size() - 1).getTimestamp();
         try {
           Instant latestCommitInstant = HoodieActiveTimeline.parseDateFromInstantTime(commitTimeline.lastInstant().get().getTimestamp()).toInstant();
-          ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(latestCommitInstant, ZoneId.systemDefault());
+          ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(latestCommitInstant, HoodieInstantTimeGenerator.getTimelineTimeZone().getZoneId());
           String earliestTimeToRetain = HoodieActiveTimeline.formatDate(Date.from(currentDateTime.minusHours(config.getCleanerHoursRetained()).toInstant()));
           if (HoodieTimeline.compareTimestamps(latestCommitToArchive, GREATER_THAN_OR_EQUALS, earliestTimeToRetain)) {
             throw new HoodieIOException("Please align your archival configs based on cleaner configs. 'hoodie.keep.min.commits' : "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -45,7 +45,6 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
@@ -491,7 +490,7 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
         String latestCommitToArchive = instantsToArchive.get(instantsToArchive.size() - 1).getTimestamp();
         try {
           Instant latestCommitInstant = HoodieActiveTimeline.parseDateFromInstantTime(commitTimeline.lastInstant().get().getTimestamp()).toInstant();
-          ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(latestCommitInstant, HoodieInstantTimeGenerator.getTimelineTimeZone().getZoneId());
+          ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(latestCommitInstant, metaClient.getTableConfig().getTimelineTimezone().getZoneId());
           String earliestTimeToRetain = HoodieActiveTimeline.formatDate(Date.from(currentDateTime.minusHours(config.getCleanerHoursRetained()).toInstant()));
           if (HoodieTimeline.compareTimestamps(latestCommitToArchive, GREATER_THAN_OR_EQUALS, earliestTimeToRetain)) {
             throw new HoodieIOException("Please align your archival configs based on cleaner configs. 'hoodie.keep.min.commits' : "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -33,7 +33,6 @@ import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV1MigrationHandler;
@@ -510,7 +509,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
       }
     } else if (config.getCleanerPolicy() == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS) {
       Instant instant = Instant.now();
-      ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(instant, HoodieInstantTimeGenerator.getTimelineTimeZone().getZoneId());
+      ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(instant, hoodieTable.getMetaClient().getTableConfig().getTimelineTimezone().getZoneId());
       String earliestTimeToRetain = HoodieActiveTimeline.formatDate(Date.from(currentDateTime.minusHours(hoursRetained).toInstant()));
       earliestCommitToRetain = Option.fromJavaOptional(commitTimeline.getInstantsAsStream().filter(i -> HoodieTimeline.compareTimestamps(i.getTimestamp(),
               HoodieTimeline.GREATER_THAN_OR_EQUALS, earliestTimeToRetain)).findFirst());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV1MigrationHandler;
@@ -53,7 +54,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -510,7 +510,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
       }
     } else if (config.getCleanerPolicy() == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS) {
       Instant instant = Instant.now();
-      ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+      ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(instant, HoodieInstantTimeGenerator.getTimelineTimeZone().getZoneId());
       String earliestTimeToRetain = HoodieActiveTimeline.formatDate(Date.from(currentDateTime.minusHours(hoursRetained).toInstant()));
       earliestCommitToRetain = Option.fromJavaOptional(commitTimeline.getInstantsAsStream().filter(i -> HoodieTimeline.compareTimestamps(i.getTimestamp(),
               HoodieTimeline.GREATER_THAN_OR_EQUALS, earliestTimeToRetain)).findFirst());

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieTimelineTimeZone.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieTimelineTimeZone.java
@@ -18,20 +18,29 @@
 
 package org.apache.hudi.common.model;
 
+import java.time.ZoneId;
+import java.util.TimeZone;
+
 /**
  * Hoodie TimelineZone.
  */
 public enum HoodieTimelineTimeZone {
-  LOCAL("local"),
-  UTC("utc");
+  LOCAL("local", ZoneId.systemDefault()),
+  UTC("utc", TimeZone.getTimeZone("UTC").toZoneId());
 
   private final String timeZone;
+  private final ZoneId zoneId;
 
-  HoodieTimelineTimeZone(String timeZone) {
+  HoodieTimelineTimeZone(String timeZone, ZoneId zoneId) {
     this.timeZone = timeZone;
+    this.zoneId = zoneId;
   }
 
   public String getTimeZone() {
     return timeZone;
+  }
+
+  public ZoneId getZoneId() {
+    return zoneId;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -449,10 +449,8 @@ public class HoodieTableConfig extends HoodieConfig {
         // Use the default bootstrap index class.
         hoodieConfig.setDefaultValue(BOOTSTRAP_INDEX_CLASS_NAME, getDefaultBootstrapIndexClass(properties));
       }
-      if (hoodieConfig.contains(TIMELINE_TIMEZONE)) {
-        HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getString(TIMELINE_TIMEZONE)));
-      }
 
+      HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getStringOrDefault(TIMELINE_TIMEZONE)));
       hoodieConfig.setDefaultValue(DROP_PARTITION_COLUMNS);
 
       storeProperties(hoodieConfig.getProps(), outputStream);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -449,8 +449,10 @@ public class HoodieTableConfig extends HoodieConfig {
         // Use the default bootstrap index class.
         hoodieConfig.setDefaultValue(BOOTSTRAP_INDEX_CLASS_NAME, getDefaultBootstrapIndexClass(properties));
       }
+      if (hoodieConfig.contains(TIMELINE_TIMEZONE)) {
+        HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getString(TIMELINE_TIMEZONE)));
+      }
 
-      HoodieInstantTimeGenerator.setCommitTimeZone(HoodieTimelineTimeZone.valueOf(hoodieConfig.getStringOrDefault(TIMELINE_TIMEZONE)));
       hoodieConfig.setDefaultValue(DROP_PARTITION_COLUMNS);
 
       storeProperties(hoodieConfig.getProps(), outputStream);
@@ -647,6 +649,10 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public String getKeyGeneratorClassName() {
     return getString(KEY_GENERATOR_CLASS_NAME);
+  }
+
+  public HoodieTimelineTimeZone getTimelineTimezone() {
+    return HoodieTimelineTimeZone.valueOf(getStringOrDefault(TIMELINE_TIMEZONE));
   }
 
   public String getHiveStylePartitioningEnable() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.model.HoodieTimelineTimeZone;
-import org.apache.hudi.common.util.Option;
 
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -58,7 +57,7 @@ public class HoodieInstantTimeGenerator {
   // when performing comparisons such as LESS_THAN_OR_EQUAL_TO
   private static final String DEFAULT_MILLIS_EXT = "999";
 
-  private static Option<HoodieTimelineTimeZone> commitTimeZoneOpt = Option.empty();
+  private static HoodieTimelineTimeZone commitTimeZone = HoodieTimelineTimeZone.LOCAL;
 
   /**
    * Returns next instant time that adds N milliseconds to the current time.
@@ -67,7 +66,6 @@ public class HoodieInstantTimeGenerator {
    * @param milliseconds Milliseconds to add to current time while generating the new instant time
    */
   public static String createNewInstantTime(long milliseconds) {
-    HoodieTimelineTimeZone commitTimeZone = commitTimeZoneOpt.get();
     return lastInstantTime.updateAndGet((oldVal) -> {
       String newCommitTime;
       do {
@@ -135,7 +133,7 @@ public class HoodieInstantTimeGenerator {
   }
 
   public static void setCommitTimeZone(HoodieTimelineTimeZone commitTimeZone) {
-    commitTimeZoneOpt = Option.of(commitTimeZone);
+    HoodieInstantTimeGenerator.commitTimeZone = commitTimeZone;
   }
 
   public static boolean isValidInstantTime(String instantTime) {
@@ -145,9 +143,5 @@ public class HoodieInstantTimeGenerator {
     } catch (NumberFormatException e) {
       return false;
     }
-  }
-
-  public static HoodieTimelineTimeZone getTimelineTimeZone() {
-    return commitTimeZoneOpt.get();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -144,4 +144,8 @@ public class HoodieInstantTimeGenerator {
       return false;
     }
   }
+
+  public static HoodieTimelineTimeZone getTimelineTimeZone() {
+    return commitTimeZone;
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.model.HoodieTimelineTimeZone;
+import org.apache.hudi.common.util.Option;
 
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -57,7 +58,7 @@ public class HoodieInstantTimeGenerator {
   // when performing comparisons such as LESS_THAN_OR_EQUAL_TO
   private static final String DEFAULT_MILLIS_EXT = "999";
 
-  private static HoodieTimelineTimeZone commitTimeZone = HoodieTimelineTimeZone.LOCAL;
+  private static Option<HoodieTimelineTimeZone> commitTimeZoneOpt = Option.empty();
 
   /**
    * Returns next instant time that adds N milliseconds to the current time.
@@ -66,6 +67,7 @@ public class HoodieInstantTimeGenerator {
    * @param milliseconds Milliseconds to add to current time while generating the new instant time
    */
   public static String createNewInstantTime(long milliseconds) {
+    HoodieTimelineTimeZone commitTimeZone = commitTimeZoneOpt.get();
     return lastInstantTime.updateAndGet((oldVal) -> {
       String newCommitTime;
       do {
@@ -133,7 +135,7 @@ public class HoodieInstantTimeGenerator {
   }
 
   public static void setCommitTimeZone(HoodieTimelineTimeZone commitTimeZone) {
-    HoodieInstantTimeGenerator.commitTimeZone = commitTimeZone;
+    commitTimeZoneOpt = Option.of(commitTimeZone);
   }
 
   public static boolean isValidInstantTime(String instantTime) {
@@ -146,6 +148,6 @@ public class HoodieInstantTimeGenerator {
   }
 
   public static HoodieTimelineTimeZone getTimelineTimeZone() {
-    return commitTimeZone;
+    return commitTimeZoneOpt.get();
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieInstant.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieInstant.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hudi.common.model.HoodieTimelineTimeZone;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.Assertions.assertStreamEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestHoodieInstant extends HoodieCommonTestHarness {
 
@@ -74,6 +76,13 @@ public class TestHoodieInstant extends HoodieCommonTestHarness {
           timeline.getInstantsAsStream().filter(s -> s.getStateTransitionTime().isEmpty()).count());
     } finally {
       cleanMetaClient();
+    }
+  }
+
+  @Test
+  public void testHoodieTimelineTimeZone() {
+    for (HoodieTimelineTimeZone timeZone : HoodieTimelineTimeZone.values()) {
+      assertNotNull(timeZone.getZoneId());
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Currently we use default zoneId while calculating earliestTimeToRetain. Jira aims to use the configured timezone.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
