### PR TITLE
[MINOR] Simplify CreateHoodieTableCommand logWarning

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -84,11 +84,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
       CreateHoodieTableCommand.createTableInCatalog(sparkSession, hoodieCatalogTable, ignoreIfExists, queryAsProp)
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Failed to create catalog table in metastore: ${e}")
-        val sw = new StringWriter
-        val pw = new PrintWriter(sw)
-        e.printStackTrace(pw)
-        logWarning(sw.toString)
+        logWarning(s"Failed to create catalog table in metastore: ", e)
     }
     Seq.empty[Row]
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -84,7 +84,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
       CreateHoodieTableCommand.createTableInCatalog(sparkSession, hoodieCatalogTable, ignoreIfExists, queryAsProp)
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Failed to create catalog table in metastore: ", e)
+        logWarning("Failed to create catalog table in metastore", e)
     }
     Seq.empty[Row]
   }


### PR DESCRIPTION
### Change Logs

Simplify CreateHoodieTableCommand logWarning

### Impact

#8251 Trying to output the call stack, but it just removes the `getMessage` call, toString and `getMessage` have the same effect, so it's not fixed.
#8996 Fixed it, but not as succinctly as we could have just used `warn(String msg, Throwable t)` to output a log.


### Risk level (write none, low medium or high below)

### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
