### PR TITLE
[HUDI-6301][UBER] Support SqlFileBasedSource for DeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SqlFileBasedSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SqlFileBasedSource.java
@@ -98,8 +98,8 @@ public class SqlFileBasedSource extends RowSource {
   /**
    * Configs supported.
    */
-  private static class Config {
-    private static final String SOURCE_SQL_FILE = "hoodie.deltastreamer.source.sql.file";
-    private static final String EMIT_EPOCH_CHECKPOINT = "hoodie.deltastreamer.source.sql.checkpoint.emit";
+  public static class Config {
+    public static final String SOURCE_SQL_FILE = "hoodie.deltastreamer.source.sql.file";
+    public static final String EMIT_EPOCH_CHECKPOINT = "hoodie.deltastreamer.source.sql.checkpoint.emit";
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SqlFileBasedSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SqlFileBasedSource.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.DataSourceUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Scanner;
+
+/**
+ * File-based SQL Source that uses SQL queries in a file to read from any table.
+ *
+ * <p>SQL file path should be configured using this hoodie config:
+ *
+ * <p>hoodie.deltastreamer.source.sql.file = 'hdfs://xxx/source.sql'
+ *
+ * <p>File-based SQL Source is used for one time backfill scenarios, this won't update the deltastreamer.checkpoint.key
+ * to the processed commit, instead it will fetch the latest successful checkpoint key and set that value as
+ * this backfill commits checkpoint so that it won't interrupt the regular incremental processing.
+ *
+ * <p>To fetch and use the latest incremental checkpoint, you need to also set this hoodie_conf for deltastremer jobs:
+ *
+ * <p>hoodie.write.meta.key.prefixes = 'deltastreamer.checkpoint.key'
+ */
+public class SqlFileBasedSource extends RowSource {
+
+  private static final Logger LOG = LogManager.getLogger(SqlFileBasedSource.class);
+  private final String sourceSqlFile;
+
+  public SqlFileBasedSource(
+      TypedProperties props,
+      JavaSparkContext sparkContext,
+      SparkSession sparkSession,
+      SchemaProvider schemaProvider) {
+    super(props, sparkContext, sparkSession, schemaProvider);
+    DataSourceUtils.checkRequiredProperties(
+        props, Collections.singletonList(SqlFileBasedSource.Config.SOURCE_SQL_FILE));
+    sourceSqlFile = props.getString(SqlFileBasedSource.Config.SOURCE_SQL_FILE);
+  }
+
+  @Override
+  protected Pair<Option<Dataset<Row>>, String> fetchNextBatch(
+      Option<String> lastCkptStr, long sourceLimit) {
+    Dataset<Row> rows = null;
+    final FileSystem fs = FSUtils.getFs(sourceSqlFile, sparkContext.hadoopConfiguration(), true);
+    try {
+      final Scanner scanner = new Scanner(fs.open(new Path(sourceSqlFile)));
+      scanner.useDelimiter(";");
+      while (scanner.hasNext()) {
+        String sqlStr = scanner.next().trim();
+        if (!sqlStr.isEmpty()) {
+          LOG.info(sqlStr);
+          // overwrite the same dataset object until the last statement then return.
+          rows = sparkSession.sql(sqlStr);
+        }
+      }
+      return Pair.of(Option.of(rows), null);
+    } catch (IOException ioe) {
+      throw new HoodieIOException("Error reading source SQL file.", ioe);
+    }
+  }
+
+  /**
+   * Configs supported.
+   */
+  private static class Config {
+    private static final String SOURCE_SQL_FILE = "hoodie.deltastreamer.source.sql.file";
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -2326,7 +2326,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   public void testCsvDFSSourceNoHeaderWithSchemaProviderAndTransformer() throws Exception {
     // The CSV files do not have header, the columns are separated by '\t'
     // File schema provider is used, transformer is applied
-    // In this case, the source and target schema come from the Avro schema files
+    // In this case, the source and target schema come from the Avro schema filesTestSqlFileBasedSour
     testCsvDFSSource(false, '\t', true, Collections.singletonList(TripsWithDistanceTransformer.class.getName()));
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -2326,7 +2326,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   public void testCsvDFSSourceNoHeaderWithSchemaProviderAndTransformer() throws Exception {
     // The CSV files do not have header, the columns are separated by '\t'
     // File schema provider is used, transformer is applied
-    // In this case, the source and target schema come from the Avro schema filesTestSqlFileBasedSour
+    // In this case, the source and target schema come from the Avro schema files
     testCsvDFSSource(false, '\t', true, Collections.singletonList(TripsWithDistanceTransformer.class.getName()));
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlFileBasedSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSqlFileBasedSource.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.deltastreamer.SourceFormatAdapter;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test against {@link SqlSource}.
+ */
+public class TestSqlFileBasedSource extends UtilitiesTestBase {
+
+  private final boolean useFlattenedSchema = false;
+  private final String sqlFileSourceConfig = "hoodie.deltastreamer.source.sql.file";
+  protected FilebasedSchemaProvider schemaProvider;
+  protected HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+  private String dfsRoot;
+  private TypedProperties props;
+  private SqlFileBasedSource sqlFileSource;
+  private SourceFormatAdapter sourceFormatAdapter;
+
+  @BeforeAll
+  public static void initClass() throws Exception {
+    UtilitiesTestBase.initClass();
+    UtilitiesTestBase.Helpers.copyToDFS(
+        "delta-streamer-config/sql-file-based-source.sql",
+        UtilitiesTestBase.dfs,
+        UtilitiesTestBase.dfsBasePath + "/sql-file-based-source.sql");
+    UtilitiesTestBase.Helpers.copyToDFS(
+        "delta-streamer-config/sql-file-based-source-invalid-table.sql",
+        UtilitiesTestBase.dfs,
+        UtilitiesTestBase.dfsBasePath + "/sql-file-based-source-invalid-table.sql");
+  }
+
+  @AfterAll
+  public static void cleanupClass() {
+    UtilitiesTestBase.cleanupClass();
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    dfsRoot = UtilitiesTestBase.dfsBasePath + "/parquetFiles";
+    UtilitiesTestBase.dfs.mkdirs(new Path(dfsRoot));
+    props = new TypedProperties();
+    super.setup();
+    schemaProvider = new FilebasedSchemaProvider(Helpers.setupSchemaOnDFS(), jsc);
+    // Produce new data, extract new data
+    generateTestTable("1", "001", 10000);
+  }
+
+  @AfterEach
+  public void teardown() throws Exception {
+    super.teardown();
+  }
+
+  /**
+   * Generates a batch of test data and writes the data to a file and register a test table.
+   *
+   * @param filename    The name of the file.
+   * @param instantTime The commit time.
+   * @param n           The number of records to generate.
+   */
+  private void generateTestTable(String filename, String instantTime, int n) throws IOException {
+    Path path = new Path(dfsRoot, filename);
+    Helpers.saveParquetToDFS(Helpers.toGenericRecords(dataGenerator.generateInserts(instantTime, n, useFlattenedSchema)), path);
+    sparkSession.read().parquet(dfsRoot).createOrReplaceTempView("test_sql_table");
+  }
+
+  /**
+   * Runs the test scenario of reading data from the source in avro format.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testSqlFileBasedSourceAvroFormat() {
+    props.setProperty(sqlFileSourceConfig, UtilitiesTestBase.dfsBasePath + "/sql-file-based-source.sql");
+    sqlFileSource = new SqlFileBasedSource(props, jsc, sparkSession, schemaProvider);
+    sourceFormatAdapter = new SourceFormatAdapter(sqlFileSource);
+
+    // Test fetching Avro format
+    InputBatch<JavaRDD<GenericRecord>> fetch1 =
+        sourceFormatAdapter.fetchNewDataInAvroFormat(Option.empty(), Long.MAX_VALUE);
+
+    // Test Avro to Row format
+    Dataset<Row> fetch1Rows = AvroConversionUtils
+        .createDataFrame(JavaRDD.toRDD(fetch1.getBatch().get()),
+            schemaProvider.getSourceSchema().toString(), sparkSession);
+    assertEquals(10000, fetch1Rows.count());
+  }
+
+  /**
+   * Runs the test scenario of reading data from the source in row format.
+   * Source has less records than source limit.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testSqlFileBasedSourceRowFormat() {
+    props.setProperty(sqlFileSourceConfig, UtilitiesTestBase.dfsBasePath + "/sql-file-based-source.sql");
+    sqlFileSource = new SqlFileBasedSource(props, jsc, sparkSession, schemaProvider);
+    sourceFormatAdapter = new SourceFormatAdapter(sqlFileSource);
+
+    // Test fetching Row format
+    InputBatch<Dataset<Row>> fetch1AsRows =
+        sourceFormatAdapter.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE);
+    assertEquals(10000, fetch1AsRows.getBatch().get().count());
+  }
+
+  /**
+   * Runs the test scenario of reading data from the source in row format.
+   * Source has more records than source limit.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testSqlFileBasedSourceMoreRecordsThanSourceLimit() {
+    props.setProperty(sqlFileSourceConfig, UtilitiesTestBase.dfsBasePath + "/sql-file-based-source.sql");
+    sqlFileSource = new SqlFileBasedSource(props, jsc, sparkSession, schemaProvider);
+    sourceFormatAdapter = new SourceFormatAdapter(sqlFileSource);
+
+    InputBatch<Dataset<Row>> fetch1AsRows =
+        sourceFormatAdapter.fetchNewDataInRowFormat(Option.empty(), 1000);
+    assertEquals(10000, fetch1AsRows.getBatch().get().count());
+  }
+
+  /**
+   * Runs the test scenario of reading data from the source in row format.
+   * Source table doesn't exists.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testSqlFileBasedSourceInvalidTable() {
+    props.setProperty(sqlFileSourceConfig, UtilitiesTestBase.dfsBasePath + "/sql-file-based-source-invalid-table.sql");
+    sqlFileSource = new SqlFileBasedSource(props, jsc, sparkSession, schemaProvider);
+    sourceFormatAdapter = new SourceFormatAdapter(sqlFileSource);
+
+    assertThrows(
+        AnalysisException.class,
+        () -> sourceFormatAdapter.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE));
+  }
+}

--- a/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source-invalid-table.sql
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source-invalid-table.sql
@@ -1,0 +1,3 @@
+select
+    *
+from not_exist_sql_table;

--- a/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source-invalid-table.sql
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source-invalid-table.sql
@@ -1,3 +1,19 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+--  regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"), you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
 select
     *
 from not_exist_sql_table;

--- a/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source.sql
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source.sql
@@ -1,3 +1,19 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+--  regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"), you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
 select
     count(*)
 from test_sql_table;

--- a/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source.sql
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/sql-file-based-source.sql
@@ -1,0 +1,7 @@
+select
+    count(*)
+from test_sql_table;
+
+select
+    *
+from test_sql_table;


### PR DESCRIPTION
### Change Logs

Introducing a new Source type called SqlFileBasedSource which can be used to create complex SQL statements by and caches datasets in-memory and running complex joins on them.

### Impact

This is a new feature should not impact existing use cases.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

Some documentation is added within the classes, but since new configs and source are introduced it requires updates to the 

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
