### PR TITLE
[HUDI-6680] - Fixing the info log to fetch column value by name instead of index

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/IncrSourceHelper.java
@@ -217,7 +217,7 @@ public class IncrSourceHelper {
       row = collectedRows.select(queryInfo.getOrderColumn(), queryInfo.getKeyColumn(), CUMULATIVE_COLUMN_NAME).orderBy(
           col(queryInfo.getOrderColumn()).desc(), col(queryInfo.getKeyColumn()).desc()).first();
     }
-    LOG.info("Processed batch size: " + row.getLong(2) + " bytes");
+    LOG.info("Processed batch size: " + row.get(row.fieldIndex(CUMULATIVE_COLUMN_NAME)) + " bytes");
     sourceData.unpersist();
     return Pair.of(new CloudObjectIncrCheckpoint(row.getString(0), row.getString(1)), collectedRows);
   }


### PR DESCRIPTION
### Change Logs

Fixing the log statement to fetch column value by name instead of index. We found spark sometimes infers the cumulative column as double and hence results in class cast exception. 

### Impact

low

### Risk level (write none, low medium or high below)

low

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] CI passed
