### PR TITLE
[HUDI-2141] Support flink stream write metrics

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
@@ -108,7 +108,7 @@ public class FlinkStreamWriteMetrics extends HoodieFlinkMetrics {
     metricGroup.meter("handleSwitchPerSecond", handleSwitchPerSecond);
 
     metricGroup.histogram("handleCreationCosts", handleCreationCosts);
-    metricGroup.histogram("handleCloseCosts", fileFlushCost);
+    metricGroup.histogram("fileFlushCost", fileFlushCost);
   }
 
   public void setWriteBufferedSize(long writeBufferedSize) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
@@ -52,7 +52,7 @@ public class FlinkStreamWriteMetrics extends HoodieFlinkMetrics {
   private long writeBufferedSize;
 
   /**
-   * Total costs for closing write handles during a checkpoint window.
+   * Total costs for flushing files during a checkpoint window.
    */
   private long fileFlushTotalCosts;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
@@ -66,7 +66,7 @@ public class FlinkStreamWriteMetrics extends HoodieFlinkMetrics {
   private long numOfOpenHandle;
 
   /**
-   * Number of files written in during a checkpoint window.
+   * Number of files written during a checkpoint window.
    */
   private long numOfFilesWritten;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamWriteMetrics.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.hudi.sink.common.AbstractStreamWriteFunction;
+
+import com.codahale.metrics.SlidingWindowReservoir;
+import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
+import org.apache.flink.dropwizard.metrics.DropwizardMeterWrapper;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metrics for flink stream write (including append write, normal/bucket stream write etc.).
+ * Used in subclasses of {@link AbstractStreamWriteFunction}.
+ */
+public class FlinkStreamWriteMetrics extends HoodieFlinkMetrics {
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkStreamWriteMetrics.class);
+
+  private static String FLUSHING_KEY = "flushing";
+  private static String HANDLE_CLOSING_KEY = "handle_closing";
+  private static String HANDLE_CREATION_KEY = "handle_creation";
+
+  /**
+   * Flush data costs during checkpoint.
+   */
+  private long flushDataCosts;
+
+  /**
+   * Number of records written in during a checkpoint window.
+   */
+  protected long writtenRecords;
+
+  /**
+   * Current write buffer size in StreamWriteFunction.
+   */
+  private long writeBufferedSize;
+
+  /**
+   * Total costs for closing write handles during a checkpoint window.
+   */
+  private long handleCloseTotalCosts;
+
+  /**
+   * Number of handles opened during a checkpoint window. Increased with partition number/bucket number etc.
+   */
+  private long numOfOpenHandle;
+
+  /**
+   * Number of files written in during a checkpoint window.
+   */
+  private long numOfFilesWritten;
+
+  /**
+   * Number of records written per seconds.
+   */
+  protected final Meter recordWrittenPerSecond;
+
+  /**
+   * Number of write handle switches per seconds.
+   */
+  private final Meter handleSwitchPerSecond;
+
+  /**
+   * Cost of write handle creation.
+   */
+  private final Histogram handleCreationCosts;
+
+  /**
+   * Cost of write handle closing.
+   */
+  private final Histogram handleCloseCosts;
+
+  public FlinkStreamWriteMetrics(MetricGroup metricGroup) {
+    super(metricGroup);
+    this.recordWrittenPerSecond = new DropwizardMeterWrapper(new com.codahale.metrics.Meter());
+    this.handleSwitchPerSecond = new DropwizardMeterWrapper(new com.codahale.metrics.Meter());
+    this.handleCreationCosts = new DropwizardHistogramWrapper(new com.codahale.metrics.Histogram(new SlidingWindowReservoir(100)));
+    this.handleCloseCosts = new DropwizardHistogramWrapper(new com.codahale.metrics.Histogram(new SlidingWindowReservoir(100)));
+  }
+
+  @Override
+  public void registerMetrics() {
+    metricGroup.meter("recordWrittenPerSecond", recordWrittenPerSecond);
+    metricGroup.gauge("currentCommitWrittenRecords", () -> writtenRecords);
+    metricGroup.gauge("writerFlushCosts", () -> flushDataCosts);
+    metricGroup.gauge("writeBufferedSize", () -> writeBufferedSize);
+
+    metricGroup.gauge("writerHandleCloseTotalCosts", () -> handleCloseTotalCosts);
+    metricGroup.gauge("numOfFilesWritten", () -> numOfFilesWritten);
+    metricGroup.gauge("numOfOpenHandle", () -> numOfOpenHandle);
+
+    metricGroup.meter("handleSwitchPerSecond", handleSwitchPerSecond);
+
+    metricGroup.histogram("handleCreationCosts", handleCreationCosts);
+    metricGroup.histogram("handleCloseCosts", handleCloseCosts);
+  }
+
+  public void setWriteBufferedSize(long writeBufferedSize) {
+    this.writeBufferedSize = writeBufferedSize;
+  }
+
+  public long getFlushDataCosts() {
+    return flushDataCosts;
+  }
+
+  public void startFlushing() {
+    startTimer(FLUSHING_KEY);
+  }
+
+  public void endFlushing() {
+    this.flushDataCosts = stopTimer(FLUSHING_KEY);
+  }
+
+  public void markRecordIn() {
+    this.writtenRecords += 1;
+    recordWrittenPerSecond.markEvent();
+  }
+
+  public void increaseNumOfFilesWritten() {
+    numOfFilesWritten += 1;
+  }
+
+  public void increaseNumOfOpenHandle() {
+    numOfOpenHandle += 1;
+    increaseNumOfFilesWritten();
+  }
+
+  public void markHandleSwitch() {
+    handleSwitchPerSecond.markEvent();
+  }
+
+  public void startHandleCreation() {
+    startTimer(HANDLE_CREATION_KEY);
+  }
+
+  public void endHandleCreation() {
+    handleCreationCosts.update(stopTimer(HANDLE_CREATION_KEY));
+  }
+
+  public void startHandleClose() {
+    startTimer(HANDLE_CLOSING_KEY);
+  }
+
+  public void endHandleClose() {
+    long costs = stopTimer(HANDLE_CLOSING_KEY);
+    handleCloseCosts.update(costs);
+    this.handleCloseTotalCosts += costs;
+  }
+
+  public void resetAfterCommit() {
+    this.writtenRecords = 0;
+    this.numOfFilesWritten = 0;
+    this.numOfOpenHandle = 0;
+    this.writeBufferedSize = 0;
+  }
+
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -460,7 +460,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
 
   @SuppressWarnings("unchecked, rawtypes")
   private void flushRemaining(boolean endInput) {
-    writeMetrics.startCheckpointFlushing();
+    writeMetrics.startDataFlush();
     this.currentInstant = instantToWrite(hasData());
     if (this.currentInstant == null) {
       // in case there are empty checkpoints that has no input data
@@ -501,7 +501,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     // blocks flushing until the coordinator starts a new instant
     this.confirming = true;
 
-    writeMetrics.endCheckpointFlushing();
+    writeMetrics.endDataFlush();
     writeMetrics.resetAfterCommit();
   }
 
@@ -513,9 +513,9 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
 
   protected List<WriteStatus> writeBucket(String instant, DataBucket bucket, List<HoodieRecord> records) {
     bucket.preWrite(records);
-    writeMetrics.startSingleFileFlush();
+    writeMetrics.startFileFlush();
     List<WriteStatus> statuses = writeFunction.apply(records, instant);
-    writeMetrics.endSingleFileFlush();
+    writeMetrics.endFileFlush();
     writeMetrics.increaseNumOfFilesWritten();
     return statuses;
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.util.ObjectSizeCalculator;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metrics.FlinkStreamWriteMetrics;
 import org.apache.hudi.sink.common.AbstractStreamWriteFunction;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
 import org.apache.hudi.table.action.commit.FlinkWriteHelper;
@@ -39,6 +40,7 @@ import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
@@ -113,6 +115,11 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   private transient TotalSizeTracer tracer;
 
   /**
+   * Metrics for flink stream write.
+   */
+  protected transient FlinkStreamWriteMetrics writeMetrics;
+
+  /**
    * Constructs a StreamingSinkFunction.
    *
    * @param config The config options
@@ -127,6 +134,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     initBuffer();
     initWriteFunction();
     initMergeClass();
+    registerMetrics();
   }
 
   @Override
@@ -385,16 +393,24 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
    * @param value HoodieRecord
    */
   protected void bufferRecord(HoodieRecord<?> value) {
+    writeMetrics.markRecordIn();
     final String bucketID = getBucketID(value);
 
     DataBucket bucket = this.buckets.computeIfAbsent(bucketID,
-        k -> new DataBucket(this.config.getDouble(FlinkOptions.WRITE_BATCH_SIZE), value));
+        k -> {
+          // create a new bucket and update metrics
+          writeMetrics.increaseNumOfOpenHandle();
+          return new DataBucket(this.config.getDouble(FlinkOptions.WRITE_BATCH_SIZE), value);
+        });
+
     final DataItem item = DataItem.fromHoodieRecord(value);
 
     bucket.records.add(item);
 
     boolean flushBucket = bucket.detector.detect(item);
     boolean flushBuffer = this.tracer.trace(bucket.detector.lastRecordSize);
+    // update buffer metrics after tracing buffer size
+    writeMetrics.setWriteBufferedSize(this.tracer.bufferSize);
     if (flushBucket) {
       if (flushBucket(bucket)) {
         this.tracer.countDown(bucket.detector.totalSize);
@@ -449,6 +465,7 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
 
   @SuppressWarnings("unchecked, rawtypes")
   private void flushRemaining(boolean endInput) {
+    writeMetrics.startFlushing();
     this.currentInstant = instantToWrite(hasData());
     if (this.currentInstant == null) {
       // in case there are empty checkpoints that has no input data
@@ -488,11 +505,24 @@ public class StreamWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     this.writeStatuses.addAll(writeStatus);
     // blocks flushing until the coordinator starts a new instant
     this.confirming = true;
+
+    writeMetrics.endFlushing();
+    writeMetrics.resetAfterCommit();
+  }
+
+  private void registerMetrics() {
+    MetricGroup metrics = getRuntimeContext().getMetricGroup();
+    writeMetrics = new FlinkStreamWriteMetrics(metrics);
+    writeMetrics.registerMetrics();
   }
 
   protected List<WriteStatus> writeBucket(String instant, DataBucket bucket, List<HoodieRecord> records) {
     bucket.preWrite(records);
-    return writeFunction.apply(records, instant);
+    writeMetrics.startHandleClose();
+    List<WriteStatus> statuses = writeFunction.apply(records, instant);
+    writeMetrics.endHandleClose();
+    writeMetrics.increaseNumOfFilesWritten();
+    return statuses;
   }
 
   private List<HoodieRecord> deduplicateRecordsIfNeeded(List<HoodieRecord> records) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -145,7 +145,7 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   }
 
   private void flushData(boolean endInput) {
-    writeMetrics.startCheckpointFlushing();
+    writeMetrics.startDataFlush();
     final List<WriteStatus> writeStatus;
     if (this.writerHelper != null) {
       writeStatus = this.writerHelper.getWriteStatuses(this.taskID);
@@ -168,9 +168,7 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     this.writeStatuses.addAll(writeStatus);
     // blocks flushing until the coordinator starts a new instant
     this.confirming = true;
-
-    writeMetrics.endCheckpointFlushing();
-    LOG.info("Flushing costs: {} ms", writeMetrics.getCheckpointFlushCosts());
+    writeMetrics.endDataFlush();
     writeMetrics.resetAfterCommit();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.sink.append;
 
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metrics.FlinkStreamWriteMetrics;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
@@ -141,7 +142,7 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     }
     this.writerHelper = new BulkInsertWriterHelper(this.config, this.writeClient.getHoodieTable(), this.writeClient.getConfig(),
         instant, this.taskID, getRuntimeContext().getNumberOfParallelSubtasks(), getRuntimeContext().getAttemptNumber(),
-        this.rowType, false, writeMetrics);
+        this.rowType, false, Option.of(writeMetrics));
   }
 
   private void flushData(boolean endInput) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -145,7 +145,7 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
   }
 
   private void flushData(boolean endInput) {
-    writeMetrics.startFlushing();
+    writeMetrics.startCheckpointFlushing();
     final List<WriteStatus> writeStatus;
     if (this.writerHelper != null) {
       writeStatus = this.writerHelper.getWriteStatuses(this.taskID);
@@ -169,8 +169,8 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     // blocks flushing until the coordinator starts a new instant
     this.confirming = true;
 
-    writeMetrics.endFlushing();
-    LOG.info("Flushing costs: {} ms", writeMetrics.getFlushDataCosts());
+    writeMetrics.endCheckpointFlushing();
+    LOG.info("Flushing costs: {} ms", writeMetrics.getCheckpointFlushCosts());
     writeMetrics.resetAfterCommit();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -222,9 +222,9 @@ public class BulkInsertWriterHelper {
   }
 
   private WriteStatus closeWriteHandle(HoodieRowDataCreateHandle rowCreateHandle) throws IOException {
-    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startSingleFileFlush);
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startFileFlush);
     WriteStatus status = rowCreateHandle.close();
-    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::endSingleFileFlush);
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::endFileFlush);
     return status;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -20,11 +20,13 @@ package org.apache.hudi.sink.bulk;
 
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.io.storage.row.HoodieRowDataCreateHandle;
+import org.apache.hudi.metrics.FlinkStreamWriteMetrics;
 import org.apache.hudi.table.HoodieTable;
 
 import org.apache.flink.configuration.Configuration;
@@ -69,14 +71,21 @@ public class BulkInsertWriterHelper {
   @Nullable
   protected final RowDataKeyGen keyGen;
 
+  protected final Option<FlinkStreamWriteMetrics> appendWriteMetrics;
+
   public BulkInsertWriterHelper(Configuration conf, HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
                                 String instantTime, int taskPartitionId, long totalSubtaskNum, long taskEpochId, RowType rowType) {
-    this(conf, hoodieTable, writeConfig, instantTime, taskPartitionId, totalSubtaskNum, taskEpochId, rowType, false);
+    this(conf, hoodieTable, writeConfig, instantTime, taskPartitionId, totalSubtaskNum, taskEpochId, rowType, false, null);
+  }
+
+  public BulkInsertWriterHelper(Configuration conf, HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
+                                String instantTime, int taskPartitionId, long taskId, long taskEpochId, RowType rowType, boolean preserveHoodieMetadata) {
+    this(conf, hoodieTable, writeConfig, instantTime, taskPartitionId, taskId, taskEpochId, rowType, preserveHoodieMetadata, null);
   }
 
   public BulkInsertWriterHelper(Configuration conf, HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
                                 String instantTime, int taskPartitionId, long totalSubtaskNum, long taskEpochId, RowType rowType,
-                                boolean preserveHoodieMetadata) {
+                                boolean preserveHoodieMetadata, FlinkStreamWriteMetrics metrics) {
     this.hoodieTable = hoodieTable;
     this.writeConfig = writeConfig;
     this.instantTime = instantTime;
@@ -88,6 +97,7 @@ public class BulkInsertWriterHelper {
     this.isInputSorted = OptionsResolver.isBulkInsertOperation(conf) && conf.getBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT);
     this.fileIdPrefix = UUID.randomUUID().toString();
     this.keyGen = preserveHoodieMetadata ? null : RowDataKeyGens.instance(conf, rowType, taskPartitionId, instantTime);
+    this.appendWriteMetrics = Option.ofNullable(metrics);
   }
 
   /**
@@ -109,8 +119,10 @@ public class BulkInsertWriterHelper {
       if ((lastKnownPartitionPath == null) || !lastKnownPartitionPath.equals(partitionPath) || !handle.canWrite()) {
         handle = getRowCreateHandle(partitionPath);
         lastKnownPartitionPath = partitionPath;
+        appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::markHandleSwitch);
       }
       handle.write(recordKey, partitionPath, record);
+      appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::markRecordIn);
     } catch (Throwable t) {
       IOException ioException = new IOException("Exception happened when bulk insert.", t);
       LOG.error("Global error thrown while trying to write records in HoodieRowCreateHandle ", ioException);
@@ -126,17 +138,20 @@ public class BulkInsertWriterHelper {
       }
 
       LOG.info("Creating new file for partition path " + partitionPath);
+      appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startHandleCreation);
       HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, getNextFileId(),
           instantTime, taskPartitionId, totalSubtaskNum, taskEpochId, rowType, preserveHoodieMetadata);
       handles.put(partitionPath, rowCreateHandle);
+
+      appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::increaseNumOfOpenHandle);
     } else if (!handles.get(partitionPath).canWrite()) {
       // even if there is a handle to the partition path, it could have reached its max size threshold. So, we close the handle here and
       // create a new one.
       LOG.info("Rolling max-size file for partition path " + partitionPath);
-      writeStatusList.add(handles.remove(partitionPath).close());
-      HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, getNextFileId(),
-          instantTime, taskPartitionId, totalSubtaskNum, taskEpochId, rowType, preserveHoodieMetadata);
+      writeStatusList.add(closeWriteHandle(handles.remove(partitionPath)));
+      HoodieRowDataCreateHandle rowCreateHandle = createWriteHandle(partitionPath);
       handles.put(partitionPath, rowCreateHandle);
+      appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::increaseNumOfFilesWritten);
     }
     return handles.get(partitionPath);
   }
@@ -144,7 +159,7 @@ public class BulkInsertWriterHelper {
   public void close() throws IOException {
     for (HoodieRowDataCreateHandle rowCreateHandle : handles.values()) {
       LOG.info("Closing bulk insert file " + rowCreateHandle.getFileName());
-      writeStatusList.add(rowCreateHandle.close());
+      writeStatusList.add(closeWriteHandle(rowCreateHandle));
     }
     handles.clear();
     handle = null;
@@ -196,6 +211,21 @@ public class BulkInsertWriterHelper {
     } catch (IOException e) {
       throw new HoodieException("Error collect the write status for task [" + taskID + "]", e);
     }
+  }
+
+  private HoodieRowDataCreateHandle createWriteHandle(String  partitionPath) {
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startHandleCreation);
+    HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, getNextFileId(),
+        instantTime, taskPartitionId, totalSubtaskNum, taskEpochId, rowType, preserveHoodieMetadata);
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::endHandleCreation);
+    return rowCreateHandle;
+  }
+
+  private WriteStatus closeWriteHandle(HoodieRowDataCreateHandle rowCreateHandle) throws IOException {
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startHandleClose);
+    WriteStatus status = rowCreateHandle.close();
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::endHandleClose);
+    return status;
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -222,9 +222,9 @@ public class BulkInsertWriterHelper {
   }
 
   private WriteStatus closeWriteHandle(HoodieRowDataCreateHandle rowCreateHandle) throws IOException {
-    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startHandleClose);
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::startSingleFileFlush);
     WriteStatus status = rowCreateHandle.close();
-    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::endHandleClose);
+    appendWriteMetrics.ifPresent(FlinkStreamWriteMetrics::endSingleFileFlush);
     return status;
   }
 


### PR DESCRIPTION
### Change Logs

Support some useful flink write metrics. Mainly toward stream write and append write. Tests will be added after the overall design is approved. 

Note that OperatorCoodinator does not support getting `metricGroup`  in the current hudi flink version(1.17.1), so this PR will not include metrics like commit metrics(see #3235) that can only gather by StreamWriteCoordinator. We add task manager metrics only in this pr. 

This pr is following #3235 and fixed #6984. 

### Impact

fixed #6984. 

### Risk level (write none, low medium or high below)

none

### Documentation Update

Will update documents in another pr

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
