### PR TITLE
[HUDI-6671] Support 'alter table add partition' sql

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddPartitionCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddPartitionCommand.scala
@@ -35,13 +35,12 @@ case class AlterHoodieTableAddPartitionCommand(
   extends HoodieLeafRunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val fullTableName = s"${tableIdentifier.database}.${tableIdentifier.table}"
-    logInfo(s"start execute alter table add partition command for $fullTableName")
+    logInfo(s"start execute alter table add partition command for $tableIdentifier")
 
     val hoodieCatalogTable = HoodieCatalogTable(sparkSession, tableIdentifier)
 
     if (!hoodieCatalogTable.isPartitionedTable) {
-      throw new AnalysisException(s"$fullTableName is a non-partitioned table that is not allowed to add partition")
+      throw new AnalysisException(s"$tableIdentifier is a non-partitioned table that is not allowed to add partition")
     }
 
     val catalog = sparkSession.sessionState.catalog
@@ -81,7 +80,7 @@ case class AlterHoodieTableAddPartitionCommand(
     parts.toIterator.grouped(batchSize).foreach { batch =>
       catalog.createPartitions(tableIdentifier, batch, ignoreIfExists = true)
     }
-    catalog.refreshTable(tableIdentifier)
+    sparkSession.catalog.refreshTable(tableIdentifier.unquotedString)
 
     Seq.empty[Row]
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddPartitionCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddPartitionCommand.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command
+
+import org.apache.hadoop.fs.Path
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodiePartitionMetadata
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.{CatalogTablePartition, HoodieCatalogTable}
+import org.apache.spark.sql.execution.command.DDLUtils
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{makePartitionPath, normalizePartitionSpec}
+import org.apache.spark.sql.internal.SQLConf
+
+case class AlterHoodieTableAddPartitionCommand(
+   tableIdentifier: TableIdentifier,
+   partitionSpecsAndLocs: Seq[(TablePartitionSpec, Option[String])],
+   ifNotExists: Boolean)
+  extends HoodieLeafRunnableCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val fullTableName = s"${tableIdentifier.database}.${tableIdentifier.table}"
+    logInfo(s"start execute alter table add partition command for $fullTableName")
+
+    val hoodieCatalogTable = HoodieCatalogTable(sparkSession, tableIdentifier)
+
+    if (!hoodieCatalogTable.isPartitionedTable) {
+      throw new AnalysisException(s"$fullTableName is a non-partitioned table that is not allowed to add partition")
+    }
+
+    val catalog = sparkSession.sessionState.catalog
+    val table = hoodieCatalogTable.table
+    DDLUtils.verifyAlterTableType(catalog, table, isView = false)
+
+    val normalizedSpecs: Seq[Map[String, String]] = partitionSpecsAndLocs.map { case (spec, location) =>
+      if (location.isDefined) {
+        throw new AnalysisException(s"Hoodie table does not support specify partition location explicitly")
+      }
+      normalizePartitionSpec(
+        spec,
+        hoodieCatalogTable.partitionFields,
+        hoodieCatalogTable.tableName,
+        sparkSession.sessionState.conf.resolver)
+    }
+
+    val basePath = new Path(hoodieCatalogTable.tableLocation)
+    val fileSystem = hoodieCatalogTable.metaClient.getFs
+    val instantTime = HoodieActiveTimeline.createNewInstantTime
+    val format = hoodieCatalogTable.tableConfig.getPartitionMetafileFormat
+    val (partitionMetadata, parts) = normalizedSpecs.map { spec =>
+      val partitionPath = makePartitionPath(hoodieCatalogTable, spec)
+      val fullPartitionPath: Path = FSUtils.getPartitionPath(basePath, partitionPath)
+      val metadata = if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, fullPartitionPath)) {
+        if (!ifNotExists) {
+          throw new AnalysisException(s"Partition metadata already exists for path: $fullPartitionPath")
+        }
+        None
+      } else Some(new HoodiePartitionMetadata(fileSystem, instantTime, basePath, fullPartitionPath, format))
+      (metadata, CatalogTablePartition(spec, table.storage.copy(locationUri = Some(fullPartitionPath.toUri))))
+    }.unzip
+    partitionMetadata.flatten.foreach(_.trySave(0))
+
+    // Sync new partitions in catalog, enable ignoreIfExists to avoid sync failure.
+    val batchSize = conf.getConf(SQLConf.ADD_PARTITION_BATCH_SIZE)
+    parts.toIterator.grouped(batchSize).foreach { batch =>
+      catalog.createPartitions(tableIdentifier, batch, ignoreIfExists = true)
+    }
+    catalog.refreshTable(tableIdentifier)
+
+    Seq.empty[Row]
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -518,11 +518,14 @@ case class HoodiePostAnalysisRule(sparkSession: SparkSession) extends Rule[Logic
         if sparkSession.sessionState.catalog.tableExists(tableName)
           && sparkAdapter.isHoodieTable(tableName, sparkSession) =>
         DropHoodieTableCommand(tableName, ifExists, false, purge)
+      // Rewrite the AlterTableAddPartitionCommand to AlterHoodieTableAddPartitionCommand
+      case AlterTableAddPartitionCommand(tableName, partitionSpecsAndLocs, ifNotExists)
+        if sparkAdapter.isHoodieTable(tableName, sparkSession) =>
+        AlterHoodieTableAddPartitionCommand(tableName, partitionSpecsAndLocs, ifNotExists)
       // Rewrite the AlterTableDropPartitionCommand to AlterHoodieTableDropPartitionCommand
       case AlterTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)
         if sparkAdapter.isHoodieTable(tableName, sparkSession) =>
           AlterHoodieTableDropPartitionCommand(tableName, specs, ifExists, purge, retainData)
