### PR TITLE
[HUDI-6239] fix clustering pool scheduler conf not take effect bug

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/SchedulerConfGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/SchedulerConfGenerator.java
@@ -51,10 +51,24 @@ public class SchedulerConfGenerator {
   public static final String SPARK_SCHEDULER_FAIR_MODE = "FAIR";
 
   private static final String SPARK_SCHEDULING_PATTERN =
-      "<?xml version=\"1.0\"?>\n<allocations>\n  <pool name=\"%s\">\n"
-          + "    <schedulingMode>%s</schedulingMode>\n    <weight>%s</weight>\n    <minShare>%s</minShare>\n"
-          + "  </pool>\n  <pool name=\"%s\">\n    <schedulingMode>%s</schedulingMode>\n"
-          + "    <weight>%s</weight>\n    <minShare>%s</minShare>\n  </pool>\n</allocations>";
+      "<?xml version=\"1.0\"?>\n"
+          + "<allocations>\n"
+          + "    <pool name=\"%s\">\n"
+          + "        <schedulingMode>%s</schedulingMode>\n"
+          + "        <weight>%s</weight>\n"
+          + "        <minShare>%s</minShare>\n"
+          + "    </pool>\n"
+          + "    <pool name=\"%s\">\n"
+          + "        <schedulingMode>%s</schedulingMode>\n"
+          + "        <weight>%s</weight>\n"
+          + "        <minShare>%s</minShare>\n"
+          + "    </pool>\n"
+          + "    <pool name=\"%s\">\n"
+          + "        <schedulingMode>%s</schedulingMode>\n"
+          + "        <weight>%s</weight>\n"
+          + "        <minShare>%s</minShare>\n"
+          + "    </pool>\n"
+          + "</allocations>";
 
   /**
    * Helper to generate spark scheduling configs in XML format with input params.
@@ -67,8 +81,8 @@ public class SchedulerConfGenerator {
    * @param clusteringWeight Minshare for clustering
    * @return Spark scheduling configs
    */
-  private static String generateConfig(Integer deltaSyncWeight, Integer compactionWeight, Integer deltaSyncMinShare,
-      Integer compactionMinShare, Integer clusteringWeight, Integer clusteringMinShare) {
+  static String generateConfig(Integer deltaSyncWeight, Integer compactionWeight, Integer deltaSyncMinShare,
+                               Integer compactionMinShare, Integer clusteringWeight, Integer clusteringMinShare) {
     return String.format(SPARK_SCHEDULING_PATTERN, DELTASYNC_POOL_NAME, SPARK_SCHEDULER_FAIR_MODE,
         deltaSyncWeight.toString(), deltaSyncMinShare.toString(), COMPACT_POOL_NAME, SPARK_SCHEDULER_FAIR_MODE,
         compactionWeight.toString(), compactionMinShare.toString(), CLUSTERING_POOL_NAME, SPARK_SCHEDULER_FAIR_MODE,

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSchedulerConfGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSchedulerConfGenerator.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -50,5 +51,30 @@ public class TestSchedulerConfGenerator {
     cfg.tableType = HoodieTableType.MERGE_ON_READ.name();
     configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
     assertNotNull(configs.get(SparkConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY()), "all satisfies");
+  }
+
+  @Test
+  public void testGenerateConfig() {
+    String targetConfig =
+        "<?xml version=\"1.0\"?>\n"
+            + "<allocations>\n"
+            + "    <pool name=\"hoodiedeltasync\">\n"
+            + "        <schedulingMode>FAIR</schedulingMode>\n"
+            + "        <weight>1</weight>\n"
+            + "        <minShare>2</minShare>\n"
+            + "    </pool>\n"
+            + "    <pool name=\"hoodiecompact\">\n"
+            + "        <schedulingMode>FAIR</schedulingMode>\n"
+            + "        <weight>3</weight>\n"
+            + "        <minShare>4</minShare>\n"
+            + "    </pool>\n"
+            + "    <pool name=\"hoodiecluster\">\n"
+            + "        <schedulingMode>FAIR</schedulingMode>\n"
+            + "        <weight>5</weight>\n"
+            + "        <minShare>6</minShare>\n"
+            + "    </pool>\n"
+            + "</allocations>";
+    String generatedConfig = SchedulerConfGenerator.generateConfig(1, 3, 2, 4, 5, 6);
+    assertEquals(targetConfig, generatedConfig);
   }
 }


### PR DESCRIPTION
### Change Logs

In the method org.apache.hudi.utilities.deltastreamer.SchedulerConfGenerator#generateConfig, it will generate the spark scheduler conf for deltasync, compaction and clustering.

But the clustering scheduler conf will not take effect.

The SPARK_SCHEDULING_PATTERN only contain 2 scheduler pool
![image](https://github.com/apache/hudi/assets/19326824/2673af27-e6b9-42cc-88ff-d3deab21793b)
While the generateConfig take 3 pool as parameter.
![image](https://github.com/apache/hudi/assets/19326824/67ca6e43-3e49-4724-8e64-d69cb57d9991)


### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
