### PR TITLE
[HUDI-6622] Reuse the table config from HoodieTableMetaClient in the …

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -120,14 +120,12 @@ public class HoodieTableMetaClient implements Serializable {
   protected HoodieMetaserverConfig metaserverConfig;
 
   /**
-   *
    * Instantiate HoodieTableMetaClient.
    * Can only be called if table already exists
-   *
    */
   protected HoodieTableMetaClient(Configuration conf, String basePath, boolean loadActiveTimelineOnLoad,
-                                ConsistencyGuardConfig consistencyGuardConfig, Option<TimelineLayoutVersion> layoutVersion,
-                                String payloadClassName, String recordMergerStrategy, FileSystemRetryConfig fileSystemRetryConfig) {
+                                  ConsistencyGuardConfig consistencyGuardConfig, Option<TimelineLayoutVersion> layoutVersion,
+                                  String payloadClassName, String recordMergerStrategy, FileSystemRetryConfig fileSystemRetryConfig) {
     LOG.info("Loading HoodieTableMetaClient from " + basePath);
     this.consistencyGuardConfig = consistencyGuardConfig;
     this.fileSystemRetryConfig = fileSystemRetryConfig;
@@ -243,7 +241,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Returns Marker folder path.
-   * 
+   *
    * @param instantTs Instant Timestamp
    * @return
    */
@@ -328,7 +326,7 @@ public class HoodieTableMetaClient implements Serializable {
 
   /**
    * Return raw file-system.
-   * 
+   *
    * @return fs
    */
   public FileSystem getRawFs() {
@@ -471,7 +469,7 @@ public class HoodieTableMetaClient implements Serializable {
    * @return Instance of HoodieTableMetaClient
    */
   public static HoodieTableMetaClient initTableAndGetMetaClient(Configuration hadoopConf, String basePath,
-      Properties props) throws IOException {
+                                                                Properties props) throws IOException {
     LOG.info("Initializing " + basePath + " as hoodie table " + basePath);
     Path basePathDir = new Path(basePath);
     final FileSystem fs = FSUtils.getFs(basePath, hadoopConf);
@@ -540,8 +538,8 @@ public class HoodieTableMetaClient implements Serializable {
   /**
    * Helper method to scan all hoodie-instant metafiles.
    *
-   * @param fs The file system implementation for this table
-   * @param metaPath The meta path where meta files are stored
+   * @param fs         The file system implementation for this table
+   * @param metaPath   The meta path where meta files are stored
    * @param nameFilter The name filter to filter meta files
    * @return An array of meta FileStatus
    * @throws IOException In case of failure
@@ -615,29 +613,29 @@ public class HoodieTableMetaClient implements Serializable {
   /**
    * Helper method to scan all hoodie-instant metafiles and construct HoodieInstant objects.
    *
-   * @param includedExtensions Included hoodie extensions
+   * @param includedExtensions        Included hoodie extensions
    * @param applyLayoutVersionFilters Depending on Timeline layout version, if there are multiple states for the same
-   * action instant, only include the highest state
+   *                                  action instant, only include the highest state
    * @return List of Hoodie Instants generated
    * @throws IOException in case of failure
    */
   public List<HoodieInstant> scanHoodieInstantsFromFileSystem(Set<String> includedExtensions,
-      boolean applyLayoutVersionFilters) throws IOException {
+                                                              boolean applyLayoutVersionFilters) throws IOException {
     return scanHoodieInstantsFromFileSystem(metaPath.get(), includedExtensions, applyLayoutVersionFilters);
   }
 
   /**
    * Helper method to scan all hoodie-instant metafiles and construct HoodieInstant objects.
    *
-   * @param timelinePath MetaPath where instant files are stored
-   * @param includedExtensions Included hoodie extensions
+   * @param timelinePath              MetaPath where instant files are stored
+   * @param includedExtensions        Included hoodie extensions
    * @param applyLayoutVersionFilters Depending on Timeline layout version, if there are multiple states for the same
-   * action instant, only include the highest state
+   *                                  action instant, only include the highest state
    * @return List of Hoodie Instants generated
    * @throws IOException in case of failure
    */
   public List<HoodieInstant> scanHoodieInstantsFromFileSystem(Path timelinePath, Set<String> includedExtensions,
-      boolean applyLayoutVersionFilters) throws IOException {
+                                                              boolean applyLayoutVersionFilters) throws IOException {
     Stream<HoodieInstant> instantStream = Arrays.stream(
         HoodieTableMetaClient
             .scanFiles(getFs(), timelinePath, path -> {
@@ -684,11 +682,12 @@ public class HoodieTableMetaClient implements Serializable {
   }
 
   private static HoodieTableMetaClient newMetaClient(Configuration conf, String basePath, boolean loadActiveTimelineOnLoad,
-      ConsistencyGuardConfig consistencyGuardConfig, Option<TimelineLayoutVersion> layoutVersion,
-      String payloadClassName, String recordMergerStrategy, FileSystemRetryConfig fileSystemRetryConfig, HoodieMetaserverConfig metaserverConfig) {
+                                                     ConsistencyGuardConfig consistencyGuardConfig, Option<TimelineLayoutVersion> layoutVersion,
+                                                     String payloadClassName, String recordMergerStrategy, FileSystemRetryConfig fileSystemRetryConfig, HoodieMetaserverConfig metaserverConfig) {
     return metaserverConfig.isMetaserverEnabled()
         ? (HoodieTableMetaClient) ReflectionUtils.loadClass("org.apache.hudi.common.table.HoodieTableMetaserverClient",
-        new Class<?>[]{Configuration.class, String.class, ConsistencyGuardConfig.class, String.class, FileSystemRetryConfig.class, String.class, String.class, HoodieMetaserverConfig.class},
+        new Class<?>[] {Configuration.class, String.class, ConsistencyGuardConfig.class, String.class,
+            FileSystemRetryConfig.class, Option.class, Option.class, HoodieMetaserverConfig.class},
         conf, basePath, consistencyGuardConfig, recordMergerStrategy, fileSystemRetryConfig,
         Option.of(metaserverConfig.getDatabaseName()), Option.of(metaserverConfig.getTableName()), metaserverConfig)
         : new HoodieTableMetaClient(conf, basePath,
@@ -991,7 +990,7 @@ public class HoodieTableMetaClient implements Serializable {
     public PropertyBuilder fromProperties(Properties properties) {
       HoodieConfig hoodieConfig = new HoodieConfig(properties);
 
-      for (String key: HoodieTableConfig.PERSISTED_CONFIG_LIST) {
+      for (String key : HoodieTableConfig.PERSISTED_CONFIG_LIST) {
         Object value = hoodieConfig.getString(key);
         if (value != null) {
           set(key, value);
@@ -1193,7 +1192,7 @@ public class HoodieTableMetaClient implements Serializable {
      * Init Table with the properties build by this builder.
      *
      * @param configuration The hadoop config.
-     * @param basePath The base path for hoodie table.
+     * @param basePath      The base path for hoodie table.
      */
     public HoodieTableMetaClient initTable(Configuration configuration, String basePath)
         throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -689,7 +689,7 @@ public class HoodieTableMetaClient implements Serializable {
         new Class<?>[] {Configuration.class, String.class, ConsistencyGuardConfig.class, String.class,
             FileSystemRetryConfig.class, Option.class, Option.class, HoodieMetaserverConfig.class},
         conf, basePath, consistencyGuardConfig, recordMergerStrategy, fileSystemRetryConfig,
-        Option.of(metaserverConfig.getDatabaseName()), Option.of(metaserverConfig.getTableName()), metaserverConfig)
+        Option.ofNullable(metaserverConfig.getDatabaseName()), Option.ofNullable(metaserverConfig.getTableName()), metaserverConfig)
         : new HoodieTableMetaClient(conf, basePath,
         loadActiveTimelineOnLoad, consistencyGuardConfig, layoutVersion, payloadClassName, recordMergerStrategy, fileSystemRetryConfig);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -690,7 +690,7 @@ public class HoodieTableMetaClient implements Serializable {
         ? (HoodieTableMetaClient) ReflectionUtils.loadClass("org.apache.hudi.common.table.HoodieTableMetaserverClient",
         new Class<?>[]{Configuration.class, String.class, ConsistencyGuardConfig.class, String.class, FileSystemRetryConfig.class, String.class, String.class, HoodieMetaserverConfig.class},
         conf, basePath, consistencyGuardConfig, recordMergerStrategy, fileSystemRetryConfig,
-        metaserverConfig.getDatabaseName(), metaserverConfig.getTableName(), metaserverConfig)
+        Option.of(metaserverConfig.getDatabaseName()), Option.of(metaserverConfig.getTableName()), metaserverConfig)
         : new HoodieTableMetaClient(conf, basePath,
         loadActiveTimelineOnLoad, consistencyGuardConfig, layoutVersion, payloadClassName, recordMergerStrategy, fileSystemRetryConfig);
   }

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/HoodieTableMetaserverClient.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/HoodieTableMetaserverClient.java
@@ -44,9 +44,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.hudi.common.util.StringUtils.nonEmpty;
-import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
-
 /**
  * HoodieTableMetaClient implementation for hoodie table whose metadata is stored in the hoodie metaserver.
  */
@@ -60,16 +57,14 @@ public class HoodieTableMetaserverClient extends HoodieTableMetaClient {
 
   public HoodieTableMetaserverClient(Configuration conf, String basePath, ConsistencyGuardConfig consistencyGuardConfig,
                                      String mergerStrategy, FileSystemRetryConfig fileSystemRetryConfig,
-                                     HoodieMetaserverConfig config) {
+                                     String databaseName, String tableName, HoodieMetaserverConfig config) {
     super(conf, basePath, false, consistencyGuardConfig, Option.of(TimelineLayoutVersion.CURR_LAYOUT_VERSION),
         config.getString(HoodieTableConfig.PAYLOAD_CLASS_NAME), mergerStrategy, fileSystemRetryConfig);
-    checkArgument(nonEmpty(tableConfig.getDatabaseName()), "database name is required.");
-    checkArgument(nonEmpty(tableConfig.getTableName()), "table name is required.");
-    this.databaseName = tableConfig.getDatabaseName();
-    this.tableName = tableConfig.getTableName();
+    this.databaseName = databaseName != null ? databaseName : tableConfig.getDatabaseName();
+    this.tableName = tableName != null ? tableName : tableConfig.getTableName();
     this.metaserverConfig = config;
     this.metaserverClient = HoodieMetaserverClientProxy.getProxy(config);
-    this.table = initOrGetTable(tableConfig.getDatabaseName(), tableConfig.getTableName(), config);
+    this.table = initOrGetTable(this.databaseName, this.tableName, config);
     // TODO: transfer table parameters to table config
     tableConfig.setTableVersion(HoodieTableVersion.current());
     tableConfig.setAll(config.getProps());
@@ -133,12 +128,12 @@ public class HoodieTableMetaserverClient extends HoodieTableMetaClient {
   }
 
   public List<HoodieInstant> scanHoodieInstantsFromFileSystem(Set<String> includedExtensions,
-      boolean applyLayoutVersionFilters) {
+                                                              boolean applyLayoutVersionFilters) {
     throw new HoodieException("Unsupport operation");
   }
 
   public List<HoodieInstant> scanHoodieInstantsFromFileSystem(Path timelinePath, Set<String> includedExtensions,
-      boolean applyLayoutVersionFilters) {
+                                                              boolean applyLayoutVersionFilters) {
     throw new HoodieException("Unsupport operation");
   }
 

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/HoodieTableMetaserverClient.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/common/table/HoodieTableMetaserverClient.java
@@ -60,18 +60,17 @@ public class HoodieTableMetaserverClient extends HoodieTableMetaClient {
 
   public HoodieTableMetaserverClient(Configuration conf, String basePath, ConsistencyGuardConfig consistencyGuardConfig,
                                      String mergerStrategy, FileSystemRetryConfig fileSystemRetryConfig,
-                                     String databaseName, String tableName, HoodieMetaserverConfig config) {
+                                     HoodieMetaserverConfig config) {
     super(conf, basePath, false, consistencyGuardConfig, Option.of(TimelineLayoutVersion.CURR_LAYOUT_VERSION),
         config.getString(HoodieTableConfig.PAYLOAD_CLASS_NAME), mergerStrategy, fileSystemRetryConfig);
-    checkArgument(nonEmpty(databaseName), "database name is required.");
-    checkArgument(nonEmpty(tableName), "table name is required.");
-    this.databaseName = databaseName;
-    this.tableName = tableName;
+    checkArgument(nonEmpty(tableConfig.getDatabaseName()), "database name is required.");
+    checkArgument(nonEmpty(tableConfig.getTableName()), "table name is required.");
+    this.databaseName = tableConfig.getDatabaseName();
+    this.tableName = tableConfig.getTableName();
     this.metaserverConfig = config;
     this.metaserverClient = HoodieMetaserverClientProxy.getProxy(config);
-    this.table = initOrGetTable(databaseName, tableName, config);
+    this.table = initOrGetTable(tableConfig.getDatabaseName(), tableConfig.getTableName(), config);
     // TODO: transfer table parameters to table config
-    this.tableConfig = new HoodieTableConfig();
     tableConfig.setTableVersion(HoodieTableVersion.current());
     tableConfig.setAll(config.getProps());
   }


### PR DESCRIPTION
…HoodieTableMetaserverClient

### Change Logs

Reuse the table config from HoodieTableMetaClient in the HoodieTableMetaserverClient,
to avoid the loss of table parameters

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