-      // Rewrite the AlterTableRenameCommand to AlterHoodieTableRenameCommand
       // Rewrite the AlterTableAddColumnsCommand to AlterHoodieTableAddColumnsCommand
       case AlterTableAddColumnsCommand(tableId, colsToAdd)
         if sparkAdapter.isHoodieTable(tableId, sparkSession) =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableAddPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableAddPartition.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi
+
+class TestAlterTableAddPartition extends HoodieSparkSqlTestBase {
+
+  test("Add partition for non-partitioned table") {
+    val tableName = generateTableName
+    // create table
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  id bigint,
+         |  name string,
+         |  ts string,
+         |  dt string
+         | )
+         | using hudi
+         | tblproperties (
+         |  primaryKey = 'id',
+         |  preCombineField = 'ts'
+         | )
+         |""".stripMargin)
+
+    checkExceptionContain(s"alter table $tableName add partition (dt='2023-08-01')")(
+      s"$tableName is a non-partitioned table that is not allowed to add partition")
+
+    // show partitions
+    checkAnswer(s"show partitions $tableName")(Seq.empty: _*)
+  }
+
+  test("Add partition with location") {
+    val tableName = generateTableName
+    // create table
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  id bigint,
+         |  name string,
+         |  ts string,
+         |  dt string
+         | )
+         | using hudi
+         | tblproperties (
+         |  primaryKey = 'id',
+         |  preCombineField = 'ts'
+         | )
+         | partitioned by (dt)
+         |""".stripMargin)
+
+    checkExceptionContain(s"alter table $tableName add partition (dt='2023-08-01') location '/tmp/path'")(
+      "Hoodie table does not support specify partition location explicitly")
+
+    // show partitions
+    checkAnswer(s"show partitions $tableName")(Seq.empty: _*)
+  }
+
+  test("Add partition if not exists") {
+    val tableName = generateTableName
+    // create table
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  id bigint,
+         |  name string,
+         |  ts string,
+         |  dt string
+         | )
+         | using hudi
+         | tblproperties (
+         |  primaryKey = 'id',
+         |  preCombineField = 'ts'
+         | )
+         | partitioned by (dt)
+         |""".stripMargin)
+
+    spark.sql(s"alter table $tableName add partition (dt='2023-08-01')")
+    // show partitions
+    checkAnswer(s"show partitions $tableName")(Seq("dt=2023-08-01"))
+
+    // no exception
+    spark.sql(s"alter table $tableName add if not exists partition (dt='2023-08-01')")
+
+    checkExceptionContain(s"alter table $tableName add partition (dt='2023-08-01')")(
+      "Partition metadata already exists for path")
+  }
+
+  Seq(false, true).foreach { hiveStyle =>
+    test(s"Add partition for single-partition table, isHiveStylePartitioning: $hiveStyle") {
+      val tableName = generateTableName
+      // create table
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  dt string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  hoodie.datasource.write.hive_style_partitioning = '$hiveStyle'
+           | )
+           | partitioned by (dt)
+           |""".stripMargin)
+
+      spark.sql(s"alter table $tableName add partition (dt='2023-08-01')")
+
+      // show partitions
+      checkAnswer(s"show partitions $tableName")(
+        if (hiveStyle) Seq("dt=2023-08-01") else Seq("2023-08-01")
+      )
+    }
+
+    test(s"Add partition for multi-level partitioned table, isHiveStylePartitioning: $hiveStyle") {
+      val tableName = generateTableName
+      // create table
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  year string,
+           |  month string,
+           |  day string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  hoodie.datasource.write.hive_style_partitioning = '$hiveStyle'
+           | )
+           | partitioned by (year, month, day)
+           |""".stripMargin)
+
+      spark.sql(s"alter table $tableName add partition (year='2023', month='08', day='01')")
+
+      // show partitions
+      checkAnswer(s"show partitions $tableName")(
+        if (hiveStyle) Seq("year=2023/month=08/day=01") else Seq("2023/08/01")
+      )
+    }
+  }
+
+  Seq(false, true).foreach { urlEncode =>
+    test(s"Add partition for single-partition table, urlEncode: $urlEncode") {
+      val tableName = generateTableName
+      // create table
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  p_a string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  hoodie.datasource.write.partitionpath.urlencode = '$urlEncode'
+           | )
+           | partitioned by (p_a)
+           |""".stripMargin)
+
+      spark.sql(s"alter table $tableName add partition (p_a='url%a')")
+
+      // show partitions
+      checkAnswer(s"show partitions $tableName")(
+        if (urlEncode) Seq("p_a=url%25a") else Seq("p_a=url%a")
+      )
+    }
+
+    test(s"Add partition for multi-level partitioned table, urlEncode: $urlEncode") {
+      val tableName = generateTableName
+      // create table
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  p_a string,
+           |  p_b string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  hoodie.datasource.write.partitionpath.urlencode = '$urlEncode'
+           | )
+           | partitioned by (p_a, p_b)
+           |""".stripMargin)
+
+      spark.sql(s"alter table $tableName add partition (p_a='url%a', p_b='key=val')")
+
+      // show partitions
+      checkAnswer(s"show partitions $tableName")(
+        if (urlEncode) Seq("p_a=url%25a/p_b=key%3Dval") else Seq("p_a=url%a/p_b=key=val")
+      )
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs
Hoodie does not support 'add partition' sql now, so we can not get partitions added by 'add partition' command.
In this patch, we implement add partition in Hoodie side:
1. add new command `AlterHoodieTableAddPartitionCommand`
2. add new unit test `TestAlterTableAddPartition`


### Impact
No

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
