### PR TITLE
[HUDI-6424] getOldestInstantToRetainForCompaction needs to add clean validation

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -129,7 +129,7 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
 
     try {
       earliestCommitToRetain = CleanerUtils.getEarliestCommitToRetain(
-          metaClient.getActiveTimeline().getCommitsTimeline(),
+          metaClient.getActiveTimeline().getCommitsAndMergesTimeline(),
           cleanerPolicy,
           cleanerCommitsRetained,
           latestCommit.isPresent()
@@ -519,7 +519,7 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
               && (config.getInlineCompactTriggerStrategy() == CompactionTriggerStrategy.NUM_COMMITS
               || config.getInlineCompactTriggerStrategy() == CompactionTriggerStrategy.NUM_AND_TIME))
               ? CompactionUtils.getOldestInstantToRetainForCompaction(
-              table.getActiveTimeline(), config.getInlineCompactDeltaCommitMax())
+              table.getActiveTimeline(), table.getMetaClient(), config.getInlineCompactDeltaCommitMax())
               : Option.empty();
 
       // The clustering commit instant can not be archived unless we ensure that the replaced files have been cleaned,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -268,6 +268,20 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   /**
+   * Get all instants (commits, delta commits, replace, compaction) that produce new data or merge file, in the active timeline.
+   */
+  public HoodieTimeline getCommitsAndMergesTimeline() {
+    return getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, COMPACTION_ACTION));
+  }
+
+  /**
+   * Get all instants (commits, compaction) that produce new data or merge file, in the active timeline.
+   */
+  public HoodieTimeline getCommitAndCompactionTimeline() {
+    return getTimelineOfActions(CollectionUtils.createSet(COMMIT_ACTION, COMPACTION_ACTION));
+  }
+
+  /**
    * Get all instants (commits, delta commits, compaction, clean, savepoint, rollback, replace commits, index) that result in actions,
    * in the active timeline.
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -205,7 +205,7 @@ public class CleanerUtils {
 
   public static Option<HoodieInstant> getOldestInstantToRetainFromTimeline(
           HoodieActiveTimeline activeTimeline, HoodieTableMetaClient metaClient, HoodieTimeline timeline) throws IOException {
-    Option<HoodieInstant> oldestInstantToRetain = Option.empty();
+    final Option<HoodieInstant> oldestInstantToRetain;
     Option<HoodieInstant> cleanInstantOpt =
             activeTimeline.getCleanerTimeline().filterCompletedInstants().lastInstant();
     if (cleanInstantOpt.isPresent()) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.util;
 
-import org.apache.hudi.avro.model.HoodieActionInstant;
 import org.apache.hudi.avro.model.HoodieClusteringGroup;
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.avro.model.HoodieClusteringStrategy;
@@ -248,39 +247,7 @@ public class ClusteringUtils {
     Option<HoodieInstant> oldestInstantToRetain = Option.empty();
     HoodieTimeline replaceTimeline = activeTimeline.getTimelineOfActions(CollectionUtils.createSet(HoodieTimeline.REPLACE_COMMIT_ACTION));
     if (!replaceTimeline.empty()) {
-      Option<HoodieInstant> cleanInstantOpt =
-          activeTimeline.getCleanerTimeline().filterCompletedInstants().lastInstant();
-      if (cleanInstantOpt.isPresent()) {
-        // The first clustering instant of which timestamp is greater than or equal to the earliest commit to retain of
-        // the clean metadata.
-        HoodieInstant cleanInstant = cleanInstantOpt.get();
-        HoodieActionInstant earliestInstantToRetain = CleanerUtils.getCleanerPlan(metaClient, cleanInstant.isRequested()
-                ? cleanInstant
-                : HoodieTimeline.getCleanRequestedInstant(cleanInstant.getTimestamp()))
-            .getEarliestInstantToRetain();
-        String retainLowerBound;
-        if (earliestInstantToRetain != null && !StringUtils.isNullOrEmpty(earliestInstantToRetain.getTimestamp())) {
-          retainLowerBound = earliestInstantToRetain.getTimestamp();
-        } else {
-          // no earliestInstantToRetain, indicate KEEP_LATEST_FILE_VERSIONS clean policy,
-          // retain first instant after clean instant.
-          // For KEEP_LATEST_FILE_VERSIONS cleaner policy, file versions are only maintained for active file groups
-          // not for replaced file groups. So, last clean instant can be considered as a lower bound, since
-          // the cleaner would have removed all the file groups until then. But there is a catch to this logic,
-          // while cleaner is running if there is a pending replacecommit then those files are not cleaned.
-          // TODO: This case has to be handled. HUDI-6352
-          retainLowerBound = cleanInstant.getTimestamp();
-        }
-
-        oldestInstantToRetain = replaceTimeline.filter(instant ->
-                HoodieTimeline.compareTimestamps(
-                    instant.getTimestamp(),
-                    HoodieTimeline.GREATER_THAN_OR_EQUALS,
-                    retainLowerBound))
-            .firstInstant();
-      } else {
-        oldestInstantToRetain = replaceTimeline.firstInstant();
-      }
+      oldestInstantToRetain = CleanerUtils.getOldestInstantToRetainFromTimeline(activeTimeline, metaClient, replaceTimeline);
 
       Option<HoodieInstant> pendingInstantOpt = replaceTimeline.filterInflights().firstInstant();
       if (pendingInstantOpt.isPresent()) {


### PR DESCRIPTION
### Change Logs

1.getDeltaCommitsSinceLatestCompaction wants to make sure that there are enough delta commits in the active timeline to trigger compaction scheduling,  also need to consider inflight compaction.
like timeline : dc1,dc2,compaciton1.complete,dc3,dc4,compaction1.inflight,dc5,dc6
we just need to retains dc5 and dc6.
2. getOldestInstantToRetainForCompaction also needs to check earliestInstantToRetain like getOldestInstantToRetainForClustering, to ensure that the files related to the compaction instant have been cleaned up before archiving.

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
