### PR TITLE
[MINOR] Increase timeout for Azure CI: UT spark-datasource to 240 minutes

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -164,7 +164,7 @@ stages:
             displayName: Top 100 long-running testcases
       - job: UT_FT_3
         displayName: UT spark-datasource
-        timeoutInMinutes: '180'
+        timeoutInMinutes: '240'
         steps:
           - task: Maven@4
             displayName: maven install


### PR DESCRIPTION
### Change Logs

Azure CI: UT spark-datasource job times out frequently after 3 hours duration. This PR increases the timeout to 4 hours.
https://dev.azure.com/apache-hudi-ci-org/apache-hudi-ci/_build/results?buildId=17956&view=logs&j=b1544eb9-7ff1-5db9-0187-3e05abf459bc&t=e0ae894b-41c9-5f4b-7ed2-bdf5243b02e7 

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
