### PR TITLE
[HUDI-6511] Mark more recently added configs advanced as appropriate

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -159,8 +159,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> CLUSTERING_MAX_PARALLELISM = ConfigProperty
       .key("hoodie.clustering.max.parallelism")
       .defaultValue(15)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of parallelism jobs submitted in clustering operation. "
           + "If the resource is sufficient(Like Spark engine has enough idle executors), increasing this "
           + "value will let the clustering job run faster, while it will give additional pressure to the "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -160,6 +160,7 @@ public class HoodieClusteringConfig extends HoodieConfig {
       .key("hoodie.clustering.max.parallelism")
       .defaultValue(15)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Maximum number of parallelism jobs submitted in clustering operation. "
           + "If the resource is sufficient(Like Spark engine has enough idle executors), increasing this "
           + "value will let the clustering job run faster, while it will give additional pressure to the "

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -64,6 +64,7 @@ public class HoodieCompactionConfig extends HoodieConfig {
   public static final ConfigProperty<String> ENABLE_LOG_COMPACTION = ConfigProperty
       .key("hoodie.log.compaction.enable")
       .defaultValue("false")
+      .markAdvanced()
       .sinceVersion("0.14")
       .withDocumentation("By enabling log compaction through this config, log compaction will also get enabled for the metadata table.");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -700,11 +700,13 @@ public class HoodieWriteConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ROLLBACK_INSTANT_BACKUP_ENABLED = ConfigProperty
       .key("hoodie.rollback.instant.backup.enabled")
       .defaultValue(false)
+      .markAdvanced()
       .withDocumentation("Backup instants removed during rollback and restore (useful for debugging)");
 
   public static final ConfigProperty<String> ROLLBACK_INSTANT_BACKUP_DIRECTORY = ConfigProperty
       .key("hoodie.rollback.instant.backup.dir")
       .defaultValue(".rollback_backup")
+      .markAdvanced()
       .withDocumentation("Path where instants being rolled back are copied. If not absolute path then a directory relative to .hoodie folder is created.");
 
   public static final ConfigProperty<String> CLIENT_INIT_CALLBACK_CLASS_NAMES = ConfigProperty

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -97,6 +97,7 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<String> HOODIE_FS_ATOMIC_CREATION_SUPPORT = ConfigProperty
       .key("hoodie.fs.atomic_creation.support")
       .defaultValue("")
+      .markAdvanced()
       .withDocumentation("This config is used to specify the file system which supports atomic file creation . "
           + "atomic means that an operation either succeeds and has an effect or has fails and has no effect;"
           + " now this feature is used by FileSystemLockProvider to guaranteeing that only one writer can create the lock file at a time."

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -99,12 +99,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".log.compaction.enable")
       .defaultValue("false")
       .sinceVersion("0.14")
+      .markAdvanced()
       .withDocumentation("This configs enables logcompaction for the metadata table.");
 
   // Log blocks threshold, after a file slice crosses this threshold log compact operation is scheduled.
   public static final ConfigProperty<Integer> LOG_COMPACT_BLOCKS_THRESHOLD = ConfigProperty
       .key(METADATA_PREFIX + ".log.compaction.blocks.threshold")
       .defaultValue(5)
+      .markAdvanced()
       .withDocumentation("Controls the criteria to log compacted files groups in metadata table.");
 
   // Regex to filter out matching directories during bootstrap
@@ -251,30 +253,35 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".record.index.enable")
       .defaultValue(false)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Create the HUDI Record Index within the Metadata Table");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MIN_FILE_GROUP_COUNT_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.min.filegroup.count")
       .defaultValue(10)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Minimum number of file groups to use for Record Index.");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MAX_FILE_GROUP_COUNT_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.max.filegroup.count")
       .defaultValue(1000)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Maximum number of file groups to use for Record Index.");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MAX_FILE_GROUP_SIZE_BYTES_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.max.filegroup.size")
       .defaultValue(1024 * 1024 * 1024)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Maximum size in bytes of a single file group. Large file group takes longer to compact.");
 
   public static final ConfigProperty<Float> RECORD_INDEX_GROWTH_FACTOR_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.growth.factor")
       .defaultValue(2.0f)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("The current number of records are multiplied by this number when estimating the number of "
           + "file groups to create automatically. This helps account for growth in the number of records in the dataset.");
 
