### PR TITLE
[HUDI-6173] Fix classpath and conf dir in shells

### DIFF
--- a/hudi-cli/hudi-cli.sh
+++ b/hudi-cli/hudi-cli.sh
@@ -27,5 +27,5 @@ fi
 
 OTHER_JARS=`ls ${DIR}/target/lib/* | grep -v 'hudi-[^/]*jar' | tr '\n' ':'`
 
-echo "Running : java -cp ${HADOOP_CONF_DIR}:${SPARK_CONF_DIR}:${HOODIE_JAR}:${OTHER_JARS}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@"
-java -cp ${HADOOP_CONF_DIR}:${SPARK_CONF_DIR}:${HOODIE_JAR}:${OTHER_JARS}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@
+echo "Running : java -cp ${HOODIE_JAR}:${OTHER_JARS}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@"
+java -cp ${HOODIE_JAR}:${OTHER_JARS}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@

--- a/hudi-spark-datasource/hudi-spark/run_hoodie_app.sh
+++ b/hudi-spark-datasource/hudi-spark/run_hoodie_app.sh
@@ -36,5 +36,5 @@ fi
 
 OTHER_JARS=`ls -1 $DIR/target/lib/*jar | grep -v '*avro*-1.' | tr '\n' ':'`
 #TODO - Need to move TestDataGenerator and HoodieJavaApp out of tests
-echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HADOOP_CONF_DIR}:$HUDI_JAR:${CLIENT_JAR}:$OTHER_JARS $@"
-java -Xmx1G -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HADOOP_CONF_DIR}:$HUDI_JAR:${CLIENT_JAR}:$OTHER_JARS HoodieJavaApp "$@"
+echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HUDI_JAR}:${CLIENT_JAR}:${OTHER_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} HoodieJavaApp $@"
+java -Xmx1G -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HUDI_JAR}:${CLIENT_JAR}:${OTHER_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} HoodieJavaApp "$@"

--- a/hudi-spark-datasource/hudi-spark/run_hoodie_generate_app.sh
+++ b/hudi-spark-datasource/hudi-spark/run_hoodie_generate_app.sh
@@ -36,5 +36,5 @@ fi
 
 OTHER_JARS=`ls -1 $DIR/target/lib/*jar | grep -v '*avro*-1.' | tr '\n' ':'`
 #TODO - Need to move TestDataGenerator and HoodieJavaApp out of tests
-echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HADOOP_CONF_DIR}:$HUDI_JAR:${CLIENT_JAR}:$OTHER_JARS $@"
-java -Xmx1G -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HADOOP_CONF_DIR}:$HUDI_JAR:${CLIENT_JAR}:$OTHER_JARS HoodieJavaGenerateApp "$@"
+echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HUDI_JAR}:${CLIENT_JAR}:${OTHER_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} HoodieJavaGenerateApp $@"
+java -Xmx1G -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HUDI_JAR}:${CLIENT_JAR}:${OTHER_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} HoodieJavaGenerateApp "$@"

--- a/hudi-spark-datasource/hudi-spark/run_hoodie_streaming_app.sh
+++ b/hudi-spark-datasource/hudi-spark/run_hoodie_streaming_app.sh
@@ -36,5 +36,5 @@ fi
 
 OTHER_JARS=`ls -1 $DIR/target/lib/*jar | grep -v '*avro*-1.' | tr '\n' ':'`
 #TODO - Need to move TestDataGenerator and HoodieJavaApp out of tests
-echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HADOOP_CONF_DIR}:$HUDI_JAR:${CLIENT_JAR}:$OTHER_JARS HoodieJavaStreamingApp $@"
-java -Xmx1G -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HADOOP_CONF_DIR}:$HUDI_JAR:${CLIENT_JAR}:$OTHER_JARS HoodieJavaStreamingApp "$@"
+echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HUDI_JAR}:${CLIENT_JAR}:${OTHER_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} HoodieJavaStreamingApp $@"
+java -Xmx1G -cp $DIR/target/test-classes/:$DIR/../hudi-client/target/test-classes/:${HUDI_JAR}:${CLIENT_JAR}:${OTHER_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} HoodieJavaStreamingApp "$@"

--- a/hudi-sync/hudi-hive-sync/run_hive_global_commit_tool.sh
+++ b/hudi-sync/hudi-hive-sync/run_hive_global_commit_tool.sh
@@ -65,5 +65,5 @@ if ! [ -z "$HIVE_CONF_DIR" ]; then
   error_exit "Don't set HIVE_CONF_DIR; use config xml file"
 fi
 
