### PR TITLE
[MINOR] Remove unused properties from BootstrapPartitionPathTranslator

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/translator/BootstrapPartitionPathTranslator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/translator/BootstrapPartitionPathTranslator.java
@@ -19,14 +19,10 @@
 package org.apache.hudi.client.bootstrap.translator;
 
 import java.io.Serializable;
-import org.apache.hudi.common.config.TypedProperties;
 
 public abstract class BootstrapPartitionPathTranslator implements Serializable {
 
-  private final TypedProperties properties;
-
-  public BootstrapPartitionPathTranslator(TypedProperties properties) {
-    this.properties = properties;
+  public BootstrapPartitionPathTranslator() {
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/translator/IdentityBootstrapPartitionPathTranslator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/translator/IdentityBootstrapPartitionPathTranslator.java
@@ -18,15 +18,13 @@
 
 package org.apache.hudi.client.bootstrap.translator;
 
-import org.apache.hudi.common.config.TypedProperties;
-
 /**
  * Return same path as bootstrap partition path.
  */
 public class IdentityBootstrapPartitionPathTranslator extends BootstrapPartitionPathTranslator {
 
-  public IdentityBootstrapPartitionPathTranslator(TypedProperties properties) {
-    super(properties);
+  public IdentityBootstrapPartitionPathTranslator() {
+    super();
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
@@ -359,8 +359,7 @@ public class SparkBootstrapCommitActionExecutor<T>
       throw new HoodieKeyGeneratorException("Init keyGenerator failed ", e);
     }
 
-    BootstrapPartitionPathTranslator translator = (BootstrapPartitionPathTranslator) ReflectionUtils.loadClass(
-        config.getBootstrapPartitionPathTranslatorClass(), properties);
+    BootstrapPartitionPathTranslator translator = ReflectionUtils.loadClass(config.getBootstrapPartitionPathTranslatorClass());
 
     List<Pair<String, Pair<String, HoodieFileStatus>>> bootstrapPaths = partitions.stream()
         .flatMap(p -> {


### PR DESCRIPTION
### Change Logs

Remove unused properties from `BootstrapPartitionPathTranslator`. Avoid unnecessary serialization.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
