### PR TITLE
[HUDI-6605] Write handlers not close with try block in ClientIds

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
@@ -190,12 +190,13 @@ public class DirectWriteMarkers extends WriteMarkers {
     } catch (IOException e) {
       throw new HoodieIOException("Failed to make dir " + dirPath, e);
     }
-    try (FSDataOutputStream fsDataOutputStream = fs.create(markerPath, false)) {
+    try {
       if (checkIfExists && fs.exists(markerPath)) {
         LOG.warn("Marker Path=" + markerPath + " already exists, cancel creation");
         return Option.empty();
       }
       LOG.info("Creating Marker Path=" + markerPath);
+      fs.create(markerPath, false).close();
     } catch (IOException e) {
       throw new HoodieException("Failed to create marker file " + markerPath, e);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
@@ -37,7 +37,6 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/DirectWriteMarkers.java
@@ -37,6 +37,7 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
@@ -189,13 +190,12 @@ public class DirectWriteMarkers extends WriteMarkers {
     } catch (IOException e) {
       throw new HoodieIOException("Failed to make dir " + dirPath, e);
     }
-    try {
+    try (FSDataOutputStream fsDataOutputStream = fs.create(markerPath, false)) {
       if (checkIfExists && fs.exists(markerPath)) {
         LOG.warn("Marker Path=" + markerPath + " already exists, cancel creation");
         return Option.empty();
       }
       LOG.info("Creating Marker Path=" + markerPath);
-      fs.create(markerPath, false).close();
     } catch (IOException e) {
       throw new HoodieException("Failed to create marker file " + markerPath, e);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
@@ -163,6 +163,7 @@ public class ClientIds implements AutoCloseable, Serializable {
 
   private void updateHeartbeat(Path heartbeatFilePath) throws HoodieHeartbeatException {
     try (OutputStream outputStream = this.fs.create(heartbeatFilePath, true)) {
+      // no operation
       LOG.debug("create hearbeat file in path: {}", heartbeatFilePath);
     } catch (IOException io) {
       throw new HoodieHeartbeatException("Unable to generate heartbeat for file path " + heartbeatFilePath, io);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
@@ -163,6 +163,7 @@ public class ClientIds implements AutoCloseable, Serializable {
 
   private void updateHeartbeat(Path heartbeatFilePath) throws HoodieHeartbeatException {
     try (OutputStream outputStream = this.fs.create(heartbeatFilePath, true)) {
+      LOG.debug("create hearbeat file in path: {}", heartbeatFilePath);
     } catch (IOException io) {
       throw new HoodieHeartbeatException("Unable to generate heartbeat for file path " + heartbeatFilePath, io);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
@@ -162,10 +162,7 @@ public class ClientIds implements AutoCloseable, Serializable {
   }
 
   private void updateHeartbeat(Path heartbeatFilePath) throws HoodieHeartbeatException {
-    try {
-      OutputStream outputStream =
-          this.fs.create(heartbeatFilePath, true);
-      outputStream.close();
+    try (OutputStream outputStream = this.fs.create(heartbeatFilePath, true)) {
     } catch (IOException io) {
       throw new HoodieHeartbeatException("Unable to generate heartbeat for file path " + heartbeatFilePath, io);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
@@ -164,7 +164,6 @@ public class ClientIds implements AutoCloseable, Serializable {
   private void updateHeartbeat(Path heartbeatFilePath) throws HoodieHeartbeatException {
     try (OutputStream outputStream = this.fs.create(heartbeatFilePath, true)) {
       // no operation
-      LOG.debug("create hearbeat file in path: {}", heartbeatFilePath);
     } catch (IOException io) {
       throw new HoodieHeartbeatException("Unable to generate heartbeat for file path " + heartbeatFilePath, io);
     }


### PR DESCRIPTION


### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._
[HUDI-6605] write handlers not close in find way in ClientIds and DirectWriteMarkers

### Impact

_Describe any public API or user-facing feature change or any performance impact._
none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
