### PR TITLE
[HUDI-6558] support SQL update for no-precombine field tables

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
@@ -38,8 +38,6 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
                                     hoodieCatalogTable: HoodieCatalogTable): Map[String, String] = {
     val optimizedWrite = sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key()
       , SPARK_SQL_OPTIMIZED_WRITES.defaultValue()) == "true"
-
-    // as for MERGE_ON_READ precombine field is required but it's not enforced during table creation
     val shouldCombine = !StringUtils.isNullOrEmpty(hoodieCatalogTable.preCombineKey.getOrElse(""))
 
     if (!shouldCombine && hoodieCatalogTable.tableType.name().equals("MERGE_ON_READ")) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/UpdateHoodieTableCommand.scala
@@ -36,8 +36,8 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
 
   private def buildUpdateConfig( sparkSession: SparkSession,
                                     hoodieCatalogTable: HoodieCatalogTable): Map[String, String] = {
-    val optimizedWrite = sparkSession.sqlContext.conf.getConfString(ENABLE_OPTIMIZED_SQL_WRITES.key()
-      , ENABLE_OPTIMIZED_SQL_WRITES.defaultValue()) == "true"
+    val optimizedWrite = sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key()
+      , SPARK_SQL_OPTIMIZED_WRITES.defaultValue()) == "true"
 
     // as for MERGE_ON_READ precombine field is required but it's not enforced during table creation
     val shouldCombine = !StringUtils.isNullOrEmpty(hoodieCatalogTable.preCombineKey.getOrElse(""))
@@ -47,7 +47,7 @@ case class UpdateHoodieTableCommand(ut: UpdateTable) extends HoodieLeafRunnableC
     }
 
     // Set config to show that this is a prepped write.
-    val preppedWriteConfig = if (optimizedWrite) Map(DATASOURCE_WRITE_PREPPED_KEY -> "true") else Map().empty
+    val preppedWriteConfig = if (optimizedWrite) Map(SPARK_SQL_WRITES_PREPPED_KEY -> "true") else Map().empty
     val combineBeforeUpsertConfig = Map(HoodieWriteConfig.COMBINE_BEFORE_UPSERT.key() -> shouldCombine.toString)
 
     buildHoodieConfig(hoodieCatalogTable) ++ preppedWriteConfig ++ combineBeforeUpsertConfig

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestUpdateTable.scala
@@ -19,12 +19,10 @@ package org.apache.spark.sql.hudi
 
 import org.apache.hudi.DataSourceWriteOptions.SPARK_SQL_OPTIMIZED_WRITES
 import org.apache.hudi.HoodieSparkUtils.isSpark2
-import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
-import org.scalatest.Ignore
 
 class TestUpdateTable extends HoodieSparkSqlTestBase {
 
-  ignore("Test Update Table") {
+  test("Test Update Table") {
     withRecordType()(withTempDir { tmp =>
       Seq(true, false).foreach { sparkSqlOptimizedWrites =>
         Seq("cow", "mor").foreach { tableType =>


### PR DESCRIPTION
### Change Logs

Support SQL update for no-precombine field tables, improves user experience and makes it easier to start with Hudi, this is now (current master, 0.14) supported in MERGE INTO and upsert can also skip to "combine" records, if user does not want to define pcf field, let allow them to do sql updates out of the box, we do not expect duplicates here anyways.


### Impact

Changes behaviour of SQL Update command in spark, now users can update records in tables where no precombine field is specified. For MOR tables with no precombine fields throws an error since MOR requires precombine field.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

Need to update Spark quickstart, to note non-pcf sql updates are supported for CoW.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
