### PR TITLE
The build times org.apache.http package cannot be found

### DIFF
--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -280,5 +280,10 @@
       <artifactId>disruptor</artifactId>
       <version>${disruptor.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
…org.apache.http package cannot be found

### Change Logs
Add http dependency in ../hudi-common/pom.xml

```html
<dependencies>
    ...
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpcore</artifactId>
    </dependency>
    ...
</dependencies>
```

### Impact
node


### Risk level (write none, low medium or high below)
low


### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
