### PR TITLE
[HUDI-6216] Get table type and payload class from table config in fli…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -126,6 +126,14 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
               && !conf.contains(FlinkOptions.HIVE_STYLE_PARTITIONING)) {
             conf.setBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING, tableConfig.getBoolean(HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE));
           }
+          if (tableConfig.contains(HoodieTableConfig.TYPE)
+              && !conf.contains(FlinkOptions.TABLE_TYPE)) {
+            conf.setString(FlinkOptions.TABLE_TYPE, tableConfig.getString(HoodieTableConfig.TYPE));
+          }
+          if (tableConfig.contains(HoodieTableConfig.PAYLOAD_CLASS_NAME)
+              && !conf.contains(FlinkOptions.PAYLOAD_CLASS_NAME)) {
+            conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, tableConfig.getString(HoodieTableConfig.PAYLOAD_CLASS_NAME));
+          }
         });
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -221,6 +221,9 @@ public class TestHoodieTableFactory {
     tableConf.setString(FlinkOptions.TABLE_NAME, "t2");
     tableConf.setString(FlinkOptions.RECORD_KEY_FIELD, "f0,f1");
     tableConf.setString(FlinkOptions.PRECOMBINE_FIELD, "f2");
+    tableConf.setString(FlinkOptions.TABLE_TYPE, FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+    tableConf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, "my_payload");
+    tableConf.setString(FlinkOptions.PARTITION_PATH_FIELD, "partition");
 
     StreamerUtil.initTableIfNotExists(tableConf);
 
@@ -246,6 +249,14 @@ public class TestHoodieTableFactory {
         source1.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f2"));
     assertThat("pre-combine key not provided, fallback to table config",
         sink1.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f2"));
+    assertThat("table type not provided, fallback to table config",
+        source1.getConf().get(FlinkOptions.TABLE_TYPE), is(FlinkOptions.TABLE_TYPE_MERGE_ON_READ));
+    assertThat("table type not provided, fallback to table config",
+        sink1.getConf().get(FlinkOptions.TABLE_TYPE), is(FlinkOptions.TABLE_TYPE_MERGE_ON_READ));
+    assertThat("payload class not provided, fallback to table config",
+        source1.getConf().get(FlinkOptions.PAYLOAD_CLASS_NAME), is("my_payload"));
+    assertThat("payload class not provided, fallback to table config",
+        sink1.getConf().get(FlinkOptions.PAYLOAD_CLASS_NAME), is("my_payload"));
 
     // write config always has higher priority
     // set up a different primary key and pre_combine key with table config options


### PR DESCRIPTION
…nk table factory when not provided

If create hudi table in HMS with hive sync, table type is not sync to HMS, if read such table with flink, will only get parquet data, data in log will be ignore because flink think table type is the default COW.

### Change Logs

In hudi flink table factory, if table type and payload class not provided, try to get it from table config.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
