### PR TITLE
Fix parquet bloom filters impl and tests

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieParquetBloom.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieParquetBloom.scala
@@ -62,6 +62,10 @@ class TestHoodieParquetBloomFilter {
   def testBloomFilter(operation: WriteOperationType): Unit = {
     // setup hadoop conf with bloom col enabled
     spark.sparkContext.hadoopConfiguration.set("parquet.bloom.filter.enabled#bloom_col", "true")
+    spark.sparkContext.hadoopConfiguration.set("parquet.bloom.filter.expected.ndv#bloom_col", "2")
+    // ensure nothing but bloom can trigger read skip
+    spark.sql("set parquet.filter.columnindex.enabled=false")
+    spark.sql("set parquet.filter.stats.enabled=false")
 
     val basePath = java.nio.file.Files.createTempDirectory("hoodie_bloom_source_path").toAbsolutePath.toString
     val opts = Map(


### PR DESCRIPTION
### Change Logs

This makes the parquet bloom filter work correctly. After trying out the #8716 the bloom where not being created

1. the reflexion usage was incorrect and this was silently doing nothing
1. The reason is the test was not verifying correctly the bloom is created. A side effect of parquet stats was used in place of bloom in newer versions of parquet

This PR :
1. fixes the impl
1. fixes the test

Double check with parquet-cli after the patch confirmed the bloom exist. We cannot yet use such checks since only recent version of parquet can verify the bloom exist

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
