### PR TITLE
[HUDI-6477] Lazy fetching partition path & file slice when refresh in…

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -319,18 +319,18 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
         .mode(SaveMode.Overwrite)
         .save(basePath)
 
+      fileIndex.refresh()
+
+      val partitionFilter2 = And(
+        EqualTo(attribute("dt"), literal("2021/03/01")),
+        EqualTo(attribute("hh"), literal("10"))
+      )
+
       // NOTE: That if file-index is in lazy-listing mode and we can't parse partition values, there's no way
       //       to recover from this since Spark by default have to inject partition values parsed from the partition paths.
       if (listingModeOverride == DataSourceReadOptions.FILE_INDEX_LISTING_MODE_LAZY) {
-        assertThrows(classOf[HoodieException]) { fileIndex.refresh() }
+        assertThrows(classOf[HoodieException]) { fileIndex.listFiles(Seq(partitionFilter2), Seq.empty) }
       } else {
-        fileIndex.refresh()
-
-        val partitionFilter2 = And(
-          EqualTo(attribute("dt"), literal("2021/03/01")),
-          EqualTo(attribute("hh"), literal("10"))
-        )
-
         val partitionAndFilesNoPruning = fileIndex.listFiles(Seq(partitionFilter2), Seq.empty)
 
         assertEquals(1, partitionAndFilesNoPruning.size)


### PR DESCRIPTION
… HoodieFileIndex

### Change Logs

Currently there is a lazy list mechanism in `hoodieFileIndex`, but it only takes effect during initialization. We can also make it take effect when do refresh. 

Because at present, almost all spark commands in HUDI will do refresh, such as DDL alter table operation, which don’t need to do list file at all.

### Impact

Lazy fetching partition path & file slice when refresh in HoodieFileIndex

### Risk level (write none, low medium or high below)

medium

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
