### PR TITLE
[MINOR] Avoid synchronized block in HoodieLockMetrics if key is present in cache

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/metrics/HoodieLockMetrics.java
@@ -72,11 +72,13 @@ public class HoodieLockMetrics {
 
   private Timer createTimerForMetrics(MetricRegistry registry, String metric) {
     String metricName = getMetricsName(metric);
-    synchronized (REGISTRY_LOCK) {
-      if (registry.getMetrics().get(metricName) == null) {
-        lockDuration = new Timer(new SlidingWindowReservoir(keepLastNtimes));
-        registry.register(metricName, lockDuration);
-        return lockDuration;
+    if (registry.getMetrics().get(metricName) == null) {
+      synchronized (REGISTRY_LOCK) {
+        if (registry.getMetrics().get(metricName) == null) {
+          lockDuration = new Timer(new SlidingWindowReservoir(keepLastNtimes));
+          registry.register(metricName, lockDuration);
+          return lockDuration;
+        }
       }
     }
     return (Timer) registry.getMetrics().get(metricName);


### PR DESCRIPTION
### Change Logs

Avoids acquiring a lock to check whether a value is present in a cache to allow better performance when the value is already in the cache.

### Impact

1、This provide a minor improvement in execution time.
2、When executing the 'registry. register (metricName, lockDuration)' method on line 79, it is possible to avoid errors caused by the existing key. The reasons are as follows:
![image](https://github.com/apache/hudi/assets/53458004/48a42e5e-9f13-4ee8-846b-1a8f95344b1d)


### Risk level (write none, low medium or high below)

NONE

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
