### PR TITLE
Revert "[HUDI-6476] Improve the performance of getAllPartitionPaths (#9121)"

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -26,8 +26,8 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Implementation of {@link HoodieTableMetadata} based file-system-backed table metadata.
@@ -168,57 +167,66 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
       // TODO: Get the parallelism from HoodieWriteConfig
       int listingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, pathsToList.size());
 
-      // List all directories in parallel:
-      // if current dictionary contains PartitionMetadata, add it to result
-      // if current dictionary does not contain PartitionMetadata, add its subdirectory to queue to be processed.
+      // List all directories in parallel
       engineContext.setJobStatus(this.getClass().getSimpleName(), "Listing all partitions with prefix " + relativePathPrefix);
-      // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
-      // and second entry holds optionally a directory path to be processed further.
-      List<Pair<Option<String>, Option<Path>>> result = engineContext.flatMap(pathsToList, path -> {
+      List<FileStatus> dirToFileListing = engineContext.flatMap(pathsToList, path -> {
         FileSystem fileSystem = path.getFileSystem(hadoopConf.get());
-        if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, path)) {
-          return Stream.of(Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), path)), Option.empty()));
-        }
-        return Arrays.stream(fileSystem.listStatus(path, p -> {
-          try {
-            return fileSystem.isDirectory(p) && !p.getName().equals(HoodieTableMetaClient.METAFOLDER_NAME);
-          } catch (IOException e) {
-            // noop
-          }
-          return false;
-        })).map(status -> Pair.of(Option.empty(), Option.of(status.getPath())));
+        return Arrays.stream(fileSystem.listStatus(path));
       }, listingParallelism);
       pathsToList.clear();
 
-      partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
-          .map(entry -> entry.getKey().get())
-          .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
-              || (Boolean) fullBoundExpr.eval(
-                      extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
-          .collect(Collectors.toList()));
+      // if current dictionary contains PartitionMetadata, add it to result
+      // if current dictionary does not contain PartitionMetadata, add it to queue to be processed.
+      int fileListingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, dirToFileListing.size());
+      if (!dirToFileListing.isEmpty()) {
+        // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
+        // and second entry holds optionally a directory path to be processed further.
+        engineContext.setJobStatus(this.getClass().getSimpleName(), "Processing listed partitions");
+        List<Pair<Option<String>, Option<Path>>> result = engineContext.map(dirToFileListing, fileStatus -> {
+          FileSystem fileSystem = fileStatus.getPath().getFileSystem(hadoopConf.get());
+          if (fileStatus.isDirectory()) {
+            if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, fileStatus.getPath())) {
+              return Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), fileStatus.getPath())), Option.empty());
+            } else if (!fileStatus.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
+              return Pair.of(Option.empty(), Option.of(fileStatus.getPath()));
+            }
+          } else if (fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)) {
+            String partitionName = FSUtils.getRelativePartitionPath(dataBasePath.get(), fileStatus.getPath().getParent());
+            return Pair.of(Option.of(partitionName), Option.empty());
+          }
+          return Pair.of(Option.empty(), Option.empty());
+        }, fileListingParallelism);
 
-      Expression partialBoundExpr;
-      // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
-      // are filtered already.
-      if (needPushDownExpressions && partitionPaths.isEmpty()) {
-        // Here we assume the path level matches the number of partition columns, so we'll rebuild
-        // new schema based on current path level.
-        // e.g. partition columns are <region, date, hh>, if we're listing the second level, then
-        // currentSchema would be <region, date>
-        // `PartialBindVisitor` will bind reference if it can be found from `currentSchema`, otherwise
-        // will change the expression to `alwaysTrue`. Can see `PartialBindVisitor` for details.
-        Types.RecordType currentSchema = Types.RecordType.get(partitionFields.fields().subList(0, ++currentPartitionLevel));
-        PartialBindVisitor partialBindVisitor = new PartialBindVisitor(currentSchema, caseSensitive);
-        partialBoundExpr = pushedExpr.accept(partialBindVisitor);
-      } else {
-        partialBoundExpr = Predicates.alwaysTrue();
+        partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
+            .map(entry -> entry.getKey().get())
+            .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
+                || (Boolean) fullBoundExpr.eval(
+                extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
+            .collect(Collectors.toList()));
+
+        Expression partialBoundExpr;
+        // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
+        // are filtered already.
+        if (needPushDownExpressions && partitionPaths.isEmpty()) {
+          // Here we assume the path level matches the number of partition columns, so we'll rebuild
+          // new schema based on current path level.
+          // e.g. partition columns are <region, date, hh>, if we're listing the second level, then
+          // currentSchema would be <region, date>
+          // `PartialBindVisitor` will bind reference if it can be found from `currentSchema`, otherwise
+          // will change the expression to `alwaysTrue`. Can see `PartialBindVisitor` for details.
+          Types.RecordType currentSchema = Types.RecordType.get(partitionFields.fields().subList(0, ++currentPartitionLevel));
+          PartialBindVisitor partialBindVisitor = new PartialBindVisitor(currentSchema, caseSensitive);
+          partialBoundExpr = pushedExpr.accept(partialBindVisitor);
+        } else {
+          partialBoundExpr = Predicates.alwaysTrue();
+        }
+
+        pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
+            .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+                || (Boolean) partialBoundExpr.eval(
+                extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+            .collect(Collectors.toList()));
       }
-
-      pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-              .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-                  || (Boolean) partialBoundExpr.eval(
-                      extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-          .collect(Collectors.toList()));
     }
     return partitionPaths;
   }


### PR DESCRIPTION
### Change Logs

This reverts commit 72f047715fe8f2ad9ff19a31728fbfb761fbe0d9. We observed performance regression especially when the query has no partition predicates. ~Even though there is one stage reduced but there are too many tasks doing `fs.exists` calls.~
The number of tasks look the same in attached screenshots in https://github.com/apache/hudi/pull/9343#discussion_r1283447863 but  there is a difference in what stages are executed.

### Impact

Fix performance regression.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
