### PR TITLE
[HUDI-6192] HoodieFlinkCompactor and HoodieFlinkClusteringJob supports streaming mode in service mode

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringOperator.java
@@ -177,7 +177,7 @@ public class ClusteringOperator extends TableStreamOperator<ClusteringCommitEven
     final String instantTime = event.getClusteringInstantTime();
     final List<ClusteringOperation> clusteringOperations = event.getClusteringGroupInfo().getOperations();
     if (this.asyncClustering) {
-      // executes the compaction task asynchronously to not block the checkpoint barrier propagate.
+      // executes the clustering task asynchronously to not block the checkpoint barrier propagate.
       executor.execute(
           () -> doClustering(instantTime, clusteringOperations),
           (errMsg, t) -> collector.collect(new ClusteringCommitEvent(instantTime, getFileIds(clusteringOperations), taskID)),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/FlinkClusteringConfig.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/FlinkClusteringConfig.java
@@ -29,8 +29,10 @@ import org.apache.hudi.util.StreamerUtil;
 
 import com.beust.jcommander.Parameter;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.hadoop.fs.Path;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -193,6 +195,9 @@ public class FlinkClusteringConfig extends Configuration {
     conf.setInteger(FlinkOptions.CLUSTERING_MAX_NUM_GROUPS, config.maxNumGroups);
     conf.setInteger(FlinkOptions.CLUSTERING_TARGET_PARTITIONS, config.targetPartitions);
     conf.setBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED, config.cleanAsyncEnable);
+
+    // execution checkpointing
+    conf.set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(config.minClusteringIntervalSeconds));
 
     // use synchronous clustering always
     conf.setBoolean(FlinkOptions.CLUSTERING_ASYNC_ENABLED, false);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/HoodieFlinkClusteringJob.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/HoodieFlinkClusteringJob.java
@@ -27,9 +27,11 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.sink.common.ServiceSourceFunction;
 import org.apache.hudi.sink.compact.HoodieFlinkCompactor;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.util.AvroSchemaConverter;
@@ -45,6 +47,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.client.deployment.application.ApplicationExecutionException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.types.DataType;
@@ -100,7 +103,7 @@ public class HoodieFlinkClusteringJob {
     } else {
       LOG.info("Hoodie Flink Clustering running only single round");
       try {
-        clusteringScheduleService.cluster();
+        clusteringScheduleService.cluster(false);
       } catch (ApplicationExecutionException aee) {
         if (aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
           LOG.info("Clustering is not performed");
@@ -149,11 +152,6 @@ public class HoodieFlinkClusteringJob {
     private final Configuration conf;
 
     /**
-     * Meta Client.
-     */
-    private final HoodieTableMetaClient metaClient;
-
-    /**
      * Write Client.
      */
     private final HoodieFlinkWriteClient<?> writeClient;
@@ -174,7 +172,7 @@ public class HoodieFlinkClusteringJob {
       this.executor = Executors.newFixedThreadPool(1);
 
       // create metaClient
-      this.metaClient = StreamerUtil.createMetaClient(conf);
+      HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(conf);
 
       // set table name
       conf.setString(FlinkOptions.TABLE_NAME, metaClient.getTableConfig().getTableName());
@@ -207,8 +205,7 @@ public class HoodieFlinkClusteringJob {
         try {
           while (!isShutdownRequested()) {
             try {
-              cluster();
-              Thread.sleep(cfg.minClusteringIntervalSeconds * 1000);
+              cluster(true);
             } catch (ApplicationExecutionException aee) {
               if (aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
                 LOG.info("Clustering is not performed.");
@@ -229,17 +226,18 @@ public class HoodieFlinkClusteringJob {
     }
 
     /**
-     * Follows the same execution methodology of HoodieFlinkCompactor, where only one clustering job is allowed to be
+     * Follows the same execution methodology of {@link HoodieFlinkCompactor}, where only one clustering job is allowed to be
      * executed at any point in time.
-     * <p>
-     * If there is an inflight clustering job, it will be rolled back and re-attempted.
-     * <p>
-     * A clustering plan will be generated if `schedule` is true.
      *
-     * @throws Exception
+     * <p> If there is an inflight clustering job, it will be rolled back and re-attempted.
+     *
+     * <p> A clustering plan will be generated if `schedule` is true.
+     *
+     * @param serviceMode Whether to run clustering in service mode.
+     * @throws Exception Thrown if the execution failed.
      * @see HoodieFlinkCompactor
      */
-    private void cluster() throws Exception {
+    private void cluster(boolean serviceMode) throws Exception {
       table.getMetaClient().reloadActiveTimeline();
 
       if (cfg.schedule) {
@@ -259,93 +257,105 @@ public class HoodieFlinkClusteringJob {
         table.getMetaClient().reloadActiveTimeline();
       }
 
-      // fetch the instant based on the configured execution sequence
-      List<HoodieInstant> instants = ClusteringUtils.getPendingClusteringInstantTimes(table.getMetaClient());
-      if (instants.isEmpty()) {
-        // do nothing.
-        LOG.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
-        return;
-      }
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
 
-      final HoodieInstant clusteringInstant;
-      if (cfg.clusteringInstantTime != null) {
-        clusteringInstant = instants.stream()
-            .filter(i -> i.getTimestamp().equals(cfg.clusteringInstantTime))
-            .findFirst()
-            .orElseThrow(() -> new HoodieException("Clustering instant [" + cfg.clusteringInstantTime + "] not found"));
+      int clusteringParallelism;
+      DataStream<ClusteringPlanEvent> planStream;
+      HoodieInstant clusteringInstant = null;
+      if (serviceMode) {
+        clusteringParallelism = conf.getInteger(FlinkOptions.CLUSTERING_TASKS);
+        planStream = env.addSource(new ServiceSourceFunction(conf.get(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL)))
+            .name("clustering_service_source")
+            .uid("uid_clustering_service_source")
+            .setParallelism(1)
+            .transform("cluster_plan_generate", TypeInformation.of(ClusteringPlanEvent.class), new ClusteringPlanOperator(conf))
+            .setParallelism(1);
       } else {
-        // check for inflight clustering plans and roll them back if required
-        clusteringInstant =
-            CompactionUtil.isLIFO(cfg.clusteringSeq) ? instants.get(instants.size() - 1) : instants.get(0);
-      }
+        // fetch the instant based on the configured execution sequence
+        List<HoodieInstant> instants = ClusteringUtils.getPendingClusteringInstantTimes(table.getMetaClient());
+        if (instants.isEmpty()) {
+          // do nothing.
+          LOG.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
+          return;
+        }
 
-      HoodieInstant inflightInstant = HoodieTimeline.getReplaceCommitInflightInstant(
-          clusteringInstant.getTimestamp());
-      if (table.getMetaClient().getActiveTimeline().containsInstant(inflightInstant)) {
-        LOG.info("Rollback inflight clustering instant: [" + clusteringInstant + "]");
-        table.rollbackInflightClustering(inflightInstant,
-            commitToRollback -> writeClient.getTableServiceClient().getPendingRollbackInfo(table.getMetaClient(), commitToRollback, false));
+        if (cfg.clusteringInstantTime != null) {
+          clusteringInstant = instants.stream()
+              .filter(i -> i.getTimestamp().equals(cfg.clusteringInstantTime))
+              .findFirst()
+              .orElseThrow(() -> new HoodieException("Clustering instant [" + cfg.clusteringInstantTime + "] not found"));
+        } else {
+          // check for inflight clustering plans and roll them back if required
+          clusteringInstant =
+              CompactionUtil.isLIFO(cfg.clusteringSeq) ? instants.get(instants.size() - 1) : instants.get(0);
+        }
+
+        HoodieInstant inflightInstant = HoodieTimeline.getReplaceCommitInflightInstant(
+            clusteringInstant.getTimestamp());
+        if (table.getMetaClient().getActiveTimeline().containsInstant(inflightInstant)) {
+          LOG.info("Rollback inflight clustering instant: [" + clusteringInstant + "]");
+          table.rollbackInflightClustering(inflightInstant,
+              commitToRollback -> writeClient.getTableServiceClient().getPendingRollbackInfo(table.getMetaClient(), commitToRollback, false));
+          table.getMetaClient().reloadActiveTimeline();
+        }
+
+        // generate clustering plan
+        // should support configurable commit metadata
+        Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
+            table.getMetaClient(), clusteringInstant);
+
+        if (!clusteringPlanOption.isPresent()) {
+          // do nothing.
+          LOG.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
+          return;
+        }
+
+        HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
+
+        if (clusteringPlan == null || (clusteringPlan.getInputGroups() == null)
+            || (clusteringPlan.getInputGroups().isEmpty())) {
+          // no clustering plan, do nothing and return.
+          LOG.info("No clustering plan for instant " + clusteringInstant.getTimestamp());
+          return;
+        }
+
+        HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstant.getTimestamp());
+
+        // get clusteringParallelism.
+        clusteringParallelism = conf.getInteger(FlinkOptions.CLUSTERING_TASKS) == -1
+            ? clusteringPlan.getInputGroups().size() : conf.getInteger(FlinkOptions.CLUSTERING_TASKS);
+
+        // Mark instant as clustering inflight
+        table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
         table.getMetaClient().reloadActiveTimeline();
+
+        // setup configuration
+        long ckpTimeout = env.getCheckpointConfig().getCheckpointTimeout();
+        conf.setLong(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT, ckpTimeout);
+
+        planStream = env.addSource(new ClusteringPlanSourceFunction(clusteringInstant.getTimestamp(), clusteringPlan))
+            .name("clustering_source")
+            .uid("uid_clustering_source");
       }
-
-      // generate clustering plan
-      // should support configurable commit metadata
-      Option<Pair<HoodieInstant, HoodieClusteringPlan>> clusteringPlanOption = ClusteringUtils.getClusteringPlan(
-          table.getMetaClient(), clusteringInstant);
-
-      if (!clusteringPlanOption.isPresent()) {
-        // do nothing.
-        LOG.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
-        return;
-      }
-
-      HoodieClusteringPlan clusteringPlan = clusteringPlanOption.get().getRight();
-
-      if (clusteringPlan == null || (clusteringPlan.getInputGroups() == null)
-          || (clusteringPlan.getInputGroups().isEmpty())) {
-        // no clustering plan, do nothing and return.
-        LOG.info("No clustering plan for instant " + clusteringInstant.getTimestamp());
-        return;
-      }
-
-      HoodieInstant instant = HoodieTimeline.getReplaceCommitRequestedInstant(clusteringInstant.getTimestamp());
-
-      // get clusteringParallelism.
-      int clusteringParallelism = conf.getInteger(FlinkOptions.CLUSTERING_TASKS) == -1
-          ? clusteringPlan.getInputGroups().size() : conf.getInteger(FlinkOptions.CLUSTERING_TASKS);
-
-      // Mark instant as clustering inflight
-      table.getActiveTimeline().transitionReplaceRequestedToInflight(instant, Option.empty());
-
       final Schema tableAvroSchema = StreamerUtil.getTableAvroSchema(table.getMetaClient(), false);
       final DataType rowDataType = AvroSchemaConverter.convertToDataType(tableAvroSchema);
       final RowType rowType = (RowType) rowDataType.getLogicalType();
-
-      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-
-      // setup configuration
-      long ckpTimeout = env.getCheckpointConfig().getCheckpointTimeout();
-      conf.setLong(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT, ckpTimeout);
-
-      DataStream<ClusteringCommitEvent> dataStream = env.addSource(new ClusteringPlanSourceFunction(clusteringInstant.getTimestamp(), clusteringPlan))
-          .name("clustering_source")
-          .uid("uid_clustering_source")
-          .rebalance()
+      DataStream<ClusteringCommitEvent> commitStream = planStream.rebalance()
           .transform("clustering_task",
               TypeInformation.of(ClusteringCommitEvent.class),
               new ClusteringOperator(conf, rowType))
           .setParallelism(clusteringParallelism);
 
-      ExecNodeUtil.setManagedMemoryWeight(dataStream.getTransformation(),
+      ExecNodeUtil.setManagedMemoryWeight(commitStream.getTransformation(),
           conf.getInteger(FlinkOptions.WRITE_SORT_MEMORY) * 1024L * 1024L);
 
-      dataStream
+      commitStream
           .addSink(new ClusteringCommitSink(conf))
           .name("clustering_commit")
           .uid("uid_clustering_commit")
           .setParallelism(1);
 
-      env.execute("flink_hudi_clustering_" + clusteringInstant.getTimestamp());
+      env.execute(String.format("flink_hudi_clustering%s", serviceMode ? StringUtils.EMPTY_STRING : "_" + clusteringInstant.getTimestamp()));
     }
 
     /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/ServiceSourceFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/ServiceSourceFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.common;
+
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+
+import java.time.Duration;
+
+/**
+ * Source function for service mode that creates a permanent thread.
+ */
+public class ServiceSourceFunction extends RichSourceFunction<Object> {
+
+  private final Duration interval;
+  private volatile boolean isRunning = true;
+
+  public ServiceSourceFunction(Duration interval) {
+    this.interval = interval;
+  }
+
+  @Override
+  public void run(SourceContext<Object> sourceContext) throws Exception {
+    while (isRunning) {
+      try {
+        Thread.sleep(interval.toMillis());
+      } catch (InterruptedException ignored) {
+        // no handle
+      }
+    }
+  }
+
+  @Override
+  public void cancel() {
+    this.isRunning = false;
+  }
+
+  @Override
+  public void close() throws Exception {
+    cancel();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/FlinkCompactionConfig.java
@@ -24,6 +24,9 @@ import org.apache.hudi.sink.compact.strategy.CompactionPlanStrategy;
 
 import com.beust.jcommander.Parameter;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+
+import java.time.Duration;
 
 /**
  * Configurations for Hoodie Flink compaction.
@@ -145,6 +148,8 @@ public class FlinkCompactionConfig extends Configuration {
     conf.setLong(FlinkOptions.COMPACTION_TARGET_IO, config.compactionTargetIo);
     conf.setInteger(FlinkOptions.COMPACTION_TASKS, config.compactionTasks);
     conf.setBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED, config.cleanAsyncEnable);
+    // execution checkpointing
+    conf.set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(config.minCompactionIntervalSeconds));
     // use synchronous compaction always
     conf.setBoolean(FlinkOptions.COMPACTION_ASYNC_ENABLED, false);
     conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, config.schedule);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClusteringJob.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/cluster/ITTestHoodieFlinkClusteringJob.java
@@ -82,7 +82,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * IT cases for {@link HoodieFlinkClusteringJob}.
  */
 @ExtendWith(FlinkMiniCluster.class)
-public class ITTestHoodieFlinkClustering {
+public class ITTestHoodieFlinkClusteringJob {
 
   private static final Map<String, String> EXPECTED = new HashMap<>();
 
@@ -227,7 +227,7 @@ public class ITTestHoodieFlinkClustering {
     asyncClusteringService.start(null);
 
     // wait for the asynchronous commit to finish
-    TimeUnit.SECONDS.sleep(5);
+    TimeUnit.SECONDS.sleep(10);
 
     asyncClusteringService.shutDown();
 


### PR DESCRIPTION
### Change Logs

`HoodieFlinkCompactor` and `HoodieFlinkClusteringJob` supports streaming mode in service mode of Flink offline compaction and clustering.

### Impact

`HoodieFlinkCompactor` and `HoodieFlinkClusteringJob` runs offline compaction and clustering job with streaming mode in service mode.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed