### PR TITLE
[HUDI-6180] Use ConfigProperty for Timestamp keygen configs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
@@ -17,8 +17,8 @@
 
 package org.apache.hudi.keygen;
 
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.PartitionPathEncodeUtils;
@@ -28,6 +28,8 @@ import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.keygen.parser.BaseHoodieDateTimeParser;
 import org.apache.hudi.keygen.parser.HoodieDateTimeParser;
+
+import org.apache.avro.generic.GenericRecord;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -77,12 +79,13 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
 
   TimestampBasedAvroKeyGenerator(TypedProperties config, String recordKeyField, String partitionPathField) throws IOException {
     super(config, Option.ofNullable(recordKeyField), partitionPathField);
-    String dateTimeParserClass = config.getString(KeyGeneratorOptions.Config.DATE_TIME_PARSER_PROP, HoodieDateTimeParser.class.getName());
+    String dateTimeParserClass = config.getString(
+        TimestampKeyGeneratorConfig.DATE_TIME_PARSER.key(), HoodieDateTimeParser.class.getName());
     this.parser = KeyGenUtils.createDateTimeParser(config, dateTimeParserClass);
     this.inputDateTimeZone = parser.getInputDateTimeZone();
     this.outputDateTimeZone = parser.getOutputDateTimeZone();
     this.outputDateFormat = parser.getOutputDateFormat();
-    this.timestampType = TimestampType.valueOf(config.getString(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP));
+    this.timestampType = TimestampType.valueOf(config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key()));
 
     switch (this.timestampType) {
       case EPOCHMILLISECONDS:
@@ -92,7 +95,8 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
         timeUnit = SECONDS;
         break;
       case SCALAR:
-        String timeUnitStr = config.getString(KeyGeneratorOptions.Config.INPUT_TIME_UNIT, TimeUnit.SECONDS.toString());
+        String timeUnitStr = config.getString(
+            TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key(), TimeUnit.SECONDS.toString());
         timeUnit = TimeUnit.valueOf(timeUnitStr.toUpperCase());
         break;
       default:
@@ -126,7 +130,7 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
       // {Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP} won't be null, it has been checked in the initialization process of
       // inputFormatter
       String delimiter = parser.getConfigInputDateFormatDelimiter();
-      String format = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP, "").split(delimiter)[0];
+      String format = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), "").split(delimiter)[0];
 
       // if both input and output timeZone are not configured, use GMT.
       if (null != inputDateTimeZone) {
@@ -181,7 +185,9 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
       timeMs = convertLongTimeToMillis(((LocalDate) partitionVal).toEpochDay());
     } else if (partitionVal instanceof CharSequence) {
       if (!inputFormatter.isPresent()) {
-        throw new HoodieException("Missing input formatter. Ensure " + KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP + " config is set when timestampType is DATE_STRING or MIXED!");
+        throw new HoodieException("Missing input formatter. Ensure "
+            + TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key()
+            + " config is set when timestampType is DATE_STRING or MIXED!");
       }
       DateTime parsedDateTime = inputFormatter.get().parseDateTime(partitionVal.toString());
       if (this.outputDateTimeZone == null) {
@@ -205,7 +211,8 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
   private long convertLongTimeToMillis(Long partitionVal) {
     if (timeUnit == null) {
       // should not be possible
-      throw new RuntimeException(KeyGeneratorOptions.Config.INPUT_TIME_UNIT + " is not specified but scalar it supplied as time value");
+      throw new RuntimeException(TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key()
+          + " is not specified but scalar it supplied as time value");
     }
     return MILLISECONDS.convert(partitionVal, timeUnit);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/BaseHoodieDateTimeParser.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/BaseHoodieDateTimeParser.java
@@ -17,9 +17,10 @@
 
 package org.apache.hudi.keygen.parser;
 
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -36,7 +37,8 @@ public abstract class BaseHoodieDateTimeParser implements Serializable {
   }
 
   private String initInputDateFormatDelimiter() {
-    String inputDateFormatDelimiter = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX_PROP, ",").trim();
+    String inputDateFormatDelimiter = config.getString(
+        TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(), ",").trim();
     inputDateFormatDelimiter = inputDateFormatDelimiter.isEmpty() ? "," : inputDateFormatDelimiter;
     return inputDateFormatDelimiter;
   }
@@ -45,7 +47,7 @@ public abstract class BaseHoodieDateTimeParser implements Serializable {
    * Returns the output date format in which the partition paths will be created for the hudi dataset.
    */
   public String getOutputDateFormat() {
-    return config.getString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP);
+    return config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/BaseHoodieDateTimeParser.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/BaseHoodieDateTimeParser.java
@@ -17,7 +17,6 @@
 
 package org.apache.hudi.keygen.parser;
 
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 
@@ -25,6 +24,9 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.io.Serializable;
+
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
 
 public abstract class BaseHoodieDateTimeParser implements Serializable {
 
@@ -38,7 +40,7 @@ public abstract class BaseHoodieDateTimeParser implements Serializable {
 
   private String initInputDateFormatDelimiter() {
     String inputDateFormatDelimiter = config.getString(
-        TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(), ",").trim();
+        TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(), ",").trim();
     inputDateFormatDelimiter = inputDateFormatDelimiter.isEmpty() ? "," : inputDateFormatDelimiter;
     return inputDateFormatDelimiter;
   }
@@ -47,7 +49,7 @@ public abstract class BaseHoodieDateTimeParser implements Serializable {
    * Returns the output date format in which the partition paths will be created for the hudi dataset.
    */
   public String getOutputDateFormat() {
-    return config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key());
+    return config.getString(TIMESTAMP_OUTPUT_DATE_FORMAT.key());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/HoodieDateTimeParser.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/HoodieDateTimeParser.java
@@ -17,11 +17,12 @@
 
 package org.apache.hudi.keygen.parser;
 
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator.TimestampType;
 import org.apache.hudi.keygen.KeyGenUtils;
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator.TimestampType;
+
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -42,13 +43,15 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
 
   public HoodieDateTimeParser(TypedProperties config) {
     super(config);
-    KeyGenUtils.checkRequiredProperties(config, Arrays.asList(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP, KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP));
+    KeyGenUtils.checkRequiredProperties(config,
+        Arrays.asList(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
+            TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key()));
     this.inputDateTimeZone = getInputDateTimeZone();
   }
 
   private DateTimeFormatter getInputDateFormatter() {
     if (this.configInputDateFormatList.isEmpty()) {
-      throw new IllegalArgumentException(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP + " configuration is required");
+      throw new IllegalArgumentException(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key() + " configuration is required");
     }
 
     DateTimeFormatter formatter = new DateTimeFormatterBuilder()
@@ -72,16 +75,17 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
 
   @Override
   public String getOutputDateFormat() {
-    return config.getString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP);
+    return config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key());
   }
 
   @Override
   public Option<DateTimeFormatter> getInputFormatter() {
-    TimestampType timestampType = TimestampType.valueOf(config.getString(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP));
+    TimestampType timestampType = TimestampType.valueOf(
+        config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key()));
     if (timestampType == TimestampType.DATE_STRING || timestampType == TimestampType.MIXED) {
       KeyGenUtils.checkRequiredProperties(config,
-          Collections.singletonList(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP));
-      this.configInputDateFormatList = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP, "");
+          Collections.singletonList(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key()));
+      this.configInputDateFormatList = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), "");
       return Option.of(getInputDateFormatter());
     }
 
