### PR TITLE
[HUDI-6343] Fixing fileId format for all mdt partitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1453,11 +1453,7 @@ public class HoodieTableMetadataUtil {
    * @return The fileID
    */
   public static String getFileIDForFileGroup(MetadataPartitionType partitionType, int index) {
-    if (partitionType == MetadataPartitionType.FILES) {
-      return String.format("%s%04d-%d", partitionType.getFileIdPrefix(), index, 0);
-    } else {
-      return String.format("%s%04d", partitionType.getFileIdPrefix(), index);
-    }
+    return String.format("%s%04d-%d", partitionType.getFileIdPrefix(), index, 0);
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
@@ -85,7 +85,6 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
       .save(basePath)
 
     val mdtDf = spark.read.format("hudi").load(s"$basePath/.hoodie/metadata")
-    mdtDf.show()
 
     // files partition
     val filesDf = mdtDf.where("type = 2 or type = 1").select("key")
@@ -97,7 +96,6 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
       .sorted
 
     val expectedKeys = Seq("2015/03/16", "2015/03/17", "2016/03/15", "__all_partitions__")
-
     assertEquals(expectedKeys, partitions)
 
     // Column Stats Index partition of MT


### PR DESCRIPTION
### Change Logs

Fixing fileId format for all mdt partitions. When bulk_insert gets triggered, the fileId will get suffixed with "-0" in the end. And so, we might need to ensure the initial instantiation also follows the same format. 

### Impact

Fixing fileId format for all mdt partitions

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
