### PR TITLE
[HUDI-6244] Add bundle validation images for Spark 3.0 and 3.4

### DIFF
--- a/packaging/bundle-validation/base/build_flink1146hive313spark302.sh
+++ b/packaging/bundle-validation/base/build_flink1146hive313spark302.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+docker build \
+ --build-arg HIVE_VERSION=3.1.3 \
+ --build-arg FLINK_VERSION=1.14.6 \
+ --build-arg SPARK_VERSION=3.0.2 \
+ --build-arg SPARK_HADOOP_VERSION=2.7 \
+ -t hudi-ci-bundle-validation-base:flink1146hive313spark302 .
+docker image tag hudi-ci-bundle-validation-base:flink1146hive313spark302 apachehudi/hudi-ci-bundle-validation-base:flink1146hive313spark302

--- a/packaging/bundle-validation/base/build_flink1170hive313spark340.sh
+++ b/packaging/bundle-validation/base/build_flink1170hive313spark340.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+docker build \
+ --build-arg HIVE_VERSION=3.1.3 \
+ --build-arg FLINK_VERSION=1.17.0 \
+ --build-arg SPARK_VERSION=3.4.0 \
+ --build-arg SPARK_HADOOP_VERSION=3 \
+ --build-arg HADOOP_VERSION=3.3.5 \
+ -t hudi-ci-bundle-validation-base:flink1170hive313spark340 .
+docker image tag hudi-ci-bundle-validation-base:flink1170hive313spark340 apachehudi/hudi-ci-bundle-validation-base:flink1170hive313spark340


### PR DESCRIPTION
### Change Logs

This PR adds the script for building bundle validation images for Spark 3.0 and 3.4.  The following two images are pushed to Docker Hub:
- `apachehudi/hudi-ci-bundle-validation-base:flink1146hive313spark302`
- `apachehudi/hudi-ci-bundle-validation-base:flink1170hive313spark340`

### Impact

Enables bundle validation on Spark 3.0 and 3.4

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
