### PR TITLE
[HUDI-6606] Use record level index with SQL equality queries

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -344,6 +344,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getBooleanOrDefault(ENABLE_METADATA_INDEX_COLUMN_STATS);
   }
 
+  public boolean isRecordIndexEnabled() {
+    return getBooleanOrDefault(RECORD_INDEX_ENABLE_PROP);
+  }
+
   public List<String> getColumnsEnabledForColumnStatsIndex() {
     return StringUtils.split(getString(COLUMN_STATS_INDEX_FOR_COLUMNS), CONFIG_VALUES_DELIMITER);
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -226,7 +226,7 @@ case class HoodieFileIndex(spark: SparkSession,
     lazy val queryReferencedColumns = collectReferencedColumns(spark, queryFilters, schema)
 
     if (recordLevelIndex.isIndexApplicable(queryFilters)) {
-      return Try(Option.apply(recordLevelIndex.getCandidateFiles(allFiles, queryFilters)))
+      Try(Option.apply(recordLevelIndex.getCandidateFiles(allFiles, queryFilters)))
     }
     if (!isMetadataTableEnabled || !isDataSkippingEnabled || !columnStatsIndex.isIndexAvailable) {
       validateConfig()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -226,9 +226,8 @@ case class HoodieFileIndex(spark: SparkSession,
     lazy val queryReferencedColumns = collectReferencedColumns(spark, queryFilters, schema)
 
     if (recordLevelIndex.isIndexApplicable(queryFilters)) {
-      Try(Option.apply(recordLevelIndex.getCandidateFiles(allFiles, queryFilters)))
-    }
-    if (!isMetadataTableEnabled || !isDataSkippingEnabled || !columnStatsIndex.isIndexAvailable) {
+      Option.apply(recordLevelIndex.getCandidateFiles(allFiles, queryFilters))
+    } else if (!isMetadataTableEnabled || !isDataSkippingEnabled || !columnStatsIndex.isIndexAvailable) {
       validateConfig()
       Option.empty
     } else if (queryFilters.isEmpty || queryReferencedColumns.isEmpty) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi
 
 import org.apache.hadoop.fs.FileStatus

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -68,12 +68,13 @@ class RecordLevelIndexSupport(spark: SparkSession,
     Option.apply(recordKeyOpt.orElse(null))
   }
 
-  def attributeMatchesRecordKey(attributeName: String): Boolean = {
+  private def attributeMatchesRecordKey(attributeName: String): Boolean = {
     val recordKeyOpt = getRecordKey
     if (recordKeyOpt.isDefined && recordKeyOpt.get == attributeName) {
       true
+    } else {
+      HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == recordKeyOpt.get
     }
-    HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == recordKeyOpt.get
   }
 
   private def getAttributeLiteralTuple(expression1: Expression, expression2: Expression): Option[(AttributeReference, Literal)] = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -1,0 +1,108 @@
+package org.apache.hudi
+
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.metadata.{HoodieTableMetadata, HoodieTableMetadataUtil}
+import org.apache.hudi.util.JFunction
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, Literal}
+
+import scala.collection.{JavaConverters, mutable}
+
+class RecordLevelIndexSupport(spark: SparkSession,
+                              metadataConfig: HoodieMetadataConfig,
+                              metaClient: HoodieTableMetaClient) {
+
+  @transient private lazy val engineCtx = new HoodieSparkEngineContext(new JavaSparkContext(spark.sparkContext))
+  @transient private lazy val metadataTable: HoodieTableMetadata =
+    HoodieTableMetadata.create(engineCtx, metadataConfig, metaClient.getBasePathV2.toString)
+
+  def getCandidateFiles(allFiles: Seq[FileStatus], queryFilters: Seq[Expression]): Set[String] = {
+    val (_, recordKeys) = filterQueryFiltersWithRecordKey(queryFilters)
+    val recordKeyLocationsMap = metadataTable.readRecordIndex(JavaConverters.seqAsJavaListConverter(recordKeys).asJava)
+    val fileIdToPartitionMap: mutable.Map[String, String] = mutable.Map.empty
+    val candidateFiles: mutable.Set[String] = mutable.Set.empty
+    for (location <- JavaConverters.collectionAsScalaIterableConverter(recordKeyLocationsMap.values()).asScala) {
+      fileIdToPartitionMap.put(location.getFileId, location.getPartitionPath)
+    }
+    for (file <- allFiles) {
+      val fileId = FSUtils.getFileIdFromFilePath(file.getPath)
+      val partitionOpt = fileIdToPartitionMap.get(fileId)
+      if (partitionOpt.isDefined) {
+        candidateFiles += file.getPath.getName
+      }
+    }
+    candidateFiles.toSet
+  }
+
+  def getRecordKey: Option[String] = {
+    val recordKeysOpt: org.apache.hudi.common.util.Option[Array[String]] = metaClient.getTableConfig.getRecordKeyFields
+    val recordKeyOpt = recordKeysOpt.map[String](JFunction.toJavaFunction[Array[String], String](arr =>
+      if (arr.length == 1) {
+        arr(0)
+      } else {
+        null
+      }))
+    Option.apply(recordKeyOpt.orElse(null))
+  }
+
+  def attributeMatchesRecordKey(attributeName: String): Boolean = {
+    val recordKeyOpt = getRecordKey
+    if (recordKeyOpt.isDefined && recordKeyOpt.get == attributeName) {
+      return true
+    }
+    HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == recordKeyOpt.get
+  }
+
+  private def getAttributeLiteralTuple(expression1: Expression, expression2: Expression): Option[(AttributeReference, Literal)] = {
+    expression1 match {
+      case attr: AttributeReference => expression2 match {
+        case literal: Literal =>
+          Option.apply(attr, literal)
+        case _ =>
+          Option.empty
+      }
+      case literal: Literal => expression2 match {
+        case attr: AttributeReference =>
+          Option.apply(attr, literal)
+        case _ =>
+          Option.empty
+      }
+      case _ => Option.empty
+    }
+
+  }
+
+  private def filterQueryFiltersWithRecordKey(queryFilters: Seq[Expression]): (List[Expression], List[String]) = {
+    var recordKeyQueries: List[Expression] = List.empty
+    var recordKeys: List[String] = List.empty
+    for (query <- queryFilters) {
+      query match {
+        case equalToQuery: EqualTo =>
+          val (attribute, literal) = getAttributeLiteralTuple(equalToQuery.left, equalToQuery.right).orNull
+          if (attribute != null && attribute.name != null && attributeMatchesRecordKey(attribute.name)) {
+            recordKeys = recordKeys :+ literal.value.toString
+            recordKeyQueries = recordKeyQueries :+ equalToQuery
+          }
+        case _ =>
+      }
+    }
+    Tuple2.apply(recordKeyQueries, recordKeys)
+  }
+
+  /**
+   * Returns true in cases when metadata table is enabled and Record Level Index is built.
+   */
+  def isIndexApplicable(queryFilters: Seq[Expression]): Boolean = {
+    isIndexAvailable && filterQueryFiltersWithRecordKey(queryFilters)._1.nonEmpty
+  }
+
+  private def isIndexAvailable: Boolean = {
+    metadataConfig.enabled && metaClient.getTableConfig.getMetadataPartitions.contains(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -39,6 +39,12 @@ class RecordLevelIndexSupport(spark: SparkSession,
   @transient private lazy val metadataTable: HoodieTableMetadata =
     HoodieTableMetadata.create(engineCtx, metadataConfig, metaClient.getBasePathV2.toString)
 
+  /**
+   * Returns the list of candidate files which should be queried after pruning based on query filters.
+   * @param allFiles - List of all files which needs to be considered for the query
+   * @param queryFilters - Input query filters. List of candidate files are pruned based on these query filters.
+   * @return Sequence of file names which need to be queried
+   */
   def getCandidateFiles(allFiles: Seq[FileStatus], queryFilters: Seq[Expression]): Set[String] = {
     val (_, recordKeys) = filterQueryFiltersWithRecordKey(queryFilters)
     val recordKeyLocationsMap = metadataTable.readRecordIndex(JavaConverters.seqAsJavaListConverter(recordKeys).asJava)
@@ -57,7 +63,10 @@ class RecordLevelIndexSupport(spark: SparkSession,
     candidateFiles.toSet
   }
 
-  def getRecordKey: Option[String] = {
+  /**
+   * Returns the configured record key for the table if it is a simple record key else returns empty option.
+   */
+  private def getRecordKeyConfig: Option[String] = {
     val recordKeysOpt: org.apache.hudi.common.util.Option[Array[String]] = metaClient.getTableConfig.getRecordKeyFields
     val recordKeyOpt = recordKeysOpt.map[String](JFunction.toJavaFunction[Array[String], String](arr =>
       if (arr.length == 1) {
@@ -68,8 +77,13 @@ class RecordLevelIndexSupport(spark: SparkSession,
     Option.apply(recordKeyOpt.orElse(null))
   }
 
+  /**
+   * Matches the configured simple record key with the input attribute name.
+   * @param attributeName The attribute name provided in the query
+   * @return true if input attribute name matches the configured simple record key
+   */
   private def attributeMatchesRecordKey(attributeName: String): Boolean = {
-    val recordKeyOpt = getRecordKey
+    val recordKeyOpt = getRecordKeyConfig
     if (recordKeyOpt.isDefined && recordKeyOpt.get == attributeName) {
       true
     } else {
@@ -77,6 +91,13 @@ class RecordLevelIndexSupport(spark: SparkSession,
     }
   }
 
+  /**
+   * Returns the attribute and literal pair given the operands of a binary operator. The pair is returned only if one of
+   * the operand is an attribute and other is literal. In other cases it returns an empty Option.
+   * @param expression1 - Left operand of the binary operator
+   * @param expression2 - Right operand of the binary operator
+   * @return Attribute and literal pair
+   */
   private def getAttributeLiteralTuple(expression1: Expression, expression2: Expression): Option[(AttributeReference, Literal)] = {
     expression1 match {
       case attr: AttributeReference => expression2 match {
@@ -96,6 +117,12 @@ class RecordLevelIndexSupport(spark: SparkSession,
 
   }
 
+  /**
+   * Given query filters, it filters the EqualTo queries on simple record key columns and returns a tuple of list of such
+   * queries and list of record key literals present in the query.
+   * @param queryFilters The queries that need to be filtered.
+   * @return Tuple of List of filtered queries and list of record key literals that need to be matched
+   */
   private def filterQueryFiltersWithRecordKey(queryFilters: Seq[Expression]): (List[Expression], List[String]) = {
     var recordKeyQueries: List[Expression] = List.empty
     var recordKeys: List[String] = List.empty
@@ -120,6 +147,9 @@ class RecordLevelIndexSupport(spark: SparkSession,
     isIndexAvailable && filterQueryFiltersWithRecordKey(queryFilters)._1.nonEmpty
   }
 
+  /**
+   * Return true is metadata table is enabled and record index metadata partition is enabled.
+   */
   private def isIndexAvailable: Boolean = {
     metadataConfig.enabled && metaClient.getTableConfig.getMetadataPartitions.contains(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX)
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -148,7 +148,7 @@ class RecordLevelIndexSupport(spark: SparkSession,
   }
 
   /**
-   * Return true is metadata table is enabled and record index metadata partition is enabled.
+   * Return true if metadata table is enabled and record index metadata partition is available.
    */
   private def isIndexAvailable: Boolean = {
     metadataConfig.enabled && metaClient.getTableConfig.getMetadataPartitions.contains(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -71,7 +71,7 @@ class RecordLevelIndexSupport(spark: SparkSession,
   def attributeMatchesRecordKey(attributeName: String): Boolean = {
     val recordKeyOpt = getRecordKey
     if (recordKeyOpt.isDefined && recordKeyOpt.get == attributeName) {
-      return true
+      true
     }
     HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName == recordKeyOpt.get
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -1,0 +1,266 @@
+package org.apache.hudi.functional
+
+import org.apache.hadoop.fs.Path
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.client.utils.MetadataConversionUtils
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.model._
+import org.apache.hudi.common.table.timeline.HoodieInstant
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieTableMetadataUtil, MetadataPartitionType}
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.util.JavaConversions
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{col, not}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api._
+
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.Collectors
+import scala.collection.JavaConverters._
+import scala.collection.{JavaConverters, mutable}
+import scala.util.Using
+
+class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
+  var spark: SparkSession = _
+  var instantTime: AtomicInteger = _
+  val metadataOpts = Map(
+    HoodieMetadataConfig.ENABLE.key -> "true",
+    HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key -> "true"
+  )
+  val commonOpts = Map(
+    "hoodie.insert.shuffle.parallelism" -> "4",
+    "hoodie.upsert.shuffle.parallelism" -> "4",
+    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+    RECORDKEY_FIELD.key -> "_row_key",
+    PARTITIONPATH_FIELD.key -> "partition",
+    PRECOMBINE_FIELD.key -> "timestamp",
+    HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+  ) ++ metadataOpts
+  var mergedDfList: List[DataFrame] = List.empty
+
+  @BeforeEach
+  override def setUp() {
+    initPath()
+    initSparkContexts()
+    initFileSystem()
+    initTestDataGenerator()
+
+    setTableName("hoodie_test")
+    initMetaClient()
+
+    instantTime = new AtomicInteger(1)
+
+    spark = sqlContext.sparkSession
+  }
+
+  @AfterEach
+  override def tearDown() = {
+    cleanupFileSystem()
+    cleanupSparkContexts()
+  }
+
+  protected def getLatestMetaClient(enforce: Boolean): HoodieTableMetaClient = {
+    val lastInsant = String.format("%03d", new Integer(instantTime.incrementAndGet()))
+    if (enforce || metaClient.getActiveTimeline.lastInstant().get().getTimestamp.compareTo(lastInsant) < 0) {
+      println("Reloaded timeline")
+      metaClient.reloadActiveTimeline()
+      metaClient
+    }
+    metaClient
+  }
+
+  protected def rollbackLastInstant(hudiOpts: Map[String, String]): HoodieInstant = {
+    val lastInstant = getLatestMetaClient(false).getActiveTimeline
+      .filter(JavaConversions.getPredicate(instant => instant.getAction != ActionType.rollback.name()))
+      .lastInstant().get()
+    if (getLatestCompactionInstant() != getLatestMetaClient(false).getActiveTimeline.lastInstant()
+      && lastInstant.getAction != ActionType.replacecommit.name()
+      && lastInstant.getAction != ActionType.clean.name()) {
+      mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+    }
+    val writeConfig = getWriteConfig(hudiOpts)
+    new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), writeConfig)
+      .rollback(lastInstant.getTimestamp)
+
+    if (lastInstant.getAction != ActionType.clean.name()) {
+      assertEquals(ActionType.rollback.name(), getLatestMetaClient(true).getActiveTimeline.lastInstant().get().getAction)
+    }
+    lastInstant
+  }
+
+  protected def executeFunctionNTimes[T](function0: Function0[T], n: Int): Unit = {
+    for (i <- 1 to n) {
+      function0.apply()
+    }
+  }
+
+  protected def deleteLastCompletedCommitFromDataAndMetadataTimeline(hudiOpts: Map[String, String]): Unit = {
+    val writeConfig = getWriteConfig(hudiOpts)
+    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
+    val metadataTableMetaClient = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
+    val metadataTableLastInstant = metadataTableMetaClient.getCommitsTimeline.lastInstant().get()
+    assertTrue(fs.delete(new Path(metaClient.getMetaPath, lastInstant.getFileName), false))
+    assertTrue(fs.delete(new Path(metadataTableMetaClient.getMetaPath, metadataTableLastInstant.getFileName), false))
+    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  }
+
+  protected def deleteLastCompletedCommitFromTimeline(hudiOpts: Map[String, String]): Unit = {
+    val writeConfig = getWriteConfig(hudiOpts)
+    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
+    assertTrue(fs.delete(new Path(metaClient.getMetaPath, lastInstant.getFileName), false))
+    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
+  }
+
+  protected def getMetadataMetaClient(hudiOpts: Map[String, String]): HoodieTableMetaClient = {
+    getHoodieTable(metaClient, getWriteConfig(hudiOpts)).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
+  }
+
+  protected def getLatestCompactionInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
+    getLatestMetaClient(false).getActiveTimeline
+      .filter(JavaConversions.getPredicate(s => Option(
+        try {
+          val commitMetadata = MetadataConversionUtils.getHoodieCommitMetadata(metaClient, s)
+            .orElse(new HoodieCommitMetadata())
+          commitMetadata
+        } catch {
+          case _: Exception => new HoodieCommitMetadata()
+        })
+        .map(c => c.getOperationType == WriteOperationType.COMPACT)
+        .get))
+      .lastInstant()
+  }
+
+  protected def getLatestClusteringInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
+    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceTimeline.lastInstant()
+  }
+
+  protected def doWriteAndValidateDataAndRecordIndex(hudiOpts: Map[String, String],
+                                                   operation: String,
+                                                   saveMode: SaveMode,
+                                                   validate: Boolean = true): DataFrame = {
+    var latestBatch: mutable.Buffer[String] = null
+    if (operation == UPSERT_OPERATION_OPT_VAL) {
+      val instantTime = getInstantTime()
+      val records = recordsToStrings(dataGen.generateUniqueUpdates(instantTime, 1))
+      records.addAll(recordsToStrings(dataGen.generateInserts(instantTime, 1)))
+      latestBatch = records.asScala
+    } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
+      latestBatch = recordsToStrings(dataGen.generateInsertsForPartition(
+        getInstantTime(), 5, dataGen.getPartitionPaths.last)).asScala
+    } else {
+      latestBatch = recordsToStrings(dataGen.generateInserts(getInstantTime(), 5)).asScala
+    }
+    val latestBatchDf = spark.read.json(spark.sparkContext.parallelize(latestBatch, 2))
+    latestBatchDf.cache()
+    latestBatchDf.write.format("org.apache.hudi")
+      .options(hudiOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, operation)
+      .mode(saveMode)
+      .save(basePath)
+    val deletedDf = calculateMergedDf(latestBatchDf, operation)
+    deletedDf.cache()
+    if (validate) {
+      validateDataAndRecordIndices(hudiOpts, deletedDf)
+    }
+    deletedDf.unpersist()
+    latestBatchDf
+  }
+
+  /**
+   * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
+   */
+  protected def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = {
+    val prevDfOpt = mergedDfList.lastOption
+    if (prevDfOpt.isEmpty) {
+      mergedDfList = mergedDfList :+ latestBatchDf
+      sparkSession.emptyDataFrame
+    } else {
+      if (operation == INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL) {
+        mergedDfList = mergedDfList :+ latestBatchDf
+        // after insert_overwrite_table, all previous snapshot's records should be deleted from RLI
+        prevDfOpt.get
+      } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
+        val overwrittenPartitions = latestBatchDf.select("partition")
+          .collectAsList().stream().map[String](JavaConversions.getFunction[Row, String](r => r.getString(0))).collect(Collectors.toList[String])
+        val prevDf = prevDfOpt.get
+        val latestSnapshot = prevDf
+          .filter(not(col("partition").isInCollection(overwrittenPartitions)))
+          .union(latestBatchDf)
+        mergedDfList = mergedDfList :+ latestSnapshot
+
+        // after insert_overwrite (partition), all records in the overwritten partitions should be deleted from RLI
+        prevDf.filter(col("partition").isInCollection(overwrittenPartitions))
+      } else {
+        val prevDf = prevDfOpt.get
+        val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key")
+          && prevDf("partition") === latestBatchDf("partition"), "leftanti")
+        val latestSnapshot = prevDfOld.union(latestBatchDf)
+        mergedDfList = mergedDfList :+ latestSnapshot
+        sparkSession.emptyDataFrame
+      }
+    }
+  }
+
+  private def getInstantTime(): String = {
+    String.format("%03d", new Integer(instantTime.incrementAndGet()))
+  }
+
+  protected def getWriteConfig(hudiOpts: Map[String, String]): HoodieWriteConfig = {
+    val props = new Properties()
+    props.putAll(JavaConverters.mapAsJavaMapConverter(hudiOpts).asJava)
+    HoodieWriteConfig.newBuilder()
+      .withProps(props)
+      .withPath(basePath)
+      .build()
+  }
+
+  protected def getFileGroupCountForRecordIndex(writeConfig: HoodieWriteConfig): Long = {
+    val tableMetadata = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata]
+    tableMetadata.getMetadataFileSystemView.getAllFileGroups(MetadataPartitionType.RECORD_INDEX.getPartitionPath).count
+  }
+
+  protected def validateDataAndRecordIndices(hudiOpts: Map[String, String],
+                                           deletedDf: DataFrame = sparkSession.emptyDataFrame): Unit = {
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    val writeConfig = getWriteConfig(hudiOpts)
+    val metadata = metadataWriter(writeConfig).getTableMetadata
+    val readDf = spark.read.format("hudi").load(basePath)
+    val rowArr = readDf.collect()
+    val recordIndexMap = metadata.readRecordIndex(
+      JavaConverters.seqAsJavaListConverter(rowArr.map(row => row.getAs("_hoodie_record_key").toString).toList).asJava)
+
+    assertTrue(rowArr.length > 0)
+    for (row <- rowArr) {
+      val recordKey: String = row.getAs("_hoodie_record_key")
+      val partitionPath: String = row.getAs("_hoodie_partition_path")
+      val fileName: String = row.getAs("_hoodie_file_name")
+      val recordLocation = recordIndexMap.get(recordKey)
+      assertEquals(partitionPath, recordLocation.getPartitionPath)
+      assertTrue(fileName.startsWith(recordLocation.getFileId), fileName + " should start with " + recordLocation.getFileId)
+    }
+
+    val deletedRows = deletedDf.collect()
+    val recordIndexMapForDeletedRows = metadata.readRecordIndex(
+      JavaConverters.seqAsJavaListConverter(deletedRows.map(row => row.getAs("_row_key").toString).toList).asJava)
+    assertEquals(0, recordIndexMapForDeletedRows.size(), "deleted records should not present in RLI")
+
+    assertEquals(rowArr.length, recordIndexMap.keySet.size)
+    val estimatedFileGroupCount = HoodieTableMetadataUtil.estimateFileGroupCount(MetadataPartitionType.RECORD_INDEX, rowArr.length, 48,
+      writeConfig.getRecordIndexMinFileGroupCount, writeConfig.getRecordIndexMaxFileGroupCount,
+      writeConfig.getRecordIndexGrowthFactor, writeConfig.getRecordIndexMaxFileGroupSizeBytes)
+    assertEquals(estimatedFileGroupCount, getFileGroupCountForRecordIndex(writeConfig))
+    val prevDf = mergedDfList.last.drop("tip_history")
+    val nonMatchingRecords = readDf.drop("_hoodie_commit_time", "_hoodie_commit_seqno", "_hoodie_record_key",
+      "_hoodie_partition_path", "_hoodie_file_name", "tip_history")
+      .join(prevDf, prevDf.columns, "leftanti")
+    assertEquals(0, nonMatchingRecords.count())
+    assertEquals(readDf.count(), prevDf.count())
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.functional
 
 import org.apache.hadoop.fs.Path

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -18,81 +18,32 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hadoop.fs.Path
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.DataSourceWriteOptions._
-import org.apache.hudi.client.SparkRDDWriteClient
-import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.client.transaction.PreferWriterConflictResolutionStrategy
-import org.apache.hudi.client.utils.MetadataConversionUtils
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model._
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
-import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
-import org.apache.hudi.config.{HoodieCleanConfig, HoodieClusteringConfig, HoodieCompactionConfig, HoodieLockConfig, HoodieWriteConfig}
+import org.apache.hudi.config._
 import org.apache.hudi.exception.HoodieWriteConflictException
-import org.apache.hudi.metadata.{HoodieBackedTableMetadata, HoodieTableMetadataUtil, MetadataPartitionType}
-import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.metadata.{HoodieBackedTableMetadata, MetadataPartitionType}
 import org.apache.hudi.util.JavaConversions
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{col, not}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, EnumSource}
 
+import java.util.Collections
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.stream.Collectors
-import java.util.{Collections, Properties}
 import scala.collection.JavaConverters._
-import scala.collection.{JavaConverters, mutable}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.Using
 
 @Tag("functional")
-class TestRecordLevelIndex extends HoodieSparkClientTestBase {
-  var spark: SparkSession = _
-  var instantTime: AtomicInteger = _
-  val metadataOpts = Map(
-    HoodieMetadataConfig.ENABLE.key -> "true",
-    HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key -> "true"
-  )
-  val commonOpts = Map(
-    "hoodie.insert.shuffle.parallelism" -> "4",
-    "hoodie.upsert.shuffle.parallelism" -> "4",
-    HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
-    RECORDKEY_FIELD.key -> "_row_key",
-    PARTITIONPATH_FIELD.key -> "partition",
-    PRECOMBINE_FIELD.key -> "timestamp",
-    HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
-  ) ++ metadataOpts
-  var mergedDfList: List[DataFrame] = List.empty
-
-  @BeforeEach
-  override def setUp() {
-    initPath()
-    initSparkContexts()
-    initFileSystem()
-    initTestDataGenerator()
-
-    setTableName("hoodie_test")
-    initMetaClient()
-
-    instantTime = new AtomicInteger(1)
-
-    spark = sqlContext.sparkSession
-  }
-
-  @AfterEach
-  override def tearDown() = {
-    cleanupFileSystem()
-    cleanupSparkContexts()
-  }
-
+class TestRecordLevelIndex extends RecordLevelIndexTestBase {
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
   def testRLIInitialization(tableType: HoodieTableType): Unit = {
@@ -517,203 +468,5 @@ class TestRecordLevelIndex extends HoodieSparkClientTestBase {
     assertTrue(f1.value.get.get || f2.value.get.get)
     executor.shutdownNow()
     validateDataAndRecordIndices(hudiOpts)
-  }
-
-  private def getLatestMetaClient(enforce: Boolean): HoodieTableMetaClient = {
-    val lastInsant = String.format("%03d", new Integer(instantTime.incrementAndGet()))
-    if (enforce || metaClient.getActiveTimeline.lastInstant().get().getTimestamp.compareTo(lastInsant) < 0) {
-      println("Reloaded timeline")
-      metaClient.reloadActiveTimeline()
-      metaClient
-    }
-    metaClient
-  }
-
-  private def rollbackLastInstant(hudiOpts: Map[String, String]): HoodieInstant = {
-    val lastInstant = getLatestMetaClient(false).getActiveTimeline
-      .filter(JavaConversions.getPredicate(instant => instant.getAction != ActionType.rollback.name()))
-      .lastInstant().get()
-    if (getLatestCompactionInstant() != getLatestMetaClient(false).getActiveTimeline.lastInstant()
-      && lastInstant.getAction != ActionType.replacecommit.name()
-      && lastInstant.getAction != ActionType.clean.name()) {
-      mergedDfList = mergedDfList.take(mergedDfList.size - 1)
-    }
-    val writeConfig = getWriteConfig(hudiOpts)
-    new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), writeConfig)
-      .rollback(lastInstant.getTimestamp)
-
-    if (lastInstant.getAction != ActionType.clean.name()) {
-      assertEquals(ActionType.rollback.name(), getLatestMetaClient(true).getActiveTimeline.lastInstant().get().getAction)
-    }
-    lastInstant
-  }
-
-  private def executeFunctionNTimes[T](function0: Function0[T], n : Int): Unit = {
-    for (i <- 1 to n) {
-      function0.apply()
-    }
-  }
-
-  private def deleteLastCompletedCommitFromDataAndMetadataTimeline(hudiOpts: Map[String, String]): Unit = {
-    val writeConfig = getWriteConfig(hudiOpts)
-    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
-    val metadataTableMetaClient = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
-    val metadataTableLastInstant = metadataTableMetaClient.getCommitsTimeline.lastInstant().get()
-    assertTrue(fs.delete(new Path(metaClient.getMetaPath, lastInstant.getFileName), false))
-    assertTrue(fs.delete(new Path(metadataTableMetaClient.getMetaPath, metadataTableLastInstant.getFileName), false))
-    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
-  }
-
-  private def deleteLastCompletedCommitFromTimeline(hudiOpts: Map[String, String]): Unit = {
-    val writeConfig = getWriteConfig(hudiOpts)
-    val lastInstant = getHoodieTable(metaClient, writeConfig).getCompletedCommitsTimeline.lastInstant().get()
-    assertTrue(fs.delete(new Path(metaClient.getMetaPath, lastInstant.getFileName), false))
-    mergedDfList = mergedDfList.take(mergedDfList.size - 1)
-  }
-
-  private def getMetadataMetaClient(hudiOpts: Map[String, String]): HoodieTableMetaClient = {
-    getHoodieTable(metaClient, getWriteConfig(hudiOpts)).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata].getMetadataMetaClient
-  }
-
-  private def getLatestCompactionInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
-    getLatestMetaClient(false).getActiveTimeline
-      .filter(JavaConversions.getPredicate(s => Option(
-        try {
-          val commitMetadata = MetadataConversionUtils.getHoodieCommitMetadata(metaClient, s)
-            .orElse(new HoodieCommitMetadata())
-          commitMetadata
-        } catch {
-          case _: Exception => new HoodieCommitMetadata()
-        })
-        .map(c => c.getOperationType == WriteOperationType.COMPACT)
-        .get))
-      .lastInstant()
-  }
-
-  private def getLatestClusteringInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
-    getLatestMetaClient(false).getActiveTimeline.getCompletedReplaceTimeline.lastInstant()
-  }
-
-  private def doWriteAndValidateDataAndRecordIndex(hudiOpts: Map[String, String],
-                                                   operation: String,
-                                                   saveMode: SaveMode,
-                                                   validate: Boolean = true): DataFrame = {
-    var latestBatch: mutable.Buffer[String] = null
-    if (operation == UPSERT_OPERATION_OPT_VAL) {
-      val instantTime = getInstantTime()
-      val records = recordsToStrings(dataGen.generateUniqueUpdates(instantTime, 1))
-      records.addAll(recordsToStrings(dataGen.generateInserts(instantTime, 1)))
-      latestBatch = records.asScala
-    } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
-      latestBatch = recordsToStrings(dataGen.generateInsertsForPartition(
-        getInstantTime(), 5, dataGen.getPartitionPaths.last)).asScala
-    } else {
-      latestBatch = recordsToStrings(dataGen.generateInserts(getInstantTime(), 5)).asScala
-    }
-    val latestBatchDf = spark.read.json(spark.sparkContext.parallelize(latestBatch, 2))
-    latestBatchDf.cache()
-    latestBatchDf.write.format("org.apache.hudi")
-      .options(hudiOpts)
-      .option(DataSourceWriteOptions.OPERATION.key, operation)
-      .mode(saveMode)
-      .save(basePath)
-    val deletedDf = calculateMergedDf(latestBatchDf, operation)
-    deletedDf.cache()
-    if (validate) {
-      validateDataAndRecordIndices(hudiOpts, deletedDf)
-    }
-    deletedDf.unpersist()
-    latestBatchDf
-  }
-
-  /**
-   * @return [[DataFrame]] that should not exist as of the latest instant; used for non-existence validation.
-   */
-  def calculateMergedDf(latestBatchDf: DataFrame, operation: String): DataFrame = {
-    val prevDfOpt = mergedDfList.lastOption
-    if (prevDfOpt.isEmpty) {
-      mergedDfList = mergedDfList :+ latestBatchDf
-      sparkSession.emptyDataFrame
-    } else {
-      if (operation == INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL) {
-        mergedDfList = mergedDfList :+ latestBatchDf
-        // after insert_overwrite_table, all previous snapshot's records should be deleted from RLI
-        prevDfOpt.get
-      } else if (operation == INSERT_OVERWRITE_OPERATION_OPT_VAL) {
-        val overwrittenPartitions = latestBatchDf.select("partition")
-          .collectAsList().stream().map[String](JavaConversions.getFunction[Row, String](r => r.getString(0))).collect(Collectors.toList[String])
-        val prevDf = prevDfOpt.get
-        val latestSnapshot = prevDf
-          .filter(not(col("partition").isInCollection(overwrittenPartitions)))
-          .union(latestBatchDf)
-        mergedDfList = mergedDfList :+ latestSnapshot
-
-        // after insert_overwrite (partition), all records in the overwritten partitions should be deleted from RLI
-        prevDf.filter(col("partition").isInCollection(overwrittenPartitions))
-      } else {
-        val prevDf = prevDfOpt.get
-        val prevDfOld = prevDf.join(latestBatchDf, prevDf("_row_key") === latestBatchDf("_row_key")
-          && prevDf("partition") === latestBatchDf("partition"), "leftanti")
-        val latestSnapshot = prevDfOld.union(latestBatchDf)
-        mergedDfList = mergedDfList :+ latestSnapshot
-        sparkSession.emptyDataFrame
-      }
-    }
-  }
-
-  private def getInstantTime(): String = {
-    String.format("%03d", new Integer(instantTime.incrementAndGet()))
-  }
-
-  private def getWriteConfig(hudiOpts: Map[String, String]): HoodieWriteConfig = {
-    val props = new Properties()
-    props.putAll(JavaConverters.mapAsJavaMapConverter(hudiOpts).asJava)
-    HoodieWriteConfig.newBuilder()
-      .withProps(props)
-      .withPath(basePath)
-      .build()
-  }
-
-  def getFileGroupCountForRecordIndex(writeConfig: HoodieWriteConfig): Long = {
-    val tableMetadata = getHoodieTable(metaClient, writeConfig).getMetadataTable.asInstanceOf[HoodieBackedTableMetadata]
-    tableMetadata.getMetadataFileSystemView.getAllFileGroups(MetadataPartitionType.RECORD_INDEX.getPartitionPath).count
-  }
-
-  private def validateDataAndRecordIndices(hudiOpts: Map[String, String],
-                                           deletedDf: DataFrame = sparkSession.emptyDataFrame): Unit = {
-    metaClient = HoodieTableMetaClient.reload(metaClient)
-    val writeConfig = getWriteConfig(hudiOpts)
-    val metadata = metadataWriter(writeConfig).getTableMetadata
-    val readDf = spark.read.format("hudi").load(basePath)
-    val rowArr = readDf.collect()
-    val recordIndexMap = metadata.readRecordIndex(
-      JavaConverters.seqAsJavaListConverter(rowArr.map(row => row.getAs("_hoodie_record_key").toString).toList).asJava)
-
-    assertTrue(rowArr.length > 0)
-    for (row <- rowArr) {
-      val recordKey: String = row.getAs("_hoodie_record_key")
-      val partitionPath: String = row.getAs("_hoodie_partition_path")
-      val fileName: String = row.getAs("_hoodie_file_name")
-      val recordLocation = recordIndexMap.get(recordKey)
-      assertEquals(partitionPath, recordLocation.getPartitionPath)
-      assertTrue(fileName.startsWith(recordLocation.getFileId), fileName + " should start with " + recordLocation.getFileId)
-    }
-
-    val deletedRows = deletedDf.collect()
-    val recordIndexMapForDeletedRows = metadata.readRecordIndex(
-      JavaConverters.seqAsJavaListConverter(deletedRows.map(row => row.getAs("_row_key").toString).toList).asJava)
-    assertEquals(0, recordIndexMapForDeletedRows.size(), "deleted records should not present in RLI")
-
-    assertEquals(rowArr.length, recordIndexMap.keySet.size)
-    val estimatedFileGroupCount = HoodieTableMetadataUtil.estimateFileGroupCount(MetadataPartitionType.RECORD_INDEX, rowArr.length, 48,
-      writeConfig.getRecordIndexMinFileGroupCount, writeConfig.getRecordIndexMaxFileGroupCount,
-      writeConfig.getRecordIndexGrowthFactor, writeConfig.getRecordIndexMaxFileGroupSizeBytes)
-    assertEquals(estimatedFileGroupCount, getFileGroupCountForRecordIndex(writeConfig))
-    val prevDf = mergedDfList.last.drop("tip_history")
-    val nonMatchingRecords = readDf.drop("_hoodie_commit_time", "_hoodie_commit_seqno", "_hoodie_record_key",
-      "_hoodie_partition_path", "_hoodie_file_name", "tip_history")
-      .join(prevDf, prevDf.columns, "leftanti")
-    assertEquals(0, nonMatchingRecords.count())
-    assertEquals(readDf.count(), prevDf.count())
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -1,0 +1,37 @@
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@Tag("functional")
+class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
+  val sqlTempTable = "tbl"
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("COPY_ON_WRITE"))
+  def testRLIWithSQL(tableType: String): Unit = {
+    var hudiOpts = commonOpts
+    hudiOpts = hudiOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType)
+
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite,
+      validate = false)
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      validate = false)
+
+    createTempTable(hudiOpts)
+    val reckey = mergedDfList.last.limit(1).collect()(0).getAs("_row_key").toString
+    spark.sql("select * from " + sqlTempTable + " where '" + reckey + "' = _row_key").show(false)
+  }
+
+  private def createTempTable(hudiOpts: Map[String, String]): Unit = {
+    val readDf = spark.read.format("hudi").options(hudiOpts).load(basePath)
+    readDf.registerTempTable(sqlTempTable)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.params.ParameterizedTest
@@ -31,7 +31,9 @@ class TestRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
   @ValueSource(strings = Array("COPY_ON_WRITE"))
   def testRLIWithSQL(tableType: String): Unit = {
     var hudiOpts = commonOpts
-    hudiOpts = hudiOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> tableType)
+    hudiOpts = hudiOpts + (
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType,
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true")
 
     doWriteAndValidateDataAndRecordIndex(hudiOpts,
       operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndexWithSQL.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions


### PR DESCRIPTION
### Change Logs

With Record level support in HUDI, the sql queries related to record keys can leverage the Record Index. The Jira aims to add support for equality matches with record keys.

### Impact

This should help improve performance for some sql equalTo queries on record keys.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
