### PR TITLE
[HUDI-6400] Fail when merger class not found

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
@@ -79,14 +79,7 @@ public class HoodieRecordUtils {
       return HoodieAvroRecordMerger.INSTANCE;
     } else {
       java.util.Optional<HoodieRecordMerger> mergerOpt = mergerClassList.stream()
-          .map(clazz -> {
-            try {
-              return loadRecordMerger(clazz);
-            } catch (HoodieException e) {
-              LOG.warn(String.format("Unable to init %s", clazz), e);
-              return null;
-            }
-          })
+          .map(clazz -> loadRecordMerger(clazz))
           .filter(Objects::nonNull)
           .filter(merger -> merger.getMergingStrategy().equals(recordMergerStrategy))
           .filter(merger -> recordTypeCompatibleEngine(merger.getRecordType(), engineType))

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
@@ -78,17 +78,14 @@ public class HoodieRecordUtils {
     if (mergerClassList.isEmpty() || HoodieTableMetadata.isMetadataTable(basePath)) {
       return HoodieAvroRecordMerger.INSTANCE;
     } else {
-      java.util.Optional<HoodieRecordMerger> mergerOpt = mergerClassList.stream()
+      return mergerClassList.stream()
           .map(clazz -> loadRecordMerger(clazz))
           .filter(Objects::nonNull)
           .filter(merger -> merger.getMergingStrategy().equals(recordMergerStrategy))
           .filter(merger -> recordTypeCompatibleEngine(merger.getRecordType(), engineType))
-          .findFirst();
-      if (mergerOpt.isPresent()) {
-        return mergerOpt.get();
-      } else {
-        throw new RuntimeException(String.format("No conform merger class found within %s", mergerClassList));
-      }
+          .findFirst().orElseThrow(
+              () -> new RuntimeException(String.format("No conform merger class found within %s", mergerClassList))
+          );
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A utility class for HoodieRecord.
@@ -79,7 +78,7 @@ public class HoodieRecordUtils {
     if (mergerClassList.isEmpty() || HoodieTableMetadata.isMetadataTable(basePath)) {
       return HoodieAvroRecordMerger.INSTANCE;
     } else {
-      Optional<HoodieRecordMerger> hey = mergerClassList.stream()
+      java.util.Optional<HoodieRecordMerger> mergerOpt = mergerClassList.stream()
           .map(clazz -> {
             try {
               return loadRecordMerger(clazz);
@@ -92,8 +91,8 @@ public class HoodieRecordUtils {
           .filter(merger -> merger.getMergingStrategy().equals(recordMergerStrategy))
           .filter(merger -> recordTypeCompatibleEngine(merger.getRecordType(), engineType))
           .findFirst();
-      if (hey.isPresent()) {
-        return hey.get();
+      if (mergerOpt.isPresent()) {
+        return mergerOpt.get();
       } else {
         throw new RuntimeException(String.format("No conform merger class found within %s", mergerClassList));
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
@@ -83,9 +83,8 @@ public class HoodieRecordUtils {
           .filter(Objects::nonNull)
           .filter(merger -> merger.getMergingStrategy().equals(recordMergerStrategy))
           .filter(merger -> recordTypeCompatibleEngine(merger.getRecordType(), engineType))
-          .findFirst().orElseThrow(
-              () -> new RuntimeException(String.format("No conform merger class found within %s", mergerClassList))
-          );
+          .findFirst()
+          .orElse(HoodieAvroRecordMerger.INSTANCE);
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
@@ -19,13 +19,17 @@
 package org.apache.hudi.common.util;
 
 import org.apache.avro.generic.GenericRecord;
+
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.exception.HoodieException;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestHoodieRecordUtils {
 
@@ -39,9 +43,15 @@ class TestHoodieRecordUtils {
   }
 
   @Test
+  void loadHoodieMergeWithWrongMerger() {
+    String mergeClassName = "wrong.package.MergerName";
+    assertThrows(HoodieException.class, () -> HoodieRecordUtils.loadRecordMerger(mergeClassName));
+  }
+
+  @Test
   void loadPayload() {
     String payloadClassName = DefaultHoodieRecordPayload.class.getName();
-    HoodieRecordPayload payload = HoodieRecordUtils.loadPayload(payloadClassName, new Object[]{null, 0}, GenericRecord.class, Comparable.class);
+    HoodieRecordPayload payload = HoodieRecordUtils.loadPayload(payloadClassName, new Object[] {null, 0}, GenericRecord.class, Comparable.class);
     assertEquals(payload.getClass().getName(), payloadClassName);
   }
 }


### PR DESCRIPTION
### Change Logs

Currently when the user's specified class does not exists, then this silently fall back to the default merger. It can corrupt silently the data by applying wrong logic and should fail instead.

### Impact

Fail when merge class not found, instead of using default merger that might corrupt the data.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
