### PR TITLE
[HUDI-6241] HIVE_SYNC_TABLE_STRATEGY in HiveSyncConfigHolder Documentation fix

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -155,5 +155,5 @@ public class HiveSyncConfigHolder {
       .defaultValue(HoodieSyncTableStrategy.ALL.name())
       .markAdvanced()
       .sinceVersion("0.13.0")
-      .withDocumentation("Hive table synchronization strategy. Available option: ONLY_RO, ONLY_RT, ALL.");
+      .withDocumentation("Hive table synchronization strategy. Available option: RO, RT, ALL.");
 }


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
document: Hive table synchronization strategy. Available option: ONLY_RO, ONLY_RT, ALL. 
 
ONLY_RO,ONLY_RT need to change to RO and RT

### Impact
_Describe any public API or user-facing feature change or any performance impact._
no impact

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
