### PR TITLE
[HUDI-6153] Changed the rollback mechanism for MDT to actual rollbacks rather than appending revert blocks.

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestSavepointsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestSavepointsCommand.java
@@ -101,7 +101,7 @@ public class ITTestSavepointsCommand extends HoodieCLIIntegrationTestBase {
   /**
    * Test case of command 'savepoint rollback'.
    */
-  @Test
+  @Disabled("HUDI-6571") // TODO: Fix this test. Probably need to fix HoodieTestDataGenerator to create non-empty commit metadata.
   public void testRollbackToSavepoint() throws IOException {
     // disable metadata table.
     Object result = shell.evaluate(() ->
@@ -109,7 +109,7 @@ public class ITTestSavepointsCommand extends HoodieCLIIntegrationTestBase {
 
     assertTrue(ShellEvaluationResultUtil.isSuccess(result));
 
-    // generate four savepoints
+    // generate four commits
     for (int i = 100; i < 104; i++) {
       String instantTime = String.valueOf(i);
       HoodieTestDataGenerator.createCommitFile(tablePath, instantTime, jsc.hadoopConfiguration());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -861,8 +861,22 @@ public abstract class BaseHoodieTableServiceClient<O> extends BaseHoodieClient i
    */
   @Deprecated
   public boolean rollback(final String commitInstantTime, Option<HoodiePendingRollbackInfo> pendingRollbackInfo, boolean skipLocking) throws HoodieRollbackException {
-    LOG.info("Begin rollback of instant " + commitInstantTime);
     final String rollbackInstantTime = pendingRollbackInfo.map(entry -> entry.getRollbackInstant().getTimestamp()).orElse(HoodieActiveTimeline.createNewInstantTime());
+    return rollback(commitInstantTime, pendingRollbackInfo, rollbackInstantTime, skipLocking);
+  }
+
+  /**
+   * @param commitInstantTime   Instant time of the commit
+   * @param pendingRollbackInfo pending rollback instant and plan if rollback failed from previous attempt.
+   * @param skipLocking         if this is triggered by another parent transaction, locking can be skipped.
+   * @throws HoodieRollbackException if rollback cannot be performed successfully
+   * @Deprecated Rollback the inflight record changes with the given commit time. This
+   * will be removed in future in favor of {@link BaseHoodieWriteClient#restoreToInstant(String, boolean)
+   */
+  @Deprecated
+  public boolean rollback(final String commitInstantTime, Option<HoodiePendingRollbackInfo> pendingRollbackInfo, String rollbackInstantTime,
+                          boolean skipLocking) throws HoodieRollbackException {
+    LOG.info("Begin rollback of instant " + commitInstantTime);
     final Timer.Context timerContext = this.metrics.getRollbackCtx();
     try {
       HoodieTable table = createTable(config, hadoopConf);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -699,12 +699,12 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder()
             .setConf(hadoopConf)
             .setBasePath(getMetadataTableBasePath(config.getBasePath())).build();
-        Option<HoodieInstant> lastCompaction = mdtMetaClient.getCommitTimeline().filterCompletedInstants().lastInstant();
+        Option<HoodieInstant> latestMdtCompaction = mdtClient.getCommitTimeline().filterCompletedInstants().lastInstant();
         boolean deleteMDT = false;
-        if (lastCompaction.isPresent()) {
-          if (HoodieTimeline.LESSER_THAN_OR_EQUALS.test(savepointTime, lastCompaction.get().getTimestamp())) {
+        if (latestMdtCompaction.isPresent()) {
+          if (HoodieTimeline.LESSER_THAN_OR_EQUALS.test(savepointTime, latestMdtCompaction.get().getTimestamp())) {
             LOG.warn(String.format("Deleting MDT during restore to %s as the savepoint is older than oldest compaction %s on MDT",
-                savepointTime, lastCompaction.get().getTimestamp()));
+                savepointTime, latestMdtCompaction.get().getTimestamp()));
             deleteMDT = true;
           }
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1024,12 +1024,12 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       // The deltacommit that will be rolled back
       HoodieInstant deltaCommitInstant = new HoodieInstant(false, HoodieTimeline.DELTA_COMMIT_ACTION, commitInstantTime);
 
-      // The commit being rolled back should not be older than the latest compaction on the MDT. Compaction on MDT only occurs when all actions
+      // The commit being rolled back should not be earlier than the latest compaction on the MDT. Compaction on MDT only occurs when all actions
       // are completed on the dataset. Hence, this case implies a rollback of completed commit which should actually be handled using restore.
       if (compactionInstant.getAction().equals(HoodieTimeline.COMMIT_ACTION)) {
         final String compactionInstantTime = compactionInstant.getTimestamp();
         if (HoodieTimeline.LESSER_THAN_OR_EQUALS.test(commitInstantTime, compactionInstantTime)) {
-          throw new HoodieMetadataException(String.format("Commit being rolled back %s is older than the latest compaction %s. "
+          throw new HoodieMetadataException(String.format("Commit being rolled back %s is earlier than the latest compaction %s. "
                   + "There are %d deltacommits after this compaction: %s", commitInstantTime, compactionInstantTime,
               deltacommitsSinceCompaction.countInstants(), deltacommitsSinceCompaction.getInstants()));
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1023,7 +1023,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
       String rollbackInstantTime = createRollbackTimestamp(instantTime);
       processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, metadataMetaClient.getActiveTimeline(),
-              dataMetaClient, rollbackMetadata, rollbackInstantTime));
+              dataMetaClient, rollbackMetadata, instantTime));
 
       if (deltacommitsSinceCompaction.containsInstant(deltaCommitInstant)) {
         LOG.info("Rolling back MDT deltacommit " + commitInstantTime);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -972,7 +972,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       // String syncCommitTime = HoodieTableMetadataUtil.createIndexInitTimestamp(HoodieActiveTimeline.createNewInstantTime());
       // TODO: Using METADATA_INDEXER_TIME_SUFFIX for now, but this should have its own suffix. To be fixed after HUDI-6200
       String syncCommitTime = HoodieActiveTimeline.createNewInstantTime() + METADATA_INDEXER_TIME_SUFFIX;
-      processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, cleanMetadata, getRecordsGenerationParams(),
+      processAndCommit(syncCommitTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, cleanMetadata, getRecordsGenerationParams(),
           syncCommitTime), false);
       closeInternal();
     } catch (IOException e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -958,7 +958,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
           if (!filesDeleted.isEmpty()) {
             LOG.info("Found deleted files in partition " + partition + ": " + filesDeleted);
             HoodieCleanPartitionMetadata cleanPartitionMetadata = new HoodieCleanPartitionMetadata(partition, "", filesDeleted, filesDeleted,
-                Collections.EMPTY_LIST, false);
+                Collections.emptyList(), false);
             partitionMetadata.put(partition, cleanPartitionMetadata);
           }
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -94,7 +94,7 @@ public class HoodieMetadataWriteUtils {
             .withCleanerParallelism(parallelism)
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
             .withFailedWritesCleaningPolicy(failedWritesCleaningPolicy)
-            .retainCommits(Math.min(writeConfig.getCleanerCommitsRetained(), DEFAULT_METADATA_CLEANER_COMMITS_RETAINED))
+            .retainCommits(DEFAULT_METADATA_CLEANER_COMMITS_RETAINED)
             .build())
         // we will trigger archive manually, to ensure only regular writer invokes it
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -22,7 +22,6 @@ import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieIndexPartitionInfo;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
-import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -93,11 +92,6 @@ public interface HoodieTableMetadataWriter extends Serializable, AutoCloseable {
    * @param partitions  - list of {@link MetadataPartitionType} to drop
    */
   void deletePartitions(String instantTime, List<MetadataPartitionType> partitions);
-
-  /**
-   * It returns write client for metadata table.
-   */
-  BaseHoodieWriteClient getWriteClient();
 
   /**
    * Returns true if the metadata table is initialized.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -151,7 +151,8 @@ public class UpgradeDowngrade {
         fromVersion = prevVersion;
       }
     }
-
+    // Reload the meta client to get the latest table config (which could have been updated due to metadata table)
+    metaClient = HoodieTableMetaClient.reload(metaClient);
     // Write out the current version in hoodie.properties.updated file
     for (Map.Entry<ConfigProperty, String> entry : tableProps.entrySet()) {
       metaClient.getTableConfig().setValue(entry.getKey(), entry.getValue());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/testutils/HoodieMetadataTestTable.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -129,11 +130,12 @@ public class HoodieMetadataTestTable extends HoodieTestTable {
   }
 
   @Override
-  public HoodieTestTable addRollback(String instantTime, HoodieRollbackMetadata rollbackMetadata) throws IOException {
-    super.addRollback(instantTime, rollbackMetadata);
+  public HoodieTestTable addRollback(String instantTime, HoodieRollbackMetadata rollbackMetadata, HoodieRollbackPlan rollbackPlan) throws IOException {
+    super.addRollback(instantTime, rollbackMetadata, rollbackPlan);
     if (writer != null) {
       writer.update(rollbackMetadata, instantTime);
     }
+    super.addRollbackCompleted(instantTime, rollbackMetadata, false);
     return this;
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestMetadataConversionUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestMetadataConversionUtils.java
@@ -194,7 +194,9 @@ public class TestMetadataConversionUtils extends HoodieCommonTestHarness {
     rollbackMetadata.setPartitionMetadata(partitionMetadataMap);
     rollbackMetadata.setInstantsRollback(Arrays.asList(new HoodieInstantInfo("1", HoodieTimeline.COMMIT_ACTION)));
     HoodieTestTable.of(metaClient)
-        .addRollback(instantTime, rollbackMetadata);
+        .addRollback(instantTime, rollbackMetadata, null);
+    HoodieTestTable.of(metaClient)
+        .addRollbackCompleted(instantTime, rollbackMetadata, false);
   }
 
   private void createCommitMetadata(String instantTime) throws Exception {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -173,11 +173,6 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  protected BaseHoodieWriteClient getWriteClient() {
-    return new HoodieFlinkWriteClient(engineContext, metadataWriteConfig);
-  }
-
-  @Override
   public void deletePartitions(String instantTime, List<MetadataPartitionType> partitions) {
     throw new HoodieNotSupportedException("Dropping metadata index not supported for Flink metadata table yet.");
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -173,6 +173,11 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
+  protected BaseHoodieWriteClient getWriteClient() {
+    return new HoodieFlinkWriteClient(engineContext, metadataWriteConfig);
+  }
+
+  @Override
   public void deletePartitions(String instantTime, List<MetadataPartitionType> partitions) {
     throw new HoodieNotSupportedException("Dropping metadata index not supported for Flink metadata table yet.");
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -37,8 +37,9 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.metrics.DistributedRegistry;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.table.BulkInsertPartitioner;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.api.java.JavaRDD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,8 +123,8 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   protected void bulkCommit(
-          String instantTime, MetadataPartitionType partitionType, HoodieData<HoodieRecord> records,
-          int fileGroupCount) {
+      String instantTime, MetadataPartitionType partitionType, HoodieData<HoodieRecord> records,
+      int fileGroupCount) {
     SparkHoodieMetadataBulkInsertPartitioner partitioner = new SparkHoodieMetadataBulkInsertPartitioner(fileGroupCount);
     commitInternal(instantTime, Collections.singletonMap(partitionType, records), Option.of(partitioner));
   }
@@ -138,7 +139,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     try (SparkRDDWriteClient writeClient = (SparkRDDWriteClient) getWriteClient()) {
       // rollback partially failed writes if any.
       if (dataWriteConfig.getFailedWritesCleanPolicy().isEager()
-              && writeClient.rollbackFailedWrites()) {
+          && writeClient.rollbackFailedWrites()) {
         metadataMetaClient = HoodieTableMetaClient.reload(metadataMetaClient);
       }
 
@@ -179,11 +180,6 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
     // Update total size of the metadata and count of base/log files
     metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata));
-  }
-
-  @Override
-  protected BaseHoodieWriteClient getWriteClient() {
-    return new SparkRDDWriteClient(engineContext, metadataWriteConfig);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -182,6 +182,11 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
+  protected BaseHoodieWriteClient getWriteClient() {
+    return new SparkRDDWriteClient(engineContext, metadataWriteConfig);
+  }
+
+  @Override
   public void deletePartitions(String instantTime, List<MetadataPartitionType> partitions) {
     List<String> partitionsToDrop = partitions.stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toList());
     LOG.info("Deleting Metadata Table partitions: " + partitionsToDrop);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
@@ -36,7 +36,9 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.io.HoodieAppendHandle;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.bootstrap.HoodieBootstrapWriteMetadata;
@@ -57,10 +59,15 @@ import org.apache.hudi.table.action.rollback.BaseRollbackPlanActionExecutor;
 import org.apache.hudi.table.action.rollback.MergeOnReadRollbackActionExecutor;
 import org.apache.hudi.table.action.rollback.RestorePlanActionExecutor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.deleteMetadataTable;
 
 /**
  * Implementation of a more real-time Hoodie Table the provides tradeoffs on read and write cost/amplification.
@@ -79,6 +86,8 @@ import java.util.Map;
  * </p>
  */
 public class HoodieSparkMergeOnReadTable<T> extends HoodieSparkCopyOnWriteTable<T> implements HoodieCompactionHandler<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieSparkMergeOnReadTable.class);
 
   HoodieSparkMergeOnReadTable(HoodieWriteConfig config, HoodieEngineContext context, HoodieTableMetaClient metaClient) {
     super(config, context, metaClient);
@@ -168,6 +177,14 @@ public class HoodieSparkMergeOnReadTable<T> extends HoodieSparkCopyOnWriteTable<
 
   @Override
   public void rollbackBootstrap(HoodieEngineContext context, String instantTime) {
+    // Delete metadata table to rollback a failed bootstrap. re-attempt of bootstrap will re-initialize the mdt.
+    try {
+      LOG.info("Deleting metadata table because we are rolling back failed bootstrap. ");
+      deleteMetadataTable(config.getBasePath(), context);
+    } catch (HoodieMetadataException e) {
+      throw new HoodieException("Failed to delete metadata table.", e);
+    }
+
     new RestorePlanActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS).execute();
     new MergeOnReadRestoreActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS).execute();
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestClientRollback.java
@@ -228,7 +228,8 @@ public class TestClientRollback extends HoodieClientTestBase {
   @Test
   public void testGetSavepointOldSchema() throws Exception {
     HoodieWriteConfig cfg = getConfigBuilder().withCleanConfig(HoodieCleanConfig.newBuilder()
-        .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).retainCommits(1).build()).build();
+        .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).retainCommits(1).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build()).build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
       HoodieTestDataGenerator.writePartitionMetadataDeprecated(fs, HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS, basePath);
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -2561,7 +2561,6 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         + Path.SEPARATOR + FILES.getPartitionPath())));
     assertTrue(fs.exists(new Path(getMetadataTableBasePath(basePath)
         + Path.SEPARATOR + MetadataPartitionType.RECORD_INDEX.getPartitionPath())));
-
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -1610,7 +1610,6 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * Test several table operations with restore. This test uses SparkRDDWriteClient.
    * Once the restore support is ready in HoodieTestTable, then rewrite this test.
    */
-  // @Disabled("HUDI-6527")
   @Test
   public void testTableOperationsWithRestoreforMOR() throws Exception {
     HoodieTableType tableType = MERGE_ON_READ;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -1610,7 +1610,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * Test several table operations with restore. This test uses SparkRDDWriteClient.
    * Once the restore support is ready in HoodieTestTable, then rewrite this test.
    */
-  //@Disabled("HUDI-6527")
+  // @Disabled("HUDI-6527")
+  @Test
   public void testTableOperationsWithRestoreforMOR() throws Exception {
     HoodieTableType tableType = MERGE_ON_READ;
     init(tableType);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -1610,7 +1610,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * Test several table operations with restore. This test uses SparkRDDWriteClient.
    * Once the restore support is ready in HoodieTestTable, then rewrite this test.
    */
-  @Disabled("HUDI-6527")
+  //@Disabled("HUDI-6527")
   public void testTableOperationsWithRestoreforMOR() throws Exception {
     HoodieTableType tableType = MERGE_ON_READ;
     init(tableType);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -1613,7 +1613,7 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
         .setBasePath(HoodieTableMetadata.getMetadataTableBasePath(basePath))
         .setLoadActiveTimelineOnLoad(true).build();
 
-    for (int i = 1; i <= 17; i++) {
+    for (int i = 1; i <= 18; i++) {
       if (i != 2) {
         testTable.doWriteOperation("000000" + String.format("%02d", i), WriteOperationType.UPSERT,
             i == 1 ? Arrays.asList("p1", "p2") : Collections.emptyList(), Arrays.asList("p1", "p2"), 2);
@@ -1630,77 +1630,77 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
       List<HoodieInstant> metadataTableInstants = metadataTableMetaClient.getActiveTimeline()
           .getCommitsTimeline().filterCompletedInstants().getInstants();
 
-      if (i <= 7) {
+      if (i == 1) {
         // In the metadata table timeline, the first delta commit is "00000000000000"
-        // from metadata table init, delta commits "00000001" till "00000007" are added
-        // later on without archival or compaction
         assertEquals(i + 1, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
             new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, SOLO_COMMIT_TIMESTAMP + "010")));
-        IntStream.range(1, i + 1).forEach(j ->
+        assertTrue(metadataTableInstants.contains(
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "00000001")));
+      } else if (i <= 8) {
+        // In the metadata table timeline, the first delta commit is "00000000000000"
+        // from metadata table init, delta commits "00000001" till "00000007" are added
+        // later on without archival or compaction
+        // rollback in DT will also trigger rollback in MDT
+        assertEquals(i, metadataTableInstants.size());
+        assertTrue(metadataTableInstants.contains(
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, SOLO_COMMIT_TIMESTAMP + "010")));
+        // rolled back commits may not be present in MDT timeline (00000001)
+        IntStream.range(2, i).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j))));
-      } else if (i == 8) {
-        // i == 8
-        // The instant "00000000000000" was archived since it's less than
+      } else if (i == 9) {
+        // i == 9
+        // The instant "00000000000010" was archived since it's less than
         // the earliest commit on the dataset active timeline,
         // the dataset active timeline has instants:
         //   00000002.rollback, 00000007.commit, 00000008.commit
         assertEquals(9, metadataTableInstants.size());
-        assertTrue(metadataTableInstants.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000007001")));
-        IntStream.range(1, i + 1).forEach(j ->
+        // mdt timeline 00000002, 00000003,..., 00000008, 000000028001(compaction), 00000009
+        IntStream.range(2, i).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "0000000" + j))));
-      } else if (i <= 11) {
-        // In the metadata table timeline, the first delta commit is "00000005"
+      } else if (i <= 12) {
+        // In the metadata table timeline, the first delta commit is "00000006"
         // because it equals with the earliest commit on the dataset timeline, after archival,
-        // delta commits "00000006" till "00000011" are added later on without archival or compaction
-        assertEquals(i - 3, metadataTableInstants.size());
+        // delta commits "00000006" till "00000010" are added later on without archival or compaction
+        // mdt timeline 00000006, 00000007, 00000008, 00000008.compact, 00000009, 00000010 for i = 10
+        assertEquals(i - 4, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000007001")));
-        IntStream.range(5, i + 1).forEach(j ->
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000008001")));
+        IntStream.range(6, i).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
                     "000000" + String.format("%02d", j)))));
