### PR TITLE
[HUDI-6667] ClientIds should generate next id automatically with random uuid instead of incremental id

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -186,8 +187,8 @@ public class ClientIds implements AutoCloseable, Serializable {
         return INIT_CLIENT_ID;
       }
       List<Path> sortedPaths = Arrays.stream(fs.listStatus(heartbeatFolderPath))
+          .sorted(Comparator.comparing(FileStatus::getModificationTime))
           .map(FileStatus::getPath)
-          .sorted(Comparator.comparing(Path::getName))
           .collect(Collectors.toList());
       if (sortedPaths.isEmpty()) {
         return INIT_CLIENT_ID;
@@ -203,9 +204,8 @@ public class ClientIds implements AutoCloseable, Serializable {
         }
         return getClientId(zombieHeartbeatPaths.get(0));
       }
-      // 2. else returns an auto inc id
-      String largestClientId = getClientId(sortedPaths.get(sortedPaths.size() - 1));
-      return INIT_CLIENT_ID.equals(largestClientId) ? "1" : (Integer.parseInt(largestClientId) + 1) + "";
+      // 2. else returns a random uuid to avoid conflict of client id
+      return UUID.randomUUID().toString();
     } catch (IOException e) {
       throw new RuntimeException("Generate next client id error", e);
     }
@@ -213,7 +213,7 @@ public class ClientIds implements AutoCloseable, Serializable {
 
   /**
    * Returns the client id from the heartbeat file path, the path name follows
-   * the naming convention: _, _1, _2, ... _N.
+   * the naming convention: _, _UUID.
    */
   private static String getClientId(Path path) {
     String[] splits = path.getName().split(HEARTBEAT_FILE_NAME_PREFIX);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsInference.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsInference.java
@@ -51,8 +51,8 @@ public class TestOptionsInference {
       try (ClientIds clientIds = ClientIds.builder().conf(conf).build()) {
         OptionsInference.setupClientId(conf);
         String expectedId = i == 0 ? ClientIds.INIT_CLIENT_ID : i + "";
-        assertThat("The client id should auto inc to " + expectedId,
-            conf.getString(FlinkOptions.WRITE_CLIENT_ID), is(expectedId));
+        assertThat("The client id should be a random uuid",
+            ClientIds.INIT_CLIENT_ID.equals(conf.getString(FlinkOptions.WRITE_CLIENT_ID)), is(i == 0));
       }
     }
 
@@ -62,10 +62,10 @@ public class TestOptionsInference {
     try (ClientIds clientIds = ClientIds.builder()
         .conf(conf)
         .heartbeatIntervalInMs(10) // max 10 milliseconds tolerable heartbeat timeout
-        .numTolerableHeartbeatMisses(1). build()) {
+        .numTolerableHeartbeatMisses(1).build()) {
       String nextId = clientIds.nextId(conf);
       assertThat("The inactive client id should be reused",
-          nextId, is(""));
+          nextId, is(ClientIds.INIT_CLIENT_ID));
     }
   }
 


### PR DESCRIPTION
### Change Logs

`ClientIds` should generate next id automatically with random uuid instead of incremental id to avoid conflict of client id for concurrent batch insert overwrite.

### Impact

`ClientIds` generates next id automatically with random uuid.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed