### PR TITLE
[HUDI-6390] Fixes partition specs generation

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -521,6 +521,8 @@ public class HoodieTableSource implements
         this.schema.getColumnDataTypes().toArray(new DataType[0]),
         this.requiredPos,
         this.conf.getString(FlinkOptions.PARTITION_DEFAULT_NAME),
+        this.conf.getString(FlinkOptions.PARTITION_PATH_FIELD),
+        this.conf.getBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING),
         this.limit == NO_LIMIT_CONSTANT ? Long.MAX_VALUE : this.limit, // ParquetInputFormat always uses the limit value
         getParquetConf(this.conf, this.hadoopConf),
         this.conf.getBoolean(FlinkOptions.UTC_TIMEZONE),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -21,9 +21,9 @@ package org.apache.hudi.table.format.cow;
 import java.util.Comparator;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
-import org.apache.hudi.util.DataTypeUtils;
 
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.FilePathFilter;
@@ -34,7 +34,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.utils.SerializableConfiguration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.utils.PartitionPathUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -72,6 +71,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
   private final DataType[] fullFieldTypes;
   private final int[] selectedFields;
   private final String partDefaultName;
+  private final String partPathField;
+  private final boolean hiveStylePartitioning;
   private final boolean utcTimestamp;
   private final SerializableConfiguration conf;
   private final long limit;
@@ -92,6 +93,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       DataType[] fullFieldTypes,
       int[] selectedFields,
       String partDefaultName,
+      String partPathField,
+      boolean hiveStylePartitioning,
       long limit,
       Configuration conf,
       boolean utcTimestamp,
@@ -99,6 +102,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     super.setFilePaths(paths);
     this.limit = limit;
     this.partDefaultName = partDefaultName;
+    this.partPathField = partPathField;
+    this.hiveStylePartitioning = hiveStylePartitioning;
     this.fullFieldNames = fullFieldNames;
     this.fullFieldTypes = fullFieldTypes;
     this.selectedFields = selectedFields;
@@ -109,25 +114,14 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   @Override
   public void open(FileInputSplit fileSplit) throws IOException {
-    // generate partition specs.
-    List<String> fieldNameList = Arrays.asList(fullFieldNames);
-    LinkedHashMap<String, String> partSpec = PartitionPathUtils.extractPartitionSpecFromPath(
-        fileSplit.getPath());
-    LinkedHashMap<String, Object> partObjects = new LinkedHashMap<>();
-    partSpec.forEach((k, v) -> {
-      final int idx = fieldNameList.indexOf(k);
-      if (idx == -1) {
-        // for any rare cases that the partition field does not exist in schema,
-        // fallback to file read
-        return;
-      }
-      DataType fieldType = fullFieldTypes[idx];
-      if (!DataTypeUtils.isDatetimeType(fieldType)) {
-        // date time type partition field is formatted specifically,
-        // read directly from the data file to avoid format mismatch or precision loss
-        partObjects.put(k, DataTypeUtils.resolvePartition(partDefaultName.equals(v) ? null : v, fieldType));
-      }
-    });
+    LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
+        fileSplit.getPath().getPath(),
+        Arrays.asList(fullFieldNames),
+        Arrays.asList(fullFieldTypes),
+        this.partDefaultName,
+        this.partPathField,
+        this.hiveStylePartitioning
+    );
 
     this.itr = RecordIterators.getParquetRecordIterator(
         internalSchemaManager,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -43,7 +43,6 @@ import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.util.AvroToRowDataConverters;
-import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.RowDataProjection;
 import org.apache.hudi.util.RowDataToAvroConverters;
 import org.apache.hudi.util.StreamerUtil;
@@ -317,26 +316,14 @@ public class MergeOnReadInputFormat
   }
 
   private ClosableIterator<RowData> getBaseFileIterator(String path, int[] requiredPos) throws IOException {
-    // generate partition specs.
-    LinkedHashMap<String, String> partSpec = FilePathUtils.extractPartitionKeyValues(
-        new org.apache.hadoop.fs.Path(path).getParent(),
-        this.conf.getBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING),
-        FilePathUtils.extractPartitionKeys(this.conf));
-    LinkedHashMap<String, Object> partObjects = new LinkedHashMap<>();
-    partSpec.forEach((k, v) -> {
-      final int idx = fieldNames.indexOf(k);
-      if (idx == -1) {
-        // for any rare cases that the partition field does not exist in schema,
-        // fallback to file read
-        return;
-      }
-      DataType fieldType = fieldTypes.get(idx);
-      if (!DataTypeUtils.isDatetimeType(fieldType)) {
-        // date time type partition field is formatted specifically,
-        // read directly from the data file to avoid format mismatch or precision loss
-        partObjects.put(k, DataTypeUtils.resolvePartition(defaultPartName.equals(v) ? null : v, fieldType));
-      }
-    });
+    LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
+        path,
+        fieldNames,
+        fieldTypes,
+        conf.getString(FlinkOptions.PARTITION_DEFAULT_NAME),
+        conf.getString(FlinkOptions.PARTITION_PATH_FIELD),
+        conf.getBoolean(FlinkOptions.HIVE_STYLE_PARTITIONING)
+    );
 
     return RecordIterators.getParquetRecordIterator(
         internalSchemaManager,


### PR DESCRIPTION
### Change Logs

COW table reads partition spec from file instead of file path (when the table is not in hive style partitioning), while In MOR table partition specs generation was correct. I extracted that correct common functionality to static method generatePartitionSpecs in FilePathUtils class and called it from MergerOnReadInputFormat and CopyOnWriteInputFormat.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
