### PR TITLE
[HUDI-5724] Fix merger api usage with more UTs

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -22,9 +22,7 @@ import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
 import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
@@ -60,6 +58,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.hudi.table.action.commit.HoodieDeleteHelper.createDeleteRecord;
 
 /**
  * Hoodie Index Utilities.
@@ -222,9 +221,8 @@ public class HoodieIndexUtils {
   /**
    * Merge the incoming record with the matching existing record loaded via {@link HoodieMergedReadHandle}. The existing record is the latest version in the table.
    */
-  private static <R> Option<HoodieRecord<R>> mergeIncomingWithExistingRecord(HoodieRecord<R> incoming, HoodieRecord<R> existing, HoodieWriteConfig config) throws IOException {
+  private static <R> Option<HoodieRecord<R>> mergeIncomingWithExistingRecord(HoodieRecord<R> incoming, HoodieRecord<R> existing, Schema writeSchema, HoodieWriteConfig config) throws IOException {
     Schema existingSchema = HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(config.getSchema()), config.allowOperationMetadataField());
-    Schema writeSchema = new Schema.Parser().parse(config.getWriteSchema());
     Schema writeSchemaWithMetaFields = HoodieAvroUtils.addMetadataFields(writeSchema, config.allowOperationMetadataField());
     // prepend the hoodie meta fields as the incoming record does not have them
     HoodieRecord incomingPrepended = incoming
@@ -273,12 +271,13 @@ public class HoodieIndexUtils {
             return Collections.singletonList(getTaggedRecord(incoming, Option.empty())).iterator();
           }
           HoodieRecord<R> existing = existingOpt.get();
-          if (incoming.getData() instanceof EmptyHoodieRecordPayload) {
+          Schema writeSchema = new Schema.Parser().parse(config.getWriteSchema());
+          if (incoming.isDelete(writeSchema, config.getProps())) {
             // incoming is a delete: force tag the incoming to the old partition
-            return Collections.singletonList(getTaggedRecord(incoming, Option.of(existing.getCurrentLocation()))).iterator();
+            return Collections.singletonList(getTaggedRecord(incoming.newInstance(existing.getKey()), Option.of(existing.getCurrentLocation()))).iterator();
           }
 
-          Option<HoodieRecord<R>> mergedOpt = mergeIncomingWithExistingRecord(incoming, existing, config);
+          Option<HoodieRecord<R>> mergedOpt = mergeIncomingWithExistingRecord(incoming, existing, writeSchema, config);
           if (!mergedOpt.isPresent()) {
             // merge resulted in delete: force tag the incoming to the old partition
             return Collections.singletonList(getTaggedRecord(incoming.newInstance(existing.getKey()), Option.of(existing.getCurrentLocation()))).iterator();
@@ -289,7 +288,7 @@ public class HoodieIndexUtils {
             return Collections.singletonList(getTaggedRecord(merged, Option.of(existing.getCurrentLocation()))).iterator();
           } else {
             // merged record has a different partition: issue a delete to the old partition and insert the merged record to the new partition
-            HoodieRecord<R> deleteRecord = new HoodieAvroRecord(existing.getKey(), new EmptyHoodieRecordPayload());
+            HoodieRecord<R> deleteRecord = createDeleteRecord(config, existing.getKey());
             deleteRecord.setCurrentLocation(existing.getCurrentLocation());
             deleteRecord.seal();
             return Arrays.asList(deleteRecord, getTaggedRecord(merged, Option.empty())).iterator();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergedReadHandle.java
@@ -158,7 +158,9 @@ public class HoodieMergedReadHandle<T, I, K, O> extends HoodieReadHandle<T, I, K
           if (!mergeResult.isPresent()) {
             continue;
           }
-          mergedRecords.add(mergeResult.get().getLeft());
+          HoodieRecord<T> r = mergeResult.get().getLeft().wrapIntoHoodieRecordPayloadWithParams(readerSchema,
+              config.getProps(), simpleKeyGenFieldsOpt, logRecordScanner.isWithOperationField(), logRecordScanner.getPartitionNameOverride(), false, Option.empty());
+          mergedRecords.add(r);
         } else {
           mergedRecords.add(record.copy());
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieDeleteHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/HoodieDeleteHelper.java
@@ -89,7 +89,7 @@ public class HoodieDeleteHelper<T, R> extends
         dedupedKeys = keys.repartition(targetParallelism);
       }
 
-      HoodieData dedupedRecords = createPhonyRecords(config, dedupedKeys);
+      HoodieData dedupedRecords = createDeleteRecords(config, dedupedKeys);
 
       Instant beginTag = Instant.now();
       // perform index loop up to get existing location of records
@@ -118,12 +118,21 @@ public class HoodieDeleteHelper<T, R> extends
     }
   }
 
-  private static HoodieData createPhonyRecords(HoodieWriteConfig config, HoodieData<HoodieKey> keys) {
+  public static HoodieData createDeleteRecords(HoodieWriteConfig config, HoodieData<HoodieKey> keys) {
     HoodieRecordType recordType = config.getRecordMerger().getRecordType();
     if (recordType == HoodieRecordType.AVRO) {
       return keys.map(key -> new HoodieAvroRecord(key, new EmptyHoodieRecordPayload()));
     } else {
       return keys.map(key -> new HoodieEmptyRecord<>(key, recordType));
+    }
+  }
+
+  public static <T> HoodieRecord<T> createDeleteRecord(HoodieWriteConfig config, HoodieKey key) {
+    HoodieRecordType recordType = config.getRecordMerger().getRecordType();
+    if (recordType == HoodieRecordType.AVRO) {
+      return new HoodieAvroRecord(key, new EmptyHoodieRecordPayload());
+    } else {
+      return new HoodieEmptyRecord<>(key, recordType);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergedReadHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieMergedReadHandle.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.client.SparkRDDWriteClient;
-import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
@@ -44,7 +43,6 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -57,7 +55,6 @@ import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
-import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA_STR;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA_WITH_METAFIELDS;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletes;
@@ -104,30 +101,28 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
       List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, partition, 0, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch0);
-      client.upsert(jsc().parallelize(insertsAtEpoch0, 1), commitTimeAtEpoch0);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 1), commitTimeAtEpoch0).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 0, payloadClass);
 
       // 2nd batch: normal updates
       String commitTimeAtEpoch5 = getCommitTimeAtUTC(5);
       List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0, 5, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch5);
-      JavaRDD<WriteStatus> writeStatusesAtEpoch5 = client.upsert(jsc().parallelize(updatesAtEpoch5, 1), commitTimeAtEpoch5);
-      assertNoWriteErrors(writeStatusesAtEpoch5.collect());
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 1), commitTimeAtEpoch5).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 5, payloadClass);
 
       // 3rd batch: delete the record with id 3 (the last one)
       String commitTimeAtEpoch6 = getCommitTimeAtUTC(6);
       client.startCommitWithTime(commitTimeAtEpoch6);
       List<HoodieRecord> deletesAtEpoch6 = getDeletes(updatesAtEpoch5.subList(totalRecords - 1, totalRecords), 6, payloadClass);
-      JavaRDD<WriteStatus> writeStatusesAtEpoch6 = client.upsert(jsc().parallelize(deletesAtEpoch6, 1), commitTimeAtEpoch6);
-      assertNoWriteErrors(writeStatusesAtEpoch6.collect());
+      assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch6, 1), commitTimeAtEpoch6).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords - 1, partition, 5, payloadClass);
 
       // 4th batch: normal updates
       String commitTimeAtEpoch9 = getCommitTimeAtUTC(9);
       List<HoodieRecord> updatesAtEpoch9 = getUpdates(updatesAtEpoch5, 9, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch9);
-      client.upsert(jsc().parallelize(updatesAtEpoch9, 1), commitTimeAtEpoch9);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 1), commitTimeAtEpoch9).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 9, payloadClass);
     }
   }
