### PR TITLE
[HUDI-6278] Fix the use of DynamoDBLockConfig class

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
@@ -76,7 +76,9 @@ public class DynamoDBBasedLockProvider implements LockProvider<LockItem> {
   }
 
   public DynamoDBBasedLockProvider(final LockConfiguration lockConfiguration, final Configuration conf, AmazonDynamoDB dynamoDB) {
-    this.dynamoDBLockConfiguration = DynamoDbBasedLockConfig.newBuilder().fromProperties(lockConfiguration.getConfig());
+    this.dynamoDBLockConfiguration = DynamoDbBasedLockConfig.newBuilder()
+        .fromProperties(lockConfiguration.getConfig())
+        .build();
     this.tableName = dynamoDBLockConfiguration.getString(DynamoDbBasedLockConfig.DYNAMODB_LOCK_TABLE_NAME);
     this.dynamoDBPartitionKey = dynamoDBLockConfiguration.getString(DynamoDbBasedLockConfig.DYNAMODB_LOCK_PARTITION_KEY);
     long leaseDuration = dynamoDBLockConfiguration.getInt(DynamoDbBasedLockConfig.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY);
@@ -86,11 +88,11 @@ public class DynamoDBBasedLockProvider implements LockProvider<LockItem> {
     // build the dynamoDb lock client
     this.client = new AmazonDynamoDBLockClient(
         AmazonDynamoDBLockClientOptions.builder(dynamoDB, tableName)
-                .withTimeUnit(TimeUnit.MILLISECONDS)
-                .withLeaseDuration(leaseDuration)
-                .withHeartbeatPeriod(leaseDuration / 3)
-                .withCreateHeartbeatBackgroundThread(true)
-                .build());
+            .withTimeUnit(TimeUnit.MILLISECONDS)
+            .withLeaseDuration(leaseDuration)
+            .withHeartbeatPeriod(leaseDuration / 3)
+            .withCreateHeartbeatBackgroundThread(true)
+            .build());
 
     if (!this.client.lockTableExists()) {
       createLockTableInDynamoDB(dynamoDB, tableName);

--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -22,13 +22,13 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
 
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
-
-import static org.apache.hudi.common.config.LockConfiguration.LOCK_PREFIX;
 
 /**
  * Hoodie Configs for Locks.
@@ -41,8 +41,12 @@ import static org.apache.hudi.common.config.LockConfiguration.LOCK_PREFIX;
         + " are auto managed internally.")
 public class DynamoDbBasedLockConfig extends HoodieConfig {
 
+  public static DynamoDbBasedLockConfig.Builder newBuilder() {
+    return new DynamoDbBasedLockConfig.Builder();
+  }
+
   // configs for DynamoDb based locks
-  public static final String DYNAMODB_BASED_LOCK_PROPERTY_PREFIX = LOCK_PREFIX + "dynamodb.";
+  public static final String DYNAMODB_BASED_LOCK_PROPERTY_PREFIX = LockConfiguration.LOCK_PREFIX + "dynamodb.";
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_TABLE_NAME = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "table")
@@ -63,8 +67,8 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
         return Option.empty();
       })
       .withDocumentation("For DynamoDB based lock provider, the partition key for the DynamoDB lock table. "
-                         + "Each Hudi dataset should has it's unique key so concurrent writers could refer to the same partition key."
-                         + " By default we use the Hudi table name specified to be the partition key");
+          + "Each Hudi dataset should has it's unique key so concurrent writers could refer to the same partition key."
+          + " By default we use the Hudi table name specified to be the partition key");
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_REGION = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "region")
@@ -79,7 +83,7 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
         return Option.empty();
       })
       .withDocumentation("For DynamoDB based lock provider, the region used in endpoint for Amazon DynamoDB service."
-                         + " Would try to first get it from AWS_REGION environment variable. If not find, by default use us-east-1");
+          + " Would try to first get it from AWS_REGION environment variable. If not find, by default use us-east-1");
 
   public static final ConfigProperty<String> DYNAMODB_LOCK_BILLING_MODE = ConfigProperty
       .key(DYNAMODB_BASED_LOCK_PROPERTY_PREFIX + "billing_mode")
@@ -115,5 +119,29 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("0.10.1")
       .withDocumentation("For DynamoDB based lock provider, the url endpoint used for Amazon DynamoDB service."
-                         + " Useful for development with a local dynamodb instance.");
+          + " Useful for development with a local dynamodb instance.");
+
+  public static final ConfigProperty<Integer> LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY = ConfigProperty
+      .key(LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY)
+      .defaultValue(LockConfiguration.DEFAULT_ACQUIRE_LOCK_WAIT_TIMEOUT_MS)
+      .markAdvanced()
+      .sinceVersion("0.10.0")
+      .withDocumentation("Lock Acquire Wait Timeout in milliseconds");
+
+  /**
+   * Builder for {@link DynamoDbBasedLockConfig}.
+   */
+  public static class Builder {
+    private final DynamoDbBasedLockConfig lockConfig = new DynamoDbBasedLockConfig();
+
+    public DynamoDbBasedLockConfig build() {
+      lockConfig.setDefaults(DynamoDbBasedLockConfig.class.getName());
+      return lockConfig;
+    }
+
+    public DynamoDbBasedLockConfig fromProperties(TypedProperties props) {
+      build().getProps().putAll(props);
+      return lockConfig;
+    }
+  }
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -22,10 +22,11 @@ import org.apache.hudi.common.config.ConfigClassProperty;
 import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
-import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.config.LockConfiguration;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
 
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
@@ -136,12 +137,19 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
 
     public DynamoDbBasedLockConfig build() {
       lockConfig.setDefaults(DynamoDbBasedLockConfig.class.getName());
+      checkRequiredProps(lockConfig);
       return lockConfig;
     }
 
     public DynamoDbBasedLockConfig fromProperties(TypedProperties props) {
       build().getProps().putAll(props);
       return lockConfig;
+    }
+
+    private void checkRequiredProps(final DynamoDbBasedLockConfig config) {
+      ValidationUtils.checkArgument(config.contains(DynamoDbBasedLockConfig.DYNAMODB_LOCK_TABLE_NAME.key()));
+      ValidationUtils.checkArgument(config.contains(DynamoDbBasedLockConfig.DYNAMODB_LOCK_REGION.key()));
+      ValidationUtils.checkArgument(config.contains(DynamoDbBasedLockConfig.DYNAMODB_LOCK_PARTITION_KEY.key()));
     }
   }
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -147,9 +147,9 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
     }
 
     private void checkRequiredProps(final DynamoDbBasedLockConfig config) {
-      ValidationUtils.checkArgument(config.contains(DynamoDbBasedLockConfig.DYNAMODB_LOCK_TABLE_NAME.key()));
-      ValidationUtils.checkArgument(config.contains(DynamoDbBasedLockConfig.DYNAMODB_LOCK_REGION.key()));
-      ValidationUtils.checkArgument(config.contains(DynamoDbBasedLockConfig.DYNAMODB_LOCK_PARTITION_KEY.key()));
+      ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_TABLE_NAME.key()));
+      ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_REGION.key()));
+      ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_PARTITION_KEY.key()));
     }
   }
 }

