### PR TITLE
[HUDI-6668] CTAS should not clear existing hoodie table path

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala
@@ -115,8 +115,11 @@ case class CreateHoodieTableAsSelectCommand(
         clearTablePath(tablePath, hadoopConf)
       }
     } catch {
-      case e: Throwable => // failed to insert data, clear table path
-        clearTablePath(tablePath, hadoopConf)
+      case e: Throwable =>
+        // clear the hoodie table path only if it did not exist previously.
+        if (!hoodieCatalogTable.hoodieTableExists) {
+          clearTablePath(tablePath, hadoopConf)
+        }
         throw e
     }
     Seq.empty[Row]


### PR DESCRIPTION
### Change Logs
Currently Hudi will clear table path if there is any exception in CTAS command:
https://github.com/apache/hudi/blob/7102e0fbe5ff352e5cbb123c3c25b1e5cd238d78/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableAsSelectCommand.scala#L117-L121

It may mistakenly delete the path belongs to another hudi table, we need a check before the clear.

### Impact

CTAS will not clear the table path which is not generated by it any more.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
