### PR TITLE
[MINOR] Unpersist only relevent metadata table RDDs

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -56,6 +56,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -402,12 +403,12 @@ public class SparkRDDWriteClient<T> extends
     if (config.areReleaseResourceEnabled()) {
       HoodieSparkEngineContext sparkEngineContext = (HoodieSparkEngineContext) context;
       Map<Integer, JavaRDD<?>> allCachedRdds = sparkEngineContext.getJavaSparkContext().getPersistentRDDs();
-      List<Integer> dataIds = sparkEngineContext.removeCachedDataIds(HoodieDataCacheKey.of(basePath, instantTime));
+      List<Integer> allDataIds = new ArrayList<>(sparkEngineContext.removeCachedDataIds(HoodieDataCacheKey.of(basePath, instantTime)));
       if (config.isMetadataTableEnabled()) {
         String metadataTableBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath);
-        dataIds.addAll(sparkEngineContext.removeCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instantTime)));
+        allDataIds.addAll(sparkEngineContext.removeCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instantTime)));
       }
-      for (int id : dataIds) {
+      for (int id : allDataIds) {
         if (allCachedRdds.containsKey(id)) {
           allCachedRdds.get(id).unpersist();
         }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -39,6 +39,7 @@ import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.SparkHoodieIndexFactory;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.metadata.SparkHoodieBackedTableMetadataWriter;
 import org.apache.hudi.metrics.DistributedRegistry;
@@ -402,6 +403,10 @@ public class SparkRDDWriteClient<T> extends
       HoodieSparkEngineContext sparkEngineContext = (HoodieSparkEngineContext) context;
       Map<Integer, JavaRDD<?>> allCachedRdds = sparkEngineContext.getJavaSparkContext().getPersistentRDDs();
       List<Integer> dataIds = sparkEngineContext.removeCachedDataIds(HoodieDataCacheKey.of(basePath, instantTime));
+      if (config.isMetadataTableEnabled()) {
+        String metadataTableBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath);
+        dataIds.addAll(sparkEngineContext.removeCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instantTime)));
+      }
       for (int id : dataIds) {
         if (allCachedRdds.containsKey(id)) {
           allCachedRdds.get(id).unpersist();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -47,6 +47,7 @@ import org.apache.spark.sql.SQLContext;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -206,7 +207,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   @Override
   public List<Integer> getCachedDataIds(HoodieDataCacheKey cacheKey) {
     synchronized (cachedRddIds) {
-      return cachedRddIds.getOrDefault(cacheKey, new ArrayList<>());
+      return cachedRddIds.getOrDefault(cacheKey, Collections.emptyList());
     }
   }
 
@@ -214,7 +215,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   public List<Integer> removeCachedDataIds(HoodieDataCacheKey cacheKey) {
     synchronized (cachedRddIds) {
       List<Integer> removed = cachedRddIds.remove(cacheKey);
-      return removed == null ? new ArrayList<>() : removed;
+      return removed == null ? Collections.emptyList() : removed;
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -47,7 +47,6 @@ import org.apache.spark.sql.SQLContext;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -207,7 +206,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   @Override
   public List<Integer> getCachedDataIds(HoodieDataCacheKey cacheKey) {
     synchronized (cachedRddIds) {
-      return cachedRddIds.getOrDefault(cacheKey, Collections.emptyList());
+      return cachedRddIds.getOrDefault(cacheKey, new ArrayList<>());
     }
   }
 
@@ -215,7 +214,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
   public List<Integer> removeCachedDataIds(HoodieDataCacheKey cacheKey) {
     synchronized (cachedRddIds) {
       List<Integer> removed = cachedRddIds.remove(cacheKey);
-      return removed == null ? Collections.emptyList() : removed;
+      return removed == null ? new ArrayList<>() : removed;
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.avro.generic.GenericRecord;
@@ -57,10 +58,14 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
 
   static Stream<Arguments> testWriteClientReleaseResourcesShouldOnlyUnpersistRelevantRdds() {
     return Stream.of(
-        Arguments.of(HoodieTableType.COPY_ON_WRITE, true),
-        Arguments.of(HoodieTableType.MERGE_ON_READ, true),
-        Arguments.of(HoodieTableType.COPY_ON_WRITE, false),
-        Arguments.of(HoodieTableType.MERGE_ON_READ, false)
+        Arguments.of(HoodieTableType.COPY_ON_WRITE, true, true),
+        Arguments.of(HoodieTableType.COPY_ON_WRITE, true, false),
+        Arguments.of(HoodieTableType.MERGE_ON_READ, true, true),
+        Arguments.of(HoodieTableType.MERGE_ON_READ, true, false),
+        Arguments.of(HoodieTableType.COPY_ON_WRITE, false, true),
+        Arguments.of(HoodieTableType.COPY_ON_WRITE, false, false),
+        Arguments.of(HoodieTableType.MERGE_ON_READ, false, true),
+        Arguments.of(HoodieTableType.MERGE_ON_READ, false, false)
     );
   }
 
@@ -107,13 +112,14 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
 
   @ParameterizedTest
   @MethodSource
-  void testWriteClientReleaseResourcesShouldOnlyUnpersistRelevantRdds(HoodieTableType tableType, boolean shouldReleaseResource) throws IOException {
+  void testWriteClientReleaseResourcesShouldOnlyUnpersistRelevantRdds(
+      HoodieTableType tableType, boolean shouldReleaseResource, boolean metadataTableEnable) throws IOException {
     final HoodieTableMetaClient metaClient = getHoodieMetaClient(hadoopConf(), URI.create(basePath()).getPath(), tableType, new Properties());
     final HoodieWriteConfig writeConfig = getConfigBuilder(true)
         .withPath(metaClient.getBasePathV2().toString())
         .withAutoCommit(false)
         .withReleaseResourceEnabled(shouldReleaseResource)
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(metadataTableEnable).build())
         .build();
     HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEED);
 
@@ -133,6 +139,9 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
     writeClient.startCommitWithTime(instant1);
     List<WriteStatus> writeStatuses = writeClient.insert(writeRecords, instant1).collect();
     assertNoWriteErrors(writeStatuses);
+    String metadataTableBasePath = HoodieTableMetadata.getMetadataTableBasePath(writeConfig.getBasePath());
+    List<Integer> metadataTableCacheIds0 = context().getCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instant0));
+    List<Integer> metadataTableCacheIds1 = context().getCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instant1));
     writeClient.commitStats(instant1, context().parallelize(writeStatuses, 1), writeStatuses.stream().map(WriteStatus::getStat).collect(Collectors.toList()),
         Option.empty(), metaClient.getCommitActionType());
     writeClient.close();
@@ -150,6 +159,18 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
           "RDDs cached for " + instant1 + " should be cleared.");
       assertFalse(jsc().getPersistentRDDs().containsKey(writeRecords.id()),
           "RDDs cached for " + instant1 + " should be cleared.");
+      if (metadataTableEnable) {
+        assertEquals(metadataTableCacheIds0.stream().sorted().collect(Collectors.toList()),
+            context().getCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instant0)).stream().sorted().collect(Collectors.toList()),
+            "RDDs cached for metadataTable " + instant0 + " should be retained.");
+        assertEquals(Collections.emptyList(),
+            context().getCachedDataIds(HoodieDataCacheKey.of(metadataTableBasePath, instant1)),
+            "RDDs cached for metadataTable " + instant1 + " should be cleared.");
+        metadataTableCacheIds0.forEach(cacheId -> assertTrue(jsc().getPersistentRDDs().containsKey(cacheId),
+            "RDDs cached for metadataTable cacheId " + cacheId + " should be retained."));
+        metadataTableCacheIds1.forEach(cacheId -> assertFalse(jsc().getPersistentRDDs().containsKey(cacheId),
+            "RDDs cached for metadataTable cacheId " + cacheId + " should be cleared."));
+      }
     } else {
       assertEquals(Collections.singletonList(persistedRdd0.getId()),
           context().getCachedDataIds(HoodieDataCacheKey.of(writeConfig.getBasePath(), instant0)),
@@ -163,6 +184,12 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
           "RDDs cached for " + instant1 + " should be retained.");
       assertTrue(jsc().getPersistentRDDs().containsKey(writeRecords.id()),
           "RDDs cached for " + instant1 + " should be retained.");
+      if (metadataTableEnable) {
+        metadataTableCacheIds0.forEach(cacheId -> assertTrue(jsc().getPersistentRDDs().containsKey(cacheId),
+            "RDDs cached for metadataTable cacheId " + cacheId + " should be retained."));
+        metadataTableCacheIds1.forEach(cacheId -> assertTrue(jsc().getPersistentRDDs().containsKey(cacheId),
+            "RDDs cached for metadataTable cacheId " + cacheId + " should be retained."));
+      }
     }
   }
 }


### PR DESCRIPTION
### Change Logs

#7914 only remove base table cached rdd, if open mdt, mdt cached rdd need unpersist too.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
