### PR TITLE
[HUDI-6570]Cancel to send commit ack event when empty batch is not allowed to commit for flink batch job

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
@@ -46,6 +46,9 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties properties) throws IOException {
+    /*
+     * Check if the incoming record is a delete record.
+     */
     if (recordBytes.length == 0 || isDeletedRecord) {
       return Option.empty();
     }
@@ -58,9 +61,6 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
       return Option.of(currentValue);
     }
 
-    /*
-     * Now check if the incoming record is a delete record.
-     */
     return Option.of(incomingRecord);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -532,7 +532,9 @@ public class StreamWriteOperatorCoordinator
       // Send commit ack event to the write function to unblock the flushing
       // If this checkpoint has no inputs while the next checkpoint has inputs,
       // the 'isConfirming' flag should be switched with the ack event.
-      sendCommitAckEvents(checkpointId);
+      if (checkpointId != -1) {
+        sendCommitAckEvents(checkpointId);
+      }
       return false;
     }
     doCommit(instant, writeResults);


### PR DESCRIPTION
…mmit for flink batch job

### Change Logs

Cancel to send commit ack event when empty batch is not allowed to commit for flink batch job.
![image](https://github.com/apache/hudi/assets/18002496/ddcede34-b069-49f3-adcd-f6204aece710)

```java
Caused by: org.apache.flink.util.FlinkException: An OperatorEvent from an OperatorCoordinator to a task was lost. Triggering task failover to ensure consistency. Event: 'org.apache.hudi.sink.event.CommitAckEvent@6834fa', targetTask: bucket_write: dmx_jdt_dmxlmt_cus_aum_after_mid_res_s_d (9/16) - execution #0
	... 33 more
Caused by: org.apache.flink.runtime.operators.coordination.TaskNotRunningException: Task is not running, but in state FINISHED
```

### Impact

There is a certain probability of failure in the flink batch job.


