### PR TITLE
[HUDI-6201] use concurrent map when possible in filesystemview

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -199,7 +199,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   protected void resetPendingCompactionOperations(Stream<Pair<String, CompactionOperation>> operations) {
     // Build fileId to Pending Compaction Instants
     this.fgIdToPendingCompaction = createFileIdToPendingCompactionMap(operations.map(entry ->
-      Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
+      Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toConcurrentMap(Pair::getKey, Pair::getValue)));
   }
 
   @Override
@@ -232,7 +232,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   protected void resetPendingLogCompactionOperations(Stream<Pair<String, CompactionOperation>> operations) {
     // Build fileId to Pending Log Compaction Instants
     this.fgIdToPendingLogCompaction = createFileIdToPendingLogCompactionMap(operations.map(entry ->
-        Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
+        Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toConcurrentMap(Pair::getKey, Pair::getValue)));
   }
 
   @Override
@@ -333,7 +333,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   void resetBootstrapBaseFileMapping(Stream<BootstrapBaseFileMapping> bootstrapBaseFileStream) {
     // Build fileId to bootstrap Data File
     this.fgIdToBootstrapBaseFile = createFileIdToBootstrapBaseFileMap(bootstrapBaseFileStream
-        .collect(Collectors.toMap(BootstrapBaseFileMapping::getFileGroupId, x -> x)));
+        .collect(Collectors.toConcurrentMap(BootstrapBaseFileMapping::getFileGroupId, x -> x)));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -147,27 +147,25 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
 
   protected Map<HoodieFileGroupId, Pair<String, CompactionOperation>> createFileIdToPendingCompactionMap(
       Map<HoodieFileGroupId, Pair<String, CompactionOperation>> fileIdToPendingCompaction) {
-    return fileIdToPendingCompaction;
+    return new ConcurrentHashMap<>(fileIdToPendingCompaction);
   }
 
   protected Map<HoodieFileGroupId, Pair<String, CompactionOperation>> createFileIdToPendingLogCompactionMap(
       Map<HoodieFileGroupId, Pair<String, CompactionOperation>> fileIdToPendingLogCompaction) {
-    return fileIdToPendingLogCompaction;
+    return new ConcurrentHashMap<>(fileIdToPendingLogCompaction);
   }
 
   protected Map<HoodieFileGroupId, BootstrapBaseFileMapping> createFileIdToBootstrapBaseFileMap(
       Map<HoodieFileGroupId, BootstrapBaseFileMapping> fileGroupIdBootstrapBaseFileMap) {
-    return fileGroupIdBootstrapBaseFileMap;
+    return new ConcurrentHashMap<>(fileGroupIdBootstrapBaseFileMap);
   }
 
   protected Map<HoodieFileGroupId, HoodieInstant> createFileIdToReplaceInstantMap(final Map<HoodieFileGroupId, HoodieInstant> replacedFileGroups) {
-    Map<HoodieFileGroupId, HoodieInstant> replacedFileGroupsMap = new ConcurrentHashMap<>(replacedFileGroups);
-    return replacedFileGroupsMap;
+    return new ConcurrentHashMap<>(replacedFileGroups);
   }
 
   protected Map<HoodieFileGroupId, HoodieInstant> createFileIdToPendingClusteringMap(final Map<HoodieFileGroupId, HoodieInstant> fileGroupsInClustering) {
-    Map<HoodieFileGroupId, HoodieInstant> fgInpendingClustering = new ConcurrentHashMap<>(fileGroupsInClustering);
-    return fgInpendingClustering;
+    return new ConcurrentHashMap<>(fileGroupsInClustering);
   }
 
   /**
@@ -201,7 +199,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   protected void resetPendingCompactionOperations(Stream<Pair<String, CompactionOperation>> operations) {
     // Build fileId to Pending Compaction Instants
     this.fgIdToPendingCompaction = createFileIdToPendingCompactionMap(operations.map(entry ->
-      Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toConcurrentMap(Pair::getKey, Pair::getValue)));
+      Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
   }
 
   @Override
@@ -234,7 +232,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   protected void resetPendingLogCompactionOperations(Stream<Pair<String, CompactionOperation>> operations) {
     // Build fileId to Pending Log Compaction Instants
     this.fgIdToPendingLogCompaction = createFileIdToPendingLogCompactionMap(operations.map(entry ->
-        Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toConcurrentMap(Pair::getKey, Pair::getValue)));
+        Pair.of(entry.getValue().getFileGroupId(), Pair.of(entry.getKey(), entry.getValue()))).collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
   }
 
   @Override
@@ -335,7 +333,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   void resetBootstrapBaseFileMapping(Stream<BootstrapBaseFileMapping> bootstrapBaseFileStream) {
     // Build fileId to bootstrap Data File
     this.fgIdToBootstrapBaseFile = createFileIdToBootstrapBaseFileMap(bootstrapBaseFileStream
-        .collect(Collectors.toConcurrentMap(BootstrapBaseFileMapping::getFileGroupId, x -> x)));
+        .collect(Collectors.toMap(BootstrapBaseFileMapping::getFileGroupId, x -> x)));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -54,6 +54,8 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieTableFileSystemView.class);
 
+  //TODO: [HUDI-6249] change the maps below to implement ConcurrentMap
+  
   // mapping from partition paths to file groups contained within them
   protected Map<String, List<HoodieFileGroup>> partitionToFileGroupsMap;
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapRead.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapRead.java
@@ -149,8 +149,6 @@ public class TestBootstrapRead extends HoodieSparkClientTestBase {
     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType);
     options.put(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING().key(), "true");
     options.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
-    //TODO: enable timeline server with [HUDI-6201]
-    options.put("hoodie.embed.timeline.server", "false");
     if (nPartitions == 0) {
       options.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), NonpartitionedKeyGenerator.class.getName());
     } else {


### PR DESCRIPTION
### Change Logs

Issue presented as missing bootstrap base files when doing upsert. Each partition can be modifying the bootstrap fg map at the same time and mappings were dropped sometimes. A big question was why this only was happening for bootstrap but not the other maps. But we realized that those other maps were using a concurrenthashmap as their map

### Impact

Fixes data loss issue

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
