### PR TITLE
[MINOR] Fix typo about `recordMergerStrategyId` to avoid NPE

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -276,7 +276,7 @@ public class HoodieTableConfig extends HoodieConfig {
         setValue(PAYLOAD_CLASS_NAME, payloadClassName);
         needStore = true;
       }
-      if (contains(RECORD_MERGER_STRATEGY) && payloadClassName != null
+      if (contains(RECORD_MERGER_STRATEGY) && recordMergerStrategyId != null
           && !getString(RECORD_MERGER_STRATEGY).equals(recordMergerStrategyId)) {
         setValue(RECORD_MERGER_STRATEGY, recordMergerStrategyId);
         needStore = true;


### PR DESCRIPTION
### Change Logs

It will cause NullPointerException
```
Caused by: java.lang.NullPointerException
	at java.util.Hashtable.put(Hashtable.java:460)
	at java.util.Properties.setProperty(Properties.java:166)
	at org.apache.hudi.common.config.HoodieConfig.setValue(HoodieConfig.java:60)
```

### Impact

No

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