@@ -158,28 +153,28 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
       List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, partition, 0, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch0);
-      client.upsert(jsc().parallelize(insertsAtEpoch0, 1), commitTimeAtEpoch0);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 1), commitTimeAtEpoch0).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 0, payloadClass);
 
       // 2nd batch: normal updates
       String commitTimeAtEpoch5 = getCommitTimeAtUTC(5);
       List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0, 5, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch5);
-      client.upsert(jsc().parallelize(updatesAtEpoch5, 1), commitTimeAtEpoch5);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 1), commitTimeAtEpoch5).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 5, payloadClass);
 
       // 3rd batch: updates with old timestamp will be discarded
       String commitTimeAtEpoch6 = getCommitTimeAtUTC(6);
       List<HoodieRecord> updatesAtEpoch1 = getUpdates(insertsAtEpoch0, 1, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch6);
-      client.upsert(jsc().parallelize(updatesAtEpoch1, 1), commitTimeAtEpoch6);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch1, 1), commitTimeAtEpoch6).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 5, payloadClass);
 
       // 4th batch: normal updates
       String commitTimeAtEpoch9 = getCommitTimeAtUTC(9);
       List<HoodieRecord> updatesAtEpoch9 = getUpdates(updatesAtEpoch5, 9, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch9);
-      client.upsert(jsc().parallelize(updatesAtEpoch9, 1), commitTimeAtEpoch9);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 1), commitTimeAtEpoch9).collect());
       doMergedReadAndValidate(metaClient, writeConfig, totalRecords, partition, 9, payloadClass);
     }
   }
@@ -198,12 +193,6 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
     HoodieMergedReadHandle mergedReadHandle = new HoodieMergedReadHandle<>(writeConfig, Option.of(latestCommitTime), table, partitionPathAndFileIDPairs.get(0));
     List<HoodieRecord> mergedRecords = mergedReadHandle.getMergedRecords();
     assertEquals(totalRecords, mergedRecords.size());
