### PR TITLE
[HUDI-6426] Upgrade to Spark 3.4.1 for Spark 3.4 bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <http.version>4.4.1</http.version>
     <spark.version>${spark3.version}</spark.version>
     <spark2.version>2.4.4</spark2.version>
-    <spark3.version>3.3.1</spark3.version>
+    <spark3.version>3.4.1</spark3.version>
     <sparkbundle.version></sparkbundle.version>
     <flink1.17.version>1.17.1</flink1.17.version>
     <flink1.16.version>1.16.2</flink1.16.version>
@@ -161,7 +161,7 @@
     <spark31.version>3.1.3</spark31.version>
     <spark32.version>3.2.3</spark32.version>
     <spark33.version>3.3.1</spark33.version>
-    <spark34.version>3.4.0</spark34.version>
+    <spark34.version>3.4.1</spark34.version>
     <hudi.spark.module>hudi-spark3.2.x</hudi.spark.module>
     <!-- NOTE: Different Spark versions might require different number of shared
                modules being incorporated, hence we're creating multiple placeholders


### PR DESCRIPTION
### Change Logs

Upgrade to Spark 3.4.1 for Spark 3.4 bundle.

### Impact

Use the latest 3.4.x.

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
