### PR TITLE
[HUDI-6237] Fix call stats_file_sizes failure error due to empty glob…

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsFileSizeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/StatsFileSizeProcedure.scala
@@ -21,6 +21,7 @@ import com.codahale.metrics.{Histogram, Snapshot, UniformReservoir}
 import org.apache.hadoop.fs.Path
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.util.ValidationUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hudi.command.procedures.StatsFileSizeProcedure.MAX_FILES
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
@@ -29,6 +30,15 @@ import java.util.function.Supplier
 import scala.collection.JavaConverters.{asScalaBufferConverter, mapAsScalaMapConverter}
 
 class StatsFileSizeProcedure extends BaseProcedure with ProcedureBuilder {
+
+  final def validateGlobRegex(globRegex: String, maximumPartitionDepth: Int): Unit = {
+    // filterNot to remove leading directory split if required
+    val providedPartitionDepth = globRegex.split("/").filterNot(x => x.isEmpty).length - 1
+    // validate globRegex
+    ValidationUtils.checkState(providedPartitionDepth == maximumPartitionDepth,
+      s"Provided partition_path file depth of $providedPartitionDepth does " +
+        s"not match table's maximum partition depth of $maximumPartitionDepth)")
+  }
 
   override def parameters: Array[ProcedureParameter] = Array[ProcedureParameter](
     ProcedureParameter.required(0, "table", DataTypes.StringType),
@@ -54,10 +64,20 @@ class StatsFileSizeProcedure extends BaseProcedure with ProcedureBuilder {
     val globRegex = getArgValueOrDefault(args, parameters(1)).get.asInstanceOf[String]
     val limit: Int = getArgValueOrDefault(args, parameters(2)).get.asInstanceOf[Int]
     val basePath = getBasePath(table)
-    val fs = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build.getFs
-    val globPath = String.format("%s/%s/*", basePath, globRegex)
+    val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
+    val fs = metaClient.getFs
+    val isTablePartitioned = metaClient.getTableConfig.isTablePartitioned
+    val maximumPartitionDepth = if (isTablePartitioned) metaClient.getTableConfig.getPartitionFields.get.length else 0
+    val sanitisedGlobRegex = (isTablePartitioned, globRegex) match {
+      case (false, _) => "/*"
+      case (true, "") =>
+        String.format("/%s/*", List.fill(maximumPartitionDepth)("*").mkString("/"))
+      case (true, _) =>
+        String.format("/%s/*", globRegex)
+    }
+    validateGlobRegex(sanitisedGlobRegex, maximumPartitionDepth)
+    val globPath = String.format("%s/%s", basePath, sanitisedGlobRegex)
     val statuses = FSUtils.getGlobStatusExcludingMetaFolder(fs, new Path(globPath))
-
     val globalHistogram = new Histogram(new UniformReservoir(MAX_FILES))
     val commitHistogramMap = new java.util.HashMap[String, Histogram]()
     statuses.asScala.foreach(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestStatsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestStatsProcedure.scala
@@ -58,7 +58,7 @@ class TestStatsProcedure extends HoodieSparkProcedureTestBase {
     }
   }
 
-  test("Test Call stats_file_sizes Procedure") {
+  test("Test Call stats_file_sizes Procedure for partitioned tables") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$tableName"
@@ -67,11 +67,11 @@ class TestStatsProcedure extends HoodieSparkProcedureTestBase {
         s"""
            |create table $tableName (
            |  id int,
-           |  name string,
            |  price double,
+           |  name string,
            |  ts long
            |) using hudi
-           | partitioned by (ts)
+           | partitioned by (name, ts)
            | location '$tablePath'
            | tblproperties (
            |  primaryKey = 'id',
@@ -79,18 +79,97 @@ class TestStatsProcedure extends HoodieSparkProcedureTestBase {
            | )
        """.stripMargin)
       // insert data to table
-      spark.sql(s"insert into $tableName select 1, 'a1', 10, 1000")
-      spark.sql(s"insert into $tableName select 2, 'a2', 20, 1500")
+      spark.sql(s"insert into $tableName select 1, 10, 'a1', 1000")
+      spark.sql(s"insert into $tableName select 2, 20, 'a2', 1500")
 
       // Check required fields
       checkExceptionContain(s"""call stats_file_sizes(limit => 10)""")(
         s"Argument: table is required")
 
-      // collect result for table
-      val result = spark.sql(
+      // collect result for partitioned table without specifying partition_path (resolve dual layer partitioning)
+      // will show an extra row with commit_time == ALL
+      val noPartitionRegexResult = spark.sql(
+        s"""call stats_file_sizes(table => '$tableName')""".stripMargin).collect()
+      assertResult(3) {
+        noPartitionRegexResult.length
+      }
+
+      // collect result for partitioned table with partition_path regex
+      val validPartitionRegexResult = spark.sql(
+        s"""call stats_file_sizes(table => '$tableName', partition_path => 'a1/*')""".stripMargin).collect()
+      assertResult(1) {
+        validPartitionRegexResult.length
+      }
+
+      // collect result for partitioned table with partition_path regex that has a leading '/' character
+      val leadingDirectoryDelimiterResult = spark.sql(
+        s"""call stats_file_sizes(table => '$tableName', partition_path => '/a1/*')""".stripMargin).collect()
+      assertResult(1) {
+        leadingDirectoryDelimiterResult.length
+      }
+
+      // collect result for partitioned table with invalid partition_path regex
+      checkExceptionContain(s"""call stats_file_sizes(table => '$tableName', partition_path => '/*')""".stripMargin)(
+        "Provided partition_path file depth of 1 does not match table's maximum partition depth of 2"
+      )
+    }
+  }
+
+  test("Test Call stats_file_sizes Procedure for un-partitioned tables") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+      // create table
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  price double,
+           |  name string,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           | )
+       """.stripMargin)
+      // insert data to table
+      spark.sql(s"insert into $tableName select 1, 10, 'a1', 1000")
+      spark.sql(s"insert into $tableName select 2, 20, 'a2', 1500")
+
+      // Check required fields
+      checkExceptionContain(s"""call stats_file_sizes(limit => 10)""")(
+        s"Argument: table is required")
+
+      // collect result for  un-partitioned table without specifying partition_path regex
+      // will show an extra row with commit_time == ALL
+      val noPartitionRegexResult = spark.sql(
+        s"""call stats_file_sizes(table => '$tableName')""".stripMargin).collect()
+      assertResult(3) {
+        noPartitionRegexResult.length
+      }
+
+      // collect result for un-partitioned table by specifying partition_path regex
+      val partitionRegexResult = spark.sql(
+        s"""call stats_file_sizes(table => '$tableName', partition_path => '*')""".stripMargin).collect()
+      assertResult(3) {
+        partitionRegexResult.length
+      }
+
+      // collect result for un-partitioned table by specifying partition_path regex
+      val leadingDirectoryDelimiterResult = spark.sql(
         s"""call stats_file_sizes(table => '$tableName', partition_path => '/*')""".stripMargin).collect()
       assertResult(3) {
-        result.length
+        leadingDirectoryDelimiterResult.length
+      }
+
+      // collect result for un-partitioned table by specifying WRONG partition_path regex
+      // globRegex is ignored for un-partitioned tables
+      val wrongPartitionRegexResult = spark.sql(
+        s"""call stats_file_sizes(table => '$tableName', partition_path => '/*')""".stripMargin).collect()
+      assertResult(3) {
+        wrongPartitionRegexResult.length
       }
     }
   }


### PR DESCRIPTION
…Regex for partitioned tables

### Change Logs

Added handling and validation checks to ensure that user provided partition_path is valid for partitioned tables

Fixes #8750

### Impact

_Describe any public API or user-facing feature change or any performance impact._

None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
