### PR TITLE
[DOCS] Update Trino engine support

### DIFF
--- a/website/docs/querying_data.md
+++ b/website/docs/querying_data.md
@@ -320,25 +320,37 @@ Beginning query by connecting hive metastore with presto client. The presto clie
 ```
 
 ## Trino
+Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using [Hive](https://trino.io/docs/current/connector/hive.html) connector or the native
+[Hudi](https://trino.io/docs/current/connector/hudi.html) connector (available since version 398). However, since version 411, Hive connector redirects to Hudi catalog for reading Hudi tables.
 
-Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using Hive connector or the native
-Hudi connector. If you're on Trino version **398** or higher, it is recommended to use the Hudi connector. To learn more
-about the usage of Hudi connector, please check out
+### Hive Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 406             | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+| > = 406           | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. **Redirection to Hudi catalog also supported.** |
+| > = 411           | NA | Snapshot querying on COW tables. Read optimized querying on MOR tables. Hudi tables can be **only** queried by [table redirection](https://trino.io/docs/current/connector/hive.html#table-redirection). |
+
+If you are using Trino version 411 or greater, and also using Hive connector to query Hudi tables, please set the below config to support table redirection.
+```
+hive.hudi-catalog-name=hudi
+```
+It is recommended to use `hudi-trino-bundle` version 0.12.2 or later for optimal query performance with Hive connector.
+
+### Hudi Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 398             | NA - can only use Hive connector to query Hudi tables | Same as that of Hive connector version < 406. |
+| > = 398           | NA - no need to place bundle jars manually, as they are compile-time dependency | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+
+To learn more about the usage of Hudi connector, please check out
 the [connector documentation](https://trino.io/docs/current/connector/hudi.html). Both the connectors are on par in
-terms of query support, i.e. 'Snapshot' queries for Copy-On-Write tables and
-'Read Optimized' queries for Merge-On-Read tables.
-
-:::note
-[Trino](https://trino.io/) (formerly PrestoSQL) was forked off of PrestoDB a few years ago. Hudi supports 'Snapshot'
-queries for Copy-On-Write tables and 'Read Optimized' queries for Merge-On-Read tables. This is through the initial
-input format based integration in PrestoDB (pre forking). This approach has known performance limitations with very
-large tables, which has been since fixed on PrestoDB. We recommend using the new Hudi connector in Trino (released since
-Trino version 398).
-:::
-
-To query Hudi tables on Trino using the Hive connector, place
-the [hudi-trino-bundle](https://mvnrepository.com/artifact/org.apache.hudi/hudi-trino-bundle) jar into the Hive
-connector installation `<trino_install>/plugin/hive`.
+terms of query support, i.e. 'Snapshot' queries for COW tables and 'Read Optimized' queries for MOR
+tables. We have an active [PR](https://github.com/trinodb/trino/pull/16034) under review to bring the performance of
+Hudi connector on par with Hive connector. Furthermore, we
+expect [MOR table snapshot query](https://github.com/trinodb/trino/pull/14786) support will soon be added to the Hudi
+connector.
 
 ## Impala (3.4 or later)
 

--- a/website/versioned_docs/version-0.12.0/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.0/query_engine_setup.md
@@ -70,13 +70,38 @@ Beginning query by connecting hive metastore with presto client. The presto clie
 ```
 
 ## Trino
