### PR TITLE
[HUDI-6213] Parallelize deletion of files during rollback.

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/FileCreateUtils.java
@@ -330,9 +330,9 @@ public class FileCreateUtils {
     if (Files.notExists(baseFilePath)) {
       Files.createFile(baseFilePath);
     }
-    RandomAccessFile raf = new RandomAccessFile(baseFilePath.toFile(), "rw");
-    raf.setLength(length);
-    raf.close();
+    try (RandomAccessFile raf = new RandomAccessFile(baseFilePath.toFile(), "rw")) {
+      raf.setLength(length);
+    }
     Files.setLastModifiedTime(baseFilePath, FileTime.fromMillis(lastModificationTimeMilli));
   }
 


### PR DESCRIPTION
[HUDI-6213] Parallelize deletion of files during rollback.

### Change Logs

Each rollback request ONLY contains a single file to be deleted instead of all files in a partition.

### Impact

Faster rollbacks when large number of files per partition are to be rolled back.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
