### PR TITLE
[HUDI-6194] prevent flink writer getting the wrong instant to write

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -422,8 +422,13 @@ public class StreamWriteOperatorCoordinator
         LOG.info("Recommit instant {}", instant);
         commitInstant(instant);
       }
-      // starts a new instant
-      startInstant();
+      String pendingInstant = ckpMetadata.lastPendingInstant();
+      if (pendingInstant == null) {
+        // starts a new instant
+        startInstant();
+      } else { // reuse pending instant if exists, depend on [HUDI-5223]
+        LOG.info("Reuse pending instant " + pendingInstant);
+      }
       // upgrade downgrade
       this.writeClient.upgradeDowngrade(this.instant, this.metaClient);
     }, "initialize instant %s", instant);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -62,6 +62,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -427,6 +428,30 @@ public class TestStreamWriteOperatorCoordinator {
       String lastCompleted = TestUtils.getLastCompleteInstant(tempFile.getAbsolutePath());
       assertThat("Commits the instant with empty batch anyway", lastCompleted, is(instant));
       assertNull(coordinator.getEventBuffer()[0]);
+    }
+  }
+
+  @Test
+  public void testReusePendingInstant() throws Exception {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    MockOperatorCoordinatorContext context = new MockOperatorCoordinatorContext(new OperatorID(), 2);
+    NonThrownExecutor executor = new MockCoordinatorExecutor(context);
+    try (StreamWriteOperatorCoordinator coordinator = new StreamWriteOperatorCoordinator(conf, context)) {
+      coordinator.start();
+      coordinator.setExecutor(executor);
+
+      // trigger a new instant
+      coordinator.handleEventFromOperator(0, WriteMetadataEvent.emptyBootstrap(0));
+      coordinator.handleEventFromOperator(1, WriteMetadataEvent.emptyBootstrap(1));
+
+      // Coordinator start the instant
+      String instant = coordinator.getInstant();
+
+      coordinator.handleEventFromOperator(0, WriteMetadataEvent.emptyBootstrap(0));
+      coordinator.handleEventFromOperator(1, WriteMetadataEvent.emptyBootstrap(1));
+      String instantAfterBoostrap = coordinator.getInstant();
+
+      assertEquals(instant, instantAfterBoostrap, "should reuse pending instant");
     }
   }
 


### PR DESCRIPTION
Flink write hudi
If all task failover and send bootstrap event to `StreamWriteOperatorCoordinator`, and StreamWriteOperatorCoordinator happen to start a new instant i1 before receiving all the bootstrap events, the `AbstractStreamWriteFunction` may start to write with instant i1 when `StreamWriteOperatorCoordinator` start to rollback i1 and start a new instant i2.
`AbstractStreamWriteFunction` will write to a wrong instant i1.

### Change Logs
`StreamWriteOperatorCoordinator` will not start a new instant if there is a pending instant but reuse the pending instant, to prevent `AbstractStreamWriteFunction` get the wrong instant to write.

### Impact

no

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
