### PR TITLE
[MINOR] fix millis append format error

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -114,7 +114,7 @@ public class HoodieInstantTimeGenerator {
 
   /**
    * Creates an instant string given a valid date-time string.
-   * @param dateString A date-time string in the format yyyy-MM-dd HH:mm:ss[:SSS]
+   * @param dateString A date-time string in the format yyyy-MM-dd HH:mm:ss[.SSS]
    * @return A timeline instant
    * @throws ParseException If we cannot parse the date string
    */
@@ -124,7 +124,7 @@ public class HoodieInstantTimeGenerator {
     } catch (Exception e) {
       // Attempt to add the milliseconds in order to complete parsing
       return getInstantFromTemporalAccessor(LocalDateTime.parse(
-          String.format("%s:%s", dateString, DEFAULT_MILLIS_EXT), MILLIS_GRANULARITY_DATE_FORMATTER));
+          String.format("%s.%s", dateString, DEFAULT_MILLIS_EXT), MILLIS_GRANULARITY_DATE_FORMATTER));
     }
   }
 


### PR DESCRIPTION
### Change Logs

MILLIS_GRANULARITY_DATE_FORMAT is `yyyy-MM-dd HH:mm:ss.SSS`

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
