### PR TITLE
[HUDI-6574] Fix the problem that incremental clean cannot be executed when the earliest ActiveTimeline is a pending commit.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -130,16 +130,16 @@ public class CleanerUtils {
 
     if (cleaningPolicy == HoodieCleaningPolicy.KEEP_LATEST_COMMITS
         && completedCommitsTimeline.countInstants() > commitsRetained) {
-      Option<HoodieInstant> earliestPendingCommits =
+      Option<HoodieInstant> earliestPendingCommit =
           commitsTimeline.filter(s -> !s.isCompleted()).firstInstant();
-      if (earliestPendingCommits.isPresent()) {
+      if (earliestPendingCommit.isPresent()) {
         // Earliest commit to retain must not be later than the earliest pending commit
         earliestCommitToRetain =
             completedCommitsTimeline.nthInstant(completedCommitsTimeline.countInstants() - commitsRetained).map(nthInstant -> {
-              if (nthInstant.compareTo(earliestPendingCommits.get()) <= 0) {
+              if (nthInstant.compareTo(earliestPendingCommit.get()) <= 0) {
                 return Option.of(nthInstant);
               } else {
-                return completedCommitsTimeline.findInstantsBefore(earliestPendingCommits.get().getTimestamp()).lastInstant();
+                return completedCommitsTimeline.findInstantsBefore(earliestPendingCommit.get().getTimestamp()).lastInstant().or(earliestPendingCommit);
               }
             }).orElse(Option.empty());
       } else {


### PR DESCRIPTION
When performing a clean in Hudi, the earliest commit to be retained is obtained by calling the getEarliestCommitToRetain method in CleanPlanner. However, if a pending commit takes a long time and becomes the earliest active timeline, calling getEarliestCommitToRetain will return empty because there is no earlier commit than the pending commit. This can cause a problem during an incremental clean, as the previous endpoint (i.e., the last commit retained in the previous clean) is used as the starting point. If this starting point is empty, a full clean will be triggered, which is very resource-intensive.
To solve this problem without affecting normal clean, we set the EarliestCommitToRetain obtained in this situation to the earliest pending commit. Since the endpoint will not be cleaned in the current clean, this approach can solve the aforementioned problem without affecting normal clean operations.

### Change Logs

Modify the method of getEarliestCommitToRetain in CleanPlanner when the first commit is a pending commit during a clean operation, to ensure that incremental clean can be executed normally.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
