### PR TITLE
[HUDI-6598]Fix the error type of sync-strategy parameter in HiveSyncConfig

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -166,8 +166,8 @@ public class HiveSyncConfig extends HoodieSyncConfig {
     @Parameter(names = {"--sync-comment"}, description = "synchronize table comments to hive")
     public Boolean syncComment;
 
-    @Parameter(names = {"--sync-strategy"}, description = "Hive table synchronization strategy. Available option: ONLY_RO, ONLY_RT, ALL")
-    public Boolean syncStrategy;
+    @Parameter(names = {"--sync-strategy"}, description = "Hive table synchronization strategy. Available option: RO, RT, ALL")
+    public String syncStrategy;
 
     public boolean isHelp() {
       return hoodieSyncConfigParams.isHelp();


### PR DESCRIPTION
### Change Logs

The parameter  `--sync-strategy` is error when use HiveSyncTool.
```java
 public static final ConfigProperty<String> HIVE_SYNC_TABLE_STRATEGY = ConfigProperty
      .key("hoodie.datasource.hive_sync.table.strategy")
      .defaultValue(HoodieSyncTableStrategy.ALL.name())
      .markAdvanced()
      .sinceVersion("0.13.0")
      .withDocumentation("Hive table synchronization strategy. Available option: RO, RT, ALL.");
```

The hoodie parameter `hoodie.datasource.hive_sync.table.strategy` 's  type is STRING.

