### PR TITLE
[HUDI-6415] Prevent create mor table without precombine spark sql

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.hudi.command
 import org.apache.hadoop.fs.Path
 import org.apache.hudi.common.model.{HoodieFileFormat, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableConfig
-import org.apache.hudi.common.util.ConfigUtils
-import org.apache.hudi.common.util.StringUtils
+import org.apache.hudi.common.util.{ConfigUtils, StringUtils}
 import org.apache.hudi.hadoop.HoodieParquetInputFormat
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils
@@ -39,7 +38,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.{SPARK_VERSION, SparkConf}
 
-import java.io.{PrintWriter, StringWriter}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala
@@ -87,7 +87,6 @@ case class CreateHoodieTableAsSelectCommand(
     val hoodieCatalogTable = HoodieCatalogTable(sparkSession, updatedTable)
     val tablePath = hoodieCatalogTable.tableLocation
     val hadoopConf = sparkSession.sessionState.newHadoopConf()
-
     try {
       // Init hoodie table
       hoodieCatalogTable.initHoodieTable()
@@ -102,6 +101,7 @@ case class CreateHoodieTableAsSelectCommand(
         DataSourceWriteOptions.SQL_ENABLE_BULK_INSERT.key -> "true"
       )
       val partitionSpec = updatedTable.partitionColumnNames.map((_, None)).toMap
+      CreateHoodieTableCommand.validateMOR(hoodieCatalogTable.tableConfig)
       val success = InsertIntoHoodieTableCommand.run(sparkSession, updatedTable, query, partitionSpec,
         mode == SaveMode.Overwrite, refreshTable = false, extraOptions = options)
       if (success) {

--- a/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
+++ b/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
@@ -33,7 +33,7 @@ set hoodie.delete.shuffle.parallelism = 1;
 
 # CTAS
 
-create table h0 using hudi options(type = '${tableType}', primaryKey = 'id')
+create table h0 using hudi options(type = '${tableType}', primaryKey = 'id', preCombineField = 'price')
 location '${tmpDir}/h0'
 as select 1 as id, 'a1' as name, 10 as price;
 +----------+
@@ -46,7 +46,7 @@ select id, name, price from h0;
 +-----------+
 
 create table h0_p using hudi partitioned by(dt)
-options(type = '${tableType}', primaryKey = 'id')
+options(type = '${tableType}', primaryKey = 'id', preCombineField = 'price')
 location '${tmpDir}/h0_p'
 as select cast('2021-05-07 00:00:00' as timestamp) as dt,
  1 as id, 'a1' as name, 10 as price;

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCreateTable.scala
@@ -197,6 +197,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
            | partitioned by (dt)
            | tblproperties (
            |  primaryKey = 'id',
+           |  preCombineField = 'ts',
            |  type = 'mor'
            | )
            | location '${tmp.getCanonicalPath}/h0'
@@ -299,6 +300,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
              | create table $tableName1 using hudi
              | tblproperties(
              |    primaryKey = 'id',
+             |    preCombineField = 'ts',
              |    type = '$tableType'
              | )
              | location '${tmp.getCanonicalPath}/$tableName1'
@@ -321,6 +323,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
              | partitioned by (dt)
              | tblproperties(
              |    primaryKey = 'id',
+             |    preCombineField = 'price',
              |    type = '$tableType'
              | )
              | location '${tmp.getCanonicalPath}/$tableName2'
@@ -346,6 +349,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
                | partitioned by (dt)
                | tblproperties(
                |    primaryKey = 'id',
+               |    preCombineField = 'price',
                |    type = '$tableType'
                | )
                | location '${tmp.getCanonicalPath}/$tableName3'
@@ -362,6 +366,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
              | partitioned by (dt)
              | tblproperties(
              |    primaryKey = 'id',
+             |    preCombineField = 'price',
              |    type = '$tableType'
              | )
              | location '${tmp.getCanonicalPath}/$tableName3'
@@ -386,6 +391,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
              | partitioned by (dt)
              | tblproperties(
              |    primaryKey = 'id',
+             |    preCombineField = 'price',
              |    type = '$tableType'
              | )
              | location '${tmp.getCanonicalPath}/$tableName4'
@@ -763,6 +769,41 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
            | select 1 as id, 'a1' as name, 1000 as ts
            | """.stripMargin
       )("Not support CTAS for the ro/rt table")
+    }
+  }
+
+  test("Test Create MOR no PreCombine") {
+    withTempDir { basePath =>
+      val tableName = generateTableName
+      assertThrows[IllegalArgumentException] {
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  ls long
+             |) using hudi
+             | tblproperties (
+             |  primaryKey = 'id',
+             |  type = 'mor'
+             | )
+             | location '$basePath/$tableName'
+          """.stripMargin)
+      }
+
+      assertThrows[IllegalArgumentException] {
+        spark.sql(
+          s"""
+             | create table $tableName using hudi
+             | tblproperties(
+             |    primaryKey = 'id',
+             |    type = 'mor'
+             | )
+             | AS
+             | select 1 as id, 'a1' as name, 10 as price, '2021-04-01' as dt, 1000 as ls
+           """.stripMargin
+        )
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -359,6 +359,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     withRecordType()(withTempDir { tmp =>
       Seq("cow", "mor").foreach { tableType =>
         withTable(generateTableName) { tableName =>
+          val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'ts'" else ""
           // Create a partitioned table
           spark.sql(
             s"""
@@ -372,6 +373,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                | tblproperties (
                |  type = '$tableType',
                |  primaryKey = 'id'
+               |  $preCombineKeyString
                | )
                | partitioned by (dt)
                | location '${tmp.getCanonicalPath}/$tableName'
@@ -659,6 +661,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       withRecordType()(withTempDir { tmp =>
         Seq("cow", "mor").foreach {tableType =>
           withTable(generateTableName) { tableName =>
+            val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'price'" else ""
             spark.sql(
               s"""
                  |create table $tableName (
@@ -670,6 +673,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | tblproperties (
                  |  type = '$tableType',
                  |  primaryKey = 'id'
+                 |  $preCombineKeyString
                  | )
                  | partitioned by (dt)
                  | location '${tmp.getCanonicalPath}/$tableName'
@@ -709,6 +713,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       withRecordType()(withTempDir { tmp =>
         Seq("cow", "mor").foreach { tableType =>
           withTable(generateTableName) { tableMultiPartition =>
+            val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'price'" else ""
             spark.sql(
               s"""
                  |create table $tableMultiPartition (
@@ -721,6 +726,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | tblproperties (
                  |  type = '$tableType',
                  |  primaryKey = 'id'
+                 |  $preCombineKeyString
                  | )
                  | partitioned by (dt, hh)
                  | location '${tmp.getCanonicalPath}/$tableMultiPartition'
@@ -760,6 +766,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       withRecordType()(withTempDir { tmp =>
         Seq("cow", "mor").foreach { tableType =>
           withTable(generateTableName) { nonPartitionedTable =>
+            val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'price'" else ""
             spark.sql(
               s"""
                  |create table $nonPartitionedTable (
@@ -770,6 +777,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | tblproperties (
                  |  type = '$tableType',
                  |  primaryKey = 'id'
+                 |  $preCombineKeyString
                  | )
                  | location '${tmp.getCanonicalPath}/$nonPartitionedTable'
          """.stripMargin)
@@ -792,6 +800,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       withRecordType()(withTempDir { tmp =>
         Seq("cow", "mor").foreach { tableType =>
           withTable(generateTableName) { inputTable =>
+            val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'price'" else ""
             spark.sql(
               s"""
                  |create table $inputTable (
@@ -803,6 +812,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | tblproperties (
                  |  type = '$tableType',
                  |  primaryKey = 'id'
+                 |  $preCombineKeyString
                  | )
                  | partitioned by (dt)
                  | location '${tmp.getCanonicalPath}/$inputTable'
@@ -817,6 +827,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                    |tblproperties(
                    | type = '$tableType',
                    | primaryKey = 'id'
+                   | $preCombineKeyString
                    |)
                    | location '${tmp.getCanonicalPath}/$target'
                    | as
@@ -840,6 +851,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       withRecordType()(withTempDir { tmp =>
         Seq("cow", "mor").foreach { tableType =>
           withTable(generateTableName) { nonPartitionedTable =>
+            val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'price'" else ""
             spark.sql(
               s"""
                  |create table $nonPartitionedTable (
@@ -850,6 +862,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | tblproperties (
                  |  type = '$tableType',
                  |  primaryKey = 'id'
+                 |  $preCombineKeyString
                  | )
                  | location '${tmp.getCanonicalPath}/$nonPartitionedTable'
          """.stripMargin)
@@ -873,6 +886,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       withRecordType()(withTempDir { tmp =>
         Seq("cow", "mor").foreach { tableType =>
           withTable(generateTableName) { partitionedTable =>
+            val preCombineKeyString = if (tableType == "mor") ", preCombineField = 'price'" else ""
             spark.sql(
               s"""
                  |create table $partitionedTable (
@@ -884,6 +898,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                  | tblproperties (
                  |  type = '$tableType',
                  |  primaryKey = 'id'
+                 |  $preCombineKeyString
                  | )
                  | partitioned by (dt)
                  | location '${tmp.getCanonicalPath}/$partitionedTable'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable.scala
@@ -407,7 +407,8 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
            | ) using hudi
            | tblproperties (
            |  type = 'mor',
-           |  primaryKey = 'id'
+           |  primaryKey = 'id',
+           |  preCombineField = 'price'
            | )
            | partitioned by(dt)
            | location '${tmp.getCanonicalPath}'
@@ -1208,7 +1209,8 @@ class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSuppo
              | ) using hudi
              | tblproperties (
              |  type = 'mor',
-             |  primaryKey = 'id'
+             |  primaryKey = 'id',
+             |  preCombineField = 'price'
              | )
              | partitioned by(dt)
              | location '${tmp.getCanonicalPath}'


### PR DESCRIPTION
### Change Logs

For spark sql create table, or CTAS, if it is an mor table and precombine is not defined, fail.

### Impact

Fails earlier so user finds error quicker

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
