### PR TITLE
[HUDI-6118] Some fixes to improve the MDT and record index code base.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2365,10 +2365,6 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBooleanOrDefault(HoodieMetadataConfig.ENABLE);
   }
 
-  public int getMetadataInsertParallelism() {
-    return getInt(HoodieMetadataConfig.INSERT_PARALLELISM_VALUE);
-  }
-
   public int getMetadataCompactDeltaCommitMax() {
     return getInt(HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -107,8 +107,7 @@ public class HoodieMetadataWriteUtils {
             .withAsyncClean(DEFAULT_METADATA_ASYNC_CLEAN)
             .withAutoClean(false)
             .withCleanerParallelism(MDT_DEFAULT_PARALLELISM)
-            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS)
-            .retainFileVersions(2)
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
             .withFailedWritesCleaningPolicy(failedWritesCleaningPolicy)
             .retainCommits(DEFAULT_METADATA_CLEANER_COMMITS_RETAINED)
             .build())
@@ -127,7 +126,7 @@ public class HoodieMetadataWriteUtils {
             // deltacommits having corresponding completed commits. Therefore, we need to compact all fileslices of all
             // partitions together requiring UnBoundedCompactionStrategy.
             .withCompactionStrategy(new UnBoundedCompactionStrategy())
-            // Check if log compaction is enabled, this is needed for tables with lot of records.
+            // Check if log compaction is enabled, this is needed for tables with a lot of records.
             .withLogCompactionEnabled(writeConfig.isLogCompactionEnabledOnMetadata())
             // Below config is only used if isLogCompactionEnabled is set.
             .withLogCompactionBlocksThreshold(writeConfig.getMetadataLogCompactBlocksThreshold())

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -160,7 +160,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     }
 
     // Update total size of the metadata and count of base/log files
-    metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata));
+    metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata, dataMetaClient.getTableConfig().getMetadataPartitions()));
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -49,7 +49,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   // Meta fields are not populated by default for metadata table
   public static final boolean DEFAULT_METADATA_POPULATE_META_FIELDS = false;
   // Default number of commits to retain, without cleaning, on metadata table
-  public static final int DEFAULT_METADATA_CLEANER_COMMITS_RETAINED = 10;
+  public static final int DEFAULT_METADATA_CLEANER_COMMITS_RETAINED = 20;
 
   public static final String METADATA_PREFIX = "hoodie.metadata";
   public static final String OPTIMIZED_LOG_BLOCKS_SCAN = ".optimized.log.blocks.scan.enable";

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -71,14 +71,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Enable publishing of metrics around metadata table.");
 
-  // Parallelism for inserts
-  public static final ConfigProperty<Integer> INSERT_PARALLELISM_VALUE = ConfigProperty
-      .key(METADATA_PREFIX + ".insert.parallelism")
-      .defaultValue(1)
-      .markAdvanced()
-      .sinceVersion("0.7.0")
-      .withDocumentation("Parallelism to use when inserting to the metadata table");
-
   // Async index
   public static final ConfigProperty<Boolean> ASYNC_INDEX_ENABLE = ConfigProperty
       .key(METADATA_PREFIX + ".index.async")
@@ -265,7 +257,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MAX_FILE_GROUP_COUNT_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.max.filegroup.count")
-      .defaultValue(1000)
+      .defaultValue(10000)
       .markAdvanced()
       .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of file groups to use for Record Index.");
@@ -284,6 +276,12 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.14.0")
       .withDocumentation("The current number of records are multiplied by this number when estimating the number of "
           + "file groups to create automatically. This helps account for growth in the number of records in the dataset.");
+
+  public static final ConfigProperty<Integer> RECORD_INDEX_MAX_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".max.init.parallelism")
+      .defaultValue(100000)
+      .sinceVersion("0.14.0")
+      .withDocumentation("Maximum parallelism to use when initializing Record Index.");
 
   public static final ConfigProperty<Long> MAX_READER_MEMORY_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".max.reader.memory")
@@ -306,6 +304,17 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("0.14.0")
       .withDocumentation("Path on local storage to use, when keys read from metadata are held in a spillable map.");
+
+  public static final ConfigProperty<Long> MAX_LOG_FILE_SIZE_BYTES_PROP = ConfigProperty
+      .key(METADATA_PREFIX + ".max.logfile.size")
+      .defaultValue(2 * 1024 * 1024 * 1024L)  // 2GB
+      .sinceVersion("0.14.0")
+      .withDocumentation("Maximum size in bytes of a single log file. Larger log files can contain larger log blocks "
+          + "thereby reducing the number of blocks to search for keys");
+
+  public long getMaxLogFileSize() {
+    return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
+  }
 
   private HoodieMetadataConfig() {
     super();
@@ -423,9 +432,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getInt(MAX_READER_BUFFER_SIZE_PROP);
   }
 
