### PR TITLE
[HUDI-6433] Make the meta sync of streaming sink thread safe

### DIFF
--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SyncUtilHelpers.java
@@ -43,6 +43,9 @@ public class SyncUtilHelpers {
    * Create an instance of an implementation of {@link HoodieSyncTool} that will sync all the relevant meta information
    * with an external metastore such as Hive etc. to ensure Hoodie tables can be queried or read via external systems.
    *
+   * <p>IMPORTANT: make this method class level thread safe to avoid concurrent modification of the same underneath meta storage.
+   * Meta store such as Hive may encounter {@code ConcurrentModificationException} for #alter_table.
+   *
    * @param syncToolClassName   Class name of the {@link HoodieSyncTool} implementation.
    * @param props               property map.
    * @param hadoopConfig        Hadoop confs.
@@ -50,7 +53,7 @@ public class SyncUtilHelpers {
    * @param targetBasePath      The target base path that contains the hoodie table.
    * @param baseFileFormat      The file format used by the hoodie table (defaults to PARQUET).
    */
-  public static void runHoodieMetaSync(String syncToolClassName,
+  public static synchronized void runHoodieMetaSync(String syncToolClassName,
                                        TypedProperties props,
                                        Configuration hadoopConfig,
                                        FileSystem fs,


### PR DESCRIPTION
### Change Logs

Prevent the meta sync happens concurrently from multi threads for the same meta client.

Here is the error trace thrown by Hive:

```xml
ConcurrentModificationException; Request ID: 0c9f3006-e454-4289-a91f-77722b0c5d18; Proxy: null)) Caused by:
org.apache.hudi.hive.HoodieHiveSyncException: Failed to get update last commit time synced to
Option{val=20230623090402189} Caused by: org.apache.hudi.exception.HoodieException: Got runtime exception when
hive syncing lks_mexc_t_spot_order_deal Caused by: org.apache.hudi.exception.HoodieException: Could not sync using
the meta sync class org.apache.hudi.hive.HiveSyncTool Exception in thread "main"
org.apache.spark.sql.streaming.StreamingQueryException: Could not sync using the meta sync class org.apache.hudi.hive.HiveSyncTool...
```

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
