### PR TITLE
[HUDI-6655] Fix TestWriteMergeOnRead#testConsistentBucketIndex

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/util/ConsistentHashingUpdateStrategyUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/util/ConsistentHashingUpdateStrategyUtils.java
@@ -83,7 +83,7 @@ public class ConsistentHashingUpdateStrategyUtils {
       ValidationUtils.checkState(p != null, "Clustering plan does not has partition info, plan: " + plan);
       // Skip unrelated clustering group
       if (!recordPartitions.contains(p)) {
-        return;
+        continue;
       }
 
       String preInstant = partitionToInstant.putIfAbsent(p, instant);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
@@ -26,7 +26,6 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.utils.TestData;
 
 import org.apache.flink.configuration.Configuration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -165,7 +164,6 @@ public class TestWriteMergeOnRead extends TestWriteCopyOnWrite {
   }
 
   @Test
-  @Disabled("HUDI-6655")
   public void testConsistentBucketIndex() throws Exception {
     conf.setString(FlinkOptions.INDEX_TYPE, "BUCKET");
     conf.setString(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, "CONSISTENT_HASHING");


### PR DESCRIPTION
### Change Logs

Fix utility class for update strategy of table with consistent bucket index.

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
