### PR TITLE
[HUDI-6182] Hive sync use state transient time to avoid losing partit…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -241,7 +241,7 @@ public class TimelineUtils {
         .findInstantsAfter(exclusiveStartInstantTime, Integer.MAX_VALUE)
         .getInstantsAsStream();
 
-    // Get 'hollow' instants that have lesser instant time than exclusiveStartInstantTime but with greater commit completion time
+    // Get 'hollow' instants that have less instant time than exclusiveStartInstantTime but with greater commit completion time
     Stream<HoodieInstant> hollowInstants = timeline.getCommitsTimeline()
         .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, exclusiveStartInstantTime))
         .filter(s -> HoodieTimeline.compareTimestamps(s.getStateTransitionTime(), GREATER_THAN, commitCompletionTime))

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -223,27 +223,35 @@ public class TimelineUtils {
    *
    * @param metaClient                {@link HoodieTableMetaClient} instance.
    * @param exclusiveStartInstantTime Start instant time (exclusive).
+   * @param commitCompletionTime Last commit completion time synced
    * @return Hudi timeline.
    */
-  public static HoodieDefaultTimeline getCommitsTimelineAfter(
-      HoodieTableMetaClient metaClient, String exclusiveStartInstantTime) {
-    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+  public static HoodieTimeline getCommitsTimelineAfter(
+      HoodieTableMetaClient metaClient, String exclusiveStartInstantTime, String commitCompletionTime) {
+    HoodieDefaultTimeline activeTimeline = metaClient.getActiveTimeline();
+
     HoodieDefaultTimeline timeline =
         activeTimeline.isBeforeTimelineStarts(exclusiveStartInstantTime)
             ? metaClient.getArchivedTimeline(exclusiveStartInstantTime)
             .mergeTimeline(activeTimeline)
             : activeTimeline;
-    return (HoodieDefaultTimeline) timeline.getCommitsTimeline()
-        .findInstantsAfter(exclusiveStartInstantTime, Integer.MAX_VALUE);
+
+    // Get new instants with greater instant time than exclusiveStartInstantTime
+    Stream<HoodieInstant> newInstants = timeline.getCommitsTimeline()
+        .findInstantsAfter(exclusiveStartInstantTime, Integer.MAX_VALUE)
+        .getInstantsAsStream();
+
+    // Get 'hollow' instants that have lesser instant time than exclusiveStartInstantTime but with greater commit completion time
+    Stream<HoodieInstant> hollowInstants = timeline.getCommitsTimeline()
+        .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, exclusiveStartInstantTime))
+        .filter(s -> HoodieTimeline.compareTimestamps(s.getStateTransitionTime(), GREATER_THAN, commitCompletionTime))
+        .getInstantsAsStream();
+
+    Stream<HoodieInstant> mergedInstantStream = Stream.concat(newInstants, hollowInstants).sorted();
+
+    return new HoodieDefaultTimeline(mergedInstantStream, timeline.details);
   }
 
