### PR TITLE
[HUDI-6171] Fix Testcase not run on windows system for TestCDCForSparkSQL

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCDCForSparkSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCDCForSparkSQL.scala
@@ -56,7 +56,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
       Seq(OP_KEY_ONLY, DATA_BEFORE, DATA_BEFORE_AFTER).foreach { loggingMode =>
         withTempDir { tmp =>
           val tableName = generateTableName
-          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          val basePath = s"${tmp.getCanonicalPath}/$tableName".replaceAll("\\\\", "\\/")
           val otherTableProperties = if (tableType == "mor") {
             "'hoodie.compact.inline'='true', 'hoodie.compact.inline.max.delta.commits'='2',"
           } else {
@@ -184,7 +184,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
       Seq(OP_KEY_ONLY, DATA_BEFORE).foreach { loggingMode =>
         withTempDir { tmp =>
           val tableName = generateTableName
-          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          val basePath = s"${tmp.getCanonicalPath}/$tableName".replaceAll("\\\\", "\\/")
           spark.sql(
             s"""
                | create table $tableName (


### PR DESCRIPTION
…kSQL

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact
no impact

when hudi sparksql case TestCDCForSparkSQL on windows system, it would report：

Can not create a Path from an empty string
java.lang.IllegalArgumentException: Can not create a Path from an empty string
    at org.apache.hadoop.fs.Path.checkPathArg(Path.java:163)
    at org.apache.hadoop.fs.Path.<init>(Path.java:232)
    at org.apache.hadoop.fs.Path.getParent(Path.java:431)
    at org.apache.hadoop.fs.RawLocalFileSystem.mkdirsWithOptionalPermission(RawLocalFileSystem.java:540)
    at org.apache.hadoop.fs.RawLocalFileSystem.mkdirs(RawLocalFileSystem.java:527)
    at org.apache.hadoop.fs.ChecksumFileSystem.mkdirs(ChecksumFileSystem.java:695)
    at org.apache.hudi.common.table.HoodieTableMetaClient.initTableAndGetMetaClient(HoodieTableMetaClient.java:478)
    at org.apache.hudi.common.table.HoodieTableMetaClient$PropertyBuilder.initTable(HoodieTableMetaClient.java:1199)
    at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.initHoodieTable(HoodieCatalogTable.scala:210)
    at org.apache.spark.sql.hudi.command.CreateHoodieTableCommand.run(CreateHoodieTableCommand.scala:71)

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
