### PR TITLE
[HUDI-6532] Fix a typo in BaseFlinkCommitActionExecutor.

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/BaseFlinkCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/BaseFlinkCommitActionExecutor.java
@@ -194,7 +194,7 @@ public abstract class BaseFlinkCommitActionExecutor<T> extends
         }
       }
     } catch (Throwable t) {
-      String msg = "Error upsetting bucketType " + bucketType + " for partition :" + partitionPath;
+      String msg = "Error upserting bucketType " + bucketType + " for partition :" + partitionPath;
       LOG.error(msg, t);
       throw new HoodieUpsertException(msg, t);
     }


### PR DESCRIPTION
### Change Logs

The word "upsetting" in exception is kind of misleading. Maybe should make a little change. 

### Impact

Only change the description.

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
