### PR TITLE
[HUDI-6275] Fix POM for building bundle jars of Spark 2

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: "scala-2.11 -Dscala.binary.version=2.11"
+          - scalaProfile: "scala-2.11"
             sparkProfile: "spark2.4"
             sparkModules: "hudi-spark-datasource/hudi-spark2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -2140,9 +2140,7 @@
       </modules>
       <properties>
         <spark.version>${spark2.version}</spark.version>
-        <sparkbundle.version>2.4</sparkbundle.version>
-        <scala.version>${scala11.version}</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <sparkbundle.version/>
         <scalatest.version>${scalatest.spark_pre31.version}</scalatest.version>
         <hudi.spark.module>hudi-spark2</hudi.spark.module>
         <hudi.spark.common.modules.1>hudi-spark2-common</hudi.spark.common.modules.1>
@@ -2176,8 +2174,6 @@
       <properties>
         <spark.version>${spark2.version}</spark.version>
         <sparkbundle.version>2.4</sparkbundle.version>
-        <scala.version>${scala11.version}</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
         <scalatest.version>${scalatest.spark_pre31.version}</scalatest.version>
         <hudi.spark.module>hudi-spark2</hudi.spark.module>
         <hudi.spark.common.modules.1>hudi-spark2-common</hudi.spark.common.modules.1>


### PR DESCRIPTION
### Change Logs

There are two issues in the POM for building bundle jars of Spark 2:
- The `spark2` profile generates `hudi-spark2.4-bundle_2.12` instead of `hudi-spark-bundle_2.12` (legacy bundle name).
- The scala profile (2.11 or 2.12) is ignored when building the Spark bundle jar for Spark 2.4.

This PR fixes both issues.

### Impact

Fixes the Spark bundle jar generation for Spark 2.4.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
