### PR TITLE
[HUDI-6537] Bump checkstyle version to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>


### PR DESCRIPTION
### Change Logs

Bump checkstyle version to 3.1.0 due to an ambiguous checkstyle message that was thrown as shown below:

```
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
    at java.lang.String.substring (String.java:1967)
    at org.apache.maven.plugins.checkstyle.RuleUtil.getCategory (RuleUtil.java:95)
    at org.apache.maven.plugins.checkstyle.CheckstyleViolationCheckMojo.countViolations (CheckstyleViolationCheckMojo.java:646)
    at org.apache.maven.plugins.checkstyle.CheckstyleViolationCheckMojo.execute (CheckstyleViolationCheckMojo.java:564)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

https://github.com/apache/hudi/actions/runs/5556435429/jobs/10148956808?pr=9133

Bug:
https://issues.apache.org/jira/browse/MCHECKSTYLE-347

Running the code with checkstyle:3.1.0 will throw the correct checkstyle error:

```log
Running the code in the same state iwith checkstyle:3.1.0 will throw the error below (expected):

final CastMapConverter[] converters = IntStream.
    range(0, fromChildren.size())
    .mapToObj(i -> {
      LogicalType fromChild = fromChildren.get(i);
      LogicalType toChild = toChildren.get(i);
      if (isPrimitiveTypeRootEqual(fromChild.getTypeRoot(), toChild.getTypeRoot())) {
        return createNoOpConverter();
...

[ERROR] src/main/java/org/apache/hudi/table/format/CastMapConverters.java:[315,52] (extension) SeparatorWrapDot: '.' should be on a new line.
```


### Impact

_Describe any public API or user-facing feature change or any performance impact._
None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
