### PR TITLE
Change image hudi-hadoop_2.8.4-history version to linux-arm64-0.10.1 adapt to MacOS M1

### DIFF
--- a/docker/compose/docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml
@@ -63,7 +63,8 @@ services:
       - namenode
 
   historyserver:
-    image: apachehudi/hudi-hadoop_2.8.4-history:latest
+    image: apachehudi/hudi-hadoop_2.8.4-history:linux-arm64-0.10.1
+    platform: linux/arm64
     hostname: historyserver
     container_name: historyserver
     environment:


### PR DESCRIPTION
### Change Logs

Change image hudi-hadoop_2.8.4-history version to linux-arm64-0.10.1 adapt to MacOS M1

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
