### PR TITLE
[HUDI-6579] Adding support for upsert and deletes with spark datasource for pk less table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -114,7 +114,7 @@ public class HoodieMetadataWriteUtils {
         // we will trigger archive manually, to ensure only regular writer invokes it
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
             .archiveCommitsWith(
-                writeConfig.getMinCommitsToKeep(), writeConfig.getMaxCommitsToKeep())
+                writeConfig.getMinCommitsToKeep() + 1, writeConfig.getMaxCommitsToKeep() + 1)
             .withAutoArchive(false)
             .build())
         // we will trigger compaction manually, to control the instant times

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/AutoRecordKeyGenerationUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/AutoRecordKeyGenerationUtils.scala
@@ -32,7 +32,7 @@ object AutoRecordKeyGenerationUtils {
   private val log = LoggerFactory.getLogger(getClass)
 
   def mayBeValidateParamsForAutoGenerationOfRecordKeys(parameters: Map[String, String], hoodieConfig: HoodieConfig): Unit = {
-    val autoGenerateRecordKeys = !parameters.contains(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()) // if record key is not configured,
+    val autoGenerateRecordKeys = isAutoGenerateRecordKeys(parameters)
     // hudi will auto generate.
     if (autoGenerateRecordKeys) {
       // de-dup is not supported with auto generation of record keys
@@ -53,5 +53,9 @@ object AutoRecordKeyGenerationUtils {
     if (hoodieConfig.contains(PRECOMBINE_FIELD.key())) {
       log.warn("Precombine field " + hoodieConfig.getString(PRECOMBINE_FIELD.key()) + " will be ignored with auto record key generation enabled")
     }
+  }
+
+  def isAutoGenerateRecordKeys(parameters: Map[String, String]): Boolean = {
+    !parameters.contains(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()) // if record key is not configured,
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -263,7 +263,7 @@ object HoodieSparkSqlWriter {
                   .asInstanceOf[BaseKeyGenerator])
               }
               it.map { avroRec =>
-                HoodieCreateRecordUtils.getHoodieKeyAndMaybeLocationFromAvroRecord(keyGenerator, avroRec, preppedSparkSqlWrites || preppedWriteOperation, preppedWriteOperation)
+                HoodieCreateRecordUtils.getHoodieKeyAndMaybeLocationFromAvroRecord(keyGenerator, avroRec, preppedSparkSqlWrites || preppedWriteOperation, preppedSparkSqlWrites || preppedSparkSqlMergeInto || preppedWriteOperation)
               }
             }).toJavaRDD()
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -160,7 +160,7 @@ object HoodieSparkSqlWriter {
     val operation = deduceOperation(hoodieConfig, paramsWithoutDefaults)
 
     val sqlMergeIntoPrepped = parameters.getOrDefault(SPARK_SQL_MERGE_INTO_PREPPED_KEY, "false").toBoolean
-    val isPrepped = canDoPrepped(hoodieConfig, parameters, operation, df)
+    val isPrepped = canDoPreppedWrites(hoodieConfig, parameters, operation, df)
 
     val jsc = new JavaSparkContext(sparkContext)
     if (asyncCompactionTriggerFn.isDefined) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -90,7 +90,17 @@ object HoodieWriterUtils {
     Map() ++ hoodieConfig.getProps.asScala ++ globalProps ++ DataSourceOptionsHelper.translateConfigurations(parameters)
   }
 
-  def canDoPrepped(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
+  /**
+   * Determines whether writes need to take prepped path or regular non-prepped path.
+   * - For spark-sql writes (UPDATES, DELETES), we could use prepped flow due to the presences of meta fields.
+   * - For pkless tables, if incoming df has meta fields, we could use prepped flow.
+   * @param hoodieConfig hoodie config of interest.
+   * @param parameters raw parameters.
+   * @param operation operation type.
+   * @param df incoming dataframe
+   * @return true if prepped writes, false otherwise.  
+   */
+  def canDoPreppedWrites(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
     var isPrepped = hoodieConfig.getBooleanOrDefault(SPARK_SQL_WRITES_PREPPED_KEY, false)
     if (!parameters.containsKey(DataSourceWriteOptions.RECORDKEY_FIELD.key())
       && parameters.getOrElse(SPARK_SQL_WRITES_PREPPED_KEY, "false") == "false"

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -21,14 +21,17 @@ import org.apache.hudi.DataSourceOptionsHelper.allAlternatives
 import org.apache.hudi.DataSourceWriteOptions.{RECORD_MERGER_IMPLS, _}
 import org.apache.hudi.common.config.HoodieMetadataConfig.ENABLE
 import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieCommonConfig, HoodieConfig, TypedProperties}
+import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.config.HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.hive.HiveSyncConfigHolder
 import org.apache.hudi.keygen.{NonpartitionedKeyGenerator, SimpleKeyGenerator}
 import org.apache.hudi.sync.common.HoodieSyncConfig
 import org.apache.hudi.util.SparkKeyGenUtils
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.hudi.command.{MergeIntoKeyGenerator, SqlKeyGenerator}
+import org.slf4j.LoggerFactory
 
 import java.util.Properties
 import scala.collection.JavaConversions.mapAsJavaMap
@@ -39,6 +42,7 @@ import scala.collection.JavaConverters._
  */
 object HoodieWriterUtils {
 
+  private val log = LoggerFactory.getLogger(getClass)
   /**
     * Add default options for unspecified write options keys.
     *
@@ -84,6 +88,24 @@ object HoodieWriterUtils {
     hoodieConfig.setDefaultValue(DROP_PARTITION_COLUMNS)
     hoodieConfig.setDefaultValue(KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED)
     Map() ++ hoodieConfig.getProps.asScala ++ globalProps ++ DataSourceOptionsHelper.translateConfigurations(parameters)
+  }
+
+  def canDoPrepped(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
+    var isPrepped = hoodieConfig.getBooleanOrDefault(SPARK_SQL_WRITES_PREPPED_KEY, false)
+    if (!parameters.containsKey(DataSourceWriteOptions.RECORDKEY_FIELD.key())
+      && parameters.getOrElse(SPARK_SQL_WRITES_PREPPED_KEY, "false") == "false"
+      && parameters.getOrElse(SPARK_SQL_MERGE_INTO_PREPPED_KEY, "false") == "false"
+      && df.schema.fieldNames.contains(HoodieRecord.RECORD_KEY_METADATA_FIELD)) {
+      // with pk less table, writes using spark-ds writer can potentially use the prepped path if meta fields are present in the incoming df.
+      if (operation == WriteOperationType.UPSERT) {
+        log.warn("Changing operation type to UPSERT PREPPED for pk less table upserts ")
+        isPrepped = true
+      } else if (operation == WriteOperationType.DELETE) {
+        log.warn("Changing operation type to DELETE PREPPED for pk less table deletes ")
+        isPrepped = true
+      }
+    }
+    isPrepped
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -101,8 +101,8 @@ object HoodieWriterUtils {
    * @return true if prepped writes, false otherwise.
    */
   def canDoPreppedWrites(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
-    var isPrepped = hoodieConfig.getBooleanOrDefault(SPARK_SQL_WRITES_PREPPED_KEY, false)
-    if (!isPrepped && AutoRecordKeyGenerationUtils.isAutoGenerateRecordKeys(parameters)
+    var isPrepped = false
+    if (AutoRecordKeyGenerationUtils.isAutoGenerateRecordKeys(parameters)
       && parameters.getOrElse(SPARK_SQL_WRITES_PREPPED_KEY, "false") == "false"
       && parameters.getOrElse(SPARK_SQL_MERGE_INTO_PREPPED_KEY, "false") == "false"
       && df.schema.fieldNames.contains(HoodieRecord.RECORD_KEY_METADATA_FIELD)) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -102,7 +102,7 @@ object HoodieWriterUtils {
    */
   def canDoPreppedWrites(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
     var isPrepped = hoodieConfig.getBooleanOrDefault(SPARK_SQL_WRITES_PREPPED_KEY, false)
-    if (!parameters.containsKey(DataSourceWriteOptions.RECORDKEY_FIELD.key())
+    if (!isPrepped && AutoRecordKeyGenerationUtils.isAutoGenerateRecordKeys(parameters)
       && parameters.getOrElse(SPARK_SQL_WRITES_PREPPED_KEY, "false") == "false"
       && parameters.getOrElse(SPARK_SQL_MERGE_INTO_PREPPED_KEY, "false") == "false"
       && df.schema.fieldNames.contains(HoodieRecord.RECORD_KEY_METADATA_FIELD)) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -98,7 +98,7 @@ object HoodieWriterUtils {
    * @param parameters raw parameters.
    * @param operation operation type.
    * @param df incoming dataframe
-   * @return true if prepped writes, false otherwise.  
+   * @return true if prepped writes, false otherwise.
    */
   def canDoPreppedWrites(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
     var isPrepped = hoodieConfig.getBooleanOrDefault(SPARK_SQL_WRITES_PREPPED_KEY, false)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -103,8 +103,8 @@ object HoodieWriterUtils {
   def canDoPreppedWrites(hoodieConfig: HoodieConfig, parameters: Map[String, String], operation : WriteOperationType, df: Dataset[Row]): Boolean = {
     var isPrepped = false
     if (AutoRecordKeyGenerationUtils.isAutoGenerateRecordKeys(parameters)
-      && parameters.getOrElse(SPARK_SQL_WRITES_PREPPED_KEY, "false") == "false"
-      && parameters.getOrElse(SPARK_SQL_MERGE_INTO_PREPPED_KEY, "false") == "false"
+      && parameters.getOrElse(SPARK_SQL_WRITES_PREPPED_KEY, "false").equals("false")
+      && parameters.getOrElse(SPARK_SQL_MERGE_INTO_PREPPED_KEY, "false").equals("false")
       && df.schema.fieldNames.contains(HoodieRecord.RECORD_KEY_METADATA_FIELD)) {
       // with pk less table, writes using spark-ds writer can potentially use the prepped path if meta fields are present in the incoming df.
       if (operation == WriteOperationType.UPSERT) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestAutoGenerationOfRecordKeys.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestAutoGenerationOfRecordKeys.scala
@@ -21,28 +21,26 @@ package org.apache.hudi.functional
 
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hudi.HoodieConversionUtils.toJavaOption
-import org.apache.hudi.common.config.HoodieMetadataConfig
-import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
-import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.common.util
-import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.ExceptionUtil.getRootCause
 import org.apache.hudi.exception.{HoodieException, HoodieKeyGeneratorException}
 import org.apache.hudi.functional.CommonOptionUtils._
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
-import org.apache.hudi.keygen.{ComplexKeyGenerator, KeyGenUtils, NonpartitionedKeyGenerator, SimpleKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions.Config
+import org.apache.hudi.keygen.{ComplexKeyGenerator, NonpartitionedKeyGenerator, SimpleKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 import org.apache.hudi.util.JFunction
 import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers, ScalaAssertionSupport}
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.{SaveMode, SparkSession, SparkSessionExtensions}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{CsvSource, EnumSource}
+import org.junit.jupiter.params.provider.CsvSource
 
 import java.util.function.Consumer
 import scala.collection.JavaConversions._
@@ -124,10 +122,6 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
       options = options -- Seq(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())
     }
 
-    // add partition Id and instant time
-    options += KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG -> "1"
-    options += KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG -> "100"
-
     // NOTE: In this test we deliberately removing record-key configuration
     //       to validate Hudi is handling this case appropriately
     val writeOpts = options -- Seq(DataSourceWriteOptions.RECORDKEY_FIELD.key)
@@ -176,14 +170,14 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
     assertEquals(10, recordKeys.size)
 
     // validate entire batch is present in snapshot read
-    val expectedInputDf = inputDF.union(inputDF2).drop("partition","rider","_hoodie_is_deleted")
-    val actualDf = readDF.drop(HoodieRecord.HOODIE_META_COLUMNS.asScala: _*).drop("partition","rider","_hoodie_is_deleted")
+    val expectedInputDf = inputDF.union(inputDF2).drop("partition", "rider", "_hoodie_is_deleted")
+    val actualDf = readDF.drop(HoodieRecord.HOODIE_META_COLUMNS.asScala: _*).drop("partition", "rider", "_hoodie_is_deleted")
     assertEquals(expectedInputDf.except(actualDf).count, 0)
   }
 
   @ParameterizedTest
   @CsvSource(value = Array(
-    "hoodie.populate.meta.fields,false","hoodie.combine.before.insert,true","hoodie.datasource.write.insert.drop.duplicates,true"
+    "hoodie.populate.meta.fields,false", "hoodie.combine.before.insert,true", "hoodie.datasource.write.insert.drop.duplicates,true"
   ))
   def testRecordKeysAutoGenInvalidParams(configKey: String, configValue: String): Unit = {
     val (writeOpts, _) = getWriterReaderOpts(HoodieRecordType.AVRO)
@@ -191,10 +185,6 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
     // NOTE: In this test we deliberately removing record-key configuration
     //       to validate Hudi is handling this case appropriately
     var opts = writeOpts -- Seq(DataSourceWriteOptions.RECORDKEY_FIELD.key)
-
-    // add partition Id and instant time
-    opts += KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG -> "1"
-    opts += KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG -> "100"
 
     // Insert Operation
     val records = recordsToStrings(dataGen.generateInserts("000", 1)).toList
@@ -227,11 +217,6 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
     val records = recordsToStrings(dataGen.generateInserts("000", 5)).toList
     val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
     inputDF.cache
-
-
-    // add partition Id and instant time
-    writeOpts += KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG -> "1"
-    writeOpts += KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG -> "100"
 
     //
     // Step #1: Persist first batch with auto-gen'd record-keys
@@ -276,5 +261,56 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
     assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
     val snapshot0 = spark.read.format("hudi").load(basePath)
     assertEquals(5, snapshot0.count())
+  }
+
+  @Test
+  def testUpsertsAndDeletesWithPkLess(): Unit = {
+    val (vanillaWriteOpts, readOpts) = getWriterReaderOpts(HoodieRecordType.AVRO)
+
+    var options: Map[String, String] = vanillaWriteOpts ++ Map(
+      DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[SimpleKeyGenerator].getCanonicalName)
+
+    var writeOpts = options -- Seq(DataSourceWriteOptions.RECORDKEY_FIELD.key)
+
+    // Insert Operation
+    val records = recordsToStrings(dataGen.generateInserts("000", 20)).toList
+    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.cache
+
+    inputDF.write.format("hudi")
+      .options(writeOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, "insert")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
+
+    val snapshotDf = spark.read.format("hudi").load(basePath)
+    snapshotDf.cache()
+    assertEquals(snapshotDf.count(), 20)
+
+    val updateDf = snapshotDf.limit(5).withColumn("rider", lit("rider-123456"))
+    updateDf.write.format("hudi")
+      .options(writeOpts)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val snapshotDf1 = spark.read.format("hudi").load(basePath)
+    snapshotDf1.cache()
+
+    assertEquals(20, snapshotDf1.count())
+    assertEquals(5, snapshotDf1.filter("rider == 'rider-123456'").count())
+
+    // delete the same 5 records.
+    snapshotDf1.filter("rider == 'rider-123456'").write.format("hudi")
+      .options(writeOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, "delete")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val snapshotDf2 = spark.read.format("hudi").load(basePath)
+    snapshotDf2.cache()
+    assertEquals(15, snapshotDf2.count())
+    assertEquals(0, snapshotDf2.filter("rider == 'rider-123456'").count())
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestAutoGenerationOfRecordKeys.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestAutoGenerationOfRecordKeys.scala
@@ -301,7 +301,8 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
     assertEquals(5, snapshotDf1.filter("rider == 'rider-123456'").count())
 
     // delete the same 5 records.
-    snapshotDf1.filter("rider == 'rider-123456'").write.format("hudi")
+    snapshotDf1.filter("rider == 'rider-123456'")
+      .write.format("hudi")
       .options(writeOpts)
       .option(DataSourceWriteOptions.OPERATION.key, "delete")
       .mode(SaveMode.Append)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestAutoGenerationOfRecordKeys.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestAutoGenerationOfRecordKeys.scala
@@ -201,7 +201,6 @@ class TestAutoGenerationOfRecordKeys extends HoodieSparkClientTestBase with Scal
     assertTrue(getRootCause(e).getMessage.contains(configKey + " is not supported with auto generation of record keys"))
   }
 
-
   @Test
   def testRecordKeysAutoGenEnableToDisable(): Unit = {
     val (vanillaWriteOpts, readOpts) = getWriterReaderOpts(HoodieRecordType.AVRO)


### PR DESCRIPTION
### Change Logs

Adding support for upsert and deletes with spark datasource for pk less table. 

### Impact

This patch opens up possibility to do updates or delete records with spark datasource writes for a primary key less table. 

For eg, if for a primary table, user prefers to delete all records for a given employee. 
```
val df = spark.read.format("hudi").load(basePath).filter("emp_id == '100')
df.write.format("hudi").option("hoodie.datasource.write.operation","delete").mode(Append).save(basePath) 
```

This is feasible for a pk less table. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
