### PR TITLE
[HUDI-6440] Fallback to default Marker Type if the content of marker file is empty

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/MarkerUtils.java
@@ -118,7 +118,11 @@ public class MarkerUtils {
         return Option.empty();
       }
       fsDataInputStream = fileSystem.open(markerTypeFilePath);
-      content = Option.of(MarkerType.valueOf(FileIOUtils.readAsUTFString(fsDataInputStream)));
+      String markerType = FileIOUtils.readAsUTFString(fsDataInputStream);
+      if (StringUtils.isNullOrEmpty(markerType)) {
+        return Option.empty();
+      }
+      content = Option.of(MarkerType.valueOf(markerType));
     } catch (IOException e) {
       throw new HoodieIOException("Cannot read marker type file " + markerTypeFilePath.toString()
           + "; " + e.getMessage(), e);

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/MarkerUtilsTest.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/MarkerUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.exception.HoodieException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.apache.hudi.common.util.MarkerUtils.MARKER_TYPE_FILENAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MarkerUtilsTest extends HoodieCommonTestHarness {
+
+  protected FileSystem fs;
+
+  @BeforeEach
+  public void setup() {
+    initPath();
+    fs = FSUtils.getFs(basePath, new Configuration());
+  }
+
+  @Test
+  public void testReadMarkerType() throws IOException {
+    // mock markers file
+    String markerDir = this.basePath + "/.hoodie/.temp/testReadMarkerType/";
+    if (MarkerUtils.doesMarkerTypeFileExist(fs, markerDir)) {
+      MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
+    }
+
+    try {
+      // marker file does not exist
+      assertEquals(Option.empty(), MarkerUtils.readMarkerType(fs, markerDir)
+              , "File does not exist, should be empty");
+
+      // HUDI-6440: Fallback to default Marker Type if the content of marker file is empty
+      assertTrue(writeEmptyMarkerTypeToFile(fs, markerDir), "Failed to create empty marker type file");
+      assertEquals(Option.empty(), MarkerUtils.readMarkerType(fs, markerDir)
+              , "File exists but empty, should be empty");
+
+      // marker type is DIRECT
+      MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
+      MarkerUtils.writeMarkerTypeToFile(MarkerType.DIRECT, fs, markerDir);
+      assertEquals(Option.of(MarkerType.DIRECT), MarkerUtils.readMarkerType(fs, markerDir)
+              , "File exists and contains DIRECT, should be DIRECT");
+
+      // marker type is TIMELINE_SERVER_BASED
+      MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
+      MarkerUtils.writeMarkerTypeToFile(MarkerType.TIMELINE_SERVER_BASED, fs, markerDir);
+      assertEquals(Option.of(MarkerType.TIMELINE_SERVER_BASED), MarkerUtils.readMarkerType(fs, markerDir)
+              , "File exists and contains TIMELINE_SERVER_BASED, should be TIMELINE_SERVER_BASED");
+    } finally {
+      MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
+    }
+  }
+
+  private boolean writeEmptyMarkerTypeToFile(FileSystem fileSystem, String markerDir) {
+    Path markerTypeFilePath = new Path(markerDir, MARKER_TYPE_FILENAME);
+    try {
+      return fileSystem.createNewFile(markerTypeFilePath);
+    } catch (IOException e) {
+      throw new HoodieException("Failed to create marker type file " + markerTypeFilePath.toString()
+              + "; " + e.getMessage(), e);
+    }
+  }
+
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestMarkerUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestMarkerUtils.java
@@ -34,9 +34,9 @@ import static org.apache.hudi.common.util.MarkerUtils.MARKER_TYPE_FILENAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class MarkerUtilsTest extends HoodieCommonTestHarness {
+class TestMarkerUtils extends HoodieCommonTestHarness {
 
-  protected FileSystem fs;
+  private FileSystem fs;
 
   @BeforeEach
   public void setup() {
@@ -54,25 +54,25 @@ class MarkerUtilsTest extends HoodieCommonTestHarness {
 
     try {
       // marker file does not exist
-      assertEquals(Option.empty(), MarkerUtils.readMarkerType(fs, markerDir)
-              , "File does not exist, should be empty");
+      assertEquals(Option.empty(), MarkerUtils.readMarkerType(fs, markerDir),
+          "File does not exist, should be empty");
 
       // HUDI-6440: Fallback to default Marker Type if the content of marker file is empty
       assertTrue(writeEmptyMarkerTypeToFile(fs, markerDir), "Failed to create empty marker type file");
-      assertEquals(Option.empty(), MarkerUtils.readMarkerType(fs, markerDir)
-              , "File exists but empty, should be empty");
+      assertEquals(Option.empty(), MarkerUtils.readMarkerType(fs, markerDir),
+          "File exists but empty, should be empty");
 
       // marker type is DIRECT
       MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
       MarkerUtils.writeMarkerTypeToFile(MarkerType.DIRECT, fs, markerDir);
-      assertEquals(Option.of(MarkerType.DIRECT), MarkerUtils.readMarkerType(fs, markerDir)
-              , "File exists and contains DIRECT, should be DIRECT");
+      assertEquals(Option.of(MarkerType.DIRECT), MarkerUtils.readMarkerType(fs, markerDir),
+          "File exists and contains DIRECT, should be DIRECT");
 
       // marker type is TIMELINE_SERVER_BASED
       MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
       MarkerUtils.writeMarkerTypeToFile(MarkerType.TIMELINE_SERVER_BASED, fs, markerDir);
-      assertEquals(Option.of(MarkerType.TIMELINE_SERVER_BASED), MarkerUtils.readMarkerType(fs, markerDir)
-              , "File exists and contains TIMELINE_SERVER_BASED, should be TIMELINE_SERVER_BASED");
+      assertEquals(Option.of(MarkerType.TIMELINE_SERVER_BASED), MarkerUtils.readMarkerType(fs, markerDir),
+          "File exists and contains TIMELINE_SERVER_BASED, should be TIMELINE_SERVER_BASED");
     } finally {
       MarkerUtils.deleteMarkerTypeFile(fs, markerDir);
     }
@@ -83,9 +83,7 @@ class MarkerUtilsTest extends HoodieCommonTestHarness {
     try {
       return fileSystem.createNewFile(markerTypeFilePath);
     } catch (IOException e) {
-      throw new HoodieException("Failed to create marker type file " + markerTypeFilePath.toString()
-              + "; " + e.getMessage(), e);
+      throw new HoodieException("Failed to create marker type file " + markerTypeFilePath, e);
     }
   }
-
 }


### PR DESCRIPTION
### Change Logs

[HUDI-6440] Fallback to default Marker Type if the content of marker file is empty

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