-  public static HoodieDefaultTimeline getHollowInstantsTimeline(
-      HoodieTableMetaClient metaClient, String exclusiveStartInstantTime, String commitCompletionTime) {
-    return (HoodieDefaultTimeline) metaClient.getActiveTimeline().getCommitsTimeline()
-        .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), LESSER_THAN, exclusiveStartInstantTime))
-        .filter(s -> HoodieTimeline.compareTimestamps(s.getStateTransitionTime(), GREATER_THAN, commitCompletionTime));
-  }
-  
   /**
    * Returns the commit metadata of the given instant.
    *

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -275,16 +275,19 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     String startTs = "010";
     HoodieTableMetaClient mockMetaClient = prepareMetaClient(
         Arrays.asList(
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "009"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012")),
-        Arrays.asList(new HoodieInstant(COMPLETED, COMMIT_ACTION, "001"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002")),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "009", "013"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", "010"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", "011"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012", "012")),
+        Arrays.asList(new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", "001"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", "002")),
         startTs
     );
+
+    // Commit 009 will be included in result because it has greater commit completion than 010
     verifyTimeline(
         Arrays.asList(
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "009"),
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "011"),
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "012")),
         TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs, startTs));
@@ -294,20 +297,20 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     startTs = "001";
     mockMetaClient = prepareMetaClient(
         Arrays.asList(
-            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "009"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012")),
-        Arrays.asList(new HoodieInstant(COMPLETED, COMMIT_ACTION, "001"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002")),
+            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "009", "009"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", "010"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", "011"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012", "012")),
+        Arrays.asList(new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", "001"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", "002")),
         startTs
     );
     verifyTimeline(
         Arrays.asList(
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011"),
-            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012")),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", "002"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", "010"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", "011"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012", "012")),
         TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs, startTs));
     verify(mockMetaClient, times(1)).getArchivedTimeline(any());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -287,7 +287,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         Arrays.asList(
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "011"),
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "012")),
-        TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs));
+        TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs, startTs));
     verify(mockMetaClient, never()).getArchivedTimeline(any());
 
     // Should load both archived and active timeline
@@ -308,7 +308,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "010"),
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "011"),
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "012")),
-        TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs));
+        TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs, startTs));
     verify(mockMetaClient, times(1)).getArchivedTimeline(any());
   }
 

--- a/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncTool.java
+++ b/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncTool.java
@@ -194,7 +194,7 @@ public class AdbSyncTool extends HoodieSyncTool {
     if (config.getSplitStrings(META_SYNC_PARTITION_FIELDS).isEmpty()) {
       writtenPartitionsSince = new ArrayList<>();
     } else {
-      writtenPartitionsSince = syncClient.getWrittenPartitionsSince(lastCommitTimeSynced);
+      writtenPartitionsSince = syncClient.getWrittenPartitionsSince(lastCommitTimeSynced, Option.empty());
     }
     LOG.info("Scan partitions complete, partitionNum:{}", writtenPartitionsSince.size());
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -267,8 +267,11 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
     boolean syncIncremental = config.getBoolean(META_SYNC_INCREMENTAL);
     Option<String> lastCommitTimeSynced = (tableExists && syncIncremental)
         ? syncClient.getLastCommitTimeSynced(tableName) : Option.empty();
+    Option<String> lastCommitCompletionTimeSynced = (tableExists && syncIncremental)
+        ? syncClient.getLastCommitCompletionTimeSynced(tableName) : Option.empty();
     if (syncIncremental) {
-      LOG.info("Last commit time synced was found to be " + lastCommitTimeSynced.orElse("null"));
+      LOG.info(String.format("Last commit time synced was found to be %s, last commit completion time is found to be %s",
+          lastCommitTimeSynced.orElse("null"), lastCommitCompletionTimeSynced.orElse("null")));
     } else {
       LOG.info(
           "Executing a full partition sync operation since {} is set to false.",
@@ -287,12 +290,12 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
           + ", file system: " + config.getHadoopFileSystem());
       partitionsChanged = syncAllPartitions(tableName);
     } else {
-      List<String> writtenPartitionsSince = syncClient.getWrittenPartitionsSince(lastCommitTimeSynced);
+      List<String> writtenPartitionsSince = syncClient.getWrittenPartitionsSince(lastCommitTimeSynced, lastCommitCompletionTimeSynced);
       LOG.info("Storage partitions scan complete. Found " + writtenPartitionsSince.size());
 
       // Sync the partitions if needed
       // find dropped partitions, if any, in the latest commit
-      Set<String> droppedPartitions = syncClient.getDroppedPartitionsSince(lastCommitTimeSynced);
+      Set<String> droppedPartitions = syncClient.getDroppedPartitionsSince(lastCommitTimeSynced, lastCommitCompletionTimeSynced);
       partitionsChanged = syncPartitions(tableName, writtenPartitionsSince, droppedPartitions);
     }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -21,6 +21,7 @@ package org.apache.hudi.hive;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.MapUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -281,6 +282,17 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     }
   }
 
+  @Override
+  public Option<String> getLastCommitCompletionTimeSynced(String tableName) {
+    // Get the last commit completion time from the TBLproperties
+    try {
+      Table table = client.getTable(databaseName, tableName);
+      return Option.ofNullable(table.getParameters().getOrDefault(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, null));
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException("Failed to get the last commit completion time synced from the table " + tableName, e);
+    }
+  }
+
   public Option<String> getLastReplicatedTime(String tableName) {
     // Get the last replicated time from the TBLproperties
     try {
@@ -341,8 +353,15 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
   @Override
   public void updateLastCommitTimeSynced(String tableName) {
     // Set the last commit time from the TBLproperties
-    Option<String> lastCommitSynced = getActiveTimeline().lastInstant().map(HoodieInstant::getTimestamp);
-    if (lastCommitSynced.isPresent()) {
+    HoodieTimeline activeTimeline = getActiveTimeline();
+    Option<String> lastCommitSynced = activeTimeline.lastInstant().map(HoodieInstant::getTimestamp);
+    Option<String> lastCommitCompletionSynced = getActiveTimeline()
+        .getInstantsOrderedByStateTransitionTime()
+        .skip(activeTimeline.countInstants() - 1)
+        .findFirst()
+        .map(i -> Option.of(i.getStateTransitionTime()))
+        .orElse(Option.empty());
+    if (lastCommitSynced.isPresent() && lastCommitCompletionSynced.isPresent()) {
       try {
         Table table = client.getTable(databaseName, tableName);
         String basePath = config.getString(META_SYNC_BASE_PATH);
@@ -351,6 +370,7 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
         SerDeInfo serdeInfo = sd.getSerdeInfo();
         serdeInfo.putToParameters(ConfigUtils.TABLE_SERDE_PATH, basePath);
         table.putToParameters(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitSynced.get());
+        table.putToParameters(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, lastCommitCompletionSynced.get());
         client.alter_table(databaseName, tableName, table);
       } catch (Exception e) {
         throw new HoodieHiveSyncException("Failed to get update last commit time synced to " + lastCommitSynced, e);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -352,16 +352,16 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
 
   @Override
   public void updateLastCommitTimeSynced(String tableName) {
-    // Set the last commit time from the TBLproperties
+    // Set the last commit time and commit completion from the TBLproperties
     HoodieTimeline activeTimeline = getActiveTimeline();
     Option<String> lastCommitSynced = activeTimeline.lastInstant().map(HoodieInstant::getTimestamp);
-    Option<String> lastCommitCompletionSynced = getActiveTimeline()
+    Option<String> lastCommitCompletionSynced = activeTimeline
         .getInstantsOrderedByStateTransitionTime()
         .skip(activeTimeline.countInstants() - 1)
         .findFirst()
         .map(i -> Option.of(i.getStateTransitionTime()))
         .orElse(Option.empty());
-    if (lastCommitSynced.isPresent() && lastCommitCompletionSynced.isPresent()) {
+    if (lastCommitSynced.isPresent()) {
       try {
         Table table = client.getTable(databaseName, tableName);
         String basePath = config.getString(META_SYNC_BASE_PATH);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -695,7 +695,7 @@ public class TestHiveSyncTool {
 
     // Lets do the sync
     reSyncHiveTable();
-    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(commitTime1), Option.empty());
+    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(commitTime1), Option.of(commitTime1));
     assertEquals(1, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
     List<org.apache.hudi.sync.common.model.Partition> hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
@@ -1077,7 +1077,7 @@ public class TestHiveSyncTool {
     HiveTestUtil.addCOWPartition("2010/01/02", true, true, commitTime2);
 
     reInitHiveSyncClient();
-    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(instantTime), Option.empty());
+    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(instantTime), Option.of(getLastCommitCompletionTimeSynced()));
     assertEquals(1, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
     List<org.apache.hudi.sync.common.model.Partition> hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
@@ -1107,7 +1107,7 @@ public class TestHiveSyncTool {
         "Table partitions should match the number of partitions we wrote");
     assertEquals(commitTime3, hiveClient.getLastCommitTimeSynced(HiveTestUtil.TABLE_NAME).get(),
         "The last commit that was synced should be updated in the TBLPROPERTIES");
-    assertEquals(1, hiveClient.getWrittenPartitionsSince(Option.of(commitTime2), Option.empty()).size());
+    assertEquals(1, hiveClient.getWrittenPartitionsSince(Option.of(commitTime2), Option.of(getLastCommitCompletionTimeSynced())).size());
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieSyncTableStrategy;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.testutils.NetworkTestUtils;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.Option;
@@ -323,7 +324,7 @@ public class TestHiveSyncTool {
         + FSUtils.getPartitionPath(basePath, "2050/1/1").toString() + "'");
 
     hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
-    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.empty());
+    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.empty(), Option.empty());
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
     assertEquals(1, partitionEvents.size(), "There should be only one partition event");
     assertEquals(PartitionEventType.UPDATE, partitionEvents.iterator().next().eventType,
@@ -691,7 +692,7 @@ public class TestHiveSyncTool {
 
     // Lets do the sync
     reSyncHiveTable();
-    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(commitTime1));
+    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(commitTime1), Option.empty());
     assertEquals(1, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
     List<org.apache.hudi.sync.common.model.Partition> hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
@@ -1073,7 +1074,7 @@ public class TestHiveSyncTool {
     HiveTestUtil.addCOWPartition("2010/01/02", true, true, commitTime2);
 
     reInitHiveSyncClient();
-    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(instantTime));
+    List<String> writtenPartitionsSince = hiveClient.getWrittenPartitionsSince(Option.of(instantTime), Option.empty());
     assertEquals(1, writtenPartitionsSince.size(), "We should have one partition written after 100 commit");
     List<org.apache.hudi.sync.common.model.Partition> hivePartitions = hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME);
     List<PartitionEvent> partitionEvents = hiveClient.getPartitionEvents(hivePartitions, writtenPartitionsSince, Collections.emptySet());
@@ -1103,7 +1104,7 @@ public class TestHiveSyncTool {
         "Table partitions should match the number of partitions we wrote");
     assertEquals(commitTime3, hiveClient.getLastCommitTimeSynced(HiveTestUtil.TABLE_NAME).get(),
         "The last commit that was synced should be updated in the TBLPROPERTIES");
-    assertEquals(1, hiveClient.getWrittenPartitionsSince(Option.of(commitTime2)).size());
+    assertEquals(1, hiveClient.getWrittenPartitionsSince(Option.of(commitTime2), Option.empty()).size());
   }
 
   @ParameterizedTest
@@ -1503,6 +1504,59 @@ public class TestHiveSyncTool {
     reInitHiveSyncClient();
     reSyncHiveTable();
     assertEquals(commitTime1, hiveClient.getLastCommitTimeSynced(tableName).get());
+  }
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testHiveSyncWithMultiWriter(String syncMode) throws Exception {
+    String tableName = HiveTestUtil.TABLE_NAME + HiveSyncTool.SUFFIX_SNAPSHOT_TABLE;
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), syncMode);
+    hiveSyncProps.setProperty(META_SYNC_CONDITIONAL_SYNC.key(), "true");
+
+    String commitTime0 = HoodieInstantTimeGenerator.createNewInstantTime(0);
+    String commitTime1 = HoodieInstantTimeGenerator.createNewInstantTime(1);
+    String commitTime2 = HoodieInstantTimeGenerator.createNewInstantTime(2);
+    String commitTime3 = HoodieInstantTimeGenerator.createNewInstantTime(3);
+    String commitTime4 = HoodieInstantTimeGenerator.createNewInstantTime(4);
+    String commitTime5 = HoodieInstantTimeGenerator.createNewInstantTime(5);
+
+    // Commit 2 and commit3 will be committed first
+    HiveTestUtil.createMORTable(commitTime2, commitTime3, 2, true, true);
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+
+    assertTrue(hiveClient.tableExists(tableName));
+    String lastCommitCompletionTimeSynced = hiveClient.getActiveTimeline()
+        .getInstantsOrderedByStateTransitionTime()
+        .skip(hiveClient.getActiveTimeline().countInstants() - 1).findFirst().get().getStateTransitionTime();
+    assertEquals(commitTime3, hiveClient.getLastCommitTimeSynced(tableName).get());
+    assertEquals(lastCommitCompletionTimeSynced, hiveClient.getLastCommitCompletionTimeSynced(tableName).get());
+    assertEquals(2, hiveClient.getAllPartitions(tableName).size());
+
+    // Commit0 and commit1 committed after commit2 and commit3
+    HiveTestUtil.addMORPartitions(4, true, true, true, ZonedDateTime.now().plusDays(2), commitTime0, commitTime1);
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+
+    lastCommitCompletionTimeSynced = hiveClient.getActiveTimeline()
+        .getInstantsOrderedByStateTransitionTime()
+        .skip(hiveClient.getActiveTimeline().countInstants() - 1).findFirst().get().getStateTransitionTime();
+    // LastCommitTimeSynced will still be commit3
+    assertEquals(commitTime3, hiveClient.getLastCommitTimeSynced(tableName).get());
+    assertEquals(lastCommitCompletionTimeSynced, hiveClient.getLastCommitCompletionTimeSynced(tableName).get());
+    // Partitions included in commit0 and commit1 will be synced to HMS correctly
+    assertEquals(4, hiveClient.getAllPartitions(tableName).size());
+
+    // Add commit4 and commit5 to the table
+    HiveTestUtil.addMORPartitions(0, true, true, true, ZonedDateTime.now().plusDays(2), commitTime4, commitTime5);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime0, COMMIT_ACTION);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime1, DELTA_COMMIT_ACTION);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime2, COMMIT_ACTION);
+    HiveTestUtil.removeCommitFromActiveTimeline(commitTime3, DELTA_COMMIT_ACTION);
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+    // Nothing changed
+    assertEquals(lastCommitCompletionTimeSynced, hiveClient.getLastCommitCompletionTimeSynced(tableName).get());
   }
 
   private void reSyncHiveTable() {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
@@ -33,6 +33,8 @@ public interface HoodieMetaSyncOperations {
 
   String HOODIE_LAST_COMMIT_TIME_SYNC = "last_commit_time_sync";
 
+  String HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC = "last_commit_completion_time_sync";
+
   /**
    * Create the table.
    *
@@ -176,6 +178,13 @@ public interface HoodieMetaSyncOperations {
    * Get the timestamp of last sync.
    */
   default Option<String> getLastCommitTimeSynced(String tableName) {
+    return Option.empty();
+  }
+
+  /**
+   * Get the commit completion time of last sync
+   */
+  default Option<String> getLastCommitCompletionTimeSynced(String tableName) {
     return Option.empty();
   }
 

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -93,8 +93,8 @@ public abstract class HoodieSyncClient implements HoodieMetaSyncOperations, Auto
     HoodieDefaultTimeline timeline = lastCommitTimeSynced.isPresent()
         ? TimelineUtils.getCommitsTimelineAfter(metaClient, lastCommitTimeSynced.get())
         : metaClient.getActiveTimeline();
-    timeline = lastCommitCompletionTimeSynced.isPresent() ?
-        timeline.mergeTimeline(TimelineUtils.getHollowInstantsTimeline(
+    timeline = lastCommitCompletionTimeSynced.isPresent()
+        ? timeline.mergeTimeline(TimelineUtils.getHollowInstantsTimeline(
             metaClient, lastCommitTimeSynced.get(), lastCommitCompletionTimeSynced.get()))
         : timeline;
     return new HashSet<>(TimelineUtils.getDroppedPartitions(timeline));

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncClient.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
-import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.Option;


### PR DESCRIPTION
…ion in multi writer scenario


see relative issue #8500

This PR is stacked on #7627

### Change Logs

Hive sync now will use state transient time to get affected partitions instead of instant time to avoid losing partitions synced to hms due to multi-writer. 

Sill in draft, Will add tests and support for archive timeline later

### Impact


Hive sync now will use state transient time to get affected partitions
### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
