### PR TITLE
[HUDI-6420] Fixing Hfile on-demand and prefix based reads to use optimized apis

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/storage/TestHoodieHFileReaderWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/storage/TestHoodieHFileReaderWriter.java
@@ -247,6 +247,47 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
   }
 
   @Test
+  public void testReaderGetRecordIteratorByKeys() throws Exception {
+    writeFileWithSimpleSchema();
+    HoodieAvroHFileReader hfileReader =
+        (HoodieAvroHFileReader) createReader(new Configuration());
+
+    Schema avroSchema = getSchemaFromResource(TestHoodieReaderWriterBase.class, "/exampleSchema.avsc");
+
+    List<String> keys = Collections.singletonList("key");
+    Iterator<IndexedRecord> iterator =
+        hfileReader.getIndexedRecordsByKeysIterator(keys, avroSchema);
+
+    List<GenericRecord> recordsByKeys = toStream(iterator).map(r -> (GenericRecord) r).collect(Collectors.toList());
+
+    List<GenericRecord> allRecords = toStream(hfileReader.getRecordIterator())
+        .map(r -> (GenericRecord) r.getData()).collect(Collectors.toList());
+
+    // no entries should match since this is exact match.
+    assertEquals(Collections.emptyList(), recordsByKeys);
+
+    // filter for "key00001, key05, key12, key24, key16, key2, key31, key49, key61, key50". Valid entries should be matched.
+    // key00001 should not match.
+    // even though key16 exists, its not in the sorted order of keys passed in. So, will not return the matched entry.
+    // key2 : we don't have an exact match
+    // key61 is greater than max key.
+    // again, by the time we reach key50, cursor is at EOF. So no entries will be returned.
+    List<GenericRecord> expectedKey1s = allRecords.stream().filter(entry -> (
+        (entry.get("_row_key").toString()).contains("key05")
+            || (entry.get("_row_key").toString()).contains("key12")
+            || (entry.get("_row_key").toString()).contains("key24")
+            || (entry.get("_row_key").toString()).contains("key31")
+            || (entry.get("_row_key").toString()).contains("key49"))).collect(Collectors.toList());
+    iterator =
+        hfileReader.getIndexedRecordsByKeysIterator(Arrays.asList("key00001", "key05", "key12", "key24", "key16", "key31", "key49","key61","key50"), avroSchema);
+    recordsByKeys =
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+            .map(r -> (GenericRecord) r)
+            .collect(Collectors.toList());
+    assertEquals(expectedKey1s, recordsByKeys);
+  }
+
+  @Test
   public void testReaderGetRecordIteratorByKeyPrefixes() throws Exception {
     writeFileWithSimpleSchema();
     HoodieAvroHFileReader hfileReader =
@@ -303,11 +344,11 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
             .collect(Collectors.toList());
     assertEquals(Collections.emptyList(), recordsByPrefix);
 
-    // filter for "key50" and "key1" : entries from key50 and 'key10 to key19' should be matched.
+    // filter for "key1", "key30" and "key60" : entries from 'key10 to key19' and 'key30' should be matched.
     List<GenericRecord> expectedKey50and1s = allRecords.stream().filter(entry -> (entry.get("_row_key").toString()).contains("key1")
-        || (entry.get("_row_key").toString()).contains("key50")).collect(Collectors.toList());
+        || (entry.get("_row_key").toString()).contains("key30")).collect(Collectors.toList());
     iterator =
-        hfileReader.getIndexedRecordsByKeyPrefixIterator(Arrays.asList("key50", "key1"), avroSchema);
+        hfileReader.getIndexedRecordsByKeyPrefixIterator(Arrays.asList("key1", "key30","key6"), avroSchema);
     recordsByPrefix =
         StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
             .map(r -> (GenericRecord)r)
@@ -318,7 +359,7 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     List<GenericRecord> expectedKey50and0s = allRecords.stream().filter(entry -> (entry.get("_row_key").toString()).contains("key0")
         || (entry.get("_row_key").toString()).contains("key50")).collect(Collectors.toList());
     iterator =
-        hfileReader.getIndexedRecordsByKeyPrefixIterator(Arrays.asList("key50", "key0"), avroSchema);
+        hfileReader.getIndexedRecordsByKeyPrefixIterator(Arrays.asList("key0", "key50"), avroSchema);
     recordsByPrefix =
         StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
             .map(r -> (GenericRecord)r)
@@ -329,6 +370,22 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     List<GenericRecord> expectedKey1sand0s = allRecords.stream()
         .filter(entry -> (entry.get("_row_key").toString()).contains("key1") || (entry.get("_row_key").toString()).contains("key0"))
         .collect(Collectors.toList());
