### PR TITLE
add option empty check in flink mor record merge

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -844,7 +844,7 @@ public class MergeOnReadInputFormat
       HoodieAvroIndexedRecord hoodieAvroIndexedRecord = new HoodieAvroIndexedRecord(historyAvroRecord);
       try {
         Option<HoodieRecord> resultRecord = recordMerger.merge(hoodieAvroIndexedRecord, tableSchema, record, tableSchema, payloadProps).map(Pair::getLeft);
-        return resultRecord.get().toIndexedRecord(tableSchema, new Properties());
+        return resultRecord.isPresent()?resultRecord.get().toIndexedRecord(tableSchema, new Properties()):Option.empty();
       } catch (IOException e) {
         throw new HoodieIOException("Merge base and delta payloads exception", e);
       }


### PR DESCRIPTION
MergeOnReadInputFormat.MergeIterator#mergeRowWithLog

### Change Logs
A record is marked as delete and store in log (inner avro format). When reading the deleted record  both in log file and parquet file, a combine is apply as merge, a delete reocord should be ignore, consequently an option.empty() should be returned in method MergeOnReadInputFormat.MergeIterator#mergeRowWithLog.

in this pr, a check is add before a conversion is appied to as record to aviod option error happening.

### Impact
bug fixed.

### Risk level (write none, low medium or high below)
none

### Documentation Update

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [x] CI #8932
