### PR TITLE
[HUDI-6689] Add record index validation in MDT validator

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -158,7 +158,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   /**
    * FileIndex value saved in record index record when the fileId has no index (old format of base filename)
    */
-  private static final int RECORD_INDEX_MISSING_FILEINDEX_FALLBACK = -1;
+  public static final int RECORD_INDEX_MISSING_FILEINDEX_FALLBACK = -1;
 
   /**
    * NOTE: PLEASE READ CAREFULLY
@@ -761,22 +761,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    * If this is a record-level index entry, returns the file to which this is mapped.
    */
   public HoodieRecordGlobalLocation getRecordGlobalLocation() {
-    final String partition = recordIndexMetadata.getPartitionName();
-    String fileId = null;
-    if (recordIndexMetadata.getFileIdEncoding() == 0) {
-      // encoding 0 refers to UUID based fileID
-      final UUID uuid = new UUID(recordIndexMetadata.getFileIdHighBits(), recordIndexMetadata.getFileIdLowBits());
-      fileId = uuid.toString();
-      if (recordIndexMetadata.getFileIndex() != RECORD_INDEX_MISSING_FILEINDEX_FALLBACK) {
-        fileId += "-" + recordIndexMetadata.getFileIndex();
-      }
-    } else {
-      // encoding 1 refers to no encoding. fileID as is.
-      fileId = recordIndexMetadata.getFileId();
-    }
-
-    final java.util.Date instantDate = new java.util.Date(recordIndexMetadata.getInstantTime());
-    return new HoodieRecordGlobalLocation(partition, HoodieActiveTimeline.formatDate(instantDate), fileId);
+    return HoodieTableMetadataUtil.getLocationFromRecordIndexInfo(recordIndexMetadata);
   }
 
   public boolean isDeleted() {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1650,21 +1650,30 @@ public class HoodieTableMetadataUtil {
    * @return
    */
   public static HoodieRecordGlobalLocation getLocationFromRecordIndexInfo(HoodieRecordIndexInfo recordIndexInfo) {
-    final String partition = recordIndexInfo.getPartitionName();
+    return getLocationFromRecordIndexInfo(
+        recordIndexInfo.getPartitionName(), recordIndexInfo.getFileIdEncoding(),
+        recordIndexInfo.getFileIdHighBits(), recordIndexInfo.getFileIdLowBits(),
+        recordIndexInfo.getFileIndex(), recordIndexInfo.getFileId(),
+        recordIndexInfo.getInstantTime());
+  }
+
+  public static HoodieRecordGlobalLocation getLocationFromRecordIndexInfo(
+      String partition, int fileIdEncoding, long fileIdHighBits, long fileIdLowBits,
+      int fileIndex, String originalFileId, Long instantTime) {
     String fileId = null;
-    if (recordIndexInfo.getFileIdEncoding() == 0) {
+    if (fileIdEncoding == 0) {
       // encoding 0 refers to UUID based fileID
-      final UUID uuid = new UUID(recordIndexInfo.getFileIdHighBits(), recordIndexInfo.getFileIdLowBits());
+      final UUID uuid = new UUID(fileIdHighBits, fileIdLowBits);
       fileId = uuid.toString();
-      if (recordIndexInfo.getFileIndex() != RECORD_INDEX_MISSING_FILEINDEX_FALLBACK) {
-        fileId += "-" + recordIndexInfo.getFileIndex();
+      if (fileIndex != RECORD_INDEX_MISSING_FILEINDEX_FALLBACK) {
+        fileId += "-" + fileIndex;
       }
     } else {
       // encoding 1 refers to no encoding. fileID as is.
-      fileId = recordIndexInfo.getFileId();
+      fileId = originalFileId;
     }
 
-    final java.util.Date instantDate = new java.util.Date(recordIndexInfo.getInstantTime());
+    final java.util.Date instantDate = new java.util.Date(instantTime);
     return new HoodieRecordGlobalLocation(partition, HoodieActiveTimeline.formatDate(instantDate), fileId);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1646,8 +1646,10 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
-   * @param recordIndexInfo
-   * @return
+   * Gets the location from record index content.
+   *
+   * @param recordIndexInfo {@link HoodieRecordIndexInfo} instance.
+   * @return {@link HoodieRecordGlobalLocation} containing the location.
    */
   public static HoodieRecordGlobalLocation getLocationFromRecordIndexInfo(HoodieRecordIndexInfo recordIndexInfo) {
     return getLocationFromRecordIndexInfo(
@@ -1657,6 +1659,23 @@ public class HoodieTableMetadataUtil {
         recordIndexInfo.getInstantTime());
   }
 
+  /**
+   * Gets the location from record index content.
+   * Note that, a UUID based fileId is stored as 3 pieces in record index (fileIdHighBits,
+   * fileIdLowBits and fileIndex). FileID format is {UUID}-{fileIndex}.
+   * The arguments are consistent with what {@link HoodieRecordIndexInfo} contains.
+   *
+   * @param partition      The partition name the record belongs to.
+   * @param fileIdEncoding FileId encoding. Possible values are 0 and 1. O represents UUID based
+   *                       fileID, and 1 represents raw string format of the fileId.
+   * @param fileIdHighBits High 64 bits if the fileId is based on UUID format.
+   * @param fileIdLowBits  Low 64 bits if the fileId is based on UUID format.
+   * @param fileIndex      Index representing file index which is used to re-construct UUID based fileID.
+   * @param originalFileId FileId of the location where record belongs to.
+   *                       When the encoding is 1, fileID is stored in raw string format.
+   * @param instantTime    Epoch time in millisecond representing the commit time at which record was added.
+   * @return {@link HoodieRecordGlobalLocation} containing the location.
+   */
   public static HoodieRecordGlobalLocation getLocationFromRecordIndexInfo(
       String partition, int fileIdEncoding, long fileIdHighBits, long fileIdLowBits,
       int fileIndex, String originalFileId, Long instantTime) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -208,6 +208,12 @@ public class HoodieMetadataTableValidator implements Serializable {
     if (cfg.validateBloomFilters) {
       labelList.add("validate-bloom-filters");
     }
+    if (cfg.validateRecordIndexCount) {
+      labelList.add("validate-record-index-count");
+    }
+    if (cfg.validateRecordIndexContent) {
+      labelList.add("validate-record-index-content");
+    }
     return String.join(",", labelList);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -107,12 +107,16 @@ import static org.apache.hudi.metadata.HoodieTableMetadata.getMetadataTableBaseP
  * A validator with spark-submit to compare information, such as partitions, file listing, index, etc.,
  * between metadata table and filesystem.
  * <p>
- * There are five validation tasks, that can be enabled independently through the following CLI options:
+ * There are seven validation tasks, that can be enabled independently through the following CLI options:
  * - `--validate-latest-file-slices`: validate the latest file slices for all partitions.
  * - `--validate-latest-base-files`: validate the latest base files for all partitions.
  * - `--validate-all-file-groups`: validate all file groups, and all file slices within file groups.
  * - `--validate-all-column-stats`: validate column stats for all columns in the schema
  * - `--validate-bloom-filters`: validate bloom filters of base files
+ * - `--validate-record-index-count`: validate the number of entries in the record index, which
+ * should be equal to the number of record keys in the latest snapshot of the table.
+ * - `--validate-record-index-content`: validate the content of the record index so that each
+ * record key should have the correct location, and there is no additional or missing entry.
  * <p>
  * If the Hudi table is on the local file system, the base path passed to `--base-path` must have
  * "file:" prefix to avoid validation failure.
@@ -245,10 +249,16 @@ public class HoodieMetadataTableValidator implements Serializable {
     @Parameter(names = {"--validate-bloom-filters"}, description = "Validate bloom filters of base files", required = false)
     public boolean validateBloomFilters = false;
 
-    @Parameter(names = {"--validate-record-index-count"}, description = "Validate count of record index", required = false)
+    @Parameter(names = {"--validate-record-index-count"},
+        description = "Validate the number of entries in the record index, which should be equal "
+            + "to the number of record keys in the latest snapshot of the table",
+        required = false)
     public boolean validateRecordIndexCount = false;
 
-    @Parameter(names = {"--validate-record-index-content"}, description = "Validate record index content, i.e., record location", required = false)
+    @Parameter(names = {"--validate-record-index-content"},
+        description = "Validate the content of the record index so that each record key should "
+            + "have the correct location, and there is no additional or missing entry",
+        required = false)
     public boolean validateRecordIndexContent = false;
 
     @Parameter(names = {"--min-validate-interval-seconds"},


### PR DESCRIPTION
### Change Logs

This PR adds the validation of record index in MDT validator (`HoodieMetadataTableValidator`).  The following validation modes are added:
- Record index count validation (with CLI config `--validate-record-index-count`): validate the number of entries in the record index, which should be equal to the number of record keys in the latest snapshot of the table.
- Record index content validation (with CLI config `--validate-record-index-content`): validate the content of the record index so that each record key should have the correct location, and there is no additional or missing entry.  Two more configs are added for this mode: (1) `--num-record-index-error-samples`: number of error samples to show for record index validation when there are mismatches, (2) `--record-index-parallelism`: parallelism for joining record index entries with data table entries in the validation.

The new validation modes are tested on both correct and corrupted record index in MDT.  Here's the example message when the validation of record index content fails, showing the number of record keys that have mismatches and sample mismatches:
```
23/08/14 19:09:32 WARN HoodieMetadataTableValidator: Error closing HoodieMetadataValidationContext, ignoring the error as the validation is successful.
org.apache.hudi.exception.HoodieValidationException: Validation of record index content failed: 317900 keys (total 51082420) from the data table have wrong location in record index metadata. Sample mismatches: FS: <empty>, Record Index: (2023/07/03,4770cc2d-f984-4a89-ace0-e8ff8a8cdcaa-0);FS: <empty>, Record Index: (2023/07/03,4770cc2d-f984-4a89-ace0-e8ff8a8cdcaa-0);FS: <empty>, Record Index: (2023/07/03,4770cc2d-f984-4a89-ace0-e8ff8a8cdcaa-0);FS: <empty>, Record Index: (2023/07/03,4770cc2d-f984-4a89-ace0-e8ff8a8cdcaa-0);FS: <empty>, Record Index: (2023/07/03,4770cc2d-f984-4a89-ace0-e8ff8a8cdcaa-0);FS: <empty>, Record Index: (2023/07/03,4770cc2d-f984-4a89-ace0-e8ff8a8cdcaa-0)...
```

### Impact

Users can now validate the record index easily using the MDT validator.

### Risk level

none

### Documentation Update

Update the docs on MDT validator.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
