### PR TITLE
[HUDI-6439] DirectWriteMarkers create file need judge appendfile whether exist

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
@@ -182,6 +182,7 @@ public class DirectWriteMarkers extends WriteMarkers {
   private Option<Path> create(Path markerPath, boolean checkIfExists) {
     HoodieTimer timer = HoodieTimer.start();
     Path dirPath = markerPath.getParent();
+    boolean overwrite = false;
     try {
       if (!fs.exists(dirPath)) {
         fs.mkdirs(dirPath); // create a new partition as needed.
@@ -195,7 +196,10 @@ public class DirectWriteMarkers extends WriteMarkers {
         return Option.empty();
       }
       LOG.info("Creating Marker Path=" + markerPath);
-      fs.create(markerPath, false).close();
+      if (fs.exists(markerPath)) {
+        overwrite = true;
+      }
+      fs.create(markerPath, overwrite).close();
     } catch (IOException e) {
       throw new HoodieException("Failed to create marker file " + markerPath, e);
     }


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
none

### Impact
none
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

when we upsert data to hudi table，if task retry would report error with：FileAlreadyExistsException in org.apache.hudi.table.marker.DirectWriteMarkers.create

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
