### PR TITLE
[HUDI-6290] Fix Flink MDT compaction strategy

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -936,8 +936,6 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * Validates the timeline for both main and metadata tables to ensure compaction on MDT can be scheduled.
    */
   protected boolean canTriggerCompaction(String latestDeltaCommitTimeInMetadataTable) {
-    // finish off any pending compactions if any from previous attempt.
-
     // we need to find if there are any inflights in data table timeline before or equal to the latest delta commit in metadata table.
     // Whenever you want to change this logic, please ensure all below scenarios are considered.
     // a. There could be a chance that latest delta commit in MDT is committed in MDT, but failed in DT. And so findInstantsBeforeOrEquals() should be employed
@@ -971,6 +969,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * </ol>
    */
   protected void compactIfNecessary(BaseHoodieWriteClient writeClient, String instantTime) {
+    // finish off any pending compactions if any from previous attempt.
     writeClient.runAnyPendingCompactions();
 
     String latestDeltaCommitTimeInMetadataTable = metadataMetaClient.reloadActiveTimeline()

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -185,6 +185,13 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata));
   }
 
+  /**
+   * Validates the timeline for both main and metadata tables to ensure compaction on MDT can be scheduled.
+   */
+  protected boolean canTriggerCompaction(String latestDeltaCommitTimeInMetadataTable) {
+    return true;
+  }
+
   @Override
   public void deletePartitions(String instantTime, List<MetadataPartitionType> partitions) {
     throw new HoodieNotSupportedException("Dropping metadata index not supported for Flink metadata table yet.");

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -189,6 +189,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
    * Validates the timeline for both main and metadata tables to ensure compaction on MDT can be scheduled.
    */
   protected boolean canTriggerCompaction(String latestDeltaCommitTimeInMetadataTable) {
+    // Allows compaction of the metadata table to run regardless of inflight instants
     return true;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -1362,11 +1362,10 @@ public class ITTestHoodieDataSource {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     conf.setString(FlinkOptions.TABLE_NAME, "t1");
     conf.setString(FlinkOptions.TABLE_TYPE, tableType.name());
-    conf.setInteger(FlinkOptions.ARCHIVE_MIN_COMMITS, 3);
-    conf.setInteger(FlinkOptions.ARCHIVE_MAX_COMMITS, 4);
-    conf.setInteger(FlinkOptions.CLEAN_RETAIN_COMMITS, 2);
+    conf.setInteger(FlinkOptions.ARCHIVE_MIN_COMMITS, 4);
+    conf.setInteger(FlinkOptions.ARCHIVE_MAX_COMMITS, 5);
+    conf.setInteger(FlinkOptions.CLEAN_RETAIN_COMMITS, 3);
     conf.setString("hoodie.commits.archival.batch", "1");
-    conf.setBoolean(FlinkOptions.METADATA_ENABLED, false);
 
     // write 10 batches of data set
     for (int i = 0; i < 20; i += 2) {
@@ -1380,7 +1379,6 @@ public class ITTestHoodieDataSource {
         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
         .option(FlinkOptions.TABLE_TYPE, tableType)
         .option(FlinkOptions.READ_START_COMMIT, secondArchived)
-        .option(FlinkOptions.METADATA_ENABLED, false)
         .end();
     tableEnv.executeSql(hoodieTableDDL);
 


### PR DESCRIPTION
### Change Logs

Because #8797 has been fixed, we can now unblock the compaction of MDT, to be more conservertive, only Flink MDT compaction strategy restriction is loosen becasue the streaming ingestion with async table services require the MDT compaction triggers timely to unblock the archiving of both MDT and DT timeline.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
