### PR TITLE
[HUDI-6399] Warn when datadog api key is wrong

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/datadog/DatadogHttpClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/datadog/DatadogHttpClient.java
@@ -84,8 +84,8 @@ public class DatadogHttpClient implements Closeable {
     try (CloseableHttpResponse response = client.execute(request)) {
       int statusCode = response.getStatusLine().getStatusCode();
       ValidationUtils.checkState(statusCode == HttpStatus.SC_OK, "API key is invalid.");
-    } catch (IOException e) {
-      throw new IllegalStateException("Failed to connect to Datadog to validate API key.", e);
+    } catch (IOException | IllegalStateException e) {
+      LOG.warn(String.format("Failed to connect to Datadog to validate API key. %s", e.getMessage()));
     }
   }
 


### PR DESCRIPTION
### Change Logs

Currently when the datadog api key is wrong the job will fail. We likely should not fail but log a warning to avoid the whole pipeline fails 

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
