### PR TITLE
[HUDI-6476][FOLLOW-UP] Path filter by FileStatus to avoid additional fs request

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implementation of {@link HoodieTableMetadata} based file-system-backed table metadata.
@@ -167,66 +168,52 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
       // TODO: Get the parallelism from HoodieWriteConfig
       int listingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, pathsToList.size());
 
-      // List all directories in parallel
+      // List all directories in parallel:
+      // if current dictionary contains PartitionMetadata, add it to result
+      // if current dictionary does not contain PartitionMetadata, add its subdirectory to queue to be processed.
       engineContext.setJobStatus(this.getClass().getSimpleName(), "Listing all partitions with prefix " + relativePathPrefix);
-      List<FileStatus> dirToFileListing = engineContext.flatMap(pathsToList, path -> {
+      // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
+      // and second entry holds optionally a directory path to be processed further.
+      List<Pair<Option<String>, Option<Path>>> result = engineContext.flatMap(pathsToList, path -> {
         FileSystem fileSystem = path.getFileSystem(hadoopConf.get());
-        return Arrays.stream(fileSystem.listStatus(path));
+        if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, path)) {
+          return Stream.of(Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), path)), Option.empty()));
+        }
+        return Arrays.stream(fileSystem.listStatus(path))
+            .filter(status -> status.isDirectory() && !status.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME))
+            .map(status -> Pair.of(Option.empty(), Option.of(status.getPath())));
       }, listingParallelism);
       pathsToList.clear();
 
-      // if current dictionary contains PartitionMetadata, add it to result
-      // if current dictionary does not contain PartitionMetadata, add it to queue to be processed.
-      int fileListingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, dirToFileListing.size());
-      if (!dirToFileListing.isEmpty()) {
-        // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
-        // and second entry holds optionally a directory path to be processed further.
-        engineContext.setJobStatus(this.getClass().getSimpleName(), "Processing listed partitions");
-        List<Pair<Option<String>, Option<Path>>> result = engineContext.map(dirToFileListing, fileStatus -> {
-          FileSystem fileSystem = fileStatus.getPath().getFileSystem(hadoopConf.get());
-          if (fileStatus.isDirectory()) {
-            if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, fileStatus.getPath())) {
-              return Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), fileStatus.getPath())), Option.empty());
-            } else if (!fileStatus.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
-              return Pair.of(Option.empty(), Option.of(fileStatus.getPath()));
-            }
-          } else if (fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)) {
-            String partitionName = FSUtils.getRelativePartitionPath(dataBasePath.get(), fileStatus.getPath().getParent());
-            return Pair.of(Option.of(partitionName), Option.empty());
-          }
-          return Pair.of(Option.empty(), Option.empty());
-        }, fileListingParallelism);
+      partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
+          .map(entry -> entry.getKey().get())
+          .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
+              || (Boolean) fullBoundExpr.eval(
+              extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
+          .collect(Collectors.toList()));
 
-        partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
-            .map(entry -> entry.getKey().get())
-            .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
-                || (Boolean) fullBoundExpr.eval(
-                extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
-            .collect(Collectors.toList()));
-
-        Expression partialBoundExpr;
-        // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
-        // are filtered already.
-        if (needPushDownExpressions && partitionPaths.isEmpty()) {
-          // Here we assume the path level matches the number of partition columns, so we'll rebuild
-          // new schema based on current path level.
-          // e.g. partition columns are <region, date, hh>, if we're listing the second level, then
-          // currentSchema would be <region, date>
-          // `PartialBindVisitor` will bind reference if it can be found from `currentSchema`, otherwise
-          // will change the expression to `alwaysTrue`. Can see `PartialBindVisitor` for details.
-          Types.RecordType currentSchema = Types.RecordType.get(partitionFields.fields().subList(0, ++currentPartitionLevel));
-          PartialBindVisitor partialBindVisitor = new PartialBindVisitor(currentSchema, caseSensitive);
-          partialBoundExpr = pushedExpr.accept(partialBindVisitor);
-        } else {
-          partialBoundExpr = Predicates.alwaysTrue();
-        }
-
-        pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-            .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-                || (Boolean) partialBoundExpr.eval(
-                extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-            .collect(Collectors.toList()));
+      Expression partialBoundExpr;
+      // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
+      // are filtered already.
+      if (needPushDownExpressions && partitionPaths.isEmpty()) {
+        // Here we assume the path level matches the number of partition columns, so we'll rebuild
+        // new schema based on current path level.
+        // e.g. partition columns are <region, date, hh>, if we're listing the second level, then
+        // currentSchema would be <region, date>
+        // `PartialBindVisitor` will bind reference if it can be found from `currentSchema`, otherwise
+        // will change the expression to `alwaysTrue`. Can see `PartialBindVisitor` for details.
+        Types.RecordType currentSchema = Types.RecordType.get(partitionFields.fields().subList(0, ++currentPartitionLevel));
+        PartialBindVisitor partialBindVisitor = new PartialBindVisitor(currentSchema, caseSensitive);
+        partialBoundExpr = pushedExpr.accept(partialBindVisitor);
+      } else {
+        partialBoundExpr = Predicates.alwaysTrue();
       }
+
+      pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
+          .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+              || (Boolean) partialBoundExpr.eval(
+                  extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+          .collect(Collectors.toList()));
     }
     return partitionPaths;
   }


### PR DESCRIPTION
### Change Logs

As disscussed in #9343, the original HUDI-6476 has latency for partitioned table. We find the latency occurs in `fileSystem.isDirectory(p)` which can be avoid. 
Here is my test on HDFS with `show partitions` command.
After Revert:
<img width="1526" alt="image" src="https://github.com/apache/hudi/assets/65108011/a7dee6ff-e2e1-4947-ac3c-38f41e730c3a">
After this patch:
<img width="1518" alt="image" src="https://github.com/apache/hudi/assets/65108011/b5141845-76a4-4727-a237-a9b10c7bcecd">


### Impact
Fix the latency.

### Risk level (write none, low medium or high below)
low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