-    for (int i = 0; i < mergedRecords.size(); i++) {
-      HoodieRecord r = mergedRecords.get(i);
-      mergedRecords.set(i, r.wrapIntoHoodieRecordPayloadWithParams(
-          SCHEMA_WITH_METAFIELDS, writeConfig.getProps(), Option.empty(), writeConfig.allowOperationMetadataField(),
-          Option.empty(), false, Option.of(SCHEMA)));
-    }
     List<HoodieRecord> sortedMergedRecords = mergedRecords.stream()
         .sorted(Comparator.comparing(HoodieRecord::getRecordKey)).collect(Collectors.toList());
     for (int i = 0; i < sortedMergedRecords.size(); i++) {
@@ -211,7 +200,7 @@ public class TestHoodieMergedReadHandle extends SparkClientFunctionalTestHarness
       assertEquals(i, Integer.parseInt(r.getRecordKey()));
       assertEquals(partition, r.getPartitionPath());
       assertEquals(payloadClass.getName(), r.getData().getClass().getName());
-      Option<IndexedRecord> valueOpt = ((HoodieRecordPayload) r.getData()).getInsertValue(SCHEMA);
+      Option<IndexedRecord> valueOpt = ((HoodieRecordPayload) r.getData()).getInsertValue(SCHEMA_WITH_METAFIELDS);
       assertTrue(valueOpt.isPresent());
       GenericRecord avroValue = (GenericRecord) valueOpt.get();
       assertEquals(i, Integer.parseInt(avroValue.get("id").toString()));

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
@@ -117,6 +117,18 @@ public class HoodieAdaptablePayloadDataGenerator {
     return updates;
   }
 
+  public static List<HoodieRecord> getUpdates(List<HoodieRecord> baseRecords, String newPartition, long ts, Class<?> payloadClass) throws IOException {
+    RecordGen recordGen = new RecordGen(payloadClass);
+    List<HoodieRecord> updates = new ArrayList<>();
+    Properties props = new Properties();
+    for (HoodieRecord r : baseRecords) {
+      GenericRecord gr = (GenericRecord) r.toIndexedRecord(SCHEMA, props).get().getData();
+      GenericRecord updated = getUpdate(Integer.parseInt(gr.get("id").toString()), newPartition, ts, recordGen);
+      updates.add(getHoodieRecord(updated, recordGen.getPayloadClass()));
+    }
+    return updates;
+  }
+
   private static GenericRecord getUpdate(int id, String pt, long ts, RecordGen recordGen) {
     GenericRecord r = new GenericData.Record(SCHEMA);
     r.put("id", id);
@@ -131,6 +143,18 @@ public class HoodieAdaptablePayloadDataGenerator {
     for (HoodieRecord r : baseRecords) {
       GenericRecord gr = (GenericRecord) r.toIndexedRecord(SCHEMA, props).get().getData();
       GenericRecord deleted = getDelete(Integer.parseInt(gr.get("id").toString()), gr.get("pt").toString(), ts, recordGen);
+      deletes.add(getHoodieRecord(deleted, recordGen.getPayloadClass()));
+    }
+    return deletes;
+  }
+
+  public static List<HoodieRecord> getDeletes(List<HoodieRecord> baseRecords, String newPartition, long ts, Class<?> payloadClass) throws IOException {
+    RecordGen recordGen = new RecordGen(payloadClass);
+    List<HoodieRecord> deletes = new ArrayList<>();
+    Properties props = new Properties();
+    for (HoodieRecord r : baseRecords) {
+      GenericRecord gr = (GenericRecord) r.toIndexedRecord(SCHEMA, props).get().getData();
+      GenericRecord deleted = getDelete(Integer.parseInt(gr.get("id").toString()), newPartition, ts, recordGen);
       deletes.add(getHoodieRecord(deleted, recordGen.getPayloadClass()));
     }
     return deletes;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodiePayloadConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA_STR;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletes;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getInserts;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getKeyGenProps;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getPayloadProps;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getUpdates;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getCommitTimeAtUTC;
+import static org.apache.hudi.index.HoodieIndex.IndexType.GLOBAL_BLOOM;
+import static org.apache.hudi.index.HoodieIndex.IndexType.GLOBAL_SIMPLE;
+import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctionalTestHarness {
+
+  private static Stream<Arguments> getTableTypeAndIndexType() {
+    return Stream.of(
+        Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE),
+        Arguments.of(COPY_ON_WRITE, GLOBAL_BLOOM),
+        Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
+        Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTableTypeAndIndexType")
+  public void testPartitionChanges(HoodieTableType tableType, HoodieIndex.IndexType indexType) throws IOException {
+    final Class<?> payloadClass = DefaultHoodieRecordPayload.class;
+    HoodieWriteConfig writeConfig = getWriteConfig(payloadClass, indexType);
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+      final int totalRecords = 4;
+      final String p1 = "p1", p2 = "p2", p3 = "p3", p4 = "p4";
+
+      // 1st batch: inserts
+      String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
+      List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, p1, 0, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch0);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 2), commitTimeAtEpoch0).collect());
+
+      // 2nd batch: normal updates same partition
+      String commitTimeAtEpoch5 = getCommitTimeAtUTC(5);
+      List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0, 5, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch5);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch5).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 5);
+
+      // 3rd batch: update all from p1 to p2
+      String commitTimeAtEpoch6 = getCommitTimeAtUTC(6);
+      List<HoodieRecord> updatesAtEpoch6 = getUpdates(updatesAtEpoch5, p2, 6, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch6);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch6, 2), commitTimeAtEpoch6).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p2, 6);
+
+      // 4th batch: update all from p2 to p3
+      String commitTimeAtEpoch7 = getCommitTimeAtUTC(7);
+      List<HoodieRecord> updatesAtEpoch7 = getUpdates(updatesAtEpoch6, p3, 7, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch7);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch7, 2), commitTimeAtEpoch7).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p3, 7);
+
+      // 5th batch: late update all to p4; discarded
+      String commitTimeAtEpoch8 = getCommitTimeAtUTC(8);
+      List<HoodieRecord> updatesAtEpoch2 = getUpdates(insertsAtEpoch0, p4, 2, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch8);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch2, 2), commitTimeAtEpoch8).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p3, 7);
+
+      // 6th batch: update all from p3 to p1
+      String commitTimeAtEpoch9 = getCommitTimeAtUTC(9);
+      List<HoodieRecord> updatesAtEpoch9 = getUpdates(updatesAtEpoch7, p1, 9, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch9);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 2), commitTimeAtEpoch9).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 9);
+
+    }
+
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTableTypeAndIndexType")
+  public void testUpdatePartitionsThenDelete(HoodieTableType tableType, HoodieIndex.IndexType indexType) throws IOException {
+    final Class<?> payloadClass = DefaultHoodieRecordPayload.class;
+    HoodieWriteConfig writeConfig = getWriteConfig(payloadClass, indexType);
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+      final int totalRecords = 4;
+      final String p1 = "p1", p2 = "p2";
+
+      // 1st batch: inserts
+      String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
+      List<HoodieRecord> insertsAtEpoch0 = getInserts(totalRecords, p1, 0, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch0);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(insertsAtEpoch0, 2), commitTimeAtEpoch0).collect());
+
+      // 2nd batch: normal updates same partition
+      String commitTimeAtEpoch5 = getCommitTimeAtUTC(5);
+      List<HoodieRecord> updatesAtEpoch5 = getUpdates(insertsAtEpoch0, 5, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch5);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch5, 2), commitTimeAtEpoch5).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 5);
+
+      // 3rd batch: update all from p1 to p2
+      String commitTimeAtEpoch6 = getCommitTimeAtUTC(6);
+      List<HoodieRecord> updatesAtEpoch6 = getUpdates(updatesAtEpoch5, p2, 6, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch6);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch6, 2), commitTimeAtEpoch6).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p2, 6);
+
+      // 4th batch: delete records with id=0,1
+      String commitTimeAtEpoch7 = getCommitTimeAtUTC(7);
+      List<HoodieRecord> deletesAtEpoch7 = getDeletes(insertsAtEpoch0.subList(0, 2), p2, 7, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch7);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch7, 2), commitTimeAtEpoch7).collect());
+      readTableAndValidate(metaClient, new int[] {2, 3}, p2, 6);
+
+      // 5th batch: delete records with id=2 (set to unknown partition but still matched)
+      String commitTimeAtEpoch8 = getCommitTimeAtUTC(8);
+      List<HoodieRecord> deletesAtEpoch8 = getDeletes(insertsAtEpoch0.subList(2, 3), "unknown_pt", 8, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch8);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch8, 1), commitTimeAtEpoch8).collect());
+      readTableAndValidate(metaClient, new int[] {3}, p2, 6);
+
+      // 6th batch: update all to p1
+      String commitTimeAtEpoch9 = getCommitTimeAtUTC(9);
+      List<HoodieRecord> updatesAtEpoch9 = getUpdates(insertsAtEpoch0, p1, 9, payloadClass);
+      client.startCommitWithTime(commitTimeAtEpoch9);
+      assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 2), commitTimeAtEpoch9).collect());
+      readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 9);
+
+    }
+  }
+
+  private void readTableAndValidate(HoodieTableMetaClient metaClient, int[] expectedIds, String expectedPartition, long expectedTs) {
+    Dataset<Row> df = spark().read().format("hudi")
+        .load(metaClient.getBasePathV2().toString())
+        .sort("id")
+        .select("_hoodie_record_key", "_hoodie_partition_path", "id", "pt", "ts")
+        .cache();
+    int expectedCount = expectedIds.length;
+    assertEquals(expectedCount, df.count());
+    assertEquals(expectedCount, df.filter(String.format("pt = '%s'", expectedPartition)).count());
+    Row[] allRows = (Row[]) df.collect();
+    for (int i = 0; i < expectedCount; i++) {
+      int expectedId = expectedIds[i];
+      Row r = allRows[i];
+      assertEquals(String.valueOf(expectedId), r.getString(0));
+      assertEquals(expectedPartition, r.getString(1));
+      assertEquals(expectedId, r.getInt(2));
+      assertEquals(expectedPartition, r.getString(3));
+      assertEquals(expectedTs, r.getLong(4));
+    }
+    df.unpersist();
+  }
+
+  private HoodieWriteConfig getWriteConfig(Class<?> payloadClass, HoodieIndex.IndexType indexType) {
+    return getConfigBuilder(true)
+        .withProperties(getKeyGenProps(payloadClass))
+        .withParallelism(2, 2)
+        .withBulkInsertParallelism(2)
+        .withDeleteParallelism(2)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .withIndexType(indexType)
+            .bloomIndexParallelism(2)
+            .withSimpleIndexParallelism(2)
+            .withGlobalSimpleIndexParallelism(2)
+            .withGlobalIndexReconcileParallelism(2)
+            .withBloomIndexUpdatePartitionPath(true)
+            .withGlobalSimpleIndexUpdatePartitionPath(true).build())
+        .withSchema(SCHEMA_STR)
+        .withPayloadConfig(HoodiePayloadConfig.newBuilder()
+            .fromProperties(getPayloadProps(payloadClass)).build())
+        .build();
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -74,7 +74,10 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
     HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
     try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
       final int totalRecords = 4;
