### PR TITLE
[HUDI-6623] Move the sorting of HoodieMetaserverClient instants from …

### DIFF
--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/metaserver/client/HoodieMetaserverClientImp.java
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-client/src/main/java/org/apache/hudi/metaserver/client/HoodieMetaserverClientImp.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -109,7 +110,7 @@ public class HoodieMetaserverClientImp implements HoodieMetaserverClient {
   @Override
   public List<HoodieInstant> listInstants(String db, String tb, int commitNum) {
     return exceptionWrapper(() -> this.client.listInstants(db, tb, commitNum).stream()
-        .map(EntityConversions::fromTHoodieInstant)
+        .map(EntityConversions::fromTHoodieInstant).sorted(Comparator.comparing(HoodieInstant::getTimestamp))
         .collect(Collectors.toList())).get();
   }
 

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-server/src/main/resources/mybatis/TimelineMapper.xml
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-server/src/main/resources/mybatis/TimelineMapper.xml
@@ -93,6 +93,7 @@
           <foreach collection="states" item="state" open="(" close=")" separator=",">
               #{state}
           </foreach>
+        ORDER BY ts DESC
         <if test ="limit > 0">
             LIMIT #{limit}
         </if>

--- a/hudi-platform-service/hudi-metaserver/hudi-metaserver-server/src/main/resources/mybatis/TimelineMapper.xml
+++ b/hudi-platform-service/hudi-metaserver/hudi-metaserver-server/src/main/resources/mybatis/TimelineMapper.xml
@@ -93,7 +93,6 @@
           <foreach collection="states" item="state" open="(" close=")" separator=",">
               #{state}
           </foreach>
-        ORDER BY ts DESC
         <if test ="limit > 0">
             LIMIT #{limit}
         </if>


### PR DESCRIPTION
…meta server side to client side

### Change Logs

Move the sorting of HoodieMetaserverClient instants from meta server side to client side. Avoid potential disorder problems.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
