### PR TITLE
[HUDI-6531] Little adjust to avoid creating an object but no need in one case

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -78,8 +78,8 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
   @Override
   public List<String> getAllPartitionPaths() throws IOException {
     Path basePath = new Path(datasetBasePath);
-    FileSystem fs = basePath.getFileSystem(hadoopConf.get());
     if (assumeDatePartitioning) {
+      FileSystem fs = basePath.getFileSystem(hadoopConf.get());
       return FSUtils.getAllPartitionFoldersThreeLevelsDown(fs, datasetBasePath);
     }
 


### PR DESCRIPTION
### Change Logs

Change the spot of creating a FileSystem object.

### Impact

No matter the “hoodie.assume.date.partitioning” value true or false, the logic not change. 

### Risk level (write none, low medium or high below)

none

### Documentation Update

NONE

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
