### PR TITLE
[HUDI-6607] Fixing RLI schema to support different fileID formats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -68,6 +68,7 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.SimpleAvroKeyGenerator;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.metrics.datadog.DatadogHttpClient.ApiSite;
@@ -726,6 +727,11 @@ public class HoodieWriteConfig extends HoodieConfig {
    * operation are already prepped.
    */
   public static final String SPARK_SQL_MERGE_INTO_PREPPED_KEY = "_hoodie.spark.sql.merge.into.prepped";
+
+  /**
+   * An internal config referring to fileID encoding. 0 refers to UUID based encoding and 1 refers to raw string format(random string).
+   */
+  public static final String WRITES_FILEID_ENCODING =  "_hoodie.writes.fileid.encoding";
 
   private ConsistencyGuardConfig consistencyGuardConfig;
   private FileSystemRetryConfig fileSystemRetryConfig;
@@ -2562,6 +2568,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getString(CLIENT_INIT_CALLBACK_CLASS_NAMES);
   }
 
+  public Integer getWritesFileIdEncoding() {
+    return props.getInteger(WRITES_FILEID_ENCODING, HoodieMetadataPayload.RECORD_INDEX_FIELD_FILEID_ENCODING_UUID);
+  }
+
   public static class Builder {
 
     protected final HoodieWriteConfig writeConfig = new HoodieWriteConfig();
@@ -3046,6 +3056,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withClientInitCallbackClassNames(String classNames) {
       writeConfig.setValue(CLIENT_INIT_CALLBACK_CLASS_NAMES, classNames);
+      return this;
+    }
+
+    public Builder withWritesFileIdEncoding(Integer fileIdEncoding) {
+      writeConfig.setValue(WRITES_FILEID_ENCODING, Integer.toString(fileIdEncoding));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -542,7 +542,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
         public HoodieRecord next() {
           return forDelete
               ? HoodieMetadataPayload.createRecordIndexDelete(recordKeyIterator.next())
-              : HoodieMetadataPayload.createRecordIndexUpdate(recordKeyIterator.next(), partition, fileId, instantTime);
+              : HoodieMetadataPayload.createRecordIndexUpdate(recordKeyIterator.next(), partition, fileId, instantTime, 0);
         }
       };
     });
@@ -1357,7 +1357,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
             hoodieRecord = HoodieMetadataPayload.createRecordIndexUpdate(
                 recordDelegate.getRecordKey(), recordDelegate.getPartitionPath(),
-                newLocation.get().getFileId(), newLocation.get().getInstantTime());
+                newLocation.get().getFileId(), newLocation.get().getInstantTime(), dataWriteConfig.getWritesFileIdEncoding());
           } else {
             // Delete existing index for a deleted record
             hoodieRecord = HoodieMetadataPayload.createRecordIndexDelete(recordDelegate.getRecordKey());

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -369,31 +369,66 @@
                    "name": "HoodieRecordIndexInfo",
                     "fields": [
                         {
-                            "name": "partition",
-                            "type": "string",
-                            "doc": "Partition which contains the record",
-                            "avro.java.string": "String"
+                            "name": "partitionName",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "default": null,
+                            "doc": "Refers to the partition name the record belongs to"
                         },
                         {
                             "name": "fileIdHighBits",
-                            "type": "long",
-                            "doc": "fileId which contains the record (high 64 bits)"
+                            "type": [
+                                "null",
+                                "long"
+                            ],
+                            "default": null,
+                            "doc": "Refers to high 64 bits if the fileId is based on UUID format. \nA UUID based fileId is stored as 3 pieces in RLI (fileIdHighBits, fileIdLowBits and fileIndex). \nFileID format is {UUID}-{fileIndex}."
                         },
                         {
                             "name": "fileIdLowBits",
-                            "type": "long",
-                            "doc": "fileId which contains the record (low 64 bits)"
+                            "type": [
+                                "null",
+                                "long"
+                            ],
+                            "default": null,
+                            "doc": "Refers to low 64 bits if the fileId is based on UUID format. \nA UUID based fileId is stored as 3 pieces in RLI (fileIdHighBits, fileIdLowBits and fileIndex). \nFileID format is {UUID}-{fileIndex}."
                         },
                         {
                             "name": "fileIndex",
-                            "type": "int",
-                            "doc": "index of the file"
+                            "type": [
+                                "null",
+                                "int"
+                            ],
+                            "default": null,
+                            "doc": "Index representing file index which is used to re-construct UUID based fileID. Applicable when the fileId is based on UUID format. \nA UUID based fileId is stored as 3 pieces in RLI (fileIdHighBits, fileIdLowBits and fileIndex). \nFileID format is {UUID}-{fileIndex}."
                         },
                         {
+                           "name": "fileId",
+                           "type": [
+                               "null",
+                               "string"
+                            ],
+                            "default" : null,
+                            "doc": "Represents fileId of the location where record belongs to. When the encoding is 1, fileID is stored in raw string format."
+                           },
+                        {
                             "name": "instantTime",
-                            "type": "long",
-                            "doc": "Epoch time in millisecond at which record was added"
-                        }
+                            "type": [
+                                "null",
+                                "long"
+                            ],
+                            "default": null,
+                            "doc": "Epoch time in millisecond representing the commit time at which record was added"
+                        },
+
+                       {
+                           "name": "fileIdEncoding",
+                            "type": "int",
+                            "default" : 0,
+                            "doc": "Represents fileId encoding. Possible values are 0 and 1. O represents UUID based fileID, and 1 represents raw string format of the fileId. \nWhen the encoding is 0, reader can deduce fileID from fileIdLowBits, fileIdLowBits and fileIndex."
+                       }
                     ]
                 }
             ],

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -740,7 +740,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     try {
       instantTimeMillis = HoodieActiveTimeline.parseDateFromInstantTime(instantTime).getTime();
     } catch (Exception e) {
-      throw new HoodieMetadataException("Failed to create metadata payload for record index.", e);
+      throw new HoodieMetadataException("Failed to create metadata payload for record index. Instant time parsing for " + instantTime + " failed ", e);
     }
     if (fileIdEncoding == 0) {
       // Data file names have a -D suffix to denote the index (D = integer) of the file written

--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectWriterProvider.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/KafkaConnectWriterProvider.java
@@ -93,6 +93,7 @@ public class KafkaConnectWriterProvider implements ConnectWriterProvider<WriteSt
           .withCleanConfig(HoodieCleanConfig.newBuilder().withAutoClean(false).build())
           .withCompactionConfig(HoodieCompactionConfig.newBuilder().withInlineCompaction(false).build())
           .withClusteringConfig(HoodieClusteringConfig.newBuilder().withInlineClustering(false).build())
+          .withWritesFileIdEncoding(1)
           .build();
 
       context = new HoodieJavaEngineContext(hadoopConf);


### PR DESCRIPTION
### Change Logs

Enhancing RLI schema with MDT to support for different fileID formats. We can store UUID based format or any other format as well. 

### Impact

RLI can support storing fileId of any formats. 
1. UUID based one which can be reconstructed using high order bits, low order bits and fileIndex. 
2. raw string format stored using field "fileId". 

Changes in schema:
1. we are adding a field called "fileIdEncoding" to denote the fileId format. default value of 0 represents UUID based fileID, while 1 represents raw string format. 
2. Added a field named "fileId" which could store raw fileID in string format. 
3. Fixed "partition" field naming to "partitionName"
4. Made all columns nullable. 
5. Added proper docs to every field in RLI

### Risk level (write none, low medium or high below)

low.

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
