### PR TITLE
[HUDI-6219] Ensure consistency between Spark catalog schema and Hudi schema

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -168,7 +168,7 @@ private[sql] object SchemaConverters {
 
       case FloatType => builder.floatType()
       case DoubleType => builder.doubleType()
-      case StringType => builder.stringType()
+      case StringType | CharType(_) | VarcharType(_) => builder.stringType()
       case NullType => builder.nullType()
       case d: DecimalType =>
         val avroType = LogicalTypes.decimal(d.precision, d.scale)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestNestedSchemaPruningOptimization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestNestedSchemaPruningOptimization.scala
@@ -53,8 +53,8 @@ class TestNestedSchemaPruningOptimization extends HoodieSparkSqlTestBase with Sp
           val selectDF = spark.sql(s"SELECT id, item.name FROM $tableName")
 
           val expectedSchema = StructType(Seq(
-            StructField("id", IntegerType, nullable = false),
-            StructField("item" , StructType(Seq(StructField("name", StringType, nullable = false))), nullable = false)
+            StructField("id", IntegerType, nullable = true),
+            StructField("item" , StructType(Seq(StructField("name", StringType, nullable = false))), nullable = true)
           ))
 
           val expectedReadSchemaClause = "ReadSchema: struct<id:int,item:struct<name:string>>"


### PR DESCRIPTION
### Change Logs
[HUDI-4149](https://github.com/apache/hudi/pull/5672) fix the drop table error if table directory moved, but it will make the Spark catalog table schema not consistent with Hudi schema if some column types are not Avro data types.
This PR want to ensure the schema consistency when create a hoodie table. Otherwise it will throw exception in hive-sync:
```bash
Caused by: org.apache.hudi.hive.HoodieHiveSyncException: Could not convert field Type from TINYINT to int for field has_lowest_price_guarantee
	at org.apache.hudi.hive.util.HiveSchemaUtil.getSchemaDifference(HiveSchemaUtil.java:118)
	at org.apache.hudi.hive.HiveSyncTool.syncSchema(HiveSyncTool.java:369)
	at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:280)
	at org.apache.hudi.hive.HiveSyncTool.doSync(HiveSyncTool.java:198)
	at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:164)
	... 65 more
```

### Impact

None.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

None.
### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
