### PR TITLE
[HUDI-6380] Add API to fetch transformed schema in Transformer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -105,6 +105,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Function;
 
 /**
  * Bunch of helper methods.
@@ -192,11 +193,14 @@ public class UtilHelpers {
 
   }
 
-  public static Option<Transformer> createTransformer(Option<List<String>> classNamesOpt, boolean isErrorTableWriterEnabled) throws IOException {
+  public static Option<Transformer> createTransformer(Option<List<String>> classNamesOpt, Option<Schema> sourceSchema,
+                                                      boolean isErrorTableWriterEnabled) throws IOException {
+
     try {
-      return classNamesOpt.map(classNames -> classNames.isEmpty() ? null : 
-          isErrorTableWriterEnabled ? new ErrorTableAwareChainedTransformer(classNames) : new ChainedTransformer(classNames)
-      );
+      Function<List<String>, Transformer> chainedTransformerFunction = classNames ->
+          isErrorTableWriterEnabled ? new ErrorTableAwareChainedTransformer(classNames, sourceSchema)
+              : new ChainedTransformer(classNames, sourceSchema);
+      return classNamesOpt.map(classNames -> classNames.isEmpty() ? null : chainedTransformerFunction.apply(classNames));
     } catch (Throwable e) {
       throw new IOException("Could not load transformer class(es) " + classNamesOpt.get(), e);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -312,7 +312,8 @@ public class DeltaSync implements Serializable, Closeable {
         UtilHelpers.createSource(cfg.sourceClassName, props, jssc, sparkSession, schemaProvider, metrics),
         this.errorTableWriter, Option.of(props));
 
-    this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames), this.errorTableWriter.isPresent());
+    this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames),
+        Option.ofNullable(schemaProvider).map(SchemaProvider::getSourceSchema), this.errorTableWriter.isPresent());
 
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ChainedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ChainedTransformer.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utilities.transform;
 
+import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
@@ -25,10 +26,12 @@ import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer;
 import org.apache.hudi.utilities.exception.HoodieTransformPlanException;
 
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,23 +51,26 @@ public class ChainedTransformer implements Transformer {
   private static final String ID_TRANSFORMER_CLASS_NAME_DELIMITER = ":";
 
   protected final List<TransformerInfo> transformers;
+  private final Option<Schema> sourceSchemaOpt;
 
   public ChainedTransformer(List<Transformer> transformersList) {
     this.transformers = new ArrayList<>(transformersList.size());
     for (Transformer transformer : transformersList) {
       this.transformers.add(new TransformerInfo(transformer));
     }
+    this.sourceSchemaOpt = Option.empty();
   }
 
   /**
    * Creates a chained transformer using the input transformer class names. Refer {@link HoodieDeltaStreamer.Config#transformerClassNames}
    * for more information on how the transformers can be configured.
    *
-   * @param configuredTransformers List of configured transformer class names.
-   * @param ignore Added for avoiding two methods with same erasure. Ignored.
+   * @param sourceSchemaOpt                   Schema from the dataset the transform is applied to
+   * @param configuredTransformers            List of configured transformer class names.
    */
