### PR TITLE
[HUDI-6662] Fix MERGE INTO command validation

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -178,11 +178,6 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       resolving
     }).filter(_.nonEmpty).map(_.get)
 
-    if (expressionSet.nonEmpty && primaryKeyFields.isPresent) {
-      //if pkless additional expressions are allowed
-      throw new AnalysisException(s"Only simple conditions of the form `t.id = s.id` using primary key or partition path columns are allowed on tables with primary key. " +
-        s"(illegal column(s) used: `${expressionSet.map(x => x._1.name).mkString("`,`")}`")
-    }
     resolvedCols
   }
 


### PR DESCRIPTION
### Change Logs

Due to the validation, MERGE INTO fails in analysis. The validation seems unnecessary as we do support join condition on multiple columns, except that record key should be part of it.

### Impact

Relax a validation and make sure MIT works as expected when there is join on columns additional to record key.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
