### PR TITLE
[HUDI-6526] Hoodie Hive catalog sync timestamp(3) as timestamp type into Hive

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TypeInfoLogicalTypeVisitor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TypeInfoLogicalTypeVisitor.java
@@ -137,7 +137,7 @@ public class TypeInfoLogicalTypeVisitor extends LogicalTypeDefaultVisitor<TypeIn
     int precision = timestampType.getPrecision();
     // see org.apache.hudi.hive.util.HiveSchemaUtil#convertField for details.
     // default supports timestamp
-    if (precision == 6) {
+    if (precision <= 6) {
       return TypeInfoFactory.timestampTypeInfo;
     } else {
       return TypeInfoFactory.longTypeInfo;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
@@ -85,7 +85,8 @@ public class TestHoodieHiveCatalog {
           .field("name", DataTypes.STRING())
           .field("age", DataTypes.INT())
           .field("par1", DataTypes.STRING())
-          .field("ts", DataTypes.BIGINT())
+          .field("ts_3", DataTypes.TIMESTAMP(3))
+          .field("ts_6", DataTypes.TIMESTAMP(6))
           .primaryKey("uuid")
           .build();
   List<String> partitions = Collections.singletonList("par1");
@@ -135,7 +136,8 @@ public class TestHoodieHiveCatalog {
         + "uuid:int,"
         + "name:string,"
         + "age:int,"
-        + "ts:bigint";
+        + "ts_3:timestamp,"
+        + "ts_6:timestamp";
     assertEquals(expectedFieldSchema, fieldSchema);
     String partitionSchema = hiveTable.getPartitionKeys().stream()
         .map(f -> f.getName() + ":" + f.getType())
@@ -153,7 +155,8 @@ public class TestHoodieHiveCatalog {
         + "{\"name\":\"uuid\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},"
         + "{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
         + "{\"name\":\"age\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},"
-        + "{\"name\":\"ts\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"ts_3\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},"
+        + "{\"name\":\"ts_6\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},"
         + "{\"name\":\"par1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}";
     assertEquals(expectedAvroSchemaStr, avroSchemaStr);
 
@@ -166,7 +169,7 @@ public class TestHoodieHiveCatalog {
     String tableSchema = table1.getUnresolvedSchema().getColumns().stream()
         .map(Schema.UnresolvedColumn::toString)
         .collect(Collectors.joining(","));
-    String expectedTableSchema = "`uuid` INT NOT NULL,`name` STRING,`age` INT,`par1` STRING,`ts` BIGINT";
+    String expectedTableSchema = "`uuid` INT NOT NULL,`name` STRING,`age` INT,`par1` STRING,`ts_3` TIMESTAMP(3),`ts_6` TIMESTAMP(6)";
     assertEquals(expectedTableSchema, tableSchema);
     assertEquals(Collections.singletonList("uuid"), table1.getUnresolvedSchema().getPrimaryKey().get().getColumnNames());
     assertEquals(Collections.singletonList("par1"), ((CatalogTable) table1).getPartitionKeys());


### PR DESCRIPTION
### Change Logs

After HUDI-6307, timestamp(3) is also synced as timestamp type in Hive.

### Impact

The table created through hive catalog would sync the timestamp(3) as timestamp in Hive.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