-  /**
-   * Builder for {@link HoodieMetadataConfig}.
-   */
+  public int getRecordIndexMaxParallelism() {
+    return getInt(RECORD_INDEX_MAX_PARALLELISM);
+  }
+
   public static class Builder {
 
     private EngineType engineType = EngineType.SPARK;
@@ -498,11 +508,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withInsertParallelism(int parallelism) {
-      metadataConfig.setValue(INSERT_PARALLELISM_VALUE, String.valueOf(parallelism));
-      return this;
-    }
-
     public Builder withAsyncIndex(boolean asyncIndex) {
       metadataConfig.setValue(ASYNC_INDEX_ENABLE, String.valueOf(asyncIndex));
       return this;
@@ -525,6 +530,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withFileListingParallelism(int parallelism) {
       metadataConfig.setValue(FILE_LISTING_PARALLELISM_VALUE, String.valueOf(parallelism));
+      return this;
+    }
+
+    public Builder withMaxInitParallelism(int parallelism) {
+      metadataConfig.setValue(RECORD_INDEX_MAX_PARALLELISM, String.valueOf(parallelism));
       return this;
     }
 
@@ -599,6 +609,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
+    public Builder withMaxLogFileSizeBytes(long sizeInBytes) {
+      metadataConfig.setValue(MAX_LOG_FILE_SIZE_BYTES_PROP, String.valueOf(sizeInBytes));
+      return this;
+    }
+
     public HoodieMetadataConfig build() {
       metadataConfig.setDefaultValue(ENABLE, getDefaultMetadataEnable(engineType));
       metadataConfig.setDefaults(HoodieMetadataConfig.class.getName());
@@ -639,17 +654,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
    */
   @Deprecated
   public static final boolean DEFAULT_METADATA_METRICS_ENABLE = METRICS_ENABLE.defaultValue();
-
-  /**
-   * @deprecated Use {@link #INSERT_PARALLELISM_VALUE} and its methods.
-   */
-  @Deprecated
-  public static final String METADATA_INSERT_PARALLELISM_PROP = INSERT_PARALLELISM_VALUE.key();
-  /**
-   * @deprecated Use {@link #INSERT_PARALLELISM_VALUE} and its methods.
-   */
-  @Deprecated
-  public static final int DEFAULT_METADATA_INSERT_PARALLELISM = INSERT_PARALLELISM_VALUE.defaultValue();
 
   /**
    * @deprecated Use {@link #COMPACT_NUM_DELTA_COMMITS} and its methods.

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -533,7 +533,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withMaxInitParallelism(int parallelism) {
+    public Builder withRecordIndexMaxParallelism(int parallelism) {
       metadataConfig.setValue(RECORD_INDEX_MAX_PARALLELISM, String.valueOf(parallelism));
       return this;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -778,7 +778,7 @@ public class HoodieTableConfig extends HoodieConfig {
     setValue(TABLE_METADATA_PARTITIONS, partitions.stream().sorted().collect(Collectors.joining(CONFIG_VALUES_DELIMITER)));
     setValue(TABLE_METADATA_PARTITIONS_INFLIGHT, partitionsInflight.stream().sorted().collect(Collectors.joining(CONFIG_VALUES_DELIMITER)));
     update(metaClient.getFs(), new Path(metaClient.getMetaPath()), getProps());
-    LOG.info(String.format("MDT %s partition %s has been %s", metaClient.getBasePathV2(), partitionType, enabled ? "enabled" : "disabled"));
+    LOG.info(String.format("MDT %s partition %s has been %s", metaClient.getBasePathV2(), partitionType.name(), enabled ? "enabled" : "disabled"));
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -341,11 +341,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
         long beginTs = System.currentTimeMillis();
         // Not loaded yet
         try {
-          if (partitionSet.size() < 100) {
-            LOG.info("Building file system view for partitions: " + partitionSet);
-          } else {
-            LOG.info("Building file system view for " + partitionSet.size() + " partitions");
-          }
+          LOG.debug("Building file system view for partitions: " + partitionSet);
 
           // Pairs of relative partition path and absolute partition path
           List<Pair<String, Path>> absolutePartitionPathList = partitionSet.stream()

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -341,7 +341,11 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
         long beginTs = System.currentTimeMillis();
         // Not loaded yet
         try {
-          LOG.info("Building file system view for partitions " + partitionSet);
+          if (partitionSet.size() < 100) {
+            LOG.info("Building file system view for partitions: " + partitionSet);
+          } else {
+            LOG.info("Building file system view for " + partitionSet.size() + " partitions");
+          }
 
           // Pairs of relative partition path and absolute partition path
           List<Pair<String, Path>> absolutePartitionPathList = partitionSet.stream()

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -383,7 +382,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
         })
         .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
-    LOG.info("Listed files in partitions from metadata: partition list =" + Arrays.toString(partitionPaths.toArray()));
+    LOG.info("Listed files in " + partitionPaths.size() + " partitions from metadata");
 
     return partitionPathToFilesMap;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -543,7 +544,8 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
   }
 
   public Map<String, String> stats() {
-    return metrics.map(m -> m.getStats(true, metadataMetaClient, this)).orElse(new HashMap<>());
+    Set<String> allMetadataPartitionPaths = Arrays.stream(MetadataPartitionType.values()).map(MetadataPartitionType::getPartitionPath).collect(Collectors.toSet());
+    return metrics.map(m -> m.getStats(true, metadataMetaClient, this, allMetadataPartitionPaths)).orElse(new HashMap<>());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -47,6 +47,12 @@ public class HoodieMetadataMetrics implements Serializable {
   public static final String LOOKUP_FILES_STR = "lookup_files";
   public static final String LOOKUP_BLOOM_FILTERS_METADATA_STR = "lookup_meta_index_bloom_filters";
   public static final String LOOKUP_COLUMN_STATS_METADATA_STR = "lookup_meta_index_column_ranges";
+  // Time for lookup from record index
+  public static final String LOOKUP_RECORD_INDEX_TIME_STR = "lookup_record_index_time";
+  // Number of keys looked up in a call
+  public static final String LOOKUP_RECORD_INDEX_KEYS_COUNT_STR = "lookup_record_index_key_count";
+  // Number of keys found in record index
+  public static final String LOOKUP_RECORD_INDEX_KEYS_HITS_COUNT_STR = "lookup_record_index_key_count";
   public static final String SCAN_STR = "scan";
   public static final String BASEFILE_READ_STR = "basefile_read";
   public static final String INITIALIZE_STR = "initialize";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -74,7 +74,6 @@ public class HoodieMetadataMetrics implements Serializable {
 
   public Map<String, String> getStats(boolean detailed, HoodieTableMetaClient metaClient, HoodieTableMetadata metadata, Set<String> metadataPartitions) {
     try {
-      metaClient.reloadActiveTimeline();
       HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
       return getStats(fsView, detailed, metadata, metadataPartitions);
     } catch (IOException ioe) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1634,7 +1634,7 @@ public class HoodieTableMetadataUtil {
 
     LOG.info(String.format("Estimated file group count for MDT partition %s is %d "
             + "[recordCount=%d, avgRecordSize=%d, minFileGroupCount=%d, maxFileGroupCount=%d, growthFactor=%f, "
-            + "maxFileGroupSizeBytes=%d]", partitionType, fileGroupCount, recordCount, averageRecordSize, minFileGroupCount,
+            + "maxFileGroupSizeBytes=%d]", partitionType.name(), fileGroupCount, recordCount, averageRecordSize, minFileGroupCount,
         maxFileGroupCount, growthFactor, maxFileGroupSizeBytes));
     return fileGroupCount;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.metadata;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,14 +46,6 @@ public enum MetadataPartitionType {
 
   public String getFileIdPrefix() {
     return fileIdPrefix;
-  }
-
-  public static List<String> allPaths() {
-    return Arrays.asList(
-        FILES.getPartitionPath(),
-        COLUMN_STATS.getPartitionPath(),
-        BLOOM_FILTERS.getPartitionPath()
-    );
   }
 
   /**


### PR DESCRIPTION
[HUDI-6118] Some fixes to improve the MDT and record index code base.

### Change Logs

1. Print MDT partition name instead of the enum tostring in logs
2. Use fsView.loadAllPartitions()
3. When publishing size metrics for MDT, only consider partitions which have been initialized
4. Fixed job status names
5. Limited logs which were printing the entire list of partitions. This is very verbose for datasets with large number of partitions
6. Added a config to reduce the max parallelism of record index initialization.
7. Changed defaults for MDT write configs to reasonable values
8. Added config for MDT logBlock size. Larger blocks are preferred to reduce lookup time.
9. Fixed the size metrics for MDT. These metrics should be set instead of incremented.


### Impact

Fixes issues for the recently commited RI and MDT changes

### Risk level (write none, low medium or high below)

Low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
