### PR TITLE
[HUDI-6446][WIP] Fixing MDT commit time parsing and RLI instantiation with MDT

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -85,6 +85,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.MILLIS_INSTANT_ID_LENGTH;
+import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.SECS_INSTANT_ID_LENGTH;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
@@ -131,7 +133,8 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
           metaClient.getActiveTimeline().getCommitsTimeline(),
           cleanerPolicy,
           cleanerCommitsRetained,
-          latestCommit.isPresent()
+          latestCommit.isPresent() && (latestCommit.get().getTimestamp().length() == MILLIS_INSTANT_ID_LENGTH
+              ||  latestCommit.get().getTimestamp().length() == SECS_INSTANT_ID_LENGTH)
               ? HoodieActiveTimeline.parseDateFromInstantTime(latestCommit.get().getTimestamp()).toInstant()
               : Instant.now(),
           cleanerHoursRetained,


### PR DESCRIPTION
### Change Logs

[HUDI-6446] Fixing MDT commit time parsing and RLI instantiation with MDT. 

For a fresh table, when both FILES and RLI is enabled, we use default values for num file groups i.e 10 for RLI. and this also creates a log file and does not create a base file since there are no records to instantiate as such. So, we should defer the instantiation to later. either at the end of first commit or when the data table has atleast 1 completed commit. 

For an already existing table, this is not an issue since if there are valid records, we will dynamically determine the number of file groups. 

### Impact

Deferring instantiation of RLI for a fresh table to later when we have atleast 1 completed commit in DT. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
