### PR TITLE
[HUDI-6478] Simplifying INSERT_INTO configs for spark-sql

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -438,6 +438,7 @@ object DataSourceWriteOptions {
     .key("hoodie.sql.bulk.insert.enable")
     .defaultValue("false")
     .markAdvanced()
+    .deprecatedAfter("0.14.0")
     .withDocumentation("When set to true, the sql insert statement will use bulk insert. " +
       "This config is deprecated as of 0.14.0. Please use " + SQL_WRITE_OPERATION.key() + " instead.")
 
@@ -445,6 +446,7 @@ object DataSourceWriteOptions {
   val SQL_INSERT_MODE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.sql.insert.mode")
     .defaultValue("upsert")
+    .deprecatedAfter("0.14.0")
     .withDocumentation("Insert mode when insert data to pk-table. The optional modes are: upsert, strict and non-strict." +
       "For upsert mode, insert statement do the upsert operation for the pk-table which will update the duplicate record." +
       "For strict mode, insert statement will keep the primary key uniqueness constraint which do not allow duplicate record." +
@@ -526,6 +528,7 @@ object DataSourceWriteOptions {
   val SQL_WRITE_OPERATION: ConfigProperty[String] = ConfigProperty
     .key("hoodie.sql.write.operation")
     .defaultValue("insert")
+    .withValidValues("bulk_insert","insert","upsert")
     .withDocumentation("Sql write operation to use with INSERT_INTO spark sql command. This comes with 3 possible values, bulk_insert, " +
       "insert and upsert. bulk_insert is generally meant for initial loads and is known to be performant compared to insert. But bulk_insert may not " +
       "do small file managmeent. If you prefer hudi to automatically managee small files, then you can go with \"insert\". There is no precombine " +
@@ -540,6 +543,7 @@ object DataSourceWriteOptions {
   val INSERT_DUP_POLICY: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.insert.dup.policy")
     .defaultValue(NONE_INSERT_DUP_POLICY)
+    .withValidValues(NONE_INSERT_DUP_POLICY, DROP_INSERT_DUP_POLICY, FAIL_INSERT_DUP_POLICY)
     .withDocumentation("When operation type is set to \"insert\", users can optionally enforce a dedup policy. This policy will be employed "
       + " when records being ingested already exists in storage. Default policy is none and no action will be taken. Another option is to choose " +
     " \"drop\", on which matching records from incoming will be dropped and the rest will be ingested. Third option is \"fail\" which will " +

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -440,7 +440,7 @@ object DataSourceWriteOptions {
     .markAdvanced()
     .deprecatedAfter("0.14.0")
     .withDocumentation("When set to true, the sql insert statement will use bulk insert. " +
-      "This config is deprecated as of 0.14.0. Please use " + SQL_WRITE_OPERATION.key() + " instead.")
+      "This config is deprecated as of 0.14.0. Please use hoodie.sql.write.operation instead.")
 
   @Deprecated
   val SQL_INSERT_MODE: ConfigProperty[String] = ConfigProperty
@@ -450,8 +450,8 @@ object DataSourceWriteOptions {
     .withDocumentation("Insert mode when insert data to pk-table. The optional modes are: upsert, strict and non-strict." +
       "For upsert mode, insert statement do the upsert operation for the pk-table which will update the duplicate record." +
       "For strict mode, insert statement will keep the primary key uniqueness constraint which do not allow duplicate record." +
-      "While for non-strict mode, hudi just do the insert operation for the pk-table. This config is deprecated as of 0.14.0. Please use "
-      + SQL_WRITE_OPERATION.key() + " and " + INSERT_DUP_POLICY.key() + " as you see fit.")
+      "While for non-strict mode, hudi just do the insert operation for the pk-table. This config is deprecated as of 0.14.0. Please use " +
+      "hoodie.sql.write.operation and hoodie.datasource.insert.dup.policy as you see fit.")
 
   val COMMIT_METADATA_KEYPREFIX: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.commitmeta.key.prefix")
@@ -466,7 +466,7 @@ object DataSourceWriteOptions {
     .defaultValue("false")
     .markAdvanced()
     .withDocumentation("If set to true, records from the incoming dataframe will not overwrite existing records with the same key during the write operation. " +
-    "This config is deprecated as of 0.14.0. Please use " + INSERT_DUP_POLICY.key() + " instead.");
+    "This config is deprecated as of 0.14.0. Please use hoodie.datasource.insert.dup.policy instead.");
 
   val PARTITIONS_TO_DELETE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.partitions.to.delete")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -1113,6 +1113,11 @@ object HoodieSparkSqlWriter {
     if (mergedParams.contains(PRECOMBINE_FIELD.key())) {
       mergedParams.put(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, mergedParams(PRECOMBINE_FIELD.key()))
     }
+    if (mergedParams.get(OPERATION.key()).get == INSERT_OPERATION_OPT_VAL && mergedParams.contains(DataSourceWriteOptions.INSERT_DUP_POLICY.key())
+      && mergedParams.get(DataSourceWriteOptions.INSERT_DUP_POLICY.key()).get != FAIL_INSERT_DUP_POLICY) {
+      // enable merge allow duplicates when operation type is insert
+      mergedParams.put(HoodieWriteConfig.MERGE_ALLOW_DUPLICATE_ON_INSERTS_ENABLE.key(), "true")
+    }
     val params = mergedParams.toMap
     (params, HoodieWriterUtils.convertMapToHoodieConfig(params))
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -220,9 +220,9 @@ trait ProvidesHoodieConfig extends Logging {
     )
 
     // try to use new insert dup policy instead of legacy insert mode to deduce payload class. If only insert mode is explicitly specified,
-    // w/o specifying any value for insert dup policy, leagcy configs will be honored. But on all other cases (i.e when neither of the configs is set,
+    // w/o specifying any value for insert dup policy, legacy configs will be honored. But on all other cases (i.e when neither of the configs is set,
     // or when both configs are set, or when only insert dup policy is set), we honor insert dup policy and ignore the insert mode.
-    val useLegacyInsertDropDupFlow = insertDupPolicySet && !sqlWriteOperationSet
+    val useLegacyInsertDropDupFlow = insertModeSet && !insertDupPolicySet
     val payloadClassName =  if (useLegacyInsertDropDupFlow) {
       deducePayloadClassNameLegacy(operation, tableType, insertMode)
     } else {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/HoodieSparkSqlTestBase.scala
@@ -201,9 +201,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  protected def withRecordType(recordConfig: Map[HoodieRecordType, Map[String, String]]=Map.empty)(f: => Unit) {
+  protected def withRecordType(recordTypes: Seq[HoodieRecordType] = Seq(HoodieRecordType.AVRO, HoodieRecordType.SPARK),
+                               recordConfig: Map[HoodieRecordType, Map[String, String]]=Map.empty)(f: => Unit) {
     // TODO HUDI-5264 Test parquet log with avro record in spark sql test
-    Seq(HoodieRecordType.AVRO, HoodieRecordType.SPARK).foreach { recordType =>
+    recordTypes.foreach { recordType =>
       val (merger, format) = recordType match {
         case HoodieRecordType.SPARK => (classOf[HoodieSparkRecordMerger].getName, "parquet")
         case _ => (classOf[HoodieAvroRecordMerger].getName, "avro")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -417,6 +417,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
         spark.sql(s"""insert into $tableName values (2, "l4", "v1", "2021", "10", "02")""")
 
         checkAnswer(s"select id, name, ts, year, month, day from $tableName")(
+          Seq(2, "l4", "v1", "2021", "10", "02"),
           Seq(2, "l4", "v1", "2021", "10", "02")
         )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCDCForSparkSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCDCForSparkSQL.scala
@@ -102,6 +102,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
         withTempDir { tmp =>
           val tableName = generateTableName
           val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          spark.sql("set hoodie.sql.write.operation=upsert")
           val otherTableProperties = if (tableType == "mor") {
             "'hoodie.compact.inline'='true', 'hoodie.compact.inline.max.delta.commits'='2',"
           } else {
@@ -215,6 +216,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
         }
       }
     }
+    spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestCreateTable.scala
@@ -409,6 +409,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
     withTempDir { tmp =>
       val parentPath = tmp.getCanonicalPath
       val tableName1 = generateTableName
+      spark.sql("set hoodie.sql.write.operation=upsert")
       spark.sql(
         s"""
            |create table $tableName1 (
@@ -467,6 +468,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
         Seq(1, "a2", 1100)
       )
     }
+    spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
   }
 
   test("Test Create ro/rt Table In The Wrong Way") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieTableValuedFunction.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestHoodieTableValuedFunction.scala
@@ -27,6 +27,7 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
       withTempDir { tmp =>
         Seq("cow", "mor").foreach { tableType =>
           val tableName = generateTableName
+          spark.sql("set hoodie.sql.write.operation=upsert")
           spark.sql(
             s"""
                |create table $tableName (
@@ -80,6 +81,7 @@ class TestHoodieTableValuedFunction extends HoodieSparkSqlTestBase {
         }
       }
     }
+    spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
   }
 
   test(s"Test hudi_table_changes latest_state") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -1585,6 +1585,10 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
    * When neither of strict mode nor sql.write.operation is set, sql write operation takes precedence and default value is chosen.
    */
   test("Test sql write operation with INSERT_INTO No explicit configs") {
+    spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
+    spark.sessionState.conf.unsetConf("hoodie.sql.insert.mode")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.insert.dup.policy")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")
       withRecordType()(withTempDir { tmp =>
         Seq("cow","mor").foreach {tableType =>
           withTable(generateTableName) { tableName =>
@@ -1621,6 +1625,11 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   }
 
   test("Test sql write operation with INSERT_INTO override only strict mode") {
+    spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
+    spark.sessionState.conf.unsetConf("hoodie.sql.insert.mode")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.insert.dup.policy")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")
+    spark.sessionState.conf.unsetConf("hoodie.sql.bulk.insert.enable")
     withRecordType()(withTempDir { tmp =>
       Seq("cow","mor").foreach {tableType =>
         withTable(generateTableName) { tableName =>
@@ -1664,8 +1673,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
       Seq(1, "a1", 10.0, "2021-07-18")
     )
 
-    // insert record again but w/ diff values but same primary key. Since "insert" is chosen as operation type,
-    // dups should be seen w/ snapshot query
+    // insert record again but w/ diff values but same primary key.
     spark.sql(
       s"""
          | insert into $tableName values

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -1578,6 +1578,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
         )
       }
     }
+    spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")
   }
 
   /**
@@ -1633,6 +1634,10 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
   def ingestAndValidateData(tableType: String, tableName: String, tmp: File,
                             expectedOperationtype: WriteOperationType = WriteOperationType.INSERT,
                             setOptions: List[String] = List.empty) : Unit = {
+    setOptions.foreach(entry => {
+      spark.sql(entry)
+    })
+
     spark.sql(
       s"""
          |create table $tableName (
@@ -1649,9 +1654,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
          | partitioned by (dt)
          | location '${tmp.getCanonicalPath}/$tableName'
          """.stripMargin)
-    setOptions.foreach(entry => {
-      spark.sql(entry)
-    })
 
     spark.sql(s"insert into $tableName values(1, 'a1', 10, '2021-07-18')")
 
@@ -1692,6 +1694,8 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     }
     spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
     spark.sessionState.conf.unsetConf("hoodie.sql.insert.mode")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.insert.dup.policy")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")
   }
 
   test("Test insert dup policy with INSERT_INTO explicit new configs INSERT operation ") {
@@ -1755,6 +1759,12 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
                             expectedOperationtype: WriteOperationType = WriteOperationType.INSERT,
                             setOptions: List[String] = List.empty, insertDupPolicy : String = NONE_INSERT_DUP_POLICY,
                                     expectExceptionOnSecondBatch: Boolean = false) : Unit = {
+
+    // set additional options
+    setOptions.foreach(entry => {
+      spark.sql(entry)
+    })
+
     spark.sql(
       s"""
          |create table $tableName (
@@ -1771,10 +1781,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
          | partitioned by (dt)
          | location '${tmp.getCanonicalPath}/$tableName'
          """.stripMargin)
-    // set additional options
-    setOptions.foreach(entry => {
-      spark.sql(entry)
-    })
 
     spark.sql(s"insert into $tableName values(1, 'a1', 10, '2021-07-18')")
 
@@ -1847,11 +1853,17 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
     spark.sessionState.conf.unsetConf("hoodie.sql.insert.mode")
     spark.sessionState.conf.unsetConf("hoodie.datasource.insert.dup.policy")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")
   }
 
   def ingestAndValidateDropDupPolicyBulkInsert(tableType: String, tableName: String, tmp: File,
                                      expectedOperationtype: WriteOperationType = WriteOperationType.BULK_INSERT,
                                      setOptions: List[String] = List.empty) : Unit = {
+
+    // set additional options
+    setOptions.foreach(entry => {
+      spark.sql(entry)
+    })
     spark.sql(
       s"""
          |create table $tableName (
@@ -1868,10 +1880,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
          | partitioned by (dt)
          | location '${tmp.getCanonicalPath}/$tableName'
          """.stripMargin)
-    // set additional options
-    setOptions.foreach(entry => {
-      spark.sql(entry)
-    })
 
     // drop dups is not supported in bulk_insert row writer path.
     assertThrows[HoodieException] {
@@ -1889,5 +1897,6 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
     spark.sessionState.conf.unsetConf("hoodie.sql.insert.mode")
     spark.sessionState.conf.unsetConf("hoodie.datasource.insert.dup.policy")
+    spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -74,6 +74,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         val tableName = generateTableName
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
         if (HoodieSparkUtils.gteqSpark3_1) {
+          spark.sql("set hoodie.sql.write.operation=upsert")
           spark.sql("set hoodie.schema.on.read.enable=true")
           // NOTE: This is required since as this tests use type coercions which were only permitted in Spark 2.x
           //       and are disallowed now by default in Spark 3.x
@@ -134,6 +135,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           )
           spark.sessionState.catalog.dropTable(TableIdentifier(tableName), true, true)
           spark.sessionState.catalog.refreshTable(TableIdentifier(tableName))
+          spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
         }
       }
     })
@@ -235,6 +237,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
         if (HoodieSparkUtils.gteqSpark3_1) {
           spark.sql("set hoodie.schema.on.read.enable=true")
+          spark.sql("set hoodie.sql.write.operation=upsert")
           // NOTE: This is required since as this tests use type coercions which were only permitted in Spark 2.x
           //       and are disallowed now by default in Spark 3.x
           spark.sql("set spark.sql.storeAssignmentPolicy=legacy")
@@ -327,6 +330,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           spark.sql(s"select id, col1_new, col2 from $tableName where id = 1 or id = 6 or id = 2 or id = 11 order by id").show(false)
         }
       }
+      spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
     })
   }
 
@@ -337,6 +341,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
         if (HoodieSparkUtils.gteqSpark3_1) {
           spark.sql("set hoodie.schema.on.read.enable=true")
+          spark.sql("set hoodie.sql.write.operation=upsert")
           spark.sql(
             s"""
                |create table $tableName (
@@ -353,7 +358,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           spark.sql(
             s"""
                | insert into $tableName values
-               | (1,3,'李明', '读书', 100,180.0001,99.0001,'2021-12-25', '2021-12-26')
+               | (1,3,'李明', '读书', 100,180.0001,99.0001,DATE'2021-12-25', DATE'2021-12-26')
                |""".stripMargin)
           spark.sql(s"alter table $tableName rename column col9 to `爱好_Best`")
 
@@ -361,7 +366,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           spark.sql(
             s"""
                | insert into $tableName values
-               | (1,3,'李明', '读书', 100,180.0001,99.0001,'2021-12-26', '2021-12-26')
+               | (1,3,'李明', '读书', 100,180.0001,99.0001,DATE'2021-12-26', DATE'2021-12-26')
                |""".stripMargin)
 
           // alter date to string
@@ -377,6 +382,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           )
         }
       }
+      spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
     })
   }
 
@@ -516,6 +522,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
         if (HoodieSparkUtils.gteqSpark3_1) {
           spark.sql("set hoodie.schema.on.read.enable=true")
+          spark.sql("set hoodie.sql.write.operation=upsert")
           spark.sql(
             s"""
                |create table $tableName (
@@ -594,6 +601,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           )
         }
       }
+      spark.sessionState.conf.unsetConf("hoodie.sql.write.operation")
     })
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
@@ -54,6 +54,7 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
         spark.sql(s"insert into $tableName1 values(1, 'a2', 20, 2000)")
 
         checkAnswer(s"select id, name, price, ts from $tableName1")(
+          Seq(1, "a1", 10.0, 1000),
           Seq(1, "a2", 20.0, 2000)
         )
 
@@ -283,6 +284,7 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
         spark.sql(s"insert into $tableName values(1, 'a2', 20, 2000)")
 
         checkAnswer(s"select id, name, price, ts from $tableName distribute by cast(rand() * 2 as int)")(
+          Seq(1, "a1", 10.0, 1000),
           Seq(1, "a2", 20.0, 2000)
         )
 


### PR DESCRIPTION
### Change Logs

With the intent to simplify different config options with INSERT_INTO spark-sql, we are doing a overhaul. We have 3 to 4 configs with INSERT_INTO like Operation type, insert mode, drop dupes, enable bulk insert configs. Here is what the simplification brings in. 

```
- We will introduce a new config named "hoodie.sql.write.operation" which will have 3 values ("insert", "bulk_insert" and "upsert"). Default value will be "insert" for INSERT_INTO.
         - Deprecate hoodie.sql.insert.mode and "hoodie.sql.bulk.insert.enable".
         - Also, enable "hoodie.merge.allow.duplicate.on.inserts" = true if operation type is "Insert" for both spark-sql and spark-ds. This will maintain duplicates but still help w/ small file management with "insert"s.
- Introduce a new config named "hoodie.datasource.insert.dedupe.policy" whose valid values are "ignore, fail and drop". Make "ignore" as default. "fail" will mimic "STRICT" mode we support as of now. 
         - Deprecate hoodie.datasource.insert.drop.dups.
```

When both old and new configs are set, new config will take effect. 
When only new configs are set, new config will take effect. 
When neither is set, new configs and their default will take effect. 
When only old configs are set, old configs will take effect. Please do note that we are deprecating the use of these old configs. In 2 releases, we will completely remove these configs. So, would recommend users to migrate to new configs. 

Note: old refers to "hoodie.sql.insert.mode" and new config refers to "hoodie.sql.write.operation".

Behavior change: 
With this patch, we are also switching the default behavior with INSERT_INTO to use "insert" as the operation underneath. Until 0.13.1, default behavior was "upsert". In other words, if you ingest same batch of records in commit1 and in commit2, hudi will do an upsert and will return only the latest value with snapshot read. But with this patch, we are changing the default behavior to use "insert" as the name (INSERT_INTO) signifies. So, ingesting the same batch of records in commit1 and in commit2 will result in duplicates records with snapshot read. If users override the respective config, we will honor them, but the default behavior where none of the respective configs are overridden explicitly, will see a behavior change. 

### Impact

Usability will be improved for spark-sql users as we have deprecated few confusing configs and tried to align with spark datasource writes. Also, this brings in a behavior change as well. With this patch, we are also switching the default behavior with INSERT_INTO to use "insert" as the operation underneath. Until 0.13.1, default behavior was "upsert". In other words, if you ingest same batch of records in commit1 and in commit2, hudi will do an upsert and will return only the latest value with snapshot read. But with this patch, we are changing the default behavior to use "insert" as the name (INSERT_INTO) signifies. So, ingesting the same batch of records in commit1 and in commit2 will result in duplicates records with snapshot read. If users override the respective config, we will honor them, but the default behavior where none of the respective configs are overridden explicitly, will see a behavior change. 

### Risk level (write none, low medium or high below)

medium

### Documentation Update

We will have to call out the behavior change as part of our release docs and also update our quick start guide around the same. 
https://issues.apache.org/jira/browse/HUDI-6479

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
