### PR TITLE
[HUDI-6406] Pass in Spark Engine Context Wrapper for DeltaSync instead of spark engine context

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -181,6 +181,16 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
     return Collections.emptyList();
   }
 
+  @Override
+  public void cancelJob(String jobId) {
+    // no operation for now
+  }
+
+  @Override
+  public void cancelAllJobs() {
+    // no operation for now
+  }
+
   /**
    * Override the flink context supplier to return constant write token.
    */

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/client/common/HoodieJavaEngineContext.java
@@ -161,4 +161,14 @@ public class HoodieJavaEngineContext extends HoodieEngineContext {
   public List<Integer> removeCachedDataIds(HoodieDataCacheKey cacheKey) {
     return Collections.emptyList();
   }
+
+  @Override
+  public void cancelJob(String jobId) {
+    // no operation for now
+  }
+
+  @Override
+  public void cancelAllJobs() {
+    // no operation for now
+  }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -219,6 +219,16 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
     }
   }
 
+  @Override
+  public void cancelJob(String groupId) {
+    javaSparkContext.cancelJobGroup(groupId);
+  }
+
+  @Override
+  public void cancelAllJobs() {
+    javaSparkContext.cancelAllJobs();
+  }
+
   public SparkConf getConf() {
     return javaSparkContext.getConf();
   }
@@ -229,13 +239,5 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
 
   public <T> JavaRDD<T> emptyRDD() {
     return javaSparkContext.emptyRDD();
-  }
-
-  public void cancelJobGroup(String groupId) {
-    javaSparkContext.cancelJobGroup(groupId);
-  }
-
-  public void cancelAllJobs() {
-    javaSparkContext.cancelAllJobs();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -223,10 +223,6 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
     return javaSparkContext.getConf();
   }
 
-  public SparkConf getSparkConf() {
-    return javaSparkContext.sc().getConf();
-  }
-
   public Configuration hadoopConfiguration() {
     return javaSparkContext.hadoopConfiguration();
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -37,6 +37,9 @@ import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.data.HoodieSparkLongAccumulator;
 import org.apache.hudi.exception.HoodieException;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.sql.SQLContext;
@@ -76,6 +79,10 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   }
 
   public JavaSparkContext getJavaSparkContext() {
+    return javaSparkContext;
+  }
+
+  public JavaSparkContext jsc() {
     return javaSparkContext;
   }
 