@@ -282,12 +289,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".max.reader.memory")
       .defaultValue(1024 * 1024 * 1024L)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Max memory to use for the reader to read from metadata");
 
   public static final ConfigProperty<Integer> MAX_READER_BUFFER_SIZE_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".max.reader.buffer.size")
       .defaultValue(10 * 1024 * 1024)
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Max memory to use for the reader buffer while merging log blocks");
 
   public static final ConfigProperty<String> SPILLABLE_MAP_DIR_PROP = ConfigProperty
@@ -295,6 +304,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .noDefaultValue()
       .withInferFunction(cfg -> Option.of(cfg.getStringOrDefault(FileSystemViewStorageConfig.SPILLABLE_DIR)))
       .sinceVersion("0.14.0")
+      .markAdvanced()
       .withDocumentation("Path on local storage to use, when keys read from metadata are held in a spillable map.");
 
   private HoodieMetadataConfig() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -98,8 +98,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<String> ENABLE_LOG_COMPACTION_ON_METADATA_TABLE = ConfigProperty
       .key(METADATA_PREFIX + ".log.compaction.enable")
       .defaultValue("false")
-      .sinceVersion("0.14")
       .markAdvanced()
+      .sinceVersion("0.14")
       .withDocumentation("This configs enables logcompaction for the metadata table.");
 
   // Log blocks threshold, after a file slice crosses this threshold log compact operation is scheduled.
@@ -252,59 +252,59 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> RECORD_INDEX_ENABLE_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.enable")
       .defaultValue(false)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Create the HUDI Record Index within the Metadata Table");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MIN_FILE_GROUP_COUNT_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.min.filegroup.count")
       .defaultValue(10)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Minimum number of file groups to use for Record Index.");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MAX_FILE_GROUP_COUNT_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.max.filegroup.count")
       .defaultValue(1000)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Maximum number of file groups to use for Record Index.");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MAX_FILE_GROUP_SIZE_BYTES_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.max.filegroup.size")
       .defaultValue(1024 * 1024 * 1024)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Maximum size in bytes of a single file group. Large file group takes longer to compact.");
 
   public static final ConfigProperty<Float> RECORD_INDEX_GROWTH_FACTOR_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".record.index.growth.factor")
       .defaultValue(2.0f)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("The current number of records are multiplied by this number when estimating the number of "
           + "file groups to create automatically. This helps account for growth in the number of records in the dataset.");
 
   public static final ConfigProperty<Long> MAX_READER_MEMORY_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".max.reader.memory")
       .defaultValue(1024 * 1024 * 1024L)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Max memory to use for the reader to read from metadata");
 
   public static final ConfigProperty<Integer> MAX_READER_BUFFER_SIZE_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".max.reader.buffer.size")
       .defaultValue(10 * 1024 * 1024)
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Max memory to use for the reader buffer while merging log blocks");
 
   public static final ConfigProperty<String> SPILLABLE_MAP_DIR_PROP = ConfigProperty
       .key(METADATA_PREFIX + ".spillable.map.path")
       .noDefaultValue()
       .withInferFunction(cfg -> Option.of(cfg.getStringOrDefault(FileSystemViewStorageConfig.SPILLABLE_DIR)))