-      final String p1 = "p1", p2 = "p2", p3 = "p3", p4 = "p4";
+      final String p1 = "p1";
+      final String p2 = "p2";
+      final String p3 = "p3";
+      final String p4 = "p4";
 
       // 1st batch: inserts
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);
@@ -129,7 +132,8 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
     HoodieTableMetaClient metaClient = getHoodieMetaClient(tableType, writeConfig.getProps());
     try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
       final int totalRecords = 4;
-      final String p1 = "p1", p2 = "p2";
+      final String p1 = "p1";
+      final String p2 = "p2";
 
       // 1st batch: inserts
       String commitTimeAtEpoch0 = getCommitTimeAtUTC(0);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -44,7 +44,8 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA_STR;
-import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletes;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletesWithEmptyPayloadAndNewPartition;
+import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletesWithNewPartition;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getInserts;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getKeyGenProps;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getPayloadProps;
@@ -157,14 +158,14 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
 
       // 4th batch: delete records with id=0,1
       String commitTimeAtEpoch7 = getCommitTimeAtUTC(7);
-      List<HoodieRecord> deletesAtEpoch7 = getDeletes(insertsAtEpoch0.subList(0, 2), p2, 7, payloadClass);
+      List<HoodieRecord> deletesAtEpoch7 = getDeletesWithNewPartition(insertsAtEpoch0.subList(0, 2), p2, 7, payloadClass);
       client.startCommitWithTime(commitTimeAtEpoch7);
       assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch7, 2), commitTimeAtEpoch7).collect());
       readTableAndValidate(metaClient, new int[] {2, 3}, p2, 6);
 
       // 5th batch: delete records with id=2 (set to unknown partition but still matched)
       String commitTimeAtEpoch8 = getCommitTimeAtUTC(8);
-      List<HoodieRecord> deletesAtEpoch8 = getDeletes(insertsAtEpoch0.subList(2, 3), "unknown_pt", 8, payloadClass);
+      List<HoodieRecord> deletesAtEpoch8 = getDeletesWithEmptyPayloadAndNewPartition(insertsAtEpoch0.subList(2, 3), "unknown_pt");
       client.startCommitWithTime(commitTimeAtEpoch8);
       assertNoWriteErrors(client.upsert(jsc().parallelize(deletesAtEpoch8, 1), commitTimeAtEpoch8).collect());
       readTableAndValidate(metaClient, new int[] {3}, p2, 6);


### PR DESCRIPTION
### Change Logs

- Fix merged read handle to wrap merged result back to the original payload.
- Add more test cases around global index

### Impact

Use global index with update partition = true

### Risk level

Medium

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