@@ -165,9 +172,9 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
 
   @Override
   public void setProperty(EngineProperty key, String value) {
-    if (key == EngineProperty.COMPACTION_POOL_NAME) {
-      javaSparkContext.setLocalProperty("spark.scheduler.pool", value);
-    } else if (key == EngineProperty.CLUSTERING_POOL_NAME) {
+    if (key.equals(EngineProperty.COMPACTION_POOL_NAME)
+        || key.equals(EngineProperty.CLUSTERING_POOL_NAME)
+        || key.equals(EngineProperty.DELTASYNC_POOL_NAME)) {
       javaSparkContext.setLocalProperty("spark.scheduler.pool", value);
     } else {
       throw new HoodieException("Unknown engine property :" + key);
@@ -210,5 +217,21 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
       List<Integer> removed = cachedRddIds.remove(cacheKey);
       return removed == null ? Collections.emptyList() : removed;
     }
+  }
+
+  public SparkConf getConf() {
+    return javaSparkContext.getConf();
+  }
+
+  public SparkConf getSparkConf() {
+    return javaSparkContext.sc().getConf();
+  }
+
+  public Configuration hadoopConfiguration() {
+    return javaSparkContext.hadoopConfiguration();
+  }
+
+  public <T> JavaRDD<T> emptyRDD() {
+    return javaSparkContext.emptyRDD();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -230,4 +230,12 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   public <T> JavaRDD<T> emptyRDD() {
     return javaSparkContext.emptyRDD();
   }
+
+  public void cancelJobGroup(String groupId) {
+    javaSparkContext.cancelJobGroup(groupId);
+  }
+
+  public void cancelAllJobs() {
+    javaSparkContext.cancelAllJobs();
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/EngineProperty.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/EngineProperty.java
@@ -31,5 +31,6 @@ public enum EngineProperty {
   // Amount of total memory available to each engine executor
   TOTAL_MEMORY_AVAILABLE,
   // Fraction of that memory, that is already in use by the engine
-  MEMORY_FRACTION_IN_USE
+  MEMORY_FRACTION_IN_USE,
+  DELTASYNC_POOL_NAME
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
@@ -101,4 +101,8 @@ public abstract class HoodieEngineContext {
   public abstract List<Integer> getCachedDataIds(HoodieDataCacheKey cacheKey);
 
   public abstract List<Integer> removeCachedDataIds(HoodieDataCacheKey cacheKey);
+
+  public abstract void cancelJob(String jobId);
+
+  public abstract void cancelAllJobs();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieLocalEngineContext.java
@@ -160,4 +160,14 @@ public final class HoodieLocalEngineContext extends HoodieEngineContext {
   public List<Integer> removeCachedDataIds(HoodieDataCacheKey cacheKey) {
     return Collections.emptyList();
   }
+
+  @Override
+  public void cancelJob(String jobId) {
+    // no operation for now
+  }
+
+  @Override
+  public void cancelAllJobs() {
+    // no operation for now
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.util.VisibleForTesting;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 
 /**
@@ -45,7 +44,7 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> {
   public static String ERROR_TABLE_CURRUPT_RECORD_COL_NAME = "_corrupt_record";
 
   public BaseErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-							  TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
+                              TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
@@ -44,7 +44,7 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> {
   public static String ERROR_TABLE_CURRUPT_RECORD_COL_NAME = "_corrupt_record";
 
   public BaseErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-                              TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
+      TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
@@ -44,7 +44,7 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> {
   public static String ERROR_TABLE_CURRUPT_RECORD_COL_NAME = "_corrupt_record";
 
   public BaseErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-                              TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
+                              TypedProperties props, HoodieSparkEngineContext hoodieSparkContext, FileSystem fs) {
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.util.Option;
@@ -44,7 +45,7 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> {
   public static String ERROR_TABLE_CURRUPT_RECORD_COL_NAME = "_corrupt_record";
 
   public BaseErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-                                   TypedProperties props, JavaSparkContext jssc, FileSystem fs) {
+							  TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/BaseErrorTableWriter.java
@@ -44,7 +44,7 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> {
   public static String ERROR_TABLE_CURRUPT_RECORD_COL_NAME = "_corrupt_record";
 
   public BaseErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-      TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
+                              TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -284,14 +284,14 @@ public class DeltaSync implements Serializable, Closeable {
 
   @Deprecated
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-      TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
-      Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+                   TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
+                   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
     this(cfg, sparkSession, schemaProvider, props, new HoodieSparkEngineContext(jssc), fs, conf, onInitializingHoodieWriteClient);
   }
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-      TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs, Configuration conf,
-      Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+                   TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs, Configuration conf,
+                   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
     this.cfg = cfg;
     this.sparkEngineContext = sparkEngineContext;
     this.jssc = sparkEngineContext.getJavaSparkContext();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -210,7 +210,7 @@ public class DeltaSync implements Serializable, Closeable {
   /**
    * Spark context Wrapper.
    */
-  private transient HoodieSparkEngineContext sparkContext;
+  private final transient HoodieSparkEngineContext sparkContext;
 
   /**
    * Spark Session.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -208,6 +208,11 @@ public class DeltaSync implements Serializable, Closeable {
   private transient FileSystem fs;
 
   /**
+   * Hoodie Spark Engine Context.
+   */
+  private transient HoodieSparkEngineContext sparkEngineContext;
+
+  /**
    * Spark context.
    */
   private transient JavaSparkContext jssc;
@@ -224,7 +229,7 @@ public class DeltaSync implements Serializable, Closeable {
 
   /**
    * Bag of properties with source, hoodie client, key generator etc.
-   *
+   * <p>
    * NOTE: These properties are already consolidated w/ CLI provided config-overrides
    */
   private final TypedProperties props;
@@ -266,7 +271,7 @@ public class DeltaSync implements Serializable, Closeable {
 
   /**
    * Unique identifier of the deltastreamer
-   * */
+   */
   private transient Option<String> multiwriterIdentifier;
 
   /**
@@ -277,43 +282,50 @@ public class DeltaSync implements Serializable, Closeable {
 
   private final boolean autoGenerateRecordKeys;
 
+  @Deprecated
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-                   TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
-                   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+				   TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
+				   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+	this(cfg, sparkSession, schemaProvider, props, new HoodieSparkEngineContext(jssc), fs, conf, onInitializingHoodieWriteClient);
+  }
 
-    this.cfg = cfg;
-    this.jssc = jssc;
-    this.sparkSession = sparkSession;
-    this.fs = fs;
-    this.onInitializingHoodieWriteClient = onInitializingHoodieWriteClient;
-    this.props = props;
-    this.userProvidedSchemaProvider = schemaProvider;
-    this.processedSchema = new SchemaSet();
-    this.autoGenerateRecordKeys = KeyGenUtils.enableAutoGenerateRecordKeys(props);
-    this.keyGenClassName = getKeyGeneratorClassName(new TypedProperties(props));
-    refreshTimeline();
-    // Register User Provided schema first
-    registerAvroSchemas(schemaProvider);
+  public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
+				   TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs, Configuration conf,
+				   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+	this.cfg = cfg;
+	this.sparkEngineContext = sparkEngineContext;
+	this.jssc = sparkEngineContext.getJavaSparkContext();
+	this.sparkSession = sparkSession;
+	this.fs = fs;
+	this.onInitializingHoodieWriteClient = onInitializingHoodieWriteClient;
+	this.props = props;
+	this.userProvidedSchemaProvider = schemaProvider;
+	this.processedSchema = new SchemaSet();
+	this.autoGenerateRecordKeys = KeyGenUtils.enableAutoGenerateRecordKeys(props);
+	this.keyGenClassName = getKeyGeneratorClassName(new TypedProperties(props));
+	refreshTimeline();
+	// Register User Provided schema first
+	registerAvroSchemas(schemaProvider);
 
 
-    this.metrics = (HoodieIngestionMetrics) ReflectionUtils.loadClass(cfg.ingestionMetricsClass, getHoodieClientConfig(this.schemaProvider));
-    this.hoodieMetrics = new HoodieMetrics(getHoodieClientConfig(this.schemaProvider));
-    this.conf = conf;
-    String id = conf.get(MUTLI_WRITER_SOURCE_CHECKPOINT_ID.key());
-    if (StringUtils.isNullOrEmpty(id)) {
-      id = props.getProperty(MUTLI_WRITER_SOURCE_CHECKPOINT_ID.key());
-    }
-    this.multiwriterIdentifier = StringUtils.isNullOrEmpty(id) ? Option.empty() : Option.of(id);
-    if (props.getBoolean(ERROR_TABLE_ENABLED.key(),ERROR_TABLE_ENABLED.defaultValue())) {
-      this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(cfg, sparkSession, props, jssc, fs);
-      this.errorWriteFailureStrategy = ErrorTableUtils.getErrorWriteFailureStrategy(props);
-    }
-    this.formatAdapter = new SourceFormatAdapter(
-        UtilHelpers.createSource(cfg.sourceClassName, props, jssc, sparkSession, schemaProvider, metrics),
-        this.errorTableWriter, Option.of(props));
+	this.metrics = (HoodieIngestionMetrics) ReflectionUtils.loadClass(cfg.ingestionMetricsClass, getHoodieClientConfig(this.schemaProvider));
+	this.hoodieMetrics = new HoodieMetrics(getHoodieClientConfig(this.schemaProvider));
+	this.conf = conf;
+	String id = conf.get(MUTLI_WRITER_SOURCE_CHECKPOINT_ID.key());
+	if (StringUtils.isNullOrEmpty(id)) {
+	  id = props.getProperty(MUTLI_WRITER_SOURCE_CHECKPOINT_ID.key());
+	}
+	this.multiwriterIdentifier = StringUtils.isNullOrEmpty(id) ? Option.empty() : Option.of(id);
+	if (props.getBoolean(ERROR_TABLE_ENABLED.key(), ERROR_TABLE_ENABLED.defaultValue())) {
+	  this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(cfg, sparkSession, props, jssc, fs);
+	  this.errorWriteFailureStrategy = ErrorTableUtils.getErrorWriteFailureStrategy(props);
+	}
+	this.formatAdapter = new SourceFormatAdapter(
+		UtilHelpers.createSource(cfg.sourceClassName, props, jssc, sparkSession, schemaProvider, metrics),
+		this.errorTableWriter, Option.of(props));
 
-    this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames),
-        Option.ofNullable(schemaProvider).map(SchemaProvider::getSourceSchema), this.errorTableWriter.isPresent());
+	this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames),
+		Option.ofNullable(schemaProvider).map(SchemaProvider::getSourceSchema), this.errorTableWriter.isPresent());
 
   }
 
@@ -323,358 +335,358 @@ public class DeltaSync implements Serializable, Closeable {
    * @throws IOException in case of any IOException
    */
   public void refreshTimeline() throws IOException {
-    if (fs.exists(new Path(cfg.targetBasePath))) {
-      try {
-        HoodieTableMetaClient meta = HoodieTableMetaClient.builder()
-            .setConf(new Configuration(fs.getConf()))
-            .setBasePath(cfg.targetBasePath)
-            .setPayloadClassName(cfg.payloadClassName)
-            .setRecordMergerStrategy(props.getProperty(HoodieWriteConfig.RECORD_MERGER_STRATEGY.key(), HoodieWriteConfig.RECORD_MERGER_STRATEGY.defaultValue()))
-            .build();
-        switch (meta.getTableType()) {
-          case COPY_ON_WRITE:
-          case MERGE_ON_READ:
-            // we can use getCommitsTimeline for both COW and MOR here, because for COW there is no deltacommit
-            this.commitsTimelineOpt = Option.of(meta.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
-            this.allCommitsTimelineOpt = Option.of(meta.getActiveTimeline().getAllCommitsTimeline());
-            break;
-          default:
-            throw new HoodieException("Unsupported table type :" + meta.getTableType());
-        }
-      } catch (HoodieIOException e) {
-        LOG.warn("Full exception msg " + e.getMessage());
-        if (e.getMessage().contains("Could not load Hoodie properties") && e.getMessage().contains(HoodieTableConfig.HOODIE_PROPERTIES_FILE)) {
-          String basePathWithForwardSlash = cfg.targetBasePath.endsWith("/") ? cfg.targetBasePath : String.format("%s/", cfg.targetBasePath);
-          String pathToHoodieProps = String.format("%s%s/%s", basePathWithForwardSlash, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableConfig.HOODIE_PROPERTIES_FILE);
-          String pathToHoodiePropsBackup = String.format("%s%s/%s", basePathWithForwardSlash, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableConfig.HOODIE_PROPERTIES_FILE_BACKUP);
-          boolean hoodiePropertiesExists = fs.exists(new Path(basePathWithForwardSlash))
-              && fs.exists(new Path(pathToHoodieProps))
-              && fs.exists(new Path(pathToHoodiePropsBackup));
-          if (!hoodiePropertiesExists) {
-            LOG.warn("Base path exists, but table is not fully initialized. Re-initializing again");
-            initializeEmptyTable();
-            // reload the timeline from metaClient and validate that its empty table. If there are any instants found, then we should fail the pipeline, bcoz hoodie.properties got deleted by mistake.
-            HoodieTableMetaClient metaClientToValidate = HoodieTableMetaClient.builder().setConf(new Configuration(fs.getConf())).setBasePath(cfg.targetBasePath).build();
-            if (metaClientToValidate.reloadActiveTimeline().countInstants() > 0) {
-              // Deleting the recreated hoodie.properties and throwing exception.
-              fs.delete(new Path(String.format("%s%s/%s", basePathWithForwardSlash, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableConfig.HOODIE_PROPERTIES_FILE)));
-              throw new HoodieIOException("hoodie.properties is missing. Likely due to some external entity. Please populate the hoodie.properties and restart the pipeline. ",
-                  e.getIOException());
-            }
-          }
-        } else {
-          throw e;
-        }
-      }
-    } else {
-      initializeEmptyTable();
-    }
+	if (fs.exists(new Path(cfg.targetBasePath))) {
+	  try {
+		HoodieTableMetaClient meta = HoodieTableMetaClient.builder()
+			.setConf(new Configuration(fs.getConf()))
+			.setBasePath(cfg.targetBasePath)
+			.setPayloadClassName(cfg.payloadClassName)
+			.setRecordMergerStrategy(props.getProperty(HoodieWriteConfig.RECORD_MERGER_STRATEGY.key(), HoodieWriteConfig.RECORD_MERGER_STRATEGY.defaultValue()))
+			.build();
+		switch (meta.getTableType()) {
+		  case COPY_ON_WRITE:
+		  case MERGE_ON_READ:
+			// we can use getCommitsTimeline for both COW and MOR here, because for COW there is no deltacommit
+			this.commitsTimelineOpt = Option.of(meta.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
+			this.allCommitsTimelineOpt = Option.of(meta.getActiveTimeline().getAllCommitsTimeline());
+			break;
+		  default:
+			throw new HoodieException("Unsupported table type :" + meta.getTableType());
+		}
+	  } catch (HoodieIOException e) {
+		LOG.warn("Full exception msg " + e.getMessage());
+		if (e.getMessage().contains("Could not load Hoodie properties") && e.getMessage().contains(HoodieTableConfig.HOODIE_PROPERTIES_FILE)) {
+		  String basePathWithForwardSlash = cfg.targetBasePath.endsWith("/") ? cfg.targetBasePath : String.format("%s/", cfg.targetBasePath);
+		  String pathToHoodieProps = String.format("%s%s/%s", basePathWithForwardSlash, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableConfig.HOODIE_PROPERTIES_FILE);
+		  String pathToHoodiePropsBackup = String.format("%s%s/%s", basePathWithForwardSlash, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableConfig.HOODIE_PROPERTIES_FILE_BACKUP);
+		  boolean hoodiePropertiesExists = fs.exists(new Path(basePathWithForwardSlash))
+			  && fs.exists(new Path(pathToHoodieProps))
+			  && fs.exists(new Path(pathToHoodiePropsBackup));
+		  if (!hoodiePropertiesExists) {
+			LOG.warn("Base path exists, but table is not fully initialized. Re-initializing again");
+			initializeEmptyTable();
+			// reload the timeline from metaClient and validate that its empty table. If there are any instants found, then we should fail the pipeline, bcoz hoodie.properties got deleted by mistake.
+			HoodieTableMetaClient metaClientToValidate = HoodieTableMetaClient.builder().setConf(new Configuration(fs.getConf())).setBasePath(cfg.targetBasePath).build();
+			if (metaClientToValidate.reloadActiveTimeline().countInstants() > 0) {
+			  // Deleting the recreated hoodie.properties and throwing exception.
+			  fs.delete(new Path(String.format("%s%s/%s", basePathWithForwardSlash, HoodieTableMetaClient.METAFOLDER_NAME, HoodieTableConfig.HOODIE_PROPERTIES_FILE)));
+			  throw new HoodieIOException("hoodie.properties is missing. Likely due to some external entity. Please populate the hoodie.properties and restart the pipeline. ",
+				  e.getIOException());
+			}
+		  }
+		} else {
+		  throw e;
+		}
+	  }
+	} else {
+	  initializeEmptyTable();
+	}
   }
 
   private void initializeEmptyTable() throws IOException {
-    this.commitsTimelineOpt = Option.empty();
-    this.allCommitsTimelineOpt = Option.empty();
-    String partitionColumns = SparkKeyGenUtils.getPartitionColumns(props);
-    HoodieTableMetaClient.withPropertyBuilder()
-        .setTableType(cfg.tableType)
-        .setTableName(cfg.targetTableName)
-        .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())
-        .setPayloadClassName(cfg.payloadClassName)
-        .setBaseFileFormat(cfg.baseFileFormat)
-        .setPartitionFields(partitionColumns)
-        .setRecordKeyFields(props.getProperty(DataSourceWriteOptions.RECORDKEY_FIELD().key()))
-        .setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
-            HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))
-        .setKeyGeneratorClassProp(keyGenClassName)
-        .setPreCombineField(cfg.sourceOrderingField)
-        .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
-            HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
-        .setCDCEnabled(props.getBoolean(HoodieTableConfig.CDC_ENABLED.key(),
-            HoodieTableConfig.CDC_ENABLED.defaultValue()))
-        .setCDCSupplementalLoggingMode(props.getString(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.key(),
-            HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.defaultValue()))
-        .setShouldDropPartitionColumns(isDropPartitionColumns())
-        .setHiveStylePartitioningEnable(props.getBoolean(HIVE_STYLE_PARTITIONING_ENABLE.key(),
-            Boolean.parseBoolean(HIVE_STYLE_PARTITIONING_ENABLE.defaultValue())))
-        .setUrlEncodePartitioning(props.getBoolean(URL_ENCODE_PARTITIONING.key(),
-            Boolean.parseBoolean(URL_ENCODE_PARTITIONING.defaultValue())))
-        .initTable(new Configuration(jssc.hadoopConfiguration()),
-            cfg.targetBasePath);
+	this.commitsTimelineOpt = Option.empty();
+	this.allCommitsTimelineOpt = Option.empty();
+	String partitionColumns = SparkKeyGenUtils.getPartitionColumns(props);
+	HoodieTableMetaClient.withPropertyBuilder()
+		.setTableType(cfg.tableType)
+		.setTableName(cfg.targetTableName)
+		.setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())
+		.setPayloadClassName(cfg.payloadClassName)
+		.setBaseFileFormat(cfg.baseFileFormat)
+		.setPartitionFields(partitionColumns)
+		.setRecordKeyFields(props.getProperty(DataSourceWriteOptions.RECORDKEY_FIELD().key()))
+		.setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
+			HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))
+		.setKeyGeneratorClassProp(keyGenClassName)
+		.setPreCombineField(cfg.sourceOrderingField)
+		.setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
+			HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
+		.setCDCEnabled(props.getBoolean(HoodieTableConfig.CDC_ENABLED.key(),
+			HoodieTableConfig.CDC_ENABLED.defaultValue()))
+		.setCDCSupplementalLoggingMode(props.getString(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.key(),
+			HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.defaultValue()))
+		.setShouldDropPartitionColumns(isDropPartitionColumns())
+		.setHiveStylePartitioningEnable(props.getBoolean(HIVE_STYLE_PARTITIONING_ENABLE.key(),
+			Boolean.parseBoolean(HIVE_STYLE_PARTITIONING_ENABLE.defaultValue())))
+		.setUrlEncodePartitioning(props.getBoolean(URL_ENCODE_PARTITIONING.key(),
+			Boolean.parseBoolean(URL_ENCODE_PARTITIONING.defaultValue())))
+		.initTable(new Configuration(jssc.hadoopConfiguration()),
+			cfg.targetBasePath);
   }
 
   /**
    * Run one round of delta sync and return new compaction instant if one got scheduled.
    */
   public Pair<Option<String>, JavaRDD<WriteStatus>> syncOnce() throws IOException {
-    Pair<Option<String>, JavaRDD<WriteStatus>> result = null;
-    Timer.Context overallTimerContext = metrics.getOverallTimerContext();
+	Pair<Option<String>, JavaRDD<WriteStatus>> result = null;
+	Timer.Context overallTimerContext = metrics.getOverallTimerContext();
 
-    // Refresh Timeline
-    refreshTimeline();
-    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+	// Refresh Timeline
+	refreshTimeline();
+	String instantTime = HoodieActiveTimeline.createNewInstantTime();
 
-    Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> srcRecordsWithCkpt = readFromSource(instantTime);
+	Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> srcRecordsWithCkpt = readFromSource(instantTime);
 
-    if (srcRecordsWithCkpt != null) {
-      final JavaRDD<HoodieRecord> recordsFromSource = srcRecordsWithCkpt.getRight().getRight();
-      // this is the first input batch. If schemaProvider not set, use it and register Avro Schema and start
-      // compactor
-      if (writeClient == null) {
-        this.schemaProvider = srcRecordsWithCkpt.getKey();
-        // Setup HoodieWriteClient and compaction now that we decided on schema
-        setupWriteClient(recordsFromSource);
-      } else {
-        Schema newSourceSchema = srcRecordsWithCkpt.getKey().getSourceSchema();
-        Schema newTargetSchema = srcRecordsWithCkpt.getKey().getTargetSchema();
-        if (!(processedSchema.isSchemaPresent(newSourceSchema))
-            || !(processedSchema.isSchemaPresent(newTargetSchema))) {
-          LOG.info("Seeing new schema. Source :" + newSourceSchema.toString(true)
-              + ", Target :" + newTargetSchema.toString(true));
-          // We need to recreate write client with new schema and register them.
-          reInitWriteClient(newSourceSchema, newTargetSchema, recordsFromSource);
-          processedSchema.addSchema(newSourceSchema);
-          processedSchema.addSchema(newTargetSchema);
-        }
-      }
+	if (srcRecordsWithCkpt != null) {
+	  final JavaRDD<HoodieRecord> recordsFromSource = srcRecordsWithCkpt.getRight().getRight();
+	  // this is the first input batch. If schemaProvider not set, use it and register Avro Schema and start
+	  // compactor
+	  if (writeClient == null) {
+		this.schemaProvider = srcRecordsWithCkpt.getKey();
+		// Setup HoodieWriteClient and compaction now that we decided on schema
+		setupWriteClient(recordsFromSource);
+	  } else {
+		Schema newSourceSchema = srcRecordsWithCkpt.getKey().getSourceSchema();
+		Schema newTargetSchema = srcRecordsWithCkpt.getKey().getTargetSchema();
+		if (!(processedSchema.isSchemaPresent(newSourceSchema))
+			|| !(processedSchema.isSchemaPresent(newTargetSchema))) {
+		  LOG.info("Seeing new schema. Source :" + newSourceSchema.toString(true)
+			  + ", Target :" + newTargetSchema.toString(true));
+		  // We need to recreate write client with new schema and register them.
+		  reInitWriteClient(newSourceSchema, newTargetSchema, recordsFromSource);
+		  processedSchema.addSchema(newSourceSchema);
+		  processedSchema.addSchema(newTargetSchema);
+		}
+	  }
 
-      // complete the pending compaction before writing to sink
-      if (cfg.retryLastPendingInlineCompactionJob && getHoodieClientConfig(this.schemaProvider).inlineCompactionEnabled()) {
-        Option<String> pendingCompactionInstant = getLastPendingCompactionInstant(allCommitsTimelineOpt);
-        if (pendingCompactionInstant.isPresent()) {
-          HoodieWriteMetadata<JavaRDD<WriteStatus>> writeMetadata = writeClient.compact(pendingCompactionInstant.get());
-          writeClient.commitCompaction(pendingCompactionInstant.get(), writeMetadata.getCommitMetadata().get(), Option.empty());
-          refreshTimeline();
-          reInitWriteClient(schemaProvider.getSourceSchema(), schemaProvider.getTargetSchema(), null);
-        }
-      } else if (cfg.retryLastPendingInlineClusteringJob && getHoodieClientConfig(this.schemaProvider).inlineClusteringEnabled()) {
-        // complete the pending clustering before writing to sink
-        Option<String> pendingClusteringInstant = getLastPendingClusteringInstant(allCommitsTimelineOpt);
-        if (pendingClusteringInstant.isPresent()) {
-          writeClient.cluster(pendingClusteringInstant.get());
-        }
-      }
+	  // complete the pending compaction before writing to sink
+	  if (cfg.retryLastPendingInlineCompactionJob && getHoodieClientConfig(this.schemaProvider).inlineCompactionEnabled()) {
+		Option<String> pendingCompactionInstant = getLastPendingCompactionInstant(allCommitsTimelineOpt);
+		if (pendingCompactionInstant.isPresent()) {
+		  HoodieWriteMetadata<JavaRDD<WriteStatus>> writeMetadata = writeClient.compact(pendingCompactionInstant.get());
+		  writeClient.commitCompaction(pendingCompactionInstant.get(), writeMetadata.getCommitMetadata().get(), Option.empty());
+		  refreshTimeline();
+		  reInitWriteClient(schemaProvider.getSourceSchema(), schemaProvider.getTargetSchema(), null);
+		}
+	  } else if (cfg.retryLastPendingInlineClusteringJob && getHoodieClientConfig(this.schemaProvider).inlineClusteringEnabled()) {
+		// complete the pending clustering before writing to sink
+		Option<String> pendingClusteringInstant = getLastPendingClusteringInstant(allCommitsTimelineOpt);
+		if (pendingClusteringInstant.isPresent()) {
+		  writeClient.cluster(pendingClusteringInstant.get());
+		}
+	  }
 
-      result = writeToSink(instantTime, recordsFromSource,
-          srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
-    }
+	  result = writeToSink(instantTime, recordsFromSource,
+		  srcRecordsWithCkpt.getRight().getLeft(), metrics, overallTimerContext);
+	}
 
-    metrics.updateDeltaStreamerSyncMetrics(System.currentTimeMillis());
-    return result;
+	metrics.updateDeltaStreamerSyncMetrics(System.currentTimeMillis());
+	return result;
   }
 
   private Option<String> getLastPendingClusteringInstant(Option<HoodieTimeline> commitTimelineOpt) {
-    if (commitTimelineOpt.isPresent()) {
-      Option<HoodieInstant> pendingClusteringInstant = commitTimelineOpt.get().filterPendingReplaceTimeline().lastInstant();
-      return pendingClusteringInstant.isPresent() ? Option.of(pendingClusteringInstant.get().getTimestamp()) : Option.empty();
-    }
-    return Option.empty();
+	if (commitTimelineOpt.isPresent()) {
+	  Option<HoodieInstant> pendingClusteringInstant = commitTimelineOpt.get().filterPendingReplaceTimeline().lastInstant();
+	  return pendingClusteringInstant.isPresent() ? Option.of(pendingClusteringInstant.get().getTimestamp()) : Option.empty();
+	}
+	return Option.empty();
   }
 
   private Option<String> getLastPendingCompactionInstant(Option<HoodieTimeline> commitTimelineOpt) {
-    if (commitTimelineOpt.isPresent()) {
-      Option<HoodieInstant> pendingCompactionInstant = commitTimelineOpt.get().filterPendingCompactionTimeline().lastInstant();
-      return pendingCompactionInstant.isPresent() ? Option.of(pendingCompactionInstant.get().getTimestamp()) : Option.empty();
-    }
-    return Option.empty();
+	if (commitTimelineOpt.isPresent()) {
+	  Option<HoodieInstant> pendingCompactionInstant = commitTimelineOpt.get().filterPendingCompactionTimeline().lastInstant();
+	  return pendingCompactionInstant.isPresent() ? Option.of(pendingCompactionInstant.get().getTimestamp()) : Option.empty();
+	}
+	return Option.empty();
   }
 
   /**
    * Read from Upstream Source and apply transformation if needed.
    *
-   * @return Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> Input data read from upstream source, consists
+   * @return Pair<SchemaProvider, Pair < String, JavaRDD < HoodieRecord>>> Input data read from upstream source, consists
    * of schemaProvider, checkpointStr and hoodieRecord
    * @throws Exception in case of any Exception
    */
   public Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> readFromSource(String instantTime) throws IOException {
-    // Retrieve the previous round checkpoints, if any
-    Option<String> resumeCheckpointStr = Option.empty();
-    if (commitsTimelineOpt.isPresent()) {
-      resumeCheckpointStr = getCheckpointToResume(commitsTimelineOpt);
-    }
+	// Retrieve the previous round checkpoints, if any
+	Option<String> resumeCheckpointStr = Option.empty();
+	if (commitsTimelineOpt.isPresent()) {
+	  resumeCheckpointStr = getCheckpointToResume(commitsTimelineOpt);
+	}
 
-    LOG.debug("Checkpoint from config: " + cfg.checkpoint);
-    if (!resumeCheckpointStr.isPresent() && cfg.checkpoint != null) {
-      resumeCheckpointStr = Option.of(cfg.checkpoint);
-    }
-    LOG.info("Checkpoint to resume from : " + resumeCheckpointStr);
+	LOG.debug("Checkpoint from config: " + cfg.checkpoint);
+	if (!resumeCheckpointStr.isPresent() && cfg.checkpoint != null) {
+	  resumeCheckpointStr = Option.of(cfg.checkpoint);
+	}
+	LOG.info("Checkpoint to resume from : " + resumeCheckpointStr);
 
-    int maxRetryCount = cfg.retryOnSourceFailures ? cfg.maxRetryCount : 1;
-    int curRetryCount = 0;
-    Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> sourceDataToSync = null;
-    while (curRetryCount++ < maxRetryCount && sourceDataToSync == null) {
-      try {
-        sourceDataToSync = fetchFromSource(resumeCheckpointStr, instantTime);
-      } catch (HoodieSourceTimeoutException e) {
-        if (curRetryCount >= maxRetryCount) {
-          throw e;
-        }
-        try {
-          LOG.error("Exception thrown while fetching data from source. Msg : " + e.getMessage() + ", class : " + e.getClass() + ", cause : " + e.getCause());
-          LOG.error("Sleeping for " + (cfg.retryIntervalSecs) + " before retrying again. Current retry count " + curRetryCount + ", max retry count " + cfg.maxRetryCount);
-          Thread.sleep(cfg.retryIntervalSecs * 1000);
-        } catch (InterruptedException ex) {
-          LOG.error("Ignoring InterruptedException while waiting to retry on source failure " + e.getMessage());
-        }
-      }
-    }
-    return sourceDataToSync;
+	int maxRetryCount = cfg.retryOnSourceFailures ? cfg.maxRetryCount : 1;
+	int curRetryCount = 0;
+	Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> sourceDataToSync = null;
+	while (curRetryCount++ < maxRetryCount && sourceDataToSync == null) {
+	  try {
+		sourceDataToSync = fetchFromSource(resumeCheckpointStr, instantTime);
+	  } catch (HoodieSourceTimeoutException e) {
+		if (curRetryCount >= maxRetryCount) {
+		  throw e;
+		}
+		try {
+		  LOG.error("Exception thrown while fetching data from source. Msg : " + e.getMessage() + ", class : " + e.getClass() + ", cause : " + e.getCause());
+		  LOG.error("Sleeping for " + (cfg.retryIntervalSecs) + " before retrying again. Current retry count " + curRetryCount + ", max retry count " + cfg.maxRetryCount);
+		  Thread.sleep(cfg.retryIntervalSecs * 1000);
+		} catch (InterruptedException ex) {
+		  LOG.error("Ignoring InterruptedException while waiting to retry on source failure " + e.getMessage());
+		}
+	  }
+	}
+	return sourceDataToSync;
   }
 
   private Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> fetchFromSource(Option<String> resumeCheckpointStr, String instantTime) {
-    HoodieRecordType recordType = createRecordMerger(props).getRecordType();
-    if (recordType == HoodieRecordType.SPARK && HoodieTableType.valueOf(cfg.tableType) == HoodieTableType.MERGE_ON_READ
-        && HoodieLogBlockType.fromId(props.getProperty(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "avro"))
-        != HoodieLogBlockType.PARQUET_DATA_BLOCK) {
-      throw new UnsupportedOperationException("Spark record only support parquet log.");
-    }
+	HoodieRecordType recordType = createRecordMerger(props).getRecordType();
+	if (recordType == HoodieRecordType.SPARK && HoodieTableType.valueOf(cfg.tableType) == HoodieTableType.MERGE_ON_READ
+		&& HoodieLogBlockType.fromId(props.getProperty(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "avro"))
+		!= HoodieLogBlockType.PARQUET_DATA_BLOCK) {
+	  throw new UnsupportedOperationException("Spark record only support parquet log.");
+	}
 
-    final Option<JavaRDD<GenericRecord>> avroRDDOptional;
-    final String checkpointStr;
-    SchemaProvider schemaProvider;
-    if (transformer.isPresent()) {
-      // Transformation is needed. Fetch New rows in Row Format, apply transformation and then convert them
-      // to generic records for writing
-      InputBatch<Dataset<Row>> dataAndCheckpoint =
-          formatAdapter.fetchNewDataInRowFormat(resumeCheckpointStr, cfg.sourceLimit);
+	final Option<JavaRDD<GenericRecord>> avroRDDOptional;
+	final String checkpointStr;
+	SchemaProvider schemaProvider;
+	if (transformer.isPresent()) {
+	  // Transformation is needed. Fetch New rows in Row Format, apply transformation and then convert them
+	  // to generic records for writing
+	  InputBatch<Dataset<Row>> dataAndCheckpoint =
+		  formatAdapter.fetchNewDataInRowFormat(resumeCheckpointStr, cfg.sourceLimit);
 
-      Option<Dataset<Row>> transformed =
-          dataAndCheckpoint.getBatch().map(data -> transformer.get().apply(jssc, sparkSession, data, props));
+	  Option<Dataset<Row>> transformed =
+		  dataAndCheckpoint.getBatch().map(data -> transformer.get().apply(jssc, sparkSession, data, props));
 
-      transformed = formatAdapter.processErrorEvents(transformed,
-          ErrorEvent.ErrorReason.CUSTOM_TRANSFORMER_FAILURE);
+	  transformed = formatAdapter.processErrorEvents(transformed,
+		  ErrorEvent.ErrorReason.CUSTOM_TRANSFORMER_FAILURE);
 
-      checkpointStr = dataAndCheckpoint.getCheckpointForNextBatch();
-      boolean reconcileSchema = props.getBoolean(DataSourceWriteOptions.RECONCILE_SCHEMA().key());
-      if (this.userProvidedSchemaProvider != null && this.userProvidedSchemaProvider.getTargetSchema() != null) {
-        // If the target schema is specified through Avro schema,
-        // pass in the schema for the Row-to-Avro conversion
-        // to avoid nullability mismatch between Avro schema and Row schema
-        if (errorTableWriter.isPresent()
-            && props.getBoolean(HoodieErrorTableConfig.ERROR_ENABLE_VALIDATE_TARGET_SCHEMA.key(),
-            HoodieErrorTableConfig.ERROR_ENABLE_VALIDATE_TARGET_SCHEMA.defaultValue())) {
-          // If the above conditions are met, trigger error events for the rows whose conversion to
-          // avro records fails.
-          avroRDDOptional = transformed.map(
-              rowDataset -> {
-                Tuple2<RDD<GenericRecord>, RDD<String>> safeCreateRDDs = HoodieSparkUtils.safeCreateRDD(rowDataset,
-                    HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE, reconcileSchema,
-                    Option.of(this.userProvidedSchemaProvider.getTargetSchema()));
-                errorTableWriter.get().addErrorEvents(safeCreateRDDs._2().toJavaRDD()
-                    .map(evStr -> new ErrorEvent<>(evStr,
-                        ErrorEvent.ErrorReason.AVRO_DESERIALIZATION_FAILURE)));
-                return safeCreateRDDs._1.toJavaRDD();
-              });
-        } else {
-          avroRDDOptional = transformed.map(
-              rowDataset -> getTransformedRDD(rowDataset, reconcileSchema, this.userProvidedSchemaProvider.getTargetSchema()));
-        }
-        schemaProvider = this.userProvidedSchemaProvider;
-      } else {
-        Option<Schema> latestTableSchemaOpt = UtilHelpers.getLatestTableSchema(jssc, fs, cfg.targetBasePath);
-        // Deduce proper target (writer's) schema for the transformed dataset, reconciling its
-        // schema w/ the table's one
-        Option<Schema> targetSchemaOpt = transformed.map(df -> {
-          Schema sourceSchema = AvroConversionUtils.convertStructTypeToAvroSchema(df.schema(),
-              latestTableSchemaOpt.map(Schema::getFullName).orElse(getAvroRecordQualifiedName(cfg.targetTableName)));
-          // Target (writer's) schema is determined based on the incoming source schema
-          // and existing table's one, reconciling the two (if necessary) based on configuration
-          return HoodieSparkSqlWriter.deduceWriterSchema(
-                  sourceSchema,
-                  HoodieConversionUtils.<Schema>toScalaOption(latestTableSchemaOpt),
-                  HoodieConversionUtils.<InternalSchema>toScalaOption(Option.empty()),
-                  HoodieConversionUtils.fromProperties(props));
-        });
-        // Override schema provider with the reconciled target schema
-        schemaProvider = targetSchemaOpt.map(targetSchema ->
-          (SchemaProvider) new DelegatingSchemaProvider(props, jssc, dataAndCheckpoint.getSchemaProvider(),
-                new SimpleSchemaProvider(jssc, targetSchema, props)))
-          .orElse(dataAndCheckpoint.getSchemaProvider());
-        // Rewrite transformed records into the expected target schema
-        avroRDDOptional = transformed.map(t -> getTransformedRDD(t, reconcileSchema, schemaProvider.getTargetSchema()));
-      }
-    } else {
-      // Pull the data from the source & prepare the write
-      InputBatch<JavaRDD<GenericRecord>> dataAndCheckpoint =
-          formatAdapter.fetchNewDataInAvroFormat(resumeCheckpointStr, cfg.sourceLimit);
-      avroRDDOptional = dataAndCheckpoint.getBatch();
-      checkpointStr = dataAndCheckpoint.getCheckpointForNextBatch();
-      schemaProvider = dataAndCheckpoint.getSchemaProvider();
-    }
+	  checkpointStr = dataAndCheckpoint.getCheckpointForNextBatch();
+	  boolean reconcileSchema = props.getBoolean(DataSourceWriteOptions.RECONCILE_SCHEMA().key());
+	  if (this.userProvidedSchemaProvider != null && this.userProvidedSchemaProvider.getTargetSchema() != null) {
+		// If the target schema is specified through Avro schema,
+		// pass in the schema for the Row-to-Avro conversion
+		// to avoid nullability mismatch between Avro schema and Row schema
+		if (errorTableWriter.isPresent()
+			&& props.getBoolean(HoodieErrorTableConfig.ERROR_ENABLE_VALIDATE_TARGET_SCHEMA.key(),
+			HoodieErrorTableConfig.ERROR_ENABLE_VALIDATE_TARGET_SCHEMA.defaultValue())) {
+		  // If the above conditions are met, trigger error events for the rows whose conversion to
+		  // avro records fails.
+		  avroRDDOptional = transformed.map(
+			  rowDataset -> {
+				Tuple2<RDD<GenericRecord>, RDD<String>> safeCreateRDDs = HoodieSparkUtils.safeCreateRDD(rowDataset,
+					HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE, reconcileSchema,
+					Option.of(this.userProvidedSchemaProvider.getTargetSchema()));
+				errorTableWriter.get().addErrorEvents(safeCreateRDDs._2().toJavaRDD()
+					.map(evStr -> new ErrorEvent<>(evStr,
+						ErrorEvent.ErrorReason.AVRO_DESERIALIZATION_FAILURE)));
+				return safeCreateRDDs._1.toJavaRDD();
+			  });
+		} else {
+		  avroRDDOptional = transformed.map(
+			  rowDataset -> getTransformedRDD(rowDataset, reconcileSchema, this.userProvidedSchemaProvider.getTargetSchema()));
+		}
+		schemaProvider = this.userProvidedSchemaProvider;
+	  } else {
+		Option<Schema> latestTableSchemaOpt = UtilHelpers.getLatestTableSchema(jssc, fs, cfg.targetBasePath);
+		// Deduce proper target (writer's) schema for the transformed dataset, reconciling its
+		// schema w/ the table's one
+		Option<Schema> targetSchemaOpt = transformed.map(df -> {
+		  Schema sourceSchema = AvroConversionUtils.convertStructTypeToAvroSchema(df.schema(),
+			  latestTableSchemaOpt.map(Schema::getFullName).orElse(getAvroRecordQualifiedName(cfg.targetTableName)));
+		  // Target (writer's) schema is determined based on the incoming source schema
+		  // and existing table's one, reconciling the two (if necessary) based on configuration
+		  return HoodieSparkSqlWriter.deduceWriterSchema(
+			  sourceSchema,
+			  HoodieConversionUtils.<Schema>toScalaOption(latestTableSchemaOpt),
+			  HoodieConversionUtils.<InternalSchema>toScalaOption(Option.empty()),
+			  HoodieConversionUtils.fromProperties(props));
+		});
+		// Override schema provider with the reconciled target schema
+		schemaProvider = targetSchemaOpt.map(targetSchema ->
+			(SchemaProvider) new DelegatingSchemaProvider(props, jssc, dataAndCheckpoint.getSchemaProvider(),
+				new SimpleSchemaProvider(jssc, targetSchema, props)))
+			.orElse(dataAndCheckpoint.getSchemaProvider());
+		// Rewrite transformed records into the expected target schema
+		avroRDDOptional = transformed.map(t -> getTransformedRDD(t, reconcileSchema, schemaProvider.getTargetSchema()));
+	  }
+	} else {
+	  // Pull the data from the source & prepare the write
+	  InputBatch<JavaRDD<GenericRecord>> dataAndCheckpoint =
+		  formatAdapter.fetchNewDataInAvroFormat(resumeCheckpointStr, cfg.sourceLimit);
+	  avroRDDOptional = dataAndCheckpoint.getBatch();
+	  checkpointStr = dataAndCheckpoint.getCheckpointForNextBatch();
+	  schemaProvider = dataAndCheckpoint.getSchemaProvider();
+	}
 
-    if (!cfg.allowCommitOnNoCheckpointChange && Objects.equals(checkpointStr, resumeCheckpointStr.orElse(null))) {
-      LOG.info("No new data, source checkpoint has not changed. Nothing to commit. Old checkpoint=("
-          + resumeCheckpointStr + "). New Checkpoint=(" + checkpointStr + ")");
-      String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
-      hoodieMetrics.updateMetricsForEmptyData(commitActionType);
-      return null;
-    }
+	if (!cfg.allowCommitOnNoCheckpointChange && Objects.equals(checkpointStr, resumeCheckpointStr.orElse(null))) {
+	  LOG.info("No new data, source checkpoint has not changed. Nothing to commit. Old checkpoint=("
+		  + resumeCheckpointStr + "). New Checkpoint=(" + checkpointStr + ")");
+	  String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
+	  hoodieMetrics.updateMetricsForEmptyData(commitActionType);
+	  return null;
+	}
 
-    jssc.setJobGroup(this.getClass().getSimpleName(), "Checking if input is empty");
-    if ((!avroRDDOptional.isPresent()) || (avroRDDOptional.get().isEmpty())) {
-      LOG.info("No new data, perform empty commit.");
-      return Pair.of(schemaProvider, Pair.of(checkpointStr, jssc.emptyRDD()));
-    }
+	jssc.setJobGroup(this.getClass().getSimpleName(), "Checking if input is empty");
+	if ((!avroRDDOptional.isPresent()) || (avroRDDOptional.get().isEmpty())) {
+	  LOG.info("No new data, perform empty commit.");
+	  return Pair.of(schemaProvider, Pair.of(checkpointStr, jssc.emptyRDD()));
+	}
 
-    boolean shouldCombine = cfg.filterDupes || cfg.operation.equals(WriteOperationType.UPSERT);
-    Set<String> partitionColumns = getPartitionColumns(props);
-    JavaRDD<GenericRecord> avroRDD = avroRDDOptional.get();
+	boolean shouldCombine = cfg.filterDupes || cfg.operation.equals(WriteOperationType.UPSERT);
+	Set<String> partitionColumns = getPartitionColumns(props);
+	JavaRDD<GenericRecord> avroRDD = avroRDDOptional.get();
 
-    JavaRDD<HoodieRecord> records;
-    SerializableSchema avroSchema = new SerializableSchema(schemaProvider.getTargetSchema());
-    SerializableSchema processedAvroSchema = new SerializableSchema(isDropPartitionColumns() ? HoodieAvroUtils.removeMetadataFields(avroSchema.get()) : avroSchema.get());
-    if (recordType == HoodieRecordType.AVRO) {
-      records = avroRDD.mapPartitions(
-          (FlatMapFunction<Iterator<GenericRecord>, HoodieRecord>) genericRecordIterator -> {
-            if (autoGenerateRecordKeys) {
-              props.setProperty(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, String.valueOf(TaskContext.getPartitionId()));
-              props.setProperty(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, instantTime);
-            }
-            BuiltinKeyGenerator builtinKeyGenerator = (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
-            List<HoodieRecord> avroRecords = new ArrayList<>();
-            while (genericRecordIterator.hasNext()) {
-              GenericRecord genRec = genericRecordIterator.next();
-              HoodieKey hoodieKey = new HoodieKey(builtinKeyGenerator.getRecordKey(genRec), builtinKeyGenerator.getPartitionPath(genRec));
-              GenericRecord gr = isDropPartitionColumns() ? HoodieAvroUtils.removeFields(genRec, partitionColumns) : genRec;
-              HoodieRecordPayload payload = shouldCombine ? DataSourceUtils.createPayload(cfg.payloadClassName, gr,
-                  (Comparable) HoodieAvroUtils.getNestedFieldVal(gr, cfg.sourceOrderingField, false, props.getBoolean(
-                      KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
-                      Boolean.parseBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()))))
-                  : DataSourceUtils.createPayload(cfg.payloadClassName, gr);
-              avroRecords.add(new HoodieAvroRecord<>(hoodieKey, payload));
-            }
-            return avroRecords.iterator();
-          });
-    } else if (recordType == HoodieRecordType.SPARK) {
-      // TODO we should remove it if we can read InternalRow from source.
-      records = avroRDD.mapPartitions(itr -> {
-        if (autoGenerateRecordKeys) {
-          props.setProperty(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, String.valueOf(TaskContext.getPartitionId()));
-          props.setProperty(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, instantTime);
-        }
-        BuiltinKeyGenerator builtinKeyGenerator = (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
-        StructType baseStructType = AvroConversionUtils.convertAvroSchemaToStructType(processedAvroSchema.get());
-        StructType targetStructType = isDropPartitionColumns() ? AvroConversionUtils
-            .convertAvroSchemaToStructType(HoodieAvroUtils.removeFields(processedAvroSchema.get(), partitionColumns)) : baseStructType;
-        HoodieAvroDeserializer deserializer = SparkAdapterSupport$.MODULE$.sparkAdapter().createAvroDeserializer(processedAvroSchema.get(), baseStructType);
+	JavaRDD<HoodieRecord> records;
+	SerializableSchema avroSchema = new SerializableSchema(schemaProvider.getTargetSchema());
+	SerializableSchema processedAvroSchema = new SerializableSchema(isDropPartitionColumns() ? HoodieAvroUtils.removeMetadataFields(avroSchema.get()) : avroSchema.get());
+	if (recordType == HoodieRecordType.AVRO) {
+	  records = avroRDD.mapPartitions(
+		  (FlatMapFunction<Iterator<GenericRecord>, HoodieRecord>) genericRecordIterator -> {
+			if (autoGenerateRecordKeys) {
+			  props.setProperty(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, String.valueOf(TaskContext.getPartitionId()));
+			  props.setProperty(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, instantTime);
+			}
+			BuiltinKeyGenerator builtinKeyGenerator = (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
+			List<HoodieRecord> avroRecords = new ArrayList<>();
+			while (genericRecordIterator.hasNext()) {
+			  GenericRecord genRec = genericRecordIterator.next();
+			  HoodieKey hoodieKey = new HoodieKey(builtinKeyGenerator.getRecordKey(genRec), builtinKeyGenerator.getPartitionPath(genRec));
+			  GenericRecord gr = isDropPartitionColumns() ? HoodieAvroUtils.removeFields(genRec, partitionColumns) : genRec;
+			  HoodieRecordPayload payload = shouldCombine ? DataSourceUtils.createPayload(cfg.payloadClassName, gr,
+				  (Comparable) HoodieAvroUtils.getNestedFieldVal(gr, cfg.sourceOrderingField, false, props.getBoolean(
+					  KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+					  Boolean.parseBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()))))
+				  : DataSourceUtils.createPayload(cfg.payloadClassName, gr);
+			  avroRecords.add(new HoodieAvroRecord<>(hoodieKey, payload));
+			}
+			return avroRecords.iterator();
+		  });
+	} else if (recordType == HoodieRecordType.SPARK) {
+	  // TODO we should remove it if we can read InternalRow from source.
+	  records = avroRDD.mapPartitions(itr -> {
+		if (autoGenerateRecordKeys) {
+		  props.setProperty(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, String.valueOf(TaskContext.getPartitionId()));
+		  props.setProperty(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, instantTime);
+		}
+		BuiltinKeyGenerator builtinKeyGenerator = (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
+		StructType baseStructType = AvroConversionUtils.convertAvroSchemaToStructType(processedAvroSchema.get());
+		StructType targetStructType = isDropPartitionColumns() ? AvroConversionUtils
+			.convertAvroSchemaToStructType(HoodieAvroUtils.removeFields(processedAvroSchema.get(), partitionColumns)) : baseStructType;
+		HoodieAvroDeserializer deserializer = SparkAdapterSupport$.MODULE$.sparkAdapter().createAvroDeserializer(processedAvroSchema.get(), baseStructType);
 
-        return new CloseableMappingIterator<>(ClosableIterator.wrap(itr), rec -> {
-          InternalRow row = (InternalRow) deserializer.deserialize(rec).get();
-          String recordKey = builtinKeyGenerator.getRecordKey(row, baseStructType).toString();
-          String partitionPath = builtinKeyGenerator.getPartitionPath(row, baseStructType).toString();
-          return new HoodieSparkRecord(new HoodieKey(recordKey, partitionPath),
-              HoodieInternalRowUtils.getCachedUnsafeProjection(baseStructType, targetStructType).apply(row), targetStructType, false);
-        });
-      });
-    } else {
-      throw new UnsupportedOperationException(recordType.name());
-    }
+		return new CloseableMappingIterator<>(ClosableIterator.wrap(itr), rec -> {
+		  InternalRow row = (InternalRow) deserializer.deserialize(rec).get();
+		  String recordKey = builtinKeyGenerator.getRecordKey(row, baseStructType).toString();
+		  String partitionPath = builtinKeyGenerator.getPartitionPath(row, baseStructType).toString();
+		  return new HoodieSparkRecord(new HoodieKey(recordKey, partitionPath),
+			  HoodieInternalRowUtils.getCachedUnsafeProjection(baseStructType, targetStructType).apply(row), targetStructType, false);
+		});
+	  });
+	} else {
+	  throw new UnsupportedOperationException(recordType.name());
+	}
 
-    return Pair.of(schemaProvider, Pair.of(checkpointStr, records));
+	return Pair.of(schemaProvider, Pair.of(checkpointStr, records));
   }
 
   private JavaRDD<GenericRecord> getTransformedRDD(Dataset<Row> rowDataset, boolean reconcileSchema, Schema readerSchema) {
-    return HoodieSparkUtils.createRdd(rowDataset, HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE, reconcileSchema,
-        Option.ofNullable(readerSchema)).toJavaRDD();
+	return HoodieSparkUtils.createRdd(rowDataset, HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE, reconcileSchema,
+		Option.ofNullable(readerSchema)).toJavaRDD();
   }
 
   /**
@@ -685,88 +697,88 @@ public class DeltaSync implements Serializable, Closeable {
    * @throws IOException
    */
   private Option<String> getCheckpointToResume(Option<HoodieTimeline> commitsTimelineOpt) throws IOException {
-    Option<String> resumeCheckpointStr = Option.empty();
-    // try get checkpoint from commits(including commit and deltacommit)
-    // in COW migrating to MOR case, the first batch of the deltastreamer will lost the checkpoint from COW table, cause the dataloss
-    HoodieTimeline deltaCommitTimeline = commitsTimelineOpt.get().filter(instant -> instant.getAction().equals(HoodieTimeline.DELTA_COMMIT_ACTION));
-    // has deltacommit means this is a MOR table, we should get .deltacommit as before
-    if (!deltaCommitTimeline.empty()) {
-      commitsTimelineOpt = Option.of(deltaCommitTimeline);
-    }
-    Option<HoodieInstant> lastCommit = commitsTimelineOpt.get().lastInstant();
-    if (lastCommit.isPresent()) {
-      // if previous commit metadata did not have the checkpoint key, try traversing previous commits until we find one.
-      Option<HoodieCommitMetadata> commitMetadataOption = getLatestCommitMetadataWithValidCheckpointInfo(commitsTimelineOpt.get());
-      if (commitMetadataOption.isPresent()) {
-        HoodieCommitMetadata commitMetadata = commitMetadataOption.get();
-        LOG.debug("Checkpoint reset from metadata: " + commitMetadata.getMetadata(CHECKPOINT_RESET_KEY));
-        if (cfg.checkpoint != null && (StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY))
-            || !cfg.checkpoint.equals(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY)))) {
-          resumeCheckpointStr = Option.of(cfg.checkpoint);
-        } else if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_KEY))) {
-          //if previous checkpoint is an empty string, skip resume use Option.empty()
-          String value = commitMetadata.getMetadata(CHECKPOINT_KEY);
-          resumeCheckpointStr = multiwriterIdentifier.isPresent() ? readCheckpointValue(value, multiwriterIdentifier.get()) : Option.of(value);
-        } else if (HoodieTimeline.compareTimestamps(HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS,
-            HoodieTimeline.LESSER_THAN, lastCommit.get().getTimestamp())) {
-          throw new HoodieDeltaStreamerException(
-              "Unable to find previous checkpoint. Please double check if this table "
-                  + "was indeed built via delta streamer. Last Commit :" + lastCommit + ", Instants :"
-                  + commitsTimelineOpt.get().getInstants() + ", CommitMetadata="
-                  + commitMetadata.toJsonString());
-        }
-        // KAFKA_CHECKPOINT_TYPE will be honored only for first batch.
-        if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY))) {
-          props.remove(KafkaSourceConfig.KAFKA_CHECKPOINT_TYPE.key());
-        }
-      } else if (cfg.checkpoint != null) { // getLatestCommitMetadataWithValidCheckpointInfo(commitTimelineOpt.get()) will never return a commit metadata w/o any checkpoint key set.
-        resumeCheckpointStr = Option.of(cfg.checkpoint);
-      }
-    }
-    return resumeCheckpointStr;
+	Option<String> resumeCheckpointStr = Option.empty();
+	// try get checkpoint from commits(including commit and deltacommit)
+	// in COW migrating to MOR case, the first batch of the deltastreamer will lost the checkpoint from COW table, cause the dataloss
+	HoodieTimeline deltaCommitTimeline = commitsTimelineOpt.get().filter(instant -> instant.getAction().equals(HoodieTimeline.DELTA_COMMIT_ACTION));
+	// has deltacommit means this is a MOR table, we should get .deltacommit as before
+	if (!deltaCommitTimeline.empty()) {
+	  commitsTimelineOpt = Option.of(deltaCommitTimeline);
+	}
+	Option<HoodieInstant> lastCommit = commitsTimelineOpt.get().lastInstant();
+	if (lastCommit.isPresent()) {
+	  // if previous commit metadata did not have the checkpoint key, try traversing previous commits until we find one.
+	  Option<HoodieCommitMetadata> commitMetadataOption = getLatestCommitMetadataWithValidCheckpointInfo(commitsTimelineOpt.get());
+	  if (commitMetadataOption.isPresent()) {
+		HoodieCommitMetadata commitMetadata = commitMetadataOption.get();
+		LOG.debug("Checkpoint reset from metadata: " + commitMetadata.getMetadata(CHECKPOINT_RESET_KEY));
+		if (cfg.checkpoint != null && (StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY))
+			|| !cfg.checkpoint.equals(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY)))) {
+		  resumeCheckpointStr = Option.of(cfg.checkpoint);
+		} else if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_KEY))) {
+		  //if previous checkpoint is an empty string, skip resume use Option.empty()
+		  String value = commitMetadata.getMetadata(CHECKPOINT_KEY);
+		  resumeCheckpointStr = multiwriterIdentifier.isPresent() ? readCheckpointValue(value, multiwriterIdentifier.get()) : Option.of(value);
+		} else if (HoodieTimeline.compareTimestamps(HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS,
+			HoodieTimeline.LESSER_THAN, lastCommit.get().getTimestamp())) {
+		  throw new HoodieDeltaStreamerException(
+			  "Unable to find previous checkpoint. Please double check if this table "
+				  + "was indeed built via delta streamer. Last Commit :" + lastCommit + ", Instants :"
+				  + commitsTimelineOpt.get().getInstants() + ", CommitMetadata="
+				  + commitMetadata.toJsonString());
+		}
+		// KAFKA_CHECKPOINT_TYPE will be honored only for first batch.
+		if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY))) {
+		  props.remove(KafkaSourceConfig.KAFKA_CHECKPOINT_TYPE.key());
+		}
+	  } else if (cfg.checkpoint != null) { // getLatestCommitMetadataWithValidCheckpointInfo(commitTimelineOpt.get()) will never return a commit metadata w/o any checkpoint key set.
+		resumeCheckpointStr = Option.of(cfg.checkpoint);
+	  }
+	}
+	return resumeCheckpointStr;
   }
 
   public static Option<String> readCheckpointValue(String value, String id) {
-    try {
-      Map<String,String> checkpointMap = OBJECT_MAPPER.readValue(value, Map.class);
-      if (!checkpointMap.containsKey(id)) {
-        return Option.empty();
-      }
-      String checkpointVal = checkpointMap.get(id);
-      return Option.of(checkpointVal);
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to parse checkpoint as map", e);
-    }
+	try {
+	  Map<String, String> checkpointMap = OBJECT_MAPPER.readValue(value, Map.class);
+	  if (!checkpointMap.containsKey(id)) {
+		return Option.empty();
+	  }
+	  String checkpointVal = checkpointMap.get(id);
+	  return Option.of(checkpointVal);
+	} catch (IOException e) {
+	  throw new HoodieIOException("Failed to parse checkpoint as map", e);
+	}
   }
 
   protected Option<Pair<String, HoodieCommitMetadata>> getLatestInstantAndCommitMetadataWithValidCheckpointInfo(HoodieTimeline timeline) throws IOException {
-    return (Option<Pair<String, HoodieCommitMetadata>>) timeline.getReverseOrderedInstants().map(instant -> {
-      try {
-        HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
-            .fromBytes(timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
-        if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_KEY)) || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY))) {
-          return Option.of(Pair.of(instant.toString(), commitMetadata));
-        } else {
-          return Option.empty();
-        }
-      } catch (IOException e) {
-        throw new HoodieIOException("Failed to parse HoodieCommitMetadata for " + instant.toString(), e);
-      }
-    }).filter(Option::isPresent).findFirst().orElse(Option.empty());
+	return (Option<Pair<String, HoodieCommitMetadata>>) timeline.getReverseOrderedInstants().map(instant -> {
+	  try {
+		HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
+			.fromBytes(timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
+		if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_KEY)) || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(CHECKPOINT_RESET_KEY))) {
+		  return Option.of(Pair.of(instant.toString(), commitMetadata));
+		} else {
+		  return Option.empty();
+		}
+	  } catch (IOException e) {
+		throw new HoodieIOException("Failed to parse HoodieCommitMetadata for " + instant.toString(), e);
+	  }
+	}).filter(Option::isPresent).findFirst().orElse(Option.empty());
   }
 
   protected Option<HoodieCommitMetadata> getLatestCommitMetadataWithValidCheckpointInfo(HoodieTimeline timeline) throws IOException {
-    return getLatestInstantAndCommitMetadataWithValidCheckpointInfo(timeline).map(pair -> pair.getRight());
+	return getLatestInstantAndCommitMetadataWithValidCheckpointInfo(timeline).map(pair -> pair.getRight());
   }
 
   protected Option<String> getLatestInstantWithValidCheckpointInfo(Option<HoodieTimeline> timelineOpt) {
-    return timelineOpt.map(timeline -> {
-      try {
-        return getLatestInstantAndCommitMetadataWithValidCheckpointInfo(timeline).map(pair -> pair.getLeft());
-      } catch (IOException e) {
-        throw new HoodieIOException("failed to get latest instant with ValidCheckpointInfo", e);
-      }
-    }).orElse(Option.empty());
+	return timelineOpt.map(timeline -> {
+	  try {
+		return getLatestInstantAndCommitMetadataWithValidCheckpointInfo(timeline).map(pair -> pair.getLeft());
+	  } catch (IOException e) {
+		throw new HoodieIOException("failed to get latest instant with ValidCheckpointInfo", e);
+	  }
+	}).orElse(Option.empty());
   }
 
   /**
@@ -780,120 +792,120 @@ public class DeltaSync implements Serializable, Closeable {
    * @return Option Compaction instant if one is scheduled
    */
   private Pair<Option<String>, JavaRDD<WriteStatus>> writeToSink(String instantTime, JavaRDD<HoodieRecord> records, String checkpointStr,
-                                                                 HoodieIngestionMetrics metrics,
-                                                                 Timer.Context overallTimerContext) {
-    Option<String> scheduledCompactionInstant = Option.empty();
-    // filter dupes if needed
-    if (cfg.filterDupes) {
-      records = DataSourceUtils.dropDuplicates(jssc, records, writeClient.getConfig());
-    }
+																 HoodieIngestionMetrics metrics,
+																 Timer.Context overallTimerContext) {
+	Option<String> scheduledCompactionInstant = Option.empty();
+	// filter dupes if needed
+	if (cfg.filterDupes) {
+	  records = DataSourceUtils.dropDuplicates(jssc, records, writeClient.getConfig());
+	}
 
-    boolean isEmpty = records.isEmpty();
-    instantTime = startCommit(instantTime, !autoGenerateRecordKeys);
-    LOG.info("Starting commit  : " + instantTime);
+	boolean isEmpty = records.isEmpty();
+	instantTime = startCommit(instantTime, !autoGenerateRecordKeys);
+	LOG.info("Starting commit  : " + instantTime);
 
-    JavaRDD<WriteStatus> writeStatusRDD;
-    switch (cfg.operation) {
-      case INSERT:
-        writeStatusRDD = writeClient.insert(records, instantTime);
-        break;
-      case UPSERT:
-        writeStatusRDD = writeClient.upsert(records, instantTime);
-        break;
-      case BULK_INSERT:
-        writeStatusRDD = writeClient.bulkInsert(records, instantTime);
-        break;
-      case INSERT_OVERWRITE:
-        writeStatusRDD = writeClient.insertOverwrite(records, instantTime).getWriteStatuses();
-        break;
-      case INSERT_OVERWRITE_TABLE:
-        writeStatusRDD = writeClient.insertOverwriteTable(records, instantTime).getWriteStatuses();
-        break;
-      case DELETE_PARTITION:
-        List<String> partitions = records.map(record -> record.getPartitionPath()).distinct().collect();
-        writeStatusRDD = writeClient.deletePartitions(partitions, instantTime).getWriteStatuses();
-        break;
-      default:
-        throw new HoodieDeltaStreamerException("Unknown operation : " + cfg.operation);
-    }
+	JavaRDD<WriteStatus> writeStatusRDD;
+	switch (cfg.operation) {
+	  case INSERT:
+		writeStatusRDD = writeClient.insert(records, instantTime);
+		break;
+	  case UPSERT:
+		writeStatusRDD = writeClient.upsert(records, instantTime);
+		break;
+	  case BULK_INSERT:
+		writeStatusRDD = writeClient.bulkInsert(records, instantTime);
+		break;
+	  case INSERT_OVERWRITE:
+		writeStatusRDD = writeClient.insertOverwrite(records, instantTime).getWriteStatuses();
+		break;
+	  case INSERT_OVERWRITE_TABLE:
+		writeStatusRDD = writeClient.insertOverwriteTable(records, instantTime).getWriteStatuses();
+		break;
+	  case DELETE_PARTITION:
+		List<String> partitions = records.map(record -> record.getPartitionPath()).distinct().collect();
+		writeStatusRDD = writeClient.deletePartitions(partitions, instantTime).getWriteStatuses();
+		break;
+	  default:
+		throw new HoodieDeltaStreamerException("Unknown operation : " + cfg.operation);
+	}
 
-    long totalErrorRecords = writeStatusRDD.mapToDouble(WriteStatus::getTotalErrorRecords).sum().longValue();
-    long totalRecords = writeStatusRDD.mapToDouble(WriteStatus::getTotalRecords).sum().longValue();
-    boolean hasErrors = totalErrorRecords > 0;
-    if (!hasErrors || cfg.commitOnErrors) {
-      HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      Option<BiConsumer<HoodieTableMetaClient, HoodieCommitMetadata>> extraPreCommitFunc = Option.empty();
-      if (!props.getBoolean(CHECKPOINT_FORCE_SKIP_PROP, DEFAULT_CHECKPOINT_FORCE_SKIP_PROP)) {
-        if (checkpointStr != null) {
-          if (multiwriterIdentifier.isPresent()) {
-            extraPreCommitFunc = Option.of(new DeltastreamerMultiWriterCkptUpdateFunc(this, checkpointStr, latestCheckpointWritten));
-          } else {
-            checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
-          }
-        }
-        if (cfg.checkpoint != null) {
-          checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
-        }
-      }
+	long totalErrorRecords = writeStatusRDD.mapToDouble(WriteStatus::getTotalErrorRecords).sum().longValue();
+	long totalRecords = writeStatusRDD.mapToDouble(WriteStatus::getTotalRecords).sum().longValue();
+	boolean hasErrors = totalErrorRecords > 0;
+	if (!hasErrors || cfg.commitOnErrors) {
+	  HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
+	  Option<BiConsumer<HoodieTableMetaClient, HoodieCommitMetadata>> extraPreCommitFunc = Option.empty();
+	  if (!props.getBoolean(CHECKPOINT_FORCE_SKIP_PROP, DEFAULT_CHECKPOINT_FORCE_SKIP_PROP)) {
+		if (checkpointStr != null) {
+		  if (multiwriterIdentifier.isPresent()) {
+			extraPreCommitFunc = Option.of(new DeltastreamerMultiWriterCkptUpdateFunc(this, checkpointStr, latestCheckpointWritten));
+		  } else {
+			checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
+		  }
+		}
+		if (cfg.checkpoint != null) {
+		  checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
+		}
+	  }
 
-      if (hasErrors) {
-        LOG.warn("Some records failed to be merged but forcing commit since commitOnErrors set. Errors/Total="
-            + totalErrorRecords + "/" + totalRecords);
-      }
-      String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
-      if (errorTableWriter.isPresent()) {
-        // Commit the error events triggered so far to the error table
-        Option<String> commitedInstantTime = getLatestInstantWithValidCheckpointInfo(commitsTimelineOpt);
-        boolean errorTableSuccess = errorTableWriter.get().upsertAndCommit(instantTime, commitedInstantTime);
-        if (!errorTableSuccess) {
-          switch (errorWriteFailureStrategy) {
-            case ROLLBACK_COMMIT:
-              LOG.info("Commit " + instantTime + " failed!");
-              writeClient.rollback(instantTime);
-              throw new HoodieDeltaStreamerWriteException("Error table commit failed");
-            case LOG_ERROR:
-              LOG.error("Error Table write failed for instant " + instantTime);
-              break;
-            default:
-              throw new HoodieDeltaStreamerWriteException("Write failure strategy not implemented for " + errorWriteFailureStrategy);
-          }
-        }
-      }
-      boolean success = writeClient.commit(instantTime, writeStatusRDD, Option.of(checkpointCommitMetadata), commitActionType, Collections.emptyMap(), extraPreCommitFunc);
-      if (success) {
-        LOG.info("Commit " + instantTime + " successful!");
-        latestCheckpointWritten = checkpointStr;
-        this.formatAdapter.getSource().onCommit(checkpointStr);
-        // Schedule compaction if needed
-        if (cfg.isAsyncCompactionEnabled()) {
-          scheduledCompactionInstant = writeClient.scheduleCompaction(Option.empty());
-        }
+	  if (hasErrors) {
+		LOG.warn("Some records failed to be merged but forcing commit since commitOnErrors set. Errors/Total="
+			+ totalErrorRecords + "/" + totalRecords);
+	  }
+	  String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
+	  if (errorTableWriter.isPresent()) {
+		// Commit the error events triggered so far to the error table
+		Option<String> commitedInstantTime = getLatestInstantWithValidCheckpointInfo(commitsTimelineOpt);
+		boolean errorTableSuccess = errorTableWriter.get().upsertAndCommit(instantTime, commitedInstantTime);
+		if (!errorTableSuccess) {
+		  switch (errorWriteFailureStrategy) {
+			case ROLLBACK_COMMIT:
+			  LOG.info("Commit " + instantTime + " failed!");
+			  writeClient.rollback(instantTime);
+			  throw new HoodieDeltaStreamerWriteException("Error table commit failed");
+			case LOG_ERROR:
+			  LOG.error("Error Table write failed for instant " + instantTime);
+			  break;
+			default:
+			  throw new HoodieDeltaStreamerWriteException("Write failure strategy not implemented for " + errorWriteFailureStrategy);
+		  }
+		}
+	  }
+	  boolean success = writeClient.commit(instantTime, writeStatusRDD, Option.of(checkpointCommitMetadata), commitActionType, Collections.emptyMap(), extraPreCommitFunc);
+	  if (success) {
+		LOG.info("Commit " + instantTime + " successful!");
+		latestCheckpointWritten = checkpointStr;
+		this.formatAdapter.getSource().onCommit(checkpointStr);
+		// Schedule compaction if needed
+		if (cfg.isAsyncCompactionEnabled()) {
+		  scheduledCompactionInstant = writeClient.scheduleCompaction(Option.empty());
+		}
 
-        if (!isEmpty || cfg.forceEmptyMetaSync) {
-          runMetaSync();
-        }
-      } else {
-        LOG.info("Commit " + instantTime + " failed!");
-        throw new HoodieDeltaStreamerWriteException("Commit " + instantTime + " failed!");
-      }
-    } else {
-      LOG.error("Delta Sync found errors when writing. Errors/Total=" + totalErrorRecords + "/" + totalRecords);
-      LOG.error("Printing out the top 100 errors");
-      writeStatusRDD.filter(WriteStatus::hasErrors).take(100).forEach(ws -> {
-        LOG.error("Global error :", ws.getGlobalError());
-        if (ws.getErrors().size() > 0) {
-          ws.getErrors().forEach((key, value) -> LOG.trace("Error for key:" + key + " is " + value));
-        }
-      });
-      // Rolling back instant
-      writeClient.rollback(instantTime);
-      throw new HoodieDeltaStreamerWriteException("Commit " + instantTime + " failed and rolled-back !");
-    }
-    long overallTimeMs = overallTimerContext != null ? overallTimerContext.stop() : 0;
+		if (!isEmpty || cfg.forceEmptyMetaSync) {
+		  runMetaSync();
+		}
+	  } else {
+		LOG.info("Commit " + instantTime + " failed!");
+		throw new HoodieDeltaStreamerWriteException("Commit " + instantTime + " failed!");
+	  }
+	} else {
+	  LOG.error("Delta Sync found errors when writing. Errors/Total=" + totalErrorRecords + "/" + totalRecords);
+	  LOG.error("Printing out the top 100 errors");
+	  writeStatusRDD.filter(WriteStatus::hasErrors).take(100).forEach(ws -> {
+		LOG.error("Global error :", ws.getGlobalError());
+		if (ws.getErrors().size() > 0) {
+		  ws.getErrors().forEach((key, value) -> LOG.trace("Error for key:" + key + " is " + value));
+		}
+	  });
+	  // Rolling back instant
+	  writeClient.rollback(instantTime);
+	  throw new HoodieDeltaStreamerWriteException("Commit " + instantTime + " failed and rolled-back !");
+	}
+	long overallTimeMs = overallTimerContext != null ? overallTimerContext.stop() : 0;
 
-    // Send DeltaStreamer Metrics
-    metrics.updateDeltaStreamerMetrics(overallTimeMs);
-    return Pair.of(scheduledCompactionInstant, writeStatusRDD);
+	// Send DeltaStreamer Metrics
+	metrics.updateDeltaStreamerMetrics(overallTimeMs);
+	return Pair.of(scheduledCompactionInstant, writeStatusRDD);
   }
 
   /**
@@ -904,71 +916,71 @@ public class DeltaSync implements Serializable, Closeable {
    * @return Instant time of the commit
    */
   private String startCommit(String instantTime, boolean retryEnabled) {
-    final int maxRetries = 2;
-    int retryNum = 1;
-    RuntimeException lastException = null;
-    while (retryNum <= maxRetries) {
-      try {
-        String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
-        writeClient.startCommitWithTime(instantTime, commitActionType);
-        return instantTime;
-      } catch (IllegalArgumentException ie) {
-        lastException = ie;
-        if (!retryEnabled) {
-          throw ie;
-        }
-        LOG.error("Got error trying to start a new commit. Retrying after sleeping for a sec", ie);
-        retryNum++;
-        try {
-          Thread.sleep(1000);
-        } catch (InterruptedException e) {
-          // No-Op
-        }
-      }
-      instantTime = HoodieActiveTimeline.createNewInstantTime();
-    }
-    throw lastException;
+	final int maxRetries = 2;
+	int retryNum = 1;
+	RuntimeException lastException = null;
+	while (retryNum <= maxRetries) {
+	  try {
+		String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
+		writeClient.startCommitWithTime(instantTime, commitActionType);
+		return instantTime;
+	  } catch (IllegalArgumentException ie) {
+		lastException = ie;
+		if (!retryEnabled) {
+		  throw ie;
+		}
+		LOG.error("Got error trying to start a new commit. Retrying after sleeping for a sec", ie);
+		retryNum++;
+		try {
+		  Thread.sleep(1000);
+		} catch (InterruptedException e) {
+		  // No-Op
+		}
+	  }
+	  instantTime = HoodieActiveTimeline.createNewInstantTime();
+	}
+	throw lastException;
   }
 
   private String getSyncClassShortName(String syncClassName) {
-    return syncClassName.substring(syncClassName.lastIndexOf(".") + 1);
+	return syncClassName.substring(syncClassName.lastIndexOf(".") + 1);
   }
 
   public void runMetaSync() {
-    Set<String> syncClientToolClasses = new HashSet<>(Arrays.asList(cfg.syncClientToolClassNames.split(",")));
-    // for backward compatibility
-    if (cfg.enableHiveSync) {
-      cfg.enableMetaSync = true;
-      syncClientToolClasses.add(HiveSyncTool.class.getName());
-      LOG.info("When set --enable-hive-sync will use HiveSyncTool for backward compatibility");
-    }
-    if (cfg.enableMetaSync) {
-      FileSystem fs = FSUtils.getFs(cfg.targetBasePath, jssc.hadoopConfiguration());
+	Set<String> syncClientToolClasses = new HashSet<>(Arrays.asList(cfg.syncClientToolClassNames.split(",")));
+	// for backward compatibility
+	if (cfg.enableHiveSync) {
+	  cfg.enableMetaSync = true;
+	  syncClientToolClasses.add(HiveSyncTool.class.getName());
+	  LOG.info("When set --enable-hive-sync will use HiveSyncTool for backward compatibility");
+	}
+	if (cfg.enableMetaSync) {
+	  FileSystem fs = FSUtils.getFs(cfg.targetBasePath, jssc.hadoopConfiguration());
 
-      TypedProperties metaProps = new TypedProperties();
-      metaProps.putAll(props);
-      metaProps.putAll(writeClient.getConfig().getProps());
-      if (props.getBoolean(HIVE_SYNC_BUCKET_SYNC.key(), HIVE_SYNC_BUCKET_SYNC.defaultValue())) {
-        metaProps.put(HIVE_SYNC_BUCKET_SYNC_SPEC.key(), HiveSyncConfig.getBucketSpec(props.getString(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key()),
-            props.getInteger(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key())));
-      }
+	  TypedProperties metaProps = new TypedProperties();
+	  metaProps.putAll(props);
+	  metaProps.putAll(writeClient.getConfig().getProps());
+	  if (props.getBoolean(HIVE_SYNC_BUCKET_SYNC.key(), HIVE_SYNC_BUCKET_SYNC.defaultValue())) {
+		metaProps.put(HIVE_SYNC_BUCKET_SYNC_SPEC.key(), HiveSyncConfig.getBucketSpec(props.getString(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key()),
+			props.getInteger(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key())));
+	  }
 
-      Map<String,HoodieException> failedMetaSyncs = new HashMap<>();
-      for (String impl : syncClientToolClasses) {
-        Timer.Context syncContext = metrics.getMetaSyncTimerContext();
-        try {
-          SyncUtilHelpers.runHoodieMetaSync(impl.trim(), metaProps, conf, fs, cfg.targetBasePath, cfg.baseFileFormat);
-        } catch (HoodieMetaSyncException e) {
-          LOG.warn("SyncTool class " + impl.trim() + " failed with exception", e);
-          failedMetaSyncs.put(impl, e);
-        }
-        long metaSyncTimeMs = syncContext != null ? syncContext.stop() : 0;
-        metrics.updateDeltaStreamerMetaSyncMetrics(getSyncClassShortName(impl), metaSyncTimeMs);
-      }
-      if (!failedMetaSyncs.isEmpty()) {
-        throw getHoodieMetaSyncException(failedMetaSyncs);
-      }
-    }
+	  Map<String, HoodieException> failedMetaSyncs = new HashMap<>();
+	  for (String impl : syncClientToolClasses) {
+		Timer.Context syncContext = metrics.getMetaSyncTimerContext();
+		try {
+		  SyncUtilHelpers.runHoodieMetaSync(impl.trim(), metaProps, conf, fs, cfg.targetBasePath, cfg.baseFileFormat);
+		} catch (HoodieMetaSyncException e) {
+		  LOG.warn("SyncTool class " + impl.trim() + " failed with exception", e);
+		  failedMetaSyncs.put(impl, e);
+		}
+		long metaSyncTimeMs = syncContext != null ? syncContext.stop() : 0;
+		metrics.updateDeltaStreamerMetaSyncMetrics(getSyncClassShortName(impl), metaSyncTimeMs);
+	  }
+	  if (!failedMetaSyncs.isEmpty()) {
+		throw getHoodieMetaSyncException(failedMetaSyncs);
+	  }
+	}
   }
 
   /**
@@ -977,38 +989,38 @@ public class DeltaSync implements Serializable, Closeable {
    * this constraint.
    */
   private void setupWriteClient(JavaRDD<HoodieRecord> records) throws IOException {
-    if ((null != schemaProvider)) {
-      Schema sourceSchema = schemaProvider.getSourceSchema();
-      Schema targetSchema = schemaProvider.getTargetSchema();
-      reInitWriteClient(sourceSchema, targetSchema, records);
-    }
+	if ((null != schemaProvider)) {
+	  Schema sourceSchema = schemaProvider.getSourceSchema();
+	  Schema targetSchema = schemaProvider.getTargetSchema();
+	  reInitWriteClient(sourceSchema, targetSchema, records);
+	}
   }
 
   private void reInitWriteClient(Schema sourceSchema, Schema targetSchema, JavaRDD<HoodieRecord> records) throws IOException {
-    LOG.info("Setting up new Hoodie Write Client");
-    if (isDropPartitionColumns()) {
-      targetSchema = HoodieAvroUtils.removeFields(targetSchema, getPartitionColumns(props));
-    }
-    registerAvroSchemas(sourceSchema, targetSchema);
-    final HoodieWriteConfig initialWriteConfig = getHoodieClientConfig(targetSchema);
-    final HoodieWriteConfig writeConfig = SparkSampleWritesUtils
-        .getWriteConfigWithRecordSizeEstimate(jssc, records, initialWriteConfig)
-        .orElse(initialWriteConfig);
+	LOG.info("Setting up new Hoodie Write Client");
+	if (isDropPartitionColumns()) {
+	  targetSchema = HoodieAvroUtils.removeFields(targetSchema, getPartitionColumns(props));
+	}
+	registerAvroSchemas(sourceSchema, targetSchema);
+	final HoodieWriteConfig initialWriteConfig = getHoodieClientConfig(targetSchema);
+	final HoodieWriteConfig writeConfig = SparkSampleWritesUtils
+		.getWriteConfigWithRecordSizeEstimate(jssc, records, initialWriteConfig)
+		.orElse(initialWriteConfig);
 
-    if (writeConfig.isEmbeddedTimelineServerEnabled()) {
-      if (!embeddedTimelineService.isPresent()) {
-        embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(new HoodieSparkEngineContext(jssc), writeConfig);
-      } else {
-        EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
-      }
-    }
+	if (writeConfig.isEmbeddedTimelineServerEnabled()) {
+	  if (!embeddedTimelineService.isPresent()) {
+		embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(sparkEngineContext, writeConfig);
+	  } else {
+		EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
+	  }
+	}
 
-    if (writeClient != null) {
-      // Close Write client.
-      writeClient.close();
-    }
-    writeClient = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), writeConfig, embeddedTimelineService);
-    onInitializingHoodieWriteClient.apply(writeClient);
+	if (writeClient != null) {
+	  // Close Write client.
+	  writeClient.close();
+	}
+	writeClient = new SparkRDDWriteClient<>(sparkEngineContext, writeConfig, embeddedTimelineService);
+	onInitializingHoodieWriteClient.apply(writeClient);
   }
 
   /**
@@ -1017,7 +1029,7 @@ public class DeltaSync implements Serializable, Closeable {
    * @param schemaProvider Schema Provider
    */
   private HoodieWriteConfig getHoodieClientConfig(SchemaProvider schemaProvider) {
-    return getHoodieClientConfig(schemaProvider != null ? schemaProvider.getTargetSchema() : null);
+	return getHoodieClientConfig(schemaProvider != null ? schemaProvider.getTargetSchema() : null);
   }
 
   /**
@@ -1026,94 +1038,94 @@ public class DeltaSync implements Serializable, Closeable {
    * @param schema Schema
    */
   private HoodieWriteConfig getHoodieClientConfig(Schema schema) {
-    final boolean combineBeforeUpsert = true;
-    final boolean autoCommit = false;
+	final boolean combineBeforeUpsert = true;
+	final boolean autoCommit = false;
 
-    // NOTE: Provided that we're injecting combined properties
-    //       (from {@code props}, including CLI overrides), there's no
-    //       need to explicitly set up some configuration aspects that
-    //       are based on these (for ex Clustering configuration)
-    HoodieWriteConfig.Builder builder =
-        HoodieWriteConfig.newBuilder()
-            .withPath(cfg.targetBasePath)
-            .combineInput(cfg.filterDupes, combineBeforeUpsert)
-            .withCompactionConfig(
-                HoodieCompactionConfig.newBuilder()
-                    .withInlineCompaction(cfg.isInlineCompactionEnabled())
-                    .build()
-            )
-            .withPayloadConfig(
-                HoodiePayloadConfig.newBuilder()
-                    .withPayloadClass(cfg.payloadClassName)
-                    .withPayloadOrderingField(cfg.sourceOrderingField)
-                    .build())
-            .forTable(cfg.targetTableName)
-            .withAutoCommit(autoCommit)
-            .withProps(props);
+	// NOTE: Provided that we're injecting combined properties
+	//       (from {@code props}, including CLI overrides), there's no
+	//       need to explicitly set up some configuration aspects that
+	//       are based on these (for ex Clustering configuration)
+	HoodieWriteConfig.Builder builder =
+		HoodieWriteConfig.newBuilder()
+			.withPath(cfg.targetBasePath)
+			.combineInput(cfg.filterDupes, combineBeforeUpsert)
+			.withCompactionConfig(
+				HoodieCompactionConfig.newBuilder()
+					.withInlineCompaction(cfg.isInlineCompactionEnabled())
+					.build()
+			)
+			.withPayloadConfig(
+				HoodiePayloadConfig.newBuilder()
+					.withPayloadClass(cfg.payloadClassName)
+					.withPayloadOrderingField(cfg.sourceOrderingField)
+					.build())
+			.forTable(cfg.targetTableName)
+			.withAutoCommit(autoCommit)
+			.withProps(props);
 
-    if (schema != null) {
-      builder.withSchema(getSchemaForWriteConfig(schema).toString());
-    }
+	if (schema != null) {
+	  builder.withSchema(getSchemaForWriteConfig(schema).toString());
+	}
 
-    HoodieWriteConfig config = builder.build();
+	HoodieWriteConfig config = builder.build();
 
-    if (config.writeCommitCallbackOn()) {
-      // set default value for {@link HoodieWriteCommitKafkaCallbackConfig} if needed.
-      if (HoodieWriteCommitKafkaCallback.class.getName().equals(config.getCallbackClass())) {
-        HoodieWriteCommitKafkaCallbackConfig.setCallbackKafkaConfigIfNeeded(config);
-      }
+	if (config.writeCommitCallbackOn()) {
+	  // set default value for {@link HoodieWriteCommitKafkaCallbackConfig} if needed.
+	  if (HoodieWriteCommitKafkaCallback.class.getName().equals(config.getCallbackClass())) {
+		HoodieWriteCommitKafkaCallbackConfig.setCallbackKafkaConfigIfNeeded(config);
+	  }
 
-      // set default value for {@link HoodieWriteCommitPulsarCallbackConfig} if needed.
-      if (HoodieWriteCommitPulsarCallback.class.getName().equals(config.getCallbackClass())) {
-        HoodieWriteCommitPulsarCallbackConfig.setCallbackPulsarConfigIfNeeded(config);
-      }
-    }
+	  // set default value for {@link HoodieWriteCommitPulsarCallbackConfig} if needed.
+	  if (HoodieWriteCommitPulsarCallback.class.getName().equals(config.getCallbackClass())) {
+		HoodieWriteCommitPulsarCallbackConfig.setCallbackPulsarConfigIfNeeded(config);
+	  }
+	}
 
-    HoodieClusteringConfig clusteringConfig = HoodieClusteringConfig.from(props);
+	HoodieClusteringConfig clusteringConfig = HoodieClusteringConfig.from(props);
 
-    // Validate what deltastreamer assumes of write-config to be really safe
-    ValidationUtils.checkArgument(config.inlineCompactionEnabled() == cfg.isInlineCompactionEnabled(),
-        String.format("%s should be set to %s", INLINE_COMPACT.key(), cfg.isInlineCompactionEnabled()));
-    ValidationUtils.checkArgument(config.inlineClusteringEnabled() == clusteringConfig.isInlineClusteringEnabled(),
-        String.format("%s should be set to %s", INLINE_CLUSTERING.key(), clusteringConfig.isInlineClusteringEnabled()));
-    ValidationUtils.checkArgument(config.isAsyncClusteringEnabled() == clusteringConfig.isAsyncClusteringEnabled(),
-        String.format("%s should be set to %s", ASYNC_CLUSTERING_ENABLE.key(), clusteringConfig.isAsyncClusteringEnabled()));
-    ValidationUtils.checkArgument(!config.shouldAutoCommit(),
-        String.format("%s should be set to %s", AUTO_COMMIT_ENABLE.key(), autoCommit));
-    ValidationUtils.checkArgument(config.shouldCombineBeforeInsert() == cfg.filterDupes,
-        String.format("%s should be set to %s", COMBINE_BEFORE_INSERT.key(), cfg.filterDupes));
-    ValidationUtils.checkArgument(config.shouldCombineBeforeUpsert(),
-        String.format("%s should be set to %s", COMBINE_BEFORE_UPSERT.key(), combineBeforeUpsert));
-    return config;
+	// Validate what deltastreamer assumes of write-config to be really safe
+	ValidationUtils.checkArgument(config.inlineCompactionEnabled() == cfg.isInlineCompactionEnabled(),
+		String.format("%s should be set to %s", INLINE_COMPACT.key(), cfg.isInlineCompactionEnabled()));
+	ValidationUtils.checkArgument(config.inlineClusteringEnabled() == clusteringConfig.isInlineClusteringEnabled(),
+		String.format("%s should be set to %s", INLINE_CLUSTERING.key(), clusteringConfig.isInlineClusteringEnabled()));
+	ValidationUtils.checkArgument(config.isAsyncClusteringEnabled() == clusteringConfig.isAsyncClusteringEnabled(),
+		String.format("%s should be set to %s", ASYNC_CLUSTERING_ENABLE.key(), clusteringConfig.isAsyncClusteringEnabled()));
+	ValidationUtils.checkArgument(!config.shouldAutoCommit(),
+		String.format("%s should be set to %s", AUTO_COMMIT_ENABLE.key(), autoCommit));
+	ValidationUtils.checkArgument(config.shouldCombineBeforeInsert() == cfg.filterDupes,
+		String.format("%s should be set to %s", COMBINE_BEFORE_INSERT.key(), cfg.filterDupes));
+	ValidationUtils.checkArgument(config.shouldCombineBeforeUpsert(),
+		String.format("%s should be set to %s", COMBINE_BEFORE_UPSERT.key(), combineBeforeUpsert));
+	return config;
   }
 
   private Schema getSchemaForWriteConfig(Schema targetSchema) {
-    Schema newWriteSchema = targetSchema;
-    try {
-      if (targetSchema != null) {
-        // check if targetSchema is equal to NULL schema
-        if (SchemaCompatibility.checkReaderWriterCompatibility(targetSchema, InputBatch.NULL_SCHEMA).getType() == SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE
-            && SchemaCompatibility.checkReaderWriterCompatibility(InputBatch.NULL_SCHEMA, targetSchema).getType() == SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE) {
-          // target schema is null. fetch schema from commit metadata and use it
-          HoodieTableMetaClient meta = HoodieTableMetaClient.builder().setConf(new Configuration(fs.getConf()))
-              .setBasePath(cfg.targetBasePath)
-              .setPayloadClassName(cfg.payloadClassName)
-              .build();
-          int totalCompleted = meta.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().countInstants();
-          if (totalCompleted > 0) {
-            try {
-              TableSchemaResolver schemaResolver = new TableSchemaResolver(meta);
-              newWriteSchema = schemaResolver.getTableAvroSchema(false);
-            } catch (IllegalArgumentException e) {
-              LOG.warn("Could not fetch schema from table. Falling back to using target schema from schema provider");
-            }
-          }
-        }
-      }
-      return newWriteSchema;
-    } catch (Exception e) {
-      throw new HoodieSchemaFetchException("Failed to fetch schema from table", e);
-    }
+	Schema newWriteSchema = targetSchema;
+	try {
+	  if (targetSchema != null) {
+		// check if targetSchema is equal to NULL schema
+		if (SchemaCompatibility.checkReaderWriterCompatibility(targetSchema, InputBatch.NULL_SCHEMA).getType() == SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE
+			&& SchemaCompatibility.checkReaderWriterCompatibility(InputBatch.NULL_SCHEMA, targetSchema).getType() == SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE) {
+		  // target schema is null. fetch schema from commit metadata and use it
+		  HoodieTableMetaClient meta = HoodieTableMetaClient.builder().setConf(new Configuration(fs.getConf()))
+			  .setBasePath(cfg.targetBasePath)
+			  .setPayloadClassName(cfg.payloadClassName)
+			  .build();
+		  int totalCompleted = meta.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().countInstants();
+		  if (totalCompleted > 0) {
+			try {
+			  TableSchemaResolver schemaResolver = new TableSchemaResolver(meta);
+			  newWriteSchema = schemaResolver.getTableAvroSchema(false);
+			} catch (IllegalArgumentException e) {
+			  LOG.warn("Could not fetch schema from table. Falling back to using target schema from schema provider");
+			}
+		  }
+		}
+	  }
+	  return newWriteSchema;
+	} catch (Exception e) {
+	  throw new HoodieSchemaFetchException("Failed to fetch schema from table", e);
+	}
   }
 
   /**
@@ -1122,9 +1134,9 @@ public class DeltaSync implements Serializable, Closeable {
    * @param schemaProvider Schema Provider
    */
   private void registerAvroSchemas(SchemaProvider schemaProvider) {
-    if (null != schemaProvider) {
-      registerAvroSchemas(schemaProvider.getSourceSchema(), schemaProvider.getTargetSchema());
-    }
+	if (null != schemaProvider) {
+	  registerAvroSchemas(schemaProvider.getSourceSchema(), schemaProvider.getTargetSchema());
+	}
   }
 
   /**
@@ -1134,63 +1146,63 @@ public class DeltaSync implements Serializable, Closeable {
    * @param targetSchema Target Schema
    */
   private void registerAvroSchemas(Schema sourceSchema, Schema targetSchema) {
-    // register the schemas, so that shuffle does not serialize the full schemas
-    if (null != sourceSchema) {
-      List<Schema> schemas = new ArrayList<>();
-      schemas.add(sourceSchema);
-      if (targetSchema != null) {
-        schemas.add(targetSchema);
-      }
+	// register the schemas, so that shuffle does not serialize the full schemas
+	if (null != sourceSchema) {
+	  List<Schema> schemas = new ArrayList<>();
+	  schemas.add(sourceSchema);
+	  if (targetSchema != null) {
+		schemas.add(targetSchema);
+	  }
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Registering Schema: " + schemas);
-      }
-      jssc.sc().getConf().registerAvroSchemas(JavaConversions.asScalaBuffer(schemas).toList());
-    }
+	  if (LOG.isDebugEnabled()) {
+		LOG.debug("Registering Schema: " + schemas);
+	  }
+	  jssc.sc().getConf().registerAvroSchemas(JavaConversions.asScalaBuffer(schemas).toList());
+	}
   }
 
   /**
    * Close all resources.
    */
   public void close() {
-    if (writeClient != null) {
-      writeClient.close();
-      writeClient = null;
-    }
+	if (writeClient != null) {
+	  writeClient.close();
+	  writeClient = null;
+	}
 
-    if (formatAdapter != null) {
-      formatAdapter.close();
-    }
+	if (formatAdapter != null) {
+	  formatAdapter.close();
+	}
 
-    LOG.info("Shutting down embedded timeline server");
-    if (embeddedTimelineService.isPresent()) {
-      embeddedTimelineService.get().stop();
-    }
+	LOG.info("Shutting down embedded timeline server");
+	if (embeddedTimelineService.isPresent()) {
+	  embeddedTimelineService.get().stop();
+	}
 
-    if (metrics != null) {
-      metrics.shutdown();
-    }
+	if (metrics != null) {
+	  metrics.shutdown();
+	}
 
   }
 
   public FileSystem getFs() {
-    return fs;
+	return fs;
   }
 
   public TypedProperties getProps() {
-    return props;
+	return props;
   }
 
   public Config getCfg() {
-    return cfg;
+	return cfg;
   }
 
   public Option<HoodieTimeline> getCommitsTimelineOpt() {
-    return commitsTimelineOpt;
+	return commitsTimelineOpt;
   }
 
   public HoodieIngestionMetrics getMetrics() {
-    return metrics;
+	return metrics;
   }
 
   /**
@@ -1200,11 +1212,11 @@ public class DeltaSync implements Serializable, Closeable {
    * @return Requested clustering instant.
    */
   public Option<String> getClusteringInstantOpt() {
-    if (writeClient != null) {
-      return writeClient.scheduleClustering(Option.empty());
-    } else {
-      return Option.empty();
-    }
+	if (writeClient != null) {
+	  return writeClient.scheduleClustering(Option.empty());
+	} else {
+	  return Option.empty();
+	}
   }
 
   /**
@@ -1212,7 +1224,7 @@ public class DeltaSync implements Serializable, Closeable {
    * When set to true, will not write the partition columns into the table.
    */
   private Boolean isDropPartitionColumns() {
-    return props.getBoolean(DROP_PARTITION_COLUMNS.key(), DROP_PARTITION_COLUMNS.defaultValue());
+	return props.getBoolean(DROP_PARTITION_COLUMNS.key(), DROP_PARTITION_COLUMNS.defaultValue());
   }
 
   /**
@@ -1222,11 +1234,11 @@ public class DeltaSync implements Serializable, Closeable {
    * @return Set of partition columns.
    */
   private Set<String> getPartitionColumns(TypedProperties props) {
-    String partitionColumns = SparkKeyGenUtils.getPartitionColumns(props);
-    return Arrays.stream(partitionColumns.split(",")).collect(Collectors.toSet());
+	String partitionColumns = SparkKeyGenUtils.getPartitionColumns(props);
+	return Arrays.stream(partitionColumns.split(",")).collect(Collectors.toSet());
   }
 
   public String getMultiwriterIdentifier() {
-    return multiwriterIdentifier.get();
+	return multiwriterIdentifier.get();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -210,12 +210,7 @@ public class DeltaSync implements Serializable, Closeable {
   /**
    * Spark context Wrapper.
    */
-  private transient HoodieSparkEngineContext sparkEngineContext;
-
-  /**
-   * Spark context.
-   */
-  private transient JavaSparkContext jssc;
+  private transient HoodieSparkEngineContext sparkContext;
 
   /**
    * Spark Session.
@@ -290,11 +285,10 @@ public class DeltaSync implements Serializable, Closeable {
   }
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-                   TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs, Configuration conf,
+                   TypedProperties props, HoodieSparkEngineContext sparkContext, FileSystem fs, Configuration conf,
                    Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
     this.cfg = cfg;
-    this.sparkEngineContext = sparkEngineContext;
-    this.jssc = sparkEngineContext.getJavaSparkContext();
+    this.sparkContext = sparkContext;
     this.sparkSession = sparkSession;
     this.fs = fs;
     this.onInitializingHoodieWriteClient = onInitializingHoodieWriteClient;
@@ -317,11 +311,11 @@ public class DeltaSync implements Serializable, Closeable {
     }
     this.multiwriterIdentifier = StringUtils.isNullOrEmpty(id) ? Option.empty() : Option.of(id);
     if (props.getBoolean(ERROR_TABLE_ENABLED.key(),ERROR_TABLE_ENABLED.defaultValue())) {
-      this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(cfg, sparkSession, props, jssc, fs);
+      this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(cfg, sparkSession, props, sparkContext, fs);
       this.errorWriteFailureStrategy = ErrorTableUtils.getErrorWriteFailureStrategy(props);
     }
     this.formatAdapter = new SourceFormatAdapter(
-        UtilHelpers.createSource(cfg.sourceClassName, props, jssc, sparkSession, schemaProvider, metrics),
+        UtilHelpers.createSource(cfg.sourceClassName, props, sparkContext.jsc(), sparkSession, schemaProvider, metrics),
         this.errorTableWriter, Option.of(props));
 
     this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames),
@@ -410,7 +404,7 @@ public class DeltaSync implements Serializable, Closeable {
             Boolean.parseBoolean(HIVE_STYLE_PARTITIONING_ENABLE.defaultValue())))
         .setUrlEncodePartitioning(props.getBoolean(URL_ENCODE_PARTITIONING.key(),
             Boolean.parseBoolean(URL_ENCODE_PARTITIONING.defaultValue())))
-        .initTable(new Configuration(jssc.hadoopConfiguration()),
+        .initTable(new Configuration(sparkContext.hadoopConfiguration()),
             cfg.targetBasePath);
   }
 
@@ -550,7 +544,7 @@ public class DeltaSync implements Serializable, Closeable {
           formatAdapter.fetchNewDataInRowFormat(resumeCheckpointStr, cfg.sourceLimit);
 
       Option<Dataset<Row>> transformed =
-          dataAndCheckpoint.getBatch().map(data -> transformer.get().apply(jssc, sparkSession, data, props));
+          dataAndCheckpoint.getBatch().map(data -> transformer.get().apply(sparkContext.jsc(), sparkSession, data, props));
 
       transformed = formatAdapter.processErrorEvents(transformed,
           ErrorEvent.ErrorReason.CUSTOM_TRANSFORMER_FAILURE);
@@ -582,7 +576,7 @@ public class DeltaSync implements Serializable, Closeable {
         }
         schemaProvider = this.userProvidedSchemaProvider;
       } else {
-        Option<Schema> latestTableSchemaOpt = UtilHelpers.getLatestTableSchema(jssc, fs, cfg.targetBasePath);
+        Option<Schema> latestTableSchemaOpt = UtilHelpers.getLatestTableSchema(sparkContext.jsc(), fs, cfg.targetBasePath);
         // Deduce proper target (writer's) schema for the transformed dataset, reconciling its
         // schema w/ the table's one
         Option<Schema> targetSchemaOpt = transformed.map(df -> {
@@ -598,8 +592,8 @@ public class DeltaSync implements Serializable, Closeable {
         });
         // Override schema provider with the reconciled target schema
         schemaProvider = targetSchemaOpt.map(targetSchema ->
-          (SchemaProvider) new DelegatingSchemaProvider(props, jssc, dataAndCheckpoint.getSchemaProvider(),
-                new SimpleSchemaProvider(jssc, targetSchema, props)))
+          (SchemaProvider) new DelegatingSchemaProvider(props, sparkContext.jsc(), dataAndCheckpoint.getSchemaProvider(),
+                                                        new SimpleSchemaProvider(sparkContext.jsc(), targetSchema, props)))
           .orElse(dataAndCheckpoint.getSchemaProvider());
         // Rewrite transformed records into the expected target schema
         avroRDDOptional = transformed.map(t -> getTransformedRDD(t, reconcileSchema, schemaProvider.getTargetSchema()));
@@ -621,10 +615,10 @@ public class DeltaSync implements Serializable, Closeable {
       return null;
     }
 
-    jssc.setJobGroup(this.getClass().getSimpleName(), "Checking if input is empty");
+    sparkContext.setJobStatus(this.getClass().getSimpleName(), "Checking if input is empty");
     if ((!avroRDDOptional.isPresent()) || (avroRDDOptional.get().isEmpty())) {
       LOG.info("No new data, perform empty commit.");
-      return Pair.of(schemaProvider, Pair.of(checkpointStr, jssc.emptyRDD()));
+      return Pair.of(schemaProvider, Pair.of(checkpointStr, sparkContext.emptyRDD()));
     }
 
     boolean shouldCombine = cfg.filterDupes || cfg.operation.equals(WriteOperationType.UPSERT);
@@ -797,7 +791,7 @@ public class DeltaSync implements Serializable, Closeable {
     Option<String> scheduledCompactionInstant = Option.empty();
     // filter dupes if needed
     if (cfg.filterDupes) {
-      records = DataSourceUtils.dropDuplicates(jssc, records, writeClient.getConfig());
+      records = DataSourceUtils.dropDuplicates(sparkContext.jsc(), records, writeClient.getConfig());
     }
 
     boolean isEmpty = records.isEmpty();
@@ -955,7 +949,7 @@ public class DeltaSync implements Serializable, Closeable {
       LOG.info("When set --enable-hive-sync will use HiveSyncTool for backward compatibility");
     }
     if (cfg.enableMetaSync) {
-      FileSystem fs = FSUtils.getFs(cfg.targetBasePath, jssc.hadoopConfiguration());
+      FileSystem fs = FSUtils.getFs(cfg.targetBasePath, sparkContext.hadoopConfiguration());
 
       TypedProperties metaProps = new TypedProperties();
       metaProps.putAll(props);
@@ -1004,12 +998,12 @@ public class DeltaSync implements Serializable, Closeable {
     registerAvroSchemas(sourceSchema, targetSchema);
     final HoodieWriteConfig initialWriteConfig = getHoodieClientConfig(targetSchema);
     final HoodieWriteConfig writeConfig = SparkSampleWritesUtils
-        .getWriteConfigWithRecordSizeEstimate(jssc, records, initialWriteConfig)
+        .getWriteConfigWithRecordSizeEstimate(sparkContext.jsc(), records, initialWriteConfig)
         .orElse(initialWriteConfig);
 
     if (writeConfig.isEmbeddedTimelineServerEnabled()) {
       if (!embeddedTimelineService.isPresent()) {
-        embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(sparkEngineContext, writeConfig);
+        embeddedTimelineService = EmbeddedTimelineServerHelper.createEmbeddedTimelineService(sparkContext, writeConfig);
       } else {
         EmbeddedTimelineServerHelper.updateWriteConfigWithTimelineServer(embeddedTimelineService.get(), writeConfig);
       }
@@ -1019,7 +1013,7 @@ public class DeltaSync implements Serializable, Closeable {
       // Close Write client.
       writeClient.close();
     }
-    writeClient = new SparkRDDWriteClient<>(sparkEngineContext, writeConfig, embeddedTimelineService);
+    writeClient = new SparkRDDWriteClient<>(sparkContext, writeConfig, embeddedTimelineService);
     onInitializingHoodieWriteClient.apply(writeClient);
   }
 
@@ -1157,7 +1151,7 @@ public class DeltaSync implements Serializable, Closeable {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Registering Schema: " + schemas);
       }
-      jssc.sc().getConf().registerAvroSchemas(JavaConversions.asScalaBuffer(schemas).toList());
+      sparkContext.getSparkConf().registerAvroSchemas(JavaConversions.asScalaBuffer(schemas).toList());
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -70,7 +70,6 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieMetaSyncException;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HiveSyncTool;
-import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.keygen.BuiltinKeyGenerator;
 import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -1151,7 +1151,8 @@ public class DeltaSync implements Serializable, Closeable {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Registering Schema: " + schemas);
       }
-      sparkContext.getSparkConf().registerAvroSchemas(JavaConversions.asScalaBuffer(schemas).toList());
+      // Use the underlying spark context in case the java context is changed during runtime
+      sparkContext.getJavaSparkContext().sc().getConf().registerAvroSchemas(JavaConversions.asScalaBuffer(schemas).toList());
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -179,119 +179,97 @@ public class DeltaSync implements Serializable, Closeable {
    * Delta Sync Config.
    */
   private final HoodieDeltaStreamer.Config cfg;
-
-  /**
-   * Source to pull deltas from.
-   */
-  private transient SourceFormatAdapter formatAdapter;
-
-  /**
-   * User Provided Schema Provider.
-   */
-  private transient SchemaProvider userProvidedSchemaProvider;
-
-  /**
-   * Schema provider that supplies the command for reading the input and writing out the target table.
-   */
-  private transient SchemaProvider schemaProvider;
-
-  /**
-   * Allows transforming source to target table before writing.
-   */
-  private transient Option<Transformer> transformer;
-
-  private String keyGenClassName;
-
-  /**
-   * Filesystem used.
-   */
-  private transient FileSystem fs;
-
-  /**
-   * Spark context Wrapper.
-   */
-  private transient HoodieSparkEngineContext sparkEngineContext;
-
-  /**
-   * Spark context.
-   */
-  private transient JavaSparkContext jssc;
-
-  /**
-   * Spark Session.
-   */
-  private transient SparkSession sparkSession;
-
-  /**
-   * Hive Config.
-   */
-  private transient Configuration conf;
-
   /**
    * Bag of properties with source, hoodie client, key generator etc.
-   *
+   * <p>
    * NOTE: These properties are already consolidated w/ CLI provided config-overrides
    */
   private final TypedProperties props;
-
-  /**
-   * Callback when write client is instantiated.
-   */
-  private transient Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient;
-
-  /**
-   * Timeline with completed commits, including both .commit and .deltacommit.
-   */
-  private transient Option<HoodieTimeline> commitsTimelineOpt;
-
-  // all commits timeline, including all (commits, delta commits, compaction, clean, savepoint, rollback, replace commits, index)
-  private transient Option<HoodieTimeline> allCommitsTimelineOpt;
-
   /**
    * Tracks whether new schema is being seen and creates client accordingly.
    */
   private final SchemaSet processedSchema;
-
+  private final boolean autoGenerateRecordKeys;
+  /**
+   * Source to pull deltas from.
+   */
+  private transient SourceFormatAdapter formatAdapter;
+  /**
+   * User Provided Schema Provider.
+   */
+  private transient SchemaProvider userProvidedSchemaProvider;
+  /**
+   * Schema provider that supplies the command for reading the input and writing out the target table.
+   */
+  private transient SchemaProvider schemaProvider;
+  /**
+   * Allows transforming source to target table before writing.
+   */
+  private transient Option<Transformer> transformer;
+  private String keyGenClassName;
+  /**
+   * Filesystem used.
+   */
+  private transient FileSystem fs;
+  /**
+   * Spark context Wrapper.
+   */
+  private transient HoodieSparkEngineContext sparkEngineContext;
+  /**
+   * Spark context.
+   */
+  private transient JavaSparkContext jssc;
+  /**
+   * Spark Session.
+   */
+  private transient SparkSession sparkSession;
+  /**
+   * Hive Config.
+   */
+  private transient Configuration conf;
+  /**
+   * Callback when write client is instantiated.
+   */
+  private transient Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient;
+  /**
+   * Timeline with completed commits, including both .commit and .deltacommit.
+   */
+  private transient Option<HoodieTimeline> commitsTimelineOpt;
+  // all commits timeline, including all (commits, delta commits, compaction, clean, savepoint, rollback, replace commits, index)
+  private transient Option<HoodieTimeline> allCommitsTimelineOpt;
   /**
    * DeltaSync will explicitly manage embedded timeline server so that they can be reused across Write Client
    * instantiations.
    */
   private transient Option<EmbeddedTimelineService> embeddedTimelineService = Option.empty();
-
   /**
    * Write Client.
    */
   private transient SparkRDDWriteClient writeClient;
-
   private Option<BaseErrorTableWriter> errorTableWriter = Option.empty();
   private HoodieErrorTableConfig.ErrorWriteFailureStrategy errorWriteFailureStrategy;
-
   private transient HoodieIngestionMetrics metrics;
   private transient HoodieMetrics hoodieMetrics;
-
   /**
    * Unique identifier of the deltastreamer
-   * */
+   */
   private transient Option<String> multiwriterIdentifier;
-
   /**
    * The last checkpoint that THIS deltastreamer instance wrote.
    * NOT the last checkpoint in the timeline.
    */
   private transient String latestCheckpointWritten;
 
-  private final boolean autoGenerateRecordKeys;
-
   @Deprecated
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-				   TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
-				   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
-	this(cfg, sparkSession, schemaProvider, props, new HoodieSparkEngineContext(jssc), fs, conf, onInitializingHoodieWriteClient);
+      TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration conf,
+      Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+    this(cfg, sparkSession, schemaProvider, props, new HoodieSparkEngineContext(jssc), fs, conf, onInitializingHoodieWriteClient);
   }
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-				   TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs, Configuration conf,
-				   Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
+      TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs, Configuration conf,
+      Function<SparkRDDWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
 
     this.cfg = cfg;
     this.sparkEngineContext = sparkEngineContext;
@@ -317,7 +295,7 @@ public class DeltaSync implements Serializable, Closeable {
       id = props.getProperty(MUTLI_WRITER_SOURCE_CHECKPOINT_ID.key());
     }
     this.multiwriterIdentifier = StringUtils.isNullOrEmpty(id) ? Option.empty() : Option.of(id);
-    if (props.getBoolean(ERROR_TABLE_ENABLED.key(),ERROR_TABLE_ENABLED.defaultValue())) {
+    if (props.getBoolean(ERROR_TABLE_ENABLED.key(), ERROR_TABLE_ENABLED.defaultValue())) {
       this.errorTableWriter = ErrorTableUtils.getErrorTableWriter(cfg, sparkSession, props, jssc, fs);
       this.errorWriteFailureStrategy = ErrorTableUtils.getErrorWriteFailureStrategy(props);
     }
@@ -328,6 +306,19 @@ public class DeltaSync implements Serializable, Closeable {
     this.transformer = UtilHelpers.createTransformer(Option.ofNullable(cfg.transformerClassNames),
         Option.ofNullable(schemaProvider).map(SchemaProvider::getSourceSchema), this.errorTableWriter.isPresent());
 
+  }
+
+  public static Option<String> readCheckpointValue(String value, String id) {
+    try {
+      Map<String, String> checkpointMap = OBJECT_MAPPER.readValue(value, Map.class);
+      if (!checkpointMap.containsKey(id)) {
+        return Option.empty();
+      }
+      String checkpointVal = checkpointMap.get(id);
+      return Option.of(checkpointVal);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to parse checkpoint as map", e);
+    }
   }
 
   /**
@@ -494,7 +485,7 @@ public class DeltaSync implements Serializable, Closeable {
   /**
    * Read from Upstream Source and apply transformation if needed.
    *
-   * @return Pair<SchemaProvider, Pair<String, JavaRDD<HoodieRecord>>> Input data read from upstream source, consists
+   * @return Pair<SchemaProvider, Pair < String, JavaRDD < HoodieRecord>>> Input data read from upstream source, consists
    * of schemaProvider, checkpointStr and hoodieRecord
    * @throws Exception in case of any Exception
    */
@@ -592,16 +583,16 @@ public class DeltaSync implements Serializable, Closeable {
           // Target (writer's) schema is determined based on the incoming source schema
           // and existing table's one, reconciling the two (if necessary) based on configuration
           return HoodieSparkSqlWriter.deduceWriterSchema(
-                  sourceSchema,
-                  HoodieConversionUtils.<Schema>toScalaOption(latestTableSchemaOpt),
-                  HoodieConversionUtils.<InternalSchema>toScalaOption(Option.empty()),
-                  HoodieConversionUtils.fromProperties(props));
+              sourceSchema,
+              HoodieConversionUtils.<Schema>toScalaOption(latestTableSchemaOpt),
+              HoodieConversionUtils.<InternalSchema>toScalaOption(Option.empty()),
+              HoodieConversionUtils.fromProperties(props));
         });
         // Override schema provider with the reconciled target schema
         schemaProvider = targetSchemaOpt.map(targetSchema ->
-          (SchemaProvider) new DelegatingSchemaProvider(props, jssc, dataAndCheckpoint.getSchemaProvider(),
+            (SchemaProvider) new DelegatingSchemaProvider(props, jssc, dataAndCheckpoint.getSchemaProvider(),
                 new SimpleSchemaProvider(jssc, targetSchema, props)))
-          .orElse(dataAndCheckpoint.getSchemaProvider());
+            .orElse(dataAndCheckpoint.getSchemaProvider());
         // Rewrite transformed records into the expected target schema
         avroRDDOptional = transformed.map(t -> getTransformedRDD(t, reconcileSchema, schemaProvider.getTargetSchema()));
       }