@@ -91,10 +95,10 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
   @Override
   public DateTimeZone getInputDateTimeZone() {
     String inputTimeZone;
-    if (config.containsKey(KeyGeneratorOptions.Config.TIMESTAMP_TIMEZONE_FORMAT_PROP)) {
-      inputTimeZone = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, "GMT");
+    if (config.containsKey(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key())) {
+      inputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(), "GMT");
     } else {
-      inputTimeZone = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_TIMEZONE_FORMAT_PROP, "");
+      inputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(), "");
     }
     return !inputTimeZone.trim().isEmpty() ? DateTimeZone.forTimeZone(TimeZone.getTimeZone(inputTimeZone)) : null;
   }
@@ -102,10 +106,10 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
   @Override
   public DateTimeZone getOutputDateTimeZone() {
     String outputTimeZone;
-    if (config.containsKey(KeyGeneratorOptions.Config.TIMESTAMP_TIMEZONE_FORMAT_PROP)) {
-      outputTimeZone = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, "GMT");
+    if (config.containsKey(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key())) {
+      outputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(), "GMT");
     } else {
-      outputTimeZone = config.getString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP, "");
+      outputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "");
     }
     return !outputTimeZone.trim().isEmpty() ? DateTimeZone.forTimeZone(TimeZone.getTimeZone(outputTimeZone)) : null;
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/HoodieDateTimeParser.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/parser/HoodieDateTimeParser.java
@@ -17,7 +17,6 @@
 
 package org.apache.hudi.keygen.parser;
 
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.keygen.KeyGenUtils;
@@ -33,6 +32,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.TimeZone;
 
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD;
+
 public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
 
   private String configInputDateFormatList;
@@ -43,15 +49,14 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
 
   public HoodieDateTimeParser(TypedProperties config) {
     super(config);
-    KeyGenUtils.checkRequiredProperties(config,
-        Arrays.asList(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
-            TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key()));
+    KeyGenUtils.checkRequiredProperties(
+        config, Arrays.asList(TIMESTAMP_TYPE_FIELD.key(), TIMESTAMP_OUTPUT_DATE_FORMAT.key()));
     this.inputDateTimeZone = getInputDateTimeZone();
   }
 
   private DateTimeFormatter getInputDateFormatter() {
     if (this.configInputDateFormatList.isEmpty()) {
-      throw new IllegalArgumentException(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key() + " configuration is required");
+      throw new IllegalArgumentException(TIMESTAMP_INPUT_DATE_FORMAT.key() + " configuration is required");
     }
 
     DateTimeFormatter formatter = new DateTimeFormatterBuilder()
@@ -75,17 +80,17 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
 
   @Override
   public String getOutputDateFormat() {
-    return config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key());
+    return config.getString(TIMESTAMP_OUTPUT_DATE_FORMAT.key());
   }
 
   @Override
   public Option<DateTimeFormatter> getInputFormatter() {
     TimestampType timestampType = TimestampType.valueOf(
-        config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key()));
+        config.getString(TIMESTAMP_TYPE_FIELD.key()));
     if (timestampType == TimestampType.DATE_STRING || timestampType == TimestampType.MIXED) {
       KeyGenUtils.checkRequiredProperties(config,
-          Collections.singletonList(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key()));
-      this.configInputDateFormatList = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), "");
+          Collections.singletonList(TIMESTAMP_INPUT_DATE_FORMAT.key()));
+      this.configInputDateFormatList = config.getString(TIMESTAMP_INPUT_DATE_FORMAT.key(), "");
       return Option.of(getInputDateFormatter());
     }
 
