### PR TITLE
[HUDI-6627] Fix NPE when spark client writer schema is null

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -825,7 +825,9 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     boolean shouldValidate = config.shouldValidateAvroSchema();
     boolean allowProjection = config.shouldAllowAutoEvolutionColumnDrop();
     if ((!shouldValidate && allowProjection)
-        || getActiveTimeline().getCommitsTimeline().filterCompletedInstants().empty()) {
+        || getActiveTimeline().getCommitsTimeline().filterCompletedInstants().empty()
+        || config.getSchema() == null
+    ) {
       // Check not required
       return;
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -827,7 +827,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     boolean allowProjection = config.shouldAllowAutoEvolutionColumnDrop();
     if ((!shouldValidate && allowProjection)
         || getActiveTimeline().getCommitsTimeline().filterCompletedInstants().empty()
-        || StringUtils.nonEmpty(config.getSchema())
+        || StringUtils.isNullOrEmpty(config.getSchema())
     ) {
       // Check not required
       return;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -62,6 +62,7 @@ import org.apache.hudi.common.table.view.TableFileSystemView.SliceView;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Functions;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -826,7 +827,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     boolean allowProjection = config.shouldAllowAutoEvolutionColumnDrop();
     if ((!shouldValidate && allowProjection)
         || getActiveTimeline().getCommitsTimeline().filterCompletedInstants().empty()
-        || config.getSchema() == null
+        || StringUtils.nonEmpty(config.getSchema())
     ) {
       // Check not required
       return;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -408,34 +408,35 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
   @Test
   public void testInertsWithEmptyCommitsHavingWriterSchemaAsNull() throws Exception {
-    // Set autoCommit false
     HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder().withAutoCommit(false);
     addConfigsForPopulateMetaFields(cfgBuilder, true);
     SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.build());
-    String firstCommit = "001";
-    int numRecords = 200;
-    JavaRDD<WriteStatus> result = insertFirstBatch(cfgBuilder.build(), client, firstCommit, "000", numRecords, SparkRDDWriteClient::insert,
-        false, false, numRecords);
-    assertTrue(client.commit(firstCommit, result), "Commit should succeed");
+    try {
+      String firstCommit = "001";
+      int numRecords = 200;
+      JavaRDD<WriteStatus> result = insertFirstBatch(cfgBuilder.build(), client, firstCommit, "000", numRecords, SparkRDDWriteClient::insert,
+          false, false, numRecords);
+      assertTrue(client.commit(firstCommit, result), "Commit should succeed");
 
-    // Re-init client with null writer schema.
-    cfgBuilder = getConfigBuilder((String) null).withAutoCommit(false);
-    client = getHoodieWriteClient(cfgBuilder.build());
-    String secondCommit = "002";
-    client.startCommitWithTime(secondCommit);
-    JavaRDD<HoodieRecord> emptyRdd = context.emptyRDD();
-    result = client.insert(emptyRdd, secondCommit);
-    assertTrue(client.commit(secondCommit, result), "Commit should succeed");
-    try (FSDataInputStream inputStream = fs.open(testTable.getCommitFilePath(secondCommit))) {
-      String everything = FileIOUtils.readAsUTFString(inputStream);
-      HoodieCommitMetadata metadata = HoodieCommitMetadata.fromJsonString(everything, HoodieCommitMetadata.class);
-      assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
+      // Re-init client with null writer schema.
+      cfgBuilder = getConfigBuilder((String) null).withAutoCommit(false);
+      client = getHoodieWriteClient(cfgBuilder.build());
+      String secondCommit = "002";
+      client.startCommitWithTime(secondCommit);
+      JavaRDD<HoodieRecord> emptyRdd = context.emptyRDD();
+      result = client.insert(emptyRdd, secondCommit);
+      assertTrue(client.commit(secondCommit, result), "Commit should succeed");
+      try (FSDataInputStream inputStream = fs.open(testTable.getCommitFilePath(secondCommit))) {
+        String everything = FileIOUtils.readAsUTFString(inputStream);
+        HoodieCommitMetadata metadata = HoodieCommitMetadata.fromJsonString(everything, HoodieCommitMetadata.class);
+        assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
+      }
+      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
+      TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
+      assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));
+    } finally {
+      client.close();
     }
-    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
-    TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
-    assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));
-    // Close.
-    client.close();
   }
 
   private void insertWithConfig(HoodieWriteConfig config, int numRecords, String instant) throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -62,7 +62,6 @@ import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -121,7 +120,6 @@ import org.apache.hudi.testutils.HoodieClientTestBase;
 import org.apache.hudi.testutils.HoodieClientTestUtils;
 import org.apache.hudi.testutils.HoodieSparkWriteableTestTable;
 
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -404,39 +402,6 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     insertWithConfig(config, numRecords, instant2);
     assertTrue(testTable.inflightCommitExists(instant1));
     assertTrue(testTable.commitExists(instant2));
