### PR TITLE
[MINOR] Expose filename when getting commit time from illegal filename

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -197,7 +197,6 @@ public class FSUtils {
       }
       return fullFileName.split("_")[2].split("\\.")[0];
     } catch (ArrayIndexOutOfBoundsException e) {
-      LOG.error("Found files with illegal filename! Full filename: " + fullFileName);
       throw new HoodieException("Failed to get commit time from filename, filename is illegal: " + fullFileName, e);
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -191,10 +191,15 @@ public class FSUtils {
   }
 
   public static String getCommitTime(String fullFileName) {
-    if (isLogFile(fullFileName)) {
-      return fullFileName.split("_")[1].split("\\.")[0];
+    try {
+      if (isLogFile(fullFileName)) {
+        return fullFileName.split("_")[1].split("\\.")[0];
+      }
+      return fullFileName.split("_")[2].split("\\.")[0];
+    } catch (ArrayIndexOutOfBoundsException e) {
+      LOG.error("Found files with illegal filename! Full filename: " + fullFileName);
+      throw new HoodieException("Failed to get commit time from filename, filename is illegal: " + fullFileName, e);
     }
-    return fullFileName.split("_")[2].split("\\.")[0];
   }
 
   public static long getFileSize(FileSystem fs, Path path) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -197,7 +197,7 @@ public class FSUtils {
       }
       return fullFileName.split("_")[2].split("\\.")[0];
     } catch (ArrayIndexOutOfBoundsException e) {
-      throw new HoodieException("Failed to get commit time from filename, filename is illegal: " + fullFileName, e);
+      throw new HoodieException("Failed to get commit time from filename: " + fullFileName, e);
     }
   }
 


### PR DESCRIPTION
### Change Logs

Sometimes users can get non-hudi files mixed in Hudi table causing `ArrayIndexOutOfBoundsException` when getting commit time from filename. This fix is to expose this error better to make it easier for users to identify problematic files.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
