### PR TITLE
[HUDI-6312] Guard incremental query for multi-writer scenario

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -87,7 +87,7 @@ public class HoodieCommonConfig extends HoodieConfig {
           + " The valid values are " + Arrays.toString(enumNames(HollowCommitHandling.class)) + ":"
           + " Use `" + HollowCommitHandling.EXCEPTION + "` to throw an exception when hollow commit is detected. This is helpful when hollow commits"
           + " are not expected."
-          + " Use `" + HollowCommitHandling.FILTER + "` to stop processing commits beyond hollow ones. This fits the case where waiting for hollow commits"
+          + " Use `" + HollowCommitHandling.BLOCK + "` to block processing commits from going beyond the hollow ones. This fits the case where waiting for hollow commits"
           + " to finish is acceptable."
           + " Use `" + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "` (experimental) to query commits in range by state transition time (completion time), instead"
           + " of commit time (start time). Using this mode will result in `begin.instanttime` and `end.instanttime` using `stateTransitionTime` "

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -89,8 +89,6 @@ public class HoodieCommonConfig extends HoodieConfig {
           + " are not expected."
           + " Use `" + HollowCommitHandling.BLOCK + "` to block processing commits from going beyond the hollow ones. This fits the case where waiting for hollow commits"
           + " to finish is acceptable."
-          + " Use `" + HollowCommitHandling.MANAGED + "` to ignore the hollow ones as the situation should have been managed by external mechanisms such as checkpointing"
-          + " the commit end time."
           + " Use `" + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "` (experimental) to query commits in range by state transition time (completion time), instead"
           + " of commit time (start time). Using this mode will result in `begin.instanttime` and `end.instanttime` using `stateTransitionTime` "
           + " instead of the instant's commit time."

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -18,13 +18,17 @@
 
 package org.apache.hudi.common.config;
 
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
+
+import static org.apache.hudi.common.util.ConfigUtils.enumNames;
 
 /**
  * Hudi configs used across engines.
@@ -72,13 +76,23 @@ public class HoodieCommonConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Turn on compression for BITCASK disk map used by the External Spillable Map");
 
-  public static final ConfigProperty<Boolean> READ_BY_STATE_TRANSITION_TIME = ConfigProperty
-      .key("hoodie.datasource.read.by.state.transition.time")
-      .defaultValue(false)
+  public static final ConfigProperty<String> INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT = ConfigProperty
+      .key("hoodie.datasource.read.handle.hollow.commit")
+      .defaultValue(HollowCommitHandling.EXCEPTION.name())
       .sinceVersion("0.14.0")
-      .withDocumentation("For incremental mode, whether to enable to pulling commits in range by state transition time(completion time) "
-          + "instead of commit time(start time). Please be aware that enabling this will result in"
-          + "`begin.instanttime` and `end.instanttime` using `stateTransitionTime` instead of the instant's commit time.");
+      .markAdvanced()
+      .withValidValues(enumNames(HollowCommitHandling.class))
+      .withDocumentation("When doing incremental queries, there could be hollow commits (requested or inflight commits that are not the latest)"
+          + " that are produced by concurrent writers and could lead to potential data loss. This config allows users to have different ways of handling this situation."
+          + " The valid values are " + Arrays.toString(enumNames(HollowCommitHandling.class)) + ":"
+          + " Use `" + HollowCommitHandling.EXCEPTION + "` to throw an exception when hollow commit is detected. This is helpful when hollow commits"
+          + " are not expected."
+          + " Use `" + HollowCommitHandling.FILTER + "` to stop processing commits beyond hollow ones. This fits the case where waiting for hollow commits"
+          + " to finish is acceptable."
+          + " Use `" + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "` (experimental) to query commits in range by state transition time (completion time), instead"
+          + " of commit time (start time). Using this mode will result in `begin.instanttime` and `end.instanttime` using `stateTransitionTime` "
+          + " instead of the instant's commit time."
+      );
 
   public static final ConfigProperty<String> HOODIE_FS_ATOMIC_CREATION_SUPPORT = ConfigProperty
       .key("hoodie.fs.atomic_creation.support")

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -89,6 +89,8 @@ public class HoodieCommonConfig extends HoodieConfig {
           + " are not expected."
           + " Use `" + HollowCommitHandling.BLOCK + "` to block processing commits from going beyond the hollow ones. This fits the case where waiting for hollow commits"
           + " to finish is acceptable."
+          + " Use `" + HollowCommitHandling.MANAGED + "` to ignore the hollow ones as the situation should have been managed by external mechanisms such as checkpointing"
+          + " the commit end time."
           + " Use `" + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "` (experimental) to query commits in range by state transition time (completion time), instead"
           + " of commit time (start time). Using this mode will result in `begin.instanttime` and `end.instanttime` using `stateTransitionTime` "
           + " instead of the instant's commit time."

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -343,11 +343,11 @@ public class TimelineUtils {
     switch (handlingMode) {
       case EXCEPTION:
         throw new HoodieException(String.format(
-            "Found hollow commit: %s. Adjust config %s accordingly if to avoid throwing this exception.",
+            "Found hollow commit: '%s'. Adjust config `%s` accordingly if to avoid throwing this exception.",
             hollowCommitTimestamp, INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key()));
-      case FILTER:
+      case BLOCK:
         LOG.warn(String.format(
-            "Found hollow commit %s. Config %s was set to %s: no data will be returned beyond %s until it's completed.",
+            "Found hollow commit '%s'. Config `%s` was set to `%s`: no data will be returned beyond '%s' until it's completed.",
             hollowCommitTimestamp, INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), handlingMode, hollowCommitTimestamp));
         return completedCommitTimeline.findInstantsBefore(hollowCommitTimestamp);
       default:
@@ -356,6 +356,6 @@ public class TimelineUtils {
   }
 
   public enum HollowCommitHandling {
-    EXCEPTION, FILTER, USE_STATE_TRANSITION_TIME;
+    EXCEPTION, BLOCK, USE_STATE_TRANSITION_TIME;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -321,7 +321,8 @@ public class TimelineUtils {
    */
   public static HoodieTimeline handleHollowCommitIfNeeded(HoodieTimeline completedCommitTimeline,
       HoodieTableMetaClient metaClient, HollowCommitHandling handlingMode) {
-    if (handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME) {
+    if (handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME
+        || handlingMode == HollowCommitHandling.MANAGED) {
       return completedCommitTimeline;
     }
 
@@ -356,6 +357,6 @@ public class TimelineUtils {
   }
 
   public enum HollowCommitHandling {
-    EXCEPTION, BLOCK, USE_STATE_TRANSITION_TIME;
+    EXCEPTION, BLOCK, MANAGED, USE_STATE_TRANSITION_TIME;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -321,8 +321,7 @@ public class TimelineUtils {
    */
   public static HoodieTimeline handleHollowCommitIfNeeded(HoodieTimeline completedCommitTimeline,
       HoodieTableMetaClient metaClient, HollowCommitHandling handlingMode) {
-    if (handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME
-        || handlingMode == HollowCommitHandling.MANAGED) {
+    if (handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME) {
       return completedCommitTimeline;
     }
 
@@ -357,6 +356,6 @@ public class TimelineUtils {
   }
 
   public enum HollowCommitHandling {
-    EXCEPTION, BLOCK, MANAGED, USE_STATE_TRANSITION_TIME;
+    EXCEPTION, BLOCK, USE_STATE_TRANSITION_TIME;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -320,7 +320,10 @@ public class TimelineUtils {
    * before a completed commit.
    */
   public static HoodieTimeline filterTimelineForIncrementalQueryIfNeeded(
-      HoodieTableMetaClient metaClient, HoodieTimeline completedCommitTimeline) {
+      HoodieTableMetaClient metaClient, HoodieTimeline completedCommitTimeline, boolean useStateTransitionTime) {
+    if (useStateTransitionTime) {
+      return completedCommitTimeline;
+    }
     Option<HoodieInstant> firstIncompleteCommit = metaClient.getCommitsTimeline()
         .filterInflightsAndRequested()
         .filter(instant ->

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -75,4 +75,9 @@ public class ConfigUtils {
 
     throw new IllegalArgumentException("No enum constant found " + enumType.getName() + "." + name);
   }
+
+  public static <T extends Enum<T>> String[] enumNames(Class<T> enumType) {
+    T[] enumConstants = enumType.getEnumConstants();
+    return Arrays.stream(enumConstants).map(Enum::name).toArray(String[]::new);
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -75,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -563,6 +564,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         assertTrue(filteredTimeline.containsInstant("005"));
         break;
       }
+      default:
+        fail("should cover all handling mode.");
     }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -36,13 +36,19 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.COMPLETED;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT;
@@ -63,8 +70,10 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.SAVEPOINT_ACTION;
+import static org.apache.hudi.common.table.timeline.TimelineUtils.handleHollowCommitIfNeeded;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -525,4 +534,35 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     return TimelineMetadataUtils.serializeCleanMetadata(cleanMetadata);
   }
 
+  @ParameterizedTest
+  @EnumSource(value = HollowCommitHandling.class)
+  public void testHandleHollowCommitIfNeeded(HollowCommitHandling handlingMode) throws Exception {
+    HoodieTestTable.of(metaClient)
+        .addCommit("001")
+        .addInflightCommit("003")
+        .addCommit("005");
+    Stream<String> completed = Stream.of("001", "005");
+    HoodieTimeline completedTimeline = new MockHoodieTimeline(completed, Stream.empty());
+    switch (handlingMode) {
+      case EXCEPTION:
+        HoodieException e = assertThrows(HoodieException.class, () ->
+            handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode));
+        assertTrue(e.getMessage().startsWith("Found hollow commit:"));
+        break;
+      case BLOCK: {
+        HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
+        assertTrue(filteredTimeline.containsInstant("001"));
+        assertFalse(filteredTimeline.containsInstant("003"));
+        assertFalse(filteredTimeline.containsInstant("005"));
+        break;
+      }
+      case USE_STATE_TRANSITION_TIME: {
+        HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
+        assertTrue(filteredTimeline.containsInstant("001"));
+        assertFalse(filteredTimeline.containsInstant("003"));
+        assertTrue(filteredTimeline.containsInstant("005"));
+        break;
+      }
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode;
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -42,6 +43,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import static org.apache.hudi.common.config.HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT;
 
 /**
  * Tool helping to resolve the flink options {@link FlinkOptions}.
@@ -268,7 +271,9 @@ public class OptionsResolver {
    * in scenarios like multiple writers.
    */
   public static boolean isReadByTxnCompletionTime(Configuration conf) {
-    return conf.getBoolean(HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME.key(), HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME.defaultValue());
+    HollowCommitHandling handlingMode = HollowCommitHandling.valueOf(conf
+        .getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue()));
+    return handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -70,7 +70,6 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
-import static org.apache.hudi.common.table.timeline.TimelineUtils.filterTimelineForIncrementalQueryIfNeeded;
 
 /**
  * Utilities to generate incremental input splits {@link MergeOnReadInputSplit}.
@@ -544,15 +543,13 @@ public class IncrementalInputSplits implements Serializable {
   }
 
   private HoodieTimeline getReadTimeline(HoodieTableMetaClient metaClient) {
-    HoodieTimeline timeline = filterTimelineForIncrementalQueryIfNeeded(metaClient,
-        metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants());
+    HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants();
     return filterInstantsAsPerUserConfigs(timeline);
   }
 
   private HoodieTimeline getArchivedReadTimeline(HoodieTableMetaClient metaClient, String startInstant) {
     HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline(startInstant, false);
-    HoodieTimeline archivedCompleteTimeline = filterTimelineForIncrementalQueryIfNeeded(metaClient,
-        archivedTimeline.getCommitsTimeline().filterCompletedInstants());
+    HoodieTimeline archivedCompleteTimeline = archivedTimeline.getCommitsTimeline().filterCompletedInstants();
     return filterInstantsAsPerUserConfigs(archivedCompleteTimeline);
   }
 
@@ -597,7 +594,7 @@ public class IncrementalInputSplits implements Serializable {
   }
 
   /**
-   * Filters out the unnecessary instants by user specified condition.
+   * Filters out the unnecessary instants as per user specified configs.
    *
    * @param timeline The timeline
    *

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -66,10 +67,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
+import static org.apache.hudi.common.table.timeline.TimelineUtils.handleHollowCommitIfNeeded;
 
 /**
  * Utilities to generate incremental input splits {@link MergeOnReadInputSplit}.
@@ -86,18 +89,16 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_O
 public class IncrementalInputSplits implements Serializable {
 
   private static final long serialVersionUID = 1L;
-
   private static final Logger LOG = LoggerFactory.getLogger(IncrementalInputSplits.class);
+
   private final Configuration conf;
   private final Path path;
   private final RowType rowType;
   private final long maxCompactionMemoryInBytes;
-  // for partition pruning
   private final PartitionPruners.PartitionPruner partitionPruner;
-  // skip compaction
   private final boolean skipCompaction;
-  // skip clustering
   private final boolean skipClustering;
+  private final HollowCommitHandling hollowCommitHandling;
 
   private IncrementalInputSplits(
       Configuration conf,
@@ -106,7 +107,8 @@ public class IncrementalInputSplits implements Serializable {
       long maxCompactionMemoryInBytes,
       @Nullable PartitionPruners.PartitionPruner partitionPruner,
       boolean skipCompaction,
-      boolean skipClustering) {
+      boolean skipClustering,
+      HollowCommitHandling hollowCommitHandling) {
     this.conf = conf;
     this.path = path;
     this.rowType = rowType;
@@ -114,6 +116,7 @@ public class IncrementalInputSplits implements Serializable {
     this.partitionPruner = partitionPruner;
     this.skipCompaction = skipCompaction;
     this.skipClustering = skipClustering;
+    this.hollowCommitHandling = hollowCommitHandling;
   }
 
   /**
@@ -544,13 +547,13 @@ public class IncrementalInputSplits implements Serializable {
 
   private HoodieTimeline getReadTimeline(HoodieTableMetaClient metaClient) {
     HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants();
-    return filterInstantsAsPerUserConfigs(timeline);
+    return filterInstantsAsPerUserConfigs(timeline, metaClient);
   }
 
   private HoodieTimeline getArchivedReadTimeline(HoodieTableMetaClient metaClient, String startInstant) {
     HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline(startInstant, false);
     HoodieTimeline archivedCompleteTimeline = archivedTimeline.getCommitsTimeline().filterCompletedInstants();
-    return filterInstantsAsPerUserConfigs(archivedCompleteTimeline);
+    return filterInstantsAsPerUserConfigs(archivedCompleteTimeline, metaClient);
   }
 
   /**
@@ -596,21 +599,22 @@ public class IncrementalInputSplits implements Serializable {
   /**
    * Filters out the unnecessary instants as per user specified configs.
    *
-   * @param timeline The timeline
+   * @param completedTimeline original completed timeline
+   * @param metaClient
    *
    * @return the filtered timeline
    */
   @VisibleForTesting
-  public HoodieTimeline filterInstantsAsPerUserConfigs(HoodieTimeline timeline) {
-    final HoodieTimeline oriTimeline = timeline;
+  public HoodieTimeline filterInstantsAsPerUserConfigs(final HoodieTimeline completedTimeline, HoodieTableMetaClient metaClient) {
+    HoodieTimeline filteredTimeline = completedTimeline;
     if (this.skipCompaction) {
       // the compaction commit uses 'commit' as action which is tricky
-      timeline = timeline.filter(instant -> !instant.getAction().equals(HoodieTimeline.COMMIT_ACTION));
+      filteredTimeline = filteredTimeline.filter(instant -> !instant.getAction().equals(HoodieTimeline.COMMIT_ACTION));
     }
     if (this.skipClustering) {
-      timeline = timeline.filter(instant -> !ClusteringUtil.isClusteringInstant(instant, oriTimeline));
+      filteredTimeline = filteredTimeline.filter(instant -> !ClusteringUtil.isClusteringInstant(instant, completedTimeline));
     }
-    return timeline;
+    return handleHollowCommitIfNeeded(filteredTimeline, metaClient, hollowCommitHandling);
   }
 
   private static <T> List<T> mergeList(List<T> list1, List<T> list2) {
@@ -679,12 +683,11 @@ public class IncrementalInputSplits implements Serializable {
     private Path path;
     private RowType rowType;
     private long maxCompactionMemoryInBytes;
-    // for partition pruning
     private PartitionPruners.PartitionPruner partitionPruner;
-    // skip compaction
     private boolean skipCompaction = false;
-    // skip clustering
     private boolean skipClustering = false;
+    private HollowCommitHandling hollowCommitHandling = HollowCommitHandling.valueOf(
+        INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue());
 
     public Builder() {
     }
@@ -724,10 +727,16 @@ public class IncrementalInputSplits implements Serializable {
       return this;
     }
 
+    public Builder handleHollowCommit(HollowCommitHandling handlingMode) {
+      this.hollowCommitHandling = handlingMode;
+      return this;
+    }
+
     public IncrementalInputSplits build() {
       return new IncrementalInputSplits(
           Objects.requireNonNull(this.conf), Objects.requireNonNull(this.path), Objects.requireNonNull(this.rowType),
-          this.maxCompactionMemoryInBytes, this.partitionPruner, this.skipCompaction, this.skipClustering);
+          this.maxCompactionMemoryInBytes, this.partitionPruner, this.skipCompaction, this.skipClustering,
+          this.hollowCommitHandling);
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.source;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -121,7 +120,6 @@ public class StreamReadMonitoringFunction
         .partitionPruner(partitionPruner)
         .skipCompaction(conf.getBoolean(FlinkOptions.READ_STREAMING_SKIP_COMPACT))
         .skipClustering(conf.getBoolean(FlinkOptions.READ_STREAMING_SKIP_CLUSTERING))
-        .handleHollowCommit(TimelineUtils.HollowCommitHandling.MANAGED)
         .build();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.source;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -120,6 +121,7 @@ public class StreamReadMonitoringFunction
         .partitionPruner(partitionPruner)
         .skipCompaction(conf.getBoolean(FlinkOptions.READ_STREAMING_SKIP_COMPACT))
         .skipClustering(conf.getBoolean(FlinkOptions.READ_STREAMING_SKIP_CLUSTERING))
+        .handleHollowCommit(TimelineUtils.HollowCommitHandling.MANAGED)
         .build();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -143,7 +143,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     timeline = timeline.reload();
 
     conf.set(FlinkOptions.READ_END_COMMIT, "3");
-    HoodieTimeline resTimeline = iis.filterInstantsByCondition(timeline);
+    HoodieTimeline resTimeline = iis.filterInstantsAsPerUserConfigs(timeline);
     // will not filter cluster commit by default
     assertEquals(3, resTimeline.getInstants().size());
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -143,7 +143,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     timeline = timeline.reload();
 
     conf.set(FlinkOptions.READ_END_COMMIT, "3");
-    HoodieTimeline resTimeline = iis.filterInstantsAsPerUserConfigs(timeline);
+    HoodieTimeline resTimeline = iis.filterInstantsAsPerUserConfigs(timeline, metaClient);
     // will not filter cluster commit by default
     assertEquals(3, resTimeline.getInstants().size());
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestIncrementalInputSplits.java
@@ -143,7 +143,7 @@ public class TestIncrementalInputSplits extends HoodieCommonTestHarness {
     timeline = timeline.reload();
 
     conf.set(FlinkOptions.READ_END_COMMIT, "3");
-    HoodieTimeline resTimeline = iis.filterInstantsAsPerUserConfigs(timeline, metaClient);
+    HoodieTimeline resTimeline = iis.filterInstantsAsPerUserConfigs(timeline);
     // will not filter cluster commit by default
     assertEquals(3, resTimeline.getInstants().size());
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -68,9 +68,11 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE;
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
+import static org.apache.hudi.common.table.timeline.TimelineUtils.filterTimelineForIncrementalQueryIfNeeded;
 
 public class HoodieInputFormatUtils {
 
@@ -283,7 +285,13 @@ public class HoodieInputFormatUtils {
     } else {
       baseTimeline = tableMetaClient.getActiveTimeline();
     }
-    return Option.of(baseTimeline.getCommitsTimeline().filterCompletedInstants());
+    HoodieTimeline filteredTimeline = filterTimelineForIncrementalQueryIfNeeded(
+        tableMetaClient,
+        baseTimeline.getCommitsTimeline(),
+        job.getConfiguration().getBoolean(READ_BY_STATE_TRANSITION_TIME.key(),
+            READ_BY_STATE_TRANSITION_TIME.defaultValue())
+    ).filterCompletedInstants();
+    return Option.of(filteredTimeline);
   }
 
   /**

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -287,10 +287,9 @@ public class HoodieInputFormatUtils {
     }
     HoodieTimeline filteredTimeline = filterTimelineForIncrementalQueryIfNeeded(
         tableMetaClient,
-        baseTimeline.getCommitsTimeline(),
+        baseTimeline.getCommitsTimeline().filterCompletedInstants(),
         job.getConfiguration().getBoolean(READ_BY_STATE_TRANSITION_TIME.key(),
-            READ_BY_STATE_TRANSITION_TIME.defaultValue())
-    ).filterCompletedInstants();
+            READ_BY_STATE_TRANSITION_TIME.defaultValue()));
     return Option.of(filteredTimeline);
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -50,6 +50,7 @@ import scala.language.implicitConversions
   * Options supported for reading hoodie tables.
   */
 object DataSourceReadOptions {
+  import DataSourceOptionsHelper._
 
   val QUERY_TYPE_SNAPSHOT_OPT_VAL = "snapshot"
   val QUERY_TYPE_READ_OPTIMIZED_OPT_VAL = "read_optimized"

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -204,7 +204,7 @@ object DataSourceReadOptions {
 
   val SCHEMA_EVOLUTION_ENABLED: ConfigProperty[java.lang.Boolean] = HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE
 
-  val READ_BY_STATE_TRANSITION_TIME: ConfigProperty[Boolean] = HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME
+  val READ_BY_STATE_TRANSITION_TIME: ConfigProperty[java.lang.Boolean] = HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME
 
 
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config._
 import org.apache.hudi.common.fs.ConsistencyGuardConfig
 import org.apache.hudi.common.model.{HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
 import org.apache.hudi.common.util.Option
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.config.{HoodieClusteringConfig, HoodieWriteConfig}
@@ -49,7 +50,6 @@ import scala.language.implicitConversions
   * Options supported for reading hoodie tables.
   */
 object DataSourceReadOptions {
-  import DataSourceOptionsHelper._
 
   val QUERY_TYPE_SNAPSHOT_OPT_VAL = "snapshot"
   val QUERY_TYPE_READ_OPTIMIZED_OPT_VAL = "read_optimized"
@@ -113,18 +113,20 @@ object DataSourceReadOptions {
   val BEGIN_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.begin.instanttime")
     .noDefaultValue()
-    .withDocumentation("Instant time to start incrementally pulling data from. The instanttime here need not necessarily " +
-      "correspond to an instant on the timeline. New data written with an instant_time > BEGIN_INSTANTTIME are fetched out. " +
-      "For e.g: ‘20170901080000’ will get all new data written after Sep 1, 2017 08:00AM. Note that if `"
-      + HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME.key() + "` enabled, will use instant's "
+    .withDocumentation("Instant time to start incrementally pulling data from. The instanttime here need not necessarily "
+      + "correspond to an instant on the timeline. New data written with an instant_time > BEGIN_INSTANTTIME are fetched out. "
+      + "For e.g: ‘20170901080000’ will get all new data written after Sep 1, 2017 08:00AM. Note that if `"
+      + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to "
+      + HollowCommitHandling.USE_STATE_TRANSITION_TIME + ", will use instant's "
       + "`stateTransitionTime` to perform comparison.")
 
   val END_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.end.instanttime")
     .noDefaultValue()
-    .withDocumentation("Instant time to limit incrementally fetched data to. " +
-      "New data written with an instant_time <= END_INSTANTTIME are fetched out. Note that if `"
-      + HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME.key() + "` enabled, will use instant's "
+    .withDocumentation("Instant time to limit incrementally fetched data to. "
+      + "New data written with an instant_time <= END_INSTANTTIME are fetched out. Note that if `"
+      + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to "
+      + HollowCommitHandling.USE_STATE_TRANSITION_TIME + ", will use instant's "
       + "`stateTransitionTime` to perform comparison.")
 
   val INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME: ConfigProperty[String] = ConfigProperty
@@ -204,8 +206,7 @@ object DataSourceReadOptions {
 
   val SCHEMA_EVOLUTION_ENABLED: ConfigProperty[java.lang.Boolean] = HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE
 
-  val READ_BY_STATE_TRANSITION_TIME: ConfigProperty[java.lang.Boolean] = HoodieCommonConfig.READ_BY_STATE_TRANSITION_TIME
-
+  val INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT: ConfigProperty[String] = HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT
 
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */
   @Deprecated

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -64,12 +64,13 @@ class IncrementalRelation(val sqlContext: SQLContext,
   private val hoodieTable = HoodieSparkTable.create(HoodieWriteConfig.newBuilder().withPath(basePath.toString).build(),
     new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
     metaClient)
-  private val commitTimeline = filterTimelineForIncrementalQueryIfNeeded(hoodieTable.getMetaClient,
-    hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants)
 
   private val useStateTransitionTime = optParams.get(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key)
     .map(_.toBoolean)
     .getOrElse(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.defaultValue)
+
+  private val commitTimeline = filterTimelineForIncrementalQueryIfNeeded(hoodieTable.getMetaClient,
+    hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants)
 
   if (commitTimeline.empty()) {
     throw new HoodieException("No instants to incrementally pull")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.client.utils.SparkInternalSchemaConverter
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieFileFormat, HoodieRecord, HoodieReplaceCommitMetadata}
+import org.apache.hudi.common.table.timeline.TimelineUtils.filterTimelineForIncrementalQueryIfNeeded
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.{HoodieTimer, InternalSchemaCache}
@@ -63,7 +64,8 @@ class IncrementalRelation(val sqlContext: SQLContext,
   private val hoodieTable = HoodieSparkTable.create(HoodieWriteConfig.newBuilder().withPath(basePath.toString).build(),
     new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
     metaClient)
-  private val commitTimeline = hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants()
+  private val commitTimeline = filterTimelineForIncrementalQueryIfNeeded(hoodieTable.getMetaClient,
+    hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants)
 
   private val useStateTransitionTime = optParams.get(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key)
     .map(_.toBoolean)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -70,7 +70,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
   private val hollowCommitHandling: HollowCommitHandling =
     optParams.get(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
       .map(HollowCommitHandling.valueOf)
-      .getOrElse(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue)
+      .getOrElse(HollowCommitHandling.valueOf(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue))
 
   private val commitTimeline = handleHollowCommitIfNeeded(
     hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -61,11 +61,11 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
 
   override protected def timeline: HoodieTimeline = {
     if (fullTableScan) {
-      handleHollowCommitIfNeeded(metaClient.getCommitsAndCompactionTimeline, metaClient, false, hollowCommitHandling)
-    } else if (useStateTransitionTime) {
+      handleHollowCommitIfNeeded(metaClient.getCommitsAndCompactionTimeline, metaClient, hollowCommitHandling)
+    } else if (hollowCommitHandling == HollowCommitHandling.USE_STATE_TRANSITION_TIME) {
       metaClient.getCommitsAndCompactionTimeline.findInstantsInRangeByStateTransitionTime(startTimestamp, endTimestamp)
     } else {
-      handleHollowCommitIfNeeded(metaClient.getCommitsAndCompactionTimeline, metaClient, false, hollowCommitHandling)
+      handleHollowCommitIfNeeded(metaClient.getCommitsAndCompactionTimeline, metaClient, hollowCommitHandling)
         .findInstantsInRange(startTimestamp, endTimestamp)
     }
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -140,7 +140,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
   protected val hollowCommitHandling: HollowCommitHandling =
     optParams.get(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
       .map(HollowCommitHandling.valueOf)
-      .getOrElse(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue)
+      .getOrElse(HollowCommitHandling.valueOf(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue))
 
   protected def startTimestamp: String = optParams(DataSourceReadOptions.BEGIN_INSTANTTIME.key)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -17,22 +17,18 @@
 
 package org.apache.spark.sql.hudi.streaming
 
-import java.util.Date
-
 import org.apache.hadoop.fs.Path
-
 import org.apache.hudi.cdc.CDCRelation
-import org.apache.hudi.{AvroConversionUtils, DataSourceReadOptions, IncrementalRelation, MergeOnReadIncrementalRelation, SparkAdapterSupport}
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.TablePathUtils
-import org.apache.spark.sql.hudi.streaming.HoodieSourceOffset.INIT_OFFSET
+import org.apache.hudi.{AvroConversionUtils, DataSourceReadOptions, IncrementalRelation, MergeOnReadIncrementalRelation, SparkAdapterSupport}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.streaming.{Offset, Source}
+import org.apache.spark.sql.hudi.streaming.HoodieSourceOffset.INIT_OFFSET
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -69,10 +65,10 @@ class HoodieStreamSource(
     parameters.get(DataSourceReadOptions.QUERY_TYPE.key).contains(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL) &&
     parameters.get(DataSourceReadOptions.INCREMENTAL_FORMAT.key).contains(DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
 
-  private val useStateTransitionTime =
-    parameters.get(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key())
+  private val useStateTransitionTime: Boolean =
+    parameters.get(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key)
       .map(_.toBoolean)
-      .getOrElse(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.defaultValue())
+      .getOrElse(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.defaultValue)
 
   @transient private lazy val initialOffsets = {
     val metadataLog = new HoodieMetadataLog(sqlContext.sparkSession, metadataPath)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -69,12 +69,11 @@ class HoodieStreamSource(
     parameters.get(DataSourceReadOptions.INCREMENTAL_FORMAT.key).contains(DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
 
   /**
-   * Note: when hollow commit is found using streaming read, unlike batch incremental query,
-   * we do not use [[HollowCommitHandling.EXCEPTION]] by default, instead we
-   * use [[HollowCommitHandling.FILTER]] to stop processing data beyond the hollow commit to
-   * avoid unintentional skip.
+   * When hollow commits are found while doing streaming read , unlike batch incremental query,
+   * we do not use [[HollowCommitHandling.EXCEPTION]] by default, instead we use [[HollowCommitHandling.FILTER]]
+   * to stop processing data beyond the hollow commit to avoid unintentional skip.
    *
-   * Users are recommended to set [[DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT]] to
+   * Users can set [[DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT]] to
    * [[HollowCommitHandling.USE_STATE_TRANSITION_TIME]] to avoid the stopping behavior.
    */
   private val hollowCommitHandling: HollowCommitHandling =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -70,16 +70,16 @@ class HoodieStreamSource(
 
   /**
    * When hollow commits are found while doing streaming read , unlike batch incremental query,
-   * we do not use [[HollowCommitHandling.EXCEPTION]] by default, instead we use [[HollowCommitHandling.FILTER]]
-   * to stop processing data beyond the hollow commit to avoid unintentional skip.
+   * we do not use [[HollowCommitHandling.EXCEPTION]] by default, instead we use [[HollowCommitHandling.BLOCK]]
+   * to block processing data from going beyond the hollow commits to avoid unintentional skip.
    *
    * Users can set [[DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT]] to
-   * [[HollowCommitHandling.USE_STATE_TRANSITION_TIME]] to avoid the stopping behavior.
+   * [[HollowCommitHandling.USE_STATE_TRANSITION_TIME]] to avoid the blocking behavior.
    */
   private val hollowCommitHandling: HollowCommitHandling =
     parameters.get(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
       .map(HollowCommitHandling.valueOf)
-      .getOrElse(HollowCommitHandling.FILTER)
+      .getOrElse(HollowCommitHandling.BLOCK)
 
   @transient private lazy val initialOffsets = {
     val metadataLog = new HoodieMetadataLog(sqlContext.sparkSession, metadataPath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
@@ -17,13 +17,14 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_STATE_TRANSITION_TIME
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.junit.jupiter.api.{AfterEach, Assertions, BeforeEach}
 import org.junit.jupiter.params.ParameterizedTest
@@ -86,7 +87,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
     val result1 = spark.read.format("org.apache.hudi")
       .option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "000")
-      .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), "true")
+      .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_STATE_TRANSITION_TIME.name())
       .option(DataSourceReadOptions.END_INSTANTTIME.key(), firstInstant.getTimestamp)
       .load(basePath)
       .count()
@@ -95,7 +96,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
     val result2 = spark.read.format("org.apache.hudi")
       .option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "000")
-      .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), "true")
+      .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_STATE_TRANSITION_TIME.name())
       .option(DataSourceReadOptions.END_INSTANTTIME.key(), firstInstant.getStateTransitionTime)
       .load(basePath)
       .count()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
@@ -20,12 +20,14 @@ package org.apache.hudi.functional
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.engine.EngineType
-import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.hudi.common.model.{HoodieFailedWritesCleaningPolicy, HoodieRecord, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_STATE_TRANSITION_TIME
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime
 import org.apache.hudi.config.{HoodieCleanConfig, HoodieWriteConfig}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.spark.api.java.JavaRDD
 
 import scala.collection.JavaConversions.asScalaBuffer
@@ -33,7 +35,7 @@ import scala.jdk.CollectionConverters.mapAsJavaMapConverter
 
 class TestStreamSourceReadByStateTransitionTime extends TestStreamingSource {
 
-  override val useTransitionTime: Boolean = true
+  override val handlingMode: HollowCommitHandling = USE_STATE_TRANSITION_TIME
 
   private val dataGen = new HoodieTestDataGenerator(System.currentTimeMillis())
 
@@ -71,7 +73,7 @@ class TestStreamSourceReadByStateTransitionTime extends TestStreamingSource {
         writeClient.insert(records2.toJavaRDD().asInstanceOf[JavaRDD[HoodieRecord[Nothing]]], instantTime2)
         val df = spark.readStream
           .format("hudi")
-          .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), useTransitionTime)
+          .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), handlingMode.name())
           .load(tablePath)
 
         testStream(df) (

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -18,11 +18,13 @@
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceReadOptions.START_OFFSET
-import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD}
 import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.{FILTER, USE_STATE_TRANSITION_TIME}
 import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSERT_PARALLELISM_VALUE, TBL_NAME, UPSERT_PARALLELISM_VALUE}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.{Row, SaveMode}
 
@@ -38,7 +40,7 @@ class TestStreamingSource extends StreamTest {
   )
   private val columns = Seq("id", "name", "price", "ts")
 
-  val useTransitionTime: Boolean = false
+  val handlingMode: HollowCommitHandling = FILTER
 
   org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level.WARN)
 
@@ -63,7 +65,7 @@ class TestStreamingSource extends StreamTest {
       addData(tablePath, Seq(("1", "a1", "10", "000")))
       val df = spark.readStream
         .format("org.apache.hudi")
-        .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), useTransitionTime)
+        .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), handlingMode.name())
         .load(tablePath)
         .select("id", "name", "price", "ts")
 
@@ -116,7 +118,7 @@ class TestStreamingSource extends StreamTest {
       addData(tablePath, Seq(("1", "a1", "10", "000")))
       val df = spark.readStream
         .format("org.apache.hudi")
-        .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), useTransitionTime)
+        .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), handlingMode.name())
         .load(tablePath)
         .select("id", "name", "price", "ts")
 
@@ -164,7 +166,7 @@ class TestStreamingSource extends StreamTest {
       val df = spark.readStream
         .format("org.apache.hudi")
         .option(START_OFFSET.key(), "latest")
-        .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), useTransitionTime)
+        .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), handlingMode.name())
         .load(tablePath)
         .select("id", "name", "price", "ts")
 
@@ -197,7 +199,7 @@ class TestStreamingSource extends StreamTest {
       addData(tablePath, Seq(("2", "a1", "11", "001")))
       addData(tablePath, Seq(("3", "a1", "12", "002")))
 
-      val timestamp = if (useTransitionTime) {
+      val timestamp = if (handlingMode == USE_STATE_TRANSITION_TIME) {
         metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
           .firstInstant().get().getStateTransitionTime
       } else {
@@ -207,7 +209,7 @@ class TestStreamingSource extends StreamTest {
       val df = spark.readStream
         .format("org.apache.hudi")
         .option(START_OFFSET.key(), timestamp)
-        .option(DataSourceReadOptions.READ_BY_STATE_TRANSITION_TIME.key(), useTransitionTime)
+        .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), handlingMode.name())
         .load(tablePath)
         .select("id", "name", "price", "ts")
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD
 import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.{FILTER, USE_STATE_TRANSITION_TIME}
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.{BLOCK, USE_STATE_TRANSITION_TIME}
 import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSERT_PARALLELISM_VALUE, TBL_NAME, UPSERT_PARALLELISM_VALUE}
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.spark.sql.streaming.StreamTest
@@ -40,7 +40,7 @@ class TestStreamingSource extends StreamTest {
   )
   private val columns = Seq("id", "name", "price", "ts")
 
-  val handlingMode: HollowCommitHandling = FILTER
+  val handlingMode: HollowCommitHandling = BLOCK
 
   org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level.WARN)
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/GcsEventsHoodieIncrSource.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.hudi.DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT;
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.DATAFILE_FORMAT;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.ENABLE_EXISTS_CHECK;
@@ -48,6 +47,7 @@ import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.HOODIE_SRC
 import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.NUM_INSTANTS_PER_FETCH;
 import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.SOURCE_FILE_FORMAT;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.calculateBeginAndEndInstants;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHollowCommitHandleMode;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getMissingCheckpointStrategy;
 
 /**
@@ -165,8 +165,7 @@ public class GcsEventsHoodieIncrSource extends HoodieIncrSource {
   private QueryInfo getQueryInfo(Option<String> lastCkptStr) {
     Option<String> beginInstant = getBeginInstant(lastCkptStr);
 
-    HollowCommitHandling handlingMode = HollowCommitHandling.valueOf(
-        props.getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT().key(), HollowCommitHandling.FILTER.name()));
+    HollowCommitHandling handlingMode = getHollowCommitHandleMode(props);
     Pair<String, Pair<String, String>> queryInfoPair = calculateBeginAndEndInstants(
         sparkContext, srcPath, numInstantsPerFetch, beginInstant, missingCheckpointStrategy, handlingMode);
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -46,6 +46,7 @@ import static org.apache.hudi.DataSourceReadOptions.QUERY_TYPE;
 import static org.apache.hudi.DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL;
 import static org.apache.hudi.utilities.UtilHelpers.createRecordMerger;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.calculateBeginAndEndInstants;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHollowCommitHandleMode;
 
 public class HoodieIncrSource extends RowSource {
 
@@ -152,8 +153,7 @@ public class HoodieIncrSource extends RowSource {
     Option<String> beginInstant =
         lastCkptStr.isPresent() ? lastCkptStr.get().isEmpty() ? Option.empty() : lastCkptStr : Option.empty();
 
-    HollowCommitHandling handlingMode = HollowCommitHandling.valueOf(
-        props.getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT().key(), HollowCommitHandling.FILTER.name()));
+    HollowCommitHandling handlingMode = getHollowCommitHandleMode(props);
     Pair<String, Pair<String, String>> queryTypeAndInstantEndpts = calculateBeginAndEndInstants(sparkContext, srcPath,
         numInstantsPerFetch, beginInstant, missingCheckpointStrategy, handlingMode);
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.utilities.sources;
 
-import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.DataSourceUtils;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSource.java
@@ -56,6 +56,7 @@ import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.SOURCE_FIL
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon.getCloudObjectMetadataPerPartition;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon.loadAsDataset;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.calculateBeginAndEndInstants;
+import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHollowCommitHandleMode;
 
 /**
  * This source will use the S3 events meta information from hoodie table generate by {@link S3EventsSource}.
@@ -120,8 +121,7 @@ public class S3EventsHoodieIncrSource extends HoodieIncrSource {
             ? lastCkptStr.get().isEmpty() ? Option.empty() : lastCkptStr
             : Option.empty();
 
-    HollowCommitHandling handlingMode = HollowCommitHandling.valueOf(
-        props.getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT().key(), HollowCommitHandling.FILTER.name()));
+    HollowCommitHandling handlingMode = getHollowCommitHandleMode(props);
     Pair<String, Pair<String, String>> queryTypeAndInstantEndpts = calculateBeginAndEndInstants(sparkContext, srcPath,
         numInstantsPerFetch, beginInstant, missingCheckpointStrategy, handlingMode);
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -34,6 +33,7 @@ import org.apache.spark.sql.Row;
 
 import java.util.Objects;
 
+import static org.apache.hudi.common.table.timeline.TimelineUtils.filterTimelineForIncrementalQueryIfNeeded;
 import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.MISSING_CHECKPOINT_STRATEGY;
 import static org.apache.hudi.utilities.config.HoodieIncrSourceConfig.READ_LATEST_INSTANT_ON_MISSING_CKPT;
 
@@ -69,23 +69,8 @@ public class IncrSourceHelper {
     ValidationUtils.checkArgument(numInstantsPerFetch > 0,
         "Make sure the config hoodie.deltastreamer.source.hoodieincr.num_instants is set to a positive value");
     HoodieTableMetaClient srcMetaClient = HoodieTableMetaClient.builder().setConf(jssc.hadoopConfiguration()).setBasePath(srcBasePath).setLoadActiveTimelineOnLoad(true).build();
-
-    // Find the earliest incomplete commit, deltacommit, or non-clustering replacecommit,
-    // so that the incremental pulls should be strictly before this instant.
-    // This is to guard around multi-writer scenarios where a commit starting later than
-    // another commit from a concurrent writer can finish earlier, leaving an inflight commit
-    // before a completed commit.
-    final Option<HoodieInstant> firstIncompleteCommit = srcMetaClient.getCommitsTimeline()
-        .filterInflightsAndRequested()
-        .filter(instant ->
-            !HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())
-                || !ClusteringUtils.getClusteringPlan(srcMetaClient, instant).isPresent())
-        .firstInstant();
-    final HoodieTimeline completedCommitTimeline =
-        srcMetaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
-    final HoodieTimeline activeCommitTimeline = firstIncompleteCommit.map(
-        commit -> completedCommitTimeline.findInstantsBefore(commit.getTimestamp())
-    ).orElse(completedCommitTimeline);
+    HoodieTimeline completedCommitTimeline = srcMetaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
+    final HoodieTimeline activeCommitTimeline = filterTimelineForIncrementalQueryIfNeeded(srcMetaClient, completedCommitTimeline);
 
     String beginInstantTime = beginInstant.orElseGet(() -> {
       if (missingCheckpointStrategy != null) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -60,15 +60,15 @@ public class IncrSourceHelper {
   /**
    * When hollow commits are found while using incremental source with {@link HoodieDeltaStreamer},
    * unlike batch incremental query, we do not use {@link HollowCommitHandling#EXCEPTION} by default,
-   * instead we use {@link HollowCommitHandling#FILTER} to stop processing data beyond the hollow commit
-   * to avoid unintentional skip.
+   * instead we use {@link HollowCommitHandling#BLOCK} to block processing data from going beyond the
+   * hollow commits to avoid unintentional skip.
    * <p>
    * Users can set {@link DataSourceReadOptions#INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT} to
-   * {@link HollowCommitHandling#USE_STATE_TRANSITION_TIME} to avoid the stopping behavior.
+   * {@link HollowCommitHandling#USE_STATE_TRANSITION_TIME} to avoid the blocking behavior.
    */
   public static HollowCommitHandling getHollowCommitHandleMode(TypedProperties props) {
     return HollowCommitHandling.valueOf(
-        props.getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT().key(), HollowCommitHandling.FILTER.name()));
+        props.getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT().key(), HollowCommitHandling.BLOCK.name()));
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/QueryInfo.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/gcs/QueryInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.utilities.sources.helpers.gcs;
 
-import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 
 import org.apache.spark.sql.DataFrameReader;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -66,6 +66,7 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.RAW_TRIPS_TEST_NA
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
@@ -329,13 +330,13 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
     // read everything until latest
     Pair<Option<Dataset<Row>>, String> batchCheckPoint = incrSource.fetchNextBatch(checkpointToPull, 500);
-    Assertions.assertNotNull(batchCheckPoint.getValue());
+    assertNotNull(batchCheckPoint.getValue());
     if (expectedCount == 0) {
       assertFalse(batchCheckPoint.getKey().isPresent());
     } else {
       assertEquals(expectedCount, batchCheckPoint.getKey().get().count());
     }
-    Assertions.assertEquals(expectedCheckpoint, batchCheckPoint.getRight());
+    assertEquals(expectedCheckpoint, batchCheckPoint.getRight());
   }
 
   private Pair<String, List<HoodieRecord>> writeRecords(SparkRDDWriteClient writeClient,


### PR DESCRIPTION
### Change Logs

Guard incremental query read paths to prevent skipping hollow commits (un-completed non-latest commits) in multi-writer scenario. This PR migrates `hoodie.datasource.read.by.state.transition.time` (introduced in #7627 ) to a new config `hoodie.datasource.read.handle.hollow.commit` that provides flexibility in handling hollow commits. The following read paths are covered.

- `HoodieCopyOnWriteTableInputFormat`
- `HoodieMergeOnReadTableInputFormat`
- `org.apache.spark.sql.hudi.streaming.HoodieStreamSource`
- `HoodieIncrSource`
- `S3EventsHoodieIncrSource`
- `GcsEventsHoodieIncrSource`

### Impact

Incremental query results.

### Risk level

Medium.

- [ ] To be validated by UT and e2e testing.


### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
