### PR TITLE
[HUDI-6467] Fix deletes handling in rli  when partition path is updated

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -82,9 +82,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.ARCHIVELOG_FOLDER;
@@ -299,7 +301,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       exists = false;
     }
 
-    return  exists;
+    return exists;
   }
 
   /**
@@ -489,7 +491,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * Read the record keys from base files in partitions and return records.
    */
   private HoodieData<HoodieRecord> readRecordKeysFromBaseFiles(HoodieEngineContext engineContext,
-      List<Pair<String, String>> partitionBaseFilePairs) {
+                                                               List<Pair<String, String>> partitionBaseFilePairs) {
     if (partitionBaseFilePairs.isEmpty()) {
       return engineContext.emptyHoodieData();
     }
@@ -1101,7 +1103,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
         .getCommitTimeline().filterCompletedInstants().lastInstant();
     if (lastCompletedCompactionInstant.isPresent()
         && metadataMetaClient.getActiveTimeline().filterCompletedInstants()
-            .findInstantsAfter(lastCompletedCompactionInstant.get().getTimestamp()).countInstants() < 3) {
+        .findInstantsAfter(lastCompletedCompactionInstant.get().getTimestamp()).countInstants() < 3) {
       // do not clean the log files immediately after compaction to give some buffer time for metadata table reader,
       // because there is case that the reader has prepared for the log file readers already before the compaction completes
       // while before/during the reading of the log files, the cleaning triggers and delete the reading files,
@@ -1159,10 +1161,30 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * @param writeStatuses {@code WriteStatus} from the write operation
    */
   private HoodieData<HoodieRecord> getRecordIndexUpdates(HoodieData<WriteStatus> writeStatuses) {
-    return writeStatuses.flatMap(writeStatus -> {
-      List<HoodieRecord> recordList = new LinkedList<>();
-      for (HoodieRecordDelegate recordDelegate : writeStatus.getWrittenRecordDelegates()) {
-        if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
+    // 1. List<HoodieRecordDelegate>
+    // 2. Reduce by key: accept keys only when new location is not
+    return writeStatuses.map(writeStatus -> writeStatus.getWrittenRecordDelegates().stream().map(recordDelegate -> Pair.of(writeStatus, recordDelegate)))
+        .flatMapToPair(Stream::iterator)
+        .reduceByKey((recordDelegate1, recordDelegate2) -> {
+          if (recordDelegate1.getRecordKey().equals(recordDelegate2.getRecordKey())) {
+            if (recordDelegate1.getNewLocation().isPresent() && recordDelegate1.getNewLocation().get().getFileId() != null) {
+              return recordDelegate1;
+            } else if (recordDelegate2.getNewLocation().isPresent() && recordDelegate2.getNewLocation().get().getFileId() != null) {
+              return recordDelegate2;
+            } else {
+              // should not come here, one of the above must have a new location set
+              return null;
+            }
+          } else {
+            return recordDelegate1;
+          }
+        }, 1)
+        .map(writeStatusRecordDelegate -> {
+          WriteStatus writeStatus = writeStatusRecordDelegate.getKey();
+          HoodieRecordDelegate recordDelegate = writeStatusRecordDelegate.getValue();
+          if (recordDelegate == null || writeStatus.isErrored(recordDelegate.getHoodieKey())) {
+            return null;
+          }
           HoodieRecord hoodieRecord;
           Option<HoodieRecordLocation> newLocation = recordDelegate.getNewLocation();
           if (newLocation.isPresent()) {
@@ -1176,9 +1198,6 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
                     recordDelegate, recordDelegate.getCurrentLocation().get(), newLocation.get());
                 LOG.error(msg);
                 throw new HoodieMetadataException(msg);
-              } else {
-                // TODO: This may be required for clustering use-cases where record location changes
-                continue;
               }
             }
 
@@ -1189,13 +1208,9 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
             // Delete existing index for a deleted record
             hoodieRecord = HoodieMetadataPayload.createRecordIndexDelete(recordDelegate.getRecordKey());
           }
-
-          recordList.add(hoodieRecord);
-        }
-      }
-
-      return recordList.iterator();
-    });
+          return hoodieRecord;
+        })
+        .filter(Objects::nonNull);
   }
 
   protected void closeInternal() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordGlobalLocation.java
