### PR TITLE
[HUDI-6260] Fix the MDT compaction reader with the instant range filt…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -469,7 +469,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     return Pair.of(baseFileReader, baseFileOpenMs);
   }
 
-  private Set<String> getValidInstantTimestamps() {
+  public static Set<String> getValidInstantTimestamps(HoodieTableMetaClient dataMetaClient, HoodieTableMetaClient metadataMetaClient) {
     // Only those log files which have a corresponding completed instant on the dataset should be read
     // This is because the metadata table is updated before the dataset instants are committed.
     HoodieActiveTimeline datasetTimeline = dataMetaClient.getActiveTimeline();
@@ -511,7 +511,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
 
     // Only those log files which have a corresponding completed instant on the dataset should be read
     // This is because the metadata table is updated before the dataset instants are committed.
-    Set<String> validInstantTimestamps = getValidInstantTimestamps();
+    Set<String> validInstantTimestamps = getValidInstantTimestamps(dataMetaClient, metadataMetaClient);
 
     Option<HoodieInstant> latestMetadataInstant = metadataMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
     String latestMetadataInstantTime = latestMetadataInstant.map(HoodieInstant::getTimestamp).orElse(SOLO_COMMIT_TIMESTAMP);
@@ -565,7 +565,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
    * @param instant  The Rollback operation to read
    * @param timeline instant of timeline from dataset.
    */
-  private List<String> getRollbackedCommits(HoodieInstant instant, HoodieActiveTimeline timeline) {
+  private static List<String> getRollbackedCommits(HoodieInstant instant, HoodieActiveTimeline timeline) {
     try {
       List<String> commitsToRollback = null;
       if (instant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION)) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataLogRecordReader.java
@@ -200,7 +200,10 @@ public class HoodieMetadataLogRecordReader implements Closeable {
     }
 
     public Builder withLogBlockTimestamps(Set<String> validLogBlockTimestamps) {
-      scannerBuilder.withInstantRange(Option.of(new ExplicitMatchRange(validLogBlockTimestamps)));
+      InstantRange instantRange = InstantRange.builder()
+          .rangeType(InstantRange.RangeType.EXPLICIT_MATCH)
+          .explicitInstants(validLogBlockTimestamps).build();
+      scannerBuilder.withInstantRange(Option.of(instantRange));
       return this;
     }
 
@@ -216,23 +219,6 @@ public class HoodieMetadataLogRecordReader implements Closeable {
 
     public HoodieMetadataLogRecordReader build() {
       return new HoodieMetadataLogRecordReader(scannerBuilder.build());
-    }
-  }
-
-  /**
-   * Class to assist in checking if an instant is part of a set of instants.
-   */
-  private static class ExplicitMatchRange extends InstantRange {
-    Set<String> instants;
-
-    public ExplicitMatchRange(Set<String> instants) {
-      super(Collections.min(instants), Collections.max(instants));
-      this.instants = instants;
-    }
-
-    @Override
-    public boolean isInRange(String instant) {
-      return this.instants.contains(instant);
     }
   }
 }


### PR DESCRIPTION
…ering

### Change Logs

The MDT compaction reader should set up the instant range correctly just like we do for MDT regular read path.
This PR unblock another fix: https://github.com/apache/hudi/pull/8088

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
