### PR TITLE
[MINOR] MergeOnReadInputFormat supports to emit delete for batch input format

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -384,7 +384,7 @@ public class HoodieTableSource implements
               return InputFormats.EMPTY_INPUT_FORMAT;
             }
             return mergeOnReadInputFormat(rowType, requiredRowType, tableAvroSchema,
-                rowDataType, inputSplits, false);
+                rowDataType, inputSplits, true);
           case COPY_ON_WRITE:
             return baseFileOnlyInputFormat();
           default:
@@ -410,7 +410,7 @@ public class HoodieTableSource implements
           return cdcInputFormat(rowType, requiredRowType, tableAvroSchema, rowDataType, result.getInputSplits());
         } else {
           return mergeOnReadInputFormat(rowType, requiredRowType, tableAvroSchema,
-              rowDataType, result.getInputSplits(), false);
+              rowDataType, result.getInputSplits(), true);
         }
       default:
         String errMsg = String.format("Invalid query type : '%s', options ['%s', '%s', '%s'] are supported now", queryType,


### PR DESCRIPTION
### Change Logs

`MergeOnReadInputFormat` could support to emit delete for batch input format.

### Impact

`MergeOnReadInputFormat` emits delete for batch input format.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed