### PR TITLE
[HUDI-5394] Fix tests for RowCustomColumnsSortPartitioner

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDCustomColumnsSortPartitioner.java
@@ -30,9 +30,10 @@ import org.apache.spark.api.java.JavaRDD;
 import java.util.Arrays;
 
 /**
- * A partitioner that does sort based on specified column values for each RDD partition.
+ * A partitioner that globally sorts a {@link JavaRDD<HoodieRecord>} based on partition path column and custom columns.
  *
- * @param <T> HoodieRecordPayload type
+ * @see GlobalSortPartitioner
+ * @see BulkInsertSortMode#GLOBAL_SORT
  */
 public class RDDCustomColumnsSortPartitioner<T>
     implements BulkInsertPartitioner<JavaRDD<HoodieRecord<T>>> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowCustomColumnsSortPartitioner.java
@@ -28,7 +28,10 @@ import org.apache.spark.sql.Row;
 import java.util.Arrays;
 
 /**
- * A partitioner that does sorting based on specified column values for each spark partitions.
+ * A partitioner that globally sorts a {@link Dataset<Row>} based on partition path column and custom columns.
+ *
+ * @see GlobalSortPartitionerWithRows
+ * @see BulkInsertSortMode#GLOBAL_SORT
  */
 public class RowCustomColumnsSortPartitioner implements BulkInsertPartitioner<Dataset<Row>> {
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class TestBulkInsertInternalPartitionerForRows extends HoodieClientTestHarness {
 
-  private static final Comparator<Row> KEY_COMPARATOR =
+  private static final Comparator<Row> DEFAULT_KEY_COMPARATOR =
       Comparator.comparing(o -> (o.getAs(HoodieRecord.PARTITION_PATH_METADATA_FIELD) + "+" + o.getAs(HoodieRecord.RECORD_KEY_METADATA_FIELD)));
 
   @BeforeEach
@@ -103,8 +103,7 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieClientTestHa
                                                 boolean isGloballySorted,
                                                 boolean isLocallySorted,
                                                 boolean populateMetaFields) {
-    Dataset<Row> records1 = generateTestRecords();
-    Dataset<Row> records2 = generateTestRecords();
+    Dataset<Row> records = generateTestRecords();
 
     HoodieWriteConfig config = HoodieWriteConfig
         .newBuilder()
@@ -116,36 +115,24 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieClientTestHa
 
     testBulkInsertInternalPartitioner(
         BulkInsertInternalPartitionerWithRowsFactory.get(config, isTablePartitioned, enforceNumOutputPartitions),
-        records1,
+        records,
         enforceNumOutputPartitions,
         isGloballySorted,
         isLocallySorted,
-        generateExpectedPartitionNumRecords(records1),
-        Option.empty(),
-        populateMetaFields);
-    testBulkInsertInternalPartitioner(
-        BulkInsertInternalPartitionerWithRowsFactory.get(config, isTablePartitioned, enforceNumOutputPartitions),
-        records2,
-        enforceNumOutputPartitions,
-        isGloballySorted,
-        isLocallySorted,
-        generateExpectedPartitionNumRecords(records2),
+        generateExpectedPartitionNumRecords(records),
         Option.empty(),
         populateMetaFields);
   }
 
   @Test
   public void testCustomColumnSortPartitionerWithRows() {
-    Dataset<Row> records1 = generateTestRecords();
-    Dataset<Row> records2 = generateTestRecords();
-    String sortColumnString = records1.columns()[5];
+    Dataset<Row> records = generateTestRecords();
+    String sortColumnString = records.columns()[5];
     String[] sortColumns = sortColumnString.split(",");
     Comparator<Row> comparator = getCustomColumnComparator(sortColumns);
 
     testBulkInsertInternalPartitioner(new RowCustomColumnsSortPartitioner(sortColumns),
-        records1, true, false, true, generateExpectedPartitionNumRecords(records1), Option.of(comparator), true);
-    testBulkInsertInternalPartitioner(new RowCustomColumnsSortPartitioner(sortColumns),
-        records2, true, false, true, generateExpectedPartitionNumRecords(records2), Option.of(comparator), true);
+        records, true, true, true, generateExpectedPartitionNumRecords(records), Option.of(comparator), true);
 
     HoodieWriteConfig config = HoodieWriteConfig
         .newBuilder()
@@ -154,9 +141,7 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieClientTestHa
         .withUserDefinedBulkInsertPartitionerSortColumns(sortColumnString)
         .build();
     testBulkInsertInternalPartitioner(new RowCustomColumnsSortPartitioner(config),
-        records1, true, false, true, generateExpectedPartitionNumRecords(records1), Option.of(comparator), true);
-    testBulkInsertInternalPartitioner(new RowCustomColumnsSortPartitioner(config),
-        records2, true, false, true, generateExpectedPartitionNumRecords(records2), Option.of(comparator), true);
+        records, true, true, true, generateExpectedPartitionNumRecords(records), Option.of(comparator), true);
   }
 
   private void testBulkInsertInternalPartitioner(BulkInsertPartitioner partitioner,
@@ -227,13 +212,13 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieClientTestHa
 
   private void verifyRowsAscendingOrder(List<Row> records, Option<Comparator<Row>> comparator) {
     List<Row> expectedRecords = new ArrayList<>(records);
-    Collections.sort(expectedRecords, comparator.orElse(KEY_COMPARATOR));
+    Collections.sort(expectedRecords, comparator.orElse(DEFAULT_KEY_COMPARATOR));
     assertEquals(expectedRecords, records);
   }
 
   private Comparator<Row> getCustomColumnComparator(String[] sortColumns) {
     Comparator<Row> comparator = Comparator.comparing(row -> {
-      StringBuilder sb = new StringBuilder();
+      StringBuilder sb = new StringBuilder(row.getAs(HoodieRecord.PARTITION_PATH_METADATA_FIELD));
       for (String col : sortColumns) {
         sb.append(row.getAs(col).toString());
       }


### PR DESCRIPTION
### Change Logs

Fix test to use `RowCustomColumnsSortPartitioner` as global sort partitioner.

This blocks https://github.com/apache/hudi/pull/8445

### Impact

NA

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