-  }
-
-  @Test
-  public void testInertsWithEmptyCommitsHavingWriterSchemaAsNull() throws Exception {
-    HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder().withAutoCommit(false);
-    addConfigsForPopulateMetaFields(cfgBuilder, true);
-    SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.build());
-    try {
-      String firstCommit = "001";
-      int numRecords = 200;
-      JavaRDD<WriteStatus> result = insertFirstBatch(cfgBuilder.build(), client, firstCommit, "000", numRecords, SparkRDDWriteClient::insert,
-          false, false, numRecords);
-      assertTrue(client.commit(firstCommit, result), "Commit should succeed");
-
-      // Re-init client with null writer schema.
-      cfgBuilder = getConfigBuilder((String) null).withAutoCommit(false);
-      client = getHoodieWriteClient(cfgBuilder.build());
-      String secondCommit = "002";
-      client.startCommitWithTime(secondCommit);
-      JavaRDD<HoodieRecord> emptyRdd = context.emptyRDD();
-      result = client.insert(emptyRdd, secondCommit);
-      assertTrue(client.commit(secondCommit, result), "Commit should succeed");
-      try (FSDataInputStream inputStream = fs.open(testTable.getCommitFilePath(secondCommit))) {
-        String everything = FileIOUtils.readAsUTFString(inputStream);
-        HoodieCommitMetadata metadata = HoodieCommitMetadata.fromJsonString(everything, HoodieCommitMetadata.class);
-        assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
-      }
-      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
-      TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
-      assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));
-    } finally {
-      client.close();
-    }
   }
 
   private void insertWithConfig(HoodieWriteConfig config, int numRecords, String instant) throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -435,7 +435,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
     assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));
     // Close.
-      client.close();
+    client.close();
   }
 
   private void insertWithConfig(HoodieWriteConfig config, int numRecords, String instant) throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -62,6 +62,7 @@ import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -120,6 +121,7 @@ import org.apache.hudi.testutils.HoodieClientTestBase;
 import org.apache.hudi.testutils.HoodieClientTestUtils;
 import org.apache.hudi.testutils.HoodieSparkWriteableTestTable;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -402,6 +404,38 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     insertWithConfig(config, numRecords, instant2);
     assertTrue(testTable.inflightCommitExists(instant1));
     assertTrue(testTable.commitExists(instant2));
