### PR TITLE
[HUDI-6254] Allow using absolute path in ManifestFileWriter

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
@@ -96,7 +96,7 @@ public class BigQuerySyncTool extends HoodieSyncTool {
         .setUseFileListingFromMetadata(config.getBoolean(BIGQUERY_SYNC_USE_FILE_LISTING_FROM_METADATA))
         .setAssumeDatePartitioning(config.getBoolean(BIGQUERY_SYNC_ASSUME_DATE_PARTITIONING))
         .build();
-    manifestFileWriter.writeManifestFile();
+    manifestFileWriter.writeManifestFile(false);
 
     if (!bqSyncClient.tableExists(manifestTableName)) {
       bqSyncClient.createManifestTable(manifestTableName, manifestFileWriter.getManifestSourceUri());


### PR DESCRIPTION
### Change Logs

Allow writing the manifest file with absolute path in ManifestFileWriter. Currently the writer only uses the file name (excluding the full path). 

### Impact

This would make the generated manifest file more flexible, e.g., when a downstream desires full path.

### Risk level (write none, low medium or high below)

None. The current behavior won't change.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
