### PR TITLE
[HUDI-6349] Do not consider nullability as a criteria for schema evolution in merger

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
@@ -202,7 +202,7 @@ object HoodieInternalRowUtils {
                                 renamedColumnsMap: JMap[String, String],
                                 fieldNameStack: JDeque[String]): RowFieldUpdater = {
     (newDataType, prevDataType) match {
-      case (newType, prevType) if prevType == newType =>
+      case (newType, prevType) if prevType.sql == newType.sql =>
         (fieldUpdater, ordinal, value) => fieldUpdater.set(ordinal, value)
 
       case (newStructType: StructType, prevStructType: StructType) =>


### PR DESCRIPTION
### Change Logs

yet ugly but working way to fix #8920

Idea is to not consider nullable change in schema evolution for the spark merger, to avoid impossible deal with unsafeArray/unsafeMap

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
