### PR TITLE
[MINOR] Optimize PartitionAwareClusteringPlanStrategy build clustering group for partition with clustering max groups

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -147,7 +147,8 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
         .flatMap(
             partitionPaths,
             partitionPath -> {
-              List<FileSlice> fileSlicesEligible = getFileSlicesEligibleForClustering(partitionPath).collect(Collectors.toList());
+              List<FileSlice> fileSlicesEligible = getFileSlicesEligibleForClustering(partitionPath)
+                  .limit(getWriteConfig().getClusteringMaxNumGroups()).collect(Collectors.toList());
               return buildClusteringGroupsForPartition(partitionPath, fileSlicesEligible).limit(getWriteConfig().getClusteringMaxNumGroups());
             },
             partitionPaths.size())


### PR DESCRIPTION
### Change Logs

At present, when certain partition has many file groups, the generation of clustering plan consumes much time for building clustering group for partition. It's better to optimize `PartitionAwareClusteringPlanStrategy` build clustering group for partition with clustering max groups which could reduce the time to build clustering group.

### Impact

`PartitionAwareClusteringPlanStrategy` builds clustering group for partition with clustering max groups.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed