### PR TITLE
[HUDI-6217] Support handing '_hoodie_operation' meta field for Spark snapshot source

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -85,7 +85,7 @@ public abstract class BaseAvroPayload implements Serializable {
    */
   protected static boolean isDeleteRecord(GenericRecord genericRecord) {
     final String isDeleteKey = HoodieRecord.HOODIE_IS_DELETED_FIELD;
-    final String isDeleteKeyMeta = HoodieRecord.OPERATION_METADATA_FIELD;
+    final String operationKey = HoodieRecord.OPERATION_METADATA_FIELD;
     // Modify to be compatible with new version Avro.
     // The new version Avro throws for GenericRecord.get if the field name
     // does not exist in the schema.
@@ -94,8 +94,8 @@ public abstract class BaseAvroPayload implements Serializable {
       return (deleteMarker instanceof Boolean && (boolean) deleteMarker);
     }
 
-    if (genericRecord.getSchema().getField(isDeleteKeyMeta) != null) {
-      Object deleteMarker = genericRecord.get(isDeleteKeyMeta);
+    if (genericRecord.getSchema().getField(operationKey) != null) {
+      Object deleteMarker = genericRecord.get(operationKey);
       return (deleteMarker != null && "D".equals(deleteMarker.toString()));
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -85,13 +85,20 @@ public abstract class BaseAvroPayload implements Serializable {
    */
   protected static boolean isDeleteRecord(GenericRecord genericRecord) {
     final String isDeleteKey = HoodieRecord.HOODIE_IS_DELETED_FIELD;
+    final String isDeleteKeyMeta = HoodieRecord.OPERATION_METADATA_FIELD;
     // Modify to be compatible with new version Avro.
     // The new version Avro throws for GenericRecord.get if the field name
     // does not exist in the schema.
-    if (genericRecord.getSchema().getField(isDeleteKey) == null) {
-      return false;
+    if (genericRecord.getSchema().getField(isDeleteKey) != null) {
+      Object deleteMarker = genericRecord.get(isDeleteKey);
+      return (deleteMarker instanceof Boolean && (boolean) deleteMarker);
     }
-    Object deleteMarker = genericRecord.get(isDeleteKey);
-    return (deleteMarker instanceof Boolean && (boolean) deleteMarker);
+
+    if (genericRecord.getSchema().getField(isDeleteKeyMeta) != null) {
+      Object deleteMarker = genericRecord.get(isDeleteKeyMeta);
+      return (deleteMarker != null && "D".equals(deleteMarker.toString()));
+    }
+
+    return false;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -96,7 +96,7 @@ public abstract class BaseAvroPayload implements Serializable {
 
     if (genericRecord.getSchema().getField(operationKey) != null) {
       Object deleteMarker = genericRecord.get(operationKey);
-      return (deleteMarker != null && "D".equals(deleteMarker.toString()));
+      return (deleteMarker != null && HoodieOperation.DELETE.getName().equals(deleteMarker.toString()));
     }
 
     return false;


### PR DESCRIPTION
### Change Logs

Fix Spark reads the deleted data whose _hoodie_operation is D

### Impact


### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
