### PR TITLE
[HUDI-6450] Fix null strings handling in convertRowToJsonString

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
@@ -561,7 +561,7 @@ class HoodieCDCRDD(
       originTableSchema.structTypeSchema.zipWithIndex.foreach {
         case (field, idx) =>
           if (field.dataType.isInstanceOf[StringType]) {
-            map(field.name) = record.getString(idx)
+            map(field.name) = Option(record.getUTF8String(idx)).map(_.toString).orNull
           } else {
             map(field.name) = record.get(idx, field.dataType)
           }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
@@ -18,9 +18,6 @@
 
 package org.apache.hudi.cdc
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord, IndexedRecord}
 import org.apache.hadoop.fs.Path
@@ -47,7 +44,7 @@ import org.apache.spark.sql.avro.HoodieAvroDeserializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Projection
 import org.apache.spark.sql.execution.datasources.PartitionedFile
-import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.{Partition, SerializableWritable, TaskContext}
 
@@ -155,14 +152,6 @@ class HoodieCDCRDD(
         recordMergerImpls = List(classOf[HoodieAvroRecordMerger].getName),
         recordMergerStrategy = HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID
       )
-    }
-
-    private lazy val mapper: ObjectMapper = {
-      val _mapper = new ObjectMapper
-      _mapper.setSerializationInclusion(Include.NON_ABSENT)
-      _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-      _mapper.registerModule(DefaultScalaModule)
-      _mapper
     }
 
     protected override val avroSchema: Schema = new Schema.Parser().parse(originTableSchema.avroSchemaStr)
