### PR TITLE
[HUDI-6292] HoodieRealtimeRecordReader#constructRecordReader leads memory leak

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeRecordReader.java
@@ -68,8 +68,15 @@ public class HoodieRealtimeRecordReader implements RecordReader<NullWritable, Ar
       }
       LOG.info("Enabling merged reading of realtime records for split " + split);
       return new RealtimeCompactedRecordReader(split, jobConf, realReader);
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       LOG.error("Got exception when constructing record reader", ex);
+      try {
+        if (realReader != null) {
+          realReader.close();
+        }
+      } catch (IOException e) {
+        LOG.error("Got exception when closing parquet record reader", e);
+      }
       throw new HoodieException(ex);
     }
   }


### PR DESCRIPTION
### Change Logs

The exception caused by `HoodieRealtimeRecordReader` wich constructs record reader based on job configuration leads memory leak.

### Impact

`HoodieRealtimeRecordReader#constructRecordReader` leads memory leak.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed