### PR TITLE
[HUDI-6238] Disabling clustering for single file group

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1675,7 +1675,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public boolean shouldClusteringSingleGroup() {
-    return isClusteringSortEnabled() || isSingleGroupClusteringEnabled();
+    return isSingleGroupClusteringEnabled();
   }
 
   public String getClusteringSortColumns() {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkSizeBasedClusteringPlanStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkSizeBasedClusteringPlanStrategy.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.client.clustering.plan.strategy;
@@ -23,19 +24,23 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieSparkCopyOnWriteTable;
+import org.apache.hudi.table.action.cluster.ClusteringPlanPartitionFilterMode;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSparkSizeBasedClusteringPlanStrategy {
 
@@ -72,15 +77,41 @@ public class TestSparkSizeBasedClusteringPlanStrategy {
     List<HoodieClusteringGroup> clusteringGroups = clusteringGroupStream.collect(Collectors.toList());
 
     // FileSlices will be divided into two clusteringGroups
-    Assertions.assertEquals(2, clusteringGroups.size());
+    assertEquals(2, clusteringGroups.size());
 
     // First group: 400, 400, 400, 400, 300, and they will be merged into 2 files
-    Assertions.assertEquals(5, clusteringGroups.get(0).getSlices().size());
-    Assertions.assertEquals(2, clusteringGroups.get(0).getNumOutputFileGroups());
+    assertEquals(5, clusteringGroups.get(0).getSlices().size());
+    assertEquals(2, clusteringGroups.get(0).getNumOutputFileGroups());
 
     // Second group: 300, 200, 200, and they will be merged into 1 file
-    Assertions.assertEquals(3, clusteringGroups.get(1).getSlices().size());
-    Assertions.assertEquals(1, clusteringGroups.get(1).getNumOutputFileGroups());
+    assertEquals(3, clusteringGroups.get(1).getSlices().size());
+    assertEquals(1, clusteringGroups.get(1).getNumOutputFileGroups());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testBuildClusteringGroupsForPartitionOnlyOneFile(boolean enableSingleGroupClustering) {
+    String partition = "20221117";
+    String fileId = "fg-1";
+    List<FileSlice> fileSliceGroups = new ArrayList<>();
+    fileSliceGroups.add(generateFileSlice(partition, fileId, "0"));
+    // test buildClusteringGroupsForPartition with ClusteringSortColumns config
+    HoodieWriteConfig configWithSortEnabled = HoodieWriteConfig.newBuilder().withPath("").withClusteringConfig(
+            HoodieClusteringConfig.newBuilder()
+                .withClusteringPlanPartitionFilterMode(ClusteringPlanPartitionFilterMode.NONE)
+                .withSingleGroupClusteringEnabled(enableSingleGroupClustering)
+                .withClusteringSortColumns("f0")
+                .build())
+        .build();
+    SparkSizeBasedClusteringPlanStrategy strategyWithSortEnabled = new SparkSizeBasedClusteringPlanStrategy(table, context, configWithSortEnabled);
+    Stream<HoodieClusteringGroup> groupStreamSort = strategyWithSortEnabled.buildClusteringGroupsForPartition(partition, fileSliceGroups);
+    assertEquals(enableSingleGroupClustering ? 1 : 0, groupStreamSort.count());
+  }
+
+  private FileSlice generateFileSlice(String partitionPath, String fileId, String baseInstant) {
+    FileSlice fs = new FileSlice(new HoodieFileGroupId(partitionPath, fileId), baseInstant);
+    fs.setBaseFile(new HoodieBaseFile(FSUtils.makeBaseFileName(baseInstant, "1-0-1", fileId)));
+    return fs;
   }
 
   private FileSlice createFileSlice(long baseFileSize) {


### PR DESCRIPTION
### Change Logs

When there is only one file group for a given partition, we should avoid clustering. We added a config `hoodie.clustering.plan.strategy.single.group.clustering.enabled` to dicdate this. But the logic is such that, if sorting is enabled, and even if this config is set to true/false, we trigger clustering. 

But revisiting the logic feels, we don't really need to rely on sorting. Even if the data within single file group may not be sorted, we don't really need to sort them, since the stats are going to remain intact before and after sorting (total valid values, min and max). So, even when sorting is enabled, we should not trigger clustering when file group count is just 1. 

### Impact

Will assist in avoid repeated clustering for partitions having 1 file group. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