@@ -557,16 +546,7 @@ class HoodieCDCRDD(
      * Convert InternalRow to json string.
      */
     private def convertRowToJsonString(record: InternalRow): UTF8String = {
-      val map = scala.collection.mutable.Map.empty[String, Any]
-      originTableSchema.structTypeSchema.zipWithIndex.foreach {
-        case (field, idx) =>
-          if (field.dataType.isInstanceOf[StringType]) {
-            map(field.name) = Option(record.getUTF8String(idx)).map(_.toString).orNull
-          } else {
-            map(field.name) = record.get(idx, field.dataType)
-          }
-      }
-      convertToUTF8String(mapper.writeValueAsString(map))
+      new InternalRowToJsonStringConverter(originTableSchema).convertRowToJsonString(record)
     }
 
     /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
@@ -234,6 +234,8 @@ class HoodieCDCRDD(
      */
     private var afterImageRecords: mutable.Map[String, InternalRow] = mutable.Map.empty
 
+    private var internalRowToJsonStringConverter = new InternalRowToJsonStringConverter(originTableSchema)
+
     private def needLoadNextFile: Boolean = {
       !recordIter.hasNext &&
         !logRecordIter.hasNext &&
@@ -546,7 +548,7 @@ class HoodieCDCRDD(
      * Convert InternalRow to json string.
      */
     private def convertRowToJsonString(record: InternalRow): UTF8String = {
-      new InternalRowToJsonStringConverter(originTableSchema).convertRowToJsonString(record)
+      internalRowToJsonStringConverter.convert(record)
     }
 
     /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -36,7 +36,7 @@ class InternalRowToJsonStringConverter(originTableSchema: HoodieTableSchema) {
     _mapper
   }
 
-  def convertRowToJsonString(record: InternalRow): UTF8String = {
+  def convert(record: InternalRow): UTF8String = {
     val map = scala.collection.mutable.Map.empty[String, Any]
     originTableSchema.structTypeSchema.zipWithIndex.foreach {
       case (field, idx) =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.cdc
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -1,0 +1,33 @@
+package org.apache.hudi.cdc
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.hudi.HoodieTableSchema
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
+
+class InternalRowToJsonStringConverter(originTableSchema: HoodieTableSchema) {
+
+  private lazy val mapper: ObjectMapper = {
+    val _mapper = new ObjectMapper
+    _mapper.setSerializationInclusion(Include.NON_ABSENT)
+    _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    _mapper.registerModule(DefaultScalaModule)
+    _mapper
+  }
+
+  def convertRowToJsonString(record: InternalRow): UTF8String = {
+    val map = scala.collection.mutable.Map.empty[String, Any]
+    originTableSchema.structTypeSchema.zipWithIndex.foreach {
+      case (field, idx) =>
+        if (field.dataType.isInstanceOf[StringType]) {
+          map(field.name) = Option(record.getUTF8String(idx)).map(_.toString).orNull
+        } else {
+          map(field.name) = record.get(idx, field.dataType)
+        }
+    }
+    UTF8String.fromString(mapper.writeValueAsString(map))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -1,0 +1,56 @@
+package org.apache.hudi.cdc
+
+import org.apache.hudi.HoodieTableSchema
+import org.apache.hudi.internal.schema.InternalSchema
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TestInternalRowToJsonStringConverter {
+  private val converter = new InternalRowToJsonStringConverter(hoodieTableSchema)
+
+  @Test
+  def emptyRow(): Unit = {
+    val converter = new InternalRowToJsonStringConverter(emptyHoodieTableSchema)
+    val row = InternalRow.empty
+    val converted = converter.convertRowToJsonString(row)
+    assertEquals("{}", converted.toString)
+  }
+
+  @Test
+  def nonEmptyRow(): Unit = {
+    val row = InternalRow.fromSeq(Seq(1, UTF8String.fromString("foo")))
+    val converted = converter.convertRowToJsonString(row)
+    assertEquals("{\"name\":\"foo\",\"uuid\":1}", converted.toString)
+  }
+
+  @Test
+  def emptyString(): Unit = {
+    val row = InternalRow.fromSeq(Seq(1, UTF8String.EMPTY_UTF8))
+    val converted = converter.convertRowToJsonString(row)
+    assertEquals("{\"name\":\"\",\"uuid\":1}", converted.toString)
+  }
+
+  @Test
+  def nullString(): Unit = {
+    val row = InternalRow.fromSeq(Seq(1, null))
+    val converted = converter.convertRowToJsonString(row)
+    assertEquals("{\"uuid\":1}", converted.toString)
+  }
+
+  private def hoodieTableSchema: HoodieTableSchema = {
+    val structTypeSchema = new StructType(Array[StructField](
+      StructField("uuid", DataTypes.IntegerType, nullable = false, Metadata.empty),
+      StructField("name", DataTypes.StringType, nullable = true, Metadata.empty)))
+    val avroSchemaStr: String = "{\"type\": \"record\",\"name\": \"test\",\"fields\": [{\"name\": \"uuid\",\"type\": \"int\"},{\"name\": \"name\",\"type\": \"string\"}]}"
+    HoodieTableSchema(structTypeSchema, avroSchemaStr, Option.empty[InternalSchema])
+  }
+
+  private def emptyHoodieTableSchema: HoodieTableSchema = {
+    val structTypeSchema = new StructType()
+    val avroSchemaStr = "{\"type\": \"record\",\"name\": \"test\",\"fields\": []}"
+    HoodieTableSchema(structTypeSchema, avroSchemaStr, Option.empty[InternalSchema])
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -41,34 +41,38 @@ class TestInternalRowToJsonStringConverter {
   def nonEmptyRow(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, UTF8String.fromString("foo")))
     val converted = converter.convertRowToJsonString(row)
-    assertEquals("{\"name\":\"foo\",\"uuid\":1}", converted.toString)
+    assertEquals("""{"name":"foo","uuid":1}""", converted.toString)
   }
 
   @Test
   def emptyString(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, UTF8String.EMPTY_UTF8))
     val converted = converter.convertRowToJsonString(row)
-    assertEquals("{\"name\":\"\",\"uuid\":1}", converted.toString)
+    assertEquals("""{"name":"","uuid":1}""", converted.toString)
   }
 
   @Test
   def nullString(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, null))
     val converted = converter.convertRowToJsonString(row)
-    assertEquals("{\"uuid\":1}", converted.toString)
+    assertEquals("""{"uuid":1}""", converted.toString)
   }
 
   private def hoodieTableSchema: HoodieTableSchema = {
     val structTypeSchema = new StructType(Array[StructField](
       StructField("uuid", DataTypes.IntegerType, nullable = false, Metadata.empty),
       StructField("name", DataTypes.StringType, nullable = true, Metadata.empty)))
-    val avroSchemaStr: String = "{\"type\": \"record\",\"name\": \"test\",\"fields\": [{\"name\": \"uuid\",\"type\": \"int\"},{\"name\": \"name\",\"type\": \"string\"}]}"
+    val avroSchemaStr: String =
+      """{"type": "record", "name": "test", "fields": [
+        |{"name": "uuid", "type": "int"},
+        |{"name": "name", "type": "string"}
+        |]}""".stripMargin
     HoodieTableSchema(structTypeSchema, avroSchemaStr, Option.empty[InternalSchema])
   }
 
   private def emptyHoodieTableSchema: HoodieTableSchema = {
     val structTypeSchema = new StructType()
-    val avroSchemaStr = "{\"type\": \"record\",\"name\": \"test\",\"fields\": []}"
+    val avroSchemaStr = """{"type": "record", "name": "test", "fields": []}"""
     HoodieTableSchema(structTypeSchema, avroSchemaStr, Option.empty[InternalSchema])
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -33,28 +33,28 @@ class TestInternalRowToJsonStringConverter {
   def emptyRow(): Unit = {
     val converter = new InternalRowToJsonStringConverter(emptyHoodieTableSchema)
     val row = InternalRow.empty
-    val converted = converter.convertRowToJsonString(row)
+    val converted = converter.convert(row)
     assertEquals("{}", converted.toString)
   }
 
   @Test
   def nonEmptyRow(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, UTF8String.fromString("foo")))
-    val converted = converter.convertRowToJsonString(row)
+    val converted = converter.convert(row)
     assertEquals("""{"name":"foo","uuid":1}""", converted.toString)
   }
 
   @Test
   def emptyString(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, UTF8String.EMPTY_UTF8))
-    val converted = converter.convertRowToJsonString(row)
+    val converted = converter.convert(row)
     assertEquals("""{"name":"","uuid":1}""", converted.toString)
   }
 
   @Test
   def nullString(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, null))
-    val converted = converter.convertRowToJsonString(row)
+    val converted = converter.convert(row)
     assertEquals("""{"uuid":1}""", converted.toString)
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.cdc
 
 import org.apache.hudi.HoodieTableSchema

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -23,7 +23,7 @@ import org.apache.hudi.internal.schema.InternalSchema
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
 class TestInternalRowToJsonStringConverter {
@@ -55,7 +55,7 @@ class TestInternalRowToJsonStringConverter {
   def nullString(): Unit = {
     val row = InternalRow.fromSeq(Seq(1, null))
     val converted = converter.convert(row)
-    assertEquals("""{"uuid":1}""", converted.toString)
+    assertTrue(converted.toString.equals("""{"uuid":1}""") || converted.toString.equals("""{"name":null,"uuid":1}"""))
   }
 
   private def hoodieTableSchema: HoodieTableSchema = {


### PR DESCRIPTION
### Change Logs
Fix null strings handling in `HoodieCDCRDD.convertRowToJsonString`.

### Impact
Avoid NPEs when reading CDC info for entries with null strings.

### Risk level
Medium

### Documentation Update
NA

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed