### PR TITLE
[MINOR] Fix `pr-size-labeler` version

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@54ef367
+      - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size-xs'


### PR DESCRIPTION
### Change Logs

This PR fixes the `pr-size-labeler` version according to the apache org whitelist on the GH actions (https://issues.apache.org/jira/projects/INFRA/issues/INFRA-24560).

```
Error: Unable to resolve action `CodelyTV/pr-size-labeler@54ef367`, the provided ref `54ef367` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `54ef36785e9f4cb5ecf1949cfc9b00dbb621d761` instead.
```

### Impact

Enables PR size labeler.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
