### PR TITLE
[HUDI-6202] Validate that hiveStylePartitioningEnable is present in t…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -665,6 +665,16 @@ public class HoodieTableConfig extends HoodieConfig {
     return HoodieTimelineTimeZone.valueOf(getStringOrDefault(TIMELINE_TIMEZONE));
   }
 
+  /**
+   * Returns null if the HIVE_STYLE_PARTITION_ENABLE value is not defined in hoodie.properties/table config instead of using the default value.
+   * When trying to determine the partition format of the table, this method will not blindly return a default value if it is not defined in the tableConfig.
+   *
+   * @return HIVE_STYLE_PARTITIONING_ENABLE config value if defined in table config, else, return a null
+   */
+  public String getHiveStylePartitioningEnableOrNull() {
+    return getString(HIVE_STYLE_PARTITIONING_ENABLE);
+  }
+
   public String getHiveStylePartitioningEnable() {
     return getStringOrDefault(HIVE_STYLE_PARTITIONING_ENABLE);
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -319,6 +319,8 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
    * @return relative partition path and a flag to indicate if the path is complete (i.e., not a prefix)
    */
   private def composeRelativePartitionPath(staticPartitionColumnNameValuePairs: Seq[(String, (String, Any))]): String = {
+    // NOTE: Do not blindly use default value if tableConfig does not have the hiveStylePartitioningEnable config
+    checkState(metaClient.getTableConfig.getHiveStylePartitioningEnableOrNull != null)
     checkState(staticPartitionColumnNameValuePairs.nonEmpty)
 
     // Since static partition values might not be available for all columns, we compile


### PR DESCRIPTION
…ableConfig before using it

In [8653](https://github.com/apache/hudi/issues/8653) we found that there are some write paths that will create tables without the `hoodie.datasource.write.hive_style_partitioning` in `hoodie.properties`. 

Hence, it is unsafe to blindly assume the default value of `hoodie.datasource.write.hive_style_partitioning` when invoking `SparkHoodieTableFileIndex#composeRelativePartitionPath()`. If an assumption is used here, the method runs the risk of constructing a partitionPath that does not exists as it is in might be in the wrong format.

This is so as `BaseHoodieTableFileIndex#listPartitionPaths()` will attempt to create partitions when a partition path that does not exist is passed to it. 

As such, this ticket is to add a validation-check to prevent `hoodie.datasource.write.hive_style_partitioning` from being used in an unsafe manner.

### Change Logs

Validate that `hoodie.datasource.write.hive_style_partitioning` is in `hoodie.properties` before using it.

### Impact
None

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)
Low

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
