### PR TITLE
[HUDI-6279] Include file creation and precommit validator metrics for clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -274,6 +274,17 @@ public class HoodieMetrics {
     return config == null ? null : String.format("%s.%s.%s", config.getMetricReporterMetricsNamePrefix(), action, metric);
   }
 
+  public void updateClusteringFileCreationMetrics(long durationInMs) {
+    metrics.registerGauge(getMetricsName("replacecommit", "fileCreationTime"), durationInMs);
+  }
+
+  /**
+   * Given a commit action, metrics name and value this method publishes custom metrics.
+   */
+  public void publishMetrics(String commitAction, String metricsName, long value) {
+    metrics.registerGauge(getMetricsName(commitAction, metricsName), value);
+  }
+
   /**
    * By default, the timer context returns duration with nano seconds. Convert it to millisecond.
    */

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkValidatorUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkValidatorUtils.java
@@ -107,7 +107,7 @@ public class SparkValidatorUtils {
         LOG.info("validation complete for " + validator.getClass().getName());
         return true;
       } catch (HoodieValidationException e) {
-        LOG.error("validation failed for " + validator.getClass().getName());
+        LOG.error("validation failed for " + validator.getClass().getName(), e);
         return false;
       }
     });


### PR DESCRIPTION
### Change Logs

Adding file creation metrics and SparkPreCommitValidator metrics. Using these metrics, performance of the validators can be tracked.

### Impact

The changes adds more metrics for clustering and precommit validation phase, no impact.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

Documentation is added as part of the comments.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