+  }
+
+  @Test
+  public void testInertsWithEmptyCommitsHavingWriterSchemaAsNull() throws Exception {
+    // Set autoCommit false
+    HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder().withAutoCommit(false);
+    addConfigsForPopulateMetaFields(cfgBuilder, true);
+    SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.build());
+    String firstCommit = "001";
+    int numRecords = 200;
+    JavaRDD<WriteStatus> result = insertFirstBatch(cfgBuilder.build(), client, firstCommit, "000", numRecords, SparkRDDWriteClient::insert,
+        false, false, numRecords);
+    assertTrue(client.commit(firstCommit, result), "Commit should succeed");
+
+    // Re-init client with null writer schema.
+    cfgBuilder = getConfigBuilder((String) null).withAutoCommit(false);
+    client = getHoodieWriteClient(cfgBuilder.build());
+    String secondCommit = "002";
+    client.startCommitWithTime(secondCommit);
+    JavaRDD<HoodieRecord> emptyRdd = context.emptyRDD();
+    result = client.insert(emptyRdd, secondCommit);
+    assertTrue(client.commit(secondCommit, result), "Commit should succeed");
+    try (FSDataInputStream inputStream = fs.open(testTable.getCommitFilePath(secondCommit))) {
+      String everything = FileIOUtils.readAsUTFString(inputStream);
+      HoodieCommitMetadata metadata = HoodieCommitMetadata.fromJsonString(everything, HoodieCommitMetadata.class);
+      assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
+    }
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
+    TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
+    assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));
+    // Close.
+      client.close();
   }
 
   private void insertWithConfig(HoodieWriteConfig config, int numRecords, String instant) throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
@@ -172,7 +172,7 @@ public class HoodieClientTestBase extends HoodieClientTestHarness {
             .withEnableBackupForRemoteFileSystemView(false) // Fail test if problem connecting to timeline-server
             .withRemoteServerPort(timelineServicePort)
             .withStorageType(FileSystemViewStorageType.EMBEDDED_KV_STORE).build());
