### PR TITLE
[HUDI-6534]Support consistent hashing row writer

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
@@ -86,6 +86,10 @@ public class ConsistentBucketIdentifier extends BucketIdentifier {
     return getBucket(getHashKeys(hoodieKey.getRecordKey(), indexKeyFields));
   }
 
+  public ConsistentHashingNode getBucket(String hoodieKey, String indexKeyFields) {
+    return getBucket(getHashKeys(hoodieKey, indexKeyFields));
+  }
+
   protected ConsistentHashingNode getBucket(List<String> hashKeys) {
     int hashValue = HashID.getXXHash32(String.join("", hashKeys), 0);
     return getBucket(hashValue & HoodieConsistentHashingMetadata.HASH_VALUE_MASK);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/ConsistentHashingBucketInsertPartitioner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/ConsistentHashingBucketInsertPartitioner.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table;
+
+import org.apache.hudi.common.model.ConsistentHashingNode;
+
+import java.util.List;
+
+public interface ConsistentHashingBucketInsertPartitioner {
+  /**
+   * Set consistent hashing for partition, used in clustering
+   *
+   * @param partition partition to set Consistent Hashing nodes
+   * @param nodes     nodes from clustering plan
+   */
+  void addHashingChildrenNodes(String partition, List<ConsistentHashingNode> nodes);
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkConsistentBucketClusteringExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkConsistentBucketClusteringExecutionStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.clustering.run.strategy;
 
+import org.apache.hudi.HoodieDatasetBulkInsertHelper;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -27,7 +28,9 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieClusteringException;
+import org.apache.hudi.execution.bulkinsert.ConsistentBucketIndexBulkInsertPartitionerWithRows;
 import org.apache.hudi.execution.bulkinsert.RDDConsistentBucketBulkInsertPartitioner;
+import org.apache.hudi.table.ConsistentHashingBucketInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.cluster.strategy.BaseConsistentHashingBucketClusteringPlanStrategy;
 import org.apache.hudi.table.action.commit.SparkBulkInsertHelper;
@@ -64,7 +67,19 @@ public class SparkConsistentBucketClusteringExecutionStrategy<T extends HoodieRe
                                                                    List<HoodieFileGroupId> fileGroupIdList,
                                                                    boolean shouldPreserveHoodieMetadata,
                                                                    Map<String, String> extraMetadata) {
-    throw new HoodieClusteringException("Not implement yet");
+    LOG.info("Starting clustering for a group, parallelism:" + numOutputGroups + " commit:" + instantTime);
+    Properties props = getWriteConfig().getProps();
+
+    HoodieWriteConfig newConfig = HoodieWriteConfig.newBuilder().withProps(props).build();
+
+    ConsistentBucketIndexBulkInsertPartitionerWithRows partitioner = new ConsistentBucketIndexBulkInsertPartitionerWithRows(getHoodieTable(), shouldPreserveHoodieMetadata);
+
+    addHashingChildNodes(partitioner, extraMetadata);
+
+    Dataset<Row> repartitionedRecords = partitioner.repartitionRecords(inputRecords, numOutputGroups);
+
+    return HoodieDatasetBulkInsertHelper.bulkInsert(repartitionedRecords, instantTime, getHoodieTable(), newConfig,
+        partitioner.arePartitionRecordsSorted(), shouldPreserveHoodieMetadata);
   }
 
   @Override
@@ -79,6 +94,13 @@ public class SparkConsistentBucketClusteringExecutionStrategy<T extends HoodieRe
     HoodieWriteConfig newConfig = HoodieWriteConfig.newBuilder().withProps(props).build();
 
     RDDConsistentBucketBulkInsertPartitioner<T> partitioner = new RDDConsistentBucketBulkInsertPartitioner<>(getHoodieTable(), strategyParams, preserveHoodieMetadata);
+    addHashingChildNodes(partitioner, extraMetadata);
+
+    return (HoodieData<WriteStatus>) SparkBulkInsertHelper.newInstance()
+        .bulkInsert(inputRecords, instantTime, getHoodieTable(), newConfig, false, partitioner, true, numOutputGroups);
+  }
+
+  private void addHashingChildNodes(ConsistentHashingBucketInsertPartitioner partitioner, Map<String, String> extraMetadata) {
     try {
       List<ConsistentHashingNode> nodes = ConsistentHashingNode.fromJsonString(extraMetadata.get(BaseConsistentHashingBucketClusteringPlanStrategy.METADATA_CHILD_NODE_KEY));
       partitioner.addHashingChildrenNodes(extraMetadata.get(BaseConsistentHashingBucketClusteringPlanStrategy.METADATA_PARTITION_KEY), nodes);
@@ -86,8 +108,5 @@ public class SparkConsistentBucketClusteringExecutionStrategy<T extends HoodieRe
       LOG.error("Failed to add hashing children nodes", e);
       throw new HoodieClusteringException("Failed to add hashing children nodes", e);
     }
-
-    return (HoodieData<WriteStatus>) SparkBulkInsertHelper.newInstance()
-        .bulkInsert(inputRecords, instantTime, getHoodieTable(), newConfig, false, partitioner, true, numOutputGroups);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/ConsistentBucketIndexBulkInsertPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/ConsistentBucketIndexBulkInsertPartitionerWithRows.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.execution.bulkinsert;
+
+import org.apache.hudi.common.model.ConsistentHashingNode;
+import org.apache.hudi.common.model.HoodieConsistentHashingMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.index.bucket.ConsistentBucketIdentifier;
+import org.apache.hudi.index.bucket.ConsistentBucketIndexUtils;
+import org.apache.hudi.index.bucket.HoodieSparkConsistentBucketIndex;
+import org.apache.hudi.keygen.BuiltinKeyGenerator;
+import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory;
+import org.apache.hudi.table.BulkInsertPartitioner;
+import org.apache.hudi.table.ConsistentHashingBucketInsertPartitioner;
+import org.apache.hudi.table.HoodieTable;
+
+import org.apache.spark.Partitioner;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import scala.Tuple2;
+
+/**
+ * Bulk_insert partitioner of Spark row using consistent hashing bucket index.
+ */
+public class ConsistentBucketIndexBulkInsertPartitionerWithRows
+    implements BulkInsertPartitioner<Dataset<Row>>, ConsistentHashingBucketInsertPartitioner {
+
+  private final HoodieTable table;
+
+  private final String indexKeyFields;
+
+  private final List<String> fileIdPfxList = new ArrayList<>();
+  private final Map<String, List<ConsistentHashingNode>> hashingChildrenNodes;
+
+  private Map<String, ConsistentBucketIdentifier> partitionToIdentifier;
+
+  private final Option<BuiltinKeyGenerator> keyGeneratorOpt;
+
+  private Map<String, Map<String, Integer>> partitionToFileIdPfxIdxMap;
+
+  private final RowRecordKeyExtractor extractor;
+
+  public ConsistentBucketIndexBulkInsertPartitionerWithRows(HoodieTable table, boolean populateMetaFields) {
+    this.indexKeyFields = table.getConfig().getBucketIndexHashField();
+    this.table = table;
+    this.hashingChildrenNodes = new HashMap<>();
+    if (!populateMetaFields) {
+      this.keyGeneratorOpt = HoodieSparkKeyGeneratorFactory.getKeyGenerator(table.getConfig().getProps());
+    } else {
+      this.keyGeneratorOpt = Option.empty();
+    }
+    this.extractor = RowRecordKeyExtractor.getRowRecordKeyExtractor(populateMetaFields, keyGeneratorOpt);
+    ValidationUtils.checkArgument(table.getMetaClient().getTableType().equals(HoodieTableType.MERGE_ON_READ),
+        "Consistent hash bucket index doesn't support CoW table");
+  }
+
+  private ConsistentBucketIdentifier getBucketIdentifier(String partition) {
+    HoodieSparkConsistentBucketIndex index = (HoodieSparkConsistentBucketIndex) table.getIndex();
+    HoodieConsistentHashingMetadata metadata = ConsistentBucketIndexUtils.loadOrCreateMetadata(this.table, partition, index.getNumBuckets());
+    if (hashingChildrenNodes.containsKey(partition)) {
+      metadata.setChildrenNodes(hashingChildrenNodes.get(partition));
+    }
+    return new ConsistentBucketIdentifier(metadata);
+  }
+
+  @Override
+  public Dataset<Row> repartitionRecords(Dataset<Row> rows, int outputPartitions) {
+    JavaRDD<Row> rowJavaRDD = rows.toJavaRDD();
+    prepareRepartition(rowJavaRDD);
+    Partitioner partitioner = new Partitioner() {
+      @Override
+      public int getPartition(Object key) {
+        return (int) key;
+      }
+
+      @Override
+      public int numPartitions() {
+        return fileIdPfxList.size();
+      }
+    };
+
+    return rows.sparkSession().createDataFrame(rowJavaRDD
+        .mapToPair(row -> new Tuple2<>(getBucketId(row), row))
+        .partitionBy(partitioner)
+        .values(), rows.schema());
+  }
+
+  /**
+   * Prepare consistent hashing metadata for repartition
+   *
+   * @param rows input records
+   */
+  private void prepareRepartition(JavaRDD<Row> rows) {
+    this.partitionToIdentifier = initializeBucketIdentifier(rows);
+    this.partitionToFileIdPfxIdxMap = ConsistentBucketIndexUtils.generatePartitionToFileIdPfxIdxMap(partitionToIdentifier);
+    partitionToIdentifier.values().forEach(identifier -> {
+      fileIdPfxList.addAll(identifier.getNodes().stream().map(ConsistentHashingNode::getFileIdPrefix).collect(Collectors.toList()));
+    });
+  }
+
+  /**
+   * Initialize hashing metadata of input records. The metadata of all related partitions will be loaded, and
+   * the mapping from partition to its bucket identifier is constructed.
+   */
+  private Map<String, ConsistentBucketIdentifier> initializeBucketIdentifier(JavaRDD<Row> rows) {
+    return rows.map(this.extractor::getPartitionPath).distinct().collect().stream()
+        .collect(Collectors.toMap(p -> p, this::getBucketIdentifier));
+  }
+
+  @Override
+  public void addHashingChildrenNodes(String partition, List<ConsistentHashingNode> nodes) {
+    ValidationUtils.checkState(nodes.stream().noneMatch(n -> n.getTag() == ConsistentHashingNode.NodeTag.NORMAL),
+        "children nodes should not be tagged as NORMAL");
+    hashingChildrenNodes.put(partition, nodes);
+  }
+
+  @Override
+  public boolean arePartitionRecordsSorted() {
+    return false;
+  }
+
+  private int getBucketId(Row row) {
+    String recordKey = extractor.getRecordKey(row);
+    String partitionPath = extractor.getPartitionPath(row);
+    ConsistentHashingNode node = partitionToIdentifier.get(partitionPath).getBucket(recordKey, indexKeyFields);
+    return partitionToFileIdPfxIdxMap.get(partitionPath).get(node.getFileIdPrefix());
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDConsistentBucketBulkInsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDConsistentBucketBulkInsertPartitioner.java
@@ -18,16 +18,23 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
+import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.ConsistentHashingNode;
 import org.apache.hudi.common.model.HoodieConsistentHashingMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.bucket.ConsistentBucketIdentifier;
 import org.apache.hudi.index.bucket.ConsistentBucketIndexUtils;
 import org.apache.hudi.index.bucket.HoodieSparkConsistentBucketIndex;
+import org.apache.hudi.io.HoodieWriteHandle;
+import org.apache.hudi.io.WriteHandleFactory;
+import org.apache.hudi.table.ConsistentHashingBucketInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
+
 import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaRDD;
 
@@ -42,7 +49,7 @@ import static org.apache.hudi.config.HoodieClusteringConfig.PLAN_STRATEGY_SORT_C
 /**
  * A partitioner for (consistent hashing) bucket index used in bulk_insert
  */
-public class RDDConsistentBucketBulkInsertPartitioner<T> extends RDDBucketIndexPartitioner<T> {
+public class RDDConsistentBucketBulkInsertPartitioner<T> extends RDDBucketIndexPartitioner<T> implements ConsistentHashingBucketInsertPartitioner {
 
   private final Map<String, List<ConsistentHashingNode>> hashingChildrenNodes;
 
@@ -92,6 +99,7 @@ public class RDDConsistentBucketBulkInsertPartitioner<T> extends RDDBucketIndexP
     });
   }
 
+  @Override
   public void addHashingChildrenNodes(String partition, List<ConsistentHashingNode> nodes) {
     ValidationUtils.checkState(nodes.stream().noneMatch(n -> n.getTag() == ConsistentHashingNode.NodeTag.NORMAL), "children nodes should not be tagged as NORMAL");
     hashingChildrenNodes.put(partition, nodes);
@@ -115,26 +123,26 @@ public class RDDConsistentBucketBulkInsertPartitioner<T> extends RDDBucketIndexP
    */
   private Map<String, ConsistentBucketIdentifier> initializeBucketIdentifier(JavaRDD<HoodieRecord<T>> records) {
     return records.map(HoodieRecord::getPartitionPath).distinct().collect().stream()
-        .collect(Collectors.toMap(p -> p, p -> getBucketIdentifier(p)));
+        .collect(Collectors.toMap(p -> p, this::getBucketIdentifier));
   }
 
   /**
    * Initialize fileIdPfx for each data partition. Specifically, the following fields is constructed:
    * - fileIdPfxList: the Nth element corresponds to the Nth data partition, indicating its fileIdPfx
-   * - doAppend: represents if the Nth data partition should use AppendHandler
    * - partitionToFileIdPfxIdxMap (return value): (table partition) -> (fileIdPfx -> idx) mapping
+   * - doAppend: represents if the Nth data partition should use AppendHandler
    *
    * @param partitionToIdentifier Mapping from table partition to bucket identifier
    */
   private Map<String, Map<String, Integer>> generateFileIdPfx(Map<String, ConsistentBucketIdentifier> partitionToIdentifier) {
-    Map<String, Map<String, Integer>> partitionToFileIdPfxIdxMap = new HashMap(partitionToIdentifier.size() * 2);
+    Map<String, Map<String, Integer>> partitionToFileIdPfxIdxMap = ConsistentBucketIndexUtils.generatePartitionToFileIdPfxIdxMap(partitionToIdentifier);
     int count = 0;
     for (ConsistentBucketIdentifier identifier : partitionToIdentifier.values()) {
+      fileIdPfxList.addAll(identifier.getNodes().stream().map(ConsistentHashingNode::getFileIdPrefix).collect(Collectors.toList()));
       Map<String, Integer> fileIdPfxToIdx = new HashMap();
       for (ConsistentHashingNode node : identifier.getNodes()) {
         fileIdPfxToIdx.put(node.getFileIdPrefix(), count++);
       }
-      fileIdPfxList.addAll(identifier.getNodes().stream().map(ConsistentHashingNode::getFileIdPrefix).collect(Collectors.toList()));
       if (identifier.getMetadata().isFirstCreated()) {
         // Create new file group when the hashing metadata is new (i.e., first write to the partition)
         doAppend.addAll(Collections.nCopies(identifier.getNodes().size(), false));
@@ -144,9 +152,20 @@ public class RDDConsistentBucketBulkInsertPartitioner<T> extends RDDBucketIndexP
       }
       partitionToFileIdPfxIdxMap.put(identifier.getMetadata().getPartitionPath(), fileIdPfxToIdx);
     }
-
     ValidationUtils.checkState(fileIdPfxList.size() == partitionToIdentifier.values().stream().mapToInt(ConsistentBucketIdentifier::getNumBuckets).sum(),
         "Error state after constructing fileId & idx mapping");
     return partitionToFileIdPfxIdxMap;
+  }
+
+  @Override
+  public Option<WriteHandleFactory> getWriteHandleFactory(int idx) {
+    return super.getWriteHandleFactory(idx).map(writeHandleFactory -> new WriteHandleFactory() {
+      @Override
+      public HoodieWriteHandle create(HoodieWriteConfig config, String commitTime, HoodieTable hoodieTable, String partitionPath, String fileIdPrefix, TaskContextSupplier taskContextSupplier) {
+        // Ensure we do not create append handle for consistent hashing bulk_insert, align with `ConsistentBucketBulkInsertDataInternalWriterHelper`
+        ValidationUtils.checkArgument(!doAppend.get(idx), "Consistent Hashing bulk_insert only support write to new file group");
+        return writeHandleFactory.create(config, commitTime, hoodieTable, partitionPath, fileIdPrefix, taskContextSupplier);
+      }
+    });
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowRecordKeyExtractor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RowRecordKeyExtractor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.execution.bulkinsert;
+
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.keygen.BuiltinKeyGenerator;
+
+import org.apache.spark.sql.Row;
+
+import java.io.Serializable;
+
+public interface RowRecordKeyExtractor extends Serializable {
+  String getPartitionPath(Row row);
+
+  String getRecordKey(Row row);
+
+  static RowRecordKeyExtractor getRowRecordKeyExtractor(boolean populateMetaFields, Option<BuiltinKeyGenerator> keyGeneratorOpt) {
+    if (populateMetaFields) {
+      return new MetaFiledRowKeyExtractor();
+    } else if (keyGeneratorOpt.isPresent()) {
+      return new BuiltInKeyGenRowKeyExtractor(keyGeneratorOpt.get());
+    } else {
+      return new EmptyRowKeyExtractor();
+    }
+  }
+
+  class MetaFiledRowKeyExtractor implements RowRecordKeyExtractor {
+    @Override
+    public String getPartitionPath(Row row) {
+      // In case meta-fields are materialized w/in the table itself, we can just simply extract
+      // partition path from there
+      return row.getString(HoodieRecord.PARTITION_PATH_META_FIELD_ORD);
+    }
+
+    @Override
+    public String getRecordKey(Row row) {
+      // In case meta-fields are materialized w/in the table itself, we can just simply extract
+      // record key from there
+      return row.getString(HoodieRecord.RECORD_KEY_META_FIELD_ORD);
+    }
+  }
+
+  class BuiltInKeyGenRowKeyExtractor implements RowRecordKeyExtractor {
+    private final BuiltinKeyGenerator keyGenerator;
+
+    public BuiltInKeyGenRowKeyExtractor(BuiltinKeyGenerator keyGenerator) {
+      this.keyGenerator = keyGenerator;
+    }
+
+    @Override
+    public String getPartitionPath(Row row) {
+      return keyGenerator.getPartitionPath(row);
+    }
+
+    @Override
+    public String getRecordKey(Row row) {
+      return keyGenerator.getRecordKey(row);
+    }
+  }
+
+  class EmptyRowKeyExtractor implements RowRecordKeyExtractor {
+    @Override
+    public String getPartitionPath(Row row) {
+      return StringUtils.EMPTY_STRING;
+    }
+
+    @Override
+    public String getRecordKey(Row row) {
+      return StringUtils.EMPTY_STRING;
+    }
+  }
+
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/factory/HoodieSparkKeyGeneratorFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/factory/HoodieSparkKeyGeneratorFactory.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieKeyGeneratorException;
 import org.apache.hudi.keygen.BuiltinKeyGenerator;
 import org.apache.hudi.keygen.ComplexKeyGenerator;
@@ -44,6 +45,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.apache.hudi.config.HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY;
 import static org.apache.hudi.config.HoodieWriteConfig.KEYGENERATOR_TYPE;
@@ -114,6 +116,29 @@ public class HoodieSparkKeyGeneratorFactory {
         return GlobalDeleteKeyGenerator.class.getName();
       default:
         throw new HoodieKeyGeneratorException("Unsupported keyGenerator Type " + type);
+    }
+  }
+
+  /**
+   * Instantiate {@link BuiltinKeyGenerator}.
+   *
+   * @param properties properties map.
+   * @return the key generator thus instantiated.
+   */
+  public static Option<BuiltinKeyGenerator> getKeyGenerator(Properties properties) {
+    TypedProperties typedProperties = new TypedProperties();
+    typedProperties.putAll(properties);
+    if (Option.ofNullable(properties.get(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key()))
+        .map(v -> v.equals(NonpartitionedKeyGenerator.class.getName())).orElse(false)) {
+      return Option.empty(); // Do not instantiate NonPartitionKeyGen
+    } else {
+      try {
+        return Option.of((BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(typedProperties));
+      } catch (ClassCastException cce) {
+        throw new HoodieIOException("Only those key generators implementing BuiltInKeyGenerator interface is supported with virtual keys");
+      } catch (IOException e) {
+        throw new HoodieIOException("Key generator instantiation failed ", e);
+      }
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BucketBulkInsertDataInternalWriterHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BucketBulkInsertDataInternalWriterHelper.java
@@ -102,7 +102,9 @@ public class BucketBulkInsertDataInternalWriterHelper extends BulkInsertDataInte
         // if records are sorted, we can close all existing handles
         close();
       }
-      HoodieRowCreateHandle rowCreateHandle = new HoodieRowCreateHandle(hoodieTable, writeConfig, String.valueOf(fileId.getLeft()), getNextBucketFileId(bucketId),
+      String partitionPath = String.valueOf(fileId.getLeft());
+      LOG.info("Creating new file for partition path " + partitionPath);
+      HoodieRowCreateHandle rowCreateHandle = new HoodieRowCreateHandle(hoodieTable, writeConfig, partitionPath, getNextBucketFileId(bucketId),
           instantTime, taskPartitionId, taskId, taskEpochId, structType, shouldPreserveHoodieMetadata);
       handles.put(fileId, rowCreateHandle);
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/ConsistentBucketBulkInsertDataInternalWriterHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/ConsistentBucketBulkInsertDataInternalWriterHelper.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.commit;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.ConsistentHashingNode;
+import org.apache.hudi.common.model.HoodieConsistentHashingMetadata;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.bucket.ConsistentBucketIdentifier;
+import org.apache.hudi.index.bucket.ConsistentBucketIndexUtils;
+import org.apache.hudi.io.storage.row.HoodieRowCreateHandle;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.cluster.util.ConsistentHashingUpdateStrategyUtils;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class for native row writer for bulk_insert with consistent hashing bucket index.
+ */
+public class ConsistentBucketBulkInsertDataInternalWriterHelper extends BucketBulkInsertDataInternalWriterHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConsistentBucketBulkInsertDataInternalWriterHelper.class);
+
+  public ConsistentBucketBulkInsertDataInternalWriterHelper(HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
+                                                            String instantTime, int taskPartitionId, long taskId, long taskEpochId, StructType structType,
+                                                            boolean populateMetaFields, boolean arePartitionRecordsSorted) {
+    this(hoodieTable, writeConfig, instantTime, taskPartitionId, taskId, taskEpochId, structType, populateMetaFields, arePartitionRecordsSorted, false);
+  }
+
+  public ConsistentBucketBulkInsertDataInternalWriterHelper(HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
+                                                            String instantTime, int taskPartitionId, long taskId, long taskEpochId, StructType structType,
+                                                            boolean populateMetaFields, boolean arePartitionRecordsSorted, boolean shouldPreserveHoodieMetadata) {
+    super(hoodieTable, writeConfig, instantTime, taskPartitionId, taskId, taskEpochId, structType, populateMetaFields, arePartitionRecordsSorted, shouldPreserveHoodieMetadata);
+  }
+
+  public void write(InternalRow row) throws IOException {
+    try {
+      if (handle == null) {
+        // We can ensure that one writer has only one handle
+        String partitionPath = String.valueOf(extractPartitionPath(row));
+        String recordKey = String.valueOf(extractRecordKey(row));
+        handle = getBucketRowCreateHandle(partitionPath, recordKey);
+      }
+      handle.write(row);
+    } catch (Throwable t) {
+      LOG.error("Global error thrown while trying to write records in HoodieRowCreateHandle ", t);
+      throw new IOException(t);
+    }
+  }
+
+  private HoodieRowCreateHandle getBucketRowCreateHandle(String partitionPath, String recordKey) {
+    ConsistentBucketIdentifier identifier = getBucketIdentifier(partitionPath);
+    final ConsistentHashingNode node = identifier.getBucket(recordKey, indexKeyFields);
+    String fileId = FSUtils.createNewFileId(node.getFileIdPrefix(), 0);
+
+    ValidationUtils.checkArgument(node.getTag() != ConsistentHashingNode.NodeTag.NORMAL
+            || hoodieTable.getFileSystemView()
+            .getAllFileGroups(partitionPath)
+            // Find file groups with committed file slices
+            .filter(fg -> fg.getAllFileSlices().findAny().isPresent())
+            // Ensure only bulk insert into new file group
+            .noneMatch(fg -> fg.getFileGroupId().getFileId().equals(fileId)),
+        "Consistent Hashing bulk_insert only support write to new file group");
+
+    // Always create new base file for bulk_insert
+    return new HoodieRowCreateHandle(hoodieTable, writeConfig, partitionPath, fileId,
+        instantTime, taskPartitionId, taskId, taskEpochId, structType, shouldPreserveHoodieMetadata);
+  }
+
+  private ConsistentBucketIdentifier getBucketIdentifier(String partition) {
+    Set<HoodieFileGroupId> fileGroupsInPendingClustering = hoodieTable.getFileSystemView().getFileGroupsInPendingClustering()
+        .map(Pair::getKey).collect(Collectors.toSet());
+    if (fileGroupsInPendingClustering.stream().anyMatch(f -> f.getPartitionPath().equals(partition))) {
+      Pair<String, ConsistentBucketIdentifier> bucketIdentifierPair =
+          ConsistentHashingUpdateStrategyUtils.constructPartitionToIdentifier(Collections.singleton(partition), hoodieTable).get(partition);
+      return bucketIdentifierPair.getRight();
+    } else {
+      HoodieConsistentHashingMetadata metadata = ConsistentBucketIndexUtils.loadOrCreateMetadata(hoodieTable, String.valueOf(partition), bucketNum);
+      ValidationUtils.checkState(metadata != null);
+      return new ConsistentBucketIdentifier(metadata);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (handle != null) {
+      LOG.info("Closing bulk insert file " + handle.getFileName());
+      writeStatusList.add(handle.close());
+      handle = null;
+    }
+  }
+
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -368,7 +368,7 @@ object HoodieSparkSqlWriter {
 
             // Short-circuit if bulk_insert via row is enabled.
             // scalastyle:off
-            if (hoodieConfig.getBoolean(ENABLE_ROW_WRITER) && operation == WriteOperationType.BULK_INSERT && !isConsistentHashingBucketIndex(client)) {
+            if (hoodieConfig.getBoolean(ENABLE_ROW_WRITER) && operation == WriteOperationType.BULK_INSERT) {
               return bulkInsertAsRow(client, parameters, hoodieConfig, df, mode, tblName, basePath,
                 instantTime, writerSchema, tableConfig)
             }
@@ -1082,10 +1082,6 @@ object HoodieSparkSqlWriter {
     log.info(s"Config.asyncClusteringEnabled ? ${client.getConfig.isAsyncClusteringEnabled}")
     (asyncClusteringTriggerFnDefined && !client.getConfig.inlineClusteringEnabled
       && client.getConfig.isAsyncClusteringEnabled)
-  }
-
-  private def isConsistentHashingBucketIndex(client: SparkRDDWriteClient[_]): Boolean = {
-    client.getConfig.getIndexType == IndexType.BUCKET && client.getConfig.getBucketIndexEngineType == HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -18,13 +18,16 @@
 package org.apache.spark.sql.hudi
 
 import org.apache.hudi.DataSourceWriteOptions._
-import org.apache.hudi.{DataSourceWriteOptions, HoodieSparkUtils}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
+import org.apache.hudi.common.table.timeline.{HoodieActiveTimeline, HoodieInstant}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
-import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.config.{HoodieClusteringConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.{HoodieDuplicateKeyException, HoodieException}
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode
+import org.apache.hudi.index.HoodieIndex.IndexType
+import org.apache.hudi.{DataSourceWriteOptions, HoodieCLIUtils, HoodieSparkUtils}
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase.getLastCommitMetadata
 import org.apache.spark.sql.hudi.command.HoodieSparkValidateDuplicateKeyRecordMerger
@@ -1612,59 +1615,112 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
 
   test("Test Bulk Insert Into Consistent Hashing Bucket Index Table") {
     withSQLConf("hoodie.datasource.write.operation" -> "bulk_insert") {
-      withTempDir { tmp =>
-        val tableName = generateTableName
-        // Create a partitioned table
-        spark.sql(
-          s"""
-             |create table $tableName (
-             |  id int,
-             |  dt string,
-             |  name string,
-             |  price double,
-             |  ts long
-             |) using hudi
-             | tblproperties (
-             | primaryKey = 'id,name',
-             | type = 'mor',
-             | preCombineField = 'ts',
-             | hoodie.index.type = 'BUCKET',
-             | hoodie.index.bucket.engine = 'CONSISTENT_HASHING',
-             | hoodie.bucket.index.hash.field = 'id,name'
-             | )
-             | partitioned by (dt)
-             | location '${tmp.getCanonicalPath}'
+      Seq("false", "true").foreach { bulkInsertAsRow =>
+        withTempDir { tmp =>
+          val tableName = generateTableName
+          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          // Create a partitioned table
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  dt string,
+               |  name string,
+               |  price double,
+               |  ts long
+               |) using hudi
+               | tblproperties (
+               | primaryKey = 'id,name',
+               | type = 'mor',
+               | preCombineField = 'ts',
+               | hoodie.index.type = 'BUCKET',
+               | hoodie.index.bucket.engine = 'CONSISTENT_HASHING',
+               | hoodie.bucket.index.hash.field = 'id,name',
+               | hoodie.datasource.write.row.writer.enable = '$bulkInsertAsRow'
+               | )
+               | partitioned by (dt)
+               | location '${basePath}'
            """.stripMargin)
 
-        // Note: Do not write the field alias, the partition field must be placed last.
-        spark.sql(
-          s"""
-             | insert into $tableName values
-             | (1, 'a1,1', 10, 1000, "2021-01-05"),
-             | (2, 'a2', 20, 2000, "2021-01-06"),
-             | (3, 'a3,3', 30, 3000, "2021-01-07")
-           """.stripMargin)
+          spark.sql(
+            s"""
+               | insert into $tableName values
+               | (1, 'a1,1', 10, 1000, "2021-01-05"),
+               | (2, 'a1,2', 10, 1000, "2021-01-05"),
+               | (1, 'a2,1', 20, 2000, "2021-01-06"),
+               | (2, 'a2,2', 20, 2000, "2021-01-06"),
+               | (1, 'a3,1', 30, 3000, "2021-01-07"),
+               | (2, 'a3,2', 30, 3000, "2021-01-07")
+            """.stripMargin)
 
-        checkAnswer(s"select id, name, price, ts, dt from $tableName")(
-          Seq(1, "a1,1", 10.0, 1000, "2021-01-05"),
-          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
-          Seq(3, "a3,3", 30.0, 3000, "2021-01-07")
-        )
+          checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+            Seq(1, "a1,1", 10.0, 1000, "2021-01-05"),
+            Seq(2, "a1,2", 10.0, 1000, "2021-01-05"),
+            Seq(1, "a2,1", 20.0, 2000, "2021-01-06"),
+            Seq(2, "a2,2", 20.0, 2000, "2021-01-06"),
+            Seq(1, "a3,1", 30.0, 3000, "2021-01-07"),
+            Seq(2, "a3,2", 30.0, 3000, "2021-01-07")
+          )
 
-        spark.sql(
-          s"""
-             | insert into $tableName values
-             | (1, 'a1', 10, 1000, "2021-01-05"),
-             | (3, "a3", 30, 3000, "2021-01-07")
-         """.stripMargin)
+          // there are six files in the table, each partition contains two files
+          checkAnswer(s"select count(distinct _hoodie_file_name) from $tableName")(
+            Seq(6)
+          )
 
-        checkAnswer(s"select id, name, price, ts, dt from $tableName")(
-          Seq(1, "a1,1", 10.0, 1000, "2021-01-05"),
-          Seq(1, "a1", 10.0, 1000, "2021-01-05"),
-          Seq(2, "a2", 20.0, 2000, "2021-01-06"),
-          Seq(3, "a3,3", 30.0, 3000, "2021-01-07"),
-          Seq(3, "a3", 30.0, 3000, "2021-01-07")
-        )
+          val insertStatement =
+            s"""
+               | insert into $tableName values
+               | (1, 'a1,1', 11, 1000, "2021-01-05"),
+               | (2, 'a1,2', 11, 1000, "2021-01-05"),
+               | (3, 'a2,1', 21, 2000, "2021-01-05"),
+               | (4, 'a2,2', 21, 2000, "2021-01-05"),
+               | (5, 'a3,1', 31, 3000, "2021-01-05"),
+               | (6, 'a3,2', 31, 3000, "2021-01-05")
+            """.stripMargin
+
+          // We can only upsert to existing consistent hashing bucket index table
+          checkExceptionContain(insertStatement)("Consistent Hashing bulk_insert only support write to new file group")
+
+          spark.sql("set hoodie.datasource.write.operation = upsert")
+          spark.sql(insertStatement)
+
+          checkAnswer(s"select id, name, price, ts, dt from $tableName where dt = '2021-01-05'")(
+            Seq(1, "a1,1", 11.0, 1000, "2021-01-05"),
+            Seq(2, "a1,2", 11.0, 1000, "2021-01-05"),
+            Seq(3, "a2,1", 21.0, 2000, "2021-01-05"),
+            Seq(4, "a2,2", 21.0, 2000, "2021-01-05"),
+            Seq(5, "a3,1", 31.0, 3000, "2021-01-05"),
+            Seq(6, "a3,2", 31.0, 3000, "2021-01-05")
+          )
+
+          val clusteringOptions: Map[String, String] = Map(
+            s"${RECORDKEY_FIELD.key()}" -> "id,name",
+            s"${ENABLE_ROW_WRITER.key()}" -> s"${bulkInsertAsRow}",
+            s"${HoodieIndexConfig.INDEX_TYPE.key()}" -> s"${IndexType.BUCKET.name()}",
+            s"${HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key()}" -> "id,name",
+            s"${HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key()}" -> "CONSISTENT_HASHING",
+            s"${HoodieClusteringConfig.PLAN_STRATEGY_CLASS_NAME.key()}" -> "org.apache.hudi.client.clustering.plan.strategy.SparkConsistentBucketClusteringPlanStrategy",
+            s"${HoodieClusteringConfig.EXECUTION_STRATEGY_CLASS_NAME.key()}" -> "org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy"
+          )
+
+          val client = HoodieCLIUtils.createHoodieWriteClient(spark, basePath, clusteringOptions, Option(tableName))
+          val instant = HoodieActiveTimeline.createNewInstantTime
+
+          // Test bucket merge by clustering
+          client.scheduleClusteringAtInstant(instant, HOption.empty())
+
+          checkAnswer(s"call show_clustering(table => '$tableName')")(
+            Seq(instant, 10, HoodieInstant.State.REQUESTED.name(), "*")
+          )
+
+          client.cluster(instant)
+
+          checkAnswer(s"call show_clustering(table => '$tableName')")(
+            Seq(instant, 10, HoodieInstant.State.COMPLETED.name(), "*")
+          )
+
+          spark.sql("set hoodie.datasource.write.operation = bulk_insert")
+        }
       }
     }
     spark.sessionState.conf.unsetConf("hoodie.datasource.write.operation")

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/java/org/apache/hudi/spark3/internal/HoodieBulkInsertDataInternalWriter.java
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/java/org/apache/hudi/spark3/internal/HoodieBulkInsertDataInternalWriter.java
@@ -19,10 +19,11 @@
 package org.apache.hudi.spark3.internal;
 
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.table.action.commit.BulkInsertDataInternalWriterHelper;
-import org.apache.hudi.table.action.commit.BucketBulkInsertDataInternalWriterHelper;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.commit.BucketBulkInsertDataInternalWriterHelper;
+import org.apache.hudi.table.action.commit.BulkInsertDataInternalWriterHelper;
+import org.apache.hudi.table.action.commit.ConsistentBucketBulkInsertDataInternalWriterHelper;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
@@ -41,11 +42,19 @@ public class HoodieBulkInsertDataInternalWriter implements DataWriter<InternalRo
   public HoodieBulkInsertDataInternalWriter(HoodieTable hoodieTable, HoodieWriteConfig writeConfig,
                                             String instantTime, int taskPartitionId, long taskId, StructType structType, boolean populateMetaFields,
                                             boolean arePartitionRecordsSorted) {
-    this.bulkInsertWriterHelper = writeConfig.getIndexType() == HoodieIndex.IndexType.BUCKET
-      ? new BucketBulkInsertDataInternalWriterHelper(hoodieTable,
-        writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted)
-      : new BulkInsertDataInternalWriterHelper(hoodieTable,
-        writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted);
+
+    if (writeConfig.getIndexType() == HoodieIndex.IndexType.BUCKET) {
+      if (writeConfig.getBucketIndexEngineType() == HoodieIndex.BucketIndexEngineType.SIMPLE) {
+        this.bulkInsertWriterHelper = new BucketBulkInsertDataInternalWriterHelper(hoodieTable,
+            writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted);
+      } else {
+        this.bulkInsertWriterHelper = new ConsistentBucketBulkInsertDataInternalWriterHelper(hoodieTable,
+            writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted);
+      }
+    } else {
+      this.bulkInsertWriterHelper = new BulkInsertDataInternalWriterHelper(hoodieTable,
+          writeConfig, instantTime, taskPartitionId, taskId, 0, structType, populateMetaFields, arePartitionRecordsSorted);
+    }
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

Support consistent hashing row writer for bulk_insert load and clustering. 

### Impact

Support consistent hashing bulk_insert row writer 

### Risk level (write none, low medium or high below)

medium, will enabled by default since row writer is enabled by default

### Documentation Update

will update document after landing

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
