### PR TITLE
[HUDI-6186] Fix lock identity in InProcessLockProvider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/InProcessLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/InProcessLockProvider.java
@@ -124,7 +124,6 @@ public class InProcessLockProvider implements LockProvider<ReentrantReadWriteLoc
       lock.writeLock().unlock();
     }
     LOG.info(getLogMessage(LockState.ALREADY_RELEASED));
-    LOCK_INSTANCE_PER_BASEPATH.remove(basePath);
   }
 
   private String getLogMessage(LockState state) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
@@ -159,9 +159,7 @@ public class TestInProcessLockProvider {
 
     try {
       writer2.join();
-      LOG.info("writer 2 finishes");
       writer3.join();
-      LOG.info("writer 3 finishes");
     } catch (InterruptedException e) {
       // Ignore any exception
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestInProcessLockProvider.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,6 +52,107 @@ public class TestInProcessLockProvider {
     lockConfiguration1 = new LockConfiguration(properties);
     properties.put(HoodieWriteConfig.BASE_PATH.key(), "table2");
     lockConfiguration2 = new LockConfiguration(properties);
+  }
+
+  @Test
+  public void testLockIdentity() throws InterruptedException {
+    // The lifecycle of an InProcessLockProvider should not affect the singleton lock
+    // for a single table, i.e., all three writers should hold the same underlying lock instance
+    // on the same table.
+    // Writer 1:   lock |----------------| unlock and close
+    // Writer 2:   try lock   |      ...    lock |------| unlock and close
+    // Writer 3:                          try lock  | ...  lock |------| unlock and close
+    List<InProcessLockProvider> lockProviderList = new ArrayList<>();
+    InProcessLockProvider lockProvider1 = new InProcessLockProvider(lockConfiguration1, hadoopConfiguration);
+    lockProviderList.add(lockProvider1);
+    AtomicBoolean writer2Locked = new AtomicBoolean(false);
+    AtomicBoolean writer1Completed = new AtomicBoolean(false);
+    AtomicBoolean writer2Completed = new AtomicBoolean(false);
+    AtomicBoolean writer3Completed = new AtomicBoolean(false);
+
+    // Writer 1
+    assertDoesNotThrow(() -> {
+      LOG.info("Writer 1 tries to acquire the lock.");
+      lockProvider1.lock();
+      LOG.info("Writer 1 acquires the lock.");
+    });
+    // Writer 2 thread in parallel, should block
+    // and later acquire the lock once it is released
+    Thread writer2 = new Thread(() -> {
+      InProcessLockProvider lockProvider2 = new InProcessLockProvider(lockConfiguration1, hadoopConfiguration);
+      lockProviderList.add(lockProvider2);
+      assertDoesNotThrow(() -> {
+        LOG.info("Writer 2 tries to acquire the lock.");
+        lockProvider2.lock();
+        LOG.info("Writer 2 acquires the lock.");
+      });
+      writer2Locked.set(true);
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      assertDoesNotThrow(() -> {
+        lockProvider2.unlock();
+        LOG.info("Writer 2 releases the lock.");
+      });
+      lockProvider2.close();
+      LOG.info("Writer 2 closes the lock provider.");
+      writer2Completed.set(true);
+    });
+
+    Thread writer3 = new Thread(() -> {
+      while (!writer2Locked.get() || !writer1Completed.get()) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+
+      InProcessLockProvider lockProvider3 = new InProcessLockProvider(lockConfiguration1, hadoopConfiguration);
+      lockProviderList.add(lockProvider3);
+      assertDoesNotThrow(() -> {
+        LOG.info("Writer 3 tries to acquire the lock.");
+        lockProvider3.lock();
+        LOG.info("Writer 3 acquires the lock.");
+      });
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      assertDoesNotThrow(() -> {
+        lockProvider3.unlock();
+        LOG.info("Writer 3 releases the lock.");
+      });
+      lockProvider3.close();
+      LOG.info("Writer 3 closes the lock provider.");
+      writer3Completed.set(true);
+    });
+
+    writer2.start();
+    writer3.start();
+
+    Thread.sleep(1000);
+    assertDoesNotThrow(() -> {
+      lockProvider1.unlock();
+      LOG.info("Writer 1 releases the lock.");
+      lockProvider1.close();
+      LOG.info("Writer 1 closes the lock provider.");
+      writer1Completed.set(true);
+    });
+
+    try {
+      writer2.join();
+      writer3.join();
+    } catch (InterruptedException e) {
+      // Ignore any exception
+    }
+    Assertions.assertTrue(writer2Completed.get());
+    Assertions.assertTrue(writer3Completed.get());
+    Assertions.assertEquals(lockProviderList.get(0).getLock(), lockProviderList.get(1).getLock());
+    Assertions.assertEquals(lockProviderList.get(1).getLock(), lockProviderList.get(2).getLock());
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

This PR fixes a bug introduced by #6847.  #6847 extends the `InProcessLockProvider` to support multiple tables in the same process, by having an in-memory static final map storing the mapping of the table base path to the read-write reentrant lock, so that the writer uses the corresponding lock based on the base path.  When closing the lock provider, `close()` removes the lock entry.  Since `close()` is called when closing the write client, the lock is removed and subsequent concurrent writers will get a different lock instance on the same table, causing the locking mechanism on the same table to be useless.  Take the following example where three writers write to the same table concurrently and need to acquire the in-process lock:

```
Writer 1:   lock |----------------| unlock and close
Writer 2:   try lock   |      ...       lock |------| unlock and close
Writer 3:                                    try lock  | ...  lock |------| unlock and close
```

after Writer 1 releases the lock and closes the lock provider, the lock instance is removed from the map, and Writer 3 will get a different lock instance compared to Writer 2, making the lock ineffective.

The fix gets rid of the lock removal operation in the `close()` call since it has to be kept for concurrent writers.

This bug is uncovered while investigating the flaky test `testArchivalWithMultiWriters` (HUDI-6176) where concurrent cannot properly do archival due to the ineffective locking mechanism, although archival is guarded by locks.

A new test `TestInProcessLockProvider#testLockIdentity` based on the above scenario is added to guard the behavior.  Before this fix, the test failed because of varying lock instances (see logs below); after the fix, the test succeeds.

```
1510 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 1 tries to acquire the lock.
1521 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 0, Read locks = 0], Thread ForkJoinPool-1-worker-9, In-process lock state ACQUIRING
1521 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 1, Read locks = 0], Thread ForkJoinPool-1-worker-9, In-process lock state ACQUIRED
1521 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 1 acquires the lock.
1523 [Thread-1] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 2 tries to acquire the lock.
1523 [Thread-1] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 1, Read locks = 0], Thread Thread-1, In-process lock state ACQUIRING
1623 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 1, Read locks = 0], Thread ForkJoinPool-1-worker-9, In-process lock state RELEASING
1624 [Thread-1] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 1, Read locks = 0], Thread Thread-1, In-process lock state ACQUIRED
1624 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 0, Read locks = 0], Thread ForkJoinPool-1-worker-9, In-process lock state RELEASED
1624 [Thread-1] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 2 acquires the lock.
1624 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 1 releases the lock.
1624 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 1, Read locks = 0], Thread ForkJoinPool-1-worker-9, In-process lock state ALREADY_RELEASED
1624 [ForkJoinPool-1-worker-9] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 1 closes the lock provider.
Exception in thread "Thread-2" junit.framework.AssertionFailedError: The lock instance in Writer 3 should be held by Writer 2: java.util.concurrent.locks.ReentrantReadWriteLock@6b563e78[Write locks = 0, Read locks = 0]
	at org.apache.hudi.client.transaction.TestInProcessLockProvider.lambda$testLockIdentity$6(TestInProcessLockProvider.java:127)
	at java.lang.Thread.run(Thread.java:748)
1727 [Thread-1] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 1, Read locks = 0], Thread Thread-1, In-process lock state RELEASING
1727 [Thread-1] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 0, Read locks = 0], Thread Thread-1, In-process lock state RELEASED
1728 [Thread-1] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 2 releases the lock.
1728 [Thread-1] INFO  org.apache.hudi.client.transaction.lock.InProcessLockProvider [] - Base Path table1, Lock Instance java.util.concurrent.locks.ReentrantReadWriteLock@18488497[Write locks = 0, Read locks = 0], Thread Thread-1, In-process lock state ALREADY_RELEASED
1728 [Thread-1] INFO  org.apache.hudi.client.transaction.TestInProcessLockProvider [] - Writer 2 closes the lock provider.

org.opentest4j.AssertionFailedError: 
Expected :true
Actual   :false

at org.apache.hudi.client.transaction.TestInProcessLockProvider.testLockIdentity(TestInProcessLockProvider.java:169)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

### Impact

Fixes a bug in `InProcessLockProvider` that may make in-process lock useless on the same table.

### Risk level

low

### Documentation Update

We need to update the release notes to mention this regression.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
