### PR TITLE
[HUDI-6229] HoodieInternalWriteStatus marks failure with totalErrorRecords increment

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieInternalWriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieInternalWriteStatus.java
@@ -75,6 +75,7 @@ public class HoodieInternalWriteStatus implements Serializable {
       failedRecordKeys.add(Pair.of(recordKey, t));
     }
     totalRecords++;
+    totalErrorRecords++;
   }
 
   public boolean hasErrors() {
@@ -107,10 +108,6 @@ public class HoodieInternalWriteStatus implements Serializable {
 
   public List<String> getSuccessRecordKeys() {
     return successRecordKeys;
-  }
-
-  public long getFailedRowsSize() {
-    return failedRecordKeys.size();
   }
 
   public List<Pair<String, Throwable>> getFailedRecordKeys() {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
@@ -166,7 +166,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
     long fileSizeInBytes = FSUtils.getFileSize(table.getMetaClient().getFs(), path);
     stat.setTotalWriteBytes(fileSizeInBytes);
     stat.setFileSizeInBytes(fileSizeInBytes);
-    stat.setTotalWriteErrors(writeStatus.getFailedRowsSize());
+    stat.setTotalWriteErrors(writeStatus.getTotalErrorRecords());
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalCreateTime(currTimer.endTimer());
     stat.setRuntimeStats(runtimeStats);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -232,7 +232,7 @@ public class HoodieRowCreateHandle implements Serializable {
     long fileSizeInBytes = FSUtils.getFileSize(table.getMetaClient().getFs(), path);
     stat.setTotalWriteBytes(fileSizeInBytes);
     stat.setFileSizeInBytes(fileSizeInBytes);
-    stat.setTotalWriteErrors(writeStatus.getFailedRowsSize());
+    stat.setTotalWriteErrors(writeStatus.getTotalErrorRecords());
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalCreateTime(currTimer.endTimer());
     stat.setRuntimeStats(runtimeStats);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieInternalWriteStatus.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestHoodieInternalWriteStatus.java
@@ -44,6 +44,7 @@ public class TestHoodieInternalWriteStatus {
     // verification
     assertEquals(fileId, status.getFileId());
     assertEquals(partitionPath, status.getPartitionPath());
+    assertEquals(1000, status.getTotalErrorRecords());
     assertTrue(status.getFailedRecordKeys().size() > 0);
     assertTrue(status.getFailedRecordKeys().size() < 150); // 150 instead of 100, to prevent flaky test
     assertTrue(status.hasErrors());
@@ -66,6 +67,7 @@ public class TestHoodieInternalWriteStatus {
       // verification
       assertEquals(fileId, status.getFileId());
       assertEquals(partitionPath, status.getPartitionPath());
+      assertEquals(1000, status.getTotalErrorRecords());
       assertEquals(1000, status.getFailedRecordKeys().size());
       assertTrue(status.hasErrors());
       if (trackSuccess) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
@@ -218,7 +218,6 @@ public class TestHoodieRowCreateHandle extends HoodieClientTestHarness {
                             String instantTime, Dataset<Row> inputRows, List<String> filenames, List<String> fileAbsPaths, boolean populateMetaFields) {
     assertEquals(writeStatus.getPartitionPath(), partitionPath);
     assertEquals(writeStatus.getTotalRecords(), size);
-    assertEquals(writeStatus.getFailedRowsSize(), 0);
     assertEquals(writeStatus.getTotalErrorRecords(), 0);
     assertFalse(writeStatus.hasErrors());
     assertNull(writeStatus.getGlobalError());

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/internal/HoodieBulkInsertInternalWriterTestBase.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/internal/HoodieBulkInsertInternalWriterTestBase.java
@@ -122,7 +122,6 @@ public class HoodieBulkInsertInternalWriterTestBase extends HoodieClientTestHarn
         assertEquals(writeStatus.getTotalRecords(), sizeMap.get(HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[counter % 3]));
       }
       assertNull(writeStatus.getGlobalError());
-      assertEquals(writeStatus.getFailedRowsSize(), 0);
       assertEquals(writeStatus.getTotalErrorRecords(), 0);
       assertFalse(writeStatus.hasErrors());
       assertNotNull(writeStatus.getFileId());


### PR DESCRIPTION
### Change Logs

`HoodieInternalWriteStatus` should mark failure with `totalErrorRecords` increment. Otherwise `BulkInsertWriterHelper#toWriteStatus` could not get the correct value of `totalErrorRecords` because the `totalErrorRecords` of write status comes from the `totalErrorRecords` of internal write status for `writeStatus.setTotalErrorRecords(internalWriteStatus.getTotalErrorRecords())`, which cause that `ClusteringCommitSink` could not rollback clustering when `ClusteringCommitEvent` has errors.

### Impact

`HoodieInternalWriteStatus` marks failure with `totalErrorRecords` increment for correct `totalErrorRecords`.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed