### PR TITLE
[HUDI-6332] Fixing async indexer tests

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -89,6 +89,7 @@ import java.util.stream.IntStream;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.ARCHIVELOG_FOLDER;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
+import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.MILLIS_INSTANT_ID_LENGTH;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.getIndexInflightInstant;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeIndexPlan;
@@ -423,6 +424,10 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * @return a unique timestamp for MDT
    */
   private String generateUniqueCommitInstantTime(String initializationTime) {
+    // if its initialized via Async indexer, we don't need to alter the init time
+    if (initializationTime.length() == MILLIS_INSTANT_ID_LENGTH + METADATA_INDEXER_TIME_SUFFIX.length()) {
+      return initializationTime;
+    }
     // Add suffix to initializationTime to find an unused instant time for the next index initialization.
     // This function would be called multiple times in a single application if multiple indexes are being
     // initialized one after the other.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -167,6 +167,10 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
       } else {
         String indexUptoInstant = fileIndexPartitionInfo.getIndexUptoInstant();
         // save index commit metadata and update table config
+        // instantiation of metadata writer will automatically instantiate the partitions.
+        table.getIndexingMetadataWriter(instantTime)
+            .orElseThrow(() -> new HoodieIndexException(String.format(
+                "Could not get metadata writer to run index action for instant: %s", instantTime)));
         finalIndexPartitionInfos = Collections.singletonList(fileIndexPartitionInfo).stream()
             .map(info -> new HoodieIndexPartitionInfo(
                 info.getVersion(),

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -48,7 +48,6 @@ import org.apache.hudi.testutils.providers.SparkProvider;
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -145,7 +144,6 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   }
 
   @Test
-  @Disabled("HUDI-6332") // Investigate and fix async indexer colstats index initialization
   public void testIndexerWithFilesPartition() {
     String tableName = "indexer_test";
     // enable files and bloom_filters on the regular write client
@@ -160,7 +158,6 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   }
 
   @Test
-  @Disabled("HUDI-6332") // Investigate and fix async indexer colstats index initialization
   public void testIndexerWithWriterFinishingFirst() throws IOException {
     // Test the case where the indexer is running, i.e., the delta commit in the metadata table
     // is inflight, while the regular writer is updating metadata table.
@@ -208,7 +205,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
         CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES.defaultValue());
     heartbeatClient.start(mdtCommitTime);
 
-    upsertToTable(metadataConfig, tableName);
+    HoodieMetadataConfig metadataConfigColStats = getMetadataConfigBuilder(true, false).withMetadataIndexBloomFilter(true).withMetadataIndexColumnStats(true).build();
+    upsertToTable(metadataConfigColStats, tableName);
     metaClient = reload(metaClient);
     metadataMetaClient = reload(metadataMetaClient);
     // The delta commit from async indexer in metadata table should not be rolled back
@@ -217,7 +215,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
 
     // Simulate heartbeat timeout
     heartbeatClient.stop(mdtCommitTime);
-    upsertToTable(metadataConfig, tableName);
+    upsertToTable(metadataConfigColStats, tableName);
     metaClient = reload(metaClient);
     metadataMetaClient = reload(metadataMetaClient);
     // The delta commit from async indexer in metadata table should be rolled back now
@@ -303,7 +301,6 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
 
   @ParameterizedTest
   @MethodSource("colStatsFileGroupCountParams")
-  @Disabled("HUDI-6332") // Investigate and fix async indexer colstats index initialization
   public void testColStatsFileGroupCount(int colStatsFileGroupCount) {
     TestHoodieIndexer.colStatsFileGroupCount = colStatsFileGroupCount;
     String tableName = "indexer_test";
@@ -332,7 +329,6 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
    * with regular writers.
    */
   @Test
-  @Disabled("HUDI-6332") // Investigate and fix async indexer colstats index initialization
   public void testIndexerForExceptionWithNonFilesPartition() {
     String tableName = "indexer_test";
     // enable files and bloom_filters on the regular write client


### PR DESCRIPTION
### Change Logs

Fixing async indexer tests which was disabled when we landed RLI base patch

### Impact

Fixing async indexer tests which was disabled when we landed RLI base patch

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
