### PR TITLE
[HUDI-6448] Improve upgrade/downgrade for table ver. 6

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FiveToFourDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FiveToFourDowngradeHandler.java
@@ -23,13 +23,13 @@ import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.config.HoodieWriteConfig;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 public class FiveToFourDowngradeHandler implements DowngradeHandler {
 
   @Override
   public Map<ConfigProperty, String> downgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
-    return new HashMap<>();
+    return Collections.emptyMap();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FiveToSixUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FiveToSixUpgradeHandler.java
@@ -18,22 +18,31 @@
 
 package org.apache.hudi.table.upgrade;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
 import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.compact.CompactHelpers;
+
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
 
 /**
  * Upgrade handle to assist in upgrading hoodie table from version 5 to 6.
@@ -46,9 +55,20 @@ public class FiveToSixUpgradeHandler implements UpgradeHandler {
 
   @Override
   public Map<ConfigProperty, String> upgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
-    HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+    final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+
+    deleteCompactionRequestedFileFromAuxiliaryFolder(table);
+    checkUncompletedInstants(table);
+    compactMetadataTableIfNeeded(table, context);
+
+    return Collections.emptyMap();
+  }
+
+  /**
+   * See HUDI-6040.
+   */
+  private void deleteCompactionRequestedFileFromAuxiliaryFolder(HoodieTable table) {
     HoodieTableMetaClient metaClient = table.getMetaClient();
-    // delete compaction file from .aux
     HoodieTimeline compactionTimeline = metaClient.getActiveTimeline().filterPendingCompactionTimeline()
         .filter(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
     compactionTimeline.getInstantsAsStream().forEach(
@@ -65,6 +85,46 @@ public class FiveToSixUpgradeHandler implements UpgradeHandler {
           }
         }
     );
-    return new HashMap<>();
+  }
+
+  /**
+   * When upgrading to {@link HoodieTableVersion#SIX}, it is required that pending actions in both
+   * data table and metadata table should be either completed or rollback.
+   * <p>
+   * Note: this will be invoked for both data and metadata tables during upgrade/downgrade.
+   *
+   * @see UpgradeDowngrade#run(HoodieTableVersion, String)
+   */
+  static void checkUncompletedInstants(HoodieTable table) {
+    try {
+      List<HoodieInstant> uncompletedInstants = table.getActiveTimeline().filterInflightsAndRequested().getInstants();
+      checkState(uncompletedInstants.isEmpty(), "Found uncompleted instants: "
+          + uncompletedInstants.stream().map(HoodieInstant::getTimestamp).collect(Collectors.joining(",")));
+    } catch (Exception e) {
+      throw new HoodieUpgradeDowngradeException(
+          "There are uncompleted instants in the table's timeline at '"
+              + table.getConfig().getBasePath()
+              + "'. Please complete the operations or perform rollback before upgrade.", e);
+    }
+  }
+
+  private static void compactMetadataTableIfNeeded(HoodieTable table, HoodieEngineContext context) {
+    if (!table.isMetadataTable()) {
+      return;
+    }
+    Option<HoodieInstant> lastCommitInstantOpt = table.getActiveTimeline().getCommitsTimeline().lastInstant();
+    if (!lastCommitInstantOpt.isPresent()) {
+      return;
+    }
+    checkState(lastCommitInstantOpt.get().getState() == HoodieInstant.State.COMPLETED,
+        "Found uncompleted instants: " + lastCommitInstantOpt.get());
+    boolean shouldCompact = !lastCommitInstantOpt.get().getAction().equals(HoodieTimeline.COMMIT_ACTION);
+    if (shouldCompact) {
+      String compactionInstantTime = HoodieActiveTimeline.createNewInstantTime();
+      table.scheduleCompaction(context, compactionInstantTime, Option.empty());
+      HoodieCommitMetadata commitMetadata = (HoodieCommitMetadata) table
+          .compact(context, compactionInstantTime).getCommitMetadata().get();
+      CompactHelpers.getInstance().completeInflightCompaction(table, compactionInstantTime, commitMetadata);
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
@@ -68,11 +68,11 @@ public class FourToFiveUpgradeHandler implements UpgradeHandler {
         throw new HoodieException(String.format("Old deprecated \"%s\" partition found in hudi table. This needs a migration step before we can upgrade ",
             DEPRECATED_DEFAULT_PARTITION_PATH));
       }
+      return Collections.emptyMap();
     } catch (IOException e) {
       LOG.error("Fetching file system instance failed", e);
       throw new HoodieException("Fetching FileSystem instance failed ", e);
     }
-    return new HashMap<>();
   }
 
   private boolean hasDefaultPartitionPath(HoodieWriteConfig config, HoodieTable  table) throws IOException {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/OneToZeroDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/OneToZeroDowngradeHandler.java
@@ -50,6 +50,6 @@ public class OneToZeroDowngradeHandler implements DowngradeHandler {
       WriteMarkers writeMarkers = WriteMarkersFactory.get(config.getMarkersType(), table, inflightInstant.getTimestamp());
       writeMarkers.quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism());
     }
-    return Collections.EMPTY_MAP;
+    return Collections.emptyMap();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
@@ -18,19 +18,25 @@
 
 package org.apache.hudi.table.upgrade;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.table.HoodieTable;
+
+import org.apache.hadoop.fs.Path;
 
 import java.util.Collections;
 import java.util.Map;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.deleteMetadataTablePartition;
+import static org.apache.hudi.table.upgrade.FiveToSixUpgradeHandler.checkUncompletedInstants;
 
 /**
  * Downgrade handle to assist in downgrading hoodie table from version 6 to 5.
@@ -41,9 +47,30 @@ public class SixToFiveDowngradeHandler implements DowngradeHandler {
 
   @Override
   public Map<ConfigProperty, String> downgrade(HoodieWriteConfig config, HoodieEngineContext context, String instantTime, SupportsUpgradeDowngrade upgradeDowngradeHelper) {
-    HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+    final HoodieTable table = upgradeDowngradeHelper.getTable(config, context);
+
+    checkUncompletedInstants(table);
+    removeRecordIndexIfNeeded(table, context);
+    syncCompactionRequestedFileToAuxiliaryFolder(table);
+
+    return Collections.emptyMap();
+  }
+
+  /**
+   * Record-level index, a new partition in metadata table, was first added in
+   * 0.14.0 ({@link HoodieTableVersion#SIX}. Any downgrade from this version
+   * should remove this partition.
+   */
+  private static void removeRecordIndexIfNeeded(HoodieTable table, HoodieEngineContext context) {
     HoodieTableMetaClient metaClient = table.getMetaClient();
-    // sync compaction requested file to .aux
+    deleteMetadataTablePartition(metaClient, context, MetadataPartitionType.RECORD_INDEX, false);
+  }
+
+  /**
+   * See HUDI-6040.
+   */
+  private static void syncCompactionRequestedFileToAuxiliaryFolder(HoodieTable table) {
+    HoodieTableMetaClient metaClient = table.getMetaClient();
     HoodieTimeline compactionTimeline = new HoodieActiveTimeline(metaClient, false).filterPendingCompactionTimeline()
         .filter(instant -> instant.getState() == HoodieInstant.State.REQUESTED);
     compactionTimeline.getInstantsAsStream().forEach(instant -> {
@@ -52,6 +79,5 @@ public class SixToFiveDowngradeHandler implements DowngradeHandler {
           new Path(metaClient.getMetaPath(), fileName),
           new Path(metaClient.getMetaAuxiliaryPath(), fileName));
     });
-    return Collections.emptyMap();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
@@ -26,15 +26,15 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.FileIOUtils;
-import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.table.HoodieTable;
 
 import org.apache.hadoop.fs.Path;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_METADATA_PARTITIONS;
@@ -55,10 +55,13 @@ public class SixToFiveDowngradeHandler implements DowngradeHandler {
     removeRecordIndexIfNeeded(table, context);
     syncCompactionRequestedFileToAuxiliaryFolder(table);
 
+    Map<ConfigProperty, String> updatedTableProps = new HashMap<>();
     HoodieTableConfig tableConfig = table.getMetaClient().getTableConfig();
-    return CollectionUtils.createHashMap(
-        Pair.of(TABLE_METADATA_PARTITIONS, tableConfig.getString(TABLE_METADATA_PARTITIONS)),
-        Pair.of(TABLE_METADATA_PARTITIONS_INFLIGHT, tableConfig.getString(TABLE_METADATA_PARTITIONS_INFLIGHT)));
+    Option.ofNullable(tableConfig.getString(TABLE_METADATA_PARTITIONS))
+        .ifPresent(v -> updatedTableProps.put(TABLE_METADATA_PARTITIONS, v));
+    Option.ofNullable(tableConfig.getString(TABLE_METADATA_PARTITIONS_INFLIGHT))
+        .ifPresent(v -> updatedTableProps.put(TABLE_METADATA_PARTITIONS_INFLIGHT, v));
+    return updatedTableProps;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/TwoToOneDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/TwoToOneDowngradeHandler.java
@@ -70,7 +70,7 @@ public class TwoToOneDowngradeHandler implements DowngradeHandler {
         throw new HoodieException("Converting marker files to DIRECT style failed during downgrade", e);
       }
     }
-    return Collections.EMPTY_MAP;
+    return Collections.emptyMap();
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -2345,7 +2345,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     assertTrue(currentStatus.getModificationTime() > prevStatus.getModificationTime());
 
     initMetaClient();
-    assertEquals(metaClient.getTableConfig().getTableVersion().versionCode(), HoodieTableVersion.FIVE.versionCode());
+    assertEquals(metaClient.getTableConfig().getTableVersion().versionCode(), HoodieTableVersion.current().versionCode());
     assertTrue(fs.exists(new Path(metadataTableBasePath)), "Metadata table should exist");
     FileStatus newStatus = fs.getFileStatus(new Path(metadataTableBasePath));
     assertTrue(oldStatus.getModificationTime() < newStatus.getModificationTime());
@@ -2423,7 +2423,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }
 
     initMetaClient();
-    assertEquals(metaClient.getTableConfig().getTableVersion().versionCode(), HoodieTableVersion.FIVE.versionCode());
+    assertEquals(metaClient.getTableConfig().getTableVersion().versionCode(), HoodieTableVersion.current().versionCode());
     assertTrue(fs.exists(new Path(metadataTableBasePath)), "Metadata table should exist");
     FileStatus newStatus = fs.getFileStatus(new Path(metadataTableBasePath));
     assertTrue(oldStatus.getModificationTime() < newStatus.getModificationTime());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -771,6 +771,10 @@ public class HoodieTableConfig extends HoodieConfig {
     LOG.info(String.format("MDT %s partitions %s have been set to inflight", metaClient.getBasePathV2(), partitionTypes));
   }
 
+  public void setMetadataPartitionsInflight(HoodieTableMetaClient metaClient, MetadataPartitionType... partitionTypes) {
+    setMetadataPartitionsInflight(metaClient, Arrays.stream(partitionTypes).collect(Collectors.toList()));
+  }
+
   /**
    * Clear {@link HoodieTableConfig#TABLE_METADATA_PARTITIONS}
    * {@link HoodieTableConfig#TABLE_METADATA_PARTITIONS_INFLIGHT}.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
@@ -53,7 +53,7 @@ public enum HoodieTableVersion {
   }
 
   public static HoodieTableVersion current() {
-    return FIVE;
+    return SIX;
   }
 
   public static HoodieTableVersion versionFromCode(int versionCode) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestUpgradeOrDowngradeProcedure.scala
@@ -55,10 +55,10 @@ class TestUpgradeOrDowngradeProcedure extends HoodieSparkProcedureTestBase {
         .build
 
       // verify hoodie.table.version of the original table
-      assertResult(HoodieTableVersion.FIVE.versionCode) {
+      assertResult(HoodieTableVersion.SIX.versionCode) {
         metaClient.getTableConfig.getTableVersion.versionCode()
       }
-      assertTableVersionFromPropertyFile(metaClient, HoodieTableVersion.FIVE.versionCode)
+      assertTableVersionFromPropertyFile(metaClient, HoodieTableVersion.SIX.versionCode)
 
       // downgrade table to ZERO
       checkAnswer(s"""call downgrade_table(table => '$tableName', to_version => 'ZERO')""")(Seq(true))


### PR DESCRIPTION
### Change Logs

When downgrade from table version 6, record-index partition should be removed from metadata table if exists

### Impact

Upgrade/downgrade flows

### Risk level 

Medium.

- [x] UT and e2e verification.

### Documentation Update

- [ ] should be highlighted in the release notes as part of the migration guide

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
