### PR TITLE
[HUDI-6337] Incremental Clean ignore partitions affected by append write commits/delta commits

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -179,6 +179,12 @@ public class HoodieCleanConfig extends HoodieConfig {
           + " table receives updates/deletes. Another reason to turn this on, would be to ensure data residing in bootstrap "
           + " base files are also physically deleted, to comply with data privacy enforcement processes.");
 
+  public static final ConfigProperty<Boolean> CLEANER_IGNORE_APPEND_WRITE_COMMITS = ConfigProperty
+      .key("hoodie.cleaner.ignore.append.write.commits")
+      .defaultValue(false)
+      .markAdvanced()
+      .withDocumentation("When set to true, cleaner will ignore partition affected by commits/delta commits. This is usefule for append write mode");
+
 
   /** @deprecated Use {@link #CLEANER_POLICY} and its methods instead */
   @Deprecated
@@ -337,6 +343,11 @@ public class HoodieCleanConfig extends HoodieConfig {
 
     public HoodieCleanConfig.Builder withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy failedWritesPolicy) {
       cleanConfig.setValue(FAILED_WRITES_CLEANER_POLICY, failedWritesPolicy.name());
+      return this;
+    }
+
+    public HoodieCleanConfig.Builder ignoreAppendWriteCommits(boolean ignoreAppendWriteCommits) {
+      cleanConfig.setValue(CLEANER_IGNORE_APPEND_WRITE_COMMITS, String.valueOf(ignoreAppendWriteCommits));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -102,6 +102,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.config.HoodieCleanConfig.CLEANER_POLICY;
+import static org.apache.hudi.config.HoodieCleanConfig.CLEANER_IGNORE_APPEND_WRITE_COMMITS;
 import static org.apache.hudi.config.HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE;
 import static org.apache.hudi.table.marker.ConflictDetectionUtils.getDefaultEarlyConflictDetectionStrategy;
 
@@ -2505,6 +2506,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public String getRollbackBackupDirectory() {
     return getString(ROLLBACK_INSTANT_BACKUP_DIRECTORY);
+  }
+
+  public Boolean isCleanerIgnoreAppendWriteCommits() {
+    return getBoolean(CLEANER_IGNORE_APPEND_WRITE_COMMITS);
   }
 
   public static class Builder {


### PR DESCRIPTION
### Change Logs

Incremental Clean ignore partitions affected by append write commits/delta commits. In append write, we may write thousands of files in different partitions in one commit, and we know that we don't need to clean them at all.  However current incremental clean will try to list the partitions anyway. This pr fix this and we won't list those partitions affected by append write commits. 


### Impact

Do not fetch commit metadata and list partition for append writes ( we will still list replace commits) 


### Risk level (write none, low medium or high below)

low


### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
