### PR TITLE
Update docker-compose_hadoop284_hive233_spark244.yml

### DIFF
--- a/docker/compose/docker-compose_hadoop284_hive233_spark244.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark244.yml
@@ -330,3 +330,4 @@ volumes:
 
 networks:
   default:
+     name: hudi


### PR DESCRIPTION
Updates to fix issue https://github.com/apache/hudi/issues/8700

### Change Logs

Fixes to the docker compose yaml so that you don't get URI Exception error when remotely connecting to docker compose image.

### Impact

None

### Risk level (write none, low medium or high below)

Low

### Documentation Update

none

### Contributor's checklist

- [x ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ x] Change Logs and Impact were stated clearly
- [ x] Adequate tests were added if applicable
- [ x] CI passed
