### PR TITLE
[HUDI-6663] New Parquet File Format remove broadcast to fix performance issue for complex file slices

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/NewHoodieParquetFileFormatUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/NewHoodieParquetFileFormatUtils.scala
@@ -198,7 +198,7 @@ class NewHoodieParquetFileFormatUtils(val sqlContext: SQLContext,
     } else {
       Seq.empty
     }
-    fileIndex.shouldBroadcast = true
+    fileIndex.shouldEmbedFileSlices = true
     HadoopFsRelation(
       location = fileIndex,
       partitionSchema = fileIndex.partitionSchema,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionFileSliceMapping.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionFileSliceMapping.scala
@@ -20,17 +20,16 @@
 package org.apache.hudi
 
 import org.apache.hudi.common.model.FileSlice
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types.{DataType, Decimal}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class PartitionFileSliceMapping(internalRow: InternalRow,
-                                broadcast: Broadcast[Map[String, FileSlice]]) extends InternalRow {
+                                slices: Map[String, FileSlice]) extends InternalRow {
 
   def getSlice(fileId: String): Option[FileSlice] = {
-    broadcast.value.get(fileId)
+    slices.get(fileId)
   }
 
   def getInternalRow: InternalRow = internalRow
@@ -41,7 +40,7 @@ class PartitionFileSliceMapping(internalRow: InternalRow,
 
   override def update(i: Int, value: Any): Unit = internalRow.update(i, value)
 
-  override def copy(): InternalRow = new PartitionFileSliceMapping(internalRow.copy(), broadcast)
+  override def copy(): InternalRow = new PartitionFileSliceMapping(internalRow.copy(), slices)
 
   override def isNullAt(ordinal: Int): Boolean = internalRow.isNullAt(ordinal)
 


### PR DESCRIPTION
### Change Logs

Remove the broadcast when sending the file slices.

### Impact

1 TB tpcds bootstrap queries 1-14 performance gap between new file format and fast bootstrap went from 2.23x to 1.01x. Similar performance gains expected for MOR table where many file slices have log files


### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
