### PR TITLE
[HUDI-6363] Unify instant management with HoodieActiveTimeline

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
@@ -197,11 +197,11 @@ public class RepairsCommand {
         CleanerUtils.getCleanerPlan(client, instant);
       } catch (AvroRuntimeException e) {
         LOG.warn("Corruption found. Trying to remove corrupted clean instant file: " + instant);
-        HoodieActiveTimeline.deleteInstantFile(client.getFs(), client.getMetaPath(), instant);
+        client.getActiveTimeline().deleteInstant(instant);
       } catch (IOException ioe) {
         if (ioe.getMessage().contains("Not an Avro data file")) {
           LOG.warn("Corruption found. Trying to remove corrupted clean instant file: " + instant);
-          HoodieActiveTimeline.deleteInstantFile(client.getFs(), client.getMetaPath(), instant);
+          client.getActiveTimeline().deleteInstant(instant);
         } else {
           throw new HoodieIOException(ioe.getMessage(), ioe);
         }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
@@ -284,7 +284,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
     }
 
     metaClient.getActiveTimeline().getInstantsAsStream().filter(hoodieInstant -> Integer.parseInt(hoodieInstant.getTimestamp()) % 4 == 0).forEach(hoodieInstant -> {
-      metaClient.getActiveTimeline().deleteInstantFileIfExists(hoodieInstant);
+      metaClient.getActiveTimeline().deleteInstantIfExists(hoodieInstant);
       metaClient.getActiveTimeline().createNewInstant(hoodieInstant);
     });
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -602,14 +602,14 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
     if (!pendingInstants.isEmpty()) {
       context.foreach(
           pendingInstants,
-          instant -> activeTimeline.deleteInstantFileIfExists(instant),
+          instant -> activeTimeline.deleteInstantIfExists(instant),
           Math.min(pendingInstants.size(), config.getArchiveDeleteParallelism())
       );
     }
     if (!completedInstants.isEmpty()) {
       context.foreach(
           completedInstants,
-          instant -> activeTimeline.deleteInstantFileIfExists(instant),
+          instant -> activeTimeline.deleteInstantIfExists(instant),
           Math.min(completedInstants.size(), config.getArchiveDeleteParallelism())
       );
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -707,8 +707,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
             HoodieIndexPlan indexPlan = deserializeIndexPlan(metaClient.getActiveTimeline().readIndexPlanAsBytes(instant).get());
             if (indexPlan.getIndexPartitionInfos().stream()
                 .anyMatch(indexPartitionInfo -> indexPartitionInfo.getMetadataPartitionPath().equals(partitionPath))) {
-              metaClient.getActiveTimeline().deleteInstantFileIfExists(instant);
-              metaClient.getActiveTimeline().deleteInstantFileIfExists(getIndexInflightInstant(instant.getTimestamp()));
+              metaClient.getActiveTimeline().deleteInstantIfExists(instant);
+              metaClient.getActiveTimeline().deleteInstantIfExists(getIndexInflightInstant(instant.getTimestamp()));
             }
           } catch (IOException e) {
             LOG.error("Failed to delete the instant file corresponding to " + instant);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -209,7 +209,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
     });
 
     // delete inflight instant
-    table.getMetaClient().reloadActiveTimeline().deleteInstantFileIfExists(HoodieTimeline.getIndexInflightInstant(indexInstant.getTimestamp()));
+    table.getMetaClient().reloadActiveTimeline().deleteInstantIfExists(HoodieTimeline.getIndexInflightInstant(indexInstant.getTimestamp()));
   }
 
   private List<HoodieInstant> getInstantsToCatchup(String indexUptoInstant) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -139,6 +139,6 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
       }
     });
     // delete requested instant
-    table.getMetaClient().reloadActiveTimeline().deleteInstantFileIfExists(indexInstant);
+    table.getMetaClient().reloadActiveTimeline().deleteInstantIfExists(indexInstant);
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -134,7 +134,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
           // once rollback is complete, compaction will be retried again, which will eventually hit this code block where the respective commit is
           // already part of completed commit. So, we have to manually remove the completed instant and proceed.
           // and it is for the same reason we enabled withAllowMultiWriteOnSameInstant for metadata table.
