### PR TITLE
[HUDI-6624]Fix to return a empty list when there is no commit instant to read

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -334,6 +334,9 @@ public class HoodieTableSource implements
     HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
         // file-slice after pending compaction-requested instant-time is also considered valid
         metaClient.getCommitsAndCompactionTimeline().filterCompletedAndCompactionInstants(), fileStatuses);
+    if (!fsView.getLastInstant().isPresent()) {
+      return Collections.emptyList();
+    }
     String latestCommit = fsView.getLastInstant().get().getTimestamp();
     final String mergeType = this.conf.getString(FlinkOptions.MERGE_TYPE);
     final AtomicInteger cnt = new AtomicInteger(0);


### PR DESCRIPTION
### Change Logs

```java
org.apache.flink.runtime.rest.handler.RestHandlerException: The main method caused an error: java.util.NoSuchElementException: No value present in Option
	at org.apache.hudi.common.util.Option.get(Option.java:89)
	at org.apache.hudi.table.HoodieTableSource.buildFileIndex(HoodieTableSource.java:341)
	at org.apache.hudi.table.HoodieTableSource.getBatchInputFormat(HoodieTableSource.java:381)
	at org.apache.hudi.table.HoodieTableSource.getInputFormat(HoodieTableSource.java:366)
	at org.apache.hudi.table.HoodieTableSource.getInputFormat(HoodieTableSource.java:361)
	at org.apache.hudi.table.HoodieTableSource$1.produceDataStream(HoodieTableSource.java:198)
	at org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecTableSourceScan.translateToPlanInternal(CommonExecTableSourceScan.java:106)
	at org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecTableSourceScan.translateToPlanInternal(BatchExecTableSourceScan.java:49)
	at org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase.translateToPlan(ExecNodeBase.java:134)
	at org.apache.flink.table.planner.plan.nodes.exec.ExecEdge.translateToPlan(ExecEdge.java:250)
```
The exception is not clean enough, we can point out the exception.

