### PR TITLE
[HUDI-6257] fix upgrade table version check partition path with hive …

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -83,6 +83,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.BASE_FILE_FORMAT;
+import static org.apache.hudi.common.table.HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE;
 import static org.apache.hudi.common.table.HoodieTableConfig.TYPE;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
@@ -338,20 +339,30 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
 
   @Test
   public void testUpgradeFourtoFive() throws Exception {
-    testUpgradeFourToFiveInternal(false, false);
+    testUpgradeFourToFiveInternal(false, false, false);
   }
 
   @Test
   public void testUpgradeFourtoFiveWithDefaultPartition() throws Exception {
-    testUpgradeFourToFiveInternal(true, false);
+    testUpgradeFourToFiveInternal(true, false, false);
   }
 
   @Test
   public void testUpgradeFourtoFiveWithDefaultPartitionWithSkipValidation() throws Exception {
-    testUpgradeFourToFiveInternal(true, true);
+    testUpgradeFourToFiveInternal(true, true, false);
   }
 
-  private void testUpgradeFourToFiveInternal(boolean assertDefaultPartition, boolean skipDefaultPartitionValidation) throws Exception {
+  @Test
+  public void testUpgradeFourtoFiveWithHiveStyleDefaultPartition() throws Exception {
+    testUpgradeFourToFiveInternal(true, false, true);
+  }
+
+  @Test
+  public void testUpgradeFourtoFiveWithHiveStyleDefaultPartitionWithSkipValidation() throws Exception {
+    testUpgradeFourToFiveInternal(true, true, true);
+  }
+
+  private void testUpgradeFourToFiveInternal(boolean assertDefaultPartition, boolean skipDefaultPartitionValidation, boolean isHiveStyle) throws Exception {
     String tableName = metaClient.getTableConfig().getTableName();
     // clean up and re instantiate meta client w/ right table props
     cleanUp();
@@ -366,14 +377,19 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
 
     initMetaClient(getTableType(), properties);
     // init config, table and client.
-    HoodieWriteConfig cfg = getConfigBuilder().withAutoCommit(false).withRollbackUsingMarkers(false)
+    HoodieWriteConfig cfg = getConfigBuilder().withAutoCommit(true).withRollbackUsingMarkers(false)
         .doSkipDefaultPartitionValidation(skipDefaultPartitionValidation).withProps(params).build();
     SparkRDDWriteClient client = getHoodieWriteClient(cfg);
     // Write inserts
     doInsert(client);
 
     if (assertDefaultPartition) {
-      doInsertWithDefaultPartition(client);
+      if (isHiveStyle) {
+        doInsertWithDefaultHiveStylePartition(client);
+        cfg.setValue(HIVE_STYLE_PARTITIONING_ENABLE.key(), "true");
+      } else {
+        doInsertWithDefaultPartition(client);
+      }
     }
 
     // downgrade table props
@@ -422,6 +438,16 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
   private void doInsertWithDefaultPartition(SparkRDDWriteClient client) {
     // Write 1 (only inserts)
     dataGen = new HoodieTestDataGenerator(new String[]{DEPRECATED_DEFAULT_PARTITION_PATH});
+    String commit1 = "005";
+    client.startCommitWithTime(commit1);
+    List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);
+    JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
+    client.insert(writeRecords, commit1).collect();
+  }
+
+  private void doInsertWithDefaultHiveStylePartition(SparkRDDWriteClient client) {
+    // Write 1 (only inserts)
+    dataGen = new HoodieTestDataGenerator(new String[]{"partition_path=" + DEPRECATED_DEFAULT_PARTITION_PATH});
     String commit1 = "005";
     client.startCommitWithTime(commit1);
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);


### PR DESCRIPTION
upgrade table version four to five will check default partition, it not work for table with hive style param

### Change Logs

- use keyGen to get partitionPath when upgrade table three to four

### Impact

migrate hudi version to 0.13.x will trigger this

### Risk level (write none, low medium or high below)

low, will fallback use default if can not gen partitionPath

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
