### PR TITLE
[HUDI-6650] Do not set default preCombine field for Flink table config

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -127,6 +127,17 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns the preCombine field
+   * or null if the value is set as {@link FlinkOptions#NO_PRE_COMBINE} or the user does not config it explicitly.
+   */
+  public static String getPreCombineFieldNoDefaultValue(Configuration conf) {
+    if (!conf.contains(FlinkOptions.PRECOMBINE_FIELD)) {
+      return null;
+    }
+    return getPreCombineField(conf);
+  }
+
+  /**
    * Returns whether the compaction strategy is based on elapsed delta time.
    */
   public static boolean isDeltaTimeCompaction(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -219,7 +219,7 @@ public class StreamerUtil {
           .setDatabaseName(conf.getString(FlinkOptions.DATABASE_NAME))
           .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD, null))
           .setPayloadClassName(conf.getString(FlinkOptions.PAYLOAD_CLASS_NAME))
-          .setPreCombineField(OptionsResolver.getPreCombineField(conf))
+          .setPreCombineField(OptionsResolver.getPreCombineFieldNoDefaultValue(conf))
           .setArchiveLogFolder(ARCHIVELOG_FOLDER.defaultValue())
           .setPartitionFields(conf.getString(FlinkOptions.PARTITION_PATH_FIELD, null))
           .setKeyGeneratorClassProp(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -41,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,6 +83,16 @@ public class TestStreamerUtil {
         .build();
     assertFalse(metaClient2.getTableConfig().getPartitionFields().isPresent());
     assertEquals(metaClient2.getTableConfig().getKeyGeneratorClassName(), SimpleAvroKeyGenerator.class.getName());
+
+    // Test no explicit preCombine field.
+    conf.removeConfig(FlinkOptions.PRECOMBINE_FIELD);
+    FileIOUtils.deleteDirectory(tempFile);
+    StreamerUtil.initTableIfNotExists(conf);
+    HoodieTableMetaClient metaClient3 = HoodieTableMetaClient.builder()
+        .setBasePath(tempFile.getAbsolutePath())
+        .setConf(new org.apache.hadoop.conf.Configuration())
+        .build();
+    assertNull(metaClient3.getTableConfig().getPreCombineField());
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

Do not set preCombine field when use does not set it up explicitly. This behavior is kept in line with Spark.

### Impact

none.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
