### PR TITLE
[HUDI-6610] Optimize the toHexString method in StringUtils

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/StringUtils.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
  */
 public class StringUtils {
 
+  public static final char[] HEX_CHAR = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
   public static final String EMPTY_STRING = "";
 
   /**
@@ -86,11 +87,20 @@ public class StringUtils {
   }
 
   public static String toHexString(byte[] bytes) {
-    StringBuilder sb = new StringBuilder(bytes.length * 2);
-    for (byte b : bytes) {
-      sb.append(String.format("%02x", b));
+    return new String(encodeHex(bytes));
+  }
+
+  public static char[] encodeHex(byte[] data) {
+    int l = data.length;
+    char[] out = new char[l << 1];
+    int i = 0;
+
+    for (int var4 = 0; i < l; ++i) {
+      out[var4++] = HEX_CHAR[(240 & data[i]) >>> 4];
+      out[var4++] = HEX_CHAR[15 & data[i]];
     }
-    return sb.toString();
+
+    return out;
   }
 
   public static boolean isNullOrEmpty(String str) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestStringUtils.java
@@ -99,4 +99,18 @@ public class TestStringUtils {
     assertEquals(Arrays.asList("a", "b", "c"), StringUtils.split("a,b, c", ","));
     assertEquals(Arrays.asList("a", "b", "c"), StringUtils.split("a,b,, c ", ","));
   }
+
+  @Test
+  public void testHexString() {
+    String str = "abcd";
+    assertEquals(StringUtils.toHexString(str.getBytes()), toHexString(str.getBytes()));
+  }
+
+  private static String toHexString(byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
 }


### PR DESCRIPTION
### Change Logs

String.format is used in the implementation of the current toHexString method. In the case of a large number of cases, the performance is low, and there will be frequent memory copies, which will lead to an increase in GC frequency and further increase in CPU utilization. 

For production tasks, the spark driver process may be killed because the CPU usage threshold is exceeded.



### Impact
It will reduce GC frequency, reduce cpu usage, and improve efficiency

### Risk level (write none, low medium or high below)
high

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
