### PR TITLE
[HUDI-6389] Fix instant time check against the active timeline in meta sync

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -232,11 +232,11 @@ public class TimelineUtils {
    */
   public static HoodieTimeline getCommitsTimelineAfter(
       HoodieTableMetaClient metaClient, String exclusiveStartInstantTime, Option<String> lastMaxCompletionTime) {
-    HoodieDefaultTimeline activeTimeline = metaClient.getActiveTimeline();
+    HoodieDefaultTimeline writeTimeline = metaClient.getActiveTimeline().getWriteTimeline();
 
-    HoodieDefaultTimeline timeline = activeTimeline.isBeforeTimelineStarts(exclusiveStartInstantTime)
-        ? metaClient.getArchivedTimeline(exclusiveStartInstantTime).mergeTimeline(activeTimeline)
-        : activeTimeline;
+    HoodieDefaultTimeline timeline = writeTimeline.isBeforeTimelineStarts(exclusiveStartInstantTime)
+        ? metaClient.getArchivedTimeline(exclusiveStartInstantTime).mergeTimeline(writeTimeline)
+        : writeTimeline;
 
     HoodieDefaultTimeline timelineSinceLastSync = (HoodieDefaultTimeline) timeline.getCommitsTimeline()
         .findInstantsAfter(exclusiveStartInstantTime, Integer.MAX_VALUE);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,6 +68,9 @@ import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.LOG_COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.SAVEPOINT_ACTION;
@@ -77,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -364,6 +369,8 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     HoodieActiveTimeline activeTimeline = new HoodieActiveTimeline(mockMetaClient);
     when(mockMetaClient.getActiveTimeline())
         .thenReturn(activeTimeline);
+    Set<String> validWriteActions = CollectionUtils.createSet(
+        COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION, LOG_COMPACTION_ACTION, REPLACE_COMMIT_ACTION);
     when(mockMetaClient.getArchivedTimeline(any()))
         .thenReturn(mockArchivedTimeline);
     HoodieDefaultTimeline mergedTimeline = new HoodieDefaultTimeline(
@@ -373,6 +380,14 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         .mergeTimeline(activeTimeline);
     when(mockArchivedTimeline.mergeTimeline(eq(activeTimeline)))
         .thenReturn(mergedTimeline);
+    HoodieDefaultTimeline mergedWriteTimeline = new HoodieDefaultTimeline(
+        archivedInstants.stream()
+            .filter(instant -> instant.getTimestamp().compareTo(startTs) >= 0),
+        i -> Option.empty())
+        .mergeTimeline(activeTimeline.getWriteTimeline());
+    when(mockArchivedTimeline.mergeTimeline(argThat(timeline -> timeline.filter(
+        instant -> instant.getAction().equals(ROLLBACK_ACTION)).countInstants() == 0)))
+        .thenReturn(mergedWriteTimeline);
 
     return mockMetaClient;
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -323,6 +323,33 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "012", "012")),
         TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs, Option.of(startTs)));
     verify(mockMetaClient, times(1)).getArchivedTimeline(any());
+
+    // Should load both archived and active timeline
+    startTs = "005";
+    mockMetaClient = prepareMetaClient(
+        Arrays.asList(
+            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "003", "003"),
+            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "007", "007"),
+            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "009", "009"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", "010"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", "011"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012", "012")),
+        Arrays.asList(new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", "001"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", "002"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "005", "005"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "006", "006"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "008", "008")),
+        startTs
+    );
+    verifyTimeline(
+        Arrays.asList(
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "006", "006"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "008", "008"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", "010"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", "011"),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "012", "012")),
+        TimelineUtils.getCommitsTimelineAfter(mockMetaClient, startTs, Option.of(startTs)));
+    verify(mockMetaClient, times(1)).getArchivedTimeline(any());
   }
 
   private HoodieTableMetaClient prepareMetaClient(

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive.testutils;
 
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
@@ -81,6 +82,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -92,6 +94,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
+import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackMetadata;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
@@ -261,6 +264,32 @@ public class HiveTestUtil {
     partitionToReplaceFileIds.put(partitions, new ArrayList<>());
     replaceCommitMetadata.setPartitionToReplaceFileIds(partitionToReplaceFileIds);
     createReplaceCommitFile(replaceCommitMetadata, instantTime);
+  }
+
+  public static void addRollbackInstantToTable(String instantTime, String commitToRollback)
+      throws IOException {
+    HoodieRollbackMetadata rollbackMetadata = HoodieRollbackMetadata.newBuilder()
+        .setVersion(1)
+        .setStartRollbackTime(instantTime)
+        .setTotalFilesDeleted(1)
+        .setTimeTakenInMillis(1000)
+        .setCommitsRollback(Collections.singletonList(commitToRollback))
+        .setPartitionMetadata(Collections.emptyMap())
+        .setInstantsRollback(Collections.emptyList())
+        .build();
+
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeRequestedRollbackFileName(instantTime),
+        "".getBytes());
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeInflightRollbackFileName(instantTime),
+        "".getBytes());
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeRollbackFileName(instantTime),
+        serializeRollbackMetadata(rollbackMetadata).get());
   }
 
   public static void createCOWTableWithSchema(String instantTime, String schemaFileName)
