### PR TITLE
[HUDI-6674] Add rollback info from metadata table in timeline commands

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieTableHeaderFields.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieTableHeaderFields.java
@@ -180,7 +180,6 @@ public class HoodieTableHeaderFields {
   public static final String HEADER_REQUESTED_TIME = "Requested\nTime";
   public static final String HEADER_INFLIGHT_TIME = "Inflight\nTime";
   public static final String HEADER_COMPLETED_TIME = "Completed\nTime";
-  public static final String HEADER_ROLLBACK_INFO = "Rollback Info";
   public static final String HEADER_MT_PREFIX = "MT\n";
   public static final String HEADER_MT_ACTION = HEADER_MT_PREFIX + HEADER_ACTION;
   public static final String HEADER_MT_STATE = HEADER_MT_PREFIX + HEADER_STATE;


### PR DESCRIPTION
### Change Logs

This PR adds the rollback information from the metadata table to the output of the timeline commands in Hudi CLI, given that metadata data table also encounters more rollbacks now.  To make the table concise, the rollback information is added to the "Action" (for data table) or "MT Action" (for metadata table) column, instead of having an independent column showing the information.

Here's the new output:
```
hudi:hoodie_table->timeline show active --limit 200 --show-time-seconds --show-rollback-info
╔═════╤═══════════════════╤═══════════════════╤═══════════╤════════════════╤════════════════╤════════════════╗
║ No. │ Instant           │ Action            │ State     │ Requested      │ Inflight       │ Completed      ║
║     │                   │                   │           │ Time           │ Time           │ Time           ║
╠═════╪═══════════════════╪═══════════════════╪═══════════╪════════════════╪════════════════╪════════════════╣
...
╟─────┼───────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 11  │ 20230807154601569 │ rollback          │ COMPLETED │ 08-07 08:46:03 │ 08-07 08:46:03 │ 08-07 08:47:58 ║
║     │                   │ Rolls back        │           │                │                │                ║
║     │                   │ 20230807154346625 │           │                │                │                ║
╟─────┼───────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 12  │ 20230807154947753 │ rollback          │ COMPLETED │ 08-07 08:49:49 │ 08-07 08:49:49 │ 08-07 08:51:46 ║
║     │                   │ Rolls back        │           │                │                │                ║
║     │                   │ 20230807154720087 │           │                │                │                ║
╟─────┼───────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 13  │ 20230807155105131 │ commit            │ COMPLETED │ 08-07 08:51:47 │ 08-07 08:54:29 │ 08-07 08:55:42 ║
╟─────┼───────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
...
hudi:hoodie_table->timeline show active --with-metadata-table --limit 200 --show-time-seconds
╔═════╤══════════════════════╤═══════════════════╤═══════════╤════════════════╤════════════════╤════════════════╤══════════════════════╤═══════════╤════════════════╤════════════════╤════════════════╗
║ No. │ Instant              │ Action            │ State     │ Requested      │ Inflight       │ Completed      │ MT                   │ MT        │ MT             │ MT             │ MT             ║
║     │                      │                   │           │ Time           │ Time           │ Time           │ Action               │ State     │ Requested      │ Inflight       │ Completed      ║
║     │                      │                   │           │                │                │                │                      │           │ Time           │ Time           │ Time           ║
╠═════╪══════════════════════╪═══════════════════╪═══════════╪════════════════╪════════════════╪════════════════╪══════════════════════╪═══════════╪════════════════╪════════════════╪════════════════╣
...
╟─────┼──────────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────┼──────────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 66  │ 20230807155157772    │ -                 │ -         │ -              │ -              │ -              │ rollback             │ COMPLETED │ 08-07 08:51:59 │ 08-07 08:52:00 │ 08-07 08:52:01 ║
║     │                      │                   │           │                │                │                │ Rolls back           │           │                │                │                ║
║     │                      │                   │           │                │                │                │ 20230807154406919    │           │                │                │                ║
╟─────┼──────────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────┼──────────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 67  │ 20230807155547486    │ commit            │ INFLIGHT  │ 08-07 08:56:06 │ 08-07 08:58:27 │ -              │ -                    │ -         │ -              │ -              │ -              ║
║     │                      │ Rolled back by    │           │                │                │                │                      │           │                │                │                ║
║     │                      │ 20230807160141230 │           │                │                │                │                      │           │                │                │                ║
╟─────┼──────────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────┼──────────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 68  │ 20230807155616690    │ clean             │ COMPLETED │ 08-07 08:56:19 │ 08-07 08:56:19 │ 08-07 08:56:25 │ deltacommit          │ COMPLETED │ 08-07 08:56:21 │ 08-07 08:56:22 │ 08-07 08:56:24 ║
╟─────┼──────────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────┼──────────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 69  │ 20230807160141230    │ rollback          │ INFLIGHT  │ 08-07 09:01:44 │ 08-07 09:01:44 │ -              │ deltacommit          │ COMPLETED │ 08-07 09:01:46 │ 08-07 09:01:47 │ 08-07 09:01:50 ║
║     │                      │ Rolls back        │           │                │                │                │                      │           │                │                │                ║
║     │                      │ 20230807155547486 │           │                │                │                │                      │           │                │                │                ║
╟─────┼──────────────────────┼───────────────────┼───────────┼────────────────┼────────────────┼────────────────┼──────────────────────┼───────────┼────────────────┼────────────────┼────────────────╢
...
```

compared to previous output:
```
hudi:hoodie_table->timeline show active --limit 200 --show-time-seconds --show-rollback-info
╔═════╤═══════════════════╤══════════╤═══════════╤═══════════════════╤════════════════╤════════════════╤════════════════╗
║ No. │ Instant           │ Action   │ State     │ Rollback Info     │ Requested      │ Inflight       │ Completed      ║
║     │                   │          │           │                   │ Time           │ Time           │ Time           ║
╠═════╪═══════════════════╪══════════╪═══════════╪═══════════════════╪════════════════╪════════════════╪════════════════╣
...
╟─────┼───────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────╢
║ 11  │ 20230807154601569 │ rollback │ COMPLETED │ Rolls back        │ 08-07 08:46:03 │ 08-07 08:46:03 │ 08-07 08:47:58 ║
║     │                   │          │           │ 20230807154346625 │                │                │                ║
╟─────┼───────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────╢
║ 12  │ 20230807154947753 │ rollback │ COMPLETED │ Rolls back        │ 08-07 08:49:49 │ 08-07 08:49:49 │ 08-07 08:51:46 ║
║     │                   │          │           │ 20230807154720087 │                │                │                ║
╟─────┼───────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────╢
║ 13  │ 20230807155105131 │ commit   │ COMPLETED │ -                 │ 08-07 08:51:47 │ 08-07 08:54:29 │ 08-07 08:55:42 ║
╟─────┼───────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────╢
...
hudi:hoodie_table->timeline show active --with-metadata-table --limit 200 --show-time-seconds
╔═════╤══════════════════════╤══════════╤═══════════╤═══════════════════╤════════════════╤════════════════╤════════════════╤═════════════╤═══════════╤════════════════╤════════════════╤════════════════╗
║ No. │ Instant              │ Action   │ State     │ Rollback Info     │ Requested      │ Inflight       │ Completed      │ MT          │ MT        │ MT             │ MT             │ MT             ║
║     │                      │          │           │                   │ Time           │ Time           │ Time           │ Action      │ State     │ Requested      │ Inflight       │ Completed      ║
║     │                      │          │           │                   │                │                │                │             │           │ Time           │ Time           │ Time           ║
╠═════╪══════════════════════╪══════════╪═══════════╪═══════════════════╪════════════════╪════════════════╪════════════════╪═════════════╪═══════════╪════════════════╪════════════════╪════════════════╣
...
╟─────┼──────────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────┼─────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 66  │ 20230807155157772    │ -        │ -         │ -                 │ -              │ -              │ -              │ rollback    │ COMPLETED │ 08-07 08:51:59 │ 08-07 08:52:00 │ 08-07 08:52:01 ║
╟─────┼──────────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────┼─────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 67  │ 20230807155547486    │ commit   │ INFLIGHT  │ Rolled back by    │ 08-07 08:56:06 │ 08-07 08:58:27 │ -              │ -           │ -         │ -              │ -              │ -              ║
║     │                      │          │           │ 20230807160141230 │                │                │                │             │           │                │                │                ║
╟─────┼──────────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────┼─────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 68  │ 20230807155616690    │ clean    │ COMPLETED │ -                 │ 08-07 08:56:19 │ 08-07 08:56:19 │ 08-07 08:56:25 │ deltacommit │ COMPLETED │ 08-07 08:56:21 │ 08-07 08:56:22 │ 08-07 08:56:24 ║
╟─────┼──────────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────┼─────────────┼───────────┼────────────────┼────────────────┼────────────────╢
║ 69  │ 20230807160141230    │ rollback │ INFLIGHT  │ Rolls back        │ 08-07 09:01:44 │ 08-07 09:01:44 │ -              │ deltacommit │ COMPLETED │ 08-07 09:01:46 │ 08-07 09:01:47 │ 08-07 09:01:50 ║
║     │                      │          │           │ 20230807155547486 │                │                │                │             │           │                │                │                ║
╟─────┼──────────────────────┼──────────┼───────────┼───────────────────┼────────────────┼────────────────┼────────────────┼─────────────┼───────────┼────────────────┼────────────────┼────────────────╢
...
```

### Impact

Surfaces rollback information from the metadata table as well and make it easier to read the output.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
