### PR TITLE
[HUDI-6474] Added support for reading tables evolved using comprehensive schema evolution on Flink

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
@@ -245,7 +245,7 @@ public final class CastMap implements Serializable {
       Function<Object, Object> conversion = getConversion(fromType, toType);
       // need to handle nulls to prevent NullPointerException in #getConversion()
       ValidationUtils.checkState(conversion != null, String.format("Failed to perform ARRAY conversion when casting %s => %s", fromType, toType));
-      Object toObject = fromObject != null ? conversion .apply(fromObject) : null;
+      Object toObject = fromObject != null ? conversion.apply(fromObject) : null;
       objects[i] = toObject;
     }
     return new GenericArrayData(objects);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
@@ -19,43 +19,18 @@
 package org.apache.hudi.table.format;
 
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.table.format.CastMapConverters.CastMapConverter;
 import org.apache.hudi.util.RowDataCastProjection;
 import org.apache.hudi.util.RowDataProjection;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.table.data.ArrayData;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.GenericArrayData;
-import org.apache.flink.table.data.GenericMapData;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.MapData;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import java.io.Serializable;
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.ARRAY;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.DATE;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.DOUBLE;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.FLOAT;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.MAP;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
 
 /**
  * CastMap is responsible for conversion of flink types when full schema evolution enabled.
@@ -109,237 +84,15 @@ public final class CastMap implements Serializable {
 
   @VisibleForTesting
   void add(int pos, LogicalType fromType, LogicalType toType) {
-    Function<Object, Object> conversion = getConversion(fromType, toType);
-    if (conversion == null) {
+    CastMapConverter converter = CastMapConverters.createConverter(fromType, toType);
+    if (converter == null) {
       throw new IllegalArgumentException(String.format("Cannot create cast %s => %s at pos %s", fromType, toType, pos));
     }
-    add(pos, new Cast(fromType, toType, conversion));
+    add(pos, new Cast(fromType, toType, converter));
   }
 
   private void add(int pos, Cast cast) {
     castMap.put(pos, cast);
-  }
-
-  /**
-   * Helper function to create a callable conversion function for supported type castings.
-   * <p>
-   * NOTE: The argument must be non-null when applying it to the returned function.
-   *
-   * @param fromType The input LogicalType of the value to be converted from
-   * @param toType   The output LogicalType of the value to be converted to
-   * @return Function to perform the required conversion for the provided from and to types
-   */
-  private static Function<Object, Object> getConversion(LogicalType fromType, LogicalType toType) {
-    LogicalTypeRoot from = fromType.getTypeRoot();
-    LogicalTypeRoot to = toType.getTypeRoot();
-    switch (to) {
-      case BIGINT: {
-        if (from == INTEGER) {
-          return val -> ((Number) val).longValue();
-        }
-        break;
-      }
-      case FLOAT: {
-        if (from == INTEGER || from == BIGINT) {
-          return val -> ((Number) val).floatValue();
-        }
-        break;
-      }
-      case DOUBLE: {
-        if (from == INTEGER || from == BIGINT) {
-          return val -> ((Number) val).doubleValue();
-        }
-        if (from == FLOAT) {
-          return val -> Double.parseDouble(val.toString());
-        }
-        break;
-      }
-      case DECIMAL: {
-        if (from == INTEGER || from == BIGINT || from == DOUBLE) {
-          return val -> toDecimalData((Number) val, toType);
-        }
-        if (from == FLOAT) {
-          return val -> toDecimalData(Double.parseDouble(val.toString()), toType);
-        }
-        if (from == VARCHAR) {
-          return val -> toDecimalData(Double.parseDouble(val.toString()), toType);
-        }
-        if (from == DECIMAL) {
-          return val -> toDecimalData(((DecimalData) val).toBigDecimal(), toType);
-        }
-        break;
-      }
-      case VARCHAR: {
-        if (from == INTEGER
-            || from == BIGINT
-            || from == FLOAT
-            || from == DOUBLE
-            || from == DECIMAL) {
-          return val -> new BinaryStringData(String.valueOf(val));
-        }
-        if (from == DATE) {
-          return val -> new BinaryStringData(LocalDate.ofEpochDay(((Integer) val).longValue()).toString());
-        }
-        break;
-      }
-      case DATE: {
-        if (from == VARCHAR) {
-          return val -> (int) LocalDate.parse(val.toString()).toEpochDay();
-        }
-        break;
-      }
-      case ARRAY: {
-        if (from == ARRAY) {
-          LogicalType fromElementType =  fromType.getChildren().get(0);
-          LogicalType toElementType = toType.getChildren().get(0);
-          try {
-            return array -> doArrayConversion((ArrayData) array, fromElementType, toElementType);
-          } catch (IllegalStateException ise) {
-            return null;
-          }
-        }
-        break;
-      }
-      case MAP: {
-        if (from == MAP) {
-          try {
-            return map -> doMapConversion((MapData) map, fromType, toType);
-          } catch (IllegalStateException ise) {
-            return null;
-          }
-        }
-        break;
-      }
-      case ROW: {
-        if (from == ROW) {
-          // Assumption: InternalSchemaManager should produce a cast that is of the same size
-          try {
-            return row -> doRowConversion((RowData) row, fromType, toType);
-          } catch (IllegalStateException ise) {
-            return null;
-          }
-        }
-        break;
-      }
-      default:
-    }
-    return null;
-  }
-
-  /**
-   * Helper function to perform convert an arrayData from one LogicalType to another.
-   *
-   * @param array    Non-null array data to be converted; however array-elements are allowed to be null
-   * @param fromType The input LogicalType of the row data to be converted from
-   * @param toType   The output LogicalType of the row data to be converted to
-   * @return Converted array that has the structure/specifications of that defined by the output LogicalType
-   */
-  private static ArrayData doArrayConversion(ArrayData array, LogicalType fromType, LogicalType toType) {
-    // using Object type here as primitives are not allowed to be null
-    Object[] objects = new Object[array.size()];
-    ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(fromType);
-    for (int i = 0; i < array.size(); i++) {
-      Object fromObject = elementGetter.getElementOrNull(array, i);
-      Function<Object, Object> conversion = getConversion(fromType, toType);
-      // need to handle nulls to prevent NullPointerException in #getConversion()
-      ValidationUtils.checkState(conversion != null, String.format("Failed to perform ARRAY conversion when casting %s => %s", fromType, toType));
-      Object toObject = fromObject != null ? conversion.apply(fromObject) : null;
-      objects[i] = toObject;
-    }
-    return new GenericArrayData(objects);
-  }
-
-  /**
-   * Helper function to perform convert a MapData from one LogicalType to another.
-   *
-   * @param map      Non-null map data to be converted; however, values are allowed to be null
-   * @param fromType The input LogicalType of the row data to be converted from
-   * @param toType   The output LogicalType of the row data to be converted to
-   * @return Converted map that has the structure/specifications of that defined by the output LogicalType
-   */
-  private static MapData doMapConversion(MapData map, LogicalType fromType, LogicalType toType) {
-    // no schema evolution is allowed on the keyType, hence, we only need to care about the valueType
-    LogicalType fromValueType = fromType.getChildren().get(1);
-    LogicalType toValueType = toType.getChildren().get(1);
-    LogicalType keyType = fromType.getChildren().get(0);
-
-    final Map<Object, Object> result = new HashMap<>();
-    ArrayData.ElementGetter keyElementGetter = ArrayData.createElementGetter(keyType);
-    ArrayData.ElementGetter valueElementGetter = ArrayData.createElementGetter(fromValueType);
-    for (int i = 0; i < map.size(); i++) {
-      Object keyObject = keyElementGetter.getElementOrNull(map.keyArray(), i);
-      Object fromObject = valueElementGetter.getElementOrNull(map.valueArray(), i);
-      Function<Object, Object> conversion = getConversion(fromValueType, toValueType);
-
-      // need to handle nulls to prevent NullPointerException in #getConversion()
-      ValidationUtils.checkState(conversion != null, String.format("Failed to perform MAP conversion when cast %s => %s", fromType, toType));
-      Object toObject = fromObject != null ? conversion.apply(fromObject) : null;
-      result.put(keyObject, toObject);
-    }
-    return new GenericMapData(result);
-  }
-
-  /**
-   * Helper function to perform convert a RowData from one LogicalType to another.
-   *
-   * @param row      Non-null row data to be converted; however, fields might contain nulls
-   * @param fromType The input LogicalType of the row data to be converted from
-   * @param toType   The output LogicalType of the row data to be converted to
-   * @return Converted row that has the structure/specifications of that defined by the output LogicalType
-   */
-  private static RowData doRowConversion(RowData row, LogicalType fromType, LogicalType toType) {
-    // note: InternalSchema.merge guarantees that the schema to be read fromType is orientated in the same order as toType
-    // hence, we can match types by position as it is guaranteed that it is referencing the same field
-    List<LogicalType> fromChildren = fromType.getChildren();
-    List<LogicalType> toChildren = toType.getChildren();
-    ValidationUtils.checkArgument(fromChildren.size() == toChildren.size(),
-        "fromType [" + fromType + "] size: != toType [" + toType + "] size");
-
-    GenericRowData rowData = new GenericRowData(toType.getChildren().size());
-    for (int i = 0; i < toChildren.size(); i++) {
-      Object fromVal = RowData.createFieldGetter(fromChildren.get(i), i).getFieldOrNull(row);
-      Object toVal;
-
-      // need to handle nulls to prevent NullPointerException in #getConversion()
-      if (fromChildren.get(i).equals(toChildren.get(i)) || fromVal == null) {
-        // no conversion required if the types are the same / fromVal is null
-        toVal = fromVal;
-      } else {
-        // conversion required
-        Function<Object, Object> conversion = getConversion(fromChildren.get(i), toChildren.get(i));
-        ValidationUtils.checkState(conversion != null, String.format("Failed to perform ROW conversion when casting %s => %s", fromType, toType));
-        toVal = conversion.apply(fromVal);
-      }
-
-      rowData.setField(i, toVal);
-    }
-    return rowData;
-  }
-
-  /**
-   * Helper function to convert a Number object to Flink's DecimalData format.
-   *
-   * @param val         Number object to be converted
-   * @param decimalType DecimalType containing the output decimal's precision and scale specifications
-   * @return Converted decimal that is wrapped in Flink's DecimalData object.
-   */
-  private static DecimalData toDecimalData(Number val, LogicalType decimalType) {
-    BigDecimal valAsDecimal = BigDecimal.valueOf(val.doubleValue());
-    return toDecimalData(valAsDecimal, decimalType);
-  }
-
-  /**
-   * Helper function to convert a BigDecimal object to Flink's DecimalData format.
-   *
-   * @param valAsDecimal BigDecimal object to be converted
-   * @param decimalType  DecimalType containing the output decimal's precision and scale specifications
-   * @return Converted decimal that is wrapped in Flink's DecimalData object.
-   */
-  private static DecimalData toDecimalData(BigDecimal valAsDecimal, LogicalType decimalType) {
-    return DecimalData.fromBigDecimal(
-        valAsDecimal,
-        ((DecimalType) decimalType).getPrecision(),
-        ((DecimalType) decimalType).getScale());
   }
 
   /**
@@ -352,16 +105,16 @@ public final class CastMap implements Serializable {
 
     private final LogicalType from;
     private final LogicalType to;
-    private final Function<Object, Object> conversion;
+    private final CastMapConverter castMapConverter;
 
-    Cast(LogicalType from, LogicalType to, Function<Object, Object> conversion) {
+    Cast(LogicalType from, LogicalType to, CastMapConverter conversion) {
       this.from = from;
       this.to = to;
-      this.conversion = conversion;
+      this.castMapConverter = conversion;
     }
 
     Object convert(Object val) {
-      return conversion.apply(val);
+      return castMapConverter.getConversion(val);
     }
 
     @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
@@ -19,7 +19,7 @@
 package org.apache.hudi.table.format;
 
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.table.format.CastMapConverters.CastMapConverter;
+import org.apache.hudi.table.format.TypeConverters.TypeConverter;
 import org.apache.hudi.util.RowDataCastProjection;
 import org.apache.hudi.util.RowDataProjection;
 
@@ -84,7 +84,7 @@ public final class CastMap implements Serializable {
 
   @VisibleForTesting
   void add(int pos, LogicalType fromType, LogicalType toType) {
-    CastMapConverter converter = CastMapConverters.createConverter(fromType, toType);
+    TypeConverter converter = TypeConverters.getInstance(fromType, toType);
     if (converter == null) {
       throw new IllegalArgumentException(String.format("Cannot create cast %s => %s at pos %s", fromType, toType, pos));
     }
@@ -105,16 +105,16 @@ public final class CastMap implements Serializable {
 
     private final LogicalType from;
     private final LogicalType to;
-    private final CastMapConverter castMapConverter;
+    private final TypeConverter castMapConverter;
 
-    Cast(LogicalType from, LogicalType to, CastMapConverter conversion) {
+    Cast(LogicalType from, LogicalType to, TypeConverter conversion) {
       this.from = from;
       this.to = to;
       this.castMapConverter = conversion;
     }
 
     Object convert(Object val) {
-      return castMapConverter.getConversion(val);
+      return castMapConverter.convert(val);
     }
 
     @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMap.java
@@ -37,8 +37,6 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
-import javax.annotation.Nonnull;
-
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -236,7 +234,7 @@ public final class CastMap implements Serializable {
    * @param toType   The output LogicalType of the row data to be converted to
    * @return Converted array that has the structure/specifications of that defined by the output LogicalType
    */
