### PR TITLE
[HUDI-6662] Relax matching condition to allow non pk columns to match on

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -177,12 +177,6 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       }
       resolving
     }).filter(_.nonEmpty).map(_.get)
-
-    if (expressionSet.nonEmpty && primaryKeyFields.isPresent) {
-      //if pkless additional expressions are allowed
-      throw new AnalysisException(s"Only simple conditions of the form `t.id = s.id` using primary key or partition path columns are allowed on tables with primary key. " +
-        s"(illegal column(s) used: `${expressionSet.map(x => x._1.name).mkString("`,`")}`")
-    }
     resolvedCols
   }
 


### PR DESCRIPTION
### Change Logs

Allow merge into join condition to use any column instead of just pk and partition columns

### Impact

More flexible MIT

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
