### PR TITLE
[MINOR] Disable prepped write by default for MergeInto command

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -646,7 +646,7 @@ object DataSourceWriteOptions {
 
   val SPARK_SQL_OPTIMIZED_WRITES: ConfigProperty[String] = ConfigProperty
     .key("hoodie.spark.sql.optimized.writes.enable")
-    .defaultValue("true")
+    .defaultValue("false")
     .markAdvanced()
     .sinceVersion("0.14.0")
     .withDocumentation("Controls whether spark sql prepped update, delete, and merge are enabled.")


### PR DESCRIPTION
### Change Logs

Prepped upsert is slower. Disable it by default until we fix the performance. However, for pk-less we need meta columns and prepped upsert, so an exception for pk-less.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
