### PR TITLE
Revert [HUDI-4630] to fix CI failing.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -134,7 +134,6 @@ public class HoodieMultiTableDeltaStreamer {
       if (cfg.enableMetaSync && StringUtils.isNullOrEmpty(tableProperties.getString(HoodieSyncConfig.META_SYNC_TABLE_NAME.key(), ""))) {
         throw new HoodieException("Meta sync table field not provided!");
       }
-      populateTransformerProps(cfg, tableProperties);
       populateSchemaProviderProps(cfg, tableProperties);
       executionContext = new TableExecutionContext();
       executionContext.setProperties(tableProperties);
@@ -142,14 +141,6 @@ public class HoodieMultiTableDeltaStreamer {
       executionContext.setDatabase(database);
       executionContext.setTableName(currentTable);
       this.tableExecutionContexts.add(executionContext);
-    }
-  }
-
-  private void populateTransformerProps(HoodieDeltaStreamer.Config cfg, TypedProperties typedProperties) {
-    String transformerClass = typedProperties.getString(Constants.TRANSFORMER_CLASS, null);
-    if (transformerClass != null && !transformerClass.trim().isEmpty()) {
-      List<String> transformerClassNameOverride = Arrays.asList(transformerClass.split(","));
-      cfg.transformerClassNames = transformerClassNameOverride;
     }
   }
 
@@ -462,7 +453,6 @@ public class HoodieMultiTableDeltaStreamer {
     private static final String DELIMITER = ".";
     private static final String UNDERSCORE = "_";
     private static final String COMMA_SEPARATOR = ",";
-    private static final String TRANSFORMER_CLASS = "hoodie.deltastreamer.transformer.class";
   }
 
   public Set<String> getSuccessTables() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -42,7 +42,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -77,16 +76,6 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
     }
   }
 
-  @Test
-  public void testEmptyTransformerProps() throws IOException {
-    // HUDI-4630: If there is no transformer props passed through, don't populate the transformerClassNames
-    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, basePath + "/config", TestDataSource.class.getName(), false, false, null);
-    HoodieDeltaStreamer.Config dsConfig = new HoodieDeltaStreamer.Config();
-    TypedProperties tblProperties = new TypedProperties();
-    HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
-    assertNull(cfg.transformerClassNames);
-  }
-  
   @Test
   public void testMetaSyncConfig() throws IOException {
     HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, basePath + "/config", TestDataSource.class.getName(), true, true, null);
@@ -255,13 +244,10 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
         case "dummy_table_short_trip":
           String tableLevelKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestTableLevelGenerator.class.getName(), tableLevelKeyGeneratorClass);
-          List<String> transformerClass = tableExecutionContext.getConfig().transformerClassNames;
-          assertEquals("org.apache.hudi.utilities.transform.SqlFileBasedTransformer", transformerClass.get(0)); // HUDI-4630
           break;
         default:
           String defaultKeyGeneratorClass = tableExecutionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME().key());
           assertEquals(TestHoodieDeltaStreamer.TestGenerator.class.getName(), defaultKeyGeneratorClass);
-          assertNull(tableExecutionContext.getConfig().transformerClassNames);  //HUDI-4630
       }
     });
   }

--- a/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/short_trip_uber_config.properties
@@ -25,4 +25,3 @@ hoodie.datasource.hive_sync.table=short_trip_uber_hive_dummy_table
 hoodie.datasource.write.keygenerator.class=org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamer$TestTableLevelGenerator
 hoodie.deltastreamer.schemaprovider.registry.baseUrl=http://localhost:8081/subjects/
 hoodie.deltastreamer.schemaprovider.registry.urlSuffix=-value/versions/latest
-hoodie.deltastreamer.transformer.class=org.apache.hudi.utilities.transform.SqlFileBasedTransformer


### PR DESCRIPTION
Origin PR: Add transformer capability to individual feeds in MultiTableDeltaStreamer (#8399)"

This reverts commit b497ef1a3f09c50bca889eeb457be70f1c6544c6.

Now master CI is keep failing maybe caused by this PR https://github.com/apache/hudi/pull/8399


### Change Logs
Revert commit b497ef1a3f09c50bca889eeb457be70f1c6544c6.
```
65118 [main] ERROR org.apache.hudi.utilities.deltastreamer.HoodieMultiTableDeltaStreamer [] - error while running MultiTableDeltaStreamer for table: dummy_table_short_trip
java.lang.IllegalArgumentException: Property hoodie.deltastreamer.transformer.sql.file not found
	at org.apache.hudi.common.config.TypedProperties.checkKey(TypedProperties.java:68) ~[classes/:?]
	at org.apache.hudi.common.config.TypedProperties.getString(TypedProperties.java:73) ~[classes/:?]
	at org.apache.hudi.utilities.transform.SqlFileBasedTransformer.apply(SqlFileBasedTransformer.java:71) ~[classes/:?]
	at org.apache.hudi.utilities.transform.ChainedTransformer.apply(ChainedTransformer.java:98) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.lambda$fetchFromSource$0(DeltaSync.java:547) ~[classes/:?]
	at org.apache.hudi.common.util.Option.map(Option.java:108) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.fetchFromSource(DeltaSync.java:547) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.readFromSource(DeltaSync.java:512) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.syncOnce(DeltaSync.java:403) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer$DeltaSyncService.ingestOnce(HoodieDeltaStreamer.java:813) ~[classes/:?]
	at org.apache.hudi.utilities.ingestion.HoodieIngestionService.startIngestion(HoodieIngestionService.java:71) ~[classes/:?]
	at org.apache.hudi.common.util.Option.ifPresent(Option.java:97) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.sync(HoodieDeltaStreamer.java:212) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.HoodieMultiTableDeltaStreamer.sync(HoodieMultiTableDeltaStreamer.java:440) ~[classes/:?]
	at org.apache.hudi.utilities.deltastreamer.TestHoodieMultiTableDeltaStreamer.syncAndVerify(TestHoodieMultiTableDeltaStreamer.java:299) ~[test-classes/:?]
	at org.apache.hudi.utilities.deltastreamer.TestHoodieMultiTableDeltaStreamer.testMultiTableExecutionWithParquetSource(TestHoodieMultiTableDeltaStreamer.java:231) ~[test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_301]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_301]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_301]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_301]
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688) ~[junit-platform-commons-1.7.2.jar:1.7.2]
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:210) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:206) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:131) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:65) ~[junit-jupiter-engine-5.7.2.jar:5.7.2]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84) ~[junit-platform-engine-1.7.2.jar:1.7.2]
	at java.util.ArrayList.forEach(ArrayList.java:1259) ~[?:1.8.0_301]
	at 
```

### Impact

MultiTableDeltaStreamer

### Risk level (write none, low medium or high below)

LOW

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
