### PR TITLE
[HUDI-6312] Rename enum values of `HollowCommitHandling`

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -86,18 +86,18 @@ public class HoodieCommonConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT = ConfigProperty
       .key("hoodie.datasource.read.handle.hollow.commit")
-      .defaultValue(HollowCommitHandling.EXCEPTION.name())
+      .defaultValue(HollowCommitHandling.FAIL.name())
       .sinceVersion("0.14.0")
       .markAdvanced()
       .withValidValues(enumNames(HollowCommitHandling.class))
       .withDocumentation("When doing incremental queries, there could be hollow commits (requested or inflight commits that are not the latest)"
           + " that are produced by concurrent writers and could lead to potential data loss. This config allows users to have different ways of handling this situation."
           + " The valid values are " + Arrays.toString(enumNames(HollowCommitHandling.class)) + ":"
-          + " Use `" + HollowCommitHandling.EXCEPTION + "` to throw an exception when hollow commit is detected. This is helpful when hollow commits"
+          + " Use `" + HollowCommitHandling.FAIL + "` to throw an exception when hollow commit is detected. This is helpful when hollow commits"
           + " are not expected."
           + " Use `" + HollowCommitHandling.BLOCK + "` to block processing commits from going beyond the hollow ones. This fits the case where waiting for hollow commits"
           + " to finish is acceptable."
-          + " Use `" + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "` (experimental) to query commits in range by state transition time (completion time), instead"
+          + " Use `" + HollowCommitHandling.USE_TRANSITION_TIME + "` (experimental) to query commits in range by state transition time (completion time), instead"
           + " of commit time (start time). Using this mode will result in `begin.instanttime` and `end.instanttime` using `stateTransitionTime` "
           + " instead of the instant's commit time."
       );

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -85,7 +85,7 @@ public class HoodieCommonConfig extends HoodieConfig {
       .withDocumentation("Turn on compression for BITCASK disk map used by the External Spillable Map");
 
   public static final ConfigProperty<String> INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT = ConfigProperty
-      .key("hoodie.datasource.read.handle.hollow.commit")
+      .key("hoodie.read.timeline.holes.resolution.policy")
       .defaultValue(HollowCommitHandling.FAIL.name())
       .sinceVersion("0.14.0")
       .markAdvanced()

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -250,7 +250,7 @@ public interface HoodieTimeline extends Serializable {
   /**
    * Create new timeline with all instants that were modified after specified time.
    */
-  HoodieDefaultTimeline findInstantsModifiedAfterByStateTransitionTime(String instantTime);
+  HoodieTimeline findInstantsModifiedAfterByStateTransitionTime(String instantTime);
 
   /**
    * Create a new Timeline with all the instants after startTs.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -321,7 +321,7 @@ public class TimelineUtils {
    */
   public static HoodieTimeline handleHollowCommitIfNeeded(HoodieTimeline completedCommitTimeline,
       HoodieTableMetaClient metaClient, HollowCommitHandling handlingMode) {
-    if (handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME) {
+    if (handlingMode == HollowCommitHandling.USE_TRANSITION_TIME) {
       return completedCommitTimeline;
     }
 
@@ -341,7 +341,7 @@ public class TimelineUtils {
 
     String hollowCommitTimestamp = firstIncompleteCommit.get().getTimestamp();
     switch (handlingMode) {
-      case EXCEPTION:
+      case FAIL:
         throw new HoodieException(String.format(
             "Found hollow commit: '%s'. Adjust config `%s` accordingly if to avoid throwing this exception.",
             hollowCommitTimestamp, INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key()));
@@ -356,6 +356,6 @@ public class TimelineUtils {
   }
 
   public enum HollowCommitHandling {
-    EXCEPTION, BLOCK, USE_STATE_TRANSITION_TIME;
+    FAIL, BLOCK, USE_TRANSITION_TIME;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -587,7 +587,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
     Stream<String> completed = Stream.of("001", "005");
     HoodieTimeline completedTimeline = new MockHoodieTimeline(completed, Stream.empty());
     switch (handlingMode) {
-      case EXCEPTION:
+      case FAIL:
         HoodieException e = assertThrows(HoodieException.class, () ->
             handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode));
         assertTrue(e.getMessage().startsWith("Found hollow commit:"));
@@ -599,7 +599,7 @@ public class TestTimelineUtils extends HoodieCommonTestHarness {
         assertFalse(filteredTimeline.containsInstant("005"));
         break;
       }
-      case USE_STATE_TRANSITION_TIME: {
+      case USE_TRANSITION_TIME: {
         HoodieTimeline filteredTimeline = handleHollowCommitIfNeeded(completedTimeline, metaClient, handlingMode);
         assertTrue(filteredTimeline.containsInstant("001"));
         assertFalse(filteredTimeline.containsInstant("003"));

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -311,7 +311,7 @@ public class OptionsResolver {
   public static boolean isReadByTxnCompletionTime(Configuration conf) {
     HollowCommitHandling handlingMode = HollowCommitHandling.valueOf(conf
         .getString(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue()));
-    return handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME;
+    return handlingMode == HollowCommitHandling.USE_TRANSITION_TIME;
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -118,7 +118,7 @@ object DataSourceReadOptions {
       + "correspond to an instant on the timeline. New data written with an instant_time > BEGIN_INSTANTTIME are fetched out. "
       + "For e.g: ‘20170901080000’ will get all new data written after Sep 1, 2017 08:00AM. Note that if `"
       + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to "
-      + HollowCommitHandling.USE_STATE_TRANSITION_TIME + ", will use instant's "
+      + HollowCommitHandling.USE_TRANSITION_TIME + ", will use instant's "
       + "`stateTransitionTime` to perform comparison.")
 
   val END_INSTANTTIME: ConfigProperty[String] = ConfigProperty
@@ -129,7 +129,7 @@ object DataSourceReadOptions {
       "timeline is assumed by default. When specified, new data written with an instant_time <= END_INSTANTTIME are fetched out. " +
       "Point in time type queries make more sense with begin and end instant times specified. Note that if `"
       + HoodieCommonConfig.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key() + "` set to `"
-      + HollowCommitHandling.USE_STATE_TRANSITION_TIME + "`, will use instant's "
+      + HollowCommitHandling.USE_TRANSITION_TIME + "`, will use instant's "
       + "`stateTransitionTime` to perform comparison.")
 
   val INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME: ConfigProperty[String] = ConfigProperty

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkConfUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkConfUtils.scala
@@ -19,6 +19,8 @@
 
 package org.apache.hudi
 
+import org.apache.hudi.DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -39,5 +41,11 @@ object HoodieSparkConfUtils {
                      configKey: String,
                      defaultValue: String): String = {
     options.getOrElse(configKey, sqlConf.getConfString(configKey, defaultValue))
+  }
+
+  def getHollowCommitHandling(options: Map[String, String]): HollowCommitHandling = {
+    options.get(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
+      .map(HollowCommitHandling.valueOf)
+      .getOrElse(HollowCommitHandling.valueOf(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.client.utils.SparkInternalSchemaConverter
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieFileFormat, HoodieRecord, HoodieReplaceCommitMetadata}
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_STATE_TRANSITION_TIME
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
 import org.apache.hudi.common.table.timeline.TimelineUtils.{HollowCommitHandling, handleHollowCommitIfNeeded}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
@@ -95,7 +95,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
   private val lastInstant = commitTimeline.lastInstant().get()
 
   private val commitsTimelineToReturn = {
-    if (hollowCommitHandling == USE_STATE_TRANSITION_TIME) {
+    if (hollowCommitHandling == USE_TRANSITION_TIME) {
       commitTimeline.findInstantsInRangeByStateTransitionTime(
         optParams(DataSourceReadOptions.BEGIN_INSTANTTIME.key),
         optParams.getOrElse(DataSourceReadOptions.END_INSTANTTIME.key(), lastInstant.getStateTransitionTime))
@@ -225,7 +225,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
       val endInstantArchived = commitTimeline.isBeforeTimelineStarts(endInstantTime)
 
       val scanDf = if (fallbackToFullTableScan && (startInstantArchived || endInstantArchived)) {
-        if (hollowCommitHandling == USE_STATE_TRANSITION_TIME) {
+        if (hollowCommitHandling == USE_TRANSITION_TIME) {
           throw new HoodieException("Cannot use stateTransitionTime while enables full table scan")
         }
         log.info(s"Falling back to full table scan as startInstantArchived: $startInstantArchived, endInstantArchived: $endInstantArchived")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelation.scala
@@ -19,8 +19,9 @@ package org.apache.hudi
 
 import org.apache.avro.Schema
 import org.apache.hadoop.fs.{GlobPattern, Path}
-import org.apache.hudi.DataSourceReadOptions.{INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT, INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME}
+import org.apache.hudi.DataSourceReadOptions.INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME
 import org.apache.hudi.HoodieBaseRelation.isSchemaEvolutionEnabledOnRead
+import org.apache.hudi.HoodieSparkConfUtils.getHollowCommitHandling
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.client.utils.SparkInternalSchemaConverter
 import org.apache.hudi.common.fs.FSUtils
@@ -67,10 +68,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
     new HoodieSparkEngineContext(new JavaSparkContext(sqlContext.sparkContext)),
     metaClient)
 
-  private val hollowCommitHandling: HollowCommitHandling =
-    optParams.get(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
-      .map(HollowCommitHandling.valueOf)
-      .getOrElse(HollowCommitHandling.valueOf(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue))
+  private val hollowCommitHandling: HollowCommitHandling = getHollowCommitHandling(optParams)
 
   private val commitTimeline = handleHollowCommitIfNeeded(
     hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.{FileStatus, GlobPattern, Path}
 import org.apache.hudi.HoodieConversionUtils.toScalaOption
 import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_STATE_TRANSITION_TIME
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
 import org.apache.hudi.common.table.timeline.TimelineUtils.{HollowCommitHandling, getCommitMetadata, handleHollowCommitIfNeeded}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView
@@ -57,7 +57,7 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
   override protected def timeline: HoodieTimeline = {
     if (fullTableScan) {
       handleHollowCommitIfNeeded(metaClient.getCommitsAndCompactionTimeline, metaClient, hollowCommitHandling)
-    } else if (hollowCommitHandling == HollowCommitHandling.USE_STATE_TRANSITION_TIME) {
+    } else if (hollowCommitHandling == HollowCommitHandling.USE_TRANSITION_TIME) {
       metaClient.getCommitsAndCompactionTimeline.findInstantsInRangeByStateTransitionTime(startTimestamp, endTimestamp)
     } else {
       handleHollowCommitIfNeeded(metaClient.getCommitsAndCompactionTimeline, metaClient, hollowCommitHandling)
@@ -142,7 +142,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
 
   protected def endTimestamp: String = optParams.getOrElse(
     DataSourceReadOptions.END_INSTANTTIME.key,
-    if (hollowCommitHandling == USE_STATE_TRANSITION_TIME) super.timeline.lastInstant().get.getStateTransitionTime
+    if (hollowCommitHandling == USE_TRANSITION_TIME) super.timeline.lastInstant().get.getStateTransitionTime
     else super.timeline.lastInstant().get.getTimestamp)
 
   protected def startInstantArchived: Boolean = super.timeline.isBeforeTimelineStarts(startTimestamp)
@@ -164,7 +164,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
     if (!startInstantArchived || !endInstantArchived) {
       // If endTimestamp commit is not archived, will filter instants
       // before endTimestamp.
-      if (hollowCommitHandling == USE_STATE_TRANSITION_TIME) {
+      if (hollowCommitHandling == USE_TRANSITION_TIME) {
         super.timeline.findInstantsInRangeByStateTransitionTime(startTimestamp, endTimestamp).getInstants.asScala.toList
       } else {
         super.timeline.findInstantsInRange(startTimestamp, endTimestamp).getInstants.asScala.toList
@@ -224,7 +224,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
       throw new HoodieException("Incremental queries are not supported when meta fields are disabled")
     }
 
-    if (hollowCommitHandling == USE_STATE_TRANSITION_TIME && fullTableScan) {
+    if (hollowCommitHandling == USE_TRANSITION_TIME && fullTableScan) {
       throw new HoodieException("Cannot use stateTransitionTime while enables full table scan")
     }
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -19,6 +19,7 @@ package org.apache.hudi
 
 import org.apache.hadoop.fs.{FileStatus, GlobPattern, Path}
 import org.apache.hudi.HoodieConversionUtils.toScalaOption
+import org.apache.hudi.HoodieSparkConfUtils.getHollowCommitHandling
 import org.apache.hudi.common.model.{FileSlice, HoodieRecord}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
@@ -133,10 +134,7 @@ trait HoodieIncrementalRelationTrait extends HoodieBaseRelation {
   // Validate this Incremental implementation is properly configured
   validate()
 
-  protected val hollowCommitHandling: HollowCommitHandling =
-    optParams.get(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
-      .map(HollowCommitHandling.valueOf)
-      .getOrElse(HollowCommitHandling.valueOf(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.defaultValue))
+  protected val hollowCommitHandling: HollowCommitHandling = getHollowCommitHandling(optParams)
 
   protected def startTimestamp: String = optParams(DataSourceReadOptions.BEGIN_INSTANTTIME.key)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/streaming/HoodieStreamSource.scala
@@ -70,11 +70,11 @@ class HoodieStreamSource(
 
   /**
    * When hollow commits are found while doing streaming read , unlike batch incremental query,
-   * we do not use [[HollowCommitHandling.EXCEPTION]] by default, instead we use [[HollowCommitHandling.BLOCK]]
+   * we do not use [[HollowCommitHandling.FAIL]] by default, instead we use [[HollowCommitHandling.BLOCK]]
    * to block processing data from going beyond the hollow commits to avoid unintentional skip.
    *
    * Users can set [[DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT]] to
-   * [[HollowCommitHandling.USE_STATE_TRANSITION_TIME]] to avoid the blocking behavior.
+   * [[HollowCommitHandling.USE_TRANSITION_TIME]] to avoid the blocking behavior.
    */
   private val hollowCommitHandling: HollowCommitHandling =
     parameters.get(INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key)
@@ -115,7 +115,7 @@ class HoodieStreamSource(
       metaClient.getActiveTimeline.filterCompletedInstants(), metaClient, hollowCommitHandling)
     filteredTimeline match {
       case activeInstants if !activeInstants.empty() =>
-        val timestamp = if (hollowCommitHandling == USE_STATE_TRANSITION_TIME) {
+        val timestamp = if (hollowCommitHandling == USE_TRANSITION_TIME) {
           activeInstants.getInstantsOrderedByStateTransitionTime
             .skip(activeInstants.countInstants() - 1)
             .findFirst()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
@@ -20,7 +20,7 @@ package org.apache.hudi.functional
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_STATE_TRANSITION_TIME
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
 import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
@@ -87,7 +87,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
     val result1 = spark.read.format("org.apache.hudi")
       .option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "000")
-      .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_STATE_TRANSITION_TIME.name())
+      .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_TRANSITION_TIME.name())
       .option(DataSourceReadOptions.END_INSTANTTIME.key(), firstInstant.getTimestamp)
       .load(basePath)
       .count()
@@ -96,7 +96,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
     val result2 = spark.read.format("org.apache.hudi")
       .option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.BEGIN_INSTANTTIME.key(), "000")
-      .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_STATE_TRANSITION_TIME.name())
+      .option(DataSourceReadOptions.INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT.key(), USE_TRANSITION_TIME.name())
       .option(DataSourceReadOptions.END_INSTANTTIME.key(), firstInstant.getStateTransitionTime)
       .load(basePath)
       .count()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
@@ -23,7 +23,7 @@ import org.apache.hudi.common.engine.EngineType
 import org.apache.hudi.common.model.{HoodieFailedWritesCleaningPolicy, HoodieRecord, HoodieTableType}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_STATE_TRANSITION_TIME
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime
 import org.apache.hudi.config.{HoodieCleanConfig, HoodieWriteConfig}
@@ -35,7 +35,7 @@ import scala.jdk.CollectionConverters.mapAsJavaMapConverter
 
 class TestStreamSourceReadByStateTransitionTime extends TestStreamingSource {
 
-  override val handlingMode: HollowCommitHandling = USE_STATE_TRANSITION_TIME
+  override val handlingMode: HollowCommitHandling = USE_TRANSITION_TIME
 
   private val dataGen = new HoodieTestDataGenerator(System.currentTimeMillis())
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD
 import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling
-import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.{BLOCK, USE_STATE_TRANSITION_TIME}
+import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.{BLOCK, USE_TRANSITION_TIME}
 import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSERT_PARALLELISM_VALUE, TBL_NAME, UPSERT_PARALLELISM_VALUE}
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.spark.sql.streaming.StreamTest
@@ -199,7 +199,7 @@ class TestStreamingSource extends StreamTest {
       addData(tablePath, Seq(("2", "a1", "11", "001")))
       addData(tablePath, Seq(("3", "a1", "12", "002")))
 
-      val timestamp = if (handlingMode == USE_STATE_TRANSITION_TIME) {
+      val timestamp = if (handlingMode == USE_TRANSITION_TIME) {
         metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
           .firstInstant().get().getStateTransitionTime
       } else {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -59,12 +59,12 @@ public class IncrSourceHelper {
 
   /**
    * When hollow commits are found while using incremental source with {@link HoodieDeltaStreamer},
-   * unlike batch incremental query, we do not use {@link HollowCommitHandling#EXCEPTION} by default,
+   * unlike batch incremental query, we do not use {@link HollowCommitHandling#FAIL} by default,
    * instead we use {@link HollowCommitHandling#BLOCK} to block processing data from going beyond the
    * hollow commits to avoid unintentional skip.
    * <p>
    * Users can set {@link DataSourceReadOptions#INCREMENTAL_READ_HANDLE_HOLLOW_COMMIT} to
-   * {@link HollowCommitHandling#USE_STATE_TRANSITION_TIME} to avoid the blocking behavior.
+   * {@link HollowCommitHandling#USE_TRANSITION_TIME} to avoid the blocking behavior.
    */
   public static HollowCommitHandling getHollowCommitHandleMode(TypedProperties props) {
     return HollowCommitHandling.valueOf(
@@ -90,7 +90,7 @@ public class IncrSourceHelper {
     HoodieTableMetaClient srcMetaClient = HoodieTableMetaClient.builder().setConf(jssc.hadoopConfiguration()).setBasePath(srcBasePath).setLoadActiveTimelineOnLoad(true).build();
     HoodieTimeline completedCommitTimeline = srcMetaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
     final HoodieTimeline activeCommitTimeline = handleHollowCommitIfNeeded(completedCommitTimeline, srcMetaClient, handlingMode);
-    Function<HoodieInstant, String> timestampForLastInstant = instant -> handlingMode == HollowCommitHandling.USE_STATE_TRANSITION_TIME
+    Function<HoodieInstant, String> timestampForLastInstant = instant -> handlingMode == HollowCommitHandling.USE_TRANSITION_TIME
         ? instant.getStateTransitionTime() : instant.getTimestamp();
     String beginInstantTime = beginInstant.orElseGet(() -> {
       if (missingCheckpointStrategy != null) {


### PR DESCRIPTION
### Change Logs

- Rename `HollowCommitHandling#EXCEPTION` to `HollowCommitHandling#FAIL`
- Rename `HollowCommitHandling#USE_STATE_TRANSITION_TIME` to `HollowCommitHandling#USE_TRANSITION_TIME`

### Impact

User config change (no actual impact as this is newly added to not-yet-released 0.14.0)

### Risk level

None.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
