### PR TITLE
[MINOR] Infer the preCombine field only if the value is not null

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
@@ -128,7 +128,9 @@ public class CompactionUtil {
    */
   public static void setPreCombineField(Configuration conf, HoodieTableMetaClient metaClient) {
     String preCombineField = metaClient.getTableConfig().getPreCombineField();
-    conf.setString(FlinkOptions.PRECOMBINE_FIELD, preCombineField);
+    if (preCombineField != null) {
+      conf.setString(FlinkOptions.PRECOMBINE_FIELD, preCombineField);
+    }
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Table created by Spark may not have the preCombine field set up.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