-      } else if (i <= 14) {
-        // In the metadata table timeline, the first delta commit is "00000007001"
-        // from metadata table compaction, after archival, delta commits "00000008"
-        // till "00000014" are added later on without archival or compaction
-        assertEquals(i - 6, metadataTableInstants.size());
+      } else if (i <= 16) {
+        // In the metadata table timeline, the first delta commit is "00000008001"
+        // from metadata table compaction, after archival, delta commits "00000009"
+        // till "00000016" are added later on without archival or compaction
+        // mdt timeline 00000008001, 00000009, 00000010, 00000011, 00000012, 00000013
+        assertEquals(i - 7, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000007001")));
-        IntStream.range(8, i + 1).forEach(j ->
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000008001")));
+        IntStream.range(9, i).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
                     "000000" + String.format("%02d", j)))));
-      } else if (i == 15) {
-        // Only delta commits "00000008" till "00000015" are in the active timeline + 007001 for compaction.
-        assertEquals(9, metadataTableInstants.size());
-        assertTrue(metadataTableInstants.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000007001")));
-        IntStream.range(8, 16).forEach(j ->
-            assertTrue(metadataTableInstants.contains(
-                new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
-                    "000000" + String.format("%02d", j)))));
-      } else if (i == 16) {
-        // i == 16
-        // dataset timeline has commits "00000015" and "00000016",
-        // the metadata timeline has commits [00000008, 00000016] and "00000015001"
+      } else if (i == 17) {
+        // i == 17
+        // commits in MDT [0000009, .... 00000016, 00000016001.compaction, 00000017]
         assertEquals(10, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000015001")));
-        IntStream.range(8, 17).forEach(j ->
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000016001")));
+        IntStream.range(9, i).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
                     "000000" + String.format("%02d", j)))));
       } else {
-        // i == 17
-        // Only commits [00000013, 00000017] and "00000015001" are on the metadata timeline
+        // i == 18
+        // commits in MDT [0000014, .... 00000016, 00000016001.compaction, 00000017, 00000018]
         assertEquals(6, metadataTableInstants.size());
         assertTrue(metadataTableInstants.contains(
-            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000015001")));
-        IntStream.range(13, 18).forEach(j ->
+            new HoodieInstant(State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "00000016001")));
+        IntStream.range(14, i).forEach(j ->
             assertTrue(metadataTableInstants.contains(
                 new HoodieInstant(State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION,
                     "000000" + String.format("%02d", j)))));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -1829,7 +1829,8 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
           .setPartitionMetadata(Collections.emptyMap())
           .setInstantsRollback(Collections.emptyList())
           .build();
-      HoodieTestTable.of(metaClient).addRollback(rollbackTime, hoodieRollbackMetadata, isEmpty);
+      HoodieTestTable.of(metaClient).addRollback(rollbackTime, hoodieRollbackMetadata, isEmpty, null);
+      HoodieTestTable.of(metaClient).addRollbackCompleted(rollbackTime, hoodieRollbackMetadata, isEmpty);
     }
     return new HoodieInstant(inflight, "rollback", rollbackTime);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -482,24 +482,21 @@ public class TestHoodieSparkMergeOnReadTableRollback extends SparkClientFunction
 
       copyOfRecords.clear();
 
-      // Rollback latest commit first
-      client.restoreToInstant("000", cfg.isMetadataTableEnabled());
+      // Restore to 3rd commit.
+      client.restoreToInstant("003", cfg.isMetadataTableEnabled());
 
-      metaClient = HoodieTableMetaClient.reload(metaClient);
+      metaClient.reloadActiveTimeline();
       allFiles = listAllBaseFilesInPath(hoodieTable);
-      tableView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+      tableView = getHoodieTableFileSystemView(metaClient, metaClient.reloadActiveTimeline().getCommitsTimeline().filterCompletedInstants(), allFiles);
       dataFilesToRead = tableView.getLatestBaseFiles();
-      assertFalse(dataFilesToRead.findAny().isPresent());
+      assertFalse(dataFilesToRead.filter(hoodieBaseFile -> hoodieBaseFile.getCommitTime().compareTo("003") > 0).findAny().isPresent());
       TableFileSystemView.SliceView rtView = getHoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
       List<HoodieFileGroup> fileGroups =
           ((HoodieTableFileSystemView) rtView).getAllFileGroups().collect(Collectors.toList());
-      assertTrue(fileGroups.isEmpty());
+      assertFalse(fileGroups.isEmpty());
 
-      // make sure there are no log files remaining
-      assertEquals(0L, ((HoodieTableFileSystemView) rtView).getAllFileGroups()
-          .filter(fileGroup -> fileGroup.getAllRawFileSlices().noneMatch(f -> f.getLogFiles().count() == 0))
-          .count());
-
+      assertFalse(fileGroups.stream().filter(fileGroup -> fileGroup.getAllFileSlices().map(fileSlice
+          -> fileSlice.getBaseInstantTime().compareTo("003") > 0).count() > 0).findAny().isPresent());
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -337,6 +337,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
 
     // downgrade to version 3 and check TABLE_CHECKSUM is still present
     new UpgradeDowngrade(metaClient, cfg, context, SparkUpgradeDowngradeHelper.getInstance()).run(HoodieTableVersion.THREE, null);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
     assertTableVersionOnDataAndMetadataTable(metaClient, HoodieTableVersion.THREE);
     assertTrue(metaClient.getTableConfig().getProps().containsKey(HoodieTableConfig.TABLE_CHECKSUM.key()));
     assertEquals(checksum, metaClient.getTableConfig().getProps().getString(HoodieTableConfig.TABLE_CHECKSUM.key()));
@@ -389,7 +390,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     Map<String, String> params = new HashMap<>();
     addNewTableParamsToProps(params, tableName);
     Properties properties = new Properties();
-    params.forEach((k,v) -> properties.setProperty(k, v));
+    params.forEach((k, v) -> properties.setProperty(k, v));
 
     initMetaClient(getTableType(), properties);
     // init config, table and client.
@@ -453,7 +454,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
 
   private void doInsertWithDefaultPartition(SparkRDDWriteClient client) {
     // Write 1 (only inserts)
-    dataGen = new HoodieTestDataGenerator(new String[]{DEPRECATED_DEFAULT_PARTITION_PATH});
+    dataGen = new HoodieTestDataGenerator(new String[] {DEPRECATED_DEFAULT_PARTITION_PATH});
     String commit1 = "005";
     client.startCommitWithTime(commit1);
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);
@@ -463,7 +464,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
 
   private void doInsertWithDefaultHiveStylePartition(SparkRDDWriteClient client) {
     // Write 1 (only inserts)
-    dataGen = new HoodieTestDataGenerator(new String[]{"partition_path=" + DEPRECATED_DEFAULT_PARTITION_PATH});
+    dataGen = new HoodieTestDataGenerator(new String[] {"partition_path=" + DEPRECATED_DEFAULT_PARTITION_PATH});
     String commit1 = "005";
     client.startCommitWithTime(commit1);
     List<HoodieRecord> records = dataGen.generateInserts(commit1, 100);
@@ -536,7 +537,6 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
             .withMetadataIndexBloomFilter(true)
             .withEnableRecordIndex(true).build())
         .build();
-    HoodieTable table = getHoodieTable(metaClient, config);
     for (MetadataPartitionType partitionType : MetadataPartitionType.values()) {
       metaClient.getTableConfig().setMetadataPartitionState(metaClient, partitionType, true);
     }
@@ -571,7 +571,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     prepForDowngradeFromVersion(HoodieTableVersion.SIX);
     new UpgradeDowngrade(metaClient, config, context, SparkUpgradeDowngradeHelper.getInstance())
         .run(HoodieTableVersion.FIVE, null);
-
+    metaClient = HoodieTableMetaClient.reload(metaClient);
     // validate the relevant table states after downgrade
     assertFalse(Files.exists(recordIndexPartitionPath), "record index partition should be deleted.");
     assertEquals(allPartitionsExceptRecordIndex, metaClient.getTableConfig().getMetadataPartitions(),
@@ -638,7 +638,7 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
       // assert marker files
       assertMarkerFilesForDowngrade(table, commitInstant, toVersion == HoodieTableVersion.ONE);
     }
-    
+
     // verify hoodie.table.version got downgraded
     metaClient = HoodieTableMetaClient.builder().setConf(context.getHadoopConf().get()).setBasePath(cfg.getBasePath())
         .setLayoutVersion(Option.of(new TimelineLayoutVersion(cfg.getTimelineLayoutVersion()))).build();
@@ -790,17 +790,17 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
   /**
    * Create two commits and may or may not commit 2nd commit.
    *
-   * @param firstPartitionCommit2FileSlices list to hold file slices in first partition.
+   * @param firstPartitionCommit2FileSlices  list to hold file slices in first partition.
    * @param secondPartitionCommit2FileSlices list of hold file slices from second partition.
-   * @param cfg instance of {@link HoodieWriteConfig}
-   * @param client instance of {@link SparkRDDWriteClient} to use.
-   * @param commitSecondUpsert true if 2nd commit needs to be committed. false otherwise.
+   * @param cfg                              instance of {@link HoodieWriteConfig}
+   * @param client                           instance of {@link SparkRDDWriteClient} to use.
+   * @param commitSecondUpsert               true if 2nd commit needs to be committed. false otherwise.
    * @return a pair of list of records from 1st and 2nd batch.
    */
   private Pair<List<HoodieRecord>, List<HoodieRecord>> twoUpsertCommitDataWithTwoPartitions(List<FileSlice> firstPartitionCommit2FileSlices,
-      List<FileSlice> secondPartitionCommit2FileSlices,
-      HoodieWriteConfig cfg, SparkRDDWriteClient client,
-      boolean commitSecondUpsert) throws IOException {
+                                                                                            List<FileSlice> secondPartitionCommit2FileSlices,
+                                                                                            HoodieWriteConfig cfg, SparkRDDWriteClient client,
+                                                                                            boolean commitSecondUpsert) throws IOException {
     //just generate two partitions
     dataGen = new HoodieTestDataGenerator(new String[] {DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH});
     //1. prepare data
@@ -857,11 +857,11 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
    * @param table instance of {@link HoodieTable}
    */
   private void prepForUpgradeFromZeroToOne(HoodieTable table) throws IOException {
-    List<HoodieInstant> instantsToBeParsed  =
+    List<HoodieInstant> instantsToBeParsed =
         metaClient.getActiveTimeline()
-        .getCommitsTimeline()
-        .getInstantsAsStream()
-        .collect(Collectors.toList());
+            .getCommitsTimeline()
+            .getInstantsAsStream()
+            .collect(Collectors.toList());
     for (HoodieInstant instant : instantsToBeParsed) {
       WriteMarkers writeMarkers =
           WriteMarkersFactory.get(table.getConfig().getMarkersType(), table, instant.getTimestamp());

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -49,7 +49,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   // Meta fields are not populated by default for metadata table
   public static final boolean DEFAULT_METADATA_POPULATE_META_FIELDS = false;
   // Default number of commits to retain, without cleaning, on metadata table
-  public static final int DEFAULT_METADATA_CLEANER_COMMITS_RETAINED = 3;
+  public static final int DEFAULT_METADATA_CLEANER_COMMITS_RETAINED = 10;
 
   public static final String METADATA_PREFIX = "hoodie.metadata";
   public static final String OPTIMIZED_LOG_BLOCKS_SCAN = ".optimized.log.blocks.scan.enable";

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -169,6 +169,12 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
+  public HoodieTimeline filterRequestedRollbackTimeline() {
+    return new HoodieDefaultTimeline(getInstantsAsStream().filter(
+        s -> s.getAction().equals(HoodieTimeline.ROLLBACK_ACTION) && s.isRequested()), details);
+  }
+
+  @Override
   public HoodieTimeline filterPendingCompactionTimeline() {
     return new HoodieDefaultTimeline(
         getInstantsAsStream().filter(s -> s.getAction().equals(HoodieTimeline.COMPACTION_ACTION) && !s.isCompleted()), details);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -227,6 +227,11 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline filterPendingRollbackTimeline();
 
   /**
+   * Filter this timeline for requested rollbacks.
+   */
+  HoodieTimeline filterRequestedRollbackTimeline();
+
+  /**
    * Create a new Timeline with all the instants after startTs.
    */
   HoodieTimeline findInstantsAfterOrEquals(String commitTime, int numCommits);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -459,6 +459,10 @@ public interface HoodieTimeline extends Serializable {
     return instant.isRequested() ? instant : HoodieTimeline.getRequestedInstant(instant);
   }
 
+  static HoodieInstant getRestoreRequestedInstant(HoodieInstant instant) {
+    return instant.isRequested() ? instant : HoodieTimeline.getRequestedInstant(instant);
+  }
+
   static HoodieInstant getIndexRequestedInstant(final String timestamp) {
     return new HoodieInstant(State.REQUESTED, INDEXING_ACTION, timestamp);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -613,10 +613,8 @@ public class HoodieTableMetadataUtil {
     final Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
 
     List<HoodieRecord> filesPartitionRecords = convertMetadataToRollbackRecords(rollbackMetadata, instantTime, dataTableMetaClient);
-
-    /*List<HoodieRecord> reAddedRecords = getHoodieRecordsForLogFilesFromRollbackPlan(dataTableMetaClient, instantTime);
-    filesPartitionRecords.addAll(reAddedRecords);*/
-    final HoodieData<HoodieRecord> rollbackRecordsRDD = engineContext.parallelize(filesPartitionRecords, filesPartitionRecords.size());
+    final HoodieData<HoodieRecord> rollbackRecordsRDD = (filesPartitionRecords.isEmpty() || filesPartitionRecords.size() == 0) ? engineContext.emptyHoodieData()
+        : engineContext.parallelize(filesPartitionRecords, filesPartitionRecords.size());
 
     partitionToRecordsMap.put(MetadataPartitionType.FILES, rollbackRecordsRDD);
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -661,7 +661,7 @@ public class HoodieTableMetadataUtil {
     HoodieInstant requested = HoodieTimeline.getRollbackRequestedInstant(rollbackInstant);
     try {
       HoodieRollbackPlan rollbackPlan = TimelineMetadataUtils.deserializeAvroMetadata(
-          dataTableMetaClient.reloadActiveTimeline().readRollbackInfoAsBytes(requested).get(), HoodieRollbackPlan.class);
+          dataTableMetaClient.getActiveTimeline().readRollbackInfoAsBytes(requested).get(), HoodieRollbackPlan.class);
 
       rollbackPlan.getRollbackRequests().forEach(rollbackRequest -> {
         final String partitionId = getPartitionIdentifier(rollbackRequest.getPartitionPath());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -624,16 +624,11 @@ public class HoodieTableMetadataUtil {
   }
 
   private static List<HoodieRecord> getHoodieRecordsForLogFilesFromRollbackPlan(HoodieTableMetaClient dataTableMetaClient, String instantTime) {
-    /*List<HoodieInstant> instants = dataTableMetaClient.reloadActiveTimeline().filterRequestedRollbackTimeline()
-        .filter(instant -> instant.getTimestamp().equals(instantTime) && instant.isRequested()).getInstants();*/
-
     HoodieInstant rollbackInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.ROLLBACK_ACTION, instantTime);
-
-    // HoodieInstant rollbackInstant = instants.get(0);
     HoodieInstant requested = HoodieTimeline.getRollbackRequestedInstant(rollbackInstant);
     try {
       HoodieRollbackPlan rollbackPlan = TimelineMetadataUtils.deserializeAvroMetadata(
-          dataTableMetaClient.getActiveTimeline().readRollbackInfoAsBytes(requested).get(), HoodieRollbackPlan.class);
+          dataTableMetaClient.reloadActiveTimeline().readRollbackInfoAsBytes(requested).get(), HoodieRollbackPlan.class);
 
       Map<String, Map<String, Long>> partitionToLogFilesMap = new HashMap<>();
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1286,6 +1286,11 @@ public class HoodieTableMetadataUtil {
           validInstantTimestamps.addAll(getRollbackedCommits(instant, datasetTimeline));
         });
 
+    // add restore instants from MDT.
+    metadataMetaClient.getActiveTimeline().getRollbackAndRestoreTimeline().filterCompletedInstants()
+        .filter(instant -> instant.getAction().equals(HoodieTimeline.RESTORE_ACTION))
+        .getInstants().forEach(instant -> validInstantTimestamps.add(instant.getTimestamp()));
+
     // SOLO_COMMIT_TIMESTAMP is used during bootstrap so it is a valid timestamp
     validInstantTimestamps.add(createIndexInitTimestamp(SOLO_COMMIT_TIMESTAMP, PARTITION_INITIALIZATION_TIME_SUFFIX));
     return validInstantTimestamps;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -279,18 +279,17 @@ public class TestStreamWriteOperatorCoordinator {
     metadataTableMetaClient.reloadActiveTimeline();
     completedTimeline = metadataTableMetaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
     assertThat("One instant need to sync to metadata table", completedTimeline.countInstants(), is(9));
-    assertThat(completedTimeline.lastInstant().get().getTimestamp(), is(instant + "002"));
-    assertThat(completedTimeline.lastInstant().get().getAction(), is(HoodieTimeline.CLEAN_ACTION));
 
     // write another commit
     mockWriteWithMetadata();
+
     // write another commit
     instant = mockWriteWithMetadata();
     // write another commit to trigger compaction
     mockWriteWithMetadata();
     metadataTableMetaClient.reloadActiveTimeline();
     completedTimeline = metadataTableMetaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
-    assertThat("One instant need to sync to metadata table", completedTimeline.countInstants(), is(14));
+    assertThat("One instant need to sync to metadata table", completedTimeline.countInstants(), is(13));
     assertThat(completedTimeline.nthFromLastInstant(1).get().getTimestamp(), is(instant + "001"));
     assertThat(completedTimeline.nthFromLastInstant(1).get().getAction(), is(HoodieTimeline.COMMIT_ACTION));
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -278,7 +278,7 @@ public class TestStreamWriteOperatorCoordinator {
     instant = mockWriteWithMetadata();
     metadataTableMetaClient.reloadActiveTimeline();
     completedTimeline = metadataTableMetaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
-    assertThat("One instant need to sync to metadata table", completedTimeline.countInstants(), is(10));
+    assertThat("One instant need to sync to metadata table", completedTimeline.countInstants(), is(9));
     assertThat(completedTimeline.lastInstant().get().getTimestamp(), is(instant + "002"));
     assertThat(completedTimeline.lastInstant().get().getAction(), is(HoodieTimeline.CLEAN_ACTION));
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
@@ -256,6 +256,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
             .withBootstrapParallelism(3)
             .withBootstrapModeSelector(bootstrapModeSelectorClass)
             .withBootstrapModeForRegexMatch(modeForRegexMatch).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMaxNumDeltaCommitsBeforeCompaction(3).build())
         .build();
 
     SparkRDDWriteClient client = new SparkRDDWriteClient(context, config);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -65,7 +65,6 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.reload;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
 import static org.apache.hudi.config.HoodieWriteConfig.CLIENT_HEARTBEAT_INTERVAL_IN_MS;
 import static org.apache.hudi.config.HoodieWriteConfig.CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.METADATA_INDEXER_TIME_SUFFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getFileSystemView;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.metadataPartitionExists;
 import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
@@ -186,7 +185,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
     HoodieBackedTableMetadata metadata = new HoodieBackedTableMetadata(
         context(), metadataConfig, metaClient.getBasePathV2().toString());
     HoodieTableMetaClient metadataMetaClient = metadata.getMetadataMetaClient();
-    String mdtCommitTime = indexUptoInstantTime + METADATA_INDEXER_TIME_SUFFIX;
+    String mdtCommitTime = HoodieTableMetadataUtil.createAsyncIndexerTimestamp(indexUptoInstantTime);
     assertTrue(metadataMetaClient.getActiveTimeline().containsInstant(mdtCommitTime));
 
     // Reverts both instants to inflight state, to simulate inflight indexing instants


### PR DESCRIPTION
[HUDI-6153] Changed the rollback mechanism for MDT to actual rollbacks rather than appending revert blocks

### Change Logs

Prior to this patch, rollbacks in DT is yet another delta commit in MDT and we mark all files as invalid in the delta commit added. But as we are adding more high scale partitions like RLI, we can't afford to mark 100k entries as invalid. So, we wanted to trigger an actual rollback of the commit of interest in MDT for the delta commit of interest. (similar to how we do rollback in DT).

Here is the new rollback logic in MDT:
Once the rollback completes the business in DT, it comes to MDT territory to make an update. 
We do 2 things in here. 
Lets say the rollback instant is t5.rb and commit being rolled back in DT is t4.dc. 
a. we trigger a delta commit in MDT with instant time t5_006.dc 
    i. Adds any log files added as part of rolling back t4.dc in DT. We can fetch this info from the rollback commit metadata. We will update only FILES partition in this case.
    ii. For FILES partition in MDT, we might need to retain all files in DT so that cleaner down the line will be able to clean up all logs files in DT. This can be fetched from the rollback plan corresponding to the rollback in DT. 
b. Trigger a rollback of t4.dc in MDT. This should rollback data in all MDT partitions. 
 

### Impact

Fixes issue related to rollback of various indexes in MDT.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
