### PR TITLE
[MINOR] Fixing commit time parsing w/ archival

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTimelineArchiver.java
@@ -85,6 +85,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.MILLIS_INSTANT_ID_LENGTH;
+import static org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.SECS_INSTANT_ID_LENGTH;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN_OR_EQUALS;
@@ -131,7 +133,8 @@ public class HoodieTimelineArchiver<T extends HoodieAvroPayload, I, K, O> {
           metaClient.getActiveTimeline().getCommitsTimeline(),
           cleanerPolicy,
           cleanerCommitsRetained,
-          latestCommit.isPresent()
+          latestCommit.isPresent() && (latestCommit.get().getTimestamp().length() == MILLIS_INSTANT_ID_LENGTH
+              ||  latestCommit.get().getTimestamp().length() == SECS_INSTANT_ID_LENGTH)
               ? HoodieActiveTimeline.parseDateFromInstantTime(latestCommit.get().getTimestamp()).toInstant()
               : Instant.now(),
           cleanerHoursRetained,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -76,7 +76,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
       REQUESTED_INDEX_COMMIT_EXTENSION, INFLIGHT_INDEX_COMMIT_EXTENSION, INDEX_COMMIT_EXTENSION,
       REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION, INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION, SAVE_SCHEMA_ACTION_EXTENSION));
 
-  private static final Set<String> NOT_PARSABLE_TIMESTAMPS = new HashSet<String>(3) {{
+  public static final Set<String> NOT_PARSABLE_TIMESTAMPS = new HashSet<String>(3) {{
       add(HoodieTimeline.INIT_INSTANT_TS);
       add(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS);
       add(HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS);
@@ -480,7 +480,6 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     transitionState(inflightInstant, commitInstant, data);
     return commitInstant;
   }
-
 
   //-----------------------------------------------------------------
   //      END - COMPACTION RELATED META-DATA MANAGEMENT


### PR DESCRIPTION
### Change Logs

Recently we have started seeing lot of logs as below. 
```
WARN HoodieTimelineArchiver: Error parsing instant time: 00000000000000011
```
this happens w/ MDT since initial bootstrap instant is "00000000000000011". Fixing it to avoid parsing such instants. 

### Impact

Avoids unnecessary logging and unnecessary commit time parsing with archival. 

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