-          HoodieActiveTimeline.deleteInstantFile(metadataMetaClient.getFs(), metadataMetaClient.getMetaPath(), alreadyCompletedInstant.get());
+          metadataMetaClient.getActiveTimeline().deleteInstant(alreadyCompletedInstant.get());
           metadataMetaClient.reloadActiveTimeline();
         }
         // If the alreadyCompletedInstant is empty, that means there is a requested or inflight

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -29,7 +29,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
@@ -163,7 +162,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
           // once rollback is complete, compaction will be retried again, which will eventually hit this code block where the respective commit is
           // already part of completed commit. So, we have to manually remove the completed instant and proceed.
           // and it is for the same reason we enabled withAllowMultiWriteOnSameInstant for metadata table.
-          HoodieActiveTimeline.deleteInstantFile(metadataMetaClient.getFs(), metadataMetaClient.getMetaPath(), alreadyCompletedInstant.get());
+          metadataMetaClient.getActiveTimeline().deleteInstant(alreadyCompletedInstant.get());
           metadataMetaClient.reloadActiveTimeline();
         }
         // If the alreadyCompletedInstant is empty, that means there is a requested or inflight

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
@@ -36,8 +36,6 @@ import org.apache.hudi.table.WorkloadProfile;
 import org.apache.hudi.table.WorkloadStat;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 
-import org.apache.hadoop.fs.Path;
-
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkDeletePartitionCommitActionExecutor.java
@@ -75,8 +75,7 @@ public class SparkDeletePartitionCommitActionExecutor<T>
 
       // created requested
       HoodieInstant dropPartitionsInstant = new HoodieInstant(REQUESTED, REPLACE_COMMIT_ACTION, instantTime);
