### PR TITLE
[HUDI-6516] Correct the use of hoodie.bootstrap.mode.selector

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/selector/BootstrapRegexModeSelector.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/selector/BootstrapRegexModeSelector.java
@@ -31,6 +31,9 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * A bootstrap selector which employs bootstrap mode by specified partitions.
+ */
 public class BootstrapRegexModeSelector extends BootstrapModeSelector {
 
   private static final long serialVersionUID = 1L;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
@@ -105,11 +105,10 @@ public class HoodieBootstrapConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> PARTITION_SELECTOR_REGEX_PATTERN = ConfigProperty
       .key("hoodie.bootstrap.mode.selector.regex")
-      .noDefaultValue()
+      .defaultValue(".*")
       .markAdvanced()
       .sinceVersion("0.6.0")
-      .withDocumentation("Matches each bootstrap dataset partition against this regex and applies the mode below to it, "
-          + "when it is specified, only BootstrapRegexModeSelector can be used");
+      .withDocumentation("Matches each bootstrap dataset partition against this regex and applies the mode below to it.");
 
   public static final ConfigProperty<String> INDEX_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.index.class")
@@ -178,6 +177,11 @@ public class HoodieBootstrapConfig extends HoodieConfig {
    */
   @Deprecated
   public static final String BOOTSTRAP_MODE_SELECTOR_REGEX_MODE = PARTITION_SELECTOR_REGEX_MODE.key();
+  /**
+   * @deprecated Use {@link #PARTITION_SELECTOR_REGEX_PATTERN} and its methods instead
+   */
+  @Deprecated
+  public static final String DEFAULT_BOOTSTRAP_MODE_SELECTOR_REGEX = PARTITION_SELECTOR_REGEX_PATTERN.defaultValue();
   /**
    * @deprecated Use {@link #PARTITION_SELECTOR_REGEX_MODE} and its methods instead
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieBootstrapConfig.java
@@ -105,10 +105,11 @@ public class HoodieBootstrapConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> PARTITION_SELECTOR_REGEX_PATTERN = ConfigProperty
       .key("hoodie.bootstrap.mode.selector.regex")
-      .defaultValue(".*")
+      .noDefaultValue()
       .markAdvanced()
       .sinceVersion("0.6.0")
-      .withDocumentation("Matches each bootstrap dataset partition against this regex and applies the mode below to it.");
+      .withDocumentation("Matches each bootstrap dataset partition against this regex and applies the mode below to it, "
+          + "when it is specified, only BootstrapRegexModeSelector can be used");
 
   public static final ConfigProperty<String> INDEX_CLASS_NAME = ConfigProperty
       .key("hoodie.bootstrap.index.class")
@@ -177,11 +178,6 @@ public class HoodieBootstrapConfig extends HoodieConfig {
    */
   @Deprecated
   public static final String BOOTSTRAP_MODE_SELECTOR_REGEX_MODE = PARTITION_SELECTOR_REGEX_MODE.key();
-  /**
-   * @deprecated Use {@link #PARTITION_SELECTOR_REGEX_PATTERN} and its methods instead
-   */
-  @Deprecated
-  public static final String DEFAULT_BOOTSTRAP_MODE_SELECTOR_REGEX = PARTITION_SELECTOR_REGEX_PATTERN.defaultValue();
   /**
    * @deprecated Use {@link #PARTITION_SELECTOR_REGEX_MODE} and its methods instead
    */

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
@@ -26,7 +26,6 @@ import org.apache.hudi.client.bootstrap.FullRecordBootstrapDataProvider;
 import org.apache.hudi.client.bootstrap.HoodieBootstrapSchemaProvider;
 import org.apache.hudi.client.bootstrap.HoodieSparkBootstrapSchemaProvider;
 import org.apache.hudi.client.bootstrap.selector.BootstrapModeSelector;
-import org.apache.hudi.client.bootstrap.selector.BootstrapRegexModeSelector;
 import org.apache.hudi.client.bootstrap.translator.BootstrapPartitionPathTranslator;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.client.utils.SparkValidatorUtils;
@@ -47,7 +46,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
@@ -111,21 +109,10 @@ public class SparkBootstrapCommitActionExecutor<T>
   }
 
   private void validate() {
-    String bootstrapModeSelectorClass = config.getBootstrapModeSelectorClass();
-    String bootstrapModeSelectorRegex = config.getBootstrapModeSelectorRegex();
-
     checkArgument(config.getBootstrapSourceBasePath() != null,
         "Ensure Bootstrap Source Path is set");
-    checkArgument(bootstrapModeSelectorClass != null,
+    checkArgument(config.getBootstrapModeSelectorClass() != null,
         "Ensure Bootstrap Partition Selector is set");
-    if (!StringUtils.isNullOrEmpty(bootstrapModeSelectorRegex)) {
-      checkArgument(bootstrapModeSelectorClass.equals(BootstrapRegexModeSelector.class.getCanonicalName()),
-          "When hoodie.bootstrap.mode.selector.regex is specified, only BootstrapRegexModeSelector can be used");
-    }
-    if (BootstrapRegexModeSelector.class.getCanonicalName().equals(bootstrapModeSelectorClass)) {
-      checkArgument(!StringUtils.isNullOrEmpty(bootstrapModeSelectorRegex),
-          "When BootstrapRegexModeSelector is used, hoodie.bootstrap.mode.selector.regex must be specified");
-    }
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
@@ -272,7 +272,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
     metaClient.reloadActiveTimeline();
     assertEquals(0, metaClient.getCommitsTimeline().countInstants());
     assertEquals(0L, BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), basePath, context)
-            .stream().flatMap(f -> f.getValue().stream()).count());
+        .stream().mapToLong(f -> f.getValue().size()).sum());
 
     BootstrapIndex index = BootstrapIndex.getBootstrapIndex(metaClient);
     assertFalse(index.useIndex());
