### PR TITLE
[MINOR] HoodieAvroUtils supports enum => conversion rewrite

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -988,6 +988,9 @@ public class HoodieAvroUtils {
         }
         break;
       case STRING:
+        if (oldSchema.getType() == Schema.Type.ENUM) {
+          return String.valueOf(oldValue);
+        }
         if (oldSchema.getType() == Schema.Type.BYTES) {
           return String.valueOf(((byte[]) oldValue));
         }

--- a/hudi-common/src/test/java/org/apache/hudi/internal/schema/utils/TestAvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/internal/schema/utils/TestAvroSchemaEvolutionUtils.java
@@ -224,6 +224,7 @@ public class TestAvroSchemaEvolutionUtils {
    */
   @Test
   public void testReWriteRecordWithTypeChanged() {
+    String enumSchema = "{\"type\":\"enum\",\"name\":\"Enum\",\"namespace\":\"org.apache.hudi.internal.schema.utils.TestAvroSchemaEvolutionUtils$\",\"symbols\":[\"ENUM1\",\"ENUM2\"]}";
     Schema avroSchema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"h0_record\",\"namespace\":\"hoodie.h0\",\"fields\""
         + ":[{\"name\":\"id\",\"type\":[\"null\",\"int\"],\"default\":null},"
         + "{\"name\":\"comb\",\"type\":[\"null\",\"int\"],\"default\":null},"
@@ -246,7 +247,7 @@ public class TestAvroSchemaEvolutionUtils {
         + "{\"name\":\"col7\",\"type\":[\"null\",{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}],\"default\":null},"
         + "{\"name\":\"col8\",\"type\":[\"null\",\"boolean\"],\"default\":null},"
         + "{\"name\":\"col9\",\"type\":[\"null\",\"bytes\"],\"default\":null},{\"name\":\"par\",\"type\":[\"null\",{\"type\":\"int\",\"logicalType\":\"date\"}],\"default\":null},"
-        + "{\"name\":\"enum\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Enum\",\"namespace\":\"org.apache.hudi.internal.schema.utils.TestAvroSchemaEvolutionUtils\",\"symbols\":[\"ENUM1\",\"ENUM2\"]}],\"default\":null}"
+        + "{\"name\":\"enum\",\"type\":[\"null\"," + enumSchema + "],\"default\":null}"
         + "]}");
     // create a test record with avroSchema
     GenericData.Record avroRecord = new GenericData.Record(avroSchema);
@@ -275,7 +276,7 @@ public class TestAvroSchemaEvolutionUtils {
     avroRecord.put("col8", false);
     ByteBuffer bb = ByteBuffer.wrap(new byte[] {97, 48, 53});
     avroRecord.put("col9", bb);
-    avroRecord.put("enum", Enum.ENUM1);
+    avroRecord.put("enum", new GenericData.EnumSymbol(new Schema.Parser().parse(enumSchema), Enum.ENUM1));
     Assertions.assertEquals(GenericData.get().validate(avroSchema, avroRecord), true);
     InternalSchema internalSchema = AvroInternalSchemaConverter.convert(avroSchema);
     // do change type operation
@@ -302,6 +303,7 @@ public class TestAvroSchemaEvolutionUtils {
     Schema newAvroSchema = AvroInternalSchemaConverter.convert(newSchema, avroSchema.getFullName());
     GenericRecord newRecord = HoodieAvroUtils.rewriteRecordWithNewSchema(avroRecord, newAvroSchema, Collections.emptyMap());
 
+    Assertions.assertEquals("ENUM1", newRecord.get("enum"));
     Assertions.assertEquals(GenericData.get().validate(newAvroSchema, newRecord), true);
   }
 


### PR DESCRIPTION
Our current flows are as follows:

fetch schema:
- Fetch desired table schema in Avro format from schema registry
- Get a respective dataset schema given desired table Avro schema
- Convert respective dataset schema back to Avro schema to get an unified schema

transform input:
- Consume Kafka via Spark Streaming and receive `RDD<GenericRecord>`
- Rewrite the RDD to unified schema to resolve version differences to end up with desired schema where some fields get dropped and some datatypes get changed. Enum => String for example
	- We use a copy of the org.apache.hudi.avro.HoodieAvroUtils class to do the rewrite and require it to support aforementioned rewrite procedure
	- Hopefully we can make the changes in public repo, so we don't need to maintain a custom rewrite class
- Convert `RDD<GenricRecord>` to `Dataset<Row>`

There are situations where we read input from S3 directly resulting in `Dataset<Row>` which needs to be backfilled to table, so maintaining control over the schema on application side is beneficial for us instead of it being inferred from raw data.

### Change Logs

Rewrite to support enum => string conversion

### Impact

no impact

### Risk level (write none, low medium or high below)

none

### Documentation Update

no documentation needed

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
