### PR TITLE
[HUDI-6480] Flink lockless multi-writer

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1713,6 +1713,11 @@ public class HoodieWriteConfig extends HoodieConfig {
     return !StringUtils.isNullOrEmpty(getString(HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS));
   }
 
+  public boolean isSimpleBucketIndex() {
+    return HoodieIndex.IndexType.BUCKET.equals(getIndexType())
+        && HoodieIndex.BucketIndexEngineType.SIMPLE.equals(getBucketIndexEngineType());
+  }
+
   public HoodieClusteringConfig.LayoutOptimizationStrategy getLayoutOptimizationStrategy() {
     return HoodieClusteringConfig.LayoutOptimizationStrategy.fromValue(
         getStringOrDefault(HoodieClusteringConfig.LAYOUT_OPTIMIZE_STRATEGY));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -33,6 +33,8 @@ public class BucketIdentifier implements Serializable {
   // Compatible with the spark bucket name
   private static final Pattern BUCKET_NAME = Pattern.compile(".*_(\\d+)(?:\\..*)?$");
 
+  private static final String CONSTANT_FILE_ID_SUFFIX = "-0000-0000-0000-000000000000";
+
   public static int getBucketId(HoodieRecord record, String indexKeyFields, int numBuckets) {
     return getBucketId(record.getKey(), indexKeyFields, numBuckets);
   }
@@ -89,6 +91,10 @@ public class BucketIdentifier implements Serializable {
 
   public static String newBucketFileIdPrefix(int bucketId) {
     return newBucketFileIdPrefix(bucketIdStr(bucketId));
+  }
+
+  public static String newBucketFileIdFixedSuffix(int bucketId) {
+    return bucketIdStr(bucketId) + CONSTANT_FILE_ID_SUFFIX;
   }
 
   public static String newBucketFileIdPrefix(String fileId, int bucketId) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
@@ -109,7 +109,7 @@ public abstract class HoodieWriteHandle<T, I, K, O> extends HoodieIOHandle<T, I,
   /**
    * Generate a write token based on the currently running spark task and its place in the spark dag.
    */
-  private String makeWriteToken() {
+  protected String makeWriteToken() {
     return FSUtils.makeWriteToken(getPartitionId(), getStageId(), getAttemptId());
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -262,10 +262,12 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
 
   @Override
   protected void preCommit(HoodieCommitMetadata metadata) {
-    // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
-    // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
-    HoodieTable table = createTable(config, hadoopConf);
-    resolveWriteConflict(table, metadata, this.pendingInflightAndRequestedInstants);
+    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+      // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
+      // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
+      HoodieTable table = createTable(config, hadoopConf);
+      resolveWriteConflict(table, metadata, this.pendingInflightAndRequestedInstants);
+    }
   }
 
   /**

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/FlinkClientUtil.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/FlinkClientUtil.java
@@ -18,7 +18,9 @@
 
 package org.apache.hudi.util;
 
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
 
 import org.apache.flink.api.java.hadoop.mapred.utils.HadoopUtils;
 import org.apache.flink.configuration.Configuration;
@@ -86,5 +88,14 @@ public class FlinkClientUtil {
       return hadoopConfiguration;
     }
     return null;
+  }
+
+  /**
+   * Returns whether this is lockless multi writer ingestion.
+   */
+  public static boolean isLocklessMultiWriter(HoodieWriteConfig config) {
+    return config.getTableType().equals(HoodieTableType.MERGE_ON_READ)
+        && config.isSimpleBucketIndex()
+        && config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -320,9 +320,11 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
 
   @Override
   protected void preCommit(HoodieCommitMetadata metadata) {
-    // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
-    // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
-    HoodieTable table = createTable(config, hadoopConf);
-    resolveWriteConflict(table, metadata, this.pendingInflightAndRequestedInstants);
+    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+      // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
+      // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
+      HoodieTable table = createTable(config, hadoopConf);
+      resolveWriteConflict(table, metadata, this.pendingInflightAndRequestedInstants);
+    }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -355,10 +355,12 @@ public class SparkRDDWriteClient<T> extends
 
   @Override
   protected void preCommit(HoodieInstant inflightInstant, HoodieCommitMetadata metadata) {
-    // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
-    // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
-    HoodieTable table = createTable(config, hadoopConf);
-    resolveWriteConflict(table, metadata, this.pendingInflightAndRequestedInstants);
+    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+      // Create a Hoodie table after startTxn which encapsulated the commits and files visible.
+      // Important to create this after the lock to ensure the latest commits show up in the timeline without need for reload
+      HoodieTable table = createTable(config, hadoopConf);
+      resolveWriteConflict(table, metadata, this.pendingInflightAndRequestedInstants);
+    }
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -149,6 +149,13 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns whether the table index is simple bucket index.
+   */
+  public static boolean isSimpleBucketIndexType(Configuration conf) {
+    return isBucketIndexType(conf) && getBucketEngineType(conf).equals(HoodieIndex.BucketIndexEngineType.SIMPLE);
+  }
+
+  /**
    * Returns the default plan strategy class.
    */
   public static String getDefaultPlanStrategyClassName(Configuration conf) {
@@ -344,6 +351,13 @@ public class OptionsResolver {
    */
   public static boolean allowCommitOnEmptyBatch(Configuration conf) {
     return conf.getBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false);
+  }
+
+  /**
+   * Returns whether this is lockless multi-writer ingestion.
+   */
+  public static boolean isLocklessMultiWriter(Configuration config) {
+    return isMorTable(config) && isSimpleBucketIndexType(config) && isOptimisticConcurrencyControl(config);
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -193,6 +193,18 @@ public class CkpMetadata implements Serializable, AutoCloseable {
     return null;
   }
 
+  @VisibleForTesting
+  public String lastCompleteInstant() {
+    load();
+    for (int i = this.messages.size() - 1; i >= 0; i--) {
+      CkpMessage ckpMsg = this.messages.get(i);
+      if (ckpMsg.isComplete()) {
+        return ckpMsg.getInstant();
+      }
+    }
+    return null;
+  }
+
   public List<CkpMessage> getMessages() {
     load();
     return messages;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -183,6 +183,7 @@ public class StreamerUtil {
         properties.put(option.key(), option.defaultValue());
       }
     }
+    properties.put(HoodieTableConfig.TYPE.key(), conf.getString(FlinkOptions.TABLE_TYPE));
     return new TypedProperties(properties);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -529,9 +529,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
         .checkWrittenData(EXPECTED3, 1);
     // step to commit the 2nd txn, should throw exception
     // for concurrent modification of same fileGroups
-    pipeline1.checkpoint(1)
-        .assertNextEvent()
-        .checkpointCompleteThrows(1, HoodieWriteConflictException.class, "Cannot resolve conflicts");
+    testConcurrentCommit(pipeline1);
   }
 
   // case2: txn2's time range has partial overlap with txn1
@@ -563,7 +561,11 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
 
     // step to commit the 2nd txn, should throw exception
     // for concurrent modification of same fileGroups
-    pipeline2.checkpoint(1)
+    testConcurrentCommit(pipeline2);
+  }
+
+  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
+    pipeline.checkpoint(1)
         .assertNextEvent()
         .checkpointCompleteThrows(1, HoodieWriteConflictException.class, "Cannot resolve conflicts");
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
@@ -209,6 +209,14 @@ public class TestWriteMergeOnRead extends TestWriteCopyOnWrite {
   }
 
   @Override
+  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
+    pipeline.checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1)
+        .checkWrittenData(EXPECTED3, 1);
+  }
+
+  @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -66,6 +66,14 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   }
 
   @Override
+  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
+    pipeline.checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1)
+        .checkWrittenData(EXPECTED3, 1);
+  }
+
+  @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -467,7 +467,11 @@ public class TestWriteBase {
     }
 
     public TestHarness checkLastPendingInstantCompleted() {
-      checkInstantState(HoodieInstant.State.COMPLETED, this.lastPending);
+      // the ckp meta has been cleaned because of the failover, fetch the instant from timeline.
+      String lastCompleteInstant = OptionsResolver.isMorTable(conf)
+          ? TestUtils.getLastDeltaCompleteInstant(basePath)
+          : TestUtils.getLastCompleteInstant(basePath, HoodieTimeline.COMMIT_ACTION);
+      assertThat(lastCompleteInstant, is(this.lastPending));
       this.lastComplete = lastPending;
       this.lastPending = lastPendingInstant();
       return this;
@@ -512,9 +516,7 @@ public class TestWriteBase {
     }
 
     protected String lastCompleteInstant() {
-      return OptionsResolver.isMorTable(conf)
-          ? TestUtils.getLastDeltaCompleteInstant(basePath)
-          : TestUtils.getLastCompleteInstant(basePath, HoodieTimeline.COMMIT_ACTION);
+      return this.ckpMetadata.lastCompleteInstant();
     }
 
     public TestHarness checkCompletedInstantCount(int count) {


### PR DESCRIPTION
### Change Logs

For mor table with simple bucket index, when the concurreny control is enabled, the writer always into log files with file naming convention:

${uuid}_${instant}.log.${version}_${task_token}-${client_id}

The ${uuid} is bucket id with constant suffix.

The usage:

* config 'hoodie.write.concurrency.mode'=OPTIMISTIC_CONCURRENCY_CONTROL;
* config 'table.type'='MERGE_ON_READ';
* config 'index.type'='BUCKET';
* only enable async cleaning and compaction for one writer (by default, they are all enabled)

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
