### PR TITLE
[HUDI-6649] Fix column stat based data filtering for MOR

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -254,7 +254,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
    */
   lazy val fileIndex: HoodieFileIndex =
     HoodieFileIndex(sparkSession, metaClient, Some(tableStructSchema), optParams,
-      FileStatusCache.getOrCreate(sparkSession))
+      FileStatusCache.getOrCreate(sparkSession), shouldIncludeLogFiles())
 
   lazy val tableState: HoodieTableState = {
     val recordMergerImpls = ConfigUtils.split2List(getConfigValue(HoodieWriteConfig.RECORD_MERGER_IMPLS)).asScala.toList
@@ -643,6 +643,14 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
                              defaultValueOption: Option[String]=Option.empty): String = {
     optParams.getOrElse(config.key(),
       sqlContext.getConf(config.key(), defaultValueOption.getOrElse(config.defaultValue())))
+  }
+
+  /**
+   * Determines if fileIndex should consider log files when filtering file slices. Defaults to false.
+   * The subclass can have their own implementation based on the table or relation type.
+   */
+  protected def shouldIncludeLogFiles(): Boolean = {
+    false
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -343,7 +343,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
    */
   override final def needConversion: Boolean = false
 
-  override def inputFiles: Array[String] = fileIndex.allFiles.map(_.getPath.toUri.toString).toArray
+  override def inputFiles: Array[String] = fileIndex.allBaseFiles.map(_.getPath.toUri.toString).toArray
 
   /**
    * NOTE: DO NOT OVERRIDE THIS METHOD

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -49,6 +49,8 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
   extends BaseMergeOnReadSnapshotRelation(sqlContext, optParams, metaClient, Seq(), userSchema, prunedDataSchema)
     with HoodieIncrementalRelationTrait {
 
+  fileIndex.setIncludeLogFiles(true)
+
   override type Relation = MergeOnReadIncrementalRelation
 
   override def updatePrunedDataSchema(prunedSchema: StructType): Relation =
@@ -108,7 +110,9 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
         }.toSeq
       }
 
-      buildSplits(filterFileSlices(fileSlices, globPattern))
+      var filteredFileSlices = filterFileSlices(fileSlices, globPattern)
+      filteredFileSlices = fileIndex.filterFileSlices(dataFilters, Seq((Option.empty, filteredFileSlices))).flatMap(s => s._2)
+      buildSplits(filteredFileSlices)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelation.scala
@@ -49,8 +49,6 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
   extends BaseMergeOnReadSnapshotRelation(sqlContext, optParams, metaClient, Seq(), userSchema, prunedDataSchema)
     with HoodieIncrementalRelationTrait {
 
-  fileIndex.setIncludeLogFiles(true)
-
   override type Relation = MergeOnReadIncrementalRelation
 
   override def updatePrunedDataSchema(prunedSchema: StructType): Relation =
@@ -110,9 +108,7 @@ case class MergeOnReadIncrementalRelation(override val sqlContext: SQLContext,
         }.toSeq
       }
 
-      var filteredFileSlices = filterFileSlices(fileSlices, globPattern)
-      filteredFileSlices = fileIndex.filterFileSlices(dataFilters, Seq((Option.empty, filteredFileSlices))).flatMap(s => s._2)
-      buildSplits(filteredFileSlices)
+      buildSplits(filterFileSlices(fileSlices, globPattern))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -49,10 +49,12 @@ case class MergeOnReadSnapshotRelation(override val sqlContext: SQLContext,
 
   override type Relation = MergeOnReadSnapshotRelation
 
-  fileIndex.setIncludeLogFiles(true)
-
   override def updatePrunedDataSchema(prunedSchema: StructType): MergeOnReadSnapshotRelation =
     this.copy(prunedDataSchema = Some(prunedSchema))
+
+  override protected def shouldIncludeLogFiles(): Boolean = {
+    true
+  }
 
 }
 
@@ -70,8 +72,6 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
                                                userSchema: Option[StructType],
                                                prunedDataSchema: Option[StructType])
   extends HoodieBaseRelation(sqlContext, metaClient, optParams, userSchema, prunedDataSchema) {
-
-  fileIndex.setIncludeLogFiles(true)
 
   override type FileSplit = HoodieMergeOnReadFileSplit
 
@@ -219,7 +219,7 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
       HoodieFileIndex.convertFilterForTimestampKeyGenerator(metaClient, partitionFilters)
 
     if (globPaths.isEmpty) {
-      val fileSlices = fileIndex.filterFileSlices(dataFilters, fileIndex.getFileSlicesForPrunedPartitions(convertedPartitionFilters)).flatMap(s => s._2)
+      val fileSlices = fileIndex.filterFileSlices(dataFilters, convertedPartitionFilters).flatMap(s => s._2)
       buildSplits(fileSlices)
     } else {
       val fileSlices = listLatestFileSlices(globPaths, partitionFilters, dataFilters)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -69,6 +69,8 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
                                                prunedDataSchema: Option[StructType])
   extends HoodieBaseRelation(sqlContext, metaClient, optParams, userSchema, prunedDataSchema) {
 
+  fileIndex.setIncludeLogFiles(true)
+
   override type FileSplit = HoodieMergeOnReadFileSplit
 
   /**
@@ -215,8 +217,8 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
       HoodieFileIndex.convertFilterForTimestampKeyGenerator(metaClient, partitionFilters)
 
     if (globPaths.isEmpty) {
-      val fileSlices = fileIndex.listFileSlices(convertedPartitionFilters)
-      buildSplits(fileSlices.values.flatten.toSeq)
+      val fileSlices = fileIndex.filterFileSlices(dataFilters, fileIndex.getFileSlicesForPrunedPartitions(convertedPartitionFilters)).flatMap(s => s._2)
+      buildSplits(fileSlices)
     } else {
       val fileSlices = listLatestFileSlices(globPaths, partitionFilters, dataFilters)
       buildSplits(fileSlices)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -49,6 +49,8 @@ case class MergeOnReadSnapshotRelation(override val sqlContext: SQLContext,
 
   override type Relation = MergeOnReadSnapshotRelation
 
+  fileIndex.setIncludeLogFiles(true)
+
   override def updatePrunedDataSchema(prunedSchema: StructType): MergeOnReadSnapshotRelation =
     this.copy(prunedDataSchema = Some(prunedSchema))
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -479,7 +479,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     val expectedListedFiles = if (enablePartitionPathPrefixAnalysis) {
       getFileCountInPartitionPaths("2021/03/01/0", "2021/03/01/1", "2021/03/01/2")
     } else {
-      fileIndex.allFiles.length
+      fileIndex.allBaseFiles.length
     }
 
     assertEquals(expectedListedFiles, perPartitionFilesSeq.map(_.size).sum)
@@ -592,7 +592,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
       val expectedPartitionPaths = if (testCase._3) {
         testCase._4.map(e => e._1 + "/" + e._2)
       } else {
-        fileIndex.allFiles
+        fileIndex.allBaseFiles
           .map(file => extractPartitionPathFromFilePath(file.getPath))
           .distinct
           .sorted

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.functional
 
 import org.apache.hadoop.fs.{LocatedFileStatus, Path}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/ColumnStatIndexTestBase.scala
@@ -1,0 +1,265 @@
+package org.apache.hudi.functional
+
+import org.apache.hadoop.fs.{LocatedFileStatus, Path}
+import org.apache.hudi.ColumnStatsIndexSupport.composeIndexSchema
+import org.apache.hudi.HoodieConversionUtils.toProperties
+import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
+import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestCase
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions}
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.typedLit
+import org.apache.spark.sql.types._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api._
+import org.junit.jupiter.params.provider.Arguments
+
+import java.math.BigInteger
+import java.sql.{Date, Timestamp}
+import scala.collection.JavaConverters._
+import scala.util.Random
+
+@Tag("functional")
+class ColumnStatIndexTestBase extends HoodieSparkClientTestBase {
+  var spark: SparkSession = _
+  var dfList: Seq[DataFrame] = Seq()
+
+  val sourceTableSchema =
+    new StructType()
+      .add("c1", IntegerType)
+      .add("c2", StringType)
+      .add("c3", DecimalType(9, 3))
+      .add("c4", TimestampType)
+      .add("c5", ShortType)
+      .add("c6", DateType)
+      .add("c7", BinaryType)
+      .add("c8", ByteType)
+
+  @BeforeEach
+  override def setUp() {
+    initPath()
+    initSparkContexts()
+    initFileSystem()
+
+    setTableName("hoodie_test")
+    initMetaClient()
+
+    spark = sqlContext.sparkSession
+  }
+
+  @AfterEach
+  override def tearDown() = {
+    cleanupFileSystem()
+    cleanupSparkContexts()
+  }
+
+  protected def doWriteAndValidateColumnStats(testCase: ColumnStatsTestCase,
+                                            metadataOpts: Map[String, String],
+                                            hudiOpts: Map[String, String],
+                                            dataSourcePath: String,
+                                            expectedColStatsSourcePath: String,
+                                            operation: String,
+                                            saveMode: SaveMode,
+                                            shouldValidate: Boolean = true): Unit = {
+    val sourceJSONTablePath = getClass.getClassLoader.getResource(dataSourcePath).toString
+
+    // NOTE: Schema here is provided for validation that the input date is in the appropriate format
+    val inputDF = spark.read.schema(sourceTableSchema).json(sourceJSONTablePath)
+
+    inputDF
+      .sort("c1")
+      .repartition(4, new Column("c1"))
+      .write
+      .format("hudi")
+      .options(hudiOpts)
+      .option(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE.key, 10 * 1024)
+      .option(DataSourceWriteOptions.OPERATION.key, operation)
+      .mode(saveMode)
+      .save(basePath)
+    dfList = dfList :+ inputDF
+
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+
+    if (shouldValidate) {
+      // Currently, routine manually validating the column stats (by actually reading every column of every file)
+      // only supports parquet files. Therefore we skip such validation when delta-log files are present, and only
+      // validate in following cases: (1) COW: all operations; (2) MOR: insert only.
+      val shouldValidateColumnStatsManually = testCase.tableType == HoodieTableType.COPY_ON_WRITE ||
+        operation.equals(DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+
+      validateColumnStatsIndex(
+        testCase, metadataOpts, expectedColStatsSourcePath, shouldValidateColumnStatsManually)
+    }
+  }
+
+  protected def buildColumnStatsTableManually(tablePath: String,
+                                            includedCols: Seq[String],
+                                            indexedCols: Seq[String],
+                                            indexSchema: StructType): DataFrame = {
+    val files = {
+      val it = fs.listFiles(new Path(tablePath), true)
+      var seq = Seq[LocatedFileStatus]()
+      while (it.hasNext) {
+        seq = seq :+ it.next()
+      }
+      seq.filter(fs => fs.getPath.getName.endsWith(".parquet"))
+    }
+
+    spark.createDataFrame(
+      files.flatMap(file => {
+        val df = spark.read.schema(sourceTableSchema).parquet(file.getPath.toString)
+        val exprs: Seq[String] =
+          s"'${typedLit(file.getPath.getName)}' AS file" +:
+            s"sum(1) AS valueCount" +:
+            df.columns
+              .filter(col => includedCols.contains(col))
+              .filter(col => indexedCols.contains(col))
+              .flatMap(col => {
+                val minColName = s"${col}_minValue"
+                val maxColName = s"${col}_maxValue"
+                if (indexedCols.contains(col)) {
+                  Seq(
+                    s"min($col) AS $minColName",
+                    s"max($col) AS $maxColName",
+                    s"sum(cast(isnull($col) AS long)) AS ${col}_nullCount"
+                  )
+                } else {
+                  Seq(
+                    s"null AS $minColName",
+                    s"null AS $maxColName",
+                    s"null AS ${col}_nullCount"
+                  )
+                }
+              })
+
+        df.selectExpr(exprs: _*)
+          .collect()
+      }).asJava,
+      indexSchema
+    )
+  }
+
+  protected def validateColumnStatsIndex(testCase: ColumnStatsTestCase,
+                                       metadataOpts: Map[String, String],
+                                       expectedColStatsSourcePath: String,
+                                       validateColumnStatsManually: Boolean): Unit = {
+    val metadataConfig = HoodieMetadataConfig.newBuilder()
+      .fromProperties(toProperties(metadataOpts))
+      .build()
+
+    val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
+
+    val indexedColumns: Set[String] = {
+      val customIndexedColumns = metadataConfig.getColumnsEnabledForColumnStatsIndex
+      if (customIndexedColumns.isEmpty) {
+        sourceTableSchema.fieldNames.toSet
+      } else {
+        customIndexedColumns.asScala.toSet
+      }
+    }
+    val (expectedColStatsSchema, _) = composeIndexSchema(sourceTableSchema.fieldNames, indexedColumns, sourceTableSchema)
+    val validationSortColumns = Seq("c1_maxValue", "c1_minValue", "c2_maxValue", "c2_minValue")
+
+    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames, testCase.shouldReadInMemory) { transposedColStatsDF =>
+      // Match against expected column stats table
+      val expectedColStatsIndexTableDf =
+        spark.read
+          .schema(expectedColStatsSchema)
+          .json(getClass.getClassLoader.getResource(expectedColStatsSourcePath).toString)
+
+      assertEquals(expectedColStatsIndexTableDf.schema, transposedColStatsDF.schema)
+      // NOTE: We have to drop the `fileName` column as it contains semi-random components
+      //       that we can't control in this test. Nevertheless, since we manually verify composition of the
+      //       ColStats Index by reading Parquet footers from individual Parquet files, this is not an issue
+      assertEquals(asJson(sort(expectedColStatsIndexTableDf, validationSortColumns)),
+        asJson(sort(transposedColStatsDF.drop("fileName"), validationSortColumns)))
+
+      if (validateColumnStatsManually) {
+        // TODO(HUDI-4557): support validation of column stats of avro log files
+        // Collect Column Stats manually (reading individual Parquet files)
+        val manualColStatsTableDF =
+        buildColumnStatsTableManually(basePath, sourceTableSchema.fieldNames, sourceTableSchema.fieldNames, expectedColStatsSchema)
+
+        assertEquals(asJson(sort(manualColStatsTableDF, validationSortColumns)),
+          asJson(sort(transposedColStatsDF, validationSortColumns)))
+      }
+    }
+  }
+
+  protected def generateRandomDataFrame(spark: SparkSession): DataFrame = {
+    val sourceTableSchema =
+      new StructType()
+        .add("c1", IntegerType)
+        .add("c2", StringType)
+        // NOTE: We're testing different values for precision of the decimal to make sure
+        //       we execute paths bearing different underlying representations in Parquet
+        // REF: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#DECIMAL
+        .add("c3a", DecimalType(9, 3))
+        .add("c3b", DecimalType(10, 3))
+        .add("c3c", DecimalType(20, 3))
+        .add("c4", TimestampType)
+        .add("c5", ShortType)
+        .add("c6", DateType)
+        .add("c7", BinaryType)
+        .add("c8", ByteType)
+
+    val rdd = spark.sparkContext.parallelize(0 to 1000, 1).map { item =>
+      val c1 = Integer.valueOf(item)
+      val c2 = Random.nextString(10)
+      val c3a = java.math.BigDecimal.valueOf(Random.nextInt() % (1 << 24), 3)
+      val c3b = java.math.BigDecimal.valueOf(Random.nextLong() % (1L << 32), 3)
+      // NOTE: We cap it at 2^64 to make sure we're not exceeding target decimal's range
+      val c3c = new java.math.BigDecimal(new BigInteger(64, new java.util.Random()), 3)
+      val c4 = new Timestamp(System.currentTimeMillis())
+      val c5 = java.lang.Short.valueOf(s"${(item + 16) / 10}")
+      val c6 = Date.valueOf(s"${2020}-${item % 11 + 1}-${item % 28 + 1}")
+      val c7 = Array(item).map(_.toByte)
+      val c8 = java.lang.Byte.valueOf("9")
+
+      RowFactory.create(c1, c2, c3a, c3b, c3c, c4, c5, c6, c7, c8)
+    }
+
+    spark.createDataFrame(rdd, sourceTableSchema)
+  }
+
+  protected def asJson(df: DataFrame) =
+    df.toJSON
+      .select("value")
+      .collect()
+      .toSeq
+      .map(_.getString(0))
+      .mkString("\n")
+
+  protected def sort(df: DataFrame): DataFrame = {
+    sort(df, Seq("c1_maxValue", "c1_minValue"))
+  }
+
+  private def sort(df: DataFrame, sortColumns: Seq[String]): DataFrame = {
+    val sortedCols = df.columns.sorted
+    // Sort dataset by specified columns (to minimize non-determinism in case multiple files have the same
+    // value of the first column)
+    df.select(sortedCols.head, sortedCols.tail: _*)
+      .sort(sortColumns.head, sortColumns.tail: _*)
+  }
+}
+
+object ColumnStatIndexTestBase {
+
+  case class ColumnStatsTestCase(tableType: HoodieTableType, shouldReadInMemory: Boolean)
+
+  def testMetadataColumnStatsIndexParams: java.util.stream.Stream[Arguments] = {
+    java.util.stream.Stream.of(HoodieTableType.values().toStream.flatMap(tableType =>
+      Seq(Arguments.arguments(ColumnStatsTestCase(tableType, shouldReadInMemory = true)),
+        Arguments.arguments(ColumnStatsTestCase(tableType, shouldReadInMemory = false)))
+    ): _*)
+  }
+
+  def testMetadataColumnStatsIndexParamsForMOR: java.util.stream.Stream[Arguments] = {
+    java.util.stream.Stream.of(
+      Seq(Arguments.arguments(ColumnStatsTestCase(HoodieTableType.MERGE_ON_READ, shouldReadInMemory = true)),
+        Arguments.arguments(ColumnStatsTestCase(HoodieTableType.MERGE_ON_READ, shouldReadInMemory = false)))
+    : _*)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -19,7 +19,7 @@
 package org.apache.hudi.functional
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{LocatedFileStatus, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.hudi.ColumnStatsIndexSupport.composeIndexSchema
 import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD}
 import org.apache.hudi.HoodieConversionUtils.toProperties
@@ -28,57 +28,22 @@ import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.util.ParquetUtils
 import org.apache.hudi.config.HoodieWriteConfig
-import org.apache.hudi.functional.TestColumnStatsIndex.ColumnStatsTestCase
-import org.apache.hudi.testutils.HoodieSparkClientTestBase
-import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceReadOptions, DataSourceWriteOptions}
+import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestCase
+import org.apache.hudi.{ColumnStatsIndexSupport, DataSourceWriteOptions}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, Literal, Or}
-import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api._
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource, ValueSource}
+import org.junit.jupiter.params.provider.{EnumSource, MethodSource, ValueSource}
 
-import java.math.BigInteger
-import java.sql.{Date, Timestamp}
 import scala.collection.JavaConverters._
-import scala.util.Random
 
 @Tag("functional")
-class TestColumnStatsIndex extends HoodieSparkClientTestBase {
-  var spark: SparkSession = _
-
-  val sourceTableSchema =
-    new StructType()
-      .add("c1", IntegerType)
-      .add("c2", StringType)
-      .add("c3", DecimalType(9, 3))
-      .add("c4", TimestampType)
-      .add("c5", ShortType)
-      .add("c6", DateType)
-      .add("c7", BinaryType)
-      .add("c8", ByteType)
-
-  @BeforeEach
-  override def setUp() {
-    initPath()
-    initSparkContexts()
-    initFileSystem()
-
-    setTableName("hoodie_test")
-    initMetaClient()
-
-    spark = sqlContext.sparkSession
-  }
-
-  @AfterEach
-  override def tearDown() = {
-    cleanupFileSystem()
-    cleanupSparkContexts()
-  }
+class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
   @ParameterizedTest
   @MethodSource(Array("testMetadataColumnStatsIndexParams"))
@@ -125,89 +90,6 @@ class TestColumnStatsIndex extends HoodieSparkClientTestBase {
       saveMode = SaveMode.Append)
   }
 
-  @ParameterizedTest
-  @MethodSource(Array("testMetadataColumnStatsIndexParams"))
-  def testMetadataColumnStatsIndexWithSQL(testCase: ColumnStatsTestCase): Unit = {
-    val metadataOpts = Map(
-      HoodieMetadataConfig.ENABLE.key -> "true",
-      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
-    )
-
-    var commonOpts = Map(
-      "hoodie.insert.shuffle.parallelism" -> "4",
-      "hoodie.upsert.shuffle.parallelism" -> "4",
-      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
-      DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
-      RECORDKEY_FIELD.key -> "c1",
-      PRECOMBINE_FIELD.key -> "c1",
-      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
-      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
-      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
-    ) ++ metadataOpts
-
-    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
-      dataSourcePath = "index/colstats/input-table-json",
-      expectedColStatsSourcePath = "index/colstats/column-stats-index-table.json",
-      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
-      saveMode = SaveMode.Overwrite)
-
-    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
-      dataSourcePath = "index/colstats/another-input-table-json",
-      expectedColStatsSourcePath = "index/colstats/updated-column-stats-index-table.json",
-      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
-      saveMode = SaveMode.Append)
-
-    // NOTE: MOR and COW have different fixtures since MOR is bearing delta-log files (holding
-    //       deferred updates), diverging from COW
-    val expectedColStatsSourcePath = if (testCase.tableType == HoodieTableType.COPY_ON_WRITE) {
-      "index/colstats/cow-updated2-column-stats-index-table.json"
-    } else {
-      "index/colstats/mor-updated2-column-stats-index-table.json"
-    }
-
-    createSQLTable(commonOpts, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
-    val c5GT50WithDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
-
-    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
-      dataSourcePath = "index/colstats/update-input-table-json",
-      expectedColStatsSourcePath = expectedColStatsSourcePath,
-      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
-      saveMode = SaveMode.Append)
-
-    // verify snapshot query
-    verifySQLQueries(c5GT50WithDataSkipping, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL, commonOpts)
-
-    // verify read_optimized query
-    verifySQLQueries(c5GT50WithDataSkipping, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, commonOpts)
-
-    // verify incremental query
-    verifySQLQueries(c5GT50WithDataSkipping, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts)
-    commonOpts = commonOpts + (DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN_FOR_NON_EXISTING_FILES.key -> "true")
-    verifySQLQueries(c5GT50WithDataSkipping, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts)
-  }
-
-  private def verifySQLQueries(c5GT50WithDataSkippingAtPrevInstant: Long, queryType: String, opts: Map[String, String]): Unit = {
-    // 2 records are updated with c5 greater than 70 and one record is inserted with c5 value greater than 70
-    var commonOpts:Map[String, String] = opts
-    createSQLTable(commonOpts, queryType)
-    val increment = if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL) && metaClient.getTableType == HoodieTableType.MERGE_ON_READ) {
-      1 // only one insert
-    } else {
-      3 // one insert and two upserts
-    }
-    assertEquals(spark.sql("select * from tbl where c5 > 70").count(), c5GT50WithDataSkippingAtPrevInstant + increment)
-    val c5GT50WithDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
-
-    if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)) {
-      createIncrementalSQLTable(commonOpts, metaClient.reloadActiveTimeline().getInstants.get(1).getTimestamp)
-      assertEquals(spark.sql("select * from tbl where c5 > 70").count(), 3)
-    }
-
-    commonOpts = opts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false")
-    createSQLTable(commonOpts, queryType)
-    val c5Gt50WithoutDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
-    assertEquals(c5GT50WithDataSkipping, c5Gt50WithoutDataSkipping)
-  }
 
   @ParameterizedTest
   @EnumSource(classOf[HoodieTableType])
@@ -537,220 +419,5 @@ class TestColumnStatsIndex extends HoodieSparkClientTestBase {
       assertNotNull(max)
       assertTrue(r.getMinValue.asInstanceOf[Comparable[Object]].compareTo(r.getMaxValue.asInstanceOf[Object]) <= 0)
     })
-  }
-
-  private def createSQLTable(hudiOpts: Map[String, String], queryType: String): Unit = {
-    val opts = hudiOpts + (
-      DataSourceReadOptions.QUERY_TYPE.key -> queryType,
-      DataSourceReadOptions.BEGIN_INSTANTTIME.key() -> metaClient.getActiveTimeline.getInstants.get(0).getTimestamp.replaceFirst(".", "0")
-    )
-    val inputDF1 = spark.read.format("hudi").options(opts).load(basePath)
-    inputDF1.createOrReplaceTempView("tbl")
-  }
-
-  private def createIncrementalSQLTable(hudiOpts: Map[String, String], instantTime: String): Unit = {
-    val opts = hudiOpts + (
-      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
-      DataSourceReadOptions.BEGIN_INSTANTTIME.key() -> instantTime
-    )
-    val inputDF1 = spark.read.format("hudi").options(opts).load(basePath)
-    inputDF1.createOrReplaceTempView("tbl")
-  }
-
-  private def doWriteAndValidateColumnStats(testCase: ColumnStatsTestCase,
-                                            metadataOpts: Map[String, String],
-                                            hudiOpts: Map[String, String],
-                                            dataSourcePath: String,
-                                            expectedColStatsSourcePath: String,
-                                            operation: String,
-                                            saveMode: SaveMode): Unit = {
-    val sourceJSONTablePath = getClass.getClassLoader.getResource(dataSourcePath).toString
-
-    // NOTE: Schema here is provided for validation that the input date is in the appropriate format
-    val inputDF = spark.read.schema(sourceTableSchema).json(sourceJSONTablePath)
-
-    inputDF
-      .sort("c1")
-      .repartition(4, new Column("c1"))
-      .write
-      .format("hudi")
-      .options(hudiOpts)
-      .option(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE.key, 10 * 1024)
-      .option(DataSourceWriteOptions.OPERATION.key, operation)
-      .mode(saveMode)
-      .save(basePath)
-
-    metaClient = HoodieTableMetaClient.reload(metaClient)
-
-    // Currently, routine manually validating the column stats (by actually reading every column of every file)
-    // only supports parquet files. Therefore we skip such validation when delta-log files are present, and only
-    // validate in following cases: (1) COW: all operations; (2) MOR: insert only.
-    val shouldValidateColumnStatsManually = testCase.tableType == HoodieTableType.COPY_ON_WRITE ||
-      operation.equals(DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
-
-    validateColumnStatsIndex(
-      testCase, metadataOpts, expectedColStatsSourcePath, shouldValidateColumnStatsManually)
-  }
-
-  private def buildColumnStatsTableManually(tablePath: String,
-                                            includedCols: Seq[String],
-                                            indexedCols: Seq[String],
-                                            indexSchema: StructType): DataFrame = {
-    val files = {
-      val it = fs.listFiles(new Path(tablePath), true)
-      var seq = Seq[LocatedFileStatus]()
-      while (it.hasNext) {
-        seq = seq :+ it.next()
-      }
-      seq.filter(fs => fs.getPath.getName.endsWith(".parquet"))
-    }
-
-    spark.createDataFrame(
-      files.flatMap(file => {
-        val df = spark.read.schema(sourceTableSchema).parquet(file.getPath.toString)
-        val exprs: Seq[String] =
-          s"'${typedLit(file.getPath.getName)}' AS file" +:
-          s"sum(1) AS valueCount" +:
-            df.columns
-              .filter(col => includedCols.contains(col))
-              .filter(col => indexedCols.contains(col))
-              .flatMap(col => {
-                val minColName = s"${col}_minValue"
-                val maxColName = s"${col}_maxValue"
-                if (indexedCols.contains(col)) {
-                  Seq(
-                    s"min($col) AS $minColName",
-                    s"max($col) AS $maxColName",
-                    s"sum(cast(isnull($col) AS long)) AS ${col}_nullCount"
-                  )
-                } else {
-                  Seq(
-                    s"null AS $minColName",
-                    s"null AS $maxColName",
-                    s"null AS ${col}_nullCount"
-                  )
-                }
-              })
-
-        df.selectExpr(exprs: _*)
-          .collect()
-      }).asJava,
-      indexSchema
-    )
-  }
-
-  private def validateColumnStatsIndex(testCase: ColumnStatsTestCase,
-                                       metadataOpts: Map[String, String],
-                                       expectedColStatsSourcePath: String,
-                                       validateColumnStatsManually: Boolean): Unit = {
-    val metadataConfig = HoodieMetadataConfig.newBuilder()
-      .fromProperties(toProperties(metadataOpts))
-      .build()
-
-    val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
-
-    val indexedColumns: Set[String] = {
-      val customIndexedColumns = metadataConfig.getColumnsEnabledForColumnStatsIndex
-      if (customIndexedColumns.isEmpty) {
-        sourceTableSchema.fieldNames.toSet
-      } else {
-        customIndexedColumns.asScala.toSet
-      }
-    }
-    val (expectedColStatsSchema, _) = composeIndexSchema(sourceTableSchema.fieldNames, indexedColumns, sourceTableSchema)
-    val validationSortColumns = Seq("c1_maxValue", "c1_minValue", "c2_maxValue", "c2_minValue")
-
-    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames, testCase.shouldReadInMemory) { transposedColStatsDF =>
-      // Match against expected column stats table
-      val expectedColStatsIndexTableDf =
-        spark.read
-          .schema(expectedColStatsSchema)
-          .json(getClass.getClassLoader.getResource(expectedColStatsSourcePath).toString)
-
-      assertEquals(expectedColStatsIndexTableDf.schema, transposedColStatsDF.schema)
-      // NOTE: We have to drop the `fileName` column as it contains semi-random components
-      //       that we can't control in this test. Nevertheless, since we manually verify composition of the
-      //       ColStats Index by reading Parquet footers from individual Parquet files, this is not an issue
-      assertEquals(asJson(sort(expectedColStatsIndexTableDf, validationSortColumns)),
-        asJson(sort(transposedColStatsDF.drop("fileName"), validationSortColumns)))
-
-      if (validateColumnStatsManually) {
-        // TODO(HUDI-4557): support validation of column stats of avro log files
-        // Collect Column Stats manually (reading individual Parquet files)
-        val manualColStatsTableDF =
-          buildColumnStatsTableManually(basePath, sourceTableSchema.fieldNames, sourceTableSchema.fieldNames, expectedColStatsSchema)
-
-        assertEquals(asJson(sort(manualColStatsTableDF, validationSortColumns)),
-          asJson(sort(transposedColStatsDF, validationSortColumns)))
-      }
-    }
-  }
-
-  private def generateRandomDataFrame(spark: SparkSession): DataFrame = {
-    val sourceTableSchema =
-      new StructType()
-        .add("c1", IntegerType)
-        .add("c2", StringType)
-        // NOTE: We're testing different values for precision of the decimal to make sure
-        //       we execute paths bearing different underlying representations in Parquet
-        // REF: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#DECIMAL
-        .add("c3a", DecimalType(9, 3))
-        .add("c3b", DecimalType(10, 3))
-        .add("c3c", DecimalType(20, 3))
-        .add("c4", TimestampType)
-        .add("c5", ShortType)
-        .add("c6", DateType)
-        .add("c7", BinaryType)
-        .add("c8", ByteType)
-
-    val rdd = spark.sparkContext.parallelize(0 to 1000, 1).map { item =>
-      val c1 = Integer.valueOf(item)
-      val c2 = Random.nextString(10)
-      val c3a = java.math.BigDecimal.valueOf(Random.nextInt() % (1 << 24), 3)
-      val c3b = java.math.BigDecimal.valueOf(Random.nextLong() % (1L << 32), 3)
-      // NOTE: We cap it at 2^64 to make sure we're not exceeding target decimal's range
-      val c3c = new java.math.BigDecimal(new BigInteger(64, new java.util.Random()), 3)
-      val c4 = new Timestamp(System.currentTimeMillis())
-      val c5 = java.lang.Short.valueOf(s"${(item + 16) / 10}")
-      val c6 = Date.valueOf(s"${2020}-${item % 11 + 1}-${item % 28 + 1}")
-      val c7 = Array(item).map(_.toByte)
-      val c8 = java.lang.Byte.valueOf("9")
-
-      RowFactory.create(c1, c2, c3a, c3b, c3c, c4, c5, c6, c7, c8)
-    }
-
-    spark.createDataFrame(rdd, sourceTableSchema)
-  }
-
-  private def asJson(df: DataFrame) =
-    df.toJSON
-      .select("value")
-      .collect()
-      .toSeq
-      .map(_.getString(0))
-      .mkString("\n")
-
-  private def sort(df: DataFrame): DataFrame = {
-    sort(df, Seq("c1_maxValue", "c1_minValue"))
-  }
-
-  private def sort(df: DataFrame, sortColumns: Seq[String]): DataFrame = {
-    val sortedCols = df.columns.sorted
-    // Sort dataset by specified columns (to minimize non-determinism in case multiple files have the same
-    // value of the first column)
-    df.select(sortedCols.head, sortedCols.tail: _*)
-      .sort(sortColumns.head, sortColumns.tail: _*)
-  }
-}
-
-object TestColumnStatsIndex {
-
-  case class ColumnStatsTestCase(tableType: HoodieTableType, shouldReadInMemory: Boolean)
-
-  def testMetadataColumnStatsIndexParams: java.util.stream.Stream[Arguments] = {
-    java.util.stream.Stream.of(HoodieTableType.values().toStream.flatMap(tableType =>
-      Seq(Arguments.arguments(ColumnStatsTestCase(tableType, shouldReadInMemory = true)),
-        Arguments.arguments(ColumnStatsTestCase(tableType, shouldReadInMemory = false)))
-    ): _*)
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -260,7 +260,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
     var commonOpts: Map[String, String] = opts
     createSQLTable(commonOpts, queryType)
     val increment = if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL) && hasLogFiles()
-      && !(opts(HoodieIndexConfig.INDEX_TYPE.key()) == BUCKET.name())) {
+      && !opts.get(HoodieIndexConfig.INDEX_TYPE.key()).contains(BUCKET.name())) {
       1 // only one insert
     } else if (isLastOperationDelete) {
       0 // no increment

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -1,0 +1,324 @@
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions.{DELETE_OPERATION_OPT_VAL, PRECOMBINE_FIELD, RECORDKEY_FIELD}
+import org.apache.hudi.client.utils.MetadataConversionUtils
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.model.{FileSlice, HoodieCommitMetadata, HoodieTableType, WriteOperationType}
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.common.table.timeline.HoodieInstant
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
+import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestCase
+import org.apache.hudi.index.HoodieIndex.IndexType.BUCKET
+import org.apache.hudi.metadata.HoodieMetadataFileSystemView
+import org.apache.hudi.util.{JFunction, JavaConversions}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieFileIndex}
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, GreaterThan, Literal}
+import org.apache.spark.sql.types.StringType
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+import java.util.Properties
+import scala.collection.JavaConverters
+
+class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+
+  @ParameterizedTest
+  @MethodSource(Array("testMetadataColumnStatsIndexParams"))
+  def testMetadataColumnStatsIndexWithSQL(testCase: ColumnStatsTestCase): Unit = {
+    val metadataOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
+    )
+
+    val commonOpts = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+      RECORDKEY_FIELD.key -> "c1",
+      PRECOMBINE_FIELD.key -> "c1",
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+    ) ++ metadataOpts
+    setupTable(testCase, metadataOpts, commonOpts, shouldValidate = true)
+    verifyFileIndexAndSQLQueries(commonOpts)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("testMetadataColumnStatsIndexParamsForMOR"))
+  def testMetadataColumnStatsIndexSQLWithBucketIndex(testCase: ColumnStatsTestCase): Unit = {
+    val metadataOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
+    )
+
+    val commonOpts = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+      RECORDKEY_FIELD.key -> "c1",
+      PRECOMBINE_FIELD.key -> "c1",
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      HoodieIndexConfig.INDEX_TYPE.key() -> BUCKET.name()
+    ) ++ metadataOpts
+
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/input-table-json",
+      expectedColStatsSourcePath = "index/colstats/column-stats-index-table.json",
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite,
+      shouldValidate = false)
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/another-input-table-json",
+      expectedColStatsSourcePath = "index/colstats/updated-column-stats-index-table.json",
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      shouldValidate = false)
+    verifyFileIndexAndSQLQueries(commonOpts, isTableDataSameAsAfterSecondInstant = true, verifyFileCount = false)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("testMetadataColumnStatsIndexParams"))
+  def testMetadataColumnStatsIndexDeletionWithSQL(testCase: ColumnStatsTestCase): Unit = {
+    val metadataOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
+    )
+
+    val commonOpts = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+      RECORDKEY_FIELD.key -> "c1",
+      PRECOMBINE_FIELD.key -> "c1",
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+    ) ++ metadataOpts
+    setupTable(testCase, metadataOpts, commonOpts, shouldValidate = true)
+    val lastDf = dfList.last
+
+    lastDf.write.format("org.apache.hudi")
+      .options(commonOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, DELETE_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+    verifyFileIndexAndSQLQueries(commonOpts, isTableDataSameAsAfterSecondInstant = true)
+
+    // Add the last df back and verify the queries
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/update-input-table-json",
+      expectedColStatsSourcePath = "",
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      shouldValidate = false)
+    verifyFileIndexAndSQLQueries(commonOpts, verifyFileCount = false)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("testMetadataColumnStatsIndexParamsForMOR"))
+  def testMetadataColumnStatsIndexCompactionWithSQL(testCase: ColumnStatsTestCase): Unit = {
+    val metadataOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
+    )
+
+    val commonOpts = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+      RECORDKEY_FIELD.key -> "c1",
+      PRECOMBINE_FIELD.key -> "c1",
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+      DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      HoodieCompactionConfig.INLINE_COMPACT.key() -> "true",
+      HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "1"
+    ) ++ metadataOpts
+    setupTable(testCase, metadataOpts, commonOpts, shouldValidate = false)
+
+    assertFalse(hasLogFiles())
+    verifyFileIndexAndSQLQueries(commonOpts)
+  }
+
+  private def setupTable(testCase: ColumnStatsTestCase, metadataOpts: Map[String, String], commonOpts: Map[String, String], shouldValidate: Boolean): Unit = {
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/input-table-json",
+      expectedColStatsSourcePath = "index/colstats/column-stats-index-table.json",
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite)
+
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/another-input-table-json",
+      expectedColStatsSourcePath = "index/colstats/updated-column-stats-index-table.json",
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append)
+
+    // NOTE: MOR and COW have different fixtures since MOR is bearing delta-log files (holding
+    //       deferred updates), diverging from COW
+    val expectedColStatsSourcePath = if (testCase.tableType == HoodieTableType.COPY_ON_WRITE) {
+      "index/colstats/cow-updated2-column-stats-index-table.json"
+    } else {
+      "index/colstats/mor-updated2-column-stats-index-table.json"
+    }
+
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/update-input-table-json",
+      expectedColStatsSourcePath = expectedColStatsSourcePath,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      shouldValidate)
+  }
+
+  def verifyFileIndexAndSQLQueries(opts: Map[String, String], isTableDataSameAsAfterSecondInstant: Boolean = false, verifyFileCount: Boolean = true): Unit = {
+    var commonOpts = opts
+    val inputDF1 = spark.read.format("hudi")
+      .options(commonOpts)
+      .option("as.of.instant", metaClient.getActiveTimeline.getInstants.get(1).getTimestamp)
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
+      .option(DataSourceReadOptions.ENABLE_DATA_SKIPPING.key, "false")
+      .load(basePath)
+    inputDF1.createOrReplaceTempView("tbl")
+    val numRecordsWithC5ColumnGreaterThan70 = spark.sql("select * from tbl where c5 > 70").count()
+    // verify snapshot query
+    verifySQLQueries(numRecordsWithC5ColumnGreaterThan70, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+
+    // verify read_optimized query
+    verifySQLQueries(numRecordsWithC5ColumnGreaterThan70, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+
+    // verify incremental query
+    verifySQLQueries(numRecordsWithC5ColumnGreaterThan70, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+    commonOpts = commonOpts + (DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN_FOR_NON_EXISTING_FILES.key -> "true")
+    verifySQLQueries(numRecordsWithC5ColumnGreaterThan70, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+
+    if (verifyFileCount) {
+      // First commit creates 4 parquet files
+      // Second commit creates 4 parquet files
+      // Last commit creates one parquet file and 4 log files - total 5 files (for MOR)
+      // and 4 parquet files and no log file (for COW)
+      // therefore on deletion all those 5 files create a new log file whereas COW file count remains same
+      var numFiles = if (isTableMOR && isTableDataSameAsAfterSecondInstant) 17 else if (hasLogFiles()) 12 else 8
+      var dataFilter = GreaterThan(attribute("c5"), literal("70"))
+      verifyPruningFileCount(commonOpts, dataFilter, numFiles)
+
+      dataFilter = GreaterThan(attribute("c5"), literal("90"))
+      numFiles = if (isTableMOR && isTableDataSameAsAfterSecondInstant) 11 else if (hasLogFiles()) 7 else 4
+      verifyPruningFileCount(commonOpts, dataFilter, numFiles)
+    }
+  }
+
+  private def verifyPruningFileCount(opts: Map[String, String], dataFilter: Expression, numFiles: Int): Unit = {
+    val fileIndex = HoodieFileIndex(spark, metaClient, None, opts + ("path" -> basePath))
+    fileIndex.setIncludeLogFiles(isTableMOR())
+    val filteredPartitionDirectories = fileIndex.listFiles(Seq(), Seq(dataFilter))
+    val filteredFilesCount = filteredPartitionDirectories.flatMap(s => s.files).size
+    assertTrue(filteredFilesCount < getLatestDataFilesCount(opts))
+    assertEquals(filteredFilesCount, numFiles)
+  }
+
+  private def getLatestDataFilesCount(opts: Map[String, String]) = {
+    var totalLatestDataFiles = 0L
+    getTableFileSystenView(opts).getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
+      .values()
+      .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
+        (slices => slices.forEach(JFunction.toJavaConsumer[FileSlice](
+          slice => totalLatestDataFiles += slice.getLogFiles.count() + (if (slice.getBaseFile.isPresent) 1 else 0)))))
+    totalLatestDataFiles
+  }
+
+  private def getTableFileSystenView(opts: Map[String, String]): HoodieMetadataFileSystemView = {
+    new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline, metadataWriter(getWriteConfig(opts)).getTableMetadata)
+  }
+
+  protected def getWriteConfig(hudiOpts: Map[String, String]): HoodieWriteConfig = {
+    val props = new Properties()
+    props.putAll(JavaConverters.mapAsJavaMapConverter(hudiOpts).asJava)
+    HoodieWriteConfig.newBuilder()
+      .withProps(props)
+      .withPath(basePath)
+      .build()
+  }
+
+  private def attribute(partition: String): AttributeReference = {
+    AttributeReference(partition, StringType, true)()
+  }
+
+  private def literal(value: String): Literal = {
+    Literal.create(value)
+  }
+
+  private def verifySQLQueries(numRecordsWithC5ColumnGreaterThan70AtPrevInstant: Long, queryType: String, opts: Map[String, String], isLastOperationDelete: Boolean): Unit = {
+    // 2 records are updated with c5 greater than 70 and one record is inserted with c5 value greater than 70
+    var commonOpts: Map[String, String] = opts
+    createSQLTable(commonOpts, queryType)
+    val increment = if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL) && hasLogFiles()
+      && !(opts(HoodieIndexConfig.INDEX_TYPE.key()) == BUCKET.name())) {
+      1 // only one insert
+    } else if (isLastOperationDelete) {
+      0 // no increment
+    } else {
+      3 // one insert and two upserts
+    }
+    assertEquals(spark.sql("select * from tbl where c5 > 70").count(), numRecordsWithC5ColumnGreaterThan70AtPrevInstant + increment)
+    val numRecordsWithC5ColumnGreaterThan50WithDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
+
+    if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)) {
+      createIncrementalSQLTable(commonOpts, metaClient.reloadActiveTimeline().getInstants.get(1).getTimestamp)
+      assertEquals(spark.sql("select * from tbl where c5 > 70").count(), if (isLastOperationDelete) 0 else 3)
+    }
+
+    commonOpts = opts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false")
+    createSQLTable(commonOpts, queryType)
+    val numRecordsWithC5ColumnGreaterThan50WithoutDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
+    assertEquals(numRecordsWithC5ColumnGreaterThan50WithDataSkipping, numRecordsWithC5ColumnGreaterThan50WithoutDataSkipping)
+  }
+
+  private def createSQLTable(hudiOpts: Map[String, String], queryType: String): Unit = {
+    val opts = hudiOpts + (
+      DataSourceReadOptions.QUERY_TYPE.key -> queryType,
+      DataSourceReadOptions.BEGIN_INSTANTTIME.key() -> metaClient.getActiveTimeline.getInstants.get(0).getTimestamp.replaceFirst(".", "0")
+    )
+    val inputDF1 = spark.read.format("hudi").options(opts).load(basePath)
+    inputDF1.createOrReplaceTempView("tbl")
+  }
+
+  private def createIncrementalSQLTable(hudiOpts: Map[String, String], instantTime: String): Unit = {
+    val opts = hudiOpts + (
+      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      DataSourceReadOptions.BEGIN_INSTANTTIME.key() -> instantTime
+    )
+    val inputDF1 = spark.read.format("hudi").options(opts).load(basePath)
+    inputDF1.createOrReplaceTempView("tbl")
+  }
+
+  private def hasLogFiles(): Boolean = {
+    isTableMOR && getLatestCompactionInstant() != metaClient.getActiveTimeline.lastInstant()
+  }
+
+  private def isTableMOR(): Boolean = {
+    metaClient.getTableType == HoodieTableType.MERGE_ON_READ
+  }
+
+  protected def getLatestCompactionInstant(): org.apache.hudi.common.util.Option[HoodieInstant] = {
+    metaClient.reloadActiveTimeline()
+      .filter(JavaConversions.getPredicate(s => Option(
+        try {
+          val commitMetadata = MetadataConversionUtils.getHoodieCommitMetadata(metaClient, s)
+            .orElse(new HoodieCommitMetadata())
+          commitMetadata
+        } catch {
+          case _: Exception => new HoodieCommitMetadata()
+        })
+        .map(c => c.getOperationType == WriteOperationType.COMPACT)
+        .get))
+      .lastInstant()
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions.{DELETE_OPERATION_OPT_VAL, PRECOMBINE_FIELD, RECORDKEY_FIELD}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -19,30 +19,30 @@
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceWriteOptions.{DELETE_OPERATION_OPT_VAL, PRECOMBINE_FIELD, RECORDKEY_FIELD}
-import org.apache.hudi.async.SparkAsyncCompactService
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.client.utils.MetadataConversionUtils
 import org.apache.hudi.common.config.HoodieMetadataConfig
-import org.apache.hudi.common.model.{FileSlice, HoodieCommitMetadata, HoodieTableType, WriteOperationType}
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.functional.ColumnStatIndexTestBase.ColumnStatsTestCase
 import org.apache.hudi.index.HoodieIndex.IndexType.INMEMORY
 import org.apache.hudi.metadata.HoodieMetadataFileSystemView
-import org.apache.hudi.util.{JFunction, JavaConversions}
+import org.apache.hudi.util.JavaConversions
 import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieFileIndex}
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, GreaterThan, Literal}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, Expression, GreaterThan, Literal}
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 import java.util.Properties
 import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters.{asScalaIteratorConverter, collectionAsScalaIterableConverter}
 
 class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
 
@@ -100,9 +100,9 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
     assertEquals(4, getLatestDataFilesCount(commonOpts))
     assertEquals(0, getLatestDataFilesCount(commonOpts, includeLogFiles = false))
     var dataFilter = GreaterThan(attribute("c5"), literal("90"))
-    verifyPruningFileCount(commonOpts, dataFilter, 3)
+    verifyPruningFileCount(commonOpts, dataFilter)
     dataFilter = GreaterThan(attribute("c5"), literal("95"))
-    verifyPruningFileCount(commonOpts, dataFilter, 1)
+    verifyPruningFileCount(commonOpts, dataFilter)
   }
 
   @ParameterizedTest
@@ -171,10 +171,9 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
     verifyFileIndexAndSQLQueries(commonOpts)
   }
 
-  @Disabled("Needs more work")
   @ParameterizedTest
   @MethodSource(Array("testMetadataColumnStatsIndexParamsForMOR"))
-  def testMetadataColumnStatsIndexAsyncCompactionWithSQL(testCase: ColumnStatsTestCase): Unit = {
+  def testMetadataColumnStatsIndexScheduledCompactionWithSQL(testCase: ColumnStatsTestCase): Unit = {
     val metadataOpts = Map(
       HoodieMetadataConfig.ENABLE.key -> "true",
       HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
@@ -196,11 +195,13 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
 
     val writeClient = new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), getWriteConfig(commonOpts))
     writeClient.scheduleCompaction(org.apache.hudi.common.util.Option.empty())
-    val compactionService = new SparkAsyncCompactService(new HoodieSparkEngineContext(jsc), writeClient)
-    compactionService.enqueuePendingAsyncServiceInstant(metaClient.reloadActiveTimeline().lastInstant().get())
-    compactionService.start(JFunction.toJavaFunction(b => true))
-    compactionService.waitTillPendingAsyncServiceInstantsReducesTo(0)
-    assertFalse(hasLogFiles())
+
+    doWriteAndValidateColumnStats(testCase, metadataOpts, commonOpts,
+      dataSourcePath = "index/colstats/update-input-table-json",
+      expectedColStatsSourcePath = "",
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      shouldValidate = false)
     verifyFileIndexAndSQLQueries(commonOpts)
   }
 
@@ -242,51 +243,54 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
       .option(DataSourceReadOptions.ENABLE_DATA_SKIPPING.key, "false")
       .load(basePath)
     inputDF1.createOrReplaceTempView("tbl")
-    val numRecordsForQuery = spark.sql("select * from tbl where c5 > 70").count()
+    val numRecordsForFirstQuery = spark.sql("select * from tbl where c5 > 70").count()
+    val numRecordsForSecondQuery = spark.sql("select * from tbl where c5 > 70 and c6 >= '2020-03-28'").count()
     // verify snapshot query
-    verifySQLQueries(numRecordsForQuery, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+    verifySQLQueries(numRecordsForFirstQuery, numRecordsForSecondQuery, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
 
     // verify read_optimized query
-    verifySQLQueries(numRecordsForQuery, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+    verifySQLQueries(numRecordsForFirstQuery, numRecordsForSecondQuery, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
 
     // verify incremental query
-    verifySQLQueries(numRecordsForQuery, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+    verifySQLQueries(numRecordsForFirstQuery, numRecordsForSecondQuery, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
     commonOpts = commonOpts + (DataSourceReadOptions.INCREMENTAL_FALLBACK_TO_FULL_TABLE_SCAN_FOR_NON_EXISTING_FILES.key -> "true")
-    verifySQLQueries(numRecordsForQuery, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
+    // TODO: https://issues.apache.org/jira/browse/HUDI-6657 - Investigate why below assertions fail with full table scan enabled.
+    //verifySQLQueries(numRecordsForFirstQuery, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL, commonOpts, isTableDataSameAsAfterSecondInstant)
 
-    // First commit creates 4 parquet files
-    // Second commit creates 4 parquet files
-    // Last commit creates one parquet file and 4 log files - total 5 files (for MOR)
-    // and 4 parquet files and no log file (for COW)
-    // therefore on deletion all those 5 files create a new log file whereas COW file count remains same
-    var numFiles = if (isTableMOR && isTableDataSameAsAfterSecondInstant) 17 else if (hasLogFiles()) 12 else 8
-    var dataFilter = GreaterThan(attribute("c5"), literal("70"))
-    verifyPruningFileCount(commonOpts, dataFilter, numFiles, verifyFileCount)
-
+    var dataFilter: Expression = GreaterThan(attribute("c5"), literal("70"))
+    verifyPruningFileCount(commonOpts, dataFilter)
+    dataFilter = And(dataFilter, GreaterThan(attribute("c6"), literal("'2020-03-28'")))
+    verifyPruningFileCount(commonOpts, dataFilter)
     dataFilter = GreaterThan(attribute("c5"), literal("90"))
-    numFiles = if (isTableMOR && isTableDataSameAsAfterSecondInstant) 11 else if (hasLogFiles()) 7 else 4
-    verifyPruningFileCount(commonOpts, dataFilter, numFiles, verifyFileCount)
+    verifyPruningFileCount(commonOpts, dataFilter)
+    dataFilter = And(dataFilter, GreaterThan(attribute("c6"), literal("'2020-03-28'")))
+    verifyPruningFileCount(commonOpts, dataFilter)
   }
 
-  private def verifyPruningFileCount(opts: Map[String, String], dataFilter: Expression, numFiles: Int, verifyFileCount: Boolean = true): Unit = {
-    val fileIndex = HoodieFileIndex(spark, metaClient, None, opts + ("path" -> basePath))
-    fileIndex.setIncludeLogFiles(isTableMOR())
+  private def verifyPruningFileCount(opts: Map[String, String], dataFilter: Expression): Unit = {
+    // with data skipping
+    val commonOpts = opts + ("path" -> basePath)
+    var fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts, includeLogFiles = true)
     val filteredPartitionDirectories = fileIndex.listFiles(Seq(), Seq(dataFilter))
     val filteredFilesCount = filteredPartitionDirectories.flatMap(s => s.files).size
     assertTrue(filteredFilesCount < getLatestDataFilesCount(opts))
-    if (verifyFileCount) {
-      assertEquals(filteredFilesCount, numFiles)
-    }
+
+    // with no data skipping
+    fileIndex = HoodieFileIndex(spark, metaClient, None, commonOpts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false"), includeLogFiles = true)
+    val filesCountWithNoSkipping = fileIndex.listFiles(Seq(), Seq(dataFilter)).flatMap(s => s.files).size
+    assertTrue(filteredFilesCount < filesCountWithNoSkipping)
   }
 
   private def getLatestDataFilesCount(opts: Map[String, String], includeLogFiles: Boolean = true) = {
     var totalLatestDataFiles = 0L
-    getTableFileSystemView(opts).getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
-      .values()
-      .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
-        (slices => slices.forEach(JFunction.toJavaConsumer[FileSlice](
-          slice => totalLatestDataFiles += (if (includeLogFiles) slice.getLogFiles.count() else 0)
-            + (if (slice.getBaseFile.isPresent) 1 else 0)))))
+    val fsView = getTableFileSystemView(opts)
+    fsView.loadAllPartitions()
+    fsView.getPartitionPaths.asScala.flatMap { partitionPath =>
+      val relativePath = FSUtils.getRelativePartitionPath(metaClient.getBasePathV2, partitionPath)
+      fsView.getLatestMergedFileSlicesBeforeOrOn(relativePath, metaClient.reloadActiveTimeline().lastInstant().get().getTimestamp).iterator().asScala.toSeq
+    }.foreach(
+      slice => totalLatestDataFiles += (if (includeLogFiles) slice.getLogFiles.count() else 0)
+        + (if (slice.getBaseFile.isPresent) 1 else 0))
     totalLatestDataFiles
   }
 
@@ -311,30 +315,44 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
     Literal.create(value)
   }
 
-  private def verifySQLQueries(numRecordsForQueryAtPrevInstant: Long, queryType: String, opts: Map[String, String], isLastOperationDelete: Boolean): Unit = {
+  private def verifySQLQueries(numRecordsForFirstQueryAtPrevInstant: Long, numRecordsForSecondQueryAtPrevInstant: Long,
+                               queryType: String, opts: Map[String, String], isLastOperationDelete: Boolean): Unit = {
+    val firstQuery = "select * from tbl where c5 > 70"
+    val secondQuery = "select * from tbl where c5 > 70 and c6 >= '2020-03-28'"
     // 2 records are updated with c5 greater than 70 and one record is inserted with c5 value greater than 70
     var commonOpts: Map[String, String] = opts
     createSQLTable(commonOpts, queryType)
-    val increment = if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL) && hasLogFiles()) {
+    val incrementFirstQuery = if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL) && hasLogFiles()) {
       1 // only one insert
     } else if (isLastOperationDelete) {
       0 // no increment
     } else {
       3 // one insert and two upserts
     }
-    assertEquals(spark.sql("select * from tbl where c5 > 70").count(), numRecordsForQueryAtPrevInstant + increment)
-    val numRecordsForQueryWithDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
+    val incrementSecondQuery = if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL) && hasLogFiles()) {
+      1 // only one insert
+    } else if (isLastOperationDelete) {
+      0 // no increment
+    } else {
+      2 // one insert and two upserts
+    }
+    assertEquals(spark.sql(firstQuery).count(), numRecordsForFirstQueryAtPrevInstant + incrementFirstQuery)
+    assertEquals(spark.sql(secondQuery).count(), numRecordsForSecondQueryAtPrevInstant + incrementSecondQuery)
+    val numRecordsForFirstQueryWithDataSkipping = spark.sql(firstQuery).count()
+    val numRecordsForSecondQueryWithDataSkipping = spark.sql(secondQuery).count()
 
     if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)) {
       createIncrementalSQLTable(commonOpts, metaClient.reloadActiveTimeline().getInstants.get(1).getTimestamp)
-      assertEquals(spark.sql("select * from tbl where c5 > 70").count(), if (isLastOperationDelete) 0 else 3)
-      assertEquals(spark.sql("select * from tbl where c5 > 70 and c6 >= '2020-03-28'").count(), if (isLastOperationDelete) 0 else 2)
+      assertEquals(spark.sql(firstQuery).count(), if (isLastOperationDelete) 0 else 3)
+      assertEquals(spark.sql(secondQuery).count(), if (isLastOperationDelete) 0 else 2)
     }
 
     commonOpts = opts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false")
     createSQLTable(commonOpts, queryType)
-    val numRecordsForQueryWithoutDataSkipping = spark.sql("select * from tbl where c5 > 70").count()
-    assertEquals(numRecordsForQueryWithDataSkipping, numRecordsForQueryWithoutDataSkipping)
+    val numRecordsForFirstQueryWithoutDataSkipping = spark.sql(firstQuery).count()
+    val numRecordsForSecondQueryWithoutDataSkipping = spark.sql(secondQuery).count()
+    assertEquals(numRecordsForFirstQueryWithDataSkipping, numRecordsForFirstQueryWithoutDataSkipping)
+    assertEquals(numRecordsForSecondQueryWithDataSkipping, numRecordsForSecondQueryWithoutDataSkipping)
   }
 
   private def createSQLTable(hudiOpts: Map[String, String], queryType: String): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -290,7 +290,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
     totalLatestDataFiles
   }
 
-  private def getTableFileSystenView(opts: Map[String, String]): HoodieMetadataFileSystemView = {
+  private def getTableFileSystemView(opts: Map[String, String]): HoodieMetadataFileSystemView = {
     new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline, metadataWriter(getWriteConfig(opts)).getTableMetadata)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -281,7 +281,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
 
   private def getLatestDataFilesCount(opts: Map[String, String], includeLogFiles: Boolean = true) = {
     var totalLatestDataFiles = 0L
-    getTableFileSystenView(opts).getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
+    getTableFileSystemView(opts).getAllLatestFileSlicesBeforeOrOn(metaClient.getActiveTimeline.lastInstant().get().getTimestamp)
       .values()
       .forEach(JFunction.toJavaConsumer[java.util.stream.Stream[FileSlice]]
         (slices => slices.forEach(JFunction.toJavaConsumer[FileSlice](
@@ -328,6 +328,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
     if (queryType.equals(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)) {
       createIncrementalSQLTable(commonOpts, metaClient.reloadActiveTimeline().getInstants.get(1).getTimestamp)
       assertEquals(spark.sql("select * from tbl where c5 > 70").count(), if (isLastOperationDelete) 0 else 3)
+      assertEquals(spark.sql("select * from tbl where c5 > 70 and c6 >= '2020-03-28'").count(), if (isLastOperationDelete) 0 else 2)
     }
 
     commonOpts = opts + (DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "false")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringProcedure.scala
@@ -587,7 +587,7 @@ class TestClusteringProcedure extends HoodieSparkProcedureTestBase {
 
       metaClient.reloadActiveTimeline()
       val fileIndex1 = HoodieFileIndex(spark, metaClient, None, queryOpts)
-      val orderAllFiles = fileIndex1.allFiles.size
+      val orderAllFiles = fileIndex1.allBaseFiles.size
       val c2OrderFilterCount = fileIndex1.listFiles(Seq(), Seq(dataFilterC2)).head.files.size
       val c3OrderFilterCount = fileIndex1.listFiles(Seq(), Seq(dataFilterC3)).head.files.size
 
@@ -604,7 +604,7 @@ class TestClusteringProcedure extends HoodieSparkProcedureTestBase {
 
       metaClient.reloadActiveTimeline()
       val fileIndex2 = HoodieFileIndex(spark, metaClient, None, queryOpts)
-      val ZOrderAllFiles = fileIndex2.allFiles.size
+      val ZOrderAllFiles = fileIndex2.allBaseFiles.size
       val c2ZOrderFilterCount = fileIndex2.listFiles(Seq(), Seq(dataFilterC2)).head.files.size
       val c3ZOrderFilterCount = fileIndex2.listFiles(Seq(), Seq(dataFilterC3)).head.files.size
 


### PR DESCRIPTION
### Change Logs

Currently MOR snapshot relation does not use the column stats index for pruning the files in its queries. This PR aims to add support for pruning the file slices based on column stats in case of MOR.

The approach is similar to what was used for `org.apache.hudi.HoodieFileIndex#listFiles`. For every partition path, logic for filtering the file slices has been moved to function `org.apache.hudi.HoodieFileIndex#filterFileSlices`.  This function is called by various relations for pruning the file slices.

1. Firstly, as usual, partitions are pruned based on partition filters in `HoodieFileIndex#getFileSlicesForPrunedPartitions`.
2. Next, data filters are used to employ record index or colstats on top of pruned partitions and file slices in `HoodieFileIndex#filterFileSlices`.
      a. If there is an only equality predicate on record key, use record index if it is available.
      b. Further, if there are range filters and column stats is available for those columns, then skip some data get the candidate file names.
      c. Now, based on these candidate files (which is a **set of base and long files**), filter the file slices obtained in step 1.

### Impact

The snapshot query on Merge On Read tables would improve after the PR if column stats index is enabled and if it is able to prune file slices based on the query.

### Risk level (write none, low medium or high below)

medium. Added more SQL related tests for column stats integration.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