--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -141,15 +141,22 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
       return lockConfig;
     }
 
-    public DynamoDbBasedLockConfig fromProperties(TypedProperties props) {
-      build().getProps().putAll(props);
-      return lockConfig;
+    public Builder fromProperties(TypedProperties props) {
+      lockConfig.getProps().putAll(props);
+      return this;
     }
 
     private void checkRequiredProps(final DynamoDbBasedLockConfig config) {
-      ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_TABLE_NAME.key()));
-      ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_REGION.key()));
-      ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_PARTITION_KEY.key()));
+      String errorMsg = "Config key is not found: ";
+      ValidationUtils.checkArgument(
+          config.contains(DYNAMODB_LOCK_TABLE_NAME.key()),
+          errorMsg + DYNAMODB_LOCK_TABLE_NAME.key());
+      ValidationUtils.checkArgument(
+          config.contains(DYNAMODB_LOCK_REGION.key()),
+          errorMsg + DYNAMODB_LOCK_REGION.key());
+      ValidationUtils.checkArgument(
+          config.contains(DYNAMODB_LOCK_PARTITION_KEY.key()),
+          errorMsg + DYNAMODB_LOCK_PARTITION_KEY.key());
     }
   }
 }


### PR DESCRIPTION
### Change Logs

Fixed the use of DynamoDBLockConfig class
Before the default values of the variables and infer function were not getting used.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed