### PR TITLE
[HUDI-6236] write hive_style_partitioning_enable to table config in D…

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -141,6 +141,8 @@ import scala.collection.JavaConversions;
 import static org.apache.hudi.avro.AvroSchemaUtils.getAvroRecordQualifiedName;
 import static org.apache.hudi.common.table.HoodieTableConfig.ARCHIVELOG_FOLDER;
 import static org.apache.hudi.common.table.HoodieTableConfig.DROP_PARTITION_COLUMNS;
+import static org.apache.hudi.common.table.HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE;
+import static org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING;
 import static org.apache.hudi.config.HoodieClusteringConfig.ASYNC_CLUSTERING_ENABLE;
 import static org.apache.hudi.config.HoodieClusteringConfig.INLINE_CLUSTERING;
 import static org.apache.hudi.config.HoodieCompactionConfig.INLINE_COMPACT;
@@ -385,6 +387,10 @@ public class DeltaSync implements Serializable, Closeable {
         .setCDCSupplementalLoggingMode(props.getString(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.key(),
             HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.defaultValue()))
         .setShouldDropPartitionColumns(isDropPartitionColumns())
+        .setHiveStylePartitioningEnable(props.getBoolean(HIVE_STYLE_PARTITIONING_ENABLE.key(),
+            Boolean.parseBoolean(HIVE_STYLE_PARTITIONING_ENABLE.defaultValue())))
+        .setUrlEncodePartitioning(props.getBoolean(URL_ENCODE_PARTITIONING.key(),
+            Boolean.parseBoolean(URL_ENCODE_PARTITIONING.defaultValue())))
         .initTable(new Configuration(jssc.hadoopConfiguration()),
             cfg.targetBasePath);
   }
@@ -495,6 +501,10 @@ public class DeltaSync implements Serializable, Closeable {
           .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
               HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
           .setShouldDropPartitionColumns(isDropPartitionColumns())
+          .setHiveStylePartitioningEnable(props.getBoolean(HIVE_STYLE_PARTITIONING_ENABLE.key(),
+              Boolean.parseBoolean(HIVE_STYLE_PARTITIONING_ENABLE.defaultValue())))
+          .setUrlEncodePartitioning(props.getBoolean(URL_ENCODE_PARTITIONING.key(),
+              Boolean.parseBoolean(URL_ENCODE_PARTITIONING.defaultValue())))
           .initTable(new Configuration(jssc.hadoopConfiguration()), cfg.targetBasePath);
     }
 


### PR DESCRIPTION
…eltaStreamer entrypoints

### Change Logs

In Hudi 0.10.X, Hudi assumes that hoodie table properties contains the `hoodie.datasource.write.hive_style_partitioning` configuration value. 

As such `hoodie.properties` should contain this config for all Hudi tables created by Hudi > 0.10.X. However, in DeltaStreamer entrypoints, this configuration is not written to `hoodie.properties`, which will cause incorrect query results via Spark.

This PR fixes the aforementioned assumptions by ensuring that  `hoodie.datasource.write.hive_style_partitioning`  is written to `hoodie.properties`.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