-:::note
-[Trino](https://trino.io/) (formerly PrestoSQL) was forked off of PrestoDB a few years ago. Hudi supports 'Snapshot' queries for Copy-On-Write tables and 'Read Optimized' queries
-for Merge-On-Read tables. This is through the initial input format based integration in PrestoDB (pre forking). This approach has
-known performance limitations with very large tables, which has been since fixed on PrestoDB. We are working on replicating the same fixes on Trino as well.
-:::
 
-To query Hudi tables on Trino, please place the `hudi-trino-bundle` jar into the Hive connector installation `<trino_install>/plugin/hive-hadoop2`.
+Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using [Hive](https://trino.io/docs/current/connector/hive.html) connector or the native
+[Hudi](https://trino.io/docs/current/connector/hudi.html) connector (available since version 398). However, since version 411, Hive connector redirects to Hudi catalog for reading Hudi tables.
+
+### Hive Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 406             | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+| > = 406           | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. **Redirection to Hudi catalog also supported.** |
+| > = 411           | NA | Snapshot querying on COW tables. Read optimized querying on MOR tables. Hudi tables can be **only** queried by [table redirection](https://trino.io/docs/current/connector/hive.html#table-redirection). |
+
+If you are using Trino version 411 or greater, and also using Hive connector to query Hudi tables, please set the below config to support table redirection.
+```
+hive.hudi-catalog-name=hudi
+```
+It is recommended to use `hudi-trino-bundle` version 0.12.2 or later for optimal query performance with Hive connector.
+
+### Hudi Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 398             | NA - can only use Hive connector to query Hudi tables | Same as that of Hive connector version < 406. |
+| > = 398           | NA - no need to place bundle jars manually, as they are compile-time dependency | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+
+To learn more about the usage of Hudi connector, please check out
+the [connector documentation](https://trino.io/docs/current/connector/hudi.html). Both the connectors are on par in
+terms of query support, i.e. 'Snapshot' queries for COW tables and 'Read Optimized' queries for MOR
+tables. We have an active [PR](https://github.com/trinodb/trino/pull/16034) under review to bring the performance of
+Hudi connector on par with Hive connector. Furthermore, we
+expect [MOR table snapshot query](https://github.com/trinodb/trino/pull/14786) support will soon be added to the Hudi
+connector.
 
 ## Hive
 

--- a/website/versioned_docs/version-0.12.1/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.1/query_engine_setup.md
@@ -70,13 +70,38 @@ Beginning query by connecting hive metastore with presto client. The presto clie
 ```
 
 ## Trino
-:::note
-[Trino](https://trino.io/) (formerly PrestoSQL) was forked off of PrestoDB a few years ago. Hudi supports 'Snapshot' queries for Copy-On-Write tables and 'Read Optimized' queries
-for Merge-On-Read tables. This is through the initial input format based integration in PrestoDB (pre forking). This approach has
-known performance limitations with very large tables, which has been since fixed on PrestoDB. We are working on replicating the same fixes on Trino as well.
-:::
 
-To query Hudi tables on Trino, please place the `hudi-trino-bundle` jar into the Hive connector installation `<trino_install>/plugin/hive-hadoop2`.
+Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using [Hive](https://trino.io/docs/current/connector/hive.html) connector or the native
+[Hudi](https://trino.io/docs/current/connector/hudi.html) connector (available since version 398). However, since version 411, Hive connector redirects to Hudi catalog for reading Hudi tables.
+
+### Hive Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 406             | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+| > = 406           | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. **Redirection to Hudi catalog also supported.** |
+| > = 411           | NA | Snapshot querying on COW tables. Read optimized querying on MOR tables. Hudi tables can be **only** queried by [table redirection](https://trino.io/docs/current/connector/hive.html#table-redirection). |
+
+If you are using Trino version 411 or greater, and also using Hive connector to query Hudi tables, please set the below config to support table redirection.
+```
+hive.hudi-catalog-name=hudi
+```
+It is recommended to use `hudi-trino-bundle` version 0.12.2 or later for optimal query performance with Hive connector.
+
+### Hudi Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 398             | NA - can only use Hive connector to query Hudi tables | Same as that of Hive connector version < 406. |
+| > = 398           | NA - no need to place bundle jars manually, as they are compile-time dependency | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+
+To learn more about the usage of Hudi connector, please check out
+the [connector documentation](https://trino.io/docs/current/connector/hudi.html). Both the connectors are on par in
+terms of query support, i.e. 'Snapshot' queries for COW tables and 'Read Optimized' queries for MOR
+tables. We have an active [PR](https://github.com/trinodb/trino/pull/16034) under review to bring the performance of
+Hudi connector on par with Hive connector. Furthermore, we
+expect [MOR table snapshot query](https://github.com/trinodb/trino/pull/14786) support will soon be added to the Hudi
+connector.
 
 ## Hive
 

--- a/website/versioned_docs/version-0.12.2/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.2/query_engine_setup.md
@@ -71,20 +71,37 @@ Beginning query by connecting hive metastore with presto client. The presto clie
 
 ## Trino
 
-Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using Hive connector or the native 
-Hudi connector. If you're on Trino version **398** or higher, it is recommended to use the Hudi connector. To learn more 
-about the usage of Hudi connector, please check out the [connector documentation](https://trino.io/docs/current/connector/hudi.html).
-Both the connectors are on par in terms of query support, i.e. 'Snapshot' queries for Copy-On-Write tables and 
-'Read Optimized' queries for Merge-On-Read tables.  
+Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using [Hive](https://trino.io/docs/current/connector/hive.html) connector or the native
+[Hudi](https://trino.io/docs/current/connector/hudi.html) connector (available since version 398). However, since version 411, Hive connector redirects to Hudi catalog for reading Hudi tables.
 
-:::note
-[Trino](https://trino.io/) (formerly PrestoSQL) was forked off of PrestoDB a few years ago. Hudi supports 'Snapshot' queries for Copy-On-Write tables and 'Read Optimized' queries
-for Merge-On-Read tables. This is through the initial input format based integration in PrestoDB (pre forking). This approach has
-known performance limitations with very large tables, which has been since fixed on PrestoDB. 
-We recommend using the new Hudi connector in Trino (released since Trino version 398).
-:::
+### Hive Connector
 
-To query Hudi tables on Trino, please place the `hudi-trino-bundle` jar into the Hive connector installation `<trino_install>/plugin/hive-hadoop2`.
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 406             | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+| > = 406           | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. **Redirection to Hudi catalog also supported.** |
+| > = 411           | NA | Snapshot querying on COW tables. Read optimized querying on MOR tables. Hudi tables can be **only** queried by [table redirection](https://trino.io/docs/current/connector/hive.html#table-redirection). |
+
+If you are using Trino version 411 or greater, and also using Hive connector to query Hudi tables, please set the below config to support table redirection.
+```
+hive.hudi-catalog-name=hudi
+```
+It is recommended to use `hudi-trino-bundle` version 0.12.2 or later for optimal query performance with Hive connector.
+
+### Hudi Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 398             | NA - can only use Hive connector to query Hudi tables | Same as that of Hive connector version < 406. |
+| > = 398           | NA - no need to place bundle jars manually, as they are compile-time dependency | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+
+To learn more about the usage of Hudi connector, please check out
+the [connector documentation](https://trino.io/docs/current/connector/hudi.html). Both the connectors are on par in
+terms of query support, i.e. 'Snapshot' queries for COW tables and 'Read Optimized' queries for MOR
+tables. We have an active [PR](https://github.com/trinodb/trino/pull/16034) under review to bring the performance of
+Hudi connector on par with Hive connector. Furthermore, we
+expect [MOR table snapshot query](https://github.com/trinodb/trino/pull/14786) support will soon be added to the Hudi
+connector.
 
 ## Hive
 

--- a/website/versioned_docs/version-0.12.3/query_engine_setup.md
+++ b/website/versioned_docs/version-0.12.3/query_engine_setup.md
@@ -71,20 +71,37 @@ Beginning query by connecting hive metastore with presto client. The presto clie
 
 ## Trino
 
-Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using Hive connector or the native 
-Hudi connector. If you're on Trino version **398** or higher, it is recommended to use the Hudi connector. To learn more 
-about the usage of Hudi connector, please check out the [connector documentation](https://trino.io/docs/current/connector/hudi.html).
-Both the connectors are on par in terms of query support, i.e. 'Snapshot' queries for Copy-On-Write tables and 
-'Read Optimized' queries for Merge-On-Read tables.  
+Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using [Hive](https://trino.io/docs/current/connector/hive.html) connector or the native
+[Hudi](https://trino.io/docs/current/connector/hudi.html) connector (available since version 398). However, since version 411, Hive connector redirects to Hudi catalog for reading Hudi tables.
 
-:::note
-[Trino](https://trino.io/) (formerly PrestoSQL) was forked off of PrestoDB a few years ago. Hudi supports 'Snapshot' queries for Copy-On-Write tables and 'Read Optimized' queries
-for Merge-On-Read tables. This is through the initial input format based integration in PrestoDB (pre forking). This approach has
-known performance limitations with very large tables, which has been since fixed on PrestoDB. 
-We recommend using the new Hudi connector in Trino (released since Trino version 398).
-:::
+### Hive Connector
 
-To query Hudi tables on Trino, please place the `hudi-trino-bundle` jar into the Hive connector installation `<trino_install>/plugin/hive-hadoop2`.
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 406             | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+| > = 406           | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. **Redirection to Hudi catalog also supported.** |
+| > = 411           | NA | Snapshot querying on COW tables. Read optimized querying on MOR tables. Hudi tables can be **only** queried by [table redirection](https://trino.io/docs/current/connector/hive.html#table-redirection). |
+
+If you are using Trino version 411 or greater, and also using Hive connector to query Hudi tables, please set the below config to support table redirection.
+```
+hive.hudi-catalog-name=hudi
+```
+It is recommended to use `hudi-trino-bundle` version 0.12.2 or later for optimal query performance with Hive connector.
+
+### Hudi Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 398             | NA - can only use Hive connector to query Hudi tables | Same as that of Hive connector version < 406. |
+| > = 398           | NA - no need to place bundle jars manually, as they are compile-time dependency | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+
+To learn more about the usage of Hudi connector, please check out
+the [connector documentation](https://trino.io/docs/current/connector/hudi.html). Both the connectors are on par in
+terms of query support, i.e. 'Snapshot' queries for COW tables and 'Read Optimized' queries for MOR
+tables. We have an active [PR](https://github.com/trinodb/trino/pull/16034) under review to bring the performance of
+Hudi connector on par with Hive connector. Furthermore, we
+expect [MOR table snapshot query](https://github.com/trinodb/trino/pull/14786) support will soon be added to the Hudi
+connector.
 
 ## Hive
 

--- a/website/versioned_docs/version-0.13.0/query_engine_setup.md
+++ b/website/versioned_docs/version-0.13.0/query_engine_setup.md
@@ -71,20 +71,37 @@ Beginning query by connecting hive metastore with presto client. The presto clie
 
 ## Trino
 
-Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using Hive connector or the native 
-Hudi connector. If you're on Trino version **398** or higher, it is recommended to use the Hudi connector. To learn more 
-about the usage of Hudi connector, please check out the [connector documentation](https://trino.io/docs/current/connector/hudi.html).
-Both the connectors are on par in terms of query support, i.e. 'Snapshot' queries for Copy-On-Write tables and 
-'Read Optimized' queries for Merge-On-Read tables.  
+Just like PrestoDB, there are two ways to query Hudi tables using Trino i.e. either using [Hive](https://trino.io/docs/current/connector/hive.html) connector or the native
+[Hudi](https://trino.io/docs/current/connector/hudi.html) connector (available since version 398). However, since version 411, Hive connector redirects to Hudi catalog for reading Hudi tables.
 
-:::note
-[Trino](https://trino.io/) (formerly PrestoSQL) was forked off of PrestoDB a few years ago. Hudi supports 'Snapshot' queries for Copy-On-Write tables and 'Read Optimized' queries
-for Merge-On-Read tables. This is through the initial input format based integration in PrestoDB (pre forking). This approach has
-known performance limitations with very large tables, which has been since fixed on PrestoDB. 
-We recommend using the new Hudi connector in Trino (released since Trino version 398).
-:::
+### Hive Connector
 
-To query Hudi tables on Trino, please place the `hudi-trino-bundle` jar into the Hive connector installation `<trino_install>/plugin/hive-hadoop2`.
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 406             | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+| > = 406           | Requires the `hudi-trino-bundle` jar to be placed into `<trino_install>/plugin/hive` | Snapshot querying on COW tables. Read optimized querying on MOR tables. **Redirection to Hudi catalog also supported.** |
+| > = 411           | NA | Snapshot querying on COW tables. Read optimized querying on MOR tables. Hudi tables can be **only** queried by [table redirection](https://trino.io/docs/current/connector/hive.html#table-redirection). |
+
+If you are using Trino version 411 or greater, and also using Hive connector to query Hudi tables, please set the below config to support table redirection.
+```
+hive.hudi-catalog-name=hudi
+```
+It is recommended to use `hudi-trino-bundle` version 0.12.2 or later for optimal query performance with Hive connector.
+
+### Hudi Connector
+
+| **Trino Version** | **Installation description** | **Query types supported** |
+|-------------------|------------------------------|---------------------------|
+| < 398             | NA - can only use Hive connector to query Hudi tables | Same as that of Hive connector version < 406. |
+| > = 398           | NA - no need to place bundle jars manually, as they are compile-time dependency | Snapshot querying on COW tables. Read optimized querying on MOR tables. |
+
+To learn more about the usage of Hudi connector, please check out
+the [connector documentation](https://trino.io/docs/current/connector/hudi.html). Both the connectors are on par in
+terms of query support, i.e. 'Snapshot' queries for COW tables and 'Read Optimized' queries for MOR
+tables. We have an active [PR](https://github.com/trinodb/trino/pull/16034) under review to bring the performance of
+Hudi connector on par with Hive connector. Furthermore, we
+expect [MOR table snapshot query](https://github.com/trinodb/trino/pull/14786) support will soon be added to the Hudi
+connector.
 
 ## Hive
 


### PR DESCRIPTION
### Change Logs

Trino removed the support for querying Hudi tables through Hive connector in version 411 onwards. Instead, it provides table redirection to Hudi catalog. Update the docs accordingly.

### Impact

Following section in the website will be updated: https://hudi.apache.org/docs/query_engine_setup#trino

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
