### PR TITLE
[HUDI-6283] Improve ReflectionUtils APIs

### DIFF
--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -123,6 +123,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <!-- Avro -->
     <dependency>

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/JsonUtils.java
@@ -20,41 +20,74 @@
 package org.apache.hudi.common.util;
 
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.util.Lazy;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * Utils for JSON serialization and deserialization.
  */
 public class JsonUtils {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  static {
-    MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-    // We need to exclude custom getters, setters and creators which can use member fields
-    // to derive new fields, so that they are not included in the serialization
-    MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-    MAPPER.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-    MAPPER.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
-    MAPPER.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
-    MAPPER.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NONE);
-  }
+  private static final Lazy<ObjectMapper> MAPPER = Lazy.lazily(JsonUtils::instantiateObjectMapper);
 
   public static ObjectMapper getObjectMapper() {
-    return MAPPER;
+    return MAPPER.get();
   }
 
   public static String toString(Object value) {
     try {
-      return MAPPER.writeValueAsString(value);
+      return MAPPER.get().writeValueAsString(value);
     } catch (JsonProcessingException e) {
       throw new HoodieIOException(
           "Fail to convert the class: " + value.getClass().getName() + " to Json String", e);
     }
+  }
+
+  private static ObjectMapper instantiateObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+
+    registerModules(mapper);
+
+    // We're writing out dates as their string representations instead of (int) timestamps
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    // NOTE: This is necessary to make sure that w/ Jackson >= 2.11 colon is not infixed
+    //       into the timezone value ("+00:00" as opposed to "+0000" before 2.11)
+    //       While Jackson is able to parse both of these formats, we keep it as false
+    //       to make sure metadata produced by Hudi stays consistent across Jackson versions
+    configureColonInTimezone(mapper);
+
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    // We need to exclude custom getters, setters and creators which can use member fields
+    // to derive new fields, so that they are not included in the serialization
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+    mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+    mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+    mapper.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NONE);
+
+    return mapper;
+  }
+
+  private static void configureColonInTimezone(ObjectMapper mapper) {
+    if (ReflectionUtils.hasMethod(StdDateFormat.class, "withColonInTimeZone", boolean.class)) {
+      // NOTE: We have to rely on reflection here since this method has only been introduced in
+      //       Jackson >= 2.10
+      StdDateFormat dateFormat =
+          ReflectionUtils.invokeMethod(StdDateFormat.instance, "withColonInTimeZone", new Object[] {false}, boolean.class);
+      mapper.setDateFormat(dateFormat);
+    }
+  }
+
+  private static void registerModules(ObjectMapper mapper) {
+    // NOTE: Registering [[JavaTimeModule]] is required for Jackson >= 2.11 (Spark >= 3.3)
+    mapper.registerModules(new JavaTimeModule());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -130,6 +130,20 @@ public class ReflectionUtils {
   }
 
   /**
+   * Checks whether target class has a method w/ {@code methodName} and list of arguments
+   * designated by {@code paramTypes}
+   */
+  public static boolean hasMethod(Class<?> klass, String methodName, Class<?>... paramTypes) {
+    try {
+      klass.getMethod(methodName, paramTypes);
+      return true;
+    } catch (NoSuchMethodException e) {
+      LOG.info(String.format("No method %s found in class '%s'", methodName, klass.getName()));
+      return false;
+    }
+  }
+
+  /**
    * Scans all classes accessible from the context class loader
    * which belong to the given package and subpackages.
    *
@@ -193,12 +207,22 @@ public class ReflectionUtils {
   }
 
   /**
+   * Invokes a non-static method of a class on provided object.
+   */
+  public static <O, R> R invokeMethod(O obj, String methodName, Object[] args, Class<?>... paramTypes) {
+    Class<?> klass = obj.getClass();
+    try {
+      Method method = klass.getMethod(methodName, paramTypes);
+      return (R) method.invoke(obj, args);
+    } catch (NoSuchMethodException e) {
+      throw new HoodieException(String.format("Unable to find the method '%s' of the class '%s'", methodName, klass.getName()), e);
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      throw new HoodieException(String.format("Unable to invoke the method '%s' of the class '%s'", methodName, klass.getName()), e);
+    }
+  }
+
+  /**
    * Invoke a static method of a class.
-   * @param clazz
-   * @param methodName
-   * @param args
-   * @param parametersType
-   * @return the return value of the method
    */
   public static Object invokeStaticMethod(String clazz, String methodName, Object[] args, Class<?>... parametersType) {
     try {
@@ -207,7 +231,7 @@ public class ReflectionUtils {
     } catch (ClassNotFoundException e) {
       throw new HoodieException("Unable to find the class " + clazz, e);
     } catch (NoSuchMethodException e) {
-      throw new HoodieException(String.format("Unable to find the method %s of the class %s ",  methodName, clazz), e);
+      throw new HoodieException(String.format("Unable to find the method %s of the class %s ", methodName, clazz), e);
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new HoodieException(String.format("Unable to invoke the method %s of the class %s ", methodName, clazz), e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -20,6 +20,8 @@ package org.apache.hudi.common.util;
 
 import org.apache.hudi.exception.HoodieException;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,12 +31,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -45,24 +47,106 @@ public class ReflectionUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReflectionUtils.class);
 
-  private static final Map<String, Class<?>> CLAZZ_CACHE = new HashMap<>();
+  private static final Cache<String, Class<?>> LOADED_CLASSES_CACHE =
+      Caffeine.newBuilder()
+          .maximumSize(2000)
+          .weakValues()
+          .expireAfterAccess(Duration.of(5, ChronoUnit.MINUTES))
+          .build();
 
-  public static Class<?> getClass(String clazzName) {
-    if (!CLAZZ_CACHE.containsKey(clazzName)) {
-      synchronized (CLAZZ_CACHE) {
-        if (!CLAZZ_CACHE.containsKey(clazzName)) {
-          try {
-            Class<?> clazz = Class.forName(clazzName);
-            CLAZZ_CACHE.put(clazzName, clazz);
-          } catch (ClassNotFoundException e) {
-            throw new HoodieException("Unable to load class", e);
-          }
-        }
-      }
+  /**
+   * Tries to load class identified by provide {@code qualifiedName}.
+   * Throws {@link HoodieException} in case class couldn't be loaded
+   *
+   * @param qualifiedName target class's qualified name
+   * @return instance of {@link Class} corresponding to the class identified by the {@code qualifiedName}
+   */
+  public static Class<?> getClass(String qualifiedName) {
+    Class<?> klass = getClassNoThrow(qualifiedName);
+    if (klass != null) {
+      return klass;
     }
-    return CLAZZ_CACHE.get(clazzName);
+    throw new HoodieException(String.format("Unable to load class '%s'", qualifiedName));
   }
 
+  /**
+   * Tries to load class identified by provide {@code qualifiedName}.
+   * Returns null in case class couldn't be loaded
+   *
+   * @param qualifiedName target class's qualified name
+   * @return instance of {@link Class} corresponding to the class identified by the {@code qualifiedName}
+   */
+  public static Class<?> getClassNoThrow(String qualifiedName) {
+    return LOADED_CLASSES_CACHE.get(qualifiedName, name -> {
+      try {
+        return Class.forName(qualifiedName);
+      } catch (ClassNotFoundException e) {
+        LOG.info(String.format("Failed to load class '%s'", qualifiedName));
+        return null;
+      }
+    });
+  }
+
+
+  /**
+   * Creates new instance of the class identified by {@code classQualifiedName}.
+   * Will throw in case class couldn't be loaded or instantiated
+   */
+  public static <T> T newInstance(String classQualifiedName) {
+    try {
+      return (T) getClass(classQualifiedName).newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new HoodieException(String.format("Failed to create new instance for class '%s'", classQualifiedName), e);
+    }
+  }
+
+  /**
+   * Creates new instance of the class identified by {@code classQualifiedName}.
+   * Returns null in case class couldn't be loaded or instantiated
+   */
+  public static <T> T newInstanceNoThrow(String classQualifiedName) {
+    try {
+      Class<?> klass = getClassNoThrow(classQualifiedName);
+      return klass != null ? (T) klass.newInstance() : null;
+    } catch (InstantiationException | IllegalAccessException e) {
+      LOG.info(String.format("Failed to create new instance for class '%s'", classQualifiedName));
+      return null;
+    }
+  }
+
+  /**
+   * Creates new instance of the class identified by {@code classQualifiedName}.
+   * Will throw in case class couldn't be loaded or instantiated
+   *
+   * @param classQualifiedName qualified name of the target class
+   * @param constructorArgs    argument values to be passed into the target ctor
+   * @return new instance of the target class
+   */
+  public static Object newInstance(String classQualifiedName, Object... constructorArgs) {
+    Class<?>[] constructorArgTypes = Arrays.stream(constructorArgs).map(Object::getClass).toArray(Class<?>[]::new);
+    return newInstance(classQualifiedName, constructorArgTypes, constructorArgs);
+  }
+
+  /**
+   * Creates new instance of the class identified by {@code classQualifiedName}.
+   * Will throw in case class couldn't be loaded or instantiated
+   *
+   * @param classQualifiedName  qualified name of the target class
+   * @param constructorArgTypes corresponding types of the arguments of class' ctor that should be invoked
+   * @param constructorArgs     argument values to be passed into the target ctor
+   * @return new instance of the target class
+   */
+  public static Object newInstance(String classQualifiedName, Class<?>[] constructorArgTypes, Object... constructorArgs) {
+    try {
+      return getClass(classQualifiedName).getConstructor(constructorArgTypes).newInstance(constructorArgs);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new HoodieException("Unable to instantiate class " + classQualifiedName, e);
+    }
+  }
+
+  /**
+   * @deprecated use {@link #newInstance(String)} instead
+   */
   public static <T> T loadClass(String className) {
     try {
       return (T) getClass(className).newInstance();
@@ -72,7 +156,19 @@ public class ReflectionUtils {
   }
 
   /**
+   * Creates an instance of the given class. Constructor arg types are inferred.
+   *
+   * @deprecated Use {@link #newInstance(String, Object...)} instead.
+   */
+  public static Object loadClass(String clazz, Object... constructorArgs) {
+    Class<?>[] constructorArgTypes = Arrays.stream(constructorArgs).map(Object::getClass).toArray(Class<?>[]::new);
+    return loadClass(clazz, constructorArgTypes, constructorArgs);
+  }
+
+  /**
    * Creates an instance of the given class. Use this version when dealing with interface types as constructor args.
+   *
+   * @deprecated Use {@link #newInstance(String, Class[], Object...)} instead.
    */
   public static Object loadClass(String clazz, Class<?>[] constructorArgTypes, Object... constructorArgs) {
     try {
@@ -83,35 +179,35 @@ public class ReflectionUtils {
   }
 
   /**
-   * Check if the clazz has the target constructor or not, without throwing warn-level log.
+   * Check if the class has the target constructor or not.
    *
-   * @param clazz               Class name.
+   * @param className           Qualified class name.
    * @param constructorArgTypes Argument types of the constructor.
-   * @return
+   * @return {@code true} if the constructor exists; {@code false} otherwise.
    */
-  public static boolean hasConstructor(String clazz, Class<?>[] constructorArgTypes) {
-    return hasConstructor(clazz, constructorArgTypes, true);
+  public static boolean hasConstructor(String className, Class<?>[] constructorArgTypes) {
+    return hasConstructor(className, constructorArgTypes, true);
   }
 
   /**
-   * Check if the clazz has the target constructor or not.
+   * Check if the class has the target constructor or not.
    * <p>
    * When catch {@link HoodieException} from {@link #loadClass}, it's inconvenient to say if the exception was thrown
    * due to the instantiation's own logic or missing constructor.
    * <p>
    * TODO: ReflectionUtils should throw a specific exception to indicate Reflection problem.
    *
-   * @param clazz               Class name.
+   * @param className           Qualified class name.
    * @param constructorArgTypes Argument types of the constructor.
    * @param silenceWarning      {@code true} to use debug-level logging; otherwise, use warn-level logging.
    * @return {@code true} if the constructor exists; {@code false} otherwise.
    */
-  public static boolean hasConstructor(String clazz, Class<?>[] constructorArgTypes, boolean silenceWarning) {
+  public static boolean hasConstructor(String className, Class<?>[] constructorArgTypes, boolean silenceWarning) {
     try {
-      getClass(clazz).getConstructor(constructorArgTypes);
+      getClass(className).getConstructor(constructorArgTypes);
       return true;
     } catch (NoSuchMethodException e) {
-      String message = "Unable to instantiate class " + clazz;
+      String message = "Unable to instantiate class " + className;
       if (silenceWarning) {
         LOG.debug(message, e);
       } else {
@@ -119,14 +215,6 @@ public class ReflectionUtils {
       }
       return false;
     }
-  }
-
-  /**
-   * Creates an instance of the given class. Constructor arg types are inferred.
-   */
-  public static Object loadClass(String clazz, Object... constructorArgs) {
-    Class<?>[] constructorArgTypes = Arrays.stream(constructorArgs).map(Object::getClass).toArray(Class<?>[]::new);
-    return loadClass(clazz, constructorArgTypes, constructorArgs);
   }
 
   /**
@@ -224,16 +312,14 @@ public class ReflectionUtils {
   /**
    * Invoke a static method of a class.
    */
-  public static Object invokeStaticMethod(String clazz, String methodName, Object[] args, Class<?>... parametersType) {
+  public static Object invokeStaticMethod(String className, String methodName, Object[] args, Class<?>... parametersType) {
     try {
-      Method method = Class.forName(clazz).getMethod(methodName, parametersType);
+      Method method = getClass(className).getMethod(methodName, parametersType);
       return method.invoke(null, args);
-    } catch (ClassNotFoundException e) {
-      throw new HoodieException("Unable to find the class " + clazz, e);
     } catch (NoSuchMethodException e) {
-      throw new HoodieException(String.format("Unable to find the method %s of the class %s ", methodName, clazz), e);
+      throw new HoodieException(String.format("Unable to find the method '%s' of the class '%s' ", methodName, className), e);
     } catch (InvocationTargetException | IllegalAccessException e) {
-      throw new HoodieException(String.format("Unable to invoke the method %s of the class %s ", methodName, clazz), e);
+      throw new HoodieException(String.format("Unable to invoke the method '%s' of the class '%s' ", methodName, className), e);
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestJsonUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestJsonUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestJsonUtils {
+
+  @Test
+  void testDateTimeSerialization() {
+    List<Object> dateTimeObjs = Arrays.asList(
+        java.time.Instant.ofEpochSecond(1),
+        java.time.LocalDate.of(1970, 1, 1),
+        java.time.LocalTime.of(0, 0, 1),
+        java.time.LocalDateTime.of(1970, 1, 1, 0, 0, 1, 0),
+        java.sql.Date.valueOf("1970-01-01"),
+        java.sql.Time.valueOf("00:00:01"),
+        java.sql.Timestamp.from(Instant.ofEpochSecond(1)),
+        java.util.Date.from(Instant.ofEpochSecond(1))
+    );
+
+    List<String> actual = dateTimeObjs.stream().map(JsonUtils::toString).collect(Collectors.toList());
+    List<String> expected = Arrays.asList(
+        "\"1970-01-01T00:00:01Z\"",
+        "\"1970-01-01\"",
+        "\"00:00:01\"",
+        "\"1970-01-01T00:00:01\"",
+        "\"1970-01-01\"",
+        "\"00:00:01\"",
+        "\"1970-01-01T00:00:01.000+0000\"",
+        "\"1970-01-01T00:00:01.000+0000\""
+    );
+
+    assertEquals(expected, actual);
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -33,13 +33,12 @@ import org.apache.hudi.testutils.HoodieSparkClientTestBase
 import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, Expression, GreaterThan, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, Literal, Or}
 import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api._
-import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource, ValueSource}
 
@@ -49,12 +48,10 @@ import scala.collection.JavaConverters._
 import scala.util.Random
 
 @Tag("functional")
-@DisabledIf(value = "org.apache.hudi.HoodieSparkUtils#gteqSpark3_3",
-  disabledReason = "Jackson version conflicts (HUDI-5352)")
 class TestColumnStatsIndex extends HoodieSparkClientTestBase {
   var spark: SparkSession = _
 
-  val sourceTableSchema =
+  val sourceTableSchema: StructType =
     new StructType()
       .add("c1", IntegerType)
       .add("c2", StringType)
@@ -66,7 +63,7 @@ class TestColumnStatsIndex extends HoodieSparkClientTestBase {
       .add("c8", ByteType)
 
   @BeforeEach
-  override def setUp() {
+  override def setUp(): Unit = {
     initPath()
     initSparkContexts()
     initFileSystem()
@@ -78,7 +75,7 @@ class TestColumnStatsIndex extends HoodieSparkClientTestBase {
   }
 
   @AfterEach
-  override def tearDown() = {
+  override def tearDown(): Unit = {
     cleanupFileSystem()
     cleanupSparkContexts()
   }

--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -87,6 +87,7 @@
                                     <include>com.beust:jcommander</include>
                                     <include>commons-io:commons-io</include>
                                     <include>org.openjdk.jol:jol-core</include>
+                                    <include>com.github.ben-manes.caffeine:caffeine</include>
                                 </includes>
                             </artifactSet>
                             <relocations combine.children="append">

--- a/packaging/hudi-cli-bundle/pom.xml
+++ b/packaging/hudi-cli-bundle/pom.xml
@@ -93,6 +93,8 @@
                   <include>org.apache.hudi:hudi-cli</include>
                   <include>org.apache.hudi:hudi-utilities_${scala.binary.version}</include>
 
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
+
                   <!-- Kryo -->
                   <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>

--- a/packaging/hudi-datahub-sync-bundle/pom.xml
+++ b/packaging/hudi-datahub-sync-bundle/pom.xml
@@ -78,6 +78,7 @@
                   <include>org.apache.httpcomponents:httpasyncclient</include>
                   <include>org.apache.httpcomponents:httpcore-nio</include>
                   <include>org.openjdk.jol:jol-core</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                 </includes>
               </artifactSet>
               <relocations combine.children="append">

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -109,8 +109,9 @@
                   <include>org.apache.avro:avro</include>
                   <include>joda-time:joda-time</include>
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
-                  <include>com.fasterxml.jackson.core:jackson-databind</include>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
 
                   <include>com.lmax:disruptor</include>
                   <include>com.github.davidmoten:guava-mini</include>

--- a/packaging/hudi-gcp-bundle/pom.xml
+++ b/packaging/hudi-gcp-bundle/pom.xml
@@ -102,6 +102,7 @@
                   <include>com.beust:jcommander</include>
                   <include>commons-io:commons-io</include>
                   <include>org.openjdk.jol:jol-core</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                 </includes>
               </artifactSet>
               <relocations combine.children="append">

--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -74,6 +74,15 @@
                   <include>com.esotericsoftware:minlog</include>
                   <include>org.objenesis:objenesis</include>
 
+                  <!-- Jackson
+                       NOTE: Even though Hive bundles Jackson, it doesn't bundle JSR310 module (unlike Spark).
+                             Therefore, to make sure that JSR310 is compatible w/ the Jackson core used by Hudi, we bundle the core
+                             as well, while shading it -->
+                  <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>org.apache.avro:avro</include>
                   <include>com.yammer.metrics:metrics-core</include>
@@ -120,6 +129,10 @@
                 <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson.</pattern>
+                  <shadedPattern>org.apache.hudi.com.fasterxml.jackson.</shadedPattern>
                 </relocation>
               </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -79,6 +79,7 @@
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>commons-io:commons-io</include>
                   <include>org.openjdk.jol:jol-core</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                   <!-- Kryo -->
                   <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -71,6 +71,9 @@
                   <include>org.apache.hudi:hudi-sync-common</include>
                   <include>org.apache.hudi:hudi-hive-sync</include>
 
+                  <!-- NOTE: Only Jackson module we're bundling here is JSR310, which we need to bundle only
+                             for Spark 2.x -->
+                  <include>com.fasterxml.jackson.datatype:${fasterxml.jackson.datatype.jsr310.module}</include>
                   <include>com.beust:jcommander</include>
                   <include>org.apache.avro:avro</include>
                   <include>org.apache.parquet:parquet-avro</include>

--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -152,6 +152,7 @@
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                   <include>com.fasterxml.jackson.core:jackson-databind</include>
                   <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
+                  <include>com.fasterxml.jackson.datatype:${fasterxml.jackson.datatype.jsr310.module}</include>
 
                   <include>org.apache.curator:curator-framework</include>
                   <include>org.apache.curator:curator-client</include>
@@ -255,8 +256,8 @@
                   <shadedPattern>org.apache.hudi.org.apache.commons.codec.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.fasterxml.jackson.dataformat.</pattern>
-                  <shadedPattern>org.apache.hudi.com.fasterxml.jackson.dataformat.</shadedPattern>
+                  <pattern>com.fasterxml.jackson.</pattern>
+                  <shadedPattern>org.apache.hudi.com.fasterxml.jackson.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.parquet.avro.</pattern>

--- a/packaging/hudi-kafka-connect-bundle/pom.xml
+++ b/packaging/hudi-kafka-connect-bundle/pom.xml
@@ -128,6 +128,7 @@
                                     <include>org.scala-lang:*</include>
                                     <include>commons-io:commons-io</include>
                                     <include>org.openjdk.jol:jol-core</include>
+                                    <include>com.github.ben-manes.caffeine:caffeine</include>
                                 </includes>
                             </artifactSet>
                             <relocations combine.children="append">

--- a/packaging/hudi-kafka-connect-bundle/pom.xml
+++ b/packaging/hudi-kafka-connect-bundle/pom.xml
@@ -95,6 +95,15 @@
                                     <include>com.esotericsoftware:minlog</include>
                                     <include>org.objenesis:objenesis</include>
 
+                                    <!-- Jackson
+                                         NOTE: Even though Hive bundles Jackson, it doesn't bundle JSR310 module (unlike Spark).
+                                               Therefore, to make sure that JSR310 is compatible w/ the Jackson core used by Hudi, we bundle the core
+                                               as well, while shading it -->
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+
                                     <include>com.lmax:disruptor</include>
                                     <include>com.github.davidmoten:guava-mini</include>
                                     <include>com.github.davidmoten:hilbert-curve</include>
@@ -166,6 +175,10 @@
                                 <relocation>
                                     <pattern>org.openjdk.jol.</pattern>
                                     <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.</pattern>
+                                    <shadedPattern>org.apache.hudi.com.fasterxml.jackson.</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/packaging/hudi-metaserver-server-bundle/pom.xml
+++ b/packaging/hudi-metaserver-server-bundle/pom.xml
@@ -102,6 +102,7 @@
                                 <includes>
                                     <include>org.apache.hudi:hudi-common</include>
                                     <include>org.apache.hudi:hudi-metaserver-server</include>
+                                    <include>com.github.ben-manes.caffeine:caffeine</include>
                                     <include>org.apache.thrift:libthrift</include>
                                     <include>org.apache.logging.log4j:log4j-api</include>
                                     <include>org.apache.logging.log4j:log4j-core</include>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -91,6 +91,9 @@
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
+                  <!-- NOTE: Only Jackson module we're bundling here is JSR310, which we need to bundle only
+                             for Spark 2.x -->
+                  <include>com.fasterxml.jackson.datatype:${fasterxml.jackson.datatype.jsr310.module}</include>
 
                   <include>com.lmax:disruptor</include>
                   <include>com.github.davidmoten:guava-mini</include>

--- a/packaging/hudi-timeline-server-bundle/pom.xml
+++ b/packaging/hudi-timeline-server-bundle/pom.xml
@@ -55,6 +55,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.javalin</groupId>
@@ -183,6 +187,7 @@
                       <include>com.fasterxml.jackson.core:jackson-annotations</include>
                       <include>com.fasterxml.jackson.core:jackson-core</include>
                       <include>com.fasterxml.jackson.core:jackson-databind</include>
+                      <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
                       <include>commons-io:commons-io</include>
                       <include>log4j:log4j</include>
                       <include>org.openjdk.jol:jol-core</include>
@@ -196,6 +201,10 @@
                     <relocation>
                         <pattern>org.openjdk.jol.</pattern>
                         <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                        <pattern>com.fasterxml.jackson.</pattern>
+                        <shadedPattern>org.apache.hudi.com.fasterxml.jackson.</shadedPattern>
                     </relocation>
                 </relocations>
             </configuration>

--- a/packaging/hudi-timeline-server-bundle/pom.xml
+++ b/packaging/hudi-timeline-server-bundle/pom.xml
@@ -191,6 +191,7 @@
                       <include>commons-io:commons-io</include>
                       <include>log4j:log4j</include>
                       <include>org.openjdk.jol:jol-core</include>
+                      <include>com.github.ben-manes.caffeine:caffeine</include>
                   </includes>
                 </artifactSet>
                 <relocations combine.children="append">

--- a/packaging/hudi-trino-bundle/pom.xml
+++ b/packaging/hudi-trino-bundle/pom.xml
@@ -79,6 +79,7 @@
 
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>org.apache.avro:avro</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>org.codehaus.jackson:*</include>
                   <include>com.yammer.metrics:metrics-core</include>
                   <include>com.google.guava:guava</include>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -115,6 +115,9 @@
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
                   <include>org.apache.parquet:parquet-avro</include>
+                  <!-- NOTE: Only Jackson module we're bundling here is JSR310, which we need to bundle only
+                             for Spark 2.x -->
+                  <include>com.fasterxml.jackson.datatype:${fasterxml.jackson.datatype.jsr310.module}</include>
 
                   <include>com.lmax:disruptor</include>
                   <include>com.github.davidmoten:guava-mini</include>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -135,6 +135,7 @@
                   <include>commons-codec:commons-codec</include>
                   <include>commons-io:commons-io</include>
                   <include>org.openjdk.jol:jol-core</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                 </includes>
               </artifactSet>
               <relocations combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,8 @@
     <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
     <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
     <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+    <!-- NOTE: By default we're not including JSR310 module for Jackson since Spark >= 3.x is bundling it anyway -->
+    <fasterxml.jackson.datatype.jsr310.module/>
     <kafka.version>2.0.0</kafka.version>
     <kafka.spark3.version>2.8.0</kafka.spark3.version>
     <pulsar.version>2.8.1</pulsar.version>
@@ -850,6 +852,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
+        <version>${fasterxml.version}</version>
+      </dependency>
+      <!-- This one is necessary to support Java 8 Date/Time types (required for Jackson >= 2.13) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${fasterxml.version}</version>
       </dependency>
       <dependency>
@@ -2156,6 +2164,7 @@
         <fasterxml.jackson.databind.version>2.6.7.3</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>2.6.7.1</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>2.7.4</fasterxml.jackson.dataformat.yaml.version>
+        <fasterxml.jackson.datatype.jsr310.module>jackson-datatype-jsr310</fasterxml.jackson.datatype.jsr310.module>
         <pulsar.spark.version>${pulsar.spark.scala11.version}</pulsar.spark.version>
         <skip.hudi-spark3.unit.tests>true</skip.hudi-spark3.unit.tests>
         <skipITs>true</skipITs>
@@ -2191,6 +2200,7 @@
         <fasterxml.jackson.databind.version>2.6.7.3</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>2.6.7.1</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>2.7.4</fasterxml.jackson.dataformat.yaml.version>
+        <fasterxml.jackson.datatype.jsr310.module>jackson-datatype-jsr310</fasterxml.jackson.datatype.jsr310.module>
         <pulsar.spark.version>${pulsar.spark.scala11.version}</pulsar.spark.version>
         <skip.hudi-spark3.unit.tests>true</skip.hudi-spark3.unit.tests>
         <skipITs>false</skipITs>
@@ -2245,6 +2255,8 @@
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <!-- NOTE: By default we're not including JSR310 module for Jackson since Spark >= 3.x is bundling it anyway -->
+        <fasterxml.jackson.datatype.jsr310.module/>
         <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
@@ -2286,6 +2298,8 @@
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <!-- NOTE: By default we're not including JSR310 module for Jackson since Spark >= 3.x is bundling it anyway -->
+        <fasterxml.jackson.datatype.jsr310.module/>
         <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
@@ -2326,6 +2340,8 @@
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <!-- NOTE: By default we're not including JSR310 module for Jackson since Spark >= 3.x is bundling it anyway -->
+        <fasterxml.jackson.datatype.jsr310.module/>
         <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
@@ -2367,6 +2383,8 @@
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <!-- NOTE: By default we're not including JSR310 module for Jackson since Spark >= 3.x is bundling it anyway -->
+        <fasterxml.jackson.datatype.jsr310.module/>
         <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
@@ -2412,6 +2430,8 @@
         <fasterxml.jackson.databind.version>${fasterxml.spark3.version}</fasterxml.jackson.databind.version>
         <fasterxml.jackson.module.scala.version>${fasterxml.spark3.version}</fasterxml.jackson.module.scala.version>
         <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
+        <!-- NOTE: By default we're not including JSR310 module for Jackson since Spark >= 3.x is bundling it anyway -->
+        <fasterxml.jackson.datatype.jsr310.module/>
         <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>


### PR DESCRIPTION
### Change Logs

- Use`com.github.benmanes.caffeine.cache.Cache` (already included in `hudi-common`) for `ReflectionUtils` to cache classes
- rename API `loadClass()` to `newInstance()` for better readability
- include `com.github.ben-manes.caffeine:caffeine` in applicable bundles

Changes taken from https://github.com/apache/hudi/pull/7885

### Impact

Class loading.

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
