### PR TITLE
[MINOR] Remove unnecessary code in DeltaSync#syncOnce

### DIFF
--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieDeltaStreamerWrapper.java
@@ -80,7 +80,7 @@ public class HoodieDeltaStreamerWrapper extends HoodieDeltaStreamer {
     DeltaSync service = getDeltaSync();
     service.refreshTimeline();
     String instantTime = HoodieActiveTimeline.createNewInstantTime();
-    return service.readFromSource(service.getCommitsTimelineOpt(), instantTime);
+    return service.readFromSource(instantTime);
   }
 
   public DeltaSync getDeltaSync() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -490,28 +490,6 @@ public class DeltaSync implements Serializable, Closeable {
     Option<String> resumeCheckpointStr = Option.empty();
     if (commitsTimelineOpt.isPresent()) {
       resumeCheckpointStr = getCheckpointToResume(commitsTimelineOpt);
-    } else {
-      // initialize the table for the first time.
-      String partitionColumns = SparkKeyGenUtils.getPartitionColumns(props);
-      HoodieTableMetaClient.withPropertyBuilder()
-          .setTableType(cfg.tableType)
-          .setTableName(cfg.targetTableName)
-          .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())
-          .setPayloadClassName(cfg.payloadClassName)
-          .setBaseFileFormat(cfg.baseFileFormat)
-          .setPartitionFields(partitionColumns)
-          .setRecordKeyFields(props.getProperty(DataSourceWriteOptions.RECORDKEY_FIELD().key()))
-          .setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
-              HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))
-          .setKeyGeneratorClassProp(keyGenClassName)
-          .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
-              HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
-          .setShouldDropPartitionColumns(isDropPartitionColumns())
-          .setHiveStylePartitioningEnable(props.getBoolean(HIVE_STYLE_PARTITIONING_ENABLE.key(),
-              Boolean.parseBoolean(HIVE_STYLE_PARTITIONING_ENABLE.defaultValue())))
-          .setUrlEncodePartitioning(props.getBoolean(URL_ENCODE_PARTITIONING.key(),
-              Boolean.parseBoolean(URL_ENCODE_PARTITIONING.defaultValue())))
-          .initTable(new Configuration(jssc.hadoopConfiguration()), cfg.targetBasePath);
     }
 
     LOG.debug("Checkpoint from config: " + cfg.checkpoint);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -412,7 +412,7 @@ public class DeltaSync implements Serializable, Closeable {
     refreshTimeline();
     String instantTime = HoodieActiveTimeline.createNewInstantTime();
 
-    Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> srcRecordsWithCkpt = readFromSource(commitsTimelineOpt, instantTime);
+    Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> srcRecordsWithCkpt = readFromSource(instantTime);
 
     if (srcRecordsWithCkpt != null) {
       final JavaRDD<HoodieRecord> recordsFromSource = srcRecordsWithCkpt.getRight().getRight();
@@ -480,12 +480,11 @@ public class DeltaSync implements Serializable, Closeable {
   /**
    * Read from Upstream Source and apply transformation if needed.
    *
-   * @param commitsTimelineOpt Timeline with completed commits, including .commit and .deltacommit
    * @return Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> Input data read from upstream source, consists
    * of schemaProvider, checkpointStr and hoodieRecord
    * @throws Exception in case of any Exception
    */
-  public Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> readFromSource(Option<HoodieTimeline> commitsTimelineOpt, String instantTime) throws IOException {
+  public Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> readFromSource(String instantTime) throws IOException {
     // Retrieve the previous round checkpoints, if any
     Option<String> resumeCheckpointStr = Option.empty();
     if (commitsTimelineOpt.isPresent()) {


### PR DESCRIPTION
### Change Logs

`DeltaSync#syncOnce` invokes `DeltaSync#refreshTimeline` which initializes an empty table and sets `commitsTimelineOpt `to an empty option. 

Subsequently, the table is initialized again because `commitsTimelineOpt.isPresent() == false`. There is no need for `DeltaSync#readFromSource` to do the same thing again. 

Fields that are accessible via methods are also removed as parameters for the `DeltaSync#readFromSource` method.

This PR is meant for cleaning up these "dead" code to avoid confusion.

### Impact

_Describe any public API or user-facing feature change or any performance impact._

None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
