### PR TITLE
[HUDI-6452] Add MOR snapshot reader to integrate with query engines without using Hadoop APIs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -641,7 +641,7 @@ public abstract class AbstractHoodieLogRecordReader {
    *
    * @param hoodieRecord Hoodie Record to process
    */
-  protected abstract <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception;
+  public abstract <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception;
 
   /**
    * Process next deleted record.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -236,7 +236,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
   }
 
   @Override
-  protected <T> void processNextRecord(HoodieRecord<T> newRecord) throws IOException {
+  public <T> void processNextRecord(HoodieRecord<T> newRecord) throws IOException {
     String key = newRecord.getRecordKey();
     HoodieRecord<T> prevRecord = records.get(key);
     if (prevRecord != null) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -69,7 +69,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordReade
   }
 
   @Override
-  protected <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception {
+  public <T> void processNextRecord(HoodieRecord<T> hoodieRecord) throws Exception {
     // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
     //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
     //       it since these records will be put into queue of BoundedInMemoryExecutor.

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadSnapshotReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadSnapshotReader.java
@@ -50,12 +50,8 @@ public class HoodieMergeOnReadSnapshotReader extends AbstractRealtimeRecordReade
   private final String baseFilePath;
   private final List<HoodieLogFile> logFilePaths;
   private final String latestInstantTime;
-  private final long maxCompactionMemoryInBytes;
   private final Schema readerSchema;
   private final JobConf jobConf;
-  private final long start;
-  private final long length;
-  private final String[] hosts;
   private final HoodieMergedLogRecordScanner logRecordScanner;
   private final HoodieFileReader baseFileReader;
   private final Map<String, HoodieRecord> logRecordMap;
@@ -65,7 +61,6 @@ public class HoodieMergeOnReadSnapshotReader extends AbstractRealtimeRecordReade
   public HoodieMergeOnReadSnapshotReader(String tableBasePath, String baseFilePath,
                                          List<HoodieLogFile> logFilePaths,
                                          String latestInstantTime,
-                                         long maxCompactionMemoryInBytes,
                                          Schema readerSchema,
                                          JobConf jobConf, long start, long length, String[] hosts) throws IOException {
     super(getRealtimeSplit(tableBasePath, baseFilePath, logFilePaths, latestInstantTime, start, length, hosts), jobConf);
@@ -73,12 +68,8 @@ public class HoodieMergeOnReadSnapshotReader extends AbstractRealtimeRecordReade
     this.baseFilePath = baseFilePath;
     this.logFilePaths = logFilePaths;
     this.latestInstantTime = latestInstantTime;
-    this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
     this.readerSchema = readerSchema;
     this.jobConf = jobConf;
-    this.start = start;
-    this.length = length;
-    this.hosts = hosts;
     this.logRecordScanner = getMergedLogRecordScanner();
     this.baseFileReader = HoodieRealtimeRecordReaderUtils.getBaseFileReader(new Path(baseFilePath), jobConf);
     this.logRecordMap = logRecordScanner.getRecords();
@@ -89,7 +80,7 @@ public class HoodieMergeOnReadSnapshotReader extends AbstractRealtimeRecordReade
       HoodieRecord record = baseFileIterator.next();
       if (logRecordKeys.contains(record.getRecordKey())) {
         logRecordKeys.remove(record.getRecordKey());
-        Option<HoodieAvroIndexedRecord> mergedRecord = buildGenericRecordwithCustomPayload(logRecordMap.get(record.getRecordKey()));
+        Option<HoodieAvroIndexedRecord> mergedRecord = buildGenericRecordWithCustomPayload(logRecordMap.get(record.getRecordKey()));
         mergedRecord.ifPresent(mergedRecords::add);
       }
     }
@@ -144,7 +135,7 @@ public class HoodieMergeOnReadSnapshotReader extends AbstractRealtimeRecordReade
         .build();
   }
 
-  private Option<HoodieAvroIndexedRecord> buildGenericRecordwithCustomPayload(HoodieRecord record) throws IOException {
+  private Option<HoodieAvroIndexedRecord> buildGenericRecordWithCustomPayload(HoodieRecord record) throws IOException {
     if (usesCustomPayload) {
       return record.toIndexedRecord(getWriterSchema(), payloadProps);
     } else {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadSnapshotReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadSnapshotReader.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.hadoop.config.HoodieRealtimeConfig;
+import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
+import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.io.storage.HoodieFileReader;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class HoodieMergeOnReadSnapshotReader extends AbstractRealtimeRecordReader implements Iterator<HoodieRecord> {
+
+  private final String tableBasePath;
+  private final String baseFilePath;
+  private final List<HoodieLogFile> logFilePaths;
+  private final String latestInstantTime;
+  private final long maxCompactionMemoryInBytes;
+  private final Schema readerSchema;
+  private final JobConf jobConf;
+  private final long start;
+  private final long length;
+  private final String[] hosts;
+  private final HoodieMergedLogRecordScanner logRecordScanner;
+  private final HoodieFileReader baseFileReader;
+  private final Map<String, HoodieRecord> logRecordMap;
+  private final Set<String> logRecordKeys;
+  private final Iterator<HoodieRecord> recordsIterator;
+
+  public HoodieMergeOnReadSnapshotReader(String tableBasePath, String baseFilePath,
+                                         List<HoodieLogFile> logFilePaths,
+                                         String latestInstantTime,
+                                         long maxCompactionMemoryInBytes,
+                                         Schema readerSchema,
+                                         JobConf jobConf, long start, long length, String[] hosts) throws IOException {
+    super(getRealtimeSplit(tableBasePath, baseFilePath, logFilePaths, latestInstantTime, start, length, hosts), jobConf);
+    this.tableBasePath = tableBasePath;
+    this.baseFilePath = baseFilePath;
+    this.logFilePaths = logFilePaths;
+    this.latestInstantTime = latestInstantTime;
+    this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
+    this.readerSchema = readerSchema;
+    this.jobConf = jobConf;
+    this.start = start;
+    this.length = length;
+    this.hosts = hosts;
+    this.logRecordScanner = getMergedLogRecordScanner();
+    this.baseFileReader = HoodieRealtimeRecordReaderUtils.getBaseFileReader(new Path(baseFilePath), jobConf);
+    this.logRecordMap = logRecordScanner.getRecords();
+    this.logRecordKeys = new HashSet<>(this.logRecordMap.keySet());
+    List<HoodieRecord> mergedRecords = new ArrayList<>();
+    ClosableIterator<HoodieRecord> baseFileIterator = baseFileReader.getRecordIterator(readerSchema);
+    while (baseFileIterator.hasNext()) {
+      HoodieRecord record = baseFileIterator.next();
+      if (logRecordKeys.contains(record.getRecordKey())) {
+        logRecordKeys.remove(record.getRecordKey());
+        Option<HoodieAvroIndexedRecord> mergedRecord = buildGenericRecordwithCustomPayload(logRecordMap.get(record.getRecordKey()));
+        mergedRecord.ifPresent(mergedRecords::add);
+      }
+    }
+    this.recordsIterator = mergedRecords.iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return recordsIterator.hasNext();
+  }
+
+  @Override
+  public HoodieRecord next() {
+    return recordsIterator.next();
+  }
+
+  private static HoodieRealtimeFileSplit getRealtimeSplit(String tableBasePath, String baseFilePath,
+                                                          List<HoodieLogFile> logFilePaths,
+                                                          String latestInstantTime,
+                                                          long start, long length, String[] hosts) {
+    HoodieRealtimePath realtimePath = new HoodieRealtimePath(
+        new Path(baseFilePath).getParent(),
+        baseFilePath,
+        tableBasePath,
+        logFilePaths,
+        latestInstantTime,
+        false,
+        Option.empty());
+    return HoodieInputFormatUtils.createRealtimeFileSplit(realtimePath, start, length, hosts);
+  }
+
+  private HoodieMergedLogRecordScanner getMergedLogRecordScanner() {
+    // NOTE: HoodieCompactedLogRecordScanner will not return records for an in-flight commit
+    // but can return records for completed commits > the commit we are trying to read (if using
+    // readCommit() API)
+    return HoodieMergedLogRecordScanner.newBuilder()
+        .withFileSystem(FSUtils.getFs(split.getPath().toString(), jobConf))
+        .withBasePath(split.getBasePath())
+        .withLogFilePaths(split.getDeltaLogPaths())
+        .withReaderSchema(getLogScannerReaderSchema())
+        .withLatestInstantTime(split.getMaxCommitTime())
+        .withMaxMemorySizeInBytes(HoodieRealtimeRecordReaderUtils.getMaxCompactionMemoryInBytes(jobConf))
+        .withReadBlocksLazily(Boolean.parseBoolean(jobConf.get(HoodieRealtimeConfig.COMPACTION_LAZY_BLOCK_READ_ENABLED_PROP, HoodieRealtimeConfig.DEFAULT_COMPACTION_LAZY_BLOCK_READ_ENABLED)))
+        .withReverseReader(false)
+        .withBufferSize(jobConf.getInt(HoodieRealtimeConfig.MAX_DFS_STREAM_BUFFER_SIZE_PROP, HoodieRealtimeConfig.DEFAULT_MAX_DFS_STREAM_BUFFER_SIZE))
+        .withSpillableMapBasePath(jobConf.get(HoodieRealtimeConfig.SPILLABLE_MAP_BASE_PATH_PROP, HoodieRealtimeConfig.DEFAULT_SPILLABLE_MAP_BASE_PATH))
+        .withDiskMapType(jobConf.getEnum(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.defaultValue()))
+        .withBitCaskDiskMapCompressionEnabled(jobConf.getBoolean(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(),
+            HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.defaultValue()))
+        .withOptimizedLogBlocksScan(jobConf.getBoolean(HoodieRealtimeConfig.ENABLE_OPTIMIZED_LOG_BLOCKS_SCAN, false))
+        .withInternalSchema(schemaEvolutionContext.internalSchemaOption.orElse(InternalSchema.getEmptyInternalSchema()))
+        .build();
+  }
+
+  private Option<HoodieAvroIndexedRecord> buildGenericRecordwithCustomPayload(HoodieRecord record) throws IOException {
+    if (usesCustomPayload) {
+      return record.toIndexedRecord(getWriterSchema(), payloadProps);
+    } else {
+      return record.toIndexedRecord(getReaderSchema(), payloadProps);
+    }
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieMergeOnReadTableInputFormat.java
@@ -65,6 +65,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.createRealtimeFileSplit;
 
 /**
  * Base implementation of the Hive's {@link FileInputFormat} allowing for reading of Hudi's
@@ -304,20 +305,12 @@ public class HoodieMergeOnReadTableInputFormat extends HoodieCopyOnWriteTableInp
         .collect(Collectors.toList());
   }
 
-  private static HoodieRealtimeFileSplit createRealtimeFileSplit(HoodieRealtimePath path, long start, long length, String[] hosts) {
-    try {
-      return new HoodieRealtimeFileSplit(new FileSplit(path, start, length, hosts), path);
-    } catch (IOException e) {
-      throw new HoodieIOException(String.format("Failed to create instance of %s", HoodieRealtimeFileSplit.class.getName()), e);
-    }
-  }
-
   private static HoodieRealtimeBootstrapBaseFileSplit createRealtimeBootstrapBaseFileSplit(BootstrapBaseFileSplit split,
-                                                                                          String basePath,
-                                                                                          List<HoodieLogFile> logFiles,
-                                                                                          String maxInstantTime,
-                                                                                          boolean belongsToIncrementalQuery,
-                                                                                          Option<HoodieVirtualKeyInfo> virtualKeyInfoOpt) {
+                                                                                           String basePath,
+                                                                                           List<HoodieLogFile> logFiles,
+                                                                                           String maxInstantTime,
+                                                                                           boolean belongsToIncrementalQuery,
+                                                                                           Option<HoodieVirtualKeyInfo> virtualKeyInfoOpt) {
     try {
       String[] hosts = split.getLocationInfo() != null ? Arrays.stream(split.getLocationInfo())
           .filter(x -> !x.isInMemory()).toArray(String[]::new) : new String[0];

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeFileSplit.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeFileSplit.java
@@ -18,9 +18,10 @@
 
 package org.apache.hudi.hadoop.realtime;
 
-import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.mapred.FileSplit;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -34,9 +35,9 @@ import java.util.List;
  *   <li>Split corresponding to the base file</li>
  *   <li>List of {@link HoodieLogFile} that holds the delta to be merged (upon reading)</li>
  * </ol>
- *
+ * <p>
  * This split is correspondent to a single file-slice in the Hudi terminology.
- *
+ * <p>
  * NOTE: If you're adding fields here you need to make sure that you appropriately de-/serialize them
  *       in {@link #readFromInput(DataInput)} and {@link #writeToOutput(DataOutput)}
  */
@@ -63,11 +64,10 @@ public class HoodieRealtimeFileSplit extends FileSplit implements RealtimeSplit 
    */
   private Option<HoodieVirtualKeyInfo> virtualKeyInfo = Option.empty();
 
-  public HoodieRealtimeFileSplit() {}
+  public HoodieRealtimeFileSplit() {
+  }
 
-  public HoodieRealtimeFileSplit(FileSplit baseSplit,
-                                 HoodieRealtimePath path)
-      throws IOException {
+  public HoodieRealtimeFileSplit(FileSplit baseSplit, HoodieRealtimePath path) throws IOException {
     this(baseSplit,
         path.getBasePath(),
         path.getDeltaLogFiles(),

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -41,6 +41,8 @@ import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.LocatedFileStatusWithBootstrapBaseFile;
 import org.apache.hudi.hadoop.realtime.HoodieHFileRealtimeInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
+import org.apache.hudi.hadoop.realtime.HoodieRealtimePath;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -53,6 +55,7 @@ import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.slf4j.Logger;
@@ -187,16 +190,17 @@ public class HoodieInputFormatUtils {
   /**
    * Filter any specific instants that we do not want to process.
    * example timeline:
-   *
+   * <p>
    * t0 -> create bucket1.parquet
    * t1 -> create and append updates bucket1.log
    * t2 -> request compaction
    * t3 -> create bucket2.parquet
-   *
+   * <p>
    * if compaction at t2 takes a long time, incremental readers on RO tables can move to t3 and would skip updates in t1
-   *
+   * <p>
    * To workaround this problem, we want to stop returning data belonging to commits > t2.
    * After compaction is complete, incremental reader would see updates in t2, t3, so on.
+   *
    * @param timeline
    * @return
    */
@@ -220,6 +224,7 @@ public class HoodieInputFormatUtils {
 
   /**
    * Extract partitions touched by the commitsToCheck.
+   *
    * @param commitsToCheck
    * @param tableMetaClient
    * @param timeline
@@ -228,9 +233,9 @@ public class HoodieInputFormatUtils {
    * @throws IOException
    */
   public static Option<String> getAffectedPartitions(List<HoodieInstant> commitsToCheck,
-                                      HoodieTableMetaClient tableMetaClient,
-                                      HoodieTimeline timeline,
-                                      List<Path> inputPaths) throws IOException {
+                                                     HoodieTableMetaClient tableMetaClient,
+                                                     HoodieTimeline timeline,
+                                                     List<Path> inputPaths) throws IOException {
     Set<String> partitionsToList = new HashSet<>();
     for (HoodieInstant commit : commitsToCheck) {
       HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(timeline.getInstantDetails(commit).get(),
@@ -274,6 +279,7 @@ public class HoodieInputFormatUtils {
 
   /**
    * Extract HoodieTimeline based on HoodieTableMetaClient.
+   *
    * @param job
    * @param tableMetaClient
    * @return
@@ -298,6 +304,7 @@ public class HoodieInputFormatUtils {
 
   /**
    * Get commits for incremental query from Hive map reduce configuration.
+   *
    * @param job
    * @param tableName
    * @param timeline
@@ -325,6 +332,7 @@ public class HoodieInputFormatUtils {
 
   /**
    * Extract HoodieTableMetaClient by partition path.
+   *
    * @param conf       The hadoop conf
    * @param partitions The partitions
    * @return partition path to table meta client mapping
@@ -371,7 +379,7 @@ public class HoodieInputFormatUtils {
   public static FileStatus getFileStatus(HoodieBaseFile baseFile) throws IOException {
     if (baseFile.getBootstrapBaseFile().isPresent()) {
       if (baseFile.getFileStatus() instanceof LocatedFileStatus) {
-        return new LocatedFileStatusWithBootstrapBaseFile((LocatedFileStatus)baseFile.getFileStatus(),
+        return new LocatedFileStatusWithBootstrapBaseFile((LocatedFileStatus) baseFile.getFileStatus(),
             baseFile.getBootstrapBaseFile().get().getFileStatus());
       } else {
         return new FileStatusWithBootstrapBaseFile(baseFile.getFileStatus(),
@@ -383,6 +391,7 @@ public class HoodieInputFormatUtils {
 
   /**
    * Filter a list of FileStatus based on commitsToCheck for incremental view.
+   *
    * @param job
    * @param tableMetaClient
    * @param timeline
@@ -391,7 +400,7 @@ public class HoodieInputFormatUtils {
    * @return
    */
   public static List<FileStatus> filterIncrementalFileStatus(Job job, HoodieTableMetaClient tableMetaClient,
-      HoodieTimeline timeline, FileStatus[] fileStatuses, List<HoodieInstant> commitsToCheck) throws IOException {
+                                                             HoodieTimeline timeline, FileStatus[] fileStatuses, List<HoodieInstant> commitsToCheck) throws IOException {
     TableFileSystemView.BaseFileOnlyView roView = new HoodieTableFileSystemView(tableMetaClient, timeline, fileStatuses);
     List<String> commitsList = commitsToCheck.stream().map(HoodieInstant::getTimestamp).collect(Collectors.toList());
     List<HoodieBaseFile> filteredFiles = roView.getLatestBaseFilesInRange(commitsList).collect(Collectors.toList());
@@ -452,7 +461,7 @@ public class HoodieInputFormatUtils {
     for (Path path : snapshotPaths) {
       // Find meta client associated with the input path
       metaClientList.stream().filter(metaClient -> path.toString().contains(metaClient.getBasePath()))
-              .forEach(metaClient -> grouped.get(metaClient).add(path));
+          .forEach(metaClient -> grouped.get(metaClient).add(path));
     }
     return grouped;
   }
@@ -467,6 +476,7 @@ public class HoodieInputFormatUtils {
    * Checks the file status for a race condition which can set the file size to 0. 1. HiveInputFormat does
    * super.listStatus() and gets back a FileStatus[] 2. Then it creates the HoodieTableMetaClient for the paths listed.
    * 3. Generation of splits looks at FileStatus size to create splits, which skips this file
+   *
    * @param conf
    * @param dataFile
    * @return
@@ -493,14 +503,13 @@ public class HoodieInputFormatUtils {
    *
    * @param basePath     The table base path
    * @param metadataList The metadata list to read the data from
-   *
    * @return the affected file status array
    */
   public static FileStatus[] listAffectedFilesForCommits(Configuration hadoopConf, Path basePath, List<HoodieCommitMetadata> metadataList) {
     // TODO: Use HoodieMetaTable to extract affected file directly.
     HashMap<String, FileStatus> fullPathToFileStatus = new HashMap<>();
     // Iterate through the given commits.
-    for (HoodieCommitMetadata metadata: metadataList) {
+    for (HoodieCommitMetadata metadata : metadataList) {
       fullPathToFileStatus.putAll(metadata.getFullPathToFileStatus(hadoopConf, basePath.toString()));
     }
     return fullPathToFileStatus.values().toArray(new FileStatus[0]);
@@ -517,5 +526,13 @@ public class HoodieInputFormatUtils {
         .map(HoodieCommitMetadata::getWritePartitionPaths)
         .flatMap(Collection::stream)
         .collect(Collectors.toSet());
+  }
+
+  public static HoodieRealtimeFileSplit createRealtimeFileSplit(HoodieRealtimePath path, long start, long length, String[] hosts) {
+    try {
+      return new HoodieRealtimeFileSplit(new FileSplit(path, start, length, hosts), path);
+    } catch (IOException e) {
+      throw new HoodieIOException(String.format("Failed to create instance of %s", HoodieRealtimeFileSplit.class.getName()), e);
+    }
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -18,9 +18,12 @@
 
 package org.apache.hudi.hadoop.utils;
 
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.config.HoodieRealtimeConfig;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.JsonProperties;
@@ -30,6 +33,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
@@ -46,6 +50,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -158,7 +163,7 @@ public class HoodieRealtimeRecordReaderUtils {
       case STRING:
         return new Text(value.toString());
       case BYTES:
-        return new BytesWritable(((ByteBuffer)value).array());
+        return new BytesWritable(((ByteBuffer) value).array());
       case INT:
         if (schema.getLogicalType() != null && schema.getLogicalType().getName().equals("date")) {
           return HoodieHiveUtils.getDateWriteable((Integer) value);
@@ -295,6 +300,10 @@ public class HoodieRealtimeRecordReaderUtils {
         .filter(x -> !firstLevelFieldNames.contains(x)).collect(Collectors.toList());
 
     return appendNullSchemaFields(schema, fieldsToAdd);
+  }
+
+  public static HoodieFileReader getBaseFileReader(Path path, JobConf conf) throws IOException {
+    return HoodieFileReaderFactory.getReaderFactory(HoodieRecord.HoodieRecordType.AVRO).getFileReader(conf, path);
   }
 
   private static Schema appendNullSchemaFields(Schema schema, List<String> newFieldNames) {

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
@@ -19,11 +19,12 @@
 package org.apache.hudi.hadoop.realtime;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
-import org.apache.hudi.common.config.HoodieCommonConfig;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
@@ -34,7 +35,6 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.testutils.SchemaTestUtil;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.config.HoodieRealtimeConfig;
@@ -44,35 +44,28 @@ import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
-import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
-import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
-import org.apache.hadoop.io.ArrayWritable;
-import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.RecordReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.fs.FSUtils.getFs;
+import static org.apache.hudi.common.fs.FSUtils.getRelativePartitionPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecordReader {
 
   private static final String PARTITION_COLUMN = "datestr";
+  private static final String FILE_ID = "fileid0";
   private JobConf baseJobConf;
   private FileSystem fs;
   private Configuration hadoopConf;
@@ -84,7 +77,7 @@ public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecor
     hadoopConf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
     baseJobConf = new JobConf(hadoopConf);
     baseJobConf.set(HoodieRealtimeConfig.MAX_DFS_STREAM_BUFFER_SIZE_PROP, String.valueOf(1024 * 1024));
-    fs = FSUtils.getFs(basePath.toUri().toString(), baseJobConf);
+    fs = getFs(basePath.toUri().toString(), baseJobConf);
   }
 
   @TempDir
@@ -92,37 +85,10 @@ public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecor
 
   @Test
   public void testSnapshotReader() throws Exception {
-    testReaderInternal(ExternalSpillableMap.DiskMapType.BITCASK, false, false,
-        HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK);
+    testReaderInternal(false, HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK);
   }
 
-  private void setHiveColumnNameProps(List<Schema.Field> fields, JobConf jobConf, boolean isPartitioned) {
-    String names = fields.stream().map(Schema.Field::name).collect(Collectors.joining(","));
-    String positions = fields.stream().map(f -> String.valueOf(f.pos())).collect(Collectors.joining(","));
-    jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);
-    jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, positions);
-
-    String hiveOrderedColumnNames = fields.stream()
-        .map(Schema.Field::name)
-        .filter(name -> !name.equalsIgnoreCase(PARTITION_COLUMN))
-        .collect(Collectors.joining(","));
-    if (isPartitioned) {
-      hiveOrderedColumnNames += "," + PARTITION_COLUMN;
-      jobConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, PARTITION_COLUMN);
-    }
-    jobConf.set(hive_metastoreConstants.META_TABLE_COLUMNS, hiveOrderedColumnNames);
-  }
-
-  private static File getLogTempFile(long startTime, long endTime, String diskType) {
-    return Arrays.stream(Objects.requireNonNull(new File("/tmp").listFiles()))
-        .filter(f -> f.isDirectory() && f.getName().startsWith("hudi-" + diskType) && f.lastModified() > startTime && f.lastModified() < endTime)
-        .findFirst()
-        .orElse(new File(""));
-  }
-
-  private void testReaderInternal(ExternalSpillableMap.DiskMapType diskMapType,
-                                  boolean isCompressionEnabled,
-                                  boolean partitioned, HoodieLogBlock.HoodieLogBlockType logBlockType) throws Exception {
+  private void testReaderInternal(boolean partitioned, HoodieLogBlock.HoodieLogBlockType logBlockType) throws Exception {
     // initial commit
     Schema schema = HoodieAvroUtils.addMetadataFields(SchemaTestUtil.getEvolvedSchema());
     HoodieTestUtils.init(hadoopConf, basePath.toString(), HoodieTableType.MERGE_ON_READ);
@@ -141,9 +107,13 @@ public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecor
     List<Pair<String, Integer>> logVersionsWithAction = new ArrayList<>();
     logVersionsWithAction.add(Pair.of(HoodieTimeline.DELTA_COMMIT_ACTION, 1));
     logVersionsWithAction.add(Pair.of(HoodieTimeline.DELTA_COMMIT_ACTION, 2));
-    FileSlice fileSlice =
-        new FileSlice(partitioned ? FSUtils.getRelativePartitionPath(new Path(basePath.toString()),
-            new Path(partitionDir.getAbsolutePath())) : "default", baseInstant, "fileid0");
+    String baseFilePath = partitionDir + "/" + FILE_ID + "_1-0-1_" + baseInstant + ".parquet";
+    String partitionPath = partitioned ? getRelativePartitionPath(new Path(basePath.toString()), new Path(partitionDir.getAbsolutePath())) : "default";
+    FileSlice fileSlice = new FileSlice(
+        new HoodieFileGroupId(partitionPath, FILE_ID),
+        baseInstant,
+        new HoodieBaseFile(fs.getFileStatus(new Path(baseFilePath))),
+        new ArrayList<>());
     logVersionsWithAction.forEach(logVersionWithAction -> {
       try {
         // update files or generate new log file
@@ -157,11 +127,11 @@ public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecor
 
         HoodieLogFormat.Writer writer;
         if (action.equals(HoodieTimeline.ROLLBACK_ACTION)) {
-          writer = InputFormatTestUtil.writeRollback(partitionDir, fs, "fileid0", baseInstant, instantTime,
+          writer = InputFormatTestUtil.writeRollback(partitionDir, fs, FILE_ID, baseInstant, instantTime,
               String.valueOf(baseInstantTs + logVersion - 1), logVersion);
         } else {
           writer =
-              InputFormatTestUtil.writeDataBlockToLogFile(partitionDir, fs, schema, "fileid0", baseInstant,
+              InputFormatTestUtil.writeDataBlockToLogFile(partitionDir, fs, schema, FILE_ID, baseInstant,
                   instantTime, 120, 0, logVersion, logBlockType);
         }
         long size = writer.getCurrentSize();
@@ -172,7 +142,7 @@ public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecor
         // create a split with baseFile (parquet file written earlier) and new log file(s)
         fileSlice.addLogFile(writer.getLogFile());
         HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(
-            new FileSplit(new Path(partitionDir + "/fileid0_1-0-1_" + baseInstant + ".parquet"), 0, 1, baseJobConf),
+            new FileSplit(new Path(baseFilePath), 0, 1, baseJobConf),
             basePath.toUri().toString(), fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
             .collect(Collectors.toList()),
             instantTime,
@@ -190,40 +160,12 @@ public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecor
             1,
             new String[0]);
 
-        // create a RecordReader to be used by HoodieRealtimeRecordReader
-        RecordReader<NullWritable, ArrayWritable> reader = new MapredParquetInputFormat().getRecordReader(
-            new FileSplit(split.getPath(), 0, fs.getLength(split.getPath()), (String[]) null), baseJobConf, null);
-        JobConf jobConf = new JobConf(baseJobConf);
-        List<Schema.Field> fields = schema.getFields();
-        setHiveColumnNameProps(fields, jobConf, partitioned);
-
-        jobConf.setEnum(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), diskMapType);
-        jobConf.setBoolean(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), isCompressionEnabled);
-
-        // validate record reader compaction
-        long logTmpFileStartTime = System.currentTimeMillis();
-        HoodieRealtimeRecordReader recordReader = new HoodieRealtimeRecordReader(split, jobConf, reader);
-
-        // use reader to read base Parquet File and log file, merge in flight and return latest commit
-        // here all 100 records should be updated, see above
-        // another 20 new insert records should also output with new commit time.
-        NullWritable key = recordReader.createKey();
-        ArrayWritable value = recordReader.createValue();
-        int recordCnt = 0;
-        while (recordReader.next(key, value)) {
-          Writable[] values = value.get();
-          // check if the record written is with latest commit, here "101"
-          assertEquals(latestInstant, values[0].toString());
-          key = recordReader.createKey();
-          value = recordReader.createValue();
-          recordCnt++;
+        List<HoodieRecord> records = new ArrayList<>();
+        while (snapshotReader.hasNext()) {
+          records.add(snapshotReader.next());
         }
-        recordReader.getPos();
-        assertEquals(1.0, recordReader.getProgress(), 0.05);
-        assertEquals(120, recordCnt);
-        recordReader.close();
-        // the temp file produced by logScanner should be deleted
-        assertFalse(getLogTempFile(logTmpFileStartTime, System.currentTimeMillis(), diskMapType.toString()).exists());
+        assertEquals(100, records.size());
+        snapshotReader.close();
       } catch (Exception ioe) {
         throw new HoodieException(ioe.getMessage(), ioe);
       }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.SchemaTestUtil;
+import org.apache.hudi.common.util.CommitUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.hadoop.config.HoodieRealtimeConfig;
+import org.apache.hudi.hadoop.testutils.InputFormatTestUtil;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieMergeOnReadSnapshotReader extends TestHoodieRealtimeRecordReader {
+
+  private static final String PARTITION_COLUMN = "datestr";
+  private JobConf baseJobConf;
+  private FileSystem fs;
+  private Configuration hadoopConf;
+
+  @BeforeEach
+  public void setUp() {
+    hadoopConf = HoodieTestUtils.getDefaultHadoopConf();
+    hadoopConf.set("fs.defaultFS", "file:///");
+    hadoopConf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+    baseJobConf = new JobConf(hadoopConf);
+    baseJobConf.set(HoodieRealtimeConfig.MAX_DFS_STREAM_BUFFER_SIZE_PROP, String.valueOf(1024 * 1024));
+    fs = FSUtils.getFs(basePath.toUri().toString(), baseJobConf);
+  }
+
+  @TempDir
+  public java.nio.file.Path basePath;
+
+  @Test
+  public void testSnapshotReader() throws Exception {
+    testReaderInternal(ExternalSpillableMap.DiskMapType.BITCASK, false, false,
+        HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK);
+  }
+
+  private void setHiveColumnNameProps(List<Schema.Field> fields, JobConf jobConf, boolean isPartitioned) {
+    String names = fields.stream().map(Schema.Field::name).collect(Collectors.joining(","));
+    String positions = fields.stream().map(f -> String.valueOf(f.pos())).collect(Collectors.joining(","));
+    jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);
+    jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, positions);
+
+    String hiveOrderedColumnNames = fields.stream()
+        .map(Schema.Field::name)
+        .filter(name -> !name.equalsIgnoreCase(PARTITION_COLUMN))
+        .collect(Collectors.joining(","));
+    if (isPartitioned) {
+      hiveOrderedColumnNames += "," + PARTITION_COLUMN;
+      jobConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, PARTITION_COLUMN);
+    }
+    jobConf.set(hive_metastoreConstants.META_TABLE_COLUMNS, hiveOrderedColumnNames);
+  }
+
+  private static File getLogTempFile(long startTime, long endTime, String diskType) {
+    return Arrays.stream(Objects.requireNonNull(new File("/tmp").listFiles()))
+        .filter(f -> f.isDirectory() && f.getName().startsWith("hudi-" + diskType) && f.lastModified() > startTime && f.lastModified() < endTime)
+        .findFirst()
+        .orElse(new File(""));
+  }
+
+  private void testReaderInternal(ExternalSpillableMap.DiskMapType diskMapType,
+                                  boolean isCompressionEnabled,
+                                  boolean partitioned, HoodieLogBlock.HoodieLogBlockType logBlockType) throws Exception {
+    // initial commit
+    Schema schema = HoodieAvroUtils.addMetadataFields(SchemaTestUtil.getEvolvedSchema());
+    HoodieTestUtils.init(hadoopConf, basePath.toString(), HoodieTableType.MERGE_ON_READ);
+    String baseInstant = "100";
+    File partitionDir = partitioned ? InputFormatTestUtil.prepareParquetTable(basePath, schema, 1, 100, baseInstant,
+        HoodieTableType.MERGE_ON_READ)
+        : InputFormatTestUtil.prepareNonPartitionedParquetTable(basePath, schema, 1, 100, baseInstant,
+        HoodieTableType.MERGE_ON_READ);
+
+    HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UPSERT,
+        schema.toString(), HoodieTimeline.DELTA_COMMIT_ACTION);
+    FileCreateUtils.createDeltaCommit(basePath.toString(), baseInstant, commitMetadata);
+    // Add the paths
+    FileInputFormat.setInputPaths(baseJobConf, partitionDir.getPath());
+
+    List<Pair<String, Integer>> logVersionsWithAction = new ArrayList<>();
+    logVersionsWithAction.add(Pair.of(HoodieTimeline.DELTA_COMMIT_ACTION, 1));
+    logVersionsWithAction.add(Pair.of(HoodieTimeline.DELTA_COMMIT_ACTION, 2));
+    FileSlice fileSlice =
+        new FileSlice(partitioned ? FSUtils.getRelativePartitionPath(new Path(basePath.toString()),
+            new Path(partitionDir.getAbsolutePath())) : "default", baseInstant, "fileid0");
+    logVersionsWithAction.forEach(logVersionWithAction -> {
+      try {
+        // update files or generate new log file
+        int logVersion = logVersionWithAction.getRight();
+        String action = logVersionWithAction.getKey();
+        int baseInstantTs = Integer.parseInt(baseInstant);
+        String instantTime = String.valueOf(baseInstantTs + logVersion);
+        String latestInstant =
+            action.equals(HoodieTimeline.ROLLBACK_ACTION) ? String.valueOf(baseInstantTs + logVersion - 2)
+                : instantTime;
+
+        HoodieLogFormat.Writer writer;
+        if (action.equals(HoodieTimeline.ROLLBACK_ACTION)) {
+          writer = InputFormatTestUtil.writeRollback(partitionDir, fs, "fileid0", baseInstant, instantTime,
+              String.valueOf(baseInstantTs + logVersion - 1), logVersion);
+        } else {
+          writer =
+              InputFormatTestUtil.writeDataBlockToLogFile(partitionDir, fs, schema, "fileid0", baseInstant,
+                  instantTime, 120, 0, logVersion, logBlockType);
+        }
+        long size = writer.getCurrentSize();
+        writer.close();
+        assertTrue(size > 0, "block - size should be > 0");
+        FileCreateUtils.createDeltaCommit(basePath.toString(), instantTime, commitMetadata);
+
+        // create a split with baseFile (parquet file written earlier) and new log file(s)
+        fileSlice.addLogFile(writer.getLogFile());
+        HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(
+            new FileSplit(new Path(partitionDir + "/fileid0_1-0-1_" + baseInstant + ".parquet"), 0, 1, baseJobConf),
+            basePath.toUri().toString(), fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
+            .collect(Collectors.toList()),
+            instantTime,
+            false,
+            Option.empty());
+
+        HoodieMergeOnReadSnapshotReader snapshotReader = new HoodieMergeOnReadSnapshotReader(
+            basePath.toString(),
+            fileSlice.getBaseFile().get().getPath(),
+            fileSlice.getLogFiles().collect(Collectors.toList()),
+            instantTime,
+            schema,
+            baseJobConf,
+            0,
+            1,
+            new String[0]);
+
+        // create a RecordReader to be used by HoodieRealtimeRecordReader
+        RecordReader<NullWritable, ArrayWritable> reader = new MapredParquetInputFormat().getRecordReader(
+            new FileSplit(split.getPath(), 0, fs.getLength(split.getPath()), (String[]) null), baseJobConf, null);
+        JobConf jobConf = new JobConf(baseJobConf);
+        List<Schema.Field> fields = schema.getFields();
+        setHiveColumnNameProps(fields, jobConf, partitioned);
+
+        jobConf.setEnum(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), diskMapType);
+        jobConf.setBoolean(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), isCompressionEnabled);
+
+        // validate record reader compaction
+        long logTmpFileStartTime = System.currentTimeMillis();
+        HoodieRealtimeRecordReader recordReader = new HoodieRealtimeRecordReader(split, jobConf, reader);
+
+        // use reader to read base Parquet File and log file, merge in flight and return latest commit
+        // here all 100 records should be updated, see above
+        // another 20 new insert records should also output with new commit time.
+        NullWritable key = recordReader.createKey();
+        ArrayWritable value = recordReader.createValue();
+        int recordCnt = 0;
+        while (recordReader.next(key, value)) {
+          Writable[] values = value.get();
+          // check if the record written is with latest commit, here "101"
+          assertEquals(latestInstant, values[0].toString());
+          key = recordReader.createKey();
+          value = recordReader.createValue();
+          recordCnt++;
+        }
+        recordReader.getPos();
+        assertEquals(1.0, recordReader.getProgress(), 0.05);
+        assertEquals(120, recordCnt);
+        recordReader.close();
+        // the temp file produced by logScanner should be deleted
+        assertFalse(getLogTempFile(logTmpFileStartTime, System.currentTimeMillis(), diskMapType.toString()).exists());
+      } catch (Exception ioe) {
+        throw new HoodieException(ioe.getMessage(), ioe);
+      }
+    });
+  }
+}

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieMergeOnReadSnapshotReader.java
@@ -164,8 +164,7 @@ public class TestHoodieMergeOnReadSnapshotReader {
             schema,
             baseJobConf,
             0,
-            size,
-            new String[0]);
+            size);
         Map<String, HoodieRecord> records = snapshotReader.getRecordsByKey();
         assertEquals(TOTAL_RECORDS, records.size());
         snapshotReader.close();


### PR DESCRIPTION
### Change Logs

- Add a new `HoodieMergeOnReadSnapshotReader` that implements `Iterator<HoodieRecord>`. It merges the base Parquet data with Avro data in log files.
- Add a test for the new reader.
- This is used in https://github.com/codope/trino/commit/c744601d7b5ea08812ba174051312b7b894f14f5#diff-b55a3ef8348b943f46a40738421f333d68b880bf7817d7d513c6e4d1569154de

### Impact

It is a public API and can be used in query engines to execute Hudi MOR snapshot queries. It's an alternative to using RealtimeRecordReaders.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
