### PR TITLE
[HUDI-6628] Rely on methods in HoodieBaseFile and HoodieLogFile instead of FSUtils when possible

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
@@ -42,6 +42,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieMemoryConfig;
+import org.apache.hudi.hadoop.CachingPath;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
@@ -232,9 +233,9 @@ public class HoodieLogFileCommand {
     } else {
       for (String logFile : logFilePaths) {
         Schema writerSchema = new AvroSchemaConverter()
-            .convert(Objects.requireNonNull(TableSchemaResolver.readSchemaFromLogFile(client.getFs(), new Path(logFile))));
+            .convert(Objects.requireNonNull(TableSchemaResolver.readSchemaFromLogFile(client.getFs(), new CachingPath(logFile))));
         HoodieLogFormat.Reader reader =
-            HoodieLogFormat.newReader(fs, new HoodieLogFile(new Path(logFile)), writerSchema);
+            HoodieLogFormat.newReader(fs, new HoodieLogFile(new CachingPath(logFile)), writerSchema);
         // read the avro blocks
         while (reader.hasNext()) {
           HoodieLogBlock n = reader.next();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -41,6 +41,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.table.action.compact.OperationResult;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -244,7 +245,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
         merged.getLogFiles().filter(lf -> lf.getLogVersion() > maxVersion).collect(Collectors.toList());
     return logFilesToBeMoved.stream().map(lf -> {
       ValidationUtils.checkArgument(lf.getLogVersion() - maxVersion > 0, "Expect new log version to be sane");
-      HoodieLogFile newLogFile = new HoodieLogFile(new Path(lf.getPath().getParent(),
+      HoodieLogFile newLogFile = new HoodieLogFile(new CachingPath(lf.getPath().getParent(),
           FSUtils.makeLogFileName(lf.getFileId(), "." + lf.getFileExtension(),
               compactionInstant, lf.getLogVersion() - maxVersion, HoodieLogFormat.UNKNOWN_WRITE_TOKEN)));
       return Pair.of(lf, newLogFile);
@@ -450,7 +451,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
         .orElse(fileSliceForCompaction.getLogFiles().findFirst().map(lf -> lf.getPath().getParent().toString()).get());
     for (HoodieLogFile toRepair : logFilesToRepair) {
       int version = maxUsedVersion + 1;
-      HoodieLogFile newLf = new HoodieLogFile(new Path(parentPath, FSUtils.makeLogFileName(operation.getFileId(),
+      HoodieLogFile newLf = new HoodieLogFile(new CachingPath(parentPath, FSUtils.makeLogFileName(operation.getFileId(),
           logExtn, operation.getBaseInstantTime(), version, HoodieLogFormat.UNKNOWN_WRITE_TOKEN)));
       result.add(Pair.of(toRepair, newLf));
       maxUsedVersion = version;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -245,7 +245,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
     return logFilesToBeMoved.stream().map(lf -> {
       ValidationUtils.checkArgument(lf.getLogVersion() - maxVersion > 0, "Expect new log version to be sane");
       HoodieLogFile newLogFile = new HoodieLogFile(new Path(lf.getPath().getParent(),
-          FSUtils.makeLogFileName(lf.getFileId(), "." + FSUtils.getFileExtensionFromLog(lf.getPath()),
+          FSUtils.makeLogFileName(lf.getFileId(), "." + lf.getFileExtension(),
               compactionInstant, lf.getLogVersion() - maxVersion, HoodieLogFormat.UNKNOWN_WRITE_TOKEN)));
       return Pair.of(lf, newLogFile);
     }).collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -215,15 +215,14 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
     String keyField = hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
 
     List<Pair<String, HoodieBaseFile>> baseFilesForAllPartitions = HoodieIndexUtils.getLatestBaseFilesForAllPartitions(partitions, context, hoodieTable);
+    // Partition and file name pairs
     List<Pair<String, String>> partitionFileNameList = new ArrayList<>(baseFilesForAllPartitions.size());
     Map<Pair<String, String>, String> partitionAndFileNameToFileId = new HashMap<>(baseFilesForAllPartitions.size());
     baseFilesForAllPartitions.forEach(pair -> {
-      Pair<String, String> parititonAndFileName = Pair.of(pair.getKey(), pair.getValue().getFileName());
-      partitionFileNameList.add(parititonAndFileName);
-      partitionAndFileNameToFileId.put(parititonAndFileName, pair.getValue().getFileId());
+      Pair<String, String> partitionAndFileName = Pair.of(pair.getKey(), pair.getValue().getFileName());
+      partitionFileNameList.add(partitionAndFileName);
+      partitionAndFileNameToFileId.put(partitionAndFileName, pair.getValue().getFileId());
     });
-    // Partition and file name pairs
-    Collections.sort(partitionFileNameList); // TODO why does this need to be sorted?
 
     if (partitionFileNameList.isEmpty()) {
       return Collections.emptyList();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -217,7 +217,7 @@ public class HoodieBloomIndex extends HoodieIndex<Object, Object> {
     List<Pair<String, HoodieBaseFile>> baseFilesForAllPartitions = HoodieIndexUtils.getLatestBaseFilesForAllPartitions(partitions, context, hoodieTable);
     // Partition and file name pairs
     List<Pair<String, String>> partitionFileNameList = new ArrayList<>(baseFilesForAllPartitions.size());
-    Map<Pair<String, String>, String> partitionAndFileNameToFileId = new HashMap<>(baseFilesForAllPartitions.size());
+    Map<Pair<String, String>, String> partitionAndFileNameToFileId = new HashMap<>(baseFilesForAllPartitions.size(), 1);
     baseFilesForAllPartitions.forEach(pair -> {
       Pair<String, String> partitionAndFileName = Pair.of(pair.getKey(), pair.getValue().getFileName());
       partitionFileNameList.add(partitionAndFileName);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -173,7 +173,7 @@ public class HoodieMergeHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O>
     writeStatus.setStat(new HoodieWriteStat());
     try {
       String latestValidFilePath = baseFileToMerge.getFileName();
-      writeStatus.getStat().setPrevCommit(FSUtils.getCommitTime(latestValidFilePath));
+      writeStatus.getStat().setPrevCommit(baseFileToMerge.getCommitTime());
 
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(fs, instantTime,
           new Path(config.getBasePath()), FSUtils.getPartitionPath(config.getBasePath(), partitionPath),
@@ -471,7 +471,7 @@ public class HoodieMergeHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O>
           String.format("Record write count decreased for file: %s, Partition Path: %s (%s:%d + %d < %s:%d)",
               writeStatus.getFileId(), writeStatus.getPartitionPath(),
               instantTime, writeStatus.getStat().getNumWrites(), writeStatus.getStat().getNumDeletes(),
-              FSUtils.getCommitTime(oldFilePath.toString()), oldNumWrites));
+              baseFileToMerge.getCommitTime(), oldNumWrites));
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
@@ -253,7 +253,7 @@ public abstract class HoodieWriteHandle<T, I, K, O> extends HoodieIOHandle<T, I,
         .withSizeThreshold(config.getLogFileMaxSize())
         .withFs(fs)
         .withRolloverLogWriteToken(writeToken)
-        .withLogWriteToken(latestLogFile.map(x -> FSUtils.getWriteTokenFromLogPath(x.getPath())).orElse(writeToken))
+        .withLogWriteToken(latestLogFile.map(HoodieLogFile::getLogWriteToken).orElse(writeToken))
         .withSuffix(suffix)
         .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
   }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
@@ -253,9 +253,8 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
 
       for (HoodieBaseFile file : allFiles) {
         if (file.getFileSize() < config.getParquetSmallFileLimit()) {
-          String filename = file.getFileName();
           SmallFile sf = new SmallFile();
-          sf.location = new HoodieRecordLocation(FSUtils.getCommitTime(filename), FSUtils.getFileId(filename));
+          sf.location = new HoodieRecordLocation(file.getCommitTime(), file.getFileId());
           sf.sizeBytes = file.getFileSize();
           smallFileLocations.add(sf);
         }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieFileProbingFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieFileProbingFunction.java
@@ -20,7 +20,6 @@ package org.apache.hudi.index.bloom;
 
 import org.apache.hudi.client.utils.LazyIterableIterator;
 import org.apache.hudi.common.config.SerializableConfiguration;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -84,7 +83,7 @@ public class HoodieFileProbingFunction implements
     @Override
     protected List<HoodieKeyLookupResult> computeNext() {
       // Partition path and file name pair to list of keys
-      final Map<Pair<String, String>, HoodieBloomFilterProbingResult> fileToLookupResults = new HashMap<>();
+      final Map<Pair<String, HoodieBaseFile>, HoodieBloomFilterProbingResult> fileToLookupResults = new HashMap<>();
       final Map<String, HoodieBaseFile> fileIDBaseFileMap = new HashMap<>();
 
       while (inputItr.hasNext()) {
@@ -103,7 +102,7 @@ public class HoodieFileProbingFunction implements
           fileIDBaseFileMap.put(fileId, baseFile.get());
         }
 
-        fileToLookupResults.putIfAbsent(Pair.of(partitionPath, fileIDBaseFileMap.get(fileId).getFileName()), entry._2);
+        fileToLookupResults.putIfAbsent(Pair.of(partitionPath, fileIDBaseFileMap.get(fileId)), entry._2);
 
         if (fileToLookupResults.size() > BLOOM_FILTER_CHECK_MAX_FILE_COUNT_PER_BATCH) {
           break;
@@ -116,12 +115,11 @@ public class HoodieFileProbingFunction implements
 
       return fileToLookupResults.entrySet().stream()
           .map(entry -> {
-            Pair<String, String> partitionPathFileNamePair = entry.getKey();
+            Pair<String, HoodieBaseFile> partitionPathFileNamePair = entry.getKey();
             HoodieBloomFilterProbingResult bloomFilterKeyLookupResult = entry.getValue();
 
             final String partitionPath = partitionPathFileNamePair.getLeft();
-            final String fileName = partitionPathFileNamePair.getRight();
-            final String fileId = FSUtils.getFileId(fileName);
+            final String fileId = partitionPathFileNamePair.getRight().getFileId();
             ValidationUtils.checkState(!fileId.isEmpty());
 
             List<String> candidateRecordKeys = bloomFilterKeyLookupResult.getCandidateKeys();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomFilterProbingFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomFilterProbingFunction.java
@@ -20,7 +20,6 @@ package org.apache.hudi.index.bloom;
 
 import org.apache.hudi.client.utils.LazyIterableIterator;
 import org.apache.hudi.common.bloom.BloomFilter;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieKey;
@@ -44,6 +43,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import scala.Tuple2;
 
@@ -93,7 +93,7 @@ public class HoodieMetadataBloomFilterProbingFunction implements
     @Override
     protected Iterator<Tuple2<HoodieFileGroupId, HoodieBloomFilterProbingResult>> computeNext() {
       // Partition path and file name pair to list of keys
-      final Map<Pair<String, String>, List<HoodieKey>> fileToKeysMap = new HashMap<>();
+      final Map<Pair<String, HoodieBaseFile>, List<HoodieKey>> fileToKeysMap = new HashMap<>();
       final Map<String, HoodieBaseFile> fileIDBaseFileMap = new HashMap<>();
 
       while (inputItr.hasNext()) {
@@ -110,7 +110,7 @@ public class HoodieMetadataBloomFilterProbingFunction implements
           fileIDBaseFileMap.put(fileId, baseFile.get());
         }
 
-        fileToKeysMap.computeIfAbsent(Pair.of(partitionPath, fileIDBaseFileMap.get(fileId).getFileName()),
+        fileToKeysMap.computeIfAbsent(Pair.of(partitionPath, fileIDBaseFileMap.get(fileId)),
             k -> new ArrayList<>()).add(new HoodieKey(entry._2, partitionPath));
 
         if (fileToKeysMap.size() > BLOOM_FILTER_CHECK_MAX_FILE_COUNT_PER_BATCH) {
@@ -122,18 +122,17 @@ public class HoodieMetadataBloomFilterProbingFunction implements
         return Collections.emptyIterator();
       }
 
-      List<Pair<String, String>> partitionNameFileNameList = new ArrayList<>(fileToKeysMap.keySet());
+      List<Pair<String, String>> partitionNameFileNameList = fileToKeysMap.keySet().stream().map(pair -> Pair.of(pair.getLeft(), pair.getRight().getFileName())).collect(Collectors.toList());
       Map<Pair<String, String>, BloomFilter> fileToBloomFilterMap =
           hoodieTable.getMetadataTable().getBloomFilters(partitionNameFileNameList);
 
       return fileToKeysMap.entrySet().stream()
           .map(entry -> {
-            Pair<String, String> partitionPathFileNamePair = entry.getKey();
+            Pair<String, HoodieBaseFile> partitionPathFileNamePair = entry.getKey();
             List<HoodieKey> hoodieKeyList = entry.getValue();
 
             final String partitionPath = partitionPathFileNamePair.getLeft();
-            final String fileName = partitionPathFileNamePair.getRight();
-            final String fileId = FSUtils.getFileId(fileName);
+            final String fileId = partitionPathFileNamePair.getRight().getFileId();
             ValidationUtils.checkState(!fileId.isEmpty());
 
             if (!fileToBloomFilterMap.containsKey(partitionPathFileNamePair)) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomFilterProbingFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomFilterProbingFunction.java
@@ -128,13 +128,13 @@ public class HoodieMetadataBloomFilterProbingFunction implements
 
       return fileToKeysMap.entrySet().stream()
           .map(entry -> {
-            Pair<String, HoodieBaseFile> partitionPathFileNamePair = entry.getKey();
             List<HoodieKey> hoodieKeyList = entry.getValue();
-
-            final String partitionPath = partitionPathFileNamePair.getLeft();
-            final String fileId = partitionPathFileNamePair.getRight().getFileId();
+            final String partitionPath = entry.getKey().getLeft();
+            final HoodieBaseFile baseFile = entry.getKey().getRight();
+            final String fileId = baseFile.getFileId();
             ValidationUtils.checkState(!fileId.isEmpty());
 
+            Pair<String, String> partitionPathFileNamePair = Pair.of(partitionPath, baseFile.getFileName());
             if (!fileToBloomFilterMap.containsKey(partitionPathFileNamePair)) {
               throw new HoodieIndexException("Failed to get the bloom filter for " + partitionPathFileNamePair);
             }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/UpsertPartitioner.java
@@ -302,9 +302,8 @@ public class UpsertPartitioner<T> extends SparkHoodiePartitioner<T> {
 
       for (HoodieBaseFile file : allFiles) {
         if (file.getFileSize() < config.getParquetSmallFileLimit()) {
-          String filename = file.getFileName();
           SmallFile sf = new SmallFile();
-          sf.location = new HoodieRecordLocation(FSUtils.getCommitTime(filename), FSUtils.getFileId(filename));
+          sf.location = new HoodieRecordLocation(file.getCommitTime(), file.getFileId());
           sf.sizeBytes = file.getFileSize();
           smallFileLocations.add(sf);
         }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/deltacommit/SparkUpsertDeltaCommitPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/deltacommit/SparkUpsertDeltaCommitPartitioner.java
@@ -19,8 +19,8 @@
 package org.apache.hudi.table.action.deltacommit;
 
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -32,6 +32,7 @@ import org.apache.hudi.table.action.commit.SmallFile;
 import org.apache.hudi.table.action.commit.UpsertPartitioner;
 
 import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -69,15 +70,14 @@ public class SparkUpsertDeltaCommitPartitioner<T> extends UpsertPartitioner<T> {
     for (FileSlice smallFileSlice : smallFileSlicesCandidates) {
       SmallFile sf = new SmallFile();
       if (smallFileSlice.getBaseFile().isPresent()) {
-        // TODO : Move logic of file name, file id, base commit time handling inside file slice
-        String filename = smallFileSlice.getBaseFile().get().getFileName();
-        sf.location = new HoodieRecordLocation(FSUtils.getCommitTime(filename), FSUtils.getFileId(filename));
+        HoodieBaseFile baseFile = smallFileSlice.getBaseFile().get();
+        sf.location = new HoodieRecordLocation(baseFile.getCommitTime(), baseFile.getFileId());
         sf.sizeBytes = getTotalFileSize(smallFileSlice);
         smallFileLocations.add(sf);
       } else {
         HoodieLogFile logFile = smallFileSlice.getLogFiles().findFirst().get();
-        sf.location = new HoodieRecordLocation(FSUtils.getBaseCommitTimeFromLogPath(logFile.getPath()),
-            FSUtils.getFileIdFromLogPath(logFile.getPath()));
+        sf.location = new HoodieRecordLocation(logFile.getBaseCommitTime(),
+            logFile.getFileId());
         sf.sizeBytes = getTotalFileSize(smallFileSlice);
         smallFileLocations.add(sf);
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -193,9 +193,9 @@ public class FSUtils {
   public static String getCommitTime(String fullFileName) {
     try {
       if (isLogFile(fullFileName)) {
-        return fullFileName.split("_")[1].split("\\.")[0];
+        return fullFileName.split("_")[1].split("\\.", 2)[0];
       }
-      return fullFileName.split("_")[2].split("\\.")[0];
+      return fullFileName.split("_")[2].split("\\.", 2)[0];
     } catch (ArrayIndexOutOfBoundsException e) {
       throw new HoodieException("Failed to get commit time from filename: " + fullFileName, e);
     }
@@ -206,7 +206,7 @@ public class FSUtils {
   }
 
   public static String getFileId(String fullFileName) {
-    return fullFileName.split("_")[0];
+    return fullFileName.split("_", 2)[0];
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -538,7 +538,7 @@ public class FSUtils {
         getLatestLogFile(getAllLogFiles(fs, partitionPath, fileId, logFileExtension, baseCommitTime));
     if (latestLogFile.isPresent()) {
       return Option
-          .of(Pair.of(latestLogFile.get().getLogVersion(), getWriteTokenFromLogPath(latestLogFile.get().getPath())));
+          .of(Pair.of(latestLogFile.get().getLogVersion(), latestLogFile.get().getLogWriteToken()));
     }
     return Option.empty();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -454,15 +454,6 @@ public class FSUtils {
     return Integer.parseInt(matcher.group(4));
   }
 
-  public static String getSuffixFromLogPath(Path path) {
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
-    if (!matcher.find()) {
-      throw new InvalidHoodiePathException(path, "LogFile");
-    }
-    String val = matcher.group(10);
-    return val == null ? "" : val;
-  }
-
   public static String makeLogFileName(String fileId, String logFileExtension, String baseCommitTime, int version,
       String writeToken) {
     String suffix = (writeToken == null)

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseFile.java
@@ -36,7 +36,7 @@ public class BaseFile implements Serializable {
 
   private transient FileStatus fileStatus;
   private final String fullPath;
-  private final String fileName;
+  protected final String fileName;
   private long fileLen;
 
   public BaseFile(BaseFile dataFile) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/CompactionOperation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/CompactionOperation.java
@@ -73,8 +73,8 @@ public class CompactionOperation implements Serializable {
     } else {
       assert logFiles.size() > 0;
       this.dataFileName = Option.empty();
-      this.baseInstantTime = FSUtils.getBaseCommitTimeFromLogPath(logFiles.get(0).getPath());
-      this.id = new HoodieFileGroupId(partitionPath, FSUtils.getFileIdFromLogPath(logFiles.get(0).getPath()));
+      this.baseInstantTime = logFiles.get(0).getBaseCommitTime();
+      this.id = new HoodieFileGroupId(partitionPath, logFiles.get(0).getFileId());
       this.dataFileCommitTime = Option.empty();
       this.bootstrapFilePath = Option.empty();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieBaseFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieBaseFile.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.model;
 
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -28,12 +27,17 @@ import org.apache.hadoop.fs.FileStatus;
  * Supports APIs to get Hudi FileId, Commit Time and bootstrap file (if any).
  */
 public class HoodieBaseFile extends BaseFile {
+  private static final long serialVersionUID = 1L;
+  private final String fileId;
+  private final String commitTime;
 
   private Option<BaseFile> bootstrapBaseFile;
 
   public HoodieBaseFile(HoodieBaseFile dataFile) {
     super(dataFile);
     this.bootstrapBaseFile = dataFile.bootstrapBaseFile;
+    this.fileId = dataFile.getFileId();
+    this.commitTime = dataFile.getCommitTime();
   }
 
   public HoodieBaseFile(FileStatus fileStatus) {
@@ -43,6 +47,9 @@ public class HoodieBaseFile extends BaseFile {
   public HoodieBaseFile(FileStatus fileStatus, BaseFile bootstrapBaseFile) {
     super(fileStatus);
     this.bootstrapBaseFile = Option.ofNullable(bootstrapBaseFile);
+    String[] fileIdAndCommitTime = getFileIdAndCommitTimeFromFileName();
+    this.fileId = fileIdAndCommitTime[0];
+    this.commitTime = fileIdAndCommitTime[1];
   }
 
   public HoodieBaseFile(String filePath) {
@@ -52,14 +59,39 @@ public class HoodieBaseFile extends BaseFile {
   public HoodieBaseFile(String filePath, BaseFile bootstrapBaseFile) {
     super(filePath);
     this.bootstrapBaseFile = Option.ofNullable(bootstrapBaseFile);
+    String[] fileIdAndCommitTime = getFileIdAndCommitTimeFromFileName();
+    this.fileId = fileIdAndCommitTime[0];
+    this.commitTime = fileIdAndCommitTime[1];
+  }
+
+  private String[] getFileIdAndCommitTimeFromFileName() {
+    String[] values = new String[2];
+    short underscoreCount = 0;
+    short lastUnderscoreIndex = 0;
+    for (int i = 0; i < fileName.length(); i++) {
+      char c = fileName.charAt(i);
+      if (c == '_') {
+        if (underscoreCount == 0) {
+          values[0] = fileName.substring(0, i);
+        }
+        lastUnderscoreIndex = (short) i;
+        underscoreCount++;
+      } else if (c == '.') {
+        if (underscoreCount == 2) {
+          values[1] = fileName.substring(lastUnderscoreIndex + 1, i);
+          break;
+        }
+      }
+    }
+    return values;
   }
 
   public String getFileId() {
-    return FSUtils.getFileId(getFileName());
+    return fileId;
   }
 
   public String getCommitTime() {
-    return FSUtils.getCommitTime(getFileName());
+    return commitTime;
   }
 
   public Option<BaseFile> getBootstrapBaseFile() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieBaseFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieBaseFile.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.fs.FileStatus;
  */
 public class HoodieBaseFile extends BaseFile {
   private static final long serialVersionUID = 1L;
+  private static final char UNDERSCORE = '_';
+  private static final char DOT = '.';
   private final String fileId;
   private final String commitTime;
 
@@ -64,26 +66,30 @@ public class HoodieBaseFile extends BaseFile {
     this.commitTime = fileIdAndCommitTime[1];
   }
 
+  /**
+   * Parses the file ID and commit time from the fileName.
+   * @return String array of size 2 with fileId as the first and commitTime as the second element.
+   */
   private String[] getFileIdAndCommitTimeFromFileName() {
     String[] values = new String[2];
     short underscoreCount = 0;
     short lastUnderscoreIndex = 0;
     for (int i = 0; i < fileName.length(); i++) {
       char c = fileName.charAt(i);
-      if (c == '_') {
+      if (c == UNDERSCORE) {
         if (underscoreCount == 0) {
           values[0] = fileName.substring(0, i);
         }
         lastUnderscoreIndex = (short) i;
         underscoreCount++;
-      } else if (c == '.') {
+      } else if (c == DOT) {
         if (underscoreCount == 2) {
           values[1] = fileName.substring(lastUnderscoreIndex + 1, i);
           return values;
         }
       }
     }
-    // case where there is no '.' in file name
+    // case where there is no '.' in file name (no file suffix like .parquet)
     values[1] = fileName.substring(lastUnderscoreIndex + 1);
     return values;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieBaseFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieBaseFile.java
@@ -79,10 +79,12 @@ public class HoodieBaseFile extends BaseFile {
       } else if (c == '.') {
         if (underscoreCount == 2) {
           values[1] = fileName.substring(lastUnderscoreIndex + 1, i);
-          break;
+          return values;
         }
       }
     }
+    // case where there is no '.' in file name
+    values[1] = fileName.substring(lastUnderscoreIndex + 1);
     return values;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -53,16 +53,25 @@ public class HoodieLogFile implements Serializable {
   private transient FileStatus fileStatus;
   private transient Path path;
   private final String pathStr;
-  private final String fileId;
-  private final String baseCommitTime;
-  private final int logVersion;
-  private final String logWriteToken;
-  private final String fileExtension;
-  private final String suffix;
+  private String fileId;
+  private String baseCommitTime;
+  private int logVersion;
+  private String logWriteToken;
+  private String fileExtension;
+  private String suffix;
   private long fileLen;
 
   public HoodieLogFile(HoodieLogFile logFile) {
-    this(logFile.getFileStatus(), logFile.getPath(), logFile.pathStr, logFile.getFileSize());
+    this.fileStatus = logFile.getFileStatus();
+    this.path = logFile.getPath();
+    this.pathStr = logFile.pathStr;
+    this.fileId = logFile.getFileId();
+    this.baseCommitTime = logFile.getBaseCommitTime();
+    this.logVersion = logFile.getLogVersion();
+    this.logWriteToken = logFile.getLogWriteToken();
+    this.fileExtension = logFile.getFileExtension();
+    this.suffix = logFile.getSuffix();
+    this.fileLen = logFile.getFileSize();
   }
 
   public HoodieLogFile(FileStatus fileStatus) {
@@ -85,16 +94,14 @@ public class HoodieLogFile implements Serializable {
     this.fileStatus = fileStatus;
     this.pathStr = logPathStr;
     this.fileLen = fileLen;
-    if (logPath != null) {
-      if (logPath instanceof CachingPath) {
-        this.path = logPath;
-      } else {
-        this.path = new CachingPath(logPath.getParent(), logPath.getName());
-      }
-    } else {
-      this.path = new CachingPath(pathStr);
+    this.logVersion = -1; // mark version as uninitialized
+    if (logPath instanceof CachingPath) {
+      this.path = logPath;
     }
-    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+  }
+
+  private void parseFieldsFromPath() {
+    Matcher matcher = LOG_FILE_PATTERN.matcher(getPath().getName());
     if (!matcher.find()) {
       throw new InvalidHoodiePathException(path, "LogFile");
     }
@@ -107,26 +114,44 @@ public class HoodieLogFile implements Serializable {
   }
 
   public String getFileId() {
+    if (fileId == null) {
+      parseFieldsFromPath();
+    }
     return fileId;
   }
 
   public String getBaseCommitTime() {
+    if (baseCommitTime == null) {
+      parseFieldsFromPath();
+    }
     return baseCommitTime;
   }
 
   public int getLogVersion() {
+    if (logVersion == -1) {
+      parseFieldsFromPath();
+    }
     return logVersion;
   }
 
   public String getLogWriteToken() {
+    if (logWriteToken == null) {
+      parseFieldsFromPath();
+    }
     return logWriteToken;
   }
 
   public String getFileExtension() {
+    if (fileExtension == null) {
+      parseFieldsFromPath();
+    }
     return fileExtension;
   }
 
   public String getSuffix() {
+    if (suffix == null) {
+      parseFieldsFromPath();
+    }
     return suffix;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -103,7 +103,7 @@ public class HoodieLogFile implements Serializable {
     this.fileExtension = matcher.group(3);
     this.logVersion = Integer.parseInt(matcher.group(4));
     this.logWriteToken = matcher.group(6);
-    this.suffix = matcher.group(10);
+    this.suffix = matcher.group(10) == null ? "" : matcher.group(10);
   }
 
   public String getFileId() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -131,7 +131,7 @@ public class HoodieLogFile implements Serializable {
   }
 
   public Path getPath() {
-    return new Path(pathStr);
+    return path;
   }
 
   public String getFileName() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -51,6 +51,7 @@ public class HoodieLogFile implements Serializable {
   private static final Comparator<HoodieLogFile> LOG_FILE_COMPARATOR_REVERSED = new LogFileComparator().reversed();
 
   private transient FileStatus fileStatus;
+  private transient Path path;
   private final String pathStr;
   private final String fileId;
   private final String baseCommitTime;
@@ -58,7 +59,6 @@ public class HoodieLogFile implements Serializable {
   private final String logWriteToken;
   private final String fileExtension;
   private final String suffix;
-  private final Path path;
   private long fileLen;
 
   public HoodieLogFile(HoodieLogFile logFile) {
@@ -131,6 +131,9 @@ public class HoodieLogFile implements Serializable {
   }
 
   public Path getPath() {
+    if (path == null) {
+      path = new CachingPath(pathStr);
+    }
     return path;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.exception.InvalidHoodiePathException;
+import org.apache.hudi.hadoop.CachingPath;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -28,6 +30,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.regex.Matcher;
+
+import static org.apache.hudi.common.fs.FSUtils.LOG_FILE_PATTERN;
 
 /**
  * Abstracts a single log file. Contains methods to extract metadata like the fileId, version and extension from the log
@@ -47,60 +52,82 @@ public class HoodieLogFile implements Serializable {
 
   private transient FileStatus fileStatus;
   private final String pathStr;
+  private final String fileId;
+  private final String baseCommitTime;
+  private final int logVersion;
+  private final String logWriteToken;
+  private final String fileExtension;
+  private final String suffix;
+  private final Path path;
   private long fileLen;
 
   public HoodieLogFile(HoodieLogFile logFile) {
-    this.fileStatus = logFile.fileStatus;
-    this.pathStr = logFile.pathStr;
-    this.fileLen = logFile.fileLen;
+    this(logFile.getFileStatus(), logFile.getPath(), logFile.pathStr, logFile.getFileSize());
   }
 
   public HoodieLogFile(FileStatus fileStatus) {
-    this.fileStatus = fileStatus;
-    this.pathStr = fileStatus.getPath().toString();
-    this.fileLen = fileStatus.getLen();
+    this(fileStatus, fileStatus.getPath(), fileStatus.getPath().toString(), fileStatus.getLen());
   }
 
   public HoodieLogFile(Path logPath) {
-    this.fileStatus = null;
-    this.pathStr = logPath.toString();
-    this.fileLen = -1;
+    this(null, logPath, logPath.toString(), -1);
   }
 
-  public HoodieLogFile(Path logPath, Long fileLen) {
-    this.fileStatus = null;
-    this.pathStr = logPath.toString();
-    this.fileLen = fileLen;
+  public HoodieLogFile(Path logPath, long fileLen) {
+    this(null, logPath, logPath.toString(), fileLen);
   }
 
   public HoodieLogFile(String logPathStr) {
-    this.fileStatus = null;
+    this(null, null, logPathStr, -1);
+  }
+
+  private HoodieLogFile(FileStatus fileStatus, Path logPath, String logPathStr, long fileLen) {
+    this.fileStatus = fileStatus;
     this.pathStr = logPathStr;
-    this.fileLen = -1;
+    this.fileLen = fileLen;
+    if (logPath != null) {
+      if (logPath instanceof CachingPath) {
+        this.path = logPath;
+      } else {
+        this.path = new CachingPath(logPath.getParent(), logPath.getName());
+      }
+    } else {
+      this.path = new CachingPath(pathStr);
+    }
+    Matcher matcher = LOG_FILE_PATTERN.matcher(path.getName());
+    if (!matcher.find()) {
+      throw new InvalidHoodiePathException(path, "LogFile");
+    }
+    this.fileId = matcher.group(1);
+    this.baseCommitTime = matcher.group(2);
+    this.fileExtension = matcher.group(3);
+    this.logVersion = Integer.parseInt(matcher.group(4));
+    this.logWriteToken = matcher.group(6);
+    this.suffix = matcher.group(10);
   }
 
   public String getFileId() {
-    return FSUtils.getFileIdFromLogPath(getPath());
+    return fileId;
   }
 
   public String getBaseCommitTime() {
-    return FSUtils.getBaseCommitTimeFromLogPath(getPath());
+    return baseCommitTime;
   }
 
   public int getLogVersion() {
-    return FSUtils.getFileVersionFromLog(getPath());
+    return logVersion;
   }
 
   public String getLogWriteToken() {
-    return FSUtils.getWriteTokenFromLogPath(getPath());
+    return logWriteToken;
   }
 
   public String getFileExtension() {
-    return FSUtils.getFileExtensionFromLog(getPath());
+    return fileExtension;
   }
 
   public String getSuffix() {
-    return FSUtils.getSuffixFromLogPath(getPath());
+    return suffix;
   }
 
   public Path getPath() {
@@ -131,9 +158,9 @@ public class HoodieLogFile implements Serializable {
     String fileId = getFileId();
     String baseCommitTime = getBaseCommitTime();
     Path path = getPath();
-    String extension = "." + FSUtils.getFileExtensionFromLog(path);
+    String extension = "." + fileExtension;
     int newVersion = FSUtils.computeNextLogVersion(fs, path.getParent(), fileId, extension, baseCommitTime);
-    return new HoodieLogFile(new Path(path.getParent(),
+    return new HoodieLogFile(new CachingPath(path.getParent(),
         FSUtils.makeLogFileName(fileId, extension, baseCommitTime, newVersion, logWriteToken)));
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordReader.java
@@ -39,13 +39,13 @@ import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.action.InternalSchemaMerger;
 import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -237,7 +237,7 @@ public abstract class AbstractHoodieLogRecordReader {
     try {
       // Iterate over the paths
       logFormatReaderWrapper = new HoodieLogFormatReader(fs,
-          logFilePaths.stream().map(logFile -> new HoodieLogFile(new Path(logFile))).collect(Collectors.toList()),
+          logFilePaths.stream().map(logFile -> new HoodieLogFile(new CachingPath(logFile))).collect(Collectors.toList()),
           readerSchema, readBlocksLazily, reverseReader, bufferSize, shouldLookupRecords(), recordKeyField, internalSchema);
 
       Set<HoodieLogFile> scannedLogFiles = new HashSet<>();
@@ -396,7 +396,7 @@ public abstract class AbstractHoodieLogRecordReader {
     try {
       // Iterate over the paths
       logFormatReaderWrapper = new HoodieLogFormatReader(fs,
-          logFilePaths.stream().map(logFile -> new HoodieLogFile(new Path(logFile))).collect(Collectors.toList()),
+          logFilePaths.stream().map(logFile -> new HoodieLogFile(new CachingPath(logFile))).collect(Collectors.toList()),
           readerSchema, readBlocksLazily, reverseReader, bufferSize, shouldLookupRecords(), recordKeyField, internalSchema);
 
       /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.fs.BufferedFSInputStream;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +115,8 @@ public class HoodieLogFileReader implements HoodieLogFormat.Reader {
     // NOTE: We repackage {@code HoodieLogFile} here to make sure that the provided path
     //       is prefixed with an appropriate scheme given that we're not propagating the FS
     //       further
-    this.logFile = new HoodieLogFile(FSUtils.makeQualified(fs, logFile.getPath()), logFile.getFileSize());
+    Path updatedPath = FSUtils.makeQualified(fs, logFile.getPath());
+    this.logFile = updatedPath.equals(logFile.getPath()) ? logFile : new HoodieLogFile(updatedPath, logFile.getFileSize());
     this.inputStream = getFSDataInputStream(fs, this.logFile, bufferSize);
     this.readerSchema = readerSchema;
     this.readBlockLazily = readBlockLazily;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTablePreCommitFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTablePreCommitFileSystemView.java
@@ -21,8 +21,7 @@ package org.apache.hudi.common.table.view;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-
-import org.apache.hadoop.fs.Path;
+import org.apache.hudi.hadoop.CachingPath;
 
 import java.util.Collections;
 import java.util.List;
@@ -72,7 +71,7 @@ public class HoodieTablePreCommitFileSystemView {
     Map<String, HoodieBaseFile> newFilesWrittenForPartition = filesWritten.stream()
         .filter(file -> partitionStr.equals(file.getPartitionPath()))
         .collect(Collectors.toMap(HoodieWriteStat::getFileId, writeStat -> 
-            new HoodieBaseFile(new Path(tableMetaClient.getBasePath(), writeStat.getPath()).toString())));
+            new HoodieBaseFile(new CachingPath(tableMetaClient.getBasePath(), writeStat.getPath()).toString())));
 
     Stream<HoodieBaseFile> committedBaseFiles = this.completedCommitsFileSystemView.getLatestBaseFiles(partitionStr);
     Map<String, HoodieBaseFile> allFileIds = committedBaseFiles

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieBaseFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieBaseFile.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+public class TestHoodieBaseFile {
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieBaseFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieBaseFile.java
@@ -18,5 +18,64 @@
 
 package org.apache.hudi.common.model;
 
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class TestHoodieBaseFile {
+  private final String fileName = "136281f3-c24e-423b-a65a-95dbfbddce1d_1-0-1_100.parquet";
+  private final String pathStr = "file:/tmp/hoodie/2021/01/01/" + fileName;
+  private final String fileId = "136281f3-c24e-423b-a65a-95dbfbddce1d";
+  private final String baseCommitTime = "100";
+  private final int length = 10;
+
+  @Test
+  void createFromHoodieBaseFile() {
+    FileStatus fileStatus = new FileStatus(length, false, 0, 0, 0, 0, null, null, null, new Path(pathStr));
+    HoodieBaseFile hoodieBaseFile = new HoodieBaseFile(fileStatus);
+    assertFileGetters(fileStatus, new HoodieBaseFile(hoodieBaseFile), length, Option.empty());
+  }
+
+  @Test
+  void createFromFileStatus() {
+    FileStatus fileStatus = new FileStatus(length, false, 0, 0, 0, 0, null, null, null, new Path(pathStr));
+    HoodieBaseFile hoodieBaseFile = new HoodieBaseFile(fileStatus);
+    assertFileGetters(fileStatus, hoodieBaseFile, length, Option.empty());
+  }
+
+  @Test
+  void createFromFileStatusAndBootstrapBaseFile() {
+    HoodieBaseFile bootstrapBaseFile = new HoodieBaseFile(pathStr);
+    FileStatus fileStatus = new FileStatus(length, false, 0, 0, 0, 0, null, null, null, new Path(pathStr));
+    HoodieBaseFile hoodieBaseFile = new HoodieBaseFile(fileStatus, bootstrapBaseFile);
+    assertFileGetters(fileStatus, hoodieBaseFile, length, Option.of(bootstrapBaseFile));
+  }
+
+  @Test
+  void createFromFilePath() {
+    HoodieBaseFile hoodieBaseFile = new HoodieBaseFile(pathStr);
+    assertFileGetters(null, hoodieBaseFile, -1, Option.empty());
+  }
+
+  @Test
+  void createFromFilePathAndBootstrapBaseFile() {
+    HoodieBaseFile bootstrapBaseFile = new HoodieBaseFile(pathStr);
+    HoodieBaseFile hoodieBaseFile = new HoodieBaseFile(pathStr, bootstrapBaseFile);
+    assertFileGetters(null, hoodieBaseFile, -1, Option.of(bootstrapBaseFile));
+  }
+
+  private void assertFileGetters(FileStatus fileStatus, HoodieBaseFile hoodieBaseFile, long fileLength, Option<HoodieBaseFile> bootstrapBaseFile) {
+    assertEquals(fileId, hoodieBaseFile.getFileId());
+    assertEquals(baseCommitTime, hoodieBaseFile.getCommitTime());
+    assertEquals(bootstrapBaseFile, hoodieBaseFile.getBootstrapBaseFile());
+    assertEquals(fileName, hoodieBaseFile.getFileName());
+    assertEquals(pathStr, hoodieBaseFile.getPath());
+    assertEquals(new Path(pathStr), hoodieBaseFile.getHadoopPath());
+    assertEquals(fileLength, hoodieBaseFile.getFileSize());
+    assertEquals(fileStatus, hoodieBaseFile.getFileStatus());
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
@@ -71,15 +71,14 @@ public class TestHoodieLogFile {
     String suffix = ".cdc";
     String pathWithSuffix = pathStr + suffix;
     HoodieLogFile hoodieLogFile = new HoodieLogFile(pathWithSuffix);
-    assertFileGetters(pathWithSuffix, null, hoodieLogFile, -1);
-    assertEquals(suffix, hoodieLogFile.getSuffix());
+    assertFileGetters(pathWithSuffix, null, hoodieLogFile, -1, suffix);
   }
 
   private void assertFileGetters(FileStatus fileStatus, HoodieLogFile hoodieLogFile, long fileLength) {
-    assertFileGetters(pathStr, fileStatus, hoodieLogFile, fileLength);
+    assertFileGetters(pathStr, fileStatus, hoodieLogFile, fileLength, "");
   }
 
-  private void assertFileGetters(String pathStr, FileStatus fileStatus, HoodieLogFile hoodieLogFile, long fileLength) {
+  private void assertFileGetters(String pathStr, FileStatus fileStatus, HoodieLogFile hoodieLogFile, long fileLength, String suffix) {
     assertEquals(fileId, hoodieLogFile.getFileId());
     assertEquals(baseCommitTime, hoodieLogFile.getBaseCommitTime());
     assertEquals(logVersion, hoodieLogFile.getLogVersion());
@@ -88,5 +87,6 @@ public class TestHoodieLogFile {
     assertEquals(new Path(pathStr), hoodieLogFile.getPath());
     assertEquals(fileLength, hoodieLogFile.getFileSize());
     assertEquals(fileStatus, hoodieLogFile.getFileStatus());
+    assertEquals(suffix, hoodieLogFile.getSuffix());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
@@ -66,7 +66,20 @@ public class TestHoodieLogFile {
     assertFileGetters(null, hoodieLogFile, -1);
   }
 
+  @Test
+  void createFromStringWithSuffix() {
+    String suffix = ".cdc";
+    String pathWithSuffix = pathStr + suffix;
+    HoodieLogFile hoodieLogFile = new HoodieLogFile(pathWithSuffix);
+    assertFileGetters(pathWithSuffix, null, hoodieLogFile, -1);
+    assertEquals(suffix, hoodieLogFile.getSuffix());
+  }
+
   private void assertFileGetters(FileStatus fileStatus, HoodieLogFile hoodieLogFile, long fileLength) {
+    assertFileGetters(pathStr, fileStatus, hoodieLogFile, fileLength);
+  }
+
+  private void assertFileGetters(String pathStr, FileStatus fileStatus, HoodieLogFile hoodieLogFile, long fileLength) {
     assertEquals(fileId, hoodieLogFile.getFileId());
     assertEquals(baseCommitTime, hoodieLogFile.getBaseCommitTime());
     assertEquals(logVersion, hoodieLogFile.getLogVersion());

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestHoodieLogFile {
+  private final String pathStr = "file:///tmp/hoodie/2021/01/01/.136281f3-c24e-423b-a65a-95dbfbddce1d_100.log.2_1-0-1";
+  private final String fileId = "136281f3-c24e-423b-a65a-95dbfbddce1d";
+  private final String baseCommitTime = "100";
+  private final int logVersion = 2;
+  private final String writeToken = "1-0-1";
+  private final String fileExtension = "log";
+
+  private final int length = 10;
+
+  @Test
+  void createFromLogFile() {
+    FileStatus fileStatus = new FileStatus(length, false, 0, 0, 0, 0, null, null, null, new Path(pathStr));
+    HoodieLogFile hoodieLogFile = new HoodieLogFile(fileStatus);
+    assertFileGetters(fileStatus, new HoodieLogFile(hoodieLogFile), length);
+  }
+
+  @Test
+  void createFromFileStatus() {
+    FileStatus fileStatus = new FileStatus(length, false, 0, 0, 0, 0, null, null, null, new Path(pathStr));
+    HoodieLogFile hoodieLogFile = new HoodieLogFile(fileStatus);
+    assertFileGetters(fileStatus, hoodieLogFile, length);
+  }
+
+  @Test
+  void createFromPath() {
+    HoodieLogFile hoodieLogFile = new HoodieLogFile(new Path(pathStr));
+    assertFileGetters(null, hoodieLogFile, -1);
+  }
+
+  @Test
+  void createFromPathAndLength() {
+    HoodieLogFile hoodieLogFile = new HoodieLogFile(new Path(pathStr), length);
+    assertFileGetters(null, hoodieLogFile, length);
+  }
+
+  @Test
+  void createFromString() {
+    HoodieLogFile hoodieLogFile = new HoodieLogFile(pathStr);
+    assertFileGetters(null, hoodieLogFile, -1);
+  }
+
+  private void assertFileGetters(FileStatus fileStatus, HoodieLogFile hoodieLogFile, long fileLength) {
+    assertEquals(fileId, hoodieLogFile.getFileId());
+    assertEquals(baseCommitTime, hoodieLogFile.getBaseCommitTime());
+    assertEquals(logVersion, hoodieLogFile.getLogVersion());
+    assertEquals(writeToken, hoodieLogFile.getLogWriteToken());
+    assertEquals(fileExtension, hoodieLogFile.getFileExtension());
+    assertEquals(new Path(pathStr), hoodieLogFile.getPath());
+    assertEquals(fileLength, hoodieLogFile.getFileSize());
+    assertEquals(fileStatus, hoodieLogFile.getFileStatus());
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -19,8 +19,8 @@
 package org.apache.hudi.sink.partitioner.profile;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -70,16 +70,14 @@ public class DeltaWriteProfile extends WriteProfile {
       for (FileSlice smallFileSlice : allSmallFileSlices) {
         SmallFile sf = new SmallFile();
         if (smallFileSlice.getBaseFile().isPresent()) {
-          // TODO : Move logic of file name, file id, base commit time handling inside file slice
-          String filename = smallFileSlice.getBaseFile().get().getFileName();
-          sf.location = new HoodieRecordLocation(FSUtils.getCommitTime(filename), FSUtils.getFileId(filename));
+          HoodieBaseFile baseFile = smallFileSlice.getBaseFile().get();
+          sf.location = new HoodieRecordLocation(baseFile.getCommitTime(), baseFile.getFileId());
           sf.sizeBytes = getTotalFileSize(smallFileSlice);
           smallFileLocations.add(sf);
         } else {
           smallFileSlice.getLogFiles().findFirst().ifPresent(logFile -> {
             // in case there is something error, and the file slice has no log file
-            sf.location = new HoodieRecordLocation(FSUtils.getBaseCommitTimeFromLogPath(logFile.getPath()),
-                FSUtils.getFileIdFromLogPath(logFile.getPath()));
+            sf.location = new HoodieRecordLocation(logFile.getBaseCommitTime(), logFile.getFileId());
             sf.sizeBytes = getTotalFileSize(smallFileSlice);
             smallFileLocations.add(sf);
           });

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
@@ -20,7 +20,6 @@ package org.apache.hudi.sink.partitioner.profile;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.config.HoodieStorageConfig;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecordLocation;
@@ -210,9 +209,8 @@ public class WriteProfile {
       for (HoodieBaseFile file : allFiles) {
         // filter out the corrupted files.
         if (file.getFileSize() < config.getParquetSmallFileLimit() && file.getFileSize() > 0) {
-          String filename = file.getFileName();
           SmallFile sf = new SmallFile();
-          sf.location = new HoodieRecordLocation(FSUtils.getCommitTime(filename), FSUtils.getFileId(filename));
+          sf.location = new HoodieRecordLocation(file.getCommitTime(), file.getFileId());
           sf.sizeBytes = file.getFileSize();
           smallFileLocations.add(sf);
         }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeSplit.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeSplit.java
@@ -18,11 +18,13 @@
 
 package org.apache.hudi.hadoop.realtime;
 
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.InputSplitWithLocationInfo;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.hadoop.InputSplitUtils;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.InputSplitWithLocationInfo;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -126,7 +128,7 @@ public interface RealtimeSplit extends InputSplitWithLocationInfo {
     for (int i = 0; i < totalLogFiles; i++) {
       String logFilePath = InputSplitUtils.readString(in);
       long logFileSize = in.readLong();
-      deltaLogPaths.add(new HoodieLogFile(new Path(logFilePath), logFileSize));
+      deltaLogPaths.add(new HoodieLogFile(new CachingPath(logFilePath), logFileSize));
     }
     setDeltaLogFiles(deltaLogPaths);
 

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeFileSplit.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeFileSplit.java
@@ -70,7 +70,8 @@ public class TestHoodieRealtimeFileSplit {
   @BeforeEach
   public void setUp(@TempDir java.nio.file.Path tempDir) throws Exception {
     basePath = tempDir.toAbsolutePath().toString();
-    deltaLogFiles = Collections.singletonList(new HoodieLogFile(new Path(basePath + "/1.log"), 0L));
+    Path logPath = new Path(basePath + "/1.log");
+    deltaLogFiles = Collections.singletonList(new HoodieLogFile(logPath, 0L));
     deltaLogPaths = Collections.singletonList(basePath + "/1.log");
     fileSplitName = basePath + "/test.file";
     baseFileSplit = new FileSplit(new Path(fileSplitName), 0, 100, new String[] {});

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -875,7 +875,7 @@ public class HoodieMetadataTableValidator implements Serializable {
         }
         Schema readerSchema = converter.convert(messageType);
         reader =
-            HoodieLogFormat.newReader(fs, new HoodieLogFile(new Path(logFilePathStr)), readerSchema);
+            HoodieLogFormat.newReader(fs, new HoodieLogFile(logFilePathStr), readerSchema);
         // read the avro blocks
         if (reader.hasNext()) {
           HoodieLogBlock block = reader.next();


### PR DESCRIPTION
### Change Logs

- Updates sections of the code to use the getters in the HoodieBaseFile and HoodieLogFile instead of FSUtils to move away from relying directly on the path for getting metadata about the file when possible
- Sets file ID and commit time in HoodieBaseFile on construction and avoids running `split` on the file name twice to improve efficiency
- Sets fileId, baseCommitTime, logVersion, logWriteToken, fileExtension, suffix, and path when creating HoodieLogFile instead of making multiple calls to a regex based matcher to improve efficiency
- Uses CachingPath instead of Path in HoodieLogFile for improved efficiency

### Impact

Lowers overhead when extracting metadata about HoodieBaseFiles or HoodieLogFiles

### Risk level (write none, low medium or high below)

low, unit tests were added to assert behavior is maintained 

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