@@ -739,19 +730,6 @@ public class DeltaSync implements Serializable, Closeable {
     return resumeCheckpointStr;
   }
 
-  public static Option<String> readCheckpointValue(String value, String id) {
-    try {
-      Map<String,String> checkpointMap = OBJECT_MAPPER.readValue(value, Map.class);
-      if (!checkpointMap.containsKey(id)) {
-        return Option.empty();
-      }
-      String checkpointVal = checkpointMap.get(id);
-      return Option.of(checkpointVal);
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to parse checkpoint as map", e);
-    }
-  }
-
   protected Option<Pair<String, HoodieCommitMetadata>> getLatestInstantAndCommitMetadataWithValidCheckpointInfo(HoodieTimeline timeline) throws IOException {
     return (Option<Pair<String, HoodieCommitMetadata>>) timeline.getReverseOrderedInstants().map(instant -> {
       try {
@@ -793,8 +771,8 @@ public class DeltaSync implements Serializable, Closeable {
    * @return Option Compaction instant if one is scheduled
    */
   private Pair<Option<String>, JavaRDD<WriteStatus>> writeToSink(String instantTime, JavaRDD<HoodieRecord> records, String checkpointStr,
-                                                                 HoodieIngestionMetrics metrics,
-                                                                 Timer.Context overallTimerContext) {
+      HoodieIngestionMetrics metrics,
+      Timer.Context overallTimerContext) {
     Option<String> scheduledCompactionInstant = Option.empty();
     // filter dupes if needed
     if (cfg.filterDupes) {
@@ -966,7 +944,7 @@ public class DeltaSync implements Serializable, Closeable {
             props.getInteger(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key())));
       }
 
-      Map<String,HoodieException> failedMetaSyncs = new HashMap<>();
+      Map<String, HoodieException> failedMetaSyncs = new HashMap<>();
       for (String impl : syncClientToolClasses) {
         Timer.Context syncContext = metrics.getMetaSyncTimerContext();
         try {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/ErrorTableUtils.java
@@ -45,7 +45,7 @@ import static org.apache.hudi.utilities.deltastreamer.BaseErrorTableWriter.ERROR
 
 public final class ErrorTableUtils {
   public static Option<BaseErrorTableWriter> getErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-                                                                 TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
+                                                                 TypedProperties props, HoodieSparkEngineContext hoodieSparkContext, FileSystem fs) {
     String errorTableWriterClass = props.getString(ERROR_TABLE_WRITE_CLASS.key());
     ValidationUtils.checkState(!StringUtils.isNullOrEmpty(errorTableWriterClass),
         "Missing error table config " + ERROR_TABLE_WRITE_CLASS);
@@ -57,7 +57,7 @@ public final class ErrorTableUtils {
 
     try {
       return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(argClassArr)
-          .newInstance(cfg, sparkSession, props, sparkEngineContext, fs));
+          .newInstance(cfg, sparkSession, props, hoodieSparkContext, fs));
     } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
       throw new HoodieException(errMsg, e);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/ErrorTableUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
@@ -45,19 +46,19 @@ import static org.apache.hudi.utilities.deltastreamer.BaseErrorTableWriter.ERROR
 
 public final class ErrorTableUtils {
   public static Option<BaseErrorTableWriter> getErrorTableWriter(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession,
-                                                                 TypedProperties props, JavaSparkContext jssc, FileSystem fs) {
+                                                                 TypedProperties props, HoodieSparkEngineContext sparkEngineContext, FileSystem fs) {
     String errorTableWriterClass = props.getString(ERROR_TABLE_WRITE_CLASS.key());
     ValidationUtils.checkState(!StringUtils.isNullOrEmpty(errorTableWriterClass),
         "Missing error table config " + ERROR_TABLE_WRITE_CLASS);
 
     Class<?>[] argClassArr = new Class[]{HoodieDeltaStreamer.Config.class,
-        SparkSession.class, TypedProperties.class, JavaSparkContext.class, FileSystem.class};
+        SparkSession.class, TypedProperties.class, HoodieSparkEngineContext.class, FileSystem.class};
     String errMsg = "Unable to instantiate ErrorTableWriter with arguments type " + Arrays.toString(argClassArr);
     ValidationUtils.checkArgument(ReflectionUtils.hasConstructor(BaseErrorTableWriter.class.getName(), argClassArr, false), errMsg);
 
     try {
       return Option.of((BaseErrorTableWriter) ReflectionUtils.getClass(errorTableWriterClass).getConstructor(argClassArr)
-          .newInstance(cfg, sparkSession, props, jssc, fs));
+          .newInstance(cfg, sparkSession, props, sparkEngineContext, fs));
     } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
       throw new HoodieException(errMsg, e);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/ErrorTableUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/ErrorTableUtils.java
@@ -30,7 +30,6 @@ import org.apache.hudi.exception.HoodieException;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hudi.exception.HoodieValidationException;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -714,7 +714,7 @@ public class HoodieDeltaStreamer implements Serializable {
 
       this.schemaProvider = UtilHelpers.wrapSchemaProviderWithPostProcessor(
           UtilHelpers.createSchemaProvider(cfg.schemaProviderClassName, props, sparkEngineContext.getJavaSparkContext()),
-		  props, sparkEngineContext.getJavaSparkContext(), cfg.transformerClassNames);
+          props, sparkEngineContext.getJavaSparkContext(), cfg.transformerClassNames);
 
       deltaSync = new DeltaSync(cfg, sparkSession, schemaProvider, props, sparkEngineContext, fs, conf, this::onInitializingWriteClient);
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -621,7 +621,7 @@ public class HoodieDeltaStreamer implements Serializable {
     /**
      * Spark context Wrapper.
      */
-    private transient HoodieSparkEngineContext sparkContext;
+    private final transient HoodieSparkEngineContext sparkContext;
 
     private transient FileSystem fs;
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -162,8 +162,7 @@ public class HoodieDeltaStreamer implements Serializable {
     this.cfg = cfg;
     this.bootstrapExecutor = Option.ofNullable(
         cfg.runBootstrap ? new BootstrapExecutor(cfg, jssc, fs, conf, this.properties) : null);
-    // {@link HoodieDeltaStreamer currently only supports the Spark engine.
-	HoodieSparkEngineContext sparkEngineContext = new HoodieSparkEngineContext(jssc);
+    HoodieSparkEngineContext sparkEngineContext = new HoodieSparkEngineContext(jssc);
     this.ingestionService = Option.ofNullable(
         cfg.runBootstrap ? null : new DeltaSyncService(cfg, sparkEngineContext, fs, conf, Option.ofNullable(this.properties)));
   }
@@ -622,12 +621,12 @@ public class HoodieDeltaStreamer implements Serializable {
      */
     private transient HoodieSparkEngineContext sparkEngineContext;
 
-	/**
-	 * Spark context.
-	 */
-	private transient JavaSparkContext jssc;
+    /**
+     * Spark context.
+     */
+    private transient JavaSparkContext jssc;
 
-	private transient FileSystem fs;
+    private transient FileSystem fs;
 
     private transient Configuration hiveConf;
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.utilities.sources;
 
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -286,7 +287,7 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
 
   private BaseErrorTableWriter getAnonymousErrorTableWriter(TypedProperties props) {
     return new BaseErrorTableWriter<ErrorEvent<String>>(new HoodieDeltaStreamer.Config(),
-        spark(), props, jsc(), fs()) {
+        spark(), props, new HoodieSparkEngineContext(jsc()), fs()) {
       List<JavaRDD<HoodieAvroRecord>> errorEvents = new LinkedList();
 
       @Override
@@ -305,7 +306,7 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
       }
     };
   }
-  
+
   @Test
   public void testAppendKafkaOffset() {
     final String topic = TEST_TOPIC_PREFIX + "testKafkaOffsetAppend";


### PR DESCRIPTION
### Change Logs

Pass in Spark Engine Context Wrapper for DeltaSync instead of spark engine context. This ensures more flexibility and configuration of the spark context by the Deltastreamer when calling DeltaSync

### Impact

The current constructor of DeltaSync takes in the JavaSparkContext directly as argument. Instead, pass in the Hudi wrapper class HudiSparkEngineContext for more flexibility. Ensured backward compatibility for DeltaSync.


### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