-  private static ArrayData doArrayConversion(@Nonnull ArrayData array, LogicalType fromType, LogicalType toType) {
+  private static ArrayData doArrayConversion(ArrayData array, LogicalType fromType, LogicalType toType) {
     // using Object type here as primitives are not allowed to be null
     Object[] objects = new Object[array.size()];
     ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(fromType);
@@ -259,7 +257,7 @@ public final class CastMap implements Serializable {
    * @param toType   The output LogicalType of the row data to be converted to
    * @return Converted map that has the structure/specifications of that defined by the output LogicalType
    */
-  private static MapData doMapConversion(@Nonnull MapData map, LogicalType fromType, LogicalType toType) {
+  private static MapData doMapConversion(MapData map, LogicalType fromType, LogicalType toType) {
     // no schema evolution is allowed on the keyType, hence, we only need to care about the valueType
     LogicalType fromValueType = fromType.getChildren().get(1);
     LogicalType toValueType = toType.getChildren().get(1);
@@ -289,7 +287,7 @@ public final class CastMap implements Serializable {
    * @param toType   The output LogicalType of the row data to be converted to
    * @return Converted row that has the structure/specifications of that defined by the output LogicalType
    */
-  private static RowData doRowConversion(@Nonnull RowData row, LogicalType fromType, LogicalType toType) {
+  private static RowData doRowConversion(RowData row, LogicalType fromType, LogicalType toType) {
     // note: InternalSchema.merge guarantees that the schema to be read fromType is orientated in the same order as toType
     // hence, we can match types by position as it is guaranteed that it is referencing the same field
     List<LogicalType> fromChildren = fromType.getChildren();
@@ -362,7 +360,7 @@ public final class CastMap implements Serializable {
       this.conversion = conversion;
     }
 
-    Object convert(@Nonnull Object val) {
+    Object convert(Object val) {
       return conversion.apply(val);
     }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMapConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMapConverters.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.table.format;
 
 import org.apache.hudi.common.util.ValidationUtils;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMapConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMapConverters.java
@@ -180,11 +180,6 @@ public class CastMapConverters {
             public Object getConversion(Object val) {
               return (int) LocalDate.parse(val.toString()).toEpochDay();
             }
-
-//            @Override
-//            public Function<Object, Object> getConversion() {
-//              return val -> (int) LocalDate.parse(val.toString()).toEpochDay();
-//            }
           };
         }
         break;
@@ -220,8 +215,8 @@ public class CastMapConverters {
           try {
             // note: InternalSchema.merge guarantees that the schema to be read fromType is orientated in the same order as toType
             // hence, we can match types by position as it is guaranteed that it is referencing the same field
-            ValidationUtils.checkArgument(fromType.getChildren().size() == toType.getChildren().size(),
-                "fromType [" + fromType + "] size: != toType [" + toType + "] size");
+            // ignoring error messages here as the calling function's checked exception will ignore it
+            ValidationUtils.checkArgument(fromType.getChildren().size() == toType.getChildren().size());
             return createRowConverter(fromType, toType);
           } catch (IllegalStateException ise) {
             return null;
@@ -240,7 +235,8 @@ public class CastMapConverters {
     final CastMapConverter converter = createConverter(fromType, toType);
 
     // need to handle nulls to prevent NullPointerException in #getConversion()
-    ValidationUtils.checkState(converter != null, String.format("Failed to perform ARRAY conversion when casting %s => %s", fromType, toType));
+    // ignoring error messages here as the calling function's checked exception will ignore it
+    ValidationUtils.checkState(converter != null);
 
     return new CastMapConverter() {
       private static final long serialVersionUID = 1L;
@@ -268,8 +264,10 @@ public class CastMapConverters {
     final ArrayData.ElementGetter keyElementGetter = ArrayData.createElementGetter(keyType);
     final ArrayData.ElementGetter valueElementGetter = ArrayData.createElementGetter(fromValueType);
     final CastMapConverter converter = createConverter(fromValueType, toValueType);
+
     // need to handle nulls to prevent NullPointerException in #getConversion()
-    ValidationUtils.checkState(converter != null, String.format("Failed to perform MAP conversion when cast %s => %s", fromType, toType));
+    // ignoring error messages here as the calling function's checked exception will ignore it
+    ValidationUtils.checkState(converter != null);
 
     return new CastMapConverter() {
       private static final long serialVersionUID = 1L;
@@ -322,8 +320,8 @@ public class CastMapConverters {
         .toArray(CastMapConverter[]::new);
 
     // need to handle nulls to prevent NullPointerException in #getConversion()
-    ValidationUtils.checkState(Arrays.stream(converters).noneMatch(Objects::isNull),
-        String.format("Failed to perform ROW conversion when casting %s => %s", fromType, toType));
+    // ignoring error messages here as the calling function's checked exception will ignore it
+    ValidationUtils.checkState(Arrays.stream(converters).noneMatch(Objects::isNull));
 
     return new CastMapConverter() {
       private static final long serialVersionUID = 1L;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMapConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/CastMapConverters.java
@@ -2,6 +2,7 @@ package org.apache.hudi.table.format;
 
 import org.apache.hudi.common.util.ValidationUtils;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -36,8 +37,13 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.MAP;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
 
+/**
+ * Tool class used to perform supported casts from a {@link LogicalType} to another as defined in Hudi Comprehensive Schema Evolution's scope.
+ */
+@Internal
 public class CastMapConverters {
 
+  @FunctionalInterface
   public interface CastMapConverter extends Serializable {
     Object getConversion(Object val);
   }
@@ -306,8 +312,8 @@ public class CastMapConverters {
         .range(0, fromChildren.size())
         .mapToObj(i -> RowData.createFieldGetter(fromChildren.get(i), i))
         .toArray(FieldGetter[]::new);
-    final CastMapConverter[] converters = IntStream.
-        range(0, fromChildren.size())
+    final CastMapConverter[] converters = IntStream
+        .range(0, fromChildren.size())
         .mapToObj(i -> {
           LogicalType fromChild = fromChildren.get(i);
           LogicalType toChild = toChildren.get(i);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolution.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestSchemaEvolution.java
@@ -175,7 +175,9 @@ public class ITTestSchemaEvolution {
         + "  gender char,"
         + "  age int,"
         + "  ts timestamp,"
-        + "  f_struct row<f0 int, f1 string>,"
+        + "  f_struct row<f0 int, f1 string, drop_add string, change_type int>,"
+        + "  f_map map<string, int>,"
+        + "  f_array array<int>,"
         + "  `partition` string"
         + ") partitioned by (`partition`) with (" + tableOptions + ")"
     );
@@ -187,19 +189,21 @@ public class ITTestSchemaEvolution {
         + "  cast(gender as char),"
         + "  cast(age as int),"
         + "  cast(ts as timestamp),"
-        + "  cast(f_struct as row<f0 int, f1 string>),"
+        + "  cast(f_struct as row<f0 int, f1 string, drop_add string, change_type int>),"
+        + "  cast(f_map as map<string, int>),"
+        + "  cast(f_array as array<int>),"
         + "  cast(`partition` as string) "
         + "from (values "
-        + "  ('id0', 'Indica', 'F', 12, '2000-01-01 00:00:00', cast(null as row<f0 int, f1 string>), 'par0'),"
-        + "  ('id1', 'Danny', 'M', 23, '2000-01-01 00:00:01', row(1, 's1'), 'par1'),"
-        + "  ('id2', 'Stephen', 'M', 33, '2000-01-01 00:00:02', row(2, 's2'), 'par1'),"
-        + "  ('id3', 'Julian', 'M', 53, '2000-01-01 00:00:03', row(3, 's3'), 'par2'),"
-        + "  ('id4', 'Fabian', 'M', 31, '2000-01-01 00:00:04', row(4, 's4'), 'par2'),"
-        + "  ('id5', 'Sophia', 'F', 18, '2000-01-01 00:00:05', row(5, 's5'), 'par3'),"
-        + "  ('id6', 'Emma', 'F', 20, '2000-01-01 00:00:06', row(6, 's6'), 'par3'),"
-        + "  ('id7', 'Bob', 'M', 44, '2000-01-01 00:00:07', row(7, 's7'), 'par4'),"
-        + "  ('id8', 'Han', 'M', 56, '2000-01-01 00:00:08', row(8, 's8'), 'par4')"
-        + ") as A(uuid, name, gender, age, ts, f_struct, `partition`)"
+        + "  ('id0', 'Indica', 'F', 12, '2000-01-01 00:00:00', cast(null as row<f0 int, f1 string, drop_add string, change_type int>), map['Indica', 1212], array[12], 'par0'),"
+        + "  ('id1', 'Danny', 'M', 23, '2000-01-01 00:00:01', row(1, 's1', '', 1), map['Danny', 2323], array[23, 23], 'par1'),"
+        + "  ('id2', 'Stephen', 'M', 33, '2000-01-01 00:00:02', row(2, 's2', '', 2), map['Stephen', 3333], array[33], 'par1'),"
+        + "  ('id3', 'Julian', 'M', 53, '2000-01-01 00:00:03', row(3, 's3', '', 3), map['Julian', 5353], array[53, 53], 'par2'),"
+        + "  ('id4', 'Fabian', 'M', 31, '2000-01-01 00:00:04', row(4, 's4', '', 4), map['Fabian', 3131], array[31], 'par2'),"
+        + "  ('id5', 'Sophia', 'F', 18, '2000-01-01 00:00:05', row(5, 's5', '', 5), map['Sophia', 1818], array[18, 18], 'par3'),"
+        + "  ('id6', 'Emma', 'F', 20, '2000-01-01 00:00:06', row(6, 's6', '', 6), map['Emma', 2020], array[20], 'par3'),"
+        + "  ('id7', 'Bob', 'M', 44, '2000-01-01 00:00:07', row(7, 's7', '', 7), map['Bob', 4444], array[44, 44], 'par4'),"
+        + "  ('id8', 'Han', 'M', 56, '2000-01-01 00:00:08', row(8, 's8', '', 8), map['Han', 5656], array[56, 56, 56], 'par4')"
+        + ") as A(uuid, name, gender, age, ts, f_struct, f_map, f_array, `partition`)"
     ).await();
   }
 
@@ -209,9 +213,16 @@ public class ITTestSchemaEvolution {
         Option<String> compactionInstant = writeClient.scheduleCompaction(Option.empty());
         writeClient.compact(compactionInstant.get());
       }
+
       Schema intType = SchemaBuilder.unionOf().nullType().and().intType().endUnion();
       Schema doubleType = SchemaBuilder.unionOf().nullType().and().doubleType().endUnion();
       Schema stringType = SchemaBuilder.unionOf().nullType().and().stringType().endUnion();
+      Schema structType = SchemaBuilder.builder().record("new_row_col").fields()
+              .name("f0").type("long").noDefault()
+              .name("f1").type("string").noDefault().endRecord();
+      Schema arrayType = Schema.createUnion(SchemaBuilder.builder().array().items(stringType), SchemaBuilder.builder().nullType());
+      Schema mapType = Schema.createUnion(SchemaBuilder.builder().map().values(stringType), SchemaBuilder.builder().nullType());
+
       writeClient.addColumn("salary", doubleType, null, "name", AFTER);
       writeClient.deleteColumns("gender");
       writeClient.renameColumn("name", "first_name");
@@ -223,6 +234,21 @@ public class ITTestSchemaEvolution {
       // add a field at the end of `f_struct` column
       writeClient.addColumn("f_struct.f3", stringType);
 
+      // delete and add a field with the same name
+      // reads should not return previously inserted datum of dropped field of the same name
+      writeClient.deleteColumns("f_struct.drop_add");
+      writeClient.addColumn("f_struct.drop_add", doubleType);
+
+      // perform comprehensive evolution on complex types (struct, array, map) by promoting its primitive types
+      writeClient.updateColumnType("f_struct.change_type", Types.LongType.get());
+      writeClient.renameColumn("f_struct.change_type", "renamed_change_type");
+      writeClient.updateColumnType("f_array.element", Types.DoubleType.get());
+      writeClient.updateColumnType("f_map.value", Types.DoubleType.get());
+
+      // perform comprehensive schema evolution on table by adding complex typed columns
+      writeClient.addColumn("new_row_col", structType);
+      writeClient.addColumn("new_array_col", arrayType);
+      writeClient.addColumn("new_map_col", mapType);
     }
   }
 
@@ -242,7 +268,12 @@ public class ITTestSchemaEvolution {
         + "  last_name string,"
         + "  salary double,"
         + "  ts timestamp,"
-        + "  f_struct row<f0 int, f2 int, f1 string, f3 string>,"
+        + "  f_struct row<f0 int, f2 int, f1 string, renamed_change_type bigint, f3 string, drop_add string>,"
+        + "  f_map map<string, double>,"
+        + "  f_array array<double>,"
+        + "  new_row_col row<f0 bigint, f1 string>,"
+        + "  new_array_col array<string>,"
+        + "  new_map_col map<string, string>,"
         + "  `partition` string"
         + ") partitioned by (`partition`) with (" + tableOptions + ")"
     );
@@ -255,13 +286,21 @@ public class ITTestSchemaEvolution {
         + "  cast(last_name as string),"
         + "  cast(salary as double),"
         + "  cast(ts as timestamp),"
-        + "  cast(f_struct as row<f0 int, f2 int, f1 string, f3 string>),"
+        + "  cast(f_struct as row<f0 int, f2 int, f1 string, renamed_change_type bigint, f3 string, drop_add string>),"
+        + "  cast(f_map as map<string, double>),"
+        + "  cast(f_array as array<double>),"
+        + "  cast(new_row_col as row<f0 bigint, f1 string>),"
+        + "  cast(new_array_col as array<string>),"
+        + "  cast(new_map_col as map<string, string>),"
         + "  cast(`partition` as string) "
         + "from (values "
-        + "  ('id1', '23', 'Danny', '', 10000.1, '2000-01-01 00:00:01', row(1, 1, 's1', 't1'), 'par1'),"
-        + "  ('id9', 'unknown', 'Alice', '', 90000.9, '2000-01-01 00:00:09', row(9, 9, 's9', 't9'), 'par1'),"
-        + "  ('id3', '53', 'Julian', '', 30000.3, '2000-01-01 00:00:03', row(3, 3, 's3', 't3'), 'par2')"
-        + ") as A(uuid, age, first_name, last_name, salary, ts, f_struct, `partition`)"
+        + "  ('id1', '23', 'Danny', '', 10000.1, '2000-01-01 00:00:01', row(1, 1, 's1', 11, 't1', 'drop_add1'), map['Danny', 2323.23], array[23, 23, 23], "
+        + "  row(1, '1'), array['1'], Map['k1','v1'], 'par1'),"
+        + "  ('id9', 'unknown', 'Alice', '', 90000.9, '2000-01-01 00:00:09', row(9, 9, 's9', 99, 't9', 'drop_add9'), map['Alice', 9999.99], array[9999, 9999], "
+        + "  row(9, '9'), array['9'], Map['k9','v9'], 'par1'),"
+        + "  ('id3', '53', 'Julian', '', 30000.3, '2000-01-01 00:00:03', row(3, 3, 's3', 33, 't3', 'drop_add3'), map['Julian', 5353.53], array[53], "
+        + "  row(3, '3'), array['3'], Map['k3','v3'], 'par2')"
+        + ") as A(uuid, age, first_name, last_name, salary, ts, f_struct, f_map, f_array, new_row_col, new_array_col, new_map_col, `partition`)"
     ).await();
   }
 
@@ -291,7 +330,18 @@ public class ITTestSchemaEvolution {
 
   private void checkAnswerEvolved(String... expectedResult) throws Exception {
     //language=SQL
-    checkAnswer("select first_name, salary, age, f_struct from t1", expectedResult);
+    checkAnswer(""
+        + "select "
+        + "  first_name, "
+        + "  salary, "
+        + "  age, "
+        + "  f_struct, "
+        + "  f_map, "
+        + "  f_array, "
+        + "  new_row_col, "
+        + "  new_array_col, "
+        + "  new_map_col "
+        + "from t1", expectedResult);
   }
 
   private void checkAnswerCount(String... expectedResult) throws Exception {
@@ -316,12 +366,29 @@ public class ITTestSchemaEvolution {
         + "  last_name string,"
         + "  salary double,"
         + "  ts timestamp,"
-        + "  f_struct row<f0 int, f2 int, f1 string, f3 string>,"
+        + "  f_struct row<f0 int, f2 int, f1 string, renamed_change_type bigint, f3 string, drop_add string>,"
+        + "  f_map map<string, double>,"
+        + "  f_array array<double>,"
+        + "  new_row_col row<f0 bigint, f1 string>,"
+        + "  new_array_col array<string>,"
+        + "  new_map_col map<string, string>,"
         + "  `partition` string"
         + ") partitioned by (`partition`) with (" + tableOptions + ")"
     );
     //language=SQL
-    checkAnswer("select `_hoodie_record_key`, first_name, salary, f_struct from t1", expectedResult);
+    checkAnswer(""
+        + "select "
+        + "  `_hoodie_record_key`, "
+        + "  first_name, "
+        + "  salary, "
+        + "  age, "
+        + "  f_struct, "
+        + "  f_map, "
+        + "  f_array, "
+        + "  new_row_col, "
+        + "  new_array_col, "
+        + "  new_map_col "
+        + "from t1", expectedResult);
   }
 
   private void checkAnswer(String query, String... expectedResult) {
@@ -400,28 +467,28 @@ public class ITTestSchemaEvolution {
 
   private static final ExpectedResult EXPECTED_MERGED_RESULT = new ExpectedResult(
       new String[] {
-          "+I[Indica, null, 12, null]",
-          "+I[Danny, 10000.1, 23, +I[1, 1, s1, t1]]",
-          "+I[Stephen, null, 33, +I[2, null, s2, null]]",
-          "+I[Julian, 30000.3, 53, +I[3, 3, s3, t3]]",
-          "+I[Fabian, null, 31, +I[4, null, s4, null]]",
-          "+I[Sophia, null, 18, +I[5, null, s5, null]]",
-          "+I[Emma, null, 20, +I[6, null, s6, null]]",
-          "+I[Bob, null, 44, +I[7, null, s7, null]]",
-          "+I[Han, null, 56, +I[8, null, s8, null]]",
-          "+I[Alice, 90000.9, unknown, +I[9, 9, s9, t9]]",
+          "+I[Indica, null, 12, null, {Indica=1212.0}, [12.0], null, null, null]",
+          "+I[Danny, 10000.1, 23, +I[1, 1, s1, 11, t1, drop_add1], {Danny=2323.23}, [23.0, 23.0, 23.0], +I[1, 1], [1], {k1=v1}]",
+          "+I[Stephen, null, 33, +I[2, null, s2, 2, null, null], {Stephen=3333.0}, [33.0], null, null, null]",
+          "+I[Julian, 30000.3, 53, +I[3, 3, s3, 33, t3, drop_add3], {Julian=5353.53}, [53.0], +I[3, 3], [3], {k3=v3}]",
+          "+I[Fabian, null, 31, +I[4, null, s4, 4, null, null], {Fabian=3131.0}, [31.0], null, null, null]",
+          "+I[Sophia, null, 18, +I[5, null, s5, 5, null, null], {Sophia=1818.0}, [18.0, 18.0], null, null, null]",
+          "+I[Emma, null, 20, +I[6, null, s6, 6, null, null], {Emma=2020.0}, [20.0], null, null, null]",
+          "+I[Bob, null, 44, +I[7, null, s7, 7, null, null], {Bob=4444.0}, [44.0, 44.0], null, null, null]",
+          "+I[Han, null, 56, +I[8, null, s8, 8, null, null], {Han=5656.0}, [56.0, 56.0, 56.0], null, null, null]",
+          "+I[Alice, 90000.9, unknown, +I[9, 9, s9, 99, t9, drop_add9], {Alice=9999.99}, [9999.0, 9999.0], +I[9, 9], [9], {k9=v9}]",
       },
       new String[] {
-          "+I[uuid:id0, Indica, null, null]",
-          "+I[uuid:id1, Danny, 10000.1, +I[1, 1, s1, t1]]",
-          "+I[uuid:id2, Stephen, null, +I[2, null, s2, null]]",
-          "+I[uuid:id3, Julian, 30000.3, +I[3, 3, s3, t3]]",
-          "+I[uuid:id4, Fabian, null, +I[4, null, s4, null]]",
-          "+I[uuid:id5, Sophia, null, +I[5, null, s5, null]]",
-          "+I[uuid:id6, Emma, null, +I[6, null, s6, null]]",
-          "+I[uuid:id7, Bob, null, +I[7, null, s7, null]]",
-          "+I[uuid:id8, Han, null, +I[8, null, s8, null]]",
-          "+I[uuid:id9, Alice, 90000.9, +I[9, 9, s9, t9]]",
+          "+I[uuid:id0, Indica, null, 12, null, {Indica=1212.0}, [12.0], null, null, null]",
+          "+I[uuid:id1, Danny, 10000.1, 23, +I[1, 1, s1, 11, t1, drop_add1], {Danny=2323.23}, [23.0, 23.0, 23.0], +I[1, 1], [1], {k1=v1}]",
+          "+I[uuid:id2, Stephen, null, 33, +I[2, null, s2, 2, null, null], {Stephen=3333.0}, [33.0], null, null, null]",
+          "+I[uuid:id3, Julian, 30000.3, 53, +I[3, 3, s3, 33, t3, drop_add3], {Julian=5353.53}, [53.0], +I[3, 3], [3], {k3=v3}]",
+          "+I[uuid:id4, Fabian, null, 31, +I[4, null, s4, 4, null, null], {Fabian=3131.0}, [31.0], null, null, null]",
+          "+I[uuid:id5, Sophia, null, 18, +I[5, null, s5, 5, null, null], {Sophia=1818.0}, [18.0, 18.0], null, null, null]",
+          "+I[uuid:id6, Emma, null, 20, +I[6, null, s6, 6, null, null], {Emma=2020.0}, [20.0], null, null, null]",
+          "+I[uuid:id7, Bob, null, 44, +I[7, null, s7, 7, null, null], {Bob=4444.0}, [44.0, 44.0], null, null, null]",
+          "+I[uuid:id8, Han, null, 56, +I[8, null, s8, 8, null, null], {Han=5656.0}, [56.0, 56.0, 56.0], null, null, null]",
+          "+I[uuid:id9, Alice, 90000.9, unknown, +I[9, 9, s9, 99, t9, drop_add9], {Alice=9999.99}, [9999.0, 9999.0], +I[9, 9], [9], {k9=v9}]",
       },
       new String[] {
           "+I[1]",
@@ -448,32 +515,32 @@ public class ITTestSchemaEvolution {
 
   private static final ExpectedResult EXPECTED_UNMERGED_RESULT = new ExpectedResult(
       new String[] {
-          "+I[Indica, null, 12, null]",
-          "+I[Danny, null, 23, +I[1, null, s1, null]]",
-          "+I[Stephen, null, 33, +I[2, null, s2, null]]",
-          "+I[Julian, null, 53, +I[3, null, s3, null]]",
-          "+I[Fabian, null, 31, +I[4, null, s4, null]]",
-          "+I[Sophia, null, 18, +I[5, null, s5, null]]",
-          "+I[Emma, null, 20, +I[6, null, s6, null]]",
-          "+I[Bob, null, 44, +I[7, null, s7, null]]",
-          "+I[Han, null, 56, +I[8, null, s8, null]]",
-          "+I[Alice, 90000.9, unknown, +I[9, 9, s9, t9]]",
-          "+I[Danny, 10000.1, 23, +I[1, 1, s1, t1]]",
-          "+I[Julian, 30000.3, 53, +I[3, 3, s3, t3]]",
+          "+I[Indica, null, 12, null, {Indica=1212.0}, [12.0], null, null, null]",
+          "+I[Danny, null, 23, +I[1, null, s1, 1, null, null], {Danny=2323.0}, [23.0, 23.0], null, null, null]",
+          "+I[Stephen, null, 33, +I[2, null, s2, 2, null, null], {Stephen=3333.0}, [33.0], null, null, null]",
+          "+I[Julian, null, 53, +I[3, null, s3, 3, null, null], {Julian=5353.0}, [53.0, 53.0], null, null, null]",
+          "+I[Fabian, null, 31, +I[4, null, s4, 4, null, null], {Fabian=3131.0}, [31.0], null, null, null]",
+          "+I[Sophia, null, 18, +I[5, null, s5, 5, null, null], {Sophia=1818.0}, [18.0, 18.0], null, null, null]",
+          "+I[Emma, null, 20, +I[6, null, s6, 6, null, null], {Emma=2020.0}, [20.0], null, null, null]",
+          "+I[Bob, null, 44, +I[7, null, s7, 7, null, null], {Bob=4444.0}, [44.0, 44.0], null, null, null]",
+          "+I[Han, null, 56, +I[8, null, s8, 8, null, null], {Han=5656.0}, [56.0, 56.0, 56.0], null, null, null]",
+          "+I[Alice, 90000.9, unknown, +I[9, 9, s9, 99, t9, drop_add9], {Alice=9999.99}, [9999.0, 9999.0], +I[9, 9], [9], {k9=v9}]",
+          "+I[Danny, 10000.1, 23, +I[1, 1, s1, 11, t1, drop_add1], {Danny=2323.23}, [23.0, 23.0, 23.0], +I[1, 1], [1], {k1=v1}]",
+          "+I[Julian, 30000.3, 53, +I[3, 3, s3, 33, t3, drop_add3], {Julian=5353.53}, [53.0], +I[3, 3], [3], {k3=v3}]",
       },
       new String[] {
-          "+I[uuid:id0, Indica, null, null]",
-          "+I[uuid:id1, Danny, null, +I[1, null, s1, null]]",
-          "+I[uuid:id2, Stephen, null, +I[2, null, s2, null]]",
-          "+I[uuid:id3, Julian, null, +I[3, null, s3, null]]",
-          "+I[uuid:id4, Fabian, null, +I[4, null, s4, null]]",
-          "+I[uuid:id5, Sophia, null, +I[5, null, s5, null]]",
-          "+I[uuid:id6, Emma, null, +I[6, null, s6, null]]",
-          "+I[uuid:id7, Bob, null, +I[7, null, s7, null]]",
-          "+I[uuid:id8, Han, null, +I[8, null, s8, null]]",
-          "+I[uuid:id9, Alice, 90000.9, +I[9, 9, s9, t9]]",
-          "+I[uuid:id1, Danny, 10000.1, +I[1, 1, s1, t1]]",
-          "+I[uuid:id3, Julian, 30000.3, +I[3, 3, s3, t3]]",
+          "+I[uuid:id0, Indica, null, 12, null, {Indica=1212.0}, [12.0], null, null, null]",
+          "+I[uuid:id1, Danny, null, 23, +I[1, null, s1, 1, null, null], {Danny=2323.0}, [23.0, 23.0], null, null, null]",
+          "+I[uuid:id2, Stephen, null, 33, +I[2, null, s2, 2, null, null], {Stephen=3333.0}, [33.0], null, null, null]",
+          "+I[uuid:id3, Julian, null, 53, +I[3, null, s3, 3, null, null], {Julian=5353.0}, [53.0, 53.0], null, null, null]",
+          "+I[uuid:id4, Fabian, null, 31, +I[4, null, s4, 4, null, null], {Fabian=3131.0}, [31.0], null, null, null]",
+          "+I[uuid:id5, Sophia, null, 18, +I[5, null, s5, 5, null, null], {Sophia=1818.0}, [18.0, 18.0], null, null, null]",
+          "+I[uuid:id6, Emma, null, 20, +I[6, null, s6, 6, null, null], {Emma=2020.0}, [20.0], null, null, null]",
+          "+I[uuid:id7, Bob, null, 44, +I[7, null, s7, 7, null, null], {Bob=4444.0}, [44.0, 44.0], null, null, null]",
+          "+I[uuid:id8, Han, null, 56, +I[8, null, s8, 8, null, null], {Han=5656.0}, [56.0, 56.0, 56.0], null, null, null]",
+          "+I[uuid:id9, Alice, 90000.9, unknown, +I[9, 9, s9, 99, t9, drop_add9], {Alice=9999.99}, [9999.0, 9999.0], +I[9, 9], [9], {k9=v9}]",
+          "+I[uuid:id1, Danny, 10000.1, 23, +I[1, 1, s1, 11, t1, drop_add1], {Danny=2323.23}, [23.0, 23.0, 23.0], +I[1, 1], [1], {k1=v1}]",
+          "+I[uuid:id3, Julian, 30000.3, 53, +I[3, 3, s3, 33, t3, drop_add3], {Julian=5353.53}, [53.0], +I[3, 3], [3], {k3=v3}]",
       },
       new String[] {
           "+I[1]",

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
@@ -18,20 +18,31 @@
 
 package org.apache.hudi.table.format;
 
+import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -41,7 +52,95 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestCastMap {
 
   @Test
-  public void testCastInt() {
+  public void testCastNestedRow() {
+    RowType innerRowType = new RowType(
+        true,
+        Arrays.asList(
+            new RowType.RowField("inner_f0", new IntType()),
+            new RowType.RowField("inner_f1", new IntType()),
+            new RowType.RowField("inner_f2", new IntType())));
+
+    RowType innerEvolvedRowType = new RowType(
+        true,
+        Arrays.asList(
+            new RowType.RowField("inner_f0", new DoubleType()),
+            new RowType.RowField("inner_f1", new DoubleType()),
+            new RowType.RowField("inner_f2", new BigIntType())));
+
+    RowType fromRowType = new RowType(true,
+        Arrays.asList(
+            new RowType.RowField("f0", innerRowType),
+            new RowType.RowField("f1", new IntType())));
+
+    RowType toRowType = new RowType(true,
+        Arrays.asList(
+            new RowType.RowField("f0", innerEvolvedRowType),
+            new RowType.RowField("f1", new DoubleType())));
+
+    CastMap castMap = new CastMap();
+    castMap.add(0, fromRowType, toRowType);
+
+    // initialise row data to perform cast on
+    GenericRowData innerRowData = new GenericRowData(3);
+    innerRowData.setField(0, 333);
+    innerRowData.setField(1, null);
+    innerRowData.setField(2, 555);
+    GenericRowData inputRowData = new GenericRowData(2);
+    inputRowData.setField(0, innerRowData);
+    inputRowData.setField(1, 2);
+
+    // initialise row data as ground-truth to check against
+    GenericRowData evolvedInnerRowData = new GenericRowData(3);
+    evolvedInnerRowData.setField(0, 333.0);
+    evolvedInnerRowData.setField(1, null);
+    evolvedInnerRowData.setField(2, 555L);
+    GenericRowData expectedRowData = new GenericRowData(2);
+    expectedRowData.setField(0, evolvedInnerRowData);
+    expectedRowData.setField(1, 2.0);
+
+    assertEquals(expectedRowData, castMap.castIfNeeded(0, inputRowData));
+  }
+
+  @Test
+  public void testCastArrayType() {
+    LogicalType fromArrayType = new ArrayType(true, new IntType());
+    LogicalType toArrayType = new ArrayType(true, new DoubleType());
+    CastMap castMap = new CastMap();
+    castMap.add(0, fromArrayType, toArrayType);
+
+    // cannot use primitive class as primitive types cannot be null
+    // inserting a null to test null-handling
+    ArrayData inputArrayData = new GenericArrayData(new Integer[]{1, null, 3});
+    ArrayData expectedArrayData = new GenericArrayData(new Double[]{1.0, null, 3.0});
+
+    assertEquals(expectedArrayData, castMap.castIfNeeded(0, inputArrayData));
+  }
+
+  @Test
+  public void testCastMapType() {
+    LogicalType fromMapType = new MapType(true, new VarCharType(), new IntType());
+    LogicalType toMapType = new MapType(true, new VarCharType(), new DoubleType());
+    CastMap castMap = new CastMap();
+    castMap.add(0, fromMapType, toMapType);
+
+    Map<BinaryStringData, Integer> inputMap = new HashMap<>();
+    inputMap.put(BinaryStringData.fromString("alex"), 11);
+    inputMap.put(BinaryStringData.fromString("ben"), null);
+    inputMap.put(BinaryStringData.fromString("jack"), 12);
+
+    Map<BinaryStringData, Double> expectedMap = new HashMap<>();
+    expectedMap.put(BinaryStringData.fromString("alex"), 11.0);
+    expectedMap.put(BinaryStringData.fromString("ben"), null);
+    expectedMap.put(BinaryStringData.fromString("jack"), 12.0);
+
+    MapData inputMapData = new GenericMapData(inputMap);
+    MapData expectedMapData = new GenericMapData(expectedMap);
+
+    assertEquals(expectedMapData, castMap.castIfNeeded(0, inputMapData));
+  }
+
+  @Test
+public void testCastInt() {
     CastMap castMap = new CastMap();
     castMap.add(0, new IntType(), new BigIntType());
     castMap.add(1, new IntType(), new FloatType());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
@@ -50,102 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for {@link CastMap}.
  */
 public class TestCastMap {
-
   @Test
-  public void testCastNestedRow() {
-    RowType innerRowType = new RowType(
-        true,
-        Arrays.asList(
-            new RowType.RowField("inner_f0", new IntType()),
-            new RowType.RowField("inner_f1", new IntType()),
-            new RowType.RowField("inner_f2", new IntType()),
-            new RowType.RowField("inner_f3", new IntType())));
-
-    // adding not nulls to test handling of not-null constraints
-    RowType innerEvolvedRowType = new RowType(
-        true,
-        Arrays.asList(
-            new RowType.RowField("inner_f0", new DoubleType()),
-            new RowType.RowField("inner_f1", new IntType(false)),
-            new RowType.RowField("inner_f2", new DoubleType()),
-            new RowType.RowField("inner_f3", new BigIntType())));
-
-    RowType fromRowType = new RowType(true,
-        Arrays.asList(
-            new RowType.RowField("f0", innerRowType),
-            new RowType.RowField("f1", new IntType())));
-
-    RowType toRowType = new RowType(true,
-        Arrays.asList(
-            new RowType.RowField("f0", innerEvolvedRowType),
-            new RowType.RowField("f1", new DoubleType())));
-
-    CastMap castMap = new CastMap();
-    castMap.add(0, fromRowType, toRowType);
-
-    // initialise row data to perform cast on
-    GenericRowData innerRowData = new GenericRowData(4);
-    innerRowData.setField(0, 333);
-    innerRowData.setField(1, 444);
-    innerRowData.setField(2, null);
-    innerRowData.setField(3, 555);
-    GenericRowData inputRowData = new GenericRowData(2);
-    inputRowData.setField(0, innerRowData);
-    inputRowData.setField(1, 2);
-
-    // initialise row data as ground-truth to check against
-    GenericRowData evolvedInnerRowData = new GenericRowData(4);
-    evolvedInnerRowData.setField(0, 333.0);
-    evolvedInnerRowData.setField(1, 444);
-    evolvedInnerRowData.setField(2, null);
-    evolvedInnerRowData.setField(3, 555L);
-    GenericRowData expectedRowData = new GenericRowData(2);
-    expectedRowData.setField(0, evolvedInnerRowData);
-    expectedRowData.setField(1, 2.0);
-
-    assertEquals(expectedRowData, castMap.castIfNeeded(0, inputRowData));
-  }
-
-  @Test
-  public void testCastArrayType() {
-    LogicalType fromArrayType = new ArrayType(true, new IntType());
-    LogicalType toArrayType = new ArrayType(true, new DoubleType());
-    CastMap castMap = new CastMap();
-    castMap.add(0, fromArrayType, toArrayType);
-
-    // cannot use primitive class as primitive types cannot be null
-    // inserting a null to test null-handling
-    ArrayData inputArrayData = new GenericArrayData(new Integer[]{1, null, 3});
-    ArrayData expectedArrayData = new GenericArrayData(new Double[]{1.0, null, 3.0});
-
-    assertEquals(expectedArrayData, castMap.castIfNeeded(0, inputArrayData));
-  }
-
-  @Test
-  public void testCastMapType() {
-    LogicalType fromMapType = new MapType(true, new VarCharType(), new IntType());
-    LogicalType toMapType = new MapType(true, new VarCharType(), new DoubleType());
-    CastMap castMap = new CastMap();
-    castMap.add(0, fromMapType, toMapType);
-
-    Map<BinaryStringData, Integer> inputMap = new HashMap<>();
-    inputMap.put(BinaryStringData.fromString("alex"), 11);
-    inputMap.put(BinaryStringData.fromString("ben"), null);
-    inputMap.put(BinaryStringData.fromString("jack"), 12);
-
-    Map<BinaryStringData, Double> expectedMap = new HashMap<>();
-    expectedMap.put(BinaryStringData.fromString("alex"), 11.0);
-    expectedMap.put(BinaryStringData.fromString("ben"), null);
-    expectedMap.put(BinaryStringData.fromString("jack"), 12.0);
-
-    MapData inputMapData = new GenericMapData(inputMap);
-    MapData expectedMapData = new GenericMapData(expectedMap);
-
-    assertEquals(expectedMapData, castMap.castIfNeeded(0, inputMapData));
-  }
-
-  @Test
-public void testCastInt() {
+  public void testCastInt() {
     CastMap castMap = new CastMap();
     castMap.add(0, new IntType(), new BigIntType());
     castMap.add(1, new IntType(), new FloatType());
@@ -220,5 +126,98 @@ public void testCastInt() {
     CastMap castMap = new CastMap();
     castMap.add(0, new DateType(), new VarCharType());
     assertEquals(BinaryStringData.fromString("2022-05-12"), castMap.castIfNeeded(0, (int) LocalDate.parse("2022-05-12").toEpochDay()));
+  }
+
+  @Test
+  public void testCastArrayType() {
+    LogicalType fromArrayType = new ArrayType(true, new IntType());
+    LogicalType toArrayType = new ArrayType(true, new DoubleType());
+    CastMap castMap = new CastMap();
+    castMap.add(0, fromArrayType, toArrayType);
+
+    // cannot use primitive class as primitive types cannot be null
+    // inserting a null to test null-handling
+    ArrayData inputArrayData = new GenericArrayData(new Integer[]{1, null, 3});
+    ArrayData expectedArrayData = new GenericArrayData(new Double[]{1.0, null, 3.0});
+
+    assertEquals(expectedArrayData, castMap.castIfNeeded(0, inputArrayData));
+  }
+
+  @Test
+  public void testCastMapType() {
+    LogicalType fromMapType = new MapType(true, new VarCharType(), new IntType());
+    LogicalType toMapType = new MapType(true, new VarCharType(), new DoubleType());
+    CastMap castMap = new CastMap();
+    castMap.add(0, fromMapType, toMapType);
+
+    Map<BinaryStringData, Integer> inputMap = new HashMap<>();
+    inputMap.put(BinaryStringData.fromString("alex"), 11);
+    inputMap.put(BinaryStringData.fromString("ben"), null);
+    inputMap.put(BinaryStringData.fromString("jack"), 12);
+
+    Map<BinaryStringData, Double> expectedMap = new HashMap<>();
+    expectedMap.put(BinaryStringData.fromString("alex"), 11.0);
+    expectedMap.put(BinaryStringData.fromString("ben"), null);
+    expectedMap.put(BinaryStringData.fromString("jack"), 12.0);
+
+    MapData inputMapData = new GenericMapData(inputMap);
+    MapData expectedMapData = new GenericMapData(expectedMap);
+
+    assertEquals(expectedMapData, castMap.castIfNeeded(0, inputMapData));
+  }
+
+  @Test
+  public void testCastNestedRow() {
+    RowType innerRowType = new RowType(
+        true,
+        Arrays.asList(
+            new RowType.RowField("f0_int", new IntType()),
+            new RowType.RowField("f1_int", new IntType()),
+            new RowType.RowField("f2_int", new IntType()),
+            new RowType.RowField("f3_int", new IntType())));
+
+    // adding not nulls to test handling of not-null constraints
+    RowType innerEvolvedRowType = new RowType(
+        true,
+        Arrays.asList(
+            new RowType.RowField("f0_double", new DoubleType()),
+            new RowType.RowField("f1_int", new IntType(false)),
+            new RowType.RowField("f2_double", new DoubleType()),
+            new RowType.RowField("f3_bigint", new BigIntType())));
+
+    RowType fromRowType = new RowType(true,
+        Arrays.asList(
+            new RowType.RowField("f0_row", innerRowType),
+            new RowType.RowField("f1_int", new IntType())));
+
+    RowType toRowType = new RowType(true,
+        Arrays.asList(
+            new RowType.RowField("f0_row", innerEvolvedRowType),
+            new RowType.RowField("f1_double", new DoubleType())));
+
+    CastMap castMap = new CastMap();
+    castMap.add(0, fromRowType, toRowType);
+
+    // initialise row data to perform cast on
+    GenericRowData innerRowData = new GenericRowData(4);
+    innerRowData.setField(0, 333);
+    innerRowData.setField(1, 444);
+    innerRowData.setField(2, null);
+    innerRowData.setField(3, 555);
+    GenericRowData inputRowData = new GenericRowData(2);
+    inputRowData.setField(0, innerRowData);
+    inputRowData.setField(1, 2);
+
+    // initialise row data as ground-truth to check against
+    GenericRowData evolvedInnerRowData = new GenericRowData(4);
+    evolvedInnerRowData.setField(0, 333.0);
+    evolvedInnerRowData.setField(1, 444);
+    evolvedInnerRowData.setField(2, null);
+    evolvedInnerRowData.setField(3, 555L);
+    GenericRowData expectedRowData = new GenericRowData(2);
+    expectedRowData.setField(0, evolvedInnerRowData);
+    expectedRowData.setField(1, 2.0);
+
+    assertEquals(expectedRowData, castMap.castIfNeeded(0, inputRowData));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestCastMap.java
@@ -58,14 +58,17 @@ public class TestCastMap {
         Arrays.asList(
             new RowType.RowField("inner_f0", new IntType()),
             new RowType.RowField("inner_f1", new IntType()),
-            new RowType.RowField("inner_f2", new IntType())));
+            new RowType.RowField("inner_f2", new IntType()),
+            new RowType.RowField("inner_f3", new IntType())));
 
+    // adding not nulls to test handling of not-null constraints
     RowType innerEvolvedRowType = new RowType(
         true,
         Arrays.asList(
             new RowType.RowField("inner_f0", new DoubleType()),
-            new RowType.RowField("inner_f1", new DoubleType()),
-            new RowType.RowField("inner_f2", new BigIntType())));
+            new RowType.RowField("inner_f1", new IntType(false)),
+            new RowType.RowField("inner_f2", new DoubleType()),
+            new RowType.RowField("inner_f3", new BigIntType())));
 
     RowType fromRowType = new RowType(true,
         Arrays.asList(
@@ -81,19 +84,21 @@ public class TestCastMap {
     castMap.add(0, fromRowType, toRowType);
 
     // initialise row data to perform cast on
-    GenericRowData innerRowData = new GenericRowData(3);
+    GenericRowData innerRowData = new GenericRowData(4);
     innerRowData.setField(0, 333);
-    innerRowData.setField(1, null);
-    innerRowData.setField(2, 555);
+    innerRowData.setField(1, 444);
+    innerRowData.setField(2, null);
+    innerRowData.setField(3, 555);
     GenericRowData inputRowData = new GenericRowData(2);
     inputRowData.setField(0, innerRowData);
     inputRowData.setField(1, 2);
 
     // initialise row data as ground-truth to check against
-    GenericRowData evolvedInnerRowData = new GenericRowData(3);
+    GenericRowData evolvedInnerRowData = new GenericRowData(4);
     evolvedInnerRowData.setField(0, 333.0);
-    evolvedInnerRowData.setField(1, null);
-    evolvedInnerRowData.setField(2, 555L);
+    evolvedInnerRowData.setField(1, 444);
+    evolvedInnerRowData.setField(2, null);
+    evolvedInnerRowData.setField(3, 555L);
     GenericRowData expectedRowData = new GenericRowData(2);
     expectedRowData.setField(0, evolvedInnerRowData);
     expectedRowData.setField(1, 2.0);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -92,12 +92,16 @@ public class TestConfigurations {
           DataTypes.FIELD("ts", DataTypes.TIMESTAMP(6)),
           DataTypes.FIELD("f_struct", DataTypes.ROW(
               DataTypes.FIELD("f0", DataTypes.INT()),
-              DataTypes.FIELD("f1", DataTypes.STRING()))),
+              DataTypes.FIELD("f1", DataTypes.STRING()),
+              DataTypes.FIELD("drop_add", DataTypes.STRING()),
+              DataTypes.FIELD("change_type", DataTypes.INT()))),
+          DataTypes.FIELD("f_map", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())),
+          DataTypes.FIELD("f_array", DataTypes.ARRAY(DataTypes.INT())),
           DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
       .notNull();
 
   public static final RowType ROW_TYPE_EVOLUTION_BEFORE = (RowType) ROW_DATA_TYPE_EVOLUTION_BEFORE.getLogicalType();
-
+  // f0 int, f2 int, f1 string, renamed_change_type bigint, f3 string, drop_add string
   public static final DataType ROW_DATA_TYPE_EVOLUTION_AFTER = DataTypes.ROW(
           DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),
           DataTypes.FIELD("age", DataTypes.VARCHAR(10)), // changed type, reordered
@@ -109,7 +113,16 @@ public class TestConfigurations {
               DataTypes.FIELD("f0", DataTypes.INT()),
               DataTypes.FIELD("f2", DataTypes.INT()), // new field added in the middle of struct
               DataTypes.FIELD("f1", DataTypes.STRING()),
-              DataTypes.FIELD("f3", DataTypes.STRING()))), // new field added at the end of struct
+              DataTypes.FIELD("renamed_change_type", DataTypes.BIGINT()),
+              DataTypes.FIELD("f3", DataTypes.STRING()),
+              DataTypes.FIELD("drop_add", DataTypes.STRING()))), // new field added at the end of struct
+          DataTypes.FIELD("f_map", DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE())),
+          DataTypes.FIELD("f_array", DataTypes.ARRAY(DataTypes.DOUBLE())),
+          DataTypes.FIELD("new_row_col", DataTypes.ROW(
+              DataTypes.FIELD("f0", DataTypes.BIGINT()),
+              DataTypes.FIELD("f1", DataTypes.STRING()))),
+          DataTypes.FIELD("new_array_col", DataTypes.ARRAY(DataTypes.STRING())),
+          DataTypes.FIELD("new_map_col", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
           DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
       .notNull();
 

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -271,6 +271,30 @@ public class ParquetSplitReaderUtil {
           tv.fill(TimestampData.fromLocalDateTime((LocalDateTime) value));
         }
         return tv;
+      case ARRAY:
+        HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
+        if (value == null) {
+          arrayVector.fillWithNulls();
+          return arrayVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create array with default value.");
+        }
+      case MAP:
+        HeapMapColumnVector mapVector = new HeapMapColumnVector(batchSize, null, null);
+        if (value == null) {
+          mapVector.fillWithNulls();
+          return mapVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create map with default value.");
+        }
+      case ROW:
+        HeapRowColumnVector rowVector = new HeapRowColumnVector(batchSize);
+        if (value == null) {
+          rowVector.fillWithNulls();
+          return rowVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create row with default value.");
+        }
       default:
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -271,6 +271,30 @@ public class ParquetSplitReaderUtil {
           tv.fill(TimestampData.fromLocalDateTime((LocalDateTime) value));
         }
         return tv;
+      case ARRAY:
+        HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
+        if (value == null) {
+          arrayVector.fillWithNulls();
+          return arrayVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create array with default value.");
+        }
+      case MAP:
+        HeapMapColumnVector mapVector = new HeapMapColumnVector(batchSize, null, null);
+        if (value == null) {
+          mapVector.fillWithNulls();
+          return mapVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create map with default value.");
+        }
+      case ROW:
+        HeapRowColumnVector rowVector = new HeapRowColumnVector(batchSize);
+        if (value == null) {
+          rowVector.fillWithNulls();
+          return rowVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create row with default value.");
+        }
       default:
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -271,6 +271,30 @@ public class ParquetSplitReaderUtil {
           tv.fill(TimestampData.fromLocalDateTime((LocalDateTime) value));
         }
         return tv;
+      case ARRAY:
+        HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
+        if (value == null) {
+          arrayVector.fillWithNulls();
+          return arrayVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create array with default value.");
+        }
+      case MAP:
+        HeapMapColumnVector mapVector = new HeapMapColumnVector(batchSize, null, null);
+        if (value == null) {
+          mapVector.fillWithNulls();
+          return mapVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create map with default value.");
+        }
+      case ROW:
+        HeapRowColumnVector rowVector = new HeapRowColumnVector(batchSize);
+        if (value == null) {
+          rowVector.fillWithNulls();
+          return rowVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create row with default value.");
+        }
       default:
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -271,6 +271,30 @@ public class ParquetSplitReaderUtil {
           tv.fill(TimestampData.fromLocalDateTime((LocalDateTime) value));
         }
         return tv;
+      case ARRAY:
+        HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
+        if (value == null) {
+          arrayVector.fillWithNulls();
+          return arrayVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create array with default value.");
+        }
+      case MAP:
+        HeapMapColumnVector mapVector = new HeapMapColumnVector(batchSize, null, null);
+        if (value == null) {
+          mapVector.fillWithNulls();
+          return mapVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create map with default value.");
+        }
+      case ROW:
+        HeapRowColumnVector rowVector = new HeapRowColumnVector(batchSize);
+        if (value == null) {
+          rowVector.fillWithNulls();
+          return rowVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create row with default value.");
+        }
       default:
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }

--- a/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -271,6 +271,30 @@ public class ParquetSplitReaderUtil {
           tv.fill(TimestampData.fromLocalDateTime((LocalDateTime) value));
         }
         return tv;
+      case ARRAY:
+        HeapArrayVector arrayVector = new HeapArrayVector(batchSize);
+        if (value == null) {
+          arrayVector.fillWithNulls();
+          return arrayVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create array with default value.");
+        }
+      case MAP:
+        HeapMapColumnVector mapVector = new HeapMapColumnVector(batchSize, null, null);
+        if (value == null) {
+          mapVector.fillWithNulls();
+          return mapVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create map with default value.");
+        }
+      case ROW:
+        HeapRowColumnVector rowVector = new HeapRowColumnVector(batchSize);
+        if (value == null) {
+          rowVector.fillWithNulls();
+          return rowVector;
+        } else {
+          throw new UnsupportedOperationException("Unsupported create row with default value.");
+        }
       default:
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }


### PR DESCRIPTION
…volution on Flink

PR is co-authored by @hbgstc123.

### Change Logs

Added support for reading tables that were evolved using Hudi's comprehensive/full schema evolution

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