-      if (!table.getMetaClient().getFs().exists(new Path(table.getMetaClient().getMetaPath(),
-          dropPartitionsInstant.getFileName()))) {
+      if (!table.getActiveTimeline().instantExists(dropPartitionsInstant)) {
         HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
             .setOperationType(WriteOperationType.DELETE_PARTITION.name())
             .setExtraMetadata(extraMetadata.orElse(Collections.emptyMap()))

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -210,7 +210,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
       LOG.info("Creating a new instant " + instant);
       // Create the request replace file
       createInstant(instant,
-              TimelineMetadataUtils.serializeRequestedReplaceMetadata(new HoodieRequestedReplaceMetadata()), false);
+          TimelineMetadataUtils.serializeRequestedReplaceMetadata(new HoodieRequestedReplaceMetadata()), false);
     } catch (IOException e) {
       throw new HoodieIOException("Error create requested replace commit ", e);
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
@@ -456,7 +455,7 @@ public class TestWriteBase {
     public TestHarness rollbackLastCompleteInstantToInflight() throws Exception {
       HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(conf);
       Option<HoodieInstant> lastCompletedInstant = metaClient.getActiveTimeline().filterCompletedInstants().lastInstant();
-      HoodieActiveTimeline.deleteInstantFile(metaClient.getFs(), metaClient.getMetaPath(), lastCompletedInstant.get());
+      metaClient.getActiveTimeline().deleteInstant(lastCompletedInstant.get());
       // refresh the heartbeat in case it is timed out.
       OutputStream outputStream =
           metaClient.getFs().create(new Path(HoodieTableMetaClient.getHeartbeatFolderPath(basePath) + Path.SEPARATOR + this.lastComplete), true);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -20,7 +20,6 @@ package org.apache.hudi.utils;
 
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
@@ -127,7 +126,7 @@ public class TestUtils {
   public static HoodieCommitMetadata deleteInstantFile(HoodieTableMetaClient metaClient, HoodieInstant instant) throws Exception {
     ValidationUtils.checkArgument(instant.isCompleted());
     HoodieCommitMetadata metadata = TimelineUtils.getCommitMetadata(instant, metaClient.getActiveTimeline());
-    HoodieActiveTimeline.deleteInstantFile(metaClient.getFs(), metaClient.getMetaPath(), instant);
+    metaClient.getActiveTimeline().deleteInstant(instant);
     return metadata;
   }
 

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/timeline/HoodieMetaserverBasedTimeline.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/timeline/HoodieMetaserverBasedTimeline.java
@@ -46,7 +46,7 @@ public class HoodieMetaserverBasedTimeline extends HoodieActiveTimeline {
   }
 
   @Override
-  protected void deleteInstantFile(HoodieInstant instant) {
+  public void deleteInstant(HoodieInstant instant) {
     metaserverClient.deleteInstant(databaseName, tableName, instant);
   }
 
@@ -57,10 +57,7 @@ public class HoodieMetaserverBasedTimeline extends HoodieActiveTimeline {
   }
 
   @Override
-  public void createFileInMetaPath(String filename, Option<byte[]> content, boolean allowOverwrite) {
-    FileStatus status = new FileStatus();
-    status.setPath(new Path(filename));
-    HoodieInstant instant = new HoodieInstant(status);
+  public void createInstant(HoodieInstant instant, Option<byte[]> content, boolean allowOverwrite) {
     ValidationUtils.checkArgument(instant.getState().equals(HoodieInstant.State.REQUESTED));
     metaserverClient.createNewInstant(databaseName, tableName, instant, Option.empty());
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairCorruptedCleanFilesProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairCorruptedCleanFilesProcedure.scala
@@ -60,11 +60,11 @@ class RepairCorruptedCleanFilesProcedure extends BaseProcedure with ProcedureBui
       } catch {
         case e: AvroRuntimeException =>
           logWarning("Corruption found. Trying to remove corrupted clean instant file: " + instant)
-          HoodieActiveTimeline.deleteInstantFile(metaClient.getFs, metaClient.getMetaPath, instant)
+          metaClient.getActiveTimeline.deleteInstant(instant)
         case ioe: IOException =>
           if (ioe.getMessage.contains("Not an Avro data file")) {
             logWarning("Corruption found. Trying to remove corrupted clean instant file: " + instant)
-            HoodieActiveTimeline.deleteInstantFile(metaClient.getFs, metaClient.getMetaPath, instant)
+            metaClient.getActiveTimeline.deleteInstant(instant)
           } else {
             result = false
             throw new HoodieIOException(ioe.getMessage, ioe)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
@@ -36,7 +36,6 @@ import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
-import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -264,7 +263,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
         numInstantsAfterBootstrap, timestamp, timestamp, deltaCommit, bootstrapInstants, true);
 
     // Rollback Bootstrap
-    HoodieActiveTimeline.deleteInstantFile(metaClient.getFs(), metaClient.getMetaPath(), new HoodieInstant(State.COMPLETED,
+    metaClient.getActiveTimeline().deleteInstant(new HoodieInstant(State.COMPLETED,
         deltaCommit ? HoodieTimeline.DELTA_COMMIT_ACTION : HoodieTimeline.COMMIT_ACTION, bootstrapCommitInstantTs));
     metaClient.reloadActiveTimeline();
     client.getTableServiceClient().rollbackFailedBootstrap();

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -160,7 +160,7 @@ public class RequestHandler {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Client [ LastTs=" + lastKnownInstantFromClient + ", TimelineHash=" + timelineHashFromClient
           + "], localTimeline=" + localTimeline.getInstants());
-    } 
+    }
 
     if ((!localTimeline.getInstantsAsStream().findAny().isPresent())
         && HoodieTimeline.INVALID_INSTANT_TS.equals(lastKnownInstantFromClient)) {


### PR DESCRIPTION
### Change Logs

One can create his own implementation of instant management by inheriting `HoodieActiveTimeline`, just like `HoodieMetaserverBasedTimeline` in RFC-36. Therefore, the operations of instants like creation , deletion, and existence 
 should be managed uniformly through `HoodieActiveTimeline`.

So in this PR:
- Unified instant management. Instant cannot be created/deleted directly from the file system(**this breaks RFC-36**), it's better to use the interface in `HoodieActiveTimeline`. (In fact, I wonder how can RFC-36 run successfully without this change)
- **Since instant can't just be a file in FS (in RFC-36, it's a record in database)**, change the interfaces' name to make them more universal:
  - deleteInstant
  - instantExists
  - createInstant

After this PR, I will also modify some test cases so that they all use the above interface.

### Impact

As above

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
