### PR TITLE
[HUDI-6475] Optimize TableNotFoundException message

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -54,9 +54,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.CommitUtils.getCheckpointValueAsString;
 
@@ -80,7 +82,7 @@ public class DataSourceUtils {
       }
     }
 
-    throw new TableNotFoundException("Unable to find a hudi table for the user provided paths.");
+    throw new TableNotFoundException(Arrays.stream(userProvidedPaths).map(Path::toString).collect(Collectors.joining(",")));
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Pass userProvidedPaths to TableNotFoundException.
```
  public TableNotFoundException(String basePath) {
    super(getErrorMessage(basePath));
  }
```

### Impact

None
### Risk level (write none, low medium or high below)

None

### Documentation Update



### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
