### PR TITLE
[MINOR] Add rowId field to HoodieRecordIndexInfo in metadata payload

### DIFF
--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -393,6 +393,12 @@
                             "name": "instantTime",
                             "type": "long",
                             "doc": "Epoch time in millisecond at which record was added"
+                        },
+                        {
+                            "name": "rowId",
+                            "type": ["null", "long"],
+                            "doc": "Identifier for the row",
+                            "default": null
                         }
                     ]
                 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -283,7 +283,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_HIGH_BITS).toString()),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_LOW_BITS).toString()),
             Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILE_INDEX).toString()),
-            Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_INSTANT_TIME).toString()));
+            Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_INSTANT_TIME).toString()),
+            0L);
       }
     } else {
       this.isDeletedRecord = true;
@@ -755,7 +756,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               uuid.getMostSignificantBits(),
               uuid.getLeastSignificantBits(),
               fileIndex,
-              instantTimeMillis));
+              instantTimeMillis,
+              0L));
       return new HoodieAvroRecord<>(key, payload);
     } catch (Exception e) {
       throw new HoodieMetadataException("Failed to create metadata payload for record index.", e);


### PR DESCRIPTION
### Change Logs

Add rowId field to HoodieRecordIndexInfo in metadata payload. The rowId is not being read/written right now. Default is 0L. In future, we would want to map a record to file and rowId (to indicate offset within a page in column chunk) in record index, then this field would be useful.

### Impact

None. Just an addition of a long field which should be backwards compatible.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
