### PR TITLE
[HUDI-6550] Add Hadoop conf to HiveConf for HiveSyncConfig

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -98,8 +98,9 @@ public class HiveSyncConfig extends HoodieSyncConfig {
 
   public HiveSyncConfig(Properties props, Configuration hadoopConf) {
     super(props, hadoopConf);
-    HiveConf hiveConf = hadoopConf instanceof HiveConf
-        ? (HiveConf) hadoopConf : new HiveConf(hadoopConf, HiveConf.class);
+    HiveConf hiveConf = new HiveConf();
+    // HiveConf needs to load Hadoop conf to allow instantiation via AWSGlueClientFactory
+    hiveConf.addResource(hadoopConf);
     setHadoopConf(hiveConf);
     validateParameters();
   }


### PR DESCRIPTION
### Change Logs
- Create new HiveConf object every time when initializing `HiveSyncConfig` and add hadoopConf as resource
We have to load Hadoop conf otherwise properties like `--conf spark.hadoop.hive.metastore.client.factory.class=com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory` won't be able to passed via Spark Hudi job. This issue was introduced another PR to address the OOM issue changed it: https://github.com/apache/hudi/pull/8050

To address the OOM problem we can create a new HiveConf every time instead of casting hadoop conf to hive conf. So we don't keep references to old hadoop conf.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
