### PR TITLE
[HUDI-6197] Fix use CONTAINER_ID to judge hudi is running on yarn

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -226,16 +226,17 @@ public class FileIOUtils {
 
   private static boolean isRunningInYarnContainer() {
     // These environment variables are set by YARN.
-    return System.getenv("CONTAINER_ID") != null;
+    return System.getenv("CONTAINER_ID") != null
+        && System.getenv("LOCAL_DIRS") != null;
   }
 
   /**
    * Get the Yarn approved local directories.
    */
   private static String getYarnLocalDirs() {
-    String localDirs = Option.of(System.getenv("LOCAL_DIRS")).orElse("");
+    String localDirs = System.getenv("LOCAL_DIRS");
 
-    if (localDirs.isEmpty()) {
+    if (localDirs == null) {
       throw new HoodieIOException("Yarn Local dirs can't be empty");
     }
     return localDirs;

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestFileIOUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestFileIOUtils.java
@@ -25,9 +25,11 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,5 +75,25 @@ public class TestFileIOUtils extends HoodieCommonTestHarness {
     List<String> expectedLines = Arrays.stream(new String[]{"a", "b", "c"}).collect(Collectors.toList());
     ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
     assertEquals(expectedLines, FileIOUtils.readAsUTFStringLines(inputStream));
+  }
+  
+  @Test
+  public void testGetConfiguredLocalDirs() {
+    Map<String, String> env = System.getenv();
+    Class<?> clazz = env.getClass();
+    Map<String, String> envMaps = null;
+    try {
+      Field field = clazz.getDeclaredField("m");
+      field.setAccessible(true);
+      envMaps = (Map<String, String>) field.get(env);
+      envMaps.put("CONTAINER_ID", "xxxxx");
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalArgumentException(e);
+    }
+    assertEquals(String.join("", FileIOUtils.getConfiguredLocalDirs()),
+            System.getProperty("java.io.tmpdir"));
+    envMaps.put("LOCAL_DIRS", "/xxx");
+    assertEquals(String.join("", FileIOUtils.getConfiguredLocalDirs()),
+            envMaps.get("LOCAL_DIRS"));
   }
 }


### PR DESCRIPTION
### Change Logs

add the environment variable LOCAL_DIRS to judge hudi is running in yarn container.

### Impact

This change is to prevent hudi runs in k8s pod from following this logic. Because there is also variable CONTAINER_ID in the k8s pod, it will go to this logic and throw an exception.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
