### PR TITLE
[HUDI-6545] fix presto read parquet format log file issue

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
@@ -189,7 +189,7 @@ public class HoodieHFileDataBlock extends HoodieDataBlock {
 
     Path inlinePath = InLineFSUtils.getInlineFilePath(
         blockContentLoc.getLogFile().getPath(),
-        blockContentLoc.getLogFile().getPath().getFileSystem(inlineConf).getScheme(),
+        blockContentLoc.getLogFile().getPath().toUri().getScheme(),
         blockContentLoc.getContentPositionInLogFile(),
         blockContentLoc.getBlockSize());
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
@@ -151,7 +151,7 @@ public class HoodieParquetDataBlock extends HoodieDataBlock {
 
     Path inlineLogFilePath = InLineFSUtils.getInlineFilePath(
         blockContentLoc.getLogFile().getPath(),
-        blockContentLoc.getLogFile().getPath().getFileSystem(inlineConf).getScheme(),
+        blockContentLoc.getLogFile().getPath().toUri().getScheme(),
         blockContentLoc.getContentPositionInLogFile(),
         blockContentLoc.getBlockSize());
 


### PR DESCRIPTION
### Change Logs

Avoid using `FileSystem#getSchema()` to get schema from path, support presto read parquet format log file.

When reading parquet format log file with presto will throw error : 
```log
Caused by: io.prestosql.jdbc.$internal.client.FailureInfo$FailureException: Not implemented by the FileSystemWrapper FileSystem implementation
```
Because presto implemented `FileSystem` doesn't override method `getSchema()`, so calling `FileSystem#getSchema()` in presto will throw error.

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