-      .sinceVersion("0.14.0")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Path on local storage to use, when keys read from metadata are held in a spillable map.");
 
   private HoodieMetadataConfig() {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -127,7 +127,7 @@ object DataSourceReadOptions {
     .withDocumentation("Used when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL +
       "`. Represents the instant time to limit incrementally fetched data to. When not specified latest commit time from " +
       "timeline is assumed by default. When specified, new data written with an instant_time <= END_INSTANTTIME are fetched out. " +
-      "Point in time type queries makes more sense with begin and end instant times specified. Note that if `"
+      "Point in time type queries make more sense with begin and end instant times specified. Note that if `"
       + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to `"
       + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "`, will use instant's "
       + "`stateTransitionTime` to perform comparison.")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -60,8 +60,8 @@ object DataSourceReadOptions {
     .defaultValue(QUERY_TYPE_SNAPSHOT_OPT_VAL)
     .withAlternatives("hoodie.datasource.view.type")
     .withValidValues(QUERY_TYPE_SNAPSHOT_OPT_VAL, QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, QUERY_TYPE_INCREMENTAL_OPT_VAL)
-    .withDocumentation("Whether data needs to be read, in incremental mode (new data since an instantTime) " +
-      "(or) Read Optimized mode (obtain latest view, based on base files) (or) Snapshot mode " +
+    .withDocumentation("Whether data needs to be read, in `" + QUERY_TYPE_INCREMENTAL_OPT_VAL + "` mode (new data since an instantTime) " +
+      "(or) `" + QUERY_TYPE_READ_OPTIMIZED_OPT_VAL + "` mode (obtain latest view, based on base files) (or) `" + QUERY_TYPE_SNAPSHOT_OPT_VAL + "` mode " +
       "(obtain latest view, by merging base and (if any) log files)")
 
   val INCREMENTAL_FORMAT_LATEST_STATE_VAL = "latest_state"
@@ -114,7 +114,7 @@ object DataSourceReadOptions {
   val BEGIN_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.begin.instanttime")
     .noDefaultValue()
-    .withDocumentation("Instant time to start incrementally pulling data from. The instanttime here need not necessarily "
+    .withDocumentation("Required when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL + "`. Represents the instant time to start incrementally pulling data from. The instanttime here need not necessarily "
       + "correspond to an instant on the timeline. New data written with an instant_time > BEGIN_INSTANTTIME are fetched out. "
       + "For e.g: ‘20170901080000’ will get all new data written after Sep 1, 2017 08:00AM. Note that if `"
       + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to "
@@ -124,10 +124,12 @@ object DataSourceReadOptions {
   val END_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.end.instanttime")
     .noDefaultValue()
-    .withDocumentation("Instant time to limit incrementally fetched data to. "
-      + "New data written with an instant_time <= END_INSTANTTIME are fetched out. Note that if `"
-      + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to "
-      + HollowCommitHandling.USE_STATE_TRANSITION_TIME + ", will use instant's "
+    .withDocumentation("Used when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL +
+      "`. Represents the instant time to limit incrementally fetched data to. When not specified latest commit time from " +
+      "timeline is assumed by default. When specified, new data written with an instant_time <= END_INSTANTTIME are fetched out. " +
+      "Point in time type queries makes more sense with begin and end instant times specified. Note that if `"
+      + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to `"
+      + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "`, will use instant's "
       + "`stateTransitionTime` to perform comparison.")
 
   val INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME: ConfigProperty[String] = ConfigProperty

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieDeltaStreamerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieDeltaStreamerConfig.java
@@ -50,7 +50,7 @@ public class HoodieDeltaStreamerConfig extends HoodieConfig {
   public static final ConfigProperty<String> KAFKA_TOPIC = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "source.kafka.topic")
       .noDefaultValue()
-      .withDocumentation("Kafka topic name.");
+      .withDocumentation("Kafka topic name. The config is specific to HoodieMultiTableDeltaStreamer");
 
   public static final ConfigProperty<String> KAFKA_APPEND_OFFSETS = ConfigProperty
       .key(DELTA_STREAMER_CONFIG_PREFIX + "source.kafka.append.offsets")


### PR DESCRIPTION
### Change Logs

Marking more recently added configs as advanced for config generation tool to parse correctly for docs.

### Impact

Updating the configs as advanced for doc generation purposes.

### Risk level (write none, low medium or high below)

low 

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
