### PR TITLE
[HUDI-6222] ParquetSchemaConverter shoud always convert the Map key t…

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
@@ -650,7 +650,7 @@ public class ParquetSchemaConverter {
             .addField(
                 Types
                     .repeatedGroup()
-                    .addField(convertToParquetType("key", keyType, repetition))
+                    .addField(convertToParquetType("key", keyType, Type.Repetition.REQUIRED))
                     .addField(convertToParquetType("value", valueType, repetition))
                     .named("key_value"))
             .named(name);

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
@@ -56,7 +56,7 @@ public class TestParquetSchemaConverter {
         + "  }\n"
         + "  optional group f_map (MAP) {\n"
         + "    repeated group key_value {\n"
-        + "      optional int32 key;\n"
+        + "      required int32 key;\n"
         + "      optional binary value (STRING);\n"
         + "    }\n"
         + "  }\n"


### PR DESCRIPTION
…ype as not nullable

### Change Logs

Fixes https://github.com/apache/hudi/issues/8685.

Fix the Map key type as not nullable in order to be compatible with Spark.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
