### PR TITLE
[HUDI-6517] Throw error if deletion of invalid data file fails

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -688,7 +688,10 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
           LOG.info("Deleting invalid data file=" + partitionFilePair);
           // Delete
           try {
-            fileSystem.delete(new Path(partitionFilePair.getValue()), false);
+            boolean result = fileSystem.delete(new Path(partitionFilePair.getValue()), false);
+            if (!result) {
+              throw new HoodieIOException(String.format("Deletion of file %s was not successful", partitionFilePair.getValue()));
+            }
           } catch (IOException e) {
             throw new HoodieIOException(e.getMessage(), e);
           }


### PR DESCRIPTION
### Change Logs

Currently we do not throw an exception if invalid data file deletion fails.
```
fileSystem.delete(new Path(partitionFilePair.getValue()), false)
```
The result of the delete call is not checked today. The PR adds a check for it and throws exception in case delete fails.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