-    if (schemaStr != null) {
+    if (StringUtils.nonEmpty(schemaStr)) {
       builder.withSchema(schemaStr);
     }
     return builder;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestBase.java
@@ -158,7 +158,7 @@ public class HoodieClientTestBase extends HoodieClientTestHarness {
    */
   public HoodieWriteConfig.Builder getConfigBuilder(String schemaStr, IndexType indexType,
                                                     HoodieFailedWritesCleaningPolicy cleaningPolicy) {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(schemaStr)
+    HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)
@@ -172,6 +172,10 @@ public class HoodieClientTestBase extends HoodieClientTestHarness {
             .withEnableBackupForRemoteFileSystemView(false) // Fail test if problem connecting to timeline-server
             .withRemoteServerPort(timelineServicePort)
             .withStorageType(FileSystemViewStorageType.EMBEDDED_KV_STORE).build());
+    if (schemaStr != null) {
+      builder.withSchema(schemaStr);
+    }
+    return builder;
   }
 
   public HoodieSparkTable getHoodieTable(HoodieTableMetaClient metaClient, HoodieWriteConfig config) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.functional;
 
 import org.apache.hudi.client.SparkRDDWriteClient;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
@@ -1,0 +1,59 @@
+package org.apache.hudi.functional;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.testutils.HoodieSparkClientTestBase;
+
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaRDD;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests write client functionality.
+ */
+@Tag("functional")
+public class TestWriteClient extends HoodieSparkClientTestBase {
+
+  @Test
+  public void testInertsWithEmptyCommitsHavingWriterSchemaAsNull() throws Exception {
+    HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder().withAutoCommit(false);
+    addConfigsForPopulateMetaFields(cfgBuilder, true);
+    SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.build());
+    try {
+      String firstCommit = "001";
+      int numRecords = 200;
+      JavaRDD<WriteStatus> result = insertFirstBatch(cfgBuilder.build(), client, firstCommit, "000", numRecords, SparkRDDWriteClient::insert,
+          false, false, numRecords);
+      assertTrue(client.commit(firstCommit, result), "Commit should succeed");
+
+      // Re-init client with null writer schema.
+      cfgBuilder = getConfigBuilder((String) null).withAutoCommit(false);
+      client = getHoodieWriteClient(cfgBuilder.build());
+      String secondCommit = "002";
+      client.startCommitWithTime(secondCommit);
+      JavaRDD<HoodieRecord> emptyRdd = context.emptyRDD();
+      result = client.insert(emptyRdd, secondCommit);
+      assertTrue(client.commit(secondCommit, result), "Commit should succeed");
+      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build();
+      HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+      HoodieCommitMetadata metadata = HoodieCommitMetadata.fromBytes(timeline.getInstantDetails(timeline.lastInstant().get()).get(), HoodieCommitMetadata.class);
+      assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
+      TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
+      assertEquals(Schema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableAvroSchema(false));
+      assertEquals(numRecords, sparkSession.read().format("org.apache.hudi").load(basePath).count());
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
@@ -22,9 +22,11 @@ import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.testutils.HoodieSparkClientTestBase;
 
@@ -46,7 +48,9 @@ public class TestWriteClient extends HoodieSparkClientTestBase {
   @Test
   public void testInertsWithEmptyCommitsHavingWriterSchemaAsNull() throws Exception {
     HoodieWriteConfig.Builder cfgBuilder = getConfigBuilder().withAutoCommit(false);
-    addConfigsForPopulateMetaFields(cfgBuilder, true);
+    addConfigsForPopulateMetaFields(cfgBuilder, false);
+    // Re-init meta client with write config props.
+    metaClient = HoodieTestUtils.init(basePath, HoodieTableType.MERGE_ON_READ, cfgBuilder.build().getProps());
     SparkRDDWriteClient client = getHoodieWriteClient(cfgBuilder.build());
     try {
       String firstCommit = "001";
@@ -57,6 +61,7 @@ public class TestWriteClient extends HoodieSparkClientTestBase {
 
       // Re-init client with null writer schema.
       cfgBuilder = getConfigBuilder((String) null).withAutoCommit(false);
+      addConfigsForPopulateMetaFields(cfgBuilder, false);
       client = getHoodieWriteClient(cfgBuilder.build());
       String secondCommit = "002";
       client.startCommitWithTime(secondCommit);


### PR DESCRIPTION
### Change Logs

When source returns an empty option, the writer schema is null. This causes an NPE with the table schema validation in spark write client causing the below exception. Skipping the validation when writer schema is null.

```
org.apache.hudi.exception.HoodieInsertException: Failed insert schema compability check.
	at org.apache.hudi.table.HoodieTable.validateInsertSchema(HoodieTable.java:851)
	at org.apache.hudi.client.SparkRDDWriteClient.insert(SparkRDDWriteClient.java:185)
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.writeToSink(DeltaSync.java:690)
	at org.apache.hudi.utilities.deltastreamer.DeltaSync.syncOnce(DeltaSync.java:396)
	at org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer$DeltaSyncService.ingestOnce(HoodieDeltaStreamer.java:876)
	at org.apache.hudi.common.util.Option.ifPresent(Option.java:97)
	at com.onehouse.hudi.OnehouseDeltaStreamer$MultiTableSyncService.lambda$null$1(OnehouseDeltaStreamer.java:319)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: org.apache.hudi.exception.HoodieException: Failed to read schema/check compatibility for base path s3a://onehouse-customer-bucket-2451e78f/data-lake/chandra_data_lake_default/xml_flatten_struct_test
	at org.apache.hudi.table.HoodieTable.validateSchema(HoodieTable.java:830)
	at org.apache.hudi.table.HoodieTable.validateInsertSchema(HoodieTable.java:849)
	... 10 more
Caused by: java.lang.NullPointerException
	at com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:1158)
	at org.apache.avro.Schema$Parser.parse(Schema.java:1418)
	at org.apache.hudi.avro.HoodieAvroUtils.createHoodieWriteSchema(HoodieAvroUtils.java:302)
	at org.apache.hudi.table.HoodieTable.validateSchema(HoodieTable.java:826)
	... 11 more
```

### Impact

Deltastreamer sources returning an empty rdd with no schema won't cause NPE in the deltastreamer spark job. 

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
