### PR TITLE
[HUDI-6234] make sure clean is run after flink table service

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringCommitSink.java
@@ -90,6 +90,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
   public ClusteringCommitSink(Configuration conf) {
     super(conf);
     this.conf = conf;
+    this.runCleanInOpen = false;
   }
 
   @Override
@@ -194,7 +195,7 @@ public class ClusteringCommitSink extends CleanFunction<ClusteringCommitEvent> {
         TableServiceType.CLUSTER, writeMetadata.getCommitMetadata().get(), table, instant);
 
     // whether to clean up the input base parquet files used for clustering
-    if (!conf.getBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED) && !isCleaning) {
+    if (!conf.getBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED)) {
       LOG.info("Running inline clean");
       this.writeClient.clean();
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionCommitSink.java
@@ -85,6 +85,7 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
   public CompactionCommitSink(Configuration conf) {
     super(conf);
     this.conf = conf;
+    this.runCleanInOpen = false;
   }
 
   @Override
@@ -175,7 +176,8 @@ public class CompactionCommitSink extends CleanFunction<CompactionCommitEvent> {
     this.writeClient.commitCompaction(instant, metadata, Option.empty());
 
     // Whether to clean up the old log file when compaction
-    if (!conf.getBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED) && !isCleaning) {
+    if (!conf.getBoolean(FlinkOptions.CLEAN_ASYNC_ENABLED)) {
+      LOG.info("Running inline clean");
       this.writeClient.clean();
     }
   }


### PR DESCRIPTION
Good place to trigger clean is after table service commit, for example, in storage critical condition, user want to leave just 1 file version, then clean need to be run after each compaction/clustering commit.

But now clean trigger in `CleanFunction.open` may block the clean in `CompactionCommitSink.doCommit`/`ClusteringCommitSink.doCommit`.

### Change Logs

Disable clean in `CleanFunction.open` for CompactionCommitSink/ClusteringCommitSink.

### Impact

no

### Risk level (write none, low medium or high below)

no

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
