### PR TITLE
[HUDI-6583] Fix HoodieWriteClient confs in HoodieCLIUtils

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -32,13 +32,13 @@ import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.hudi.HoodieOptionConfig
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.isHoodieConfigKey
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter, propertiesAsScalaMapConverter}
 
 object HoodieCLIUtils {
 
   def createHoodieWriteClient(sparkSession: SparkSession,
                               basePath: String,
-                              confs: Map[String, String],
+                              conf: Map[String, String],
                               tableName: Option[String]): SparkRDDWriteClient[_] = {
     val metaClient = HoodieTableMetaClient.builder().setBasePath(basePath)
       .setConf(sparkSession.sessionState.newHadoopConf()).build()
@@ -52,12 +52,12 @@ object HoodieCLIUtils {
       case None => Map.empty
     }
 
-    // Priority: defaults < catalog props < table configs < sparkSession confs < specified confs
+    // Priority: defaults < catalog props < table config < sparkSession conf < specified conf
     val finalParameters = HoodieWriterUtils.parametersWithWriteDefaults(
       catalogProps ++
         metaClient.getTableConfig.getProps.asScala.toMap ++
         sparkSession.sqlContext.getAllConfs.filterKeys(isHoodieConfigKey) ++
-        confs
+        conf
     )
 
     val jsc = new JavaSparkContext(sparkSession.sparkContext)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -23,33 +23,41 @@ import org.apache.hudi.avro.model.HoodieClusteringGroup
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.StringUtils
+
 import org.apache.spark.SparkException
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
-import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.withSparkConf
+import org.apache.spark.sql.hudi.HoodieOptionConfig
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.isHoodieConfigKey
 
-import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter}
+import scala.collection.JavaConverters._
 
 object HoodieCLIUtils {
 
   def createHoodieWriteClient(sparkSession: SparkSession,
                               basePath: String,
-                              conf: Map[String, String],
+                              confs: Map[String, String],
                               tableName: Option[String]): SparkRDDWriteClient[_] = {
     val metaClient = HoodieTableMetaClient.builder().setBasePath(basePath)
       .setConf(sparkSession.sessionState.newHadoopConf()).build()
     val schemaUtil = new TableSchemaResolver(metaClient)
     val schemaStr = schemaUtil.getTableAvroSchema(false).toString
+
     // If tableName is provided, we need to add catalog props
     val catalogProps = tableName match {
-      case Some(value) => getHoodieCatalogTable(sparkSession, value).catalogProperties
+      case Some(value) => HoodieOptionConfig.mapSqlOptionsToDataSourceWriteConfigs(
+        getHoodieCatalogTable(sparkSession, value).catalogProperties)
       case None => Map.empty
     }
+
+    // Priority: defaults < catalog props < table configs < sparkSession confs < specified confs
     val finalParameters = HoodieWriterUtils.parametersWithWriteDefaults(
-      withSparkConf(sparkSession, Map.empty)(
-        catalogProps ++ conf + (DataSourceWriteOptions.TABLE_TYPE.key() -> metaClient.getTableType.name()))
+      catalogProps ++
+        metaClient.getTableConfig.getProps.asScala.toMap ++
+        sparkSession.sqlContext.getAllConfs.filterKeys(isHoodieConfigKey) ++
+        confs
     )
 
     val jsc = new JavaSparkContext(sparkSession.sparkContext)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -216,16 +216,6 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
   }
 
   /**
-   * Append the spark config and table options to the baseConfig.
-   */
-  def withSparkConf(spark: SparkSession, options: Map[String, String])
-                   (baseConfig: Map[String, String] = Map.empty): Map[String, String] = {
-    baseConfig ++ DFSPropertiesConfiguration.getGlobalProps.asScala ++ // Table options has the highest priority
-      (spark.sessionState.conf.getAllConfs ++ HoodieOptionConfig.mapSqlOptionsToDataSourceWriteConfigs(options))
-        .filterKeys(isHoodieConfigKey)
-  }
-
-  /**
    * Check if Sql options are Hoodie Config keys.
    *
    * TODO: standardize the key prefix so that we don't need this helper (HUDI-4935)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureUtils.scala
@@ -99,7 +99,7 @@ object HoodieProcedureUtils {
     }
   }
 
-  def fileterPendingInstantsAndGetOperation(pendingInstants: Seq[String], specificInstants: Option[String], op: Option[String]): (Seq[String], Operation) = {
+  def filterPendingInstantsAndGetOperation(pendingInstants: Seq[String], specificInstants: Option[String], op: Option[String]): (Seq[String], Operation) = {
     specificInstants match {
       case Some(inst) =>
         if (op.exists(o => !Execute.value.equalsIgnoreCase(o))) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -143,7 +143,7 @@ class RunClusteringProcedure extends BaseProcedure
     val pendingClusteringInstants = ClusteringUtils.getAllPendingClusteringPlans(metaClient)
       .iterator().asScala.map(_.getLeft.getTimestamp).toSeq.sortBy(f => f)
 
-    var (filteredPendingClusteringInstants, operation) = HoodieProcedureUtils.fileterPendingInstantsAndGetOperation(
+    var (filteredPendingClusteringInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
       pendingClusteringInstants, specificInstants.asInstanceOf[Option[String]], op.asInstanceOf[Option[String]])
 
     var client: SparkRDDWriteClient[_] = null

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -88,7 +88,7 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
       .map(_.getTimestamp)
       .toSeq.sortBy(f => f)
 
-    var (filteredPendingCompactionInstants, operation) = HoodieProcedureUtils.fileterPendingInstantsAndGetOperation(
+    var (filteredPendingCompactionInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
       pendingCompactionInstants, specificInstants.asInstanceOf[Option[String]], Option(op))
 
     var client: SparkRDDWriteClient[_] = null

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
@@ -695,8 +695,7 @@ class TestClusteringProcedure extends HoodieSparkProcedureTestBase {
            |  type = 'cow',
            |  preCombineField = 'ts',
            |  hoodie.index.type = 'BUCKET',
-           |  hoodie.bucket.index.hash.field = 'id',
-           |  hoodie.datasource.write.recordkey.field = 'id'
+           |  hoodie.bucket.index.hash.field = 'id'
            | )
            | partitioned by (ts)
            | location '$basePath'


### PR DESCRIPTION
### Change Logs

- Fix HoodieWriteClient confs in HoodieCLIUtils:
Priority: defaults < catalog props < table configs < sparkSession confs < specified confs

- Add `mapSqlOptionsToDataSourceWriteConfigs` for `catalogProperties`

### Impact

Fix HoodieWriteClient confs in HoodieCLIUtils

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