@@ -521,21 +550,17 @@ public class HiveTestUtil {
   }
 
   public static void createCommitFile(HoodieCommitMetadata commitMetadata, String instantTime, String basePath) throws IOException {
-    byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
-        + HoodieTimeline.makeCommitFileName(instantTime));
-    FSDataOutputStream fsout = fileSystem.create(fullPath, true);
-    fsout.write(bytes);
-    fsout.close();
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeCommitFileName(instantTime),
+        commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8));
   }
 
   public static void createReplaceCommitFile(HoodieReplaceCommitMetadata commitMetadata, String instantTime) throws IOException {
-    byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
-        + HoodieTimeline.makeReplaceFileName(instantTime));
-    FSDataOutputStream fsout = fileSystem.create(fullPath, true);
-    fsout.write(bytes);
-    fsout.close();
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeReplaceFileName(instantTime),
+        commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8));
   }
 
   public static void createCommitFileWithSchema(HoodieCommitMetadata commitMetadata, String instantTime, boolean isSimpleSchema) throws IOException {
@@ -545,19 +570,23 @@ public class HiveTestUtil {
 
   private static void createCompactionCommitFile(HoodieCommitMetadata commitMetadata, String instantTime)
       throws IOException {
-    byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
-        + HoodieTimeline.makeCommitFileName(instantTime));
-    FSDataOutputStream fsout = fileSystem.create(fullPath, true);
-    fsout.write(bytes);
-    fsout.close();
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeCommitFileName(instantTime),
+        commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8));
   }
 
   private static void createDeltaCommitFile(HoodieCommitMetadata deltaCommitMetadata, String deltaCommitTime)
       throws IOException {
-    byte[] bytes = deltaCommitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/"
-        + HoodieTimeline.makeDeltaFileName(deltaCommitTime));
+    createMetaFile(
+        basePath,
+        HoodieTimeline.makeDeltaFileName(deltaCommitTime),
+        deltaCommitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void createMetaFile(String basePath, String fileName, byte[] bytes)
+      throws IOException {
+    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/" + fileName);
     FSDataOutputStream fsout = fileSystem.create(fullPath, true);
     fsout.write(bytes);
     fsout.close();


### PR DESCRIPTION
### Change Logs

#7561 introduced a bug where in a case, the partition changes may be missed in the meta sync, e.g., the following active timeline:

```
ts3.rollback, ts50.commit, ts51.commit, ts52.commit, ...
```

and ts49.commit and ts48.commit are archived.

If ts47 is the last sync commit time, and ts48.commit or ts49.commit has partition changes, meta sync misses such changes.

This above issue is solved by a separate PR #8388 where the hive sync client returns the right timeline which gives write commits only for checking.

This PR makes sure the problematic API implementation (`TimelineUtils.getCommitsTimelineAfter`) is still fixed.

Existing tests are enhanced:
- `TestTimelineUtils.testGetCommitsTimelineAfter`: this test fails before this PR and passes after the PR.
- `TestHiveSyncTool. testBasicSync`: this test passes before and after this PR on master.  Note that, without #8388, this test would fail without this PR.

### Impact

Fixes a bug.

### Risk level

low

### Documentation Update

We need to update release notes on the regression.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
