### PR TITLE
[HUDI-6581] Remove unnecessary validations in function getOldestInstantToRetainForClustering

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -281,19 +281,6 @@ public class ClusteringUtils {
       } else {
         oldestInstantToRetain = replaceTimeline.firstInstant();
       }
-
-      Option<HoodieInstant> pendingInstantOpt = replaceTimeline.filterInflights().firstInstant();
-      if (pendingInstantOpt.isPresent()) {
-        // Get the previous commit before the first inflight clustering instant.
-        Option<HoodieInstant> beforePendingInstant = activeTimeline.getCommitsTimeline()
-            .filterCompletedInstants()
-            .findInstantsBefore(pendingInstantOpt.get().getTimestamp())
-            .lastInstant();
-        if (beforePendingInstant.isPresent()
-            && oldestInstantToRetain.map(instant -> instant.compareTo(beforePendingInstant.get()) > 0).orElse(true)) {
-          oldestInstantToRetain = beforePendingInstant;
-        }
-      }
     }
     return oldestInstantToRetain;
   }


### PR DESCRIPTION
### Change Logs

This PR can sufficient to ensure the retention of the previous commit for first pending clustering, no need to check again.
(https://github.com/apache/hudi/pull/8783)


### Impact

none.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
