### PR TITLE
[HUDI-6258] support olap engine query mor table in table name without ro/rt suffix

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -85,6 +85,10 @@ public class HiveSyncConfigHolder {
       .defaultValue("false")
       .markAdvanced()
       .withDocumentation("Skip the _ro suffix for Read optimized table, when registering");
+  public static final ConfigProperty<String> HIVE_SYNC_META_TO_ORIGIN_TABLE = ConfigProperty
+          .key("hoodie.datasource.hive_sync.sync_origin_table")
+          .defaultValue("false")
+          .withDocumentation("sync meta info to origin table if enable");
   public static final ConfigProperty<String> HIVE_SUPPORT_TIMESTAMP_TYPE = ConfigProperty
       .key("hoodie.datasource.hive_sync.support_timestamp")
       .defaultValue("false")

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -85,10 +85,6 @@ public class HiveSyncConfigHolder {
       .defaultValue("false")
       .markAdvanced()
       .withDocumentation("Skip the _ro suffix for Read optimized table, when registering");
-  public static final ConfigProperty<String> HIVE_SYNC_META_TO_ORIGIN_TABLE = ConfigProperty
-          .key("hoodie.datasource.hive_sync.sync_origin_table")
-          .defaultValue("false")
-          .withDocumentation("sync meta info to origin table if enable");
   public static final ConfigProperty<String> HIVE_SUPPORT_TIMESTAMP_TYPE = ConfigProperty
       .key("hoodie.datasource.hive_sync.support_timestamp")
       .defaultValue("false")

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -59,7 +59,6 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SKIP_RO_SUFFIX_FOR_
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_AS_DATA_SOURCE_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_COMMENT;
-import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_META_TO_ORIGIN_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_OMIT_METADATA_FIELDS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY;
@@ -73,6 +72,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_CONDITIONAL_SYNC;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_SNAPSHOT_WITH_TABLE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_SPARK_VERSION;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.common.util.TableUtils.tableId;
@@ -192,7 +192,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
             // sync a RT table for MOR
             syncHoodieTable(snapshotTableName, true, false);
             // sync origin table for MOR
-            if (config.getBoolean(HIVE_SYNC_META_TO_ORIGIN_TABLE)) {
+            if (config.getBoolean(META_SYNC_SNAPSHOT_WITH_TABLE_NAME)) {
               syncHoodieTable(tableName, true, false);
             }
         }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -59,6 +59,7 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SKIP_RO_SUFFIX_FOR_
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_AS_DATA_SOURCE_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_COMMENT;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_META_TO_ORIGIN_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_OMIT_METADATA_FIELDS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY;
@@ -191,7 +192,9 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
             // sync a RT table for MOR
             syncHoodieTable(snapshotTableName, true, false);
             // sync origin table for MOR
-            syncHoodieTable(tableName, true, false);
+            if (config.getBoolean(HIVE_SYNC_META_TO_ORIGIN_TABLE)) {
+              syncHoodieTable(tableName, true, false);
+            }
         }
         break;
       default:

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -190,6 +190,8 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
             syncHoodieTable(roTableName.get(), false, true);
             // sync a RT table for MOR
             syncHoodieTable(snapshotTableName, true, false);
+            // sync origin table for MOR
+            syncHoodieTable(tableName, true, false);
         }
         break;
       default:

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -176,6 +176,8 @@ public class HoodieSyncConfig extends HoodieConfig {
   public static final ConfigProperty<String> META_SYNC_SNAPSHOT_WITH_TABLE_NAME = ConfigProperty
           .key("hoodie.meta.sync.sync_snapshot_with_table_name")
           .defaultValue("false")
+          .markAdvanced()
+          .sinceVersion("0.14.0")
           .withDocumentation("sync meta info to origin table if enable");
 
   private Configuration hadoopConf;

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -173,6 +173,10 @@ public class HoodieSyncConfig extends HoodieConfig {
       .defaultValue("")
       .markAdvanced()
       .withDocumentation("The spark version used when syncing with a metastore.");
+  public static final ConfigProperty<String> META_SYNC_SNAPSHOT_WITH_TABLE_NAME = ConfigProperty
+          .key("hoodie.meta.sync.sync_snapshot_with_table_name")
+          .defaultValue("false")
+          .withDocumentation("sync meta info to origin table if enable");
 
   private Configuration hadoopConf;
 


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

query mor table with starrocks as:

MySQL [(none)]> select * from hudi_catalog_01.hudi_test.test_mor_hudi_22_rt;
+---------------------+-----------------------+--------------------+------------------------+------------------------------------------------------------
| _hoodie_commit_time | _hoodie_commit_seqno  | _hoodie_record_key | _hoodie_partition_path | _hoodie_file_name                                          
+---------------------+-----------------------+--------------------+------------------------+------------------------------------------------------------
| 20230522100703567   | 20230522100703567_0_0 | 1                  | partition=de           | f14492ed-b672-4f60-8e86-6359790feb2a-0_0-17-2013_2023052210
+---------------------+-----------------------+--------------------+------------------------+------------------------------------------------------------
1 row in set (1.03 sec)

MySQL [(none)]> select * from hudi_catalog_01.hudi_test.test_mor_hudi_22_ro;
+---------------------+-----------------------+--------------------+------------------------+------------------------------------------------------------
| _hoodie_commit_time | _hoodie_commit_seqno  | _hoodie_record_key | _hoodie_partition_path | _hoodie_file_name                                          
+---------------------+-----------------------+--------------------+------------------------+------------------------------------------------------------
| 20230522100703567   | 20230522100703567_0_0 | 1                  | partition=de           | f14492ed-b672-4f60-8e86-6359790feb2a-0_0-17-2013_2023052210
+---------------------+-----------------------+--------------------+------------------------+------------------------------------------------------------
1 row in set (0.69 sec)

MySQL [(none)]> select * from hudi_catalog_01.hudi_test.test_mor_hudi_22;
Empty set (2.63 sec)

after fix，can get data from tablename


### Impact
no impact
_Describe any public API or user-facing feature change or any performance impact._
when we query table without rt/ro，we get data with emptyset when query with starrocks/doris

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
