### PR TITLE
[HUDI-6677] Make HoodieRecordIndexInfo schema compatible with older versions

### DIFF
--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -369,7 +369,7 @@
                    "name": "HoodieRecordIndexInfo",
                     "fields": [
                         {
-                            "name": "partitionName",
+                            "name": "partition",
                             "type": [
                                 "null",
                                 "string"
@@ -405,15 +405,6 @@
                             "doc": "Index representing file index which is used to re-construct UUID based fileID. Applicable when the fileId is based on UUID format. \nA UUID based fileId is stored as 3 pieces in RLI (fileIdHighBits, fileIdLowBits and fileIndex). \nFileID format is {UUID}-{fileIndex}."
                         },
                         {
-                           "name": "fileId",
-                           "type": [
-                               "null",
-                               "string"
-                            ],
-                            "default" : null,
-                            "doc": "Represents fileId of the location where record belongs to. When the encoding is 1, fileID is stored in raw string format."
-                           },
-                        {
                             "name": "instantTime",
                             "type": [
                                 "null",
@@ -428,6 +419,15 @@
                             "type": "int",
                             "default" : 0,
                             "doc": "Represents fileId encoding. Possible values are 0 and 1. O represents UUID based fileID, and 1 represents raw string format of the fileId. \nWhen the encoding is 0, reader can deduce fileID from fileIdLowBits, fileIdLowBits and fileIndex."
+                       },
+                       {
+                            "name": "fileId",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "default" : null,
+                            "doc": "Represents fileId of the location where record belongs to. When the encoding is 1, fileID is stored in raw string format."
                        }
                     ]
                 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -145,7 +145,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   /**
    * HoodieMetadata record index payload field ids
    */
-  public static final String RECORD_INDEX_FIELD_PARTITION = "partitionName";
+  public static final String RECORD_INDEX_FIELD_PARTITION = "partition";
   public static final String RECORD_INDEX_FIELD_FILEID_HIGH_BITS = "fileIdHighBits";
   public static final String RECORD_INDEX_FIELD_FILEID_LOW_BITS = "fileIdLowBits";
   public static final String RECORD_INDEX_FIELD_FILE_INDEX = "fileIndex";
@@ -256,9 +256,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_HIGH_BITS).toString()),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_LOW_BITS).toString()),
             Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILE_INDEX).toString()),
-            recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID).toString(),
             Long.parseLong(recordIndexRecord.get(RECORD_INDEX_FIELD_INSTANT_TIME).toString()),
-            Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_ENCODING).toString()));
+            Integer.parseInt(recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID_ENCODING).toString()),
+            recordIndexRecord.get(RECORD_INDEX_FIELD_FILEID).toString());
       }
     } else {
       this.isDeletedRecord = true;
@@ -729,9 +729,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               uuid.getMostSignificantBits(),
               uuid.getLeastSignificantBits(),
               fileIndex,
-              "",
               instantTimeMillis,
-              0));
+              0,
+              ""));
       return new HoodieAvroRecord<>(key, payload);
     } else {
       HoodieMetadataPayload payload = new HoodieMetadataPayload(recordKey,
@@ -740,9 +740,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               -1L,
               -1L,
               -1,
-              fileId,
               instantTimeMillis,
-              1));
+              1,
+              fileId));
       return new HoodieAvroRecord<>(key, payload);
     }
   }
@@ -761,7 +761,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    * If this is a record-level index entry, returns the file to which this is mapped.
    */
   public HoodieRecordGlobalLocation getRecordGlobalLocation() {
-    final String partition = recordIndexMetadata.getPartitionName();
+    final String partition = recordIndexMetadata.getPartition();
     String fileId = null;
     if (recordIndexMetadata.getFileIdEncoding() == 0) {
       // encoding 0 refers to UUID based fileID


### PR DESCRIPTION
### Change Logs

Currently the metadata payload schema for record index can cause schema evolution issues for existing hudi tables. The Jira aims to fix these issues. There are two schema evolution issues -:
1. The field name has changed from partition to partitionName.
2. Also we have added a new field fileId in between a nested schema.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
