### PR TITLE
[HUDI-6320] Fix partition parsing in Spark file index for custom keygen

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
@@ -86,7 +86,7 @@ class HoodieCDCRDD(
 
   private val cdcSupplementalLoggingMode = metaClient.getTableConfig.cdcSupplementalLoggingMode
 
-  private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty)
+  private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty, metaClient)
 
   protected val payloadProps: Properties = Option(metaClient.getTableConfig.getPreCombineField)
     .map { preCombineField =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -38,7 +38,6 @@ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtil
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.common.util.StringUtils.isNullOrEmpty
 import org.apache.hudi.config.HoodieWriteConfig
-import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator.TimestampType
 import org.apache.hudi.metadata.HoodieTableMetadata
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
@@ -325,28 +324,21 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
         EqualTo(attribute("dt"), literal("2021/03/01")),
         EqualTo(attribute("hh"), literal("10"))
       )
+      val partitionAndFilesNoPruning = fileIndex.listFiles(Seq(partitionFilter2), Seq.empty)
 
-      // NOTE: That if file-index is in lazy-listing mode and we can't parse partition values, there's no way
-      //       to recover from this since Spark by default have to inject partition values parsed from the partition paths.
-      if (listingModeOverride == DataSourceReadOptions.FILE_INDEX_LISTING_MODE_LAZY) {
-        assertThrows(classOf[HoodieException]) { fileIndex.listFiles(Seq(partitionFilter2), Seq.empty) }
-      } else {
-        val partitionAndFilesNoPruning = fileIndex.listFiles(Seq(partitionFilter2), Seq.empty)
+      assertEquals(1, partitionAndFilesNoPruning.size)
+      // The partition prune would not work for this case, so the partition value it
+      // returns is a InternalRow.empty.
+      assertTrue(partitionAndFilesNoPruning.forall(_.values.numFields == 0))
+      // The returned file size should equal to the whole file size in all the partition paths.
+      assertEquals(getFileCountInPartitionPaths("2021/03/01/10", "2021/03/02/10"),
+        partitionAndFilesNoPruning.flatMap(_.files).length)
 
-        assertEquals(1, partitionAndFilesNoPruning.size)
-        // The partition prune would not work for this case, so the partition value it
-        // returns is a InternalRow.empty.
-        assertTrue(partitionAndFilesNoPruning.forall(_.values.numFields == 0))
-        // The returned file size should equal to the whole file size in all the partition paths.
-        assertEquals(getFileCountInPartitionPaths("2021/03/01/10", "2021/03/02/10"),
-          partitionAndFilesNoPruning.flatMap(_.files).length)
+      val readDF = spark.read.format("hudi").options(readerOpts).load()
 
-        val readDF = spark.read.format("hudi").options(readerOpts).load()
-
-        assertEquals(10, readDF.count())
-        // There are 5 rows in the  dt = 2021/03/01 and hh = 10
-        assertEquals(5, readDF.filter("dt = '2021/03/01' and hh ='10'").count())
-      }
+      assertEquals(10, readDF.count())
+      // There are 5 rows in the  dt = 2021/03/01 and hh = 10
+      assertEquals(5, readDF.filter("dt = '2021/03/01' and hh ='10'").count())
     }
 
     {
@@ -429,7 +421,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     val partitionAndFilesAfterPrune = fileIndex.listFiles(Seq(partitionFilters), Seq.empty)
     assertEquals(1, partitionAndFilesAfterPrune.size)
 
-    assertEquals(fileIndex.areAllPartitionPathsCached(), !complexExpressionPushDown)
+    assertTrue(fileIndex.areAllPartitionPathsCached())
 
     val PartitionDirectory(partitionActualValues, filesAfterPrune) = partitionAndFilesAfterPrune.head
     val partitionExpectValues = Seq("default", "2021-03-01", "5", "CN")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -954,7 +954,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       .option(TIMESTAMP_OUTPUT_DATE_FORMAT.key, "yyyy/MM/dd")
       .mode(SaveMode.Overwrite)
       .save(basePath)
-    var recordsReadDF = spark.read.format("org.apache.hudi")
+    var recordsReadDF = spark.read.format("hudi")
       .options(readOpts)
       .load(basePath)
     val udf_date_format = udf((data: Long) => new DateTime(data).toString(DateTimeFormat.forPattern("yyyy/MM/dd")))
@@ -968,7 +968,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       .option(TIMESTAMP_OUTPUT_DATE_FORMAT.key, "yyyy/MM/dd")
       .mode(SaveMode.Overwrite)
       .save(basePath)
-    recordsReadDF = spark.read.format("org.apache.hudi")
+    recordsReadDF = spark.read.format("hudi")
       .options(readOpts)
       .load(basePath)
     assertTrue(recordsReadDF.filter(col("_hoodie_partition_path") =!=


### PR DESCRIPTION
### Change Logs

Whem using custom key generator with timestamp field with type `EPOCHMILLISECONDS` and output date format as `yyyy/MM/dd`, partition parsing fails because partition column is thought to be of LongType even though it is string. 
Another issue is that if there are multiple partition fields with cusotm keygen, then lazy listing fails due to parsing of partitions with non-encoded slashes. This PR fixes these issues. 

It also adds a test to check partition pruning kicks in for TimestampBasedKeyGenerator.

### Impact

Fixes couple of bugs bug when using custom keygen with timestamp fields.

### Risk level (write none, low medium or high below)

low

Eager listing in case of custom keygen with multiple fields can be costlier but functional. Before this patch, it wasn't even functional.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
