### PR TITLE
[HUDI-3636] Disabling embedded timeline server with spark streaming sink

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
@@ -118,6 +118,11 @@ class HoodieStreamingSink(sqlContext: SQLContext,
     // we need auto adjustment enabled for streaming sink since async table services are feasible within the same JVM.
     updatedOptions = updatedOptions.updated(HoodieWriteConfig.AUTO_ADJUST_LOCK_CONFIGS.key, "true")
     updatedOptions = updatedOptions.updated(HoodieSparkSqlWriter.SPARK_STREAMING_BATCH_ID, batchId.toString)
+    if (!options.containsKey(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key())) {
+      // if user does not explicitly override, we are disabling timeline server for streaming sink.
+      // refer to HUDI-3636 for more details
+      updatedOptions = updatedOptions.updated(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), " false")
+    }
 
     retry(retryCnt, retryIntervalMs)(
       Try(


### PR DESCRIPTION
### Change Logs

Looks like timeline server is shutdown at the end of 1st micro batch in streaming sink. So, disabling timeline server for now w/ streaming sink. We have a proper fix https://github.com/apache/hudi/pull/5269, until then we might need to disable timeline server. 

### Impact

Looks like timeline server is shutdown at the end of 1st micro batch in streaming sink. So, disabling timeline server for now w/ streaming sink. We have a proper fix https://github.com/apache/hudi/pull/5269, until then we might need to disable timeline server. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
