### PR TITLE
[HUDI-6670] Fix timeline check in metadata table validator

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -491,10 +491,10 @@ public class HoodieMetadataTableValidator implements Serializable {
           .setConf(jsc.hadoopConfiguration()).setBasePath(new Path(cfg.basePath, HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH).toString())
           .setLoadActiveTimelineOnLoad(true)
           .build();
-      int finishedInstants = mdtMetaClient.getActiveTimeline().filterCompletedInstants().countInstants();
+      int finishedInstants = mdtMetaClient.getCommitsTimeline().filterCompletedInstants().countInstants();
       if (finishedInstants == 0) {
-        if (metaClient.getActiveTimeline().filterCompletedInstants().countInstants() == 0) {
-          LOG.info("There is no completed instant both in metadata table and corresponding data table.");
+        if (metaClient.getCommitsTimeline().filterCompletedInstants().countInstants() == 0) {
+          LOG.info("There is no completed commit in both metadata table and corresponding data table.");
           return false;
         } else {
           throw new HoodieValidationException("There is no completed instant for metadata table.");


### PR DESCRIPTION
### Change Logs

This PR fixes the timeline check in metadata table validator.

Metadata table validator (`HoodieMetadataTableValidator`) throws the following exception before this fix when there is a completed rollback and no completed commits in the data table, and there is no completed instant in the MDT.  In this case, both the data table and MDT are empty, but the timeline check has a bug causing the validation to fail, which is a false positive.

```
23/08/08 22:48:13 WARN HoodieMetadataTableValidator: Metadata table is not available to read for now, 
org.apache.hudi.exception.HoodieValidationException: There is no completed instant for metadata table.
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.checkMetadataTableIsAvailable(HoodieMetadataTableValidator.java:500)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.doMetadataTableValidation(HoodieMetadataTableValidator.java:405)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.doHoodieMetadataTableValidationOnce(HoodieMetadataTableValidator.java:377)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.run(HoodieMetadataTableValidator.java:362)
	at org.apache.hudi.utilities.HoodieMetadataTableValidator.main(HoodieMetadataTableValidator.java:342)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:958)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1046)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1055)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala) 
```
Data table timeline
```
Aug  6 22:57 20230807055713708.deltacommit.requested
Aug  6 22:57 20230807055743816.rollback
Aug  6 22:57 20230807055743816.rollback.inflight
Aug  6 22:57 20230807055743816.rollback.requested
```
MDT timeline
```
Aug  6 22:56 00000000000000010.deltacommit.inflight
Aug  6 22:56 00000000000000010.deltacommit.requested
Aug  6 22:57 20230807055748276.restore.inflight
Aug  6 22:57 20230807055748276.restore.requested
Aug  6 22:57 20230807055749482.rollback.inflight
Aug  6 22:57 20230807055749482.rollback.requested 
```
### Impact

Bug fix to make MDT validator more robust.

The fix is tested locally and the validator does not throw the exception anymore.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
