### PR TITLE
[HUDI-6436] Make the function of AlterHoodieTableChangeColumnCommand …

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableChangeColumnCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableChangeColumnCommand.scala
@@ -60,7 +60,8 @@ case class AlterHoodieTableChangeColumnCommand(
     val newTableSchema = StructType(
       hoodieCatalogTable.tableSchema.fields.map { field =>
       if (field.name == originColumn.name) {
-        newColumn
+        // Create a new column from the origin column with the new comment.
+        addComment(field, newColumn.getComment)
       } else {
         field
       }
@@ -68,7 +69,8 @@ case class AlterHoodieTableChangeColumnCommand(
     val newDataSchema = StructType(
       hoodieCatalogTable.dataSchema.fields.map { field =>
         if (field.name == columnName) {
-          newColumn
+          // Create a new column from the origin column with the new comment.
+          addComment(field, newColumn.getComment)
         } else {
           field
         }
@@ -102,4 +104,8 @@ case class AlterHoodieTableChangeColumnCommand(
         ", origin table schema :" + tableSchema + ", base path :" + metaClient.getBasePath)
     }
   }
+
+  // Add the comment to a column, if comment is empty, return the original column.
+  private def addComment(column: StructField, comment: Option[String]): StructField =
+    comment.map(column.withComment).getOrElse(column)
 }


### PR DESCRIPTION
…consistent with AlterTableChangeColumnCommand

### Change Logs

Currently `AlterTableChangeColumnCommand` only supports modifying comment, `AlterHoodieTableChangeColumnCommand` should be consistent with it

### Impact

Make the function of `AlterHoodieTableChangeColumnCommand` consistent with `AlterTableChangeColumnCommand` 

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
