### PR TITLE
[MINOR] Make `isErrorTableWriterEnabled` primitive type

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -192,7 +192,7 @@ public class UtilHelpers {
 
   }
 
-  public static Option<Transformer> createTransformer(Option<List<String>> classNamesOpt, Boolean isErrorTableWriterEnabled) throws IOException {
+  public static Option<Transformer> createTransformer(Option<List<String>> classNamesOpt, boolean isErrorTableWriterEnabled) throws IOException {
     try {
       return classNamesOpt.map(classNames -> classNames.isEmpty() ? null : 
           isErrorTableWriterEnabled ? new ErrorTableAwareChainedTransformer(classNames) : new ChainedTransformer(classNames)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
@@ -50,7 +50,7 @@ public class ErrorTableAwareChainedTransformer extends ChainedTransformer {
     for (TransformerInfo transformerInfo : transformers) {
       Transformer transformer = transformerInfo.getTransformer();
       dataset = transformer.apply(jsc, sparkSession, dataset, transformerInfo.getProperties(properties));
-      // validate in every stage to ensure it's not dropped by one of the transformer and added by next transformer.
+      // validate in every stage to ensure ErrorRecordColumn not dropped by one of the transformer and added by next transformer.
       ErrorTableUtils.validate(dataset);
     }
     return dataset;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestErrorTableAwareChainedTransformer.java
@@ -45,8 +45,6 @@ import java.util.List;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_ENABLED;
 import static org.apache.hudi.utilities.deltastreamer.BaseErrorTableWriter.ERROR_TABLE_CURRUPT_RECORD_COL_NAME;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
@@ -129,12 +127,7 @@ public class TestErrorTableAwareChainedTransformer extends SparkClientFunctional
       "org.apache.hudi.utilities.transform.FlatteningTransformer,T1:org.apache.hudi.utilities.transform.FlatteningTransformer"
   })
   public void testErrorTableAwareChainedTransformerValidationFails(String transformerName) {
-    try {
-      ErrorTableAwareChainedTransformer transformer = new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")));
-      fail();
-    } catch (Exception e) {
-      assertTrue(e instanceof HoodieTransformException, e.getMessage());
-    }
+    assertThrows(HoodieTransformException.class, () -> new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(","))));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Change Logs

make isErrorTableWriterEnabled param premitive type . 
### Impact

No impact
### Risk level (write none, low medium or high below)

low
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
