### PR TITLE
[HUDI-6685] Fix code typo in pyspark 'Insert Overwrite' section of Quick Start Guide.

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -1511,11 +1511,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \

--- a/website/versioned_docs/version-0.12.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.0/quick-start-guide.md
@@ -1443,11 +1443,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \

--- a/website/versioned_docs/version-0.12.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.1/quick-start-guide.md
@@ -1443,11 +1443,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \

--- a/website/versioned_docs/version-0.12.2/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.2/quick-start-guide.md
@@ -1475,11 +1475,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \

--- a/website/versioned_docs/version-0.12.3/quick-start-guide.md
+++ b/website/versioned_docs/version-0.12.3/quick-start-guide.md
@@ -1475,11 +1475,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \

--- a/website/versioned_docs/version-0.13.0/quick-start-guide.md
+++ b/website/versioned_docs/version-0.13.0/quick-start-guide.md
@@ -1474,11 +1474,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \

--- a/website/versioned_docs/version-0.13.1/quick-start-guide.md
+++ b/website/versioned_docs/version-0.13.1/quick-start-guide.md
@@ -1474,11 +1474,11 @@ spark.
 
 ```python
 # pyspark
-self.spark.read.format("hudi"). \
+spark.read.format("hudi"). \
     load(basePath). \
     select(["uuid", "partitionpath"]). \
     sort(["partitionpath", "uuid"]). \
-    show(n=100, truncate=False) \
+    show(n=100, truncate=False)
     
 inserts = sc._jvm.org.apache.hudi.QuickstartUtils.convertToStringList(dataGen.generateInserts(10)) 
 df = spark.read.json(spark.sparkContext.parallelize(inserts, 2)). \


### PR DESCRIPTION
Fix code typo in pyspark 'Insert Overwrite' section of Quick Start Guide.

### Change Logs

Fix code typo in pyspark 'Insert Overwrite' section of Quick Start Guide.

### Impact

Minor fix to code example.

### Risk level (write none, low medium or high below)

Low

### Documentation Update

Fix code typo in pyspark 'Insert Overwrite' section of Quick Start Guide.

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Change Logs and Impact were stated clearly
- [X] Adequate tests were added if applicable
- [X] CI passed
