### PR TITLE
[HUDI-6867] Upgrade thrift's version to 0.13.0

### DIFF
--- a/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_docker.sh
+++ b/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_docker.sh
@@ -20,7 +20,7 @@ printf "====== INSTALL THRIFT START ======\n"
 PARENT_PATH=$(dirname "$PWD")
 THRIFT_FILE_PATH=${PARENT_PATH}/src/main/thrift
 THRIFT_OUT_PATH=${PARENT_PATH}/target/generated-sources
-THRIFT_VERSION=0.12.0
+THRIFT_VERSION=0.13.0
 THRIFT_IMAGE=thrift:$THRIFT_VERSION
 docker pull $THRIFT_IMAGE
 printf "====== INSTALL THRIFT END ======\n"

--- a/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_docker.sh
+++ b/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_docker.sh
@@ -21,7 +21,7 @@ PARENT_PATH=$(dirname "$PWD")
 THRIFT_FILE_PATH=${PARENT_PATH}/src/main/thrift
 THRIFT_OUT_PATH=${PARENT_PATH}/target/generated-sources
 THRIFT_VERSION=0.13.0
-THRIFT_IMAGE=thrift:$THRIFT_VERSION
+THRIFT_IMAGE=omnisci/thrift:$THRIFT_VERSION
 docker pull $THRIFT_IMAGE
 printf "====== INSTALL THRIFT END ======\n"
 printf "====== COMPILE THRIFT SOURCE FILE START ======\n"

--- a/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_mac_m1.sh
+++ b/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_mac_m1.sh
@@ -16,14 +16,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Usage: ./scripts/checkout_pr.sh
-#
-# Checkout a PR given the PR number into a local branch. PR branches are named
-# using the convention "pull/<PR_NUMBER>", to enable pr_push_command.sh to work
-# in tandem.
-#
-
 printf "====== INSTALL THRIFT START ======\n"
 brew install thrift@0.13.0
 printf "====== INSTALL THRIFT END ======\n"

--- a/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_mac_m1.sh
+++ b/hudi-platform-service/hudi-metaserver/src/main/thrift/bin/thrift_in_mac_m1.sh
@@ -25,7 +25,7 @@
 #
 
 printf "====== INSTALL THRIFT START ======\n"
-brew install thrift@0.12.0
+brew install thrift@0.13.0
 printf "====== INSTALL THRIFT END ======\n"
 printf "====== COMPILE THRIFT SOURCE FILE START ======\n"
 PARENT_PATH=$(dirname "$PWD")

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
     <scalatest.spark3.version>3.1.0</scalatest.spark3.version>
     <scalatest.version>${scalatest.spark3.version}</scalatest.version>
     <surefire-log4j.file>log4j2-surefire.properties</surefire-log4j.file>
-    <thrift.version>0.12.0</thrift.version>
+    <thrift.version>0.13.0</thrift.version>
     <javalin.version>4.6.7</javalin.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <htrace.version>3.1.0-incubating</htrace.version>


### PR DESCRIPTION
### Change Logs

Upgrade thrift's version from 0.12.0 to 0.13.0.

There is an issue in thrift-0.12.0:
https://issues.apache.org/jira/browse/THRIFT-4805 

Will cause the following problems：

![error](https://github.com/apache/hudi/assets/90449228/3e6fa891-4bc5-4385-b5a7-d4fed4a26131)

This error message has anything to do with the hoodie，
but if there is a program connected to hoodie metaserver, this error log message will be continuously output.

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

None

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
