### PR TITLE
[HUDI-6546] Set AutoAdjustLockConfigs for flink writer config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3111,7 +3111,7 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     private void autoAdjustConfigsForConcurrencyMode(boolean isLockProviderPropertySet) {
       if (!isLockProviderPropertySet && writeConfig.isAutoAdjustLockConfigs() && isLockRequiredForSingleWriter()) {
-        // auto adjustment is required only for deltastreamer and spark streaming where async table services can be executed in the same JVM.
+        // auto adjustment is required only for flink, deltastreamer and spark streaming where async table services can be executed in the same JVM.
         // This is targeted at Single writer with async table services
         // If user does not set the lock provider, likely that the concurrency mode is not set either
         // Override the configs for metadata table

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -285,14 +285,14 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       try {
         // initialize the metadata table path
         // guard the metadata writer with concurrent lock
-        this.txnManager.getLockManager().lock();
+        this.txnManager.beginTransaction(Option.empty(), Option.empty());
         try (HoodieBackedTableMetadataWriter metadataWriter = initMetadataWriter(latestPendingInstant)) {
           metadataWriter.performTableServices(Option.empty());
         }
       } catch (Exception e) {
         throw new HoodieException("Failed to initialize metadata table", e);
       } finally {
-        this.txnManager.getLockManager().unlock();
+        this.txnManager.endTransaction(Option.empty());
       }
       // clean the obsolete index stats
       table.deleteMetadataIndexIfNecessary();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -21,7 +21,6 @@ package org.apache.hudi.util;
 import org.apache.hudi.client.FlinkTaskContextSupplier;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
-import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -225,15 +225,7 @@ public class FlinkWriteClients {
             .withSchema(getSourceSchema(conf).toString());
 
     if (OptionsResolver.isLockRequired(conf) && !conf.containsKey(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key())) {
-      // configure the fs lock provider by default
-      builder.withLockConfig(HoodieLockConfig.newBuilder()
-          .withConflictResolutionStrategy(OptionsResolver.getConflictResolutionStrategy(conf))
-          .withLockProvider(FileSystemBasedLockProvider.class)
-          .withLockWaitTimeInMillis(2000L) // 2s
-          .withFileSystemLockExpire(1) // 1 minute
-          .withClientNumRetries(30)
-          .withFileSystemLockPath(StreamerUtil.getAuxiliaryPath(conf))
-          .build());
+      builder.withAutoAdjustLockConfigs(true);
     }
 
     // do not configure cleaning strategy as LAZY until multi-writers is supported.

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -22,7 +22,6 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieWriteStat;
-import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -427,7 +427,6 @@ public class TestStreamWriteOperatorCoordinator {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     conf.setBoolean(FlinkOptions.METADATA_ENABLED, true);
 
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
     conf.setInteger("hoodie.write.lock.client.num_retries", 1);
 
     OperatorCoordinator.Context context = new MockOperatorCoordinatorContext(new OperatorID(), 1);


### PR DESCRIPTION
### Change Logs

Flink can use `autoAdjustConfigsForConcurrencyMode` like deltastreamer or spark streaming

### Impact

above

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
