### PR TITLE
[HUDI-6379] [DO NOT MERGE] Pulsar version change to fix snakeyaml CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <fasterxml.jackson.datatype.jsr310.module/>
     <kafka.version>2.0.0</kafka.version>
     <kafka.spark3.version>2.8.0</kafka.spark3.version>
-    <pulsar.version>2.8.1</pulsar.version>
+    <pulsar.version>2.10.0</pulsar.version>
     <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
     <pulsar.spark.scala11.version>2.4.5</pulsar.spark.scala11.version>
     <pulsar.spark.scala12.version>3.1.1.4</pulsar.spark.scala12.version>


### PR DESCRIPTION
### Change Logs

Upgrade Pulsar to 2.10.0 in Hudi, as current Pulsar version brings in snakeYaml < 2.0 which is a security vulnerability. 

https://github.com/apache/pulsar/pull/20085

CVE-2022-1471 : https://nvd.nist.gov/vuln/detail/CVE-2022-1471

[Need to run manual testing as we don't have any unit or functional test to check the pulsar functionality.]

### Impact

Pulsar version change to fix snakeyaml CVE.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

Not required

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
