### PR TITLE
[MINOR] Reverting disabled tests for multiwriter archival

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -683,10 +683,17 @@ public class TestHoodieTimelineArchiver extends HoodieClientTestHarness {
     assertThrows(HoodieException.class, () -> metaClient.getArchivedTimeline().reload());
   }
 
+  @Test
+  public void testArchivalWithMultiWritersMDTDisabled() throws Exception {
+    testArchivalWithMultiWriters(false);
+  }
+
   @Disabled("HUDI-6386")
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testArchivalWithMultiWriters(boolean enableMetadata) throws Exception {
+  public void testArchivalWithMultiWriters() throws Exception {
+    testArchivalWithMultiWriters(true);
+  }
+
+  private void testArchivalWithMultiWriters(boolean enableMetadata) throws Exception {
     HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(enableMetadata, 4, 5, 5, 2,
         HoodieTableType.COPY_ON_WRITE, false, 10, 209715200,
         HoodieFailedWritesCleaningPolicy.LAZY, WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL);


### PR DESCRIPTION
### Change Logs

[MINOR] Reverting disabled tests for multiwriter archival. 
When MDT is enabled, we are running into an issue where empty compaction plans are read and exception is thrown. For now, enabling the test when MDT is disabled. 

### Impact

[MINOR] Reverting disabled tests for multiwriter archival

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