+    iterator =
+        hfileReader.getIndexedRecordsByKeyPrefixIterator(Arrays.asList("key0", "key1"), avroSchema);
+    recordsByPrefix =
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+            .map(r -> (GenericRecord)r)
+            .collect(Collectors.toList());
+    Collections.sort(recordsByPrefix, new Comparator<GenericRecord>() {
+      @Override
+      public int compare(GenericRecord o1, GenericRecord o2) {
+        return o1.get("_row_key").toString().compareTo(o2.get("_row_key").toString());
+      }
+    });
+    assertEquals(expectedKey1sand0s, recordsByPrefix);
+
+    // We expect the keys to be looked up in sorted order. If not, matching entries may not be returned.
+    // key1 should have matching entries, but not key0.
     iterator =
         hfileReader.getIndexedRecordsByKeyPrefixIterator(Arrays.asList("key1", "key0"), avroSchema);
     recordsByPrefix =
@@ -341,7 +398,7 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
         return o1.get("_row_key").toString().compareTo(o2.get("_row_key").toString());
       }
     });
-    assertEquals(expectedKey1sand0s, recordsByPrefix);
+    assertEquals(expectedKey1s, recordsByPrefix);
   }
 
   @ParameterizedTest

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
@@ -182,7 +182,7 @@ public class HoodieHFileDataBlock extends HoodieDataBlock {
 
   // TODO abstract this w/in HoodieDataBlock
   @Override
-  protected <T> ClosableIterator<HoodieRecord<T>> lookupRecords(List<String> keys, boolean fullKey) throws IOException {
+  protected <T> ClosableIterator<HoodieRecord<T>> lookupRecords(List<String> sortedKeys, boolean fullKey) throws IOException {
     HoodieLogBlockContentLocation blockContentLoc = getBlockContentLocation().get();
 
     // NOTE: It's important to extend Hadoop configuration here to make sure configuration
@@ -194,11 +194,6 @@ public class HoodieHFileDataBlock extends HoodieDataBlock {
         blockContentLoc.getLogFile().getPath().getFileSystem(inlineConf).getScheme(),
         blockContentLoc.getContentPositionInLogFile(),
         blockContentLoc.getBlockSize());
-
-    // HFile read will be efficient if keys are sorted, since on storage records are sorted by key.
-    // This will avoid unnecessary seeks.
-    List<String> sortedKeys = new ArrayList<>(keys);
-    Collections.sort(sortedKeys);
 
     final HoodieAvroHFileReader reader =
              new HoodieAvroHFileReader(inlineConf, inlinePath, new CacheConfig(inlineConf), inlinePath.getFileSystem(inlineConf),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReader.java
@@ -200,7 +200,7 @@ public class HoodieAvroHFileReader extends HoodieAvroFileReaderBase implements H
     // TODO eval whether seeking scanner would be faster than pread
     HFileScanner scanner = null;
     try {
-      scanner = getHFileScanner(reader, false);
+      scanner = getHFileScanner(reader, false, false);
     } catch (IOException e) {
       throw new HoodieIOException("Instantiation HfileScanner failed for " + reader.getHFileInfo().toString());
     }
@@ -438,10 +438,16 @@ public class HoodieAvroHFileReader extends HoodieAvroFileReaderBase implements H
   }
 
   private static HFileScanner getHFileScanner(HFile.Reader reader, boolean cacheBlocks) throws IOException {
+    return getHFileScanner(reader, cacheBlocks, true);
+  }
+
+  private static HFileScanner getHFileScanner(HFile.Reader reader, boolean cacheBlocks, boolean doSeek) throws IOException {
     // NOTE: Only scanners created in Positional Read ("pread") mode could share the same reader,
     //       since scanners in default mode will be seeking w/in the underlying stream
     HFileScanner scanner = reader.getScanner(cacheBlocks, true);
-    scanner.seekTo(); // places the cursor at the beginning of the first data block.
+    if (doSeek) {
+      scanner.seekTo(); // places the cursor at the beginning of the first data block.
+    }
     return scanner;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieSeekingFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieSeekingFileReader.java
@@ -29,14 +29,6 @@ import java.util.List;
 
 public interface HoodieSeekingFileReader<T> extends HoodieFileReader<T> {
 
-  default Option<HoodieRecord<T>> getRecordByKey(String key, Schema readerSchema) throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  default Option<HoodieRecord<T>> getRecordByKey(String key) throws IOException {
-    return getRecordByKey(key, getSchema());
-  }
-
   default ClosableIterator<HoodieRecord<T>> getRecordsByKeysIterator(List<String> keys, Schema schema) throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieSeekingFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieSeekingFileReader.java
@@ -21,7 +21,6 @@ package org.apache.hudi.io.storage;
 import org.apache.avro.Schema;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.collection.ClosableIterator;
-import org.apache.hudi.common.util.Option;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -29,20 +28,20 @@ import java.util.List;
 
 public interface HoodieSeekingFileReader<T> extends HoodieFileReader<T> {
 
-  default ClosableIterator<HoodieRecord<T>> getRecordsByKeysIterator(List<String> keys, Schema schema) throws IOException {
+  default ClosableIterator<HoodieRecord<T>> getRecordsByKeysIterator(List<String> sortedKeys, Schema schema) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  default ClosableIterator<HoodieRecord<T>> getRecordsByKeysIterator(List<String> keys) throws IOException {
-    return getRecordsByKeysIterator(keys, getSchema());
+  default ClosableIterator<HoodieRecord<T>> getRecordsByKeysIterator(List<String> sortedKeys) throws IOException {
+    return getRecordsByKeysIterator(sortedKeys, getSchema());
   }
 
-  default ClosableIterator<HoodieRecord<T>> getRecordsByKeyPrefixIterator(List<String> keyPrefixes, Schema schema) throws IOException {
+  default ClosableIterator<HoodieRecord<T>> getRecordsByKeyPrefixIterator(List<String> sortedKeyPrefixes, Schema schema) throws IOException {
     throw new UnsupportedEncodingException();
   }
 
-  default ClosableIterator<HoodieRecord<T>> getRecordsByKeyPrefixIterator(List<String> keyPrefixes) throws IOException {
-    return getRecordsByKeyPrefixIterator(keyPrefixes, getSchema());
+  default ClosableIterator<HoodieRecord<T>> getRecordsByKeyPrefixIterator(List<String> sortedKeyPrefixes) throws IOException {
+    return getRecordsByKeyPrefixIterator(sortedKeyPrefixes, getSchema());
   }
 
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -217,7 +217,6 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
       return Collections.emptyMap();
     }
 
-    // sort
     Map<String, HoodieRecord<HoodieMetadataPayload>> result;
 
     // Load the file slices for the partition. Each file slice is a shard which saves a portion of the keys.
@@ -274,16 +273,18 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         return Collections.emptyMap();
       }
 
+      List<String> sortedKeys = new ArrayList<>(keys);
+      Collections.sort(sortedKeys);
       boolean fullKeys = true;
-      Map<String, HoodieRecord<HoodieMetadataPayload>> logRecords = readLogRecords(logRecordScanner, keys, fullKeys, timings);
-      return readFromBaseAndMergeWithLogRecords(baseFileReader, keys, fullKeys, logRecords, timings, partitionName);
+      Map<String, HoodieRecord<HoodieMetadataPayload>> logRecords = readLogRecords(logRecordScanner, sortedKeys, fullKeys, timings);
+      return readFromBaseAndMergeWithLogRecords(baseFileReader, sortedKeys, fullKeys, logRecords, timings, partitionName);
     } catch (IOException ioe) {
       throw new HoodieIOException("Error merging records from metadata table for  " + keys.size() + " key : ", ioe);
     }
   }
 
   private Map<String, HoodieRecord<HoodieMetadataPayload>> readLogRecords(HoodieMetadataLogRecordReader logRecordReader,
-                                                                          List<String> keys,
+                                                                          List<String> sortedKeys,
                                                                           boolean fullKey,
                                                                           List<Long> timings) {
     HoodieTimer timer = HoodieTimer.start();
@@ -294,14 +295,14 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     }
 
     try {
-      return fullKey ? logRecordReader.getRecordsByKeys(keys) : logRecordReader.getRecordsByKeyPrefixes(keys);
+      return fullKey ? logRecordReader.getRecordsByKeys(sortedKeys) : logRecordReader.getRecordsByKeyPrefixes(sortedKeys);
     } finally {
       timings.add(timer.endTimer());
     }
   }
 
   private Map<String, HoodieRecord<HoodieMetadataPayload>> readFromBaseAndMergeWithLogRecords(HoodieSeekingFileReader<?> reader,
-                                                                                              List<String> keys,
+                                                                                              List<String> sortedKeys,
                                                                                               boolean fullKeys,
                                                                                               Map<String, HoodieRecord<HoodieMetadataPayload>> logRecords,
                                                                                               List<Long> timings,
@@ -317,7 +318,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     HoodieTimer readTimer = HoodieTimer.start();
 
     Map<String, HoodieRecord<HoodieMetadataPayload>> records =
-        fetchBaseFileRecordsByKeys(reader, keys, fullKeys, partitionName);
+        fetchBaseFileRecordsByKeys(reader, sortedKeys, fullKeys, partitionName);
 
     metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.BASEFILE_READ_STR, readTimer.endTimer()));
 
@@ -336,12 +337,12 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
 
   @SuppressWarnings("unchecked")
   private Map<String, HoodieRecord<HoodieMetadataPayload>> fetchBaseFileRecordsByKeys(HoodieSeekingFileReader reader,
-                                                                                      List<String> keys,
+                                                                                      List<String> sortedKeys,
                                                                                       boolean fullKeys,
                                                                                       String partitionName) throws IOException {
     ClosableIterator<HoodieRecord<?>> records = fullKeys
-        ? reader.getRecordsByKeysIterator(keys)
-        : reader.getRecordsByKeyPrefixIterator(keys);
+        ? reader.getRecordsByKeysIterator(sortedKeys)
+        : reader.getRecordsByKeyPrefixIterator(sortedKeys);
 
     return toStream(records)
         .map(record -> {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -273,6 +273,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         return Collections.emptyMap();
       }
 
+      // Sort it here once so that we don't need to sort individually for base file and for each individual log files.
       List<String> sortedKeys = new ArrayList<>(keys);
       Collections.sort(sortedKeys);
       boolean fullKeys = true;


### PR DESCRIPTION
### Change Logs

Hfile format is known to be performant for on-demand lookup and prefix based lookup. But due to [refactoring](https://github.com/apache/hudi/pull/5208), we made minor tweaks to hfile scanner apis. Apparently, it could cause a latency hit w/ on-demand lookup when compared to full scan. The issue is, we switched [reseekTo](https://github.com/apache/hbase/blob/da171c341eab8adebab756743243d94477a9074f/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java#L66)(Key) to [seekTo](https://github.com/apache/hbase/blob/da171c341eab8adebab756743243d94477a9074f/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java#L51)(Key). Difference between seekTo() and reseekTo() is, both of them moves the cursor to the key of interest, but at the end of the call, seekTo() will rewind the cursor to the beginning of data block in Hfile, while reseekTo will leave the cursor at the same position. 
Ref from HfileScanner docs:
```
  /**
   * SeekTo or just before the passed <code>cell</code>.  Examine the return
   * code to figure whether we found the cell or not.
   * Consider the cell stream of all the cells in the file,
   * <code>c[0] .. c[n]</code>, where there are n cells in the file.
   * @param cell
   * @return -1, if cell &lt; c[0], no position;
   * 0, such that c[i] = cell and scanner is left in position i; and
   * 1, such that c[i] &lt; cell, and scanner is left in position i.
   * The scanner will position itself between c[i] and c[i+1] where
   * c[i] &lt; cell &lt;= c[i+1].
   * If there is no cell c[i+1] greater than or equal to the input cell, then the
   * scanner will position itself at the end of the file and next() will return
   * false when it is called.
   * @throws IOException
   */
  int seekTo(Cell cell) throws IOException;
```

```
  /**
   * Reseek to or just before the passed <code>cell</code>. Similar to seekTo
   * except that this can be called even if the scanner is not at the beginning
   * of a file.
   * This can be used to seek only to cells which come after the current position
   * of the scanner.
   * Consider the cell stream of all the cells in the file,
   * <code>c[0] .. c[n]</code>, where there are n cellc in the file after
   * current position of HFileScanner.
   * The scanner will position itself between c[i] and c[i+1] where
   * c[i] &lt; cell &lt;= c[i+1].
   * If there is no cell c[i+1] greater than or equal to the input cell, then the
   * scanner will position itself at the end of the file and next() will return
   * false when it is called.
   * @param cell Cell to find (should be non-null)
   * @return -1, if cell &lt; c[0], no position;
   * 0, such that c[i] = cell and scanner is left in position i; and
   * 1, such that c[i] &lt; cell, and scanner is left in position i.
   * @throws IOException
   */
  int reseekTo(Cell cell) throws IOException;
```

We sort all the keys before any on-demand look up to ensure we would not need to go back in position once the search for a given key. Bcoz, next key is going to be lexicographically greater than the current key being searched. 

This patch fixes it back to reseekTo(Key). 
Also, found another bug where in we missed to sort keys to look up in base files in HoodieBackedTableMetadata in [recent patch for RecordLevelIndex](https://github.com/apache/hudi/pull/8758/files#r1230256239). Fixed the sorting towards this. Also, removed sorting from HfileData blocks, since now we have repeated sorting. So, the fix is to sort once per file Slice within lookupKeysFromFileSlice, so that individual look ups (base file, each log files) does not need to sort. 

Fixed argument names and variable names in downstream consumers to avoid ambiguity on whether they keys are sorted or not. 

### Impact

This should improve the on-demand lookup with Hfile by a large factor. From our micro-benchmarking, we found latency improvement from 10s of seconds to 100 to 200ms(when 1000s are keys are looked up in a Hfile containing 100k entries). 

### Risk level (write none, low medium or high below)

medium

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
