### PR TITLE
[HUDI-6294] Fix log classname in SqlQuerySingleResultPreCommitValidator

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQuerySingleResultPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQuerySingleResultPreCommitValidator.java
@@ -40,7 +40,7 @@ import java.util.List;
  * Example configuration: "query1#expectedResult1;query2#expectedResult2;"
  */
 public class SqlQuerySingleResultPreCommitValidator<T, I, K, O extends HoodieData<WriteStatus>> extends SqlQueryPreCommitValidator<T, I, K, O> {
-  private static final Logger LOG = LoggerFactory.getLogger(SqlQueryInequalityPreCommitValidator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SqlQuerySingleResultPreCommitValidator.class);
 
   public SqlQuerySingleResultPreCommitValidator(HoodieSparkTable<T> table, HoodieEngineContext engineContext, HoodieWriteConfig config) {
     super(table, engineContext, config);
@@ -68,9 +68,9 @@ public class SqlQuerySingleResultPreCommitValidator<T, I, K, O extends HoodieDat
     }
     Object result = newRows.get(0).apply(0);
     if (result == null || !expectedResult.equals(result.toString())) {
-      LOG.error("Mismatch query result. Expected: " + expectedResult + " got " + result + "Query: " + query);
+      LOG.error("Mismatch query result. Expected: " + expectedResult + " got " + result + " on Query: " + query);
       throw new HoodieValidationException("Query validation failed for '" + query
-          + "'. Expected " + expectedResult + " rows, Found " + result);
+          + "'. Expected " + expectedResult + " row, Found " + result);
     } else {
       LOG.info("Query validation successful. Expected: " + expectedResult + " got " + result);
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQuerySingleResultPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQuerySingleResultPreCommitValidator.java
@@ -70,7 +70,7 @@ public class SqlQuerySingleResultPreCommitValidator<T, I, K, O extends HoodieDat
     if (result == null || !expectedResult.equals(result.toString())) {
       LOG.error("Mismatch query result. Expected: " + expectedResult + " got " + result + " on Query: " + query);
       throw new HoodieValidationException("Query validation failed for '" + query
-          + "'. Expected " + expectedResult + " row, Found " + result);
+          + "'. Expected " + expectedResult + " row(s), Found " + result);
     } else {
       LOG.info("Query validation successful. Expected: " + expectedResult + " got " + result);
     }


### PR DESCRIPTION
### Change Logs

Fix log classname in SqlQuerySingleResultPreCommitValidator

### Impact

log with correct class name

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