-  public ChainedTransformer(List<String> configuredTransformers, int... ignore) {
+  public ChainedTransformer(List<String> configuredTransformers, Option<Schema> sourceSchemaOpt) {
     this.transformers = new ArrayList<>(configuredTransformers.size());
+    this.sourceSchemaOpt = sourceSchemaOpt;
 
     Set<String> identifiers = new HashSet<>();
     for (String configuredTransformer : configuredTransformers) {
@@ -110,6 +116,30 @@ public class ChainedTransformer implements Transformer {
     } else {
       identifiers.add(id);
     }
+  }
+
+  private StructType getExpectedTransformedSchema(TransformerInfo transformerInfo, JavaSparkContext jsc, SparkSession sparkSession,
+                                                  Option<StructType> incomingStructOpt, Option<Dataset<Row>> rowDatasetOpt, TypedProperties properties) {
+    if (!sourceSchemaOpt.isPresent() && !rowDatasetOpt.isPresent()) {
+      throw new HoodieTransformPlanException("Either source schema or source dataset should be available to fetch the schema");
+    }
+    StructType incomingStruct = incomingStructOpt
+        .orElse(sourceSchemaOpt.isPresent() ? AvroConversionUtils.convertAvroSchemaToStructType(sourceSchemaOpt.get()) : rowDatasetOpt.get().schema());
+    try {
+      return transformerInfo.getTransformer().transformedSchema(jsc, sparkSession, incomingStruct, properties).asNullable();
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  @Override
+  public StructType transformedSchema(JavaSparkContext jsc, SparkSession sparkSession, StructType incomingStruct, TypedProperties properties) {
+    Option<StructType> expectedTargetStructOpt = Option.ofNullable(incomingStruct);
+    for (TransformerInfo transformerInfo : transformers) {
+      expectedTargetStructOpt = Option.of(
+          getExpectedTransformedSchema(transformerInfo, jsc, sparkSession, expectedTargetStructOpt, Option.empty(), properties));
+    }
+    return expectedTargetStructOpt.get();
   }
 
   protected static class TransformerInfo {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/ErrorTableAwareChainedTransformer.java
@@ -20,11 +20,15 @@
 package org.apache.hudi.utilities.transform;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.deltastreamer.ErrorTableUtils;
+
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
 
 import java.util.List;
 
@@ -34,8 +38,8 @@ import java.util.List;
  * if that column is not dropped in any of the transformations.
  */
 public class ErrorTableAwareChainedTransformer extends ChainedTransformer {
-  public ErrorTableAwareChainedTransformer(List<String> configuredTransformers, int... ignore) {
-    super(configuredTransformers);
+  public ErrorTableAwareChainedTransformer(List<String> configuredTransformers, Option<Schema> sourceSchemaOpt) {
+    super(configuredTransformers, sourceSchemaOpt);
   }
 
   public ErrorTableAwareChainedTransformer(List<Transformer> transformers) {
@@ -54,5 +58,10 @@ public class ErrorTableAwareChainedTransformer extends ChainedTransformer {
       ErrorTableUtils.validate(dataset);
     }
     return dataset;
+  }
+
+  @Override
+  public StructType transformedSchema(JavaSparkContext jsc, SparkSession sparkSession, StructType incomingStruct, TypedProperties properties) {
+    return super.transformedSchema(jsc, sparkSession, incomingStruct, properties);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/Transformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/Transformer.java
@@ -27,6 +27,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * Transform source to target dataset before writing.
@@ -45,4 +46,11 @@ public interface Transformer {
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.STABLE)
   Dataset<Row> apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties);
+
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  default StructType transformedSchema(JavaSparkContext jsc, SparkSession sparkSession, StructType incomingStruct, TypedProperties properties) {
+    Dataset<Row> emptyDataset = sparkSession.createDataFrame(sparkSession.emptyDataFrame().rdd(), incomingStruct);
+    Dataset<Row> transformedDataset = this.apply(jsc, sparkSession, emptyDataset, properties);
+    return transformedDataset.schema();
+  }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestChainedTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestChainedTransformer.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.utilities.functional;
 
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.exception.HoodieTransformPlanException;
 import org.apache.hudi.utilities.transform.ChainedTransformer;
@@ -38,6 +40,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.NESTED_AVRO_SCHEMA;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 import static org.apache.spark.sql.types.DataTypes.createStructField;
@@ -85,7 +88,7 @@ public class TestChainedTransformer extends SparkClientFunctionalTestHarness {
   })
   public void testChainedTransformerValidationFails(String transformerName) {
     try {
-      ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")));
+      ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option.empty());
       fail();
     } catch (Exception e) {
       assertTrue(e instanceof HoodieTransformPlanException, e.getMessage());
@@ -100,8 +103,18 @@ public class TestChainedTransformer extends SparkClientFunctionalTestHarness {
       "org.apache.hudi.utilities.transform.FlatteningTransformer,org.apache.hudi.utilities.transform.FlatteningTransformer"
   })
   public void testChainedTransformerValidationPasses(String transformerName) {
-    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")));
+    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option.empty());
     assertNotNull(transformer);
   }
 
+  @Test
+  public void testChainedTransformerTransformedSchema() {
+    String transformerName = "org.apache.hudi.utilities.transform.FlatteningTransformer";
+    ChainedTransformer transformer = new ChainedTransformer(Arrays.asList(transformerName.split(",")), Option.of(NESTED_AVRO_SCHEMA));
+    StructType transformedSchema = transformer.transformedSchema(jsc(), spark(), null, new TypedProperties());
+    // Verify transformed nested fields are present in the transformed schema
+    assertTrue(Arrays.asList(transformedSchema.fieldNames()).contains("fare_amount"));
+    assertTrue(Arrays.asList(transformedSchema.fieldNames()).contains("fare_currency"));
+    assertNotNull(transformer);
+  }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestErrorTableAwareChainedTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestErrorTableAwareChainedTransformer.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.functional;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.exception.HoodieTransformException;
@@ -127,7 +128,8 @@ public class TestErrorTableAwareChainedTransformer extends SparkClientFunctional
       "org.apache.hudi.utilities.transform.FlatteningTransformer,T1:org.apache.hudi.utilities.transform.FlatteningTransformer"
   })
   public void testErrorTableAwareChainedTransformerValidationFails(String transformerName) {
-    assertThrows(HoodieTransformException.class, () -> new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(","))));
+    assertThrows(HoodieTransformException.class,
+        () -> new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")), Option.empty()));
   }
 
   @ParameterizedTest
@@ -138,7 +140,8 @@ public class TestErrorTableAwareChainedTransformer extends SparkClientFunctional
       "org.apache.hudi.utilities.transform.FlatteningTransformer,org.apache.hudi.utilities.transform.FlatteningTransformer"
   })
   public void testErrorTableAwareChainedTransformerValidationPasses(String transformerName) {
-    ErrorTableAwareChainedTransformer transformer = new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")));
+    ErrorTableAwareChainedTransformer transformer = new ErrorTableAwareChainedTransformer(Arrays.asList(transformerName.split(",")),
+        Option.empty());
     assertNotNull(transformer);
   }
 }


### PR DESCRIPTION
### Change Logs

The jira aims to add a new API for fetching transformed schema in the Transformer. It adds the following API.
```
StructType transformedSchema(JavaSparkContext jsc, SparkSession sparkSession, StructType incomingStruct, TypedProperties properties
```
which returns StructType. The StructType represents the schema of the dataset after transformation is complete. The API has a default implementation provided.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