@@ -295,7 +295,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
 
     // Upsert case
     long updateTimestamp = Instant.now().toEpochMilli();
-    String updateSPath = tmpFolder.toAbsolutePath().toString() + "/data2";
+    String updateSPath = tmpFolder.toAbsolutePath() + "/data2";
     generateNewDataSetAndReturnSchema(updateTimestamp, totalRecords, partitions, updateSPath);
     JavaRDD<HoodieRecord> updateBatch =
         generateInputBatch(jsc, BootstrapUtils.getAllLeafFoldersWithFiles(metaClient, metaClient.getFs(), updateSPath, context),
@@ -390,7 +390,6 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
       Dataset<Row> missingBootstrapped = sqlContext.sql("select a._hoodie_record_key from bootstrapped a "
           + "where a._hoodie_record_key not in (select _row_key from original)");
       assertEquals(0, missingBootstrapped.count());
-      //sqlContext.sql("select * from bootstrapped").show(10, false);
     }
 
     // RO Input Format Read
@@ -410,7 +409,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
     }
     assertEquals(totalRecords, seenKeys.size());
 
-    //RT Input Format Read
+    // RT Input Format Read
     reloadInputFormats();
     seenKeys = new HashSet<>();
     records = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(
@@ -475,7 +474,7 @@ public class TestBootstrap extends HoodieSparkClientTestBase {
     }
     assertEquals(totalRecords, seenKeys.size());
 
-    //RT Input Format Read - Project only non-hoodie column
+    // RT Input Format Read - Project only non-hoodie column
     reloadInputFormats();
     seenKeys = new HashSet<>();
     records = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapRead.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapRead.java
@@ -41,7 +41,6 @@ import org.apache.spark.sql.functions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -59,7 +58,6 @@ import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 import static org.apache.hudi.common.testutils.RawTripTestPayload.recordToString;
 import static org.apache.hudi.config.HoodieBootstrapConfig.DATA_QUERIES_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests different layouts for bootstrap base path
@@ -150,50 +148,6 @@ public class TestBootstrapRead extends HoodieSparkClientTestBase {
     doInsert(options, "002");
     compareTables();
     verifyMetaColOnlyRead(2);
-  }
-
-  @Test
-  public void testBootstrapConf() {
-    this.dashPartitions = false;
-    this.tableType = COPY_ON_WRITE;
-    this.nPartitions = 2;
-    setupDirs();
-    Dataset<Row> bootstrapDf = sparkSession.emptyDataFrame();
-
-    Map<String, String> options = basicOptions();
-    options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL());
-    options.put(HoodieBootstrapConfig.BASE_PATH.key(), bootstrapBasePath);
-
-    // Wrong usage 1
-    options.put(HoodieBootstrapConfig.MODE_SELECTOR_CLASS_NAME.key(), MetadataOnlyBootstrapModeSelector.class.getName());
-    options.put(HoodieBootstrapConfig.PARTITION_SELECTOR_REGEX_PATTERN.key(), "partition_path=2015-03-1[5-7]/.*");
-
-    assertEquals("When hoodie.bootstrap.mode.selector.regex is specified, only BootstrapRegexModeSelector can be used",
-        assertThrows(Exception.class, () ->
-            bootstrapDf.write().format("hudi")
-                .options(options)
-                .mode(SaveMode.Overwrite)
-                .save(bootstrapTargetPath)).getMessage());
-
-    // Wrong usage 2
-    options.put(HoodieBootstrapConfig.MODE_SELECTOR_CLASS_NAME.key(), BootstrapRegexModeSelector.class.getName());
-    options.remove(HoodieBootstrapConfig.PARTITION_SELECTOR_REGEX_PATTERN.key());
-
-    assertEquals("When BootstrapRegexModeSelector is used, hoodie.bootstrap.mode.selector.regex must be specified",
-        assertThrows(Exception.class, () ->
-            bootstrapDf.write().format("hudi")
-                .options(options)
-                .mode(SaveMode.Overwrite)
-                .save(bootstrapTargetPath)).getMessage());
-
-    // Correct usage
-    options.put(HoodieBootstrapConfig.MODE_SELECTOR_CLASS_NAME.key(), BootstrapRegexModeSelector.class.getName());
-    options.put(HoodieBootstrapConfig.PARTITION_SELECTOR_REGEX_PATTERN.key(), "partition_path=2015-03-1[5-7]/.*");
-
-    bootstrapDf.write().format("hudi")
-        .options(options)
-        .mode(SaveMode.Overwrite)
-        .save(bootstrapTargetPath);
   }
 
   protected Map<String, String> basicOptions() {


### PR DESCRIPTION
### Change Logs

The following is the current configuration of bootstrap's mode selection:

- `hoodie.bootstrap.mode.selector`
- `hoodie.bootstrap.mode.selector.regex`
- `hoodie.bootstrap.mode.selector.regex.mode`

Fix https://github.com/apache/hudi/pull/6673#discussion_r1257984792, The correct use of `hoodie.bootstrap.mode.selector` is: 

- set `hoodie.bootstrap.mode.selector` as `BootstrapRegexModeSelector`, specify partitions by `hoodie.bootstrap.mode.selector.regex`, then set `hoodie.bootstrap.mode.selector.regex.mode` for the specify partitions

- set  `hoodie.bootstrap.mode.selector ` as `MetadataOnlyBootstrapModeSelector` or `FullRecordBootstrapModeSelector`

### Impact

Correct the use of hoodie.bootstrap.mode.selector

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
