### PR TITLE
[HUDI-6267] init deletedFileResult with false to avoid NPE

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -95,12 +95,12 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
       String partitionPath = partitionDelFileTuple.getLeft();
       Path deletePath = new Path(partitionDelFileTuple.getRight().getFilePath());
       String deletePathStr = deletePath.toString();
-      Boolean deletedFileResult = null;
+      boolean deletedFileResult = false;
       try {
         deletedFileResult = deleteFileAndGetResult(fs, deletePathStr);
 
       } catch (IOException e) {
-        LOG.error("Delete file failed: " + deletePathStr);
+        LOG.error("Delete file failed: " + deletePathStr, e);
       }
       final PartitionCleanStat partitionCleanStat =
           partitionCleanStatMap.computeIfAbsent(partitionPath, k -> new PartitionCleanStat(partitionPath));


### PR DESCRIPTION
### Change Logs

1）init deletedFileResult with false 
2) log exception detail 

### Impact

when encounter IOException ， deleteFile will finish normally, but may result files left in fileSystem.

### Risk level (write none, low medium or high below)

low, may result files left in fileSystem

### Documentation Update
none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
