### PR TITLE
[HUDI-6367] Fix NPE in HoodieAvroParquetReader and support complex schema with timestamp

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -445,12 +445,14 @@ public class TestHoodieAvroUtils {
     Schema originalSchema = HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(EXAMPLE_SCHEMA));
 
     Schema schema1 = HoodieAvroUtils.generateProjectionSchema(originalSchema, Arrays.asList("_row_key", "timestamp"));
-    assertEquals( 2, schema1.getFields().size());
+    assertEquals(2, schema1.getFields().size());
     List<String> fieldNames1 = schema1.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
     assertTrue(fieldNames1.contains("_row_key"));
     assertTrue(fieldNames1.contains("timestamp"));
 
-    assertEquals("Field fake_field not found in log schema. Query cannot proceed! Derived Schema Fields: [non_pii_col, _hoodie_commit_time, _row_key, _hoodie_partition_path, _hoodie_record_key, pii_col, _hoodie_commit_seqno, _hoodie_file_name, timestamp]",
+    assertEquals("Field fake_field not found in log schema. Query cannot proceed! Derived Schema Fields: " +
+            "[non_pii_col, _hoodie_commit_time, _row_key, _hoodie_partition_path, _hoodie_record_key, pii_col," +
+            " _hoodie_commit_seqno, _hoodie_file_name, timestamp]",
         assertThrows(HoodieException.class, () ->
             HoodieAvroUtils.generateProjectionSchema(originalSchema, Arrays.asList("_row_key", "timestamp", "fake_field"))).getMessage());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -36,10 +36,12 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.getNestedFieldSchemaFromWriteSchema;
 import static org.apache.hudi.avro.HoodieAvroUtils.sanitizeName;
@@ -436,5 +438,20 @@ public class TestHoodieAvroUtils {
     assertEquals("a*bc", sanitizeName("a.bc", "*"));
     assertEquals("abcdef___", sanitizeName("abcdef_."));
     assertEquals("__ab__cd__", sanitizeName("1ab*cd?"));
+  }
+
+  @Test
+  public void testGenerateProjectionSchema() {
+    Schema originalSchema = HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(EXAMPLE_SCHEMA));
+
+    Schema schema1 = HoodieAvroUtils.generateProjectionSchema(originalSchema, Arrays.asList("_row_key", "timestamp"));
+    assertEquals( 2, schema1.getFields().size());
+    List<String> fieldNames1 = schema1.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
+    assertTrue(fieldNames1.contains("_row_key"));
+    assertTrue(fieldNames1.contains("timestamp"));
+
+    assertEquals("Field fake_field not found in log schema. Query cannot proceed! Derived Schema Fields: [non_pii_col, _hoodie_commit_time, _row_key, _hoodie_partition_path, _hoodie_record_key, pii_col, _hoodie_commit_seqno, _hoodie_file_name, timestamp]",
+        assertThrows(HoodieException.class, () ->
+            HoodieAvroUtils.generateProjectionSchema(originalSchema, Arrays.asList("_row_key", "timestamp", "fake_field"))).getMessage());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroUtils.java
@@ -450,9 +450,9 @@ public class TestHoodieAvroUtils {
     assertTrue(fieldNames1.contains("_row_key"));
     assertTrue(fieldNames1.contains("timestamp"));
 
-    assertEquals("Field fake_field not found in log schema. Query cannot proceed! Derived Schema Fields: " +
-            "[non_pii_col, _hoodie_commit_time, _row_key, _hoodie_partition_path, _hoodie_record_key, pii_col," +
-            " _hoodie_commit_seqno, _hoodie_file_name, timestamp]",
+    assertEquals("Field fake_field not found in log schema. Query cannot proceed! Derived Schema Fields: "
+            + "[non_pii_col, _hoodie_commit_time, _row_key, _hoodie_partition_path, _hoodie_record_key, pii_col,"
+            + " _hoodie_commit_seqno, _hoodie_file_name, timestamp]",
         assertThrows(HoodieException.class, () ->
             HoodieAvroUtils.generateProjectionSchema(originalSchema, Arrays.asList("_row_key", "timestamp", "fake_field"))).getMessage());
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
@@ -137,8 +137,8 @@ public class HoodieColumnProjectionUtils {
     if (colTypes == null || colTypes.isEmpty()) {
       return true;
     }
-    ArrayList<TypeInfo> types = TypeInfoUtils.getTypeInfosFromTypeString(colTypes);
 
+    ArrayList<TypeInfo> types = TypeInfoUtils.getTypeInfosFromTypeString(colTypes);
     List<String> names = getIOColumns(conf);
     return IntStream.range(0, names.size()).filter(i -> readCols.contains(names.get(i)))
         .anyMatch(i -> typeContainsTimestamp(types.get(i)));
@@ -151,7 +151,7 @@ public class HoodieColumnProjectionUtils {
       case PRIMITIVE:
         return type.getTypeName().equals(TIMESTAMP_TYPE_NAME);
       case LIST:
-        ListTypeInfo listTypeInfo =  (ListTypeInfo) type;
+        ListTypeInfo listTypeInfo = (ListTypeInfo) type;
         return typeContainsTimestamp(listTypeInfo.getListElementTypeInfo());
       case MAP:
         MapTypeInfo mapTypeInfo = (MapTypeInfo) type;

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
@@ -112,18 +112,17 @@ public class HoodieColumnProjectionUtils {
   /**
    * If schema contains timestamp columns, this method is used for compatibility when there is no timestamp fields.
    *
-   * <p>We expect 3 cases to use parquet-avro reader {@link org.apache.hudi.hadoop.avro.HoodieAvroParquetReader} to read timestamp column:
+   * <p>We expect 2 cases to use parquet-avro reader {@link org.apache.hudi.hadoop.avro.HoodieAvroParquetReader} to read timestamp column:
    *
    * <ol>
    *   <li>Read columns contain timestamp type;</li>
    *   <li>Empty original columns;</li>
-   *   <li>Empty read columns but existing original columns contain timestamp type.</li>
    * </ol>
    */
   public static boolean supportTimestamp(Configuration conf) {
     List<String> readCols = Arrays.asList(getReadColumnNames(conf));
     if (readCols.isEmpty()) {
-      return getIOColumnTypes(conf).contains("timestamp");
+      return false;
     }
     List<String> names = getIOColumns(conf);
     List<String> types = getIOColumnTypes(conf);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
@@ -120,12 +120,8 @@ public class HoodieColumnProjectionUtils {
   /**
    * If schema contains timestamp columns, this method is used for compatibility when there is no timestamp fields.
    *
-   * <p>We expect 2 cases to use parquet-avro reader {@link org.apache.hudi.hadoop.avro.HoodieAvroParquetReader} to read timestamp column:
-   *
-   * <ol>
-   *   <li>Read columns contain timestamp type;</li>
-   *   <li>Empty original columns;</li>
-   * </ol>
+   * <p>We expect to use parquet-avro reader {@link org.apache.hudi.hadoop.avro.HoodieAvroParquetReader} to read
+   * timestamp column when read columns contain timestamp type.
    */
   public static boolean supportTimestamp(Configuration conf) {
     List<String> readCols = Arrays.asList(getReadColumnNames(conf));
@@ -135,7 +131,7 @@ public class HoodieColumnProjectionUtils {
 
     String colTypes = conf.get(IOConstants.COLUMNS_TYPES, "");
     if (colTypes == null || colTypes.isEmpty()) {
-      return true;
+      return false;
     }
 
     ArrayList<TypeInfo> types = TypeInfoUtils.getTypeInfosFromTypeString(colTypes);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
@@ -127,6 +127,6 @@ public class HoodieColumnProjectionUtils {
     List<String> names = getIOColumns(conf);
     List<String> types = getIOColumnTypes(conf);
     return types.isEmpty() || IntStream.range(0, names.size()).filter(i -> readCols.contains(names.get(i)))
-        .anyMatch(i -> types.get(i).equals("timestamp"));
+        .anyMatch(i -> types.get(i).contains("timestamp"));
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieColumnProjectionUtils.java
@@ -18,13 +18,19 @@
 
 package org.apache.hudi.hadoop;
 
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
 import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +40,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.apache.hadoop.hive.serde.serdeConstants.TIMESTAMP_TYPE_NAME;
 
 /**
  * Utility functions copied from Hive ColumnProjectionUtils.java.
@@ -124,9 +132,41 @@ public class HoodieColumnProjectionUtils {
     if (readCols.isEmpty()) {
       return false;
     }
+
+    String colTypes = conf.get(IOConstants.COLUMNS_TYPES, "");
+    if (colTypes == null || colTypes.isEmpty()) {
+      return true;
+    }
+    ArrayList<TypeInfo> types = TypeInfoUtils.getTypeInfosFromTypeString(colTypes);
+
     List<String> names = getIOColumns(conf);
-    List<String> types = getIOColumnTypes(conf);
-    return types.isEmpty() || IntStream.range(0, names.size()).filter(i -> readCols.contains(names.get(i)))
-        .anyMatch(i -> types.get(i).contains("timestamp"));
+    return IntStream.range(0, names.size()).filter(i -> readCols.contains(names.get(i)))
+        .anyMatch(i -> typeContainsTimestamp(types.get(i)));
+  }
+
+  public static boolean typeContainsTimestamp(TypeInfo type) {
+    Category category = type.getCategory();
+
+    switch (category) {
+      case PRIMITIVE:
+        return type.getTypeName().equals(TIMESTAMP_TYPE_NAME);
+      case LIST:
+        ListTypeInfo listTypeInfo =  (ListTypeInfo) type;
+        return typeContainsTimestamp(listTypeInfo.getListElementTypeInfo());
+      case MAP:
+        MapTypeInfo mapTypeInfo = (MapTypeInfo) type;
+        return typeContainsTimestamp(mapTypeInfo.getMapKeyTypeInfo())
+            || typeContainsTimestamp(mapTypeInfo.getMapValueTypeInfo());
+      case STRUCT:
+        StructTypeInfo structTypeInfo = (StructTypeInfo) type;
+        return structTypeInfo.getAllStructFieldTypeInfos().stream()
+            .anyMatch(HoodieColumnProjectionUtils::typeContainsTimestamp);
+      case UNION:
+        UnionTypeInfo unionTypeInfo = (UnionTypeInfo) type;
+        return unionTypeInfo.getAllUnionObjectTypeInfos().stream()
+            .anyMatch(HoodieColumnProjectionUtils::typeContainsTimestamp);
+      default:
+        return false;
+    }
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieColumnProjectionUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieColumnProjectionUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieColumnProjectionUtils {
+
+  @Test
+  void testTypeContainsTimestamp() {
+    String col1 = "timestamp";
+    TypeInfo typeInfo1 = TypeInfoUtils.getTypeInfosFromTypeString(col1).get(0);
+    assertTrue(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo1));
+
+    String col2 = "string";
+    TypeInfo typeInfo2 = TypeInfoUtils.getTypeInfosFromTypeString(col2).get(0);
+    assertFalse(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo2));
+
+    String col3 = "array<timestamp>";
+    TypeInfo typeInfo3 = TypeInfoUtils.getTypeInfosFromTypeString(col3).get(0);
+    assertTrue(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo3));
+
+    String col4 = "array<string>";
+    TypeInfo typeInfo4 = TypeInfoUtils.getTypeInfosFromTypeString(col4).get(0);
+    assertFalse(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo4));
+
+    String col5 = "map<string,timestamp>";
+    TypeInfo typeInfo5 = TypeInfoUtils.getTypeInfosFromTypeString(col5).get(0);
+    assertTrue(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo5));
+
+    String col6 = "map<string,string>";
+    TypeInfo typeInfo6 = TypeInfoUtils.getTypeInfosFromTypeString(col6).get(0);
+    assertFalse(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo6));
+
+    String col7 = "struct<name1:string,name2:timestamp>";
+    TypeInfo typeInfo7 = TypeInfoUtils.getTypeInfosFromTypeString(col7).get(0);
+    assertTrue(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo7));
+
+    String col8 = "struct<name1:string,name2:string>";
+    TypeInfo typeInfo8 = TypeInfoUtils.getTypeInfosFromTypeString(col8).get(0);
+    assertFalse(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo8));
+
+    String col9 = "uniontype<string,timestamp>";
+    TypeInfo typeInfo9 = TypeInfoUtils.getTypeInfosFromTypeString(col9).get(0);
+    assertTrue(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo9));
+
+    String col10 = "uniontype<string,int>";
+    TypeInfo typeInfo10 = TypeInfoUtils.getTypeInfosFromTypeString(col10).get(0);
+    assertFalse(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo10));
+
+    String col11 = "uniontype<string,int,map<string,array<timestamp>>>";
+    TypeInfo typeInfo11 = TypeInfoUtils.getTypeInfosFromTypeString(col11).get(0);
+    assertTrue(HoodieColumnProjectionUtils.typeContainsTimestamp(typeInfo11));
+  }
+}


### PR DESCRIPTION
### Change Logs

Fix the following two scenarios when use hive to query tables containing timestamp fields

1. No query field, like `count(*)`

```sql
-- spark
create table test_ts_tbl(
  id int, 
  ts1 timestamp)
using hudi
tblproperties(
  type='mor', 
  primaryKey='id'
);

INSERT INTO test_ts_tbl
SELECT 1,
cast ('2021-12-25 12:01:01' as timestamp);

-- hive
select count(*) from test_ts_tbl; // error
```

In this scenario, `HoodieColumnProjectionUtils.getReadColumnNames(conf)` will be empty, `baseSchema` will not be initialized, and NPE will be throwed when calling:

```java
public ArrayWritable getCurrentValue() throws IOException, InterruptedException {
   GenericRecord record = parquetRecordReader.getCurrentValue();
   return (ArrayWritable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(record, baseSchema, true);
 }
```

2. Complex fields containing timestamp are currently not supported

```sql
-- spark
create table test_ts_tbl(
  id int, 
  ts1 array<timestamp>, 
  ts2 map<string, timestamp>, 
  ts3 struct<province:timestamp, city:string>)
using hudi
tblproperties(
  type='mor', 
  primaryKey='id'
);

INSERT INTO test_ts_tbl
SELECT 1,
array(cast ('2021-12-25 12:01:01' as timestamp)),
map('key', cast ('2021-12-25 12:01:01' as timestamp)),
struct(cast ('2021-12-25 12:01:01' as timestamp), 'test');

-- hive
select * from test_ts_tbl; // error
```

### Impact

Fix the above two problems

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
