### PR TITLE
[HUDI-6355] Avoid merge records for global index when non-partitioned

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
@@ -117,6 +117,8 @@ public class HoodieGlobalSimpleIndex extends HoodieSimpleIndex {
       HoodiePairData<String, HoodieRecord<R>> incomingRecords,
       HoodiePairData<HoodieKey, HoodieRecordLocation> existingRecords,
       HoodieTable hoodieTable) {
+    final boolean shouldUpdatePartitionPath = config.getGlobalSimpleIndexUpdatePartitionPath() && hoodieTable.isPartitioned();
+
     HoodiePairData<String, Pair<String, HoodieRecordLocation>> existingRecordByRecordKey =
         existingRecords.mapToPair(
             entry -> new ImmutablePair<>(entry.getLeft().getRecordKey(),
@@ -130,7 +132,7 @@ public class HoodieGlobalSimpleIndex extends HoodieSimpleIndex {
           if (partitionPathLocationPair.isPresent()) {
             String partitionPath = partitionPathLocationPair.get().getKey();
             HoodieRecordLocation location = partitionPathLocationPair.get().getRight();
-            if (config.getGlobalSimpleIndexUpdatePartitionPath()) {
+            if (shouldUpdatePartitionPath) {
               // The incoming record may need to be inserted to a new partition; keep the location info for merging later.
               return Pair.of(inputRecord, partitionPathLocationPair);
             } else {
@@ -144,7 +146,7 @@ public class HoodieGlobalSimpleIndex extends HoodieSimpleIndex {
           }
         });
 
-    return config.getGlobalSimpleIndexUpdatePartitionPath()
+    return shouldUpdatePartitionPath
         ? mergeForPartitionUpdates(taggedRecordsAndLocationInfo, config, hoodieTable)
         : taggedRecordsAndLocationInfo.map(Pair::getLeft);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1093,6 +1093,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
       throws Exception {
     HoodieTableMetaClient.withPropertyBuilder()
         .fromMetaClient(metaClient)
+        .setPartitionFields("time")
         .setTimelineLayoutVersion(VERSION_0)
         .initTable(metaClient.getHadoopConf(), metaClient.getBasePathV2().toString());
     HoodieWriteConfig hoodieWriteConfig = getConfigBuilder()


### PR DESCRIPTION
### Change Logs

Check if table if non-partitioned for global indexing. If true, skip merge records for indexing.

### Impact

Improve global index perf in case of non-partitioned table.

### Risk level

Low.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
