### PR TITLE
[HUDI-6232] Add option to skip table archival in glue sync client

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -21,6 +21,7 @@ package org.apache.hudi.aws.sync;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.GlueCatalogSyncClientConfig;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.sync.common.HoodieSyncClient;
 import org.apache.hudi.sync.common.model.Partition;
@@ -90,10 +91,13 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   private final AWSGlue awsGlue;
   private final String databaseName;
 
+  private final Boolean skipTableArchive;
+
   public AWSGlueCatalogSyncClient(HiveSyncConfig config) {
     super(config);
     this.awsGlue = AWSGlueClientBuilder.standard().build();
     this.databaseName = config.getStringOrDefault(META_SYNC_DATABASE_NAME);
+    this.skipTableArchive = config.getBooleanOrDefault(GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE);
   }
 
   @Override
@@ -145,7 +149,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
             LOG.warn("Partitions already exist in glue: " + result.getErrors());
           } else {
             throw new HoodieGlueSyncException("Fail to add partitions to " + tableId(databaseName, tableName)
-              + " with error(s): " + result.getErrors());
+                + " with error(s): " + result.getErrors());
           }
         }
         Thread.sleep(BATCH_REQUEST_SLEEP_MILLIS);
@@ -232,7 +236,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
       return;
     }
     try {
-      updateTableParameters(awsGlue, databaseName, tableName, tableProperties, false);
+      updateTableParameters(awsGlue, databaseName, tableName, tableProperties, false, skipTableArchive);
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update properties for table " + tableId(databaseName, tableName), e);
     }
@@ -261,6 +265,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
       UpdateTableRequest request = new UpdateTableRequest()
           .withDatabaseName(databaseName)
+          .withSkipArchive(skipTableArchive)
           .withTableInput(updatedTableInput);
 
       awsGlue.updateTable(request);
@@ -271,12 +276,12 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   @Override
   public void createTable(String tableName,
-      MessageType storageSchema,
-      String inputFormatClass,
-      String outputFormatClass,
-      String serdeClass,
-      Map<String, String> serdeProperties,
-      Map<String, String> tableProperties) {
+                          MessageType storageSchema,
+                          String inputFormatClass,
+                          String outputFormatClass,
+                          String serdeClass,
+                          Map<String, String> serdeProperties,
+                          Map<String, String> tableProperties) {
     if (tableExists(tableName)) {
       return;
     }
@@ -422,7 +427,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     }
     final String lastCommitTimestamp = getActiveTimeline().lastInstant().get().getTimestamp();
     try {
-      updateTableParameters(awsGlue, databaseName, tableName, Collections.singletonMap(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitTimestamp), false);
+      updateTableParameters(awsGlue, databaseName, tableName, Collections.singletonMap(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitTimestamp), false, skipTableArchive);
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update last sync commit time for " + tableId(databaseName, tableName), e);
     }
@@ -477,7 +482,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     }
   }
 
-  private static void updateTableParameters(AWSGlue awsGlue, String databaseName, String tableName, Map<String, String> updatingParams, boolean shouldReplace) {
+  private static void updateTableParameters(AWSGlue awsGlue, String databaseName, String tableName, Map<String, String> updatingParams, boolean shouldReplace, boolean skipTableArchive) {
     final Map<String, String> newParams = new HashMap<>();
     try {
       Table table = getTable(awsGlue, databaseName, tableName);
@@ -498,6 +503,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
       UpdateTableRequest request = new UpdateTableRequest();
       request.withDatabaseName(databaseName)
+          .withSkipArchive(skipTableArchive)
           .withTableInput(updatedTableInput);
       awsGlue.updateTable(request);
     } catch (Exception e) {

--- a/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/GlueCatalogSyncClientConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.config;
+
+import org.apache.hudi.common.config.ConfigClassProperty;
+import org.apache.hudi.common.config.ConfigGroups;
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
+
+/**
+ * Hoodie Configs for Glue.
+ */
+@ConfigClassProperty(name = "Glue catalog sync based client Configurations",
+    groupName = ConfigGroups.Names.META_SYNC,
+    subGroupName = ConfigGroups.SubGroupNames.NONE,
+    description = "Configs that control Glue catalog sync based client.")
+public class GlueCatalogSyncClientConfig extends HoodieConfig {
+  public static final String GLUE_CLIENT_PROPERTY_PREFIX = "hoodie.datasource.meta.sync.glue.";
+
+  public static final ConfigProperty<Boolean> GLUE_SKIP_TABLE_ARCHIVE = ConfigProperty
+      .key(GLUE_CLIENT_PROPERTY_PREFIX + "skip_table_archive")
+      .defaultValue(true)
+      .markAdvanced()
+      .sinceVersion("0.14.0")
+      .withDocumentation("Glue catalog sync based client will skip archiving the table version if this config is set to true");
+}

--- a/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/HoodieAWSConfig.java
@@ -37,6 +37,8 @@ import static org.apache.hudi.config.DynamoDbBasedLockConfig.DYNAMODB_LOCK_REGIO
 import static org.apache.hudi.config.DynamoDbBasedLockConfig.DYNAMODB_LOCK_TABLE_NAME;
 import static org.apache.hudi.config.DynamoDbBasedLockConfig.DYNAMODB_LOCK_WRITE_CAPACITY;
 
+import static org.apache.hudi.config.GlueCatalogSyncClientConfig.GLUE_SKIP_TABLE_ARCHIVE;
+
 /**
  * Configurations used by the AWS credentials and AWS DynamoDB based lock.
  */
@@ -145,6 +147,11 @@ public class HoodieAWSConfig extends HoodieConfig {
 
     public Builder withDynamoDBWriteCapacity(String capacity) {
       awsConfig.setValue(DYNAMODB_LOCK_WRITE_CAPACITY, capacity);
+      return this;
+    }
+
+    public Builder withGlueSkipTableArchive(String skipTableArchive) {
+      awsConfig.setValue(GLUE_SKIP_TABLE_ARCHIVE, skipTableArchive);
       return this;
     }
 


### PR DESCRIPTION
### Change Logs

Glue has soft limit of 100k table versions. 
With every table update new version is created. 
In streaming scenarios we can hit 100k table versions quickly.
Users should be able to skip table archival when using glue meta sync. 

Why this change is needed?
It's been asked many times in Hudi Slack, how to reduce no of glue table versions created. There is conditional hive sync, but it does not solve the problem fully. With .skipArchive users can reduce no. of table versions created even more.

### Impact

Added GLUE_SKIP_TABLE_ARCHIVE config, defaults to true.

### Risk level (write none, low medium or high below)

medium as there are no tests for glue sync but the change is not complex

### Documentation Update

config GLUE_SKIP_TABLE_ARCHIVE - defaults to true, controls whether create new tglue able version on table update

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