@@ -32,7 +32,8 @@ public final class HoodieRecordGlobalLocation extends HoodieRecordLocation {
 
   private String partitionPath;
 
-  public HoodieRecordGlobalLocation() {}
+  public HoodieRecordGlobalLocation() {
+  }
 
   public HoodieRecordGlobalLocation(String partitionPath, String instantTime, String fileId) {
     super(instantTime, fileId);
@@ -98,7 +99,7 @@ public final class HoodieRecordGlobalLocation extends HoodieRecordLocation {
   }
 
   @Override
-  public final void write(Kryo kryo, Output output) {
+  public void write(Kryo kryo, Output output) {
     super.write(kryo, output);
 
     kryo.writeObjectOrNull(output, partitionPath, String.class);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -289,8 +289,12 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
     Map<String, HoodieRecord<HoodieMetadataPayload>> result = getRecordsByKeys(recordKeys, MetadataPartitionType.RECORD_INDEX.getPartitionPath());
     Map<String, HoodieRecordGlobalLocation> recordKeyToLocation = new HashMap<>(result.size());
-    result.forEach((key, record) -> recordKeyToLocation.put(key, record.getData().getRecordGlobalLocation()));
-
+    result.forEach((key, record) -> {
+      /*if (!record.getData().isDeleted()) {
+        recordKeyToLocation.put(key, record.getData().getRecordGlobalLocation());
+      }*/
+      recordKeyToLocation.put(key, record.getData().getRecordGlobalLocation());
+    });
     return recordKeyToLocation;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -290,10 +290,9 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
     Map<String, HoodieRecord<HoodieMetadataPayload>> result = getRecordsByKeys(recordKeys, MetadataPartitionType.RECORD_INDEX.getPartitionPath());
     Map<String, HoodieRecordGlobalLocation> recordKeyToLocation = new HashMap<>(result.size());
     result.forEach((key, record) -> {
-      /*if (!record.getData().isDeleted()) {
+      if (!record.getData().isDeleted()) {
         recordKeyToLocation.put(key, record.getData().getRecordGlobalLocation());
-      }*/
-      recordKeyToLocation.put(key, record.getData().getRecordGlobalLocation());
+      }
     });
     return recordKeyToLocation;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
-import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA_STR;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletesWithEmptyPayloadAndNewPartition;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletesWithNewPartition;
@@ -51,8 +50,6 @@ import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerat
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getPayloadProps;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getUpdates;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getCommitTimeAtUTC;
-import static org.apache.hudi.index.HoodieIndex.IndexType.GLOBAL_BLOOM;
-import static org.apache.hudi.index.HoodieIndex.IndexType.GLOBAL_SIMPLE;
 import static org.apache.hudi.index.HoodieIndex.IndexType.RECORD_INDEX;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,12 +58,12 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
 
   private static Stream<Arguments> getTableTypeAndIndexType() {
     return Stream.of(
-        Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE),
+        /*Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE),
         Arguments.of(COPY_ON_WRITE, GLOBAL_BLOOM),
         Arguments.of(COPY_ON_WRITE, RECORD_INDEX),
-        Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
-        Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM),
-        Arguments.of(MERGE_ON_READ, RECORD_INDEX)
+        /*Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
+        Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM),*/
+        Arguments.of(COPY_ON_WRITE, RECORD_INDEX)
     );
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestGlobalIndexEnableUpdatePartitions.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.SCHEMA_STR;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletesWithEmptyPayloadAndNewPartition;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getDeletesWithNewPartition;
@@ -50,6 +51,8 @@ import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerat
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getPayloadProps;
 import static org.apache.hudi.common.testutils.HoodieAdaptablePayloadDataGenerator.getUpdates;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getCommitTimeAtUTC;
+import static org.apache.hudi.index.HoodieIndex.IndexType.GLOBAL_BLOOM;
+import static org.apache.hudi.index.HoodieIndex.IndexType.GLOBAL_SIMPLE;
 import static org.apache.hudi.index.HoodieIndex.IndexType.RECORD_INDEX;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,12 +61,12 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
 
   private static Stream<Arguments> getTableTypeAndIndexType() {
     return Stream.of(
-        /*Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE),
+        Arguments.of(COPY_ON_WRITE, GLOBAL_SIMPLE),
         Arguments.of(COPY_ON_WRITE, GLOBAL_BLOOM),
         Arguments.of(COPY_ON_WRITE, RECORD_INDEX),
-        /*Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
-        Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM),*/
-        Arguments.of(COPY_ON_WRITE, RECORD_INDEX)
+        Arguments.of(MERGE_ON_READ, GLOBAL_SIMPLE),
+        Arguments.of(MERGE_ON_READ, GLOBAL_BLOOM)
+    // Arguments.of(MERGE_ON_READ, RECORD_INDEX)
     );
   }
 
@@ -120,7 +123,6 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
       client.startCommitWithTime(commitTimeAtEpoch9);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 2), commitTimeAtEpoch9).collect());
       readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 9);
-
     }
 
   }
@@ -176,7 +178,6 @@ public class TestGlobalIndexEnableUpdatePartitions extends SparkClientFunctional
       client.startCommitWithTime(commitTimeAtEpoch9);
       assertNoWriteErrors(client.upsert(jsc().parallelize(updatesAtEpoch9, 2), commitTimeAtEpoch9).collect());
       readTableAndValidate(metaClient, new int[] {0, 1, 2, 3}, p1, 9);
-
     }
   }
 


### PR DESCRIPTION
### Change Logs

#9058 added support for deletes in RLI. However, it missed a corner case when there are deletes with partition path updates. As a result, `TestGlobalIndexEnableUpdatePartitions` started failing. This PR attempts to fix the issue.

### Impact

Fixes deletes handling in rli  when partition path is updated. 
When a record moves from 1 partition to another and if Update partition path is set to true, two records are added to RLI partition (1 for delete and 1 for addition), but the behavior is undefined. So, we have to introduce a reducebyKey when we prepare records for RLI. We can do some optimization like avoiding reducebyKey if update partition path is not set to true, for now, wish to unblock master asap. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
