### PR TITLE
[MINOR] Increase CI timeout for UT FT other modules to 4 hours

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -188,7 +188,7 @@ stages:
             displayName: Top 100 long-running testcases
       - job: UT_FT_4
         displayName: UT FT other modules
-        timeoutInMinutes: '180'
+        timeoutInMinutes: '240'
         steps:
           - task: Maven@4
             displayName: maven install


### PR DESCRIPTION
### Change Logs

UT FT other modules consistenly taking more than 3 hours. HUDI-6682 to track better redistribution of tests.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