@@ -95,10 +100,10 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
   @Override
   public DateTimeZone getInputDateTimeZone() {
     String inputTimeZone;
-    if (config.containsKey(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key())) {
-      inputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(), "GMT");
+    if (config.containsKey(TIMESTAMP_TIMEZONE_FORMAT.key())) {
+      inputTimeZone = config.getString(TIMESTAMP_TIMEZONE_FORMAT.key(), "GMT");
     } else {
-      inputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(), "");
+      inputTimeZone = config.getString(TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(), "");
     }
     return !inputTimeZone.trim().isEmpty() ? DateTimeZone.forTimeZone(TimeZone.getTimeZone(inputTimeZone)) : null;
   }
@@ -106,10 +111,10 @@ public class HoodieDateTimeParser extends BaseHoodieDateTimeParser {
   @Override
   public DateTimeZone getOutputDateTimeZone() {
     String outputTimeZone;
-    if (config.containsKey(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key())) {
-      outputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(), "GMT");
+    if (config.containsKey(TIMESTAMP_TIMEZONE_FORMAT.key())) {
+      outputTimeZone = config.getString(TIMESTAMP_TIMEZONE_FORMAT.key(), "GMT");
     } else {
-      outputTimeZone = config.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "");
+      outputTimeZone = config.getString(TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "");
     }
     return !outputTimeZone.trim().isEmpty() ? DateTimeZone.forTimeZone(TimeZone.getTimeZone(outputTimeZone)) : null;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -53,6 +53,11 @@ public class ConfigGroups {
         "Index Configs",
         "Configurations that control indexing behavior, "
             + "which tags incoming records as either inserts or updates to older records."),
+    KEY_GENERATOR(
+        "Key Generator Configs",
+        "Hudi maintains keys (record key + partition path) for uniquely identifying a "
+            + "particular record. These configs allow developers to setup the Key generator class "
+            + "that extracts these out of incoming records."),
     LOCK(
         "Lock Configs",
         "Configurations that control locking mechanisms required for concurrency control "

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/TimestampKeyGeneratorConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/TimestampKeyGeneratorConfig.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Timestamp-based key generator configs.
+ */
+@ConfigClassProperty(name = "Timestamp-based key generator configs",
+    groupName = ConfigGroups.Names.WRITE_CLIENT,
+    subGroupName = ConfigGroups.SubGroupNames.KEY_GENERATOR,
+    description = "Configs used for TimestampBasedKeyGenerator which relies on timestamps for "
+        + "the partition field. The field values are interpreted as timestamps and not just "
+        + "converted to string while generating partition path value for records. Record key is "
+        + "same as before where it is chosen by field name.")
+public class TimestampKeyGeneratorConfig {
+  private static final String TIMESTAMP_KEYGEN_CONFIG_PREFIX = "hoodie.deltastreamer.keygen.timebased.";
+
+  public static final ConfigProperty<String> TIMESTAMP_TYPE_FIELD = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "timestamp.type")
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("Timestamp type of the field, which should be one of the timestamp types "
+          + "supported: `UNIX_TIMESTAMP`, `DATE_STRING`, `MIXED`, `EPOCHMILLISECONDS`, `SCALAR`.");
+
+  public static final ConfigProperty<String> INPUT_TIME_UNIT = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "timestamp.scalar.time.unit")
+      .defaultValue(TimeUnit.SECONDS.toString())
+      .markAdvanced()
+      .withDocumentation("When timestamp type `SCALAR` is used, this specifies the time unit, "
+          + "with allowed unit specified by `TimeUnit` enums (`NANOSECONDS`, `MICROSECONDS`, "
+          + "`MILLISECONDS`, `SECONDS`, `MINUTES`, `HOURS`, `DAYS`).");
+
+  //This prop can now accept list of input date formats.
+  public static final ConfigProperty<String> TIMESTAMP_INPUT_DATE_FORMAT = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "input.dateformat")
+      .defaultValue("")
+      .markAdvanced()
+      .withDocumentation("Input date format such as `yyyy-MM-dd'T'HH:mm:ss.SSSZ`.");
+
+  public static final ConfigProperty<String> TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "input.dateformat.list.delimiter.regex")
+      .defaultValue(",")
+      .markAdvanced()
+      .withDocumentation("The delimiter for allowed input date format list, usually `,`.");
+
+  public static final ConfigProperty<String> TIMESTAMP_INPUT_TIMEZONE_FORMAT = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "input.timezone")
+      .defaultValue("UTC")
+      .markAdvanced()
+      .withDocumentation("Timezone of the input timestamp, such as `UTC`.");
+
+  public static final ConfigProperty<String> TIMESTAMP_OUTPUT_DATE_FORMAT = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "output.dateformat")
+      .defaultValue("")
+      .markAdvanced()
+      .withDocumentation("Output date format such as `yyyy-MM-dd'T'HH:mm:ss.SSSZ`.");
+
+  public static final ConfigProperty<String> TIMESTAMP_OUTPUT_TIMEZONE_FORMAT = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "output.timezone")
+      .defaultValue("UTC")
+      .markAdvanced()
+      .withDocumentation("Timezone of the output timestamp, such as `UTC`.");
+
+  //still keeping this prop for backward compatibility so that functionality for existing users does not break.
+  @Deprecated
+  public static final ConfigProperty<String> TIMESTAMP_TIMEZONE_FORMAT = ConfigProperty
+      .key(TIMESTAMP_KEYGEN_CONFIG_PREFIX + "timezone")
+      .defaultValue("UTC")
+      .markAdvanced()
+      .withDocumentation("Timezone of both input and output timestamp if they are the same, such "
+          + "as `UTC`.  Please use `" + TIMESTAMP_INPUT_TIMEZONE_FORMAT.key() + "` and `"
+          + TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key() + "` instead if the input and output timezones "
+          + "are different.");
+
+  public static final ConfigProperty<String> DATE_TIME_PARSER = ConfigProperty
+      .key("hoodie.deltastreamer.keygen.datetime.parser.class")
+      .defaultValue("org.apache.hudi.keygen.parser.HoodieDateTimeParser")
+      .markAdvanced()
+      .withDocumentation("Date time parser class name.");
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.OrderedProperties;
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -40,7 +41,6 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -217,11 +217,14 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
 
   public static final List<String> PERSISTED_CONFIG_LIST = Arrays.asList(
-      Config.DATE_TIME_PARSER_PROP,
-      Config.INPUT_TIME_UNIT, Config.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX_PROP,
-      Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP, Config.TIMESTAMP_INPUT_TIMEZONE_FORMAT_PROP,
-      Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, Config.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP,
-      Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, Config.DATE_TIME_PARSER_PROP
+      TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key(),
+      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(),
+      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(),
+      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(),
+      TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(),
+      TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(),
+      TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(),
+      TimestampKeyGeneratorConfig.DATE_TIME_PARSER.key()
   );
 
   public static final String NO_OP_BOOTSTRAP_INDEX_CLASS = NoOpBootstrapIndex.class.getName();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.OrderedProperties;
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -62,6 +61,14 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.DATE_TIME_PARSER;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.INPUT_TIME_UNIT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT;
 
 /**
  * Configurations on the Hoodie Table like type of ingestion, storage formats, hive table name etc Configurations are loaded from hoodie.properties, these properties are usually set during
@@ -217,14 +224,14 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
 
   public static final List<String> PERSISTED_CONFIG_LIST = Arrays.asList(
-      TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key(),
-      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(),
-      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(),
-      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(),
-      TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(),
-      TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(),
-      TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(),
-      TimestampKeyGeneratorConfig.DATE_TIME_PARSER.key()
+      INPUT_TIME_UNIT.key(),
+      TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(),
+      TIMESTAMP_INPUT_DATE_FORMAT.key(),
+      TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(),
+      TIMESTAMP_OUTPUT_DATE_FORMAT.key(),
+      TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(),
+      TIMESTAMP_TIMEZONE_FORMAT.key(),
+      DATE_TIME_PARSER.key()
   );
 
   public static final String NO_OP_BOOTSTRAP_INDEX_CLASS = NoOpBootstrapIndex.class.getName();

--- a/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/keygen/constant/KeyGeneratorOptions.java
@@ -22,16 +22,16 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 
 /**
  * Key generator configs.
  */
 @ConfigClassProperty(name = "Key Generator Options",
     groupName = ConfigGroups.Names.WRITE_CLIENT,
-    description = "Hudi maintains keys (record key + partition path) "
-        + "for uniquely identifying a particular record. "
-        + "This config allows developers to setup the Key generator class that "
-        + "will extract these out of incoming records.")
+    subGroupName = ConfigGroups.SubGroupNames.KEY_GENERATOR,
+    areCommonConfigs = true,
+    description = "")
 public class KeyGeneratorOptions extends HoodieConfig {
 
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = ConfigProperty
@@ -105,24 +105,31 @@ public class KeyGeneratorOptions extends HoodieConfig {
   /**
    * Supported configs.
    */
+  @Deprecated
   public static class Config {
 
     // One value from TimestampType above
-    public static final String TIMESTAMP_TYPE_FIELD_PROP = "hoodie.deltastreamer.keygen.timebased.timestamp.type";
-    public static final String INPUT_TIME_UNIT =
-        "hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time.unit";
+    @Deprecated
+    public static final String TIMESTAMP_TYPE_FIELD_PROP = TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key();
+    @Deprecated
+    public static final String INPUT_TIME_UNIT = TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key();
     //This prop can now accept list of input date formats.
-    public static final String TIMESTAMP_INPUT_DATE_FORMAT_PROP =
-        "hoodie.deltastreamer.keygen.timebased.input.dateformat";
-    public static final String TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX_PROP = "hoodie.deltastreamer.keygen.timebased.input.dateformat.list.delimiter.regex";
-    public static final String TIMESTAMP_INPUT_TIMEZONE_FORMAT_PROP = "hoodie.deltastreamer.keygen.timebased.input.timezone";
-    public static final String TIMESTAMP_OUTPUT_DATE_FORMAT_PROP =
-        "hoodie.deltastreamer.keygen.timebased.output.dateformat";
+    @Deprecated
+    public static final String TIMESTAMP_INPUT_DATE_FORMAT_PROP = TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key();
+    @Deprecated
+    public static final String TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX_PROP =
+        TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key();
+    @Deprecated
+    public static final String TIMESTAMP_INPUT_TIMEZONE_FORMAT_PROP = TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key();
+    @Deprecated
+    public static final String TIMESTAMP_OUTPUT_DATE_FORMAT_PROP = TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key();
     //still keeping this prop for backward compatibility so that functionality for existing users does not break.
-    public static final String TIMESTAMP_TIMEZONE_FORMAT_PROP =
-        "hoodie.deltastreamer.keygen.timebased.timezone";
-    public static final String TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP = "hoodie.deltastreamer.keygen.timebased.output.timezone";
-    public static final String DATE_TIME_PARSER_PROP = "hoodie.deltastreamer.keygen.datetime.parser.class";
+    @Deprecated
+    public static final String TIMESTAMP_TIMEZONE_FORMAT_PROP = TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key();
+    @Deprecated
+    public static final String TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP = TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key();
+    @Deprecated
+    public static final String DATE_TIME_PARSER_PROP = TimestampKeyGeneratorConfig.DATE_TIME_PARSER.key();
   }
 }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -31,7 +32,6 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
 import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator;
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.StreamerUtil;
@@ -61,10 +61,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES;
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED;
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED;
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES;
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE;
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
 /**
@@ -324,26 +324,26 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
       int precision = DataTypeUtils.precision(fieldType.getLogicalType());
       if (precision == 0) {
         // seconds
-        conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP,
+        conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
             TimestampBasedAvroKeyGenerator.TimestampType.UNIX_TIMESTAMP.name());
       } else if (precision == 3) {
         // milliseconds
-        conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP,
+        conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
             TimestampBasedAvroKeyGenerator.TimestampType.EPOCHMILLISECONDS.name());
       }
       String outputPartitionFormat = conf.getOptional(FlinkOptions.PARTITION_FORMAT).orElse(FlinkOptions.PARTITION_FORMAT_HOUR);
-      conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, outputPartitionFormat);
+      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputPartitionFormat);
     } else {
-      conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP,
+      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
           TimestampBasedAvroKeyGenerator.TimestampType.SCALAR.name());
-      conf.setString(KeyGeneratorOptions.Config.INPUT_TIME_UNIT, TimeUnit.DAYS.toString());
+      conf.setString(TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key(), TimeUnit.DAYS.toString());
 
       String outputPartitionFormat = conf.getOptional(FlinkOptions.PARTITION_FORMAT).orElse(FlinkOptions.PARTITION_FORMAT_DAY);
-      conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, outputPartitionFormat);
+      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputPartitionFormat);
       // the option is actually useless, it only works for validation
-      conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP, FlinkOptions.PARTITION_FORMAT_DAY);
+      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), FlinkOptions.PARTITION_FORMAT_DAY);
     }
-    conf.setString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP, "UTC");
+    conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "UTC");
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -65,6 +64,11 @@ import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXE
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.INPUT_TIME_UNIT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
 /**
@@ -324,26 +328,26 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
       int precision = DataTypeUtils.precision(fieldType.getLogicalType());
       if (precision == 0) {
         // seconds
-        conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
+        conf.setString(TIMESTAMP_TYPE_FIELD.key(),
             TimestampBasedAvroKeyGenerator.TimestampType.UNIX_TIMESTAMP.name());
       } else if (precision == 3) {
         // milliseconds
-        conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
+        conf.setString(TIMESTAMP_TYPE_FIELD.key(),
             TimestampBasedAvroKeyGenerator.TimestampType.EPOCHMILLISECONDS.name());
       }
       String outputPartitionFormat = conf.getOptional(FlinkOptions.PARTITION_FORMAT).orElse(FlinkOptions.PARTITION_FORMAT_HOUR);
-      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputPartitionFormat);
+      conf.setString(TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputPartitionFormat);
     } else {
-      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(),
+      conf.setString(TIMESTAMP_TYPE_FIELD.key(),
           TimestampBasedAvroKeyGenerator.TimestampType.SCALAR.name());
-      conf.setString(TimestampKeyGeneratorConfig.INPUT_TIME_UNIT.key(), TimeUnit.DAYS.toString());
+      conf.setString(INPUT_TIME_UNIT.key(), TimeUnit.DAYS.toString());
 
       String outputPartitionFormat = conf.getOptional(FlinkOptions.PARTITION_FORMAT).orElse(FlinkOptions.PARTITION_FORMAT_DAY);
-      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputPartitionFormat);
+      conf.setString(TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputPartitionFormat);
       // the option is actually useless, it only works for validation
-      conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), FlinkOptions.PARTITION_FORMAT_DAY);
+      conf.setString(TIMESTAMP_INPUT_DATE_FORMAT.key(), FlinkOptions.PARTITION_FORMAT_DAY);
     }
-    conf.setString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "UTC");
+    conf.setString(TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "UTC");
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -53,6 +52,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -639,11 +641,11 @@ public class TestHoodieTableFactory {
     final Configuration conf1 = tableSource1.getConf();
     assertThat(conf1.get(FlinkOptions.RECORD_KEY_FIELD), is("f0"));
     assertThat(conf1.get(FlinkOptions.KEYGEN_CLASS_NAME), is(TimestampBasedAvroKeyGenerator.class.getName()));
-    assertThat(conf1.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(), "dummy"),
+    assertThat(conf1.getString(TIMESTAMP_TYPE_FIELD.key(), "dummy"),
         is("EPOCHMILLISECONDS"));
-    assertThat(conf1.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), "dummy"),
+    assertThat(conf1.getString(TIMESTAMP_OUTPUT_DATE_FORMAT.key(), "dummy"),
         is(FlinkOptions.PARTITION_FORMAT_HOUR));
-    assertThat(conf1.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "dummy"),
+    assertThat(conf1.getString(TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "dummy"),
         is("UTC"));
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.avro.AvroSchemaUtils;
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -28,7 +29,6 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
 import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator;
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.util.AvroSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.SchemaBuilder;
@@ -639,11 +639,11 @@ public class TestHoodieTableFactory {
     final Configuration conf1 = tableSource1.getConf();
     assertThat(conf1.get(FlinkOptions.RECORD_KEY_FIELD), is("f0"));
     assertThat(conf1.get(FlinkOptions.KEYGEN_CLASS_NAME), is(TimestampBasedAvroKeyGenerator.class.getName()));
-    assertThat(conf1.getString(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP, "dummy"),
+    assertThat(conf1.getString(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(), "dummy"),
         is("EPOCHMILLISECONDS"));
-    assertThat(conf1.getString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, "dummy"),
+    assertThat(conf1.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), "dummy"),
         is(FlinkOptions.PARTITION_FORMAT_HOUR));
-    assertThat(conf1.getString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP, "dummy"),
+    assertThat(conf1.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), "dummy"),
         is("UTC"));
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -20,13 +20,12 @@ package org.apache.hudi
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hudi.HoodieFileIndex.{DataSkippingFailureMode, collectReferencedColumns, getConfigProperties}
 import org.apache.hudi.HoodieSparkConfUtils.getConfigValue
-import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, TimestampKeyGeneratorConfig, TypedProperties}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.util.{CollectionUtils, StringUtils}
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.HoodieException
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 import org.apache.hudi.keygen.{TimestampBasedAvroKeyGenerator, TimestampBasedKeyGenerator}
-import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadataUtil}
+import org.apache.hudi.metadata.HoodieMetadataPayload
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{And, Expression, Literal}
@@ -39,10 +38,8 @@ import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.text.SimpleDateFormat
-import java.util
 import javax.annotation.concurrent.NotThreadSafe
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
@@ -338,10 +335,10 @@ object HoodieFileIndex extends Logging {
 
     if (keyGenerator != null && (keyGenerator.equals(classOf[TimestampBasedKeyGenerator].getCanonicalName) ||
         keyGenerator.equals(classOf[TimestampBasedAvroKeyGenerator].getCanonicalName))) {
-      val inputFormat = tableConfig.getString(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP)
-      val outputFormat = tableConfig.getString(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP)
+      val inputFormat = tableConfig.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key())
+      val outputFormat = tableConfig.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key())
       if (StringUtils.isNullOrEmpty(inputFormat) || StringUtils.isNullOrEmpty(outputFormat) ||
-          inputFormat.equals(outputFormat)) {
+        inputFormat.equals(outputFormat)) {
         partitionFilters
       } else {
         try {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -20,7 +20,8 @@ package org.apache.hudi
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hudi.HoodieFileIndex.{DataSkippingFailureMode, collectReferencedColumns, getConfigProperties}
 import org.apache.hudi.HoodieSparkConfUtils.getConfigValue
-import org.apache.hudi.common.config.{HoodieMetadataConfig, TimestampKeyGeneratorConfig, TypedProperties}
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.HoodieException
@@ -335,8 +336,8 @@ object HoodieFileIndex extends Logging {
 
     if (keyGenerator != null && (keyGenerator.equals(classOf[TimestampBasedKeyGenerator].getCanonicalName) ||
         keyGenerator.equals(classOf[TimestampBasedAvroKeyGenerator].getCanonicalName))) {
-      val inputFormat = tableConfig.getString(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key())
-      val outputFormat = tableConfig.getString(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key())
+      val inputFormat = tableConfig.getString(TIMESTAMP_INPUT_DATE_FORMAT.key())
+      val outputFormat = tableConfig.getString(TIMESTAMP_OUTPUT_DATE_FORMAT.key())
       if (StringUtils.isNullOrEmpty(inputFormat) || StringUtils.isNullOrEmpty(outputFormat) ||
         inputFormat.equals(outputFormat)) {
         partitionFilters

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/TestTimestampBasedKeyGenerator.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/TestTimestampBasedKeyGenerator.java
@@ -20,7 +20,6 @@ package org.apache.hudi.keygen;
 
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.avro.AvroSchemaUtils;
-import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
@@ -47,6 +46,13 @@ import java.math.BigDecimal;
 
 import scala.Function1;
 
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTimestampBasedKeyGenerator {
@@ -88,9 +94,9 @@ public class TestTimestampBasedKeyGenerator {
     TypedProperties properties = new TypedProperties(this.properties);
 
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), partitionPathField);
-    properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(), timestampType);
-    properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), dateFormat);
-    properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(), timezone);
+    properties.setProperty(TIMESTAMP_TYPE_FIELD.key(), timestampType);
+    properties.setProperty(TIMESTAMP_OUTPUT_DATE_FORMAT.key(), dateFormat);
+    properties.setProperty(TIMESTAMP_TIMEZONE_FORMAT.key(), timezone);
 
     if (scalarType != null) {
       properties.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time.unit", scalarType);
@@ -111,22 +117,22 @@ public class TestTimestampBasedKeyGenerator {
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), partitionPathField);
 
     if (timestampType != null) {
-      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(), timestampType);
+      properties.setProperty(TIMESTAMP_TYPE_FIELD.key(), timestampType);
     }
     if (inputFormatList != null) {
-      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), inputFormatList);
+      properties.setProperty(TIMESTAMP_INPUT_DATE_FORMAT.key(), inputFormatList);
     }
     if (inputFormatDelimiterRegex != null) {
-      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(), inputFormatDelimiterRegex);
+      properties.setProperty(TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(), inputFormatDelimiterRegex);
     }
     if (inputTimezone != null) {
-      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(), inputTimezone);
+      properties.setProperty(TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(), inputTimezone);
     }
     if (outputFormat != null) {
-      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputFormat);
+      properties.setProperty(TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputFormat);
     }
     if (outputTimezone != null) {
-      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), outputTimezone);
+      properties.setProperty(TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), outputTimezone);
     }
     return properties;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/TestTimestampBasedKeyGenerator.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/TestTimestampBasedKeyGenerator.java
@@ -18,19 +18,21 @@
 
 package org.apache.hudi.keygen;
 
-import org.apache.avro.Conversions;
-import org.apache.avro.LogicalTypes;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericFixed;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.avro.AvroSchemaUtils;
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.exception.HoodieKeyGeneratorException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.testutils.KeyGeneratorTestUtilities;
+
+import org.apache.avro.Conversions;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
@@ -39,10 +41,11 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import scala.Function1;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+
+import scala.Function1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -85,9 +88,9 @@ public class TestTimestampBasedKeyGenerator {
     TypedProperties properties = new TypedProperties(this.properties);
 
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), partitionPathField);
-    properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP, timestampType);
-    properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, dateFormat);
-    properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, timezone);
+    properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(), timestampType);
+    properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), dateFormat);
+    properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key(), timezone);
 
     if (scalarType != null) {
       properties.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time.unit", scalarType);
@@ -108,22 +111,22 @@ public class TestTimestampBasedKeyGenerator {
     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), partitionPathField);
 
     if (timestampType != null) {
-      properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_TYPE_FIELD_PROP, timestampType);
+      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key(), timestampType);
     }
     if (inputFormatList != null) {
-      properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP, inputFormatList);
+      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key(), inputFormatList);
     }
     if (inputFormatDelimiterRegex != null) {
-      properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX_PROP, inputFormatDelimiterRegex);
+      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT_LIST_DELIMITER_REGEX.key(), inputFormatDelimiterRegex);
     }
     if (inputTimezone != null) {
-      properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_INPUT_TIMEZONE_FORMAT_PROP, inputTimezone);
+      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_TIMEZONE_FORMAT.key(), inputTimezone);
     }
     if (outputFormat != null) {
-      properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, outputFormat);
+      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key(), outputFormat);
     }
     if (outputTimezone != null) {
-      properties.setProperty(KeyGeneratorOptions.Config.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT_PROP, outputTimezone);
+      properties.setProperty(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT.key(), outputTimezone);
     }
     return properties;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -25,7 +25,8 @@ import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.HoodieFileIndex.DataSkippingFailureMode
 import org.apache.hudi.client.HoodieJavaWriteClient
 import org.apache.hudi.client.common.HoodieJavaEngineContext
-import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, TimestampKeyGeneratorConfig}
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TYPE_FIELD}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.engine.EngineType
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
@@ -122,9 +123,9 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     val writer: DataFrameWriter[Row] = inputDF1.write.format("hudi")
       .options(commonOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
-      .option(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key, TimestampType.DATE_STRING.name())
-      .option(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key, "yyyy/MM/dd")
-      .option(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key, "yyyy-MM-dd")
+      .option(TIMESTAMP_TYPE_FIELD.key, TimestampType.DATE_STRING.name())
+      .option(TIMESTAMP_INPUT_DATE_FORMAT.key, "yyyy/MM/dd")
+      .option(TIMESTAMP_OUTPUT_DATE_FORMAT.key, "yyyy-MM-dd")
       .mode(SaveMode.Overwrite)
 
     if (isNullOrEmpty(keyGenerator)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.HoodieFileIndex.DataSkippingFailureMode
 import org.apache.hudi.client.HoodieJavaWriteClient
 import org.apache.hudi.client.common.HoodieJavaEngineContext
-import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, TimestampKeyGeneratorConfig}
 import org.apache.hudi.common.engine.EngineType
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
@@ -39,7 +39,6 @@ import org.apache.hudi.common.util.StringUtils.isNullOrEmpty
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator.TimestampType
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config
 import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 import org.apache.hudi.util.JFunction
@@ -123,9 +122,9 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     val writer: DataFrameWriter[Row] = inputDF1.write.format("hudi")
       .options(commonOpts)
       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
-      .option(Config.TIMESTAMP_TYPE_FIELD_PROP, TimestampType.DATE_STRING.name())
-      .option(Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP, "yyyy/MM/dd")
-      .option(Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP, "yyyy-MM-dd")
+      .option(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key, TimestampType.DATE_STRING.name())
+      .option(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key, "yyyy/MM/dd")
+      .option(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key, "yyyy-MM-dd")
       .mode(SaveMode.Overwrite)
 
     if (isNullOrEmpty(keyGenerator)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
@@ -19,7 +19,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.config.{HoodieMetadataConfig, TimestampKeyGeneratorConfig}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
@@ -27,7 +27,6 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.keygen.TimestampBasedKeyGenerator
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
@@ -81,9 +80,9 @@ class TestCOWDataSourceStorage extends SparkClientFunctionalTestHarness {
     val isTimestampBasedKeyGen: Boolean = classOf[TimestampBasedKeyGenerator].getName.equals(keyGenClass)
     if (isTimestampBasedKeyGen) {
       options += DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "_row_key"
-      options += Config.TIMESTAMP_TYPE_FIELD_PROP -> "DATE_STRING"
-      options += Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP -> "yyyy/MM/dd"
-      options += Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP -> "yyyyMMdd"
+      options += TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING"
+      options += TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key -> "yyyy/MM/dd"
+      options += TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key -> "yyyyMMdd"
     }
     val dataGen = new HoodieTestDataGenerator(0xDEED)
     val fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
@@ -19,7 +19,8 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.common.config.{HoodieMetadataConfig, TimestampKeyGeneratorConfig}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TYPE_FIELD}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
@@ -80,9 +81,9 @@ class TestCOWDataSourceStorage extends SparkClientFunctionalTestHarness {
     val isTimestampBasedKeyGen: Boolean = classOf[TimestampBasedKeyGenerator].getName.equals(keyGenClass)
     if (isTimestampBasedKeyGen) {
       options += DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "_row_key"
-      options += TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING"
-      options += TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key -> "yyyy/MM/dd"
-      options += TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key -> "yyyyMMdd"
+      options += TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING"
+      options += TIMESTAMP_INPUT_DATE_FORMAT.key -> "yyyy/MM/dd"
+      options += TIMESTAMP_OUTPUT_DATE_FORMAT.key -> "yyyyMMdd"
     }
     val dataGen = new HoodieTestDataGenerator(0xDEED)
     val fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.client.SparkRDDWriteClient
-import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, TimestampKeyGeneratorConfig}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model._
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -32,7 +32,6 @@ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, Hoodie
 import org.apache.hudi.functional.TestCOWDataSource.convertColumnsToNullable
 import org.apache.hudi.hadoop.config.HoodieRealtimeConfig
 import org.apache.hudi.index.HoodieIndex.IndexType
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieSparkClientTestBase}
 import org.apache.hudi.util.JFunction
@@ -1055,10 +1054,10 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       "hoodie.compact.inline" -> "false",
       DataSourceWriteOptions.TABLE_TYPE.key -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.TimestampBasedKeyGenerator",
-      Config.TIMESTAMP_TYPE_FIELD_PROP -> "DATE_STRING",
-      Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP -> "yyyy/MM/dd",
-      Config.TIMESTAMP_TIMEZONE_FORMAT_PROP -> "GMT+8:00",
-      Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP -> "yyyy-MM-dd"
+      TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING",
+      TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key -> "yyyy/MM/dd",
+      TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key -> "GMT+8:00",
+      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key -> "yyyy-MM-dd"
     ) ++ writeOpts
 
     val dataGen1 = new HoodieTestDataGenerator(Array("2022-01-01"))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -21,7 +21,8 @@ import org.apache.hadoop.fs.Path
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
 import org.apache.hudi.client.SparkRDDWriteClient
-import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, TimestampKeyGeneratorConfig}
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TIMEZONE_FORMAT, TIMESTAMP_TYPE_FIELD}
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model._
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -1054,10 +1055,10 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       "hoodie.compact.inline" -> "false",
       DataSourceWriteOptions.TABLE_TYPE.key -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.TimestampBasedKeyGenerator",
-      TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING",
-      TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key -> "yyyy/MM/dd",
-      TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT.key -> "GMT+8:00",
-      TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key -> "yyyy-MM-dd"
+      TIMESTAMP_TYPE_FIELD.key -> "DATE_STRING",
+      TIMESTAMP_OUTPUT_DATE_FORMAT.key -> "yyyy/MM/dd",
+      TIMESTAMP_TIMEZONE_FORMAT.key -> "GMT+8:00",
+      TIMESTAMP_INPUT_DATE_FORMAT.key -> "yyyy-MM-dd"
     ) ++ writeOpts
 
     val dataGen1 = new HoodieTestDataGenerator(Array("2022-01-01"))


### PR DESCRIPTION
### Change Logs

This PR refactors the configs for the timestamp-based key generator (`TimestampBasedKeyGenerator`) to use `ConfigProperty` so that these configs will show up in the `Configurations` page in Hudi website.  No business logic of the timestamp-based key generator configs is changed.

### Impact

Adds the timestamp key generator configs to the configuration docs.

### Risk level

none

### Documentation Update

As above

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
