### PR TITLE
[HUDI-6218] Support instant_time/commit_time of savepoint procedure optional

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -586,8 +586,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   /**
    * Create a savepoint based on the latest commit action on the timeline.
    *
-   * @param user - User creating the savepoint
-   * @param comment - Comment for the savepoint
+   * @param user    User creating the savepoint
+   * @param comment Comment for the savepoint
    */
   public void savepoint(String user, String comment) {
     HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
@@ -609,9 +609,9 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * <p>
    * Savepoint should be on a commit that could not have been cleaned.
    *
-   * @param instantTime - commit that should be savepointed
-   * @param user - User creating the savepoint
-   * @param comment - Comment for the savepoint
+   * @param instantTime Commit that should be savepointed
+   * @param user        User creating the savepoint
+   * @param comment     Comment for the savepoint
    */
   public void savepoint(String instantTime, String user, String comment) {
     HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
@@ -619,15 +619,44 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   }
 
   /**
+   * Delete a savepoint based on the latest commit action on the savepoint timeline.
+   */
+  public void deleteSavepoint() {
+    HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
+    HoodieTimeline savePointTimeline = table.getActiveTimeline().getSavePointTimeline();
+    if (savePointTimeline.empty()) {
+      throw new HoodieSavepointException("Could not savepoint. Commit timeline is empty");
+    }
+
+    String savepointTime = savePointTimeline.lastInstant().get().getTimestamp();
+    LOG.info("Deleting latest savepoint time " + savepointTime);
+    deleteSavepoint(savepointTime);
+  }
+
+  /**
    * Delete a savepoint that was created. Once the savepoint is deleted, the commit can be rolledback and cleaner may
    * clean up data files.
    *
-   * @param savepointTime - delete the savepoint
-   * @return true if the savepoint was deleted successfully
+   * @param savepointTime Savepoint time to delete
    */
   public void deleteSavepoint(String savepointTime) {
     HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
     SavepointHelpers.deleteSavepoint(table, savepointTime);
+  }
+
+  /**
+   * Restore the data to a savepoint based on the latest commit action on the savepoint timeline.
+   */
+  public void restoreToSavepoint() {
+    HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
+    HoodieTimeline savePointTimeline = table.getActiveTimeline().getSavePointTimeline();
+    if (savePointTimeline.empty()) {
+      throw new HoodieSavepointException("Could not savepoint. Commit timeline is empty");
+    }
+
+    String savepointTime = savePointTimeline.lastInstant().get().getTimestamp();
+    LOG.info("Restoring to latest savepoint time " + savepointTime);
+    restoreToSavepoint(savepointTime);
   }
 
   /**
@@ -637,8 +666,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * Queries accessing the files will mostly fail. This is expected to be a manual operation and no concurrent write or
    * compaction is expected to be running
    *
-   * @param savepointTime - savepoint time to rollback to
-   * @return true if the savepoint was restored to successfully
+   * @param savepointTime Savepoint time to rollback to
    */
   public void restoreToSavepoint(String savepointTime) {
     boolean initialMetadataTableIfNecessary = config.isMetadataTableEnabled();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -625,7 +625,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
     HoodieTimeline savePointTimeline = table.getActiveTimeline().getSavePointTimeline();
     if (savePointTimeline.empty()) {
-      throw new HoodieSavepointException("Could not savepoint. Commit timeline is empty");
+      throw new HoodieSavepointException("Could not delete savepoint. Savepoint timeline is empty");
     }
 
     String savepointTime = savePointTimeline.lastInstant().get().getTimestamp();
@@ -651,7 +651,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     HoodieTable<T, I, K, O> table = createTable(config, hadoopConf);
     HoodieTimeline savePointTimeline = table.getActiveTimeline().getSavePointTimeline();
     if (savePointTimeline.empty()) {
-      throw new HoodieSavepointException("Could not savepoint. Commit timeline is empty");
+      throw new HoodieSavepointException("Could not restore to savepoint. Savepoint timeline is empty");
     }
 
     String savepointTime = savePointTimeline.lastInstant().get().getTimestamp();

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CreateSavepointProcedure.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline
+import org.apache.hudi.common.table.timeline.HoodieTimeline
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.{HoodieException, HoodieSavepointException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -30,7 +31,7 @@ import java.util.function.Supplier
 class CreateSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
     ProcedureParameter.optional(0, "table", DataTypes.StringType),
-    ProcedureParameter.required(1, "commit_time", DataTypes.StringType),
+    ProcedureParameter.optional(1, "commit_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "user", DataTypes.StringType, ""),
     ProcedureParameter.optional(3, "comments", DataTypes.StringType, ""),
     ProcedureParameter.optional(4, "path", DataTypes.StringType)
@@ -49,16 +50,18 @@ class CreateSavepointProcedure extends BaseProcedure with ProcedureBuilder with 
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
     val tablePath = getArgValueOrDefault(args, PARAMETERS(4))
-    val commitTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
+    var commitTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
     val user = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[String]
     val comments = getArgValueOrDefault(args, PARAMETERS(3)).get.asInstanceOf[String]
 
     val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
-    val activeTimeline: HoodieActiveTimeline = metaClient.getActiveTimeline
-    if (!activeTimeline.getCommitsTimeline.filterCompletedInstants.containsInstant(commitTime)) {
-      throw new HoodieException("Commit " + commitTime + " not found in Commits " + activeTimeline)
+    val completedTimeline: HoodieTimeline = metaClient.getCommitsTimeline.filterCompletedInstants
+    if (StringUtils.isNullOrEmpty(commitTime)) {
+      commitTime = completedTimeline.lastInstant.get.getTimestamp
+    } else if (!completedTimeline.containsInstant(commitTime)) {
+      throw new HoodieException("Commit " + commitTime + " not found in Commits " + completedTimeline)
     }
 
     val client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, Map.empty,

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/DeleteSavepointProcedure.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.{HoodieException, HoodieSavepointException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -30,7 +31,7 @@ import java.util.function.Supplier
 class DeleteSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
     ProcedureParameter.optional(0, "table", DataTypes.StringType),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType),
+    ProcedureParameter.optional(1, "instant_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "path", DataTypes.StringType)
   )
 
@@ -47,13 +48,16 @@ class DeleteSavepointProcedure extends BaseProcedure with ProcedureBuilder with 
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
     val tablePath = getArgValueOrDefault(args, PARAMETERS(2))
-    val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
+    var instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
 
     val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     val completedInstants = metaClient.getActiveTimeline.getSavePointTimeline.filterCompletedInstants
     if (completedInstants.empty) throw new HoodieException("There are no completed savepoint to run delete")
+    if (StringUtils.isNullOrEmpty(instantTime)) {
+      instantTime = completedInstants.lastInstant.get.getTimestamp
+    }
     val savePoint = new HoodieInstant(false, HoodieTimeline.SAVEPOINT_ACTION, instantTime)
 
     if (!completedInstants.containsInstant(savePoint)) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToSavepointProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RollbackToSavepointProcedure.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.command.procedures
 import org.apache.hudi.HoodieCLIUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.exception.{HoodieException, HoodieSavepointException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -30,7 +31,7 @@ import java.util.function.Supplier
 class RollbackToSavepointProcedure extends BaseProcedure with ProcedureBuilder with Logging {
   private val PARAMETERS = Array[ProcedureParameter](
     ProcedureParameter.optional(0, "table", DataTypes.StringType),
-    ProcedureParameter.required(1, "instant_time", DataTypes.StringType),
+    ProcedureParameter.optional(1, "instant_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(2, "path", DataTypes.StringType)
   )
 
@@ -47,13 +48,16 @@ class RollbackToSavepointProcedure extends BaseProcedure with ProcedureBuilder w
 
     val tableName = getArgValueOrDefault(args, PARAMETERS(0))
     val tablePath = getArgValueOrDefault(args, PARAMETERS(2))
-    val instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
+    var instantTime = getArgValueOrDefault(args, PARAMETERS(1)).get.asInstanceOf[String]
 
     val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
 
     val completedInstants = metaClient.getActiveTimeline.getSavePointTimeline.filterCompletedInstants
     if (completedInstants.empty) throw new HoodieException("There are no completed savepoint to run delete")
+    if (StringUtils.isNullOrEmpty(instantTime)) {
+      instantTime = completedInstants.lastInstant.get.getTimestamp
+    }
     val savePoint = new HoodieInstant(false, HoodieTimeline.SAVEPOINT_ACTION, instantTime)
 
     if (!completedInstants.containsInstant(savePoint)) {


### PR DESCRIPTION
### Change Logs

Procedure parameter `instant_time`/`commit_time` of savepoint procedure optional could be optional and uses the latest instant when the value of `instant_time`/`commit_time` is null or empty.

### Impact

Support `instant_time/commit_time` of savepoint procedure including `create_savepoint`, `delete_savepoint` and `rollback_to_savepoint` optional.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed