### PR TITLE
[HUDI-6269] Ensure configs of one transformer are not passed to another transformer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
@@ -49,7 +49,7 @@ public class ErrorTableAwareChainedTransformer extends ChainedTransformer {
     dataset = ErrorTableUtils.addNullValueErrorTableCorruptRecordColumn(dataset);
     for (TransformerInfo transformerInfo : transformers) {
       Transformer transformer = transformerInfo.getTransformer();
-      dataset = transformer.apply(jsc, sparkSession, dataset, transformerInfo.getProperties(properties));
+      dataset = transformer.apply(jsc, sparkSession, dataset, transformerInfo.getProperties(properties, transformers));
       // validate in every stage to ensure ErrorRecordColumn not dropped by one of the transformer and added by next transformer.
       ErrorTableUtils.validate(dataset);
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestTransformer.java
@@ -91,6 +91,7 @@ public class TestTransformer extends HoodieDeltaStreamerTestBase {
                               TypedProperties properties) {
       String[] suffixes = ((String) properties.get("transformer.suffix")).split(",");
       for (String suffix : suffixes) {
+        // verify no configs with suffix are in properties
         properties.keySet().forEach(k -> assertFalse(((String) k).endsWith(suffix)));
       }
       int multiplier = Integer.parseInt((String) properties.get("timestamp.transformer.multiplier"));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestTransformer.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestTransformer extends HoodieDeltaStreamerTestBase {
 
@@ -73,6 +74,7 @@ public class TestTransformer extends HoodieDeltaStreamerTestBase {
     properties.setProperty("timestamp.transformer.increment.3", "30");
     properties.setProperty("timestamp.transformer.increment", "20");
     properties.setProperty("timestamp.transformer.multiplier", "2");
+    properties.setProperty("transformer.suffix", ".1,.2,.3");
     deltaStreamer.sync();
 
     TestHoodieDeltaStreamer.TestHelpers.assertRecordCount(parquetRecordsCount, tableBasePath, sqlContext);
@@ -87,6 +89,10 @@ public class TestTransformer extends HoodieDeltaStreamerTestBase {
     @Override
     public Dataset<Row> apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset,
                               TypedProperties properties) {
+      String[] suffixes = ((String) properties.get("transformer.suffix")).split(",");
+      for (String suffix : suffixes) {
+        properties.keySet().forEach(k -> assertFalse(((String) k).endsWith(suffix)));
+      }
       int multiplier = Integer.parseInt((String) properties.get("timestamp.transformer.multiplier"));
       int increment = Integer.parseInt((String) properties.get("timestamp.transformer.increment"));
       return rowDataset.withColumn("timestamp", functions.col("timestamp").multiply(multiplier).plus(increment));


### PR DESCRIPTION
### Change Logs

[HUDI-6113](https://issues.apache.org/jira/browse/HUDI-6113) adds support for multiple transformers sharing the same config keys. The configs can be appended with a suffix related to a speicific transformer to identify its configs.

The Jira aims to make sure that during the `org.apache.hudi.utilities.transform.Transformer#apply` API call, only the properties for that transformer are reflected.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