-echo "Running Command : java -cp $HUDI_HIVE_UBER_JAR:${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR}:${HIVE_HOME}lib/* org.apache.hudi.hive.replication.HiveSyncGlobalCommitTool $@"
-java -cp $HUDI_HIVE_UBER_JAR:${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR}:${HIVE_HOME}lib/* org.apache.hudi.hive.replication.HiveSyncGlobalCommitTool "$@"
+echo "Running Command : java -cp ${HUDI_HIVE_UBER_JAR}:${HADOOP_HIVE_JARS}:${HIVE_HOME}lib/* -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.hive.replication.HiveSyncGlobalCommitTool $@"
+java -cp ${HUDI_HIVE_UBER_JAR}:${HADOOP_HIVE_JARS}:${HIVE_HOME}lib/* -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.hive.replication.HiveSyncGlobalCommitTool "$@"

--- a/hudi-sync/hudi-hive-sync/run_sync_tool.sh
+++ b/hudi-sync/hudi-hive-sync/run_sync_tool.sh
@@ -51,5 +51,5 @@ HIVE_JARS=$HIVE_METASTORE:$HIVE_SERVICE:$HIVE_EXEC:$HIVE_JDBC:$HIVE_JACKSON
 
 HADOOP_HIVE_JARS=${HIVE_JARS}:${HADOOP_HOME}/share/hadoop/common/*:${HADOOP_HOME}/share/hadoop/mapreduce/*:${HADOOP_HOME}/share/hadoop/hdfs/*:${HADOOP_HOME}/share/hadoop/common/lib/*:${HADOOP_HOME}/share/hadoop/hdfs/lib/*
 
-echo "Running Command : java -cp ${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR}:$HUDI_HIVE_UBER_JAR org.apache.hudi.hive.HiveSyncTool $@"
-java -cp $HUDI_HIVE_UBER_JAR:${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR} org.apache.hudi.hive.HiveSyncTool "$@"
+echo "Running Command : java -cp ${HUDI_HIVE_UBER_JAR}:${HADOOP_HIVE_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.hive.HiveSyncTool $@"
+java -cp ${HUDI_HIVE_UBER_JAR}:${HADOOP_HIVE_JARS} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.hive.HiveSyncTool "$@"

--- a/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
+++ b/packaging/hudi-cli-bundle/hudi-cli-with-bundle.sh
@@ -59,5 +59,5 @@ if [ -z "$CLIENT_JAR" ]; then
   echo "Client jar location not set, please set it in conf/hudi-env.sh"
 fi
 
-echo "Running : java -cp ${HUDI_CONF_DIR}:${HUDI_AUX_LIB}/*:${SPARK_HOME}/*:${SPARK_HOME}/jars/*:${HADOOP_CONF_DIR}:${SPARK_CONF_DIR}:${CLI_BUNDLE_JAR}:${SPARK_BUNDLE_JAR}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@"
-java -cp ${HUDI_CONF_DIR}:${HUDI_AUX_LIB}/*:${SPARK_HOME}/*:${SPARK_HOME}/jars/*:${HADOOP_CONF_DIR}:${SPARK_CONF_DIR}:${CLI_BUNDLE_JAR}:${SPARK_BUNDLE_JAR}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@
+echo "Running : java -cp ${HUDI_AUX_LIB}/*:${SPARK_HOME}/jars/*:${CLI_BUNDLE_JAR}:${SPARK_BUNDLE_JAR}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@"
+java -cp ${HUDI_AUX_LIB}/*:${SPARK_HOME}/jars/*:${CLI_BUNDLE_JAR}:${SPARK_BUNDLE_JAR}:${CLIENT_JAR} -DSPARK_CONF_DIR=${SPARK_CONF_DIR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.cli.Main $@

--- a/packaging/hudi-timeline-server-bundle/run_server.sh
+++ b/packaging/hudi-timeline-server-bundle/run_server.sh
@@ -48,5 +48,5 @@ HADOOP_JARS=${HADOOP_HOME}/share/hadoop/common/*:${HADOOP_HOME}/share/hadoop/map
 HADOOP_JARS=${HADOOP_COMMON_JARS}:${HADOOP_COMMON_LIB_JARS}:${HADOOP_HDFS_JARS}:${HADOOP_HDFS_LIB_JARS}
 
 SERVLET_JAR=${DIR}/javax.servlet-api-3.1.0.jar
-echo "Running command : java -cp ${SERVLET_JAR}:${HADOOP_JARS}:${HADOOP_CONF_DIR}:$HOODIE_JAR org.apache.hudi.timeline.service.TimelineService $@"
-java -Xmx4G -cp ${SERVLET_JAR}:${HADOOP_JARS}:${HADOOP_CONF_DIR}:$HOODIE_JAR org.apache.hudi.timeline.service.TimelineService "$@"
+echo "Running command : java -cp ${SERVLET_JAR}:${HADOOP_JARS}:${HOODIE_JAR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.timeline.service.TimelineService $@"
+java -Xmx4G -cp ${SERVLET_JAR}:${HADOOP_JARS}:${HOODIE_JAR} -DHADOOP_CONF_DIR=${HADOOP_CONF_DIR} org.apache.hudi.timeline.service.TimelineService "$@"


### PR DESCRIPTION
### Change Logs

move `HADOOP_CONF_DIR` from `-cp` to `-DHADOOP_CONF_DIR`

### Impact

Use confs correctly in shells

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
