### PR TITLE
[MINOR] Migrate azure-pipelines.yml with notes

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE:
+# This config file defines how Azure CI runs tests with Spark 2.4 and Flink 1.17 profiles.
+# PRs will need to keep in sync with master's version to trigger the CI runs.
+
 trigger:
   branches:
     include:


### PR DESCRIPTION
### Change Logs

change azure pipeline's config to `azure-pipelines-20230430.yml` so that publish junit is disabled for all PRs.

### Impact

PR's CI won't be triggered until rebase master

### Risk level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
