### PR TITLE
[MINOR] Rename kafka record value variable in JsonKafkaSource and replace casting to String by calling toStrin

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/JsonKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/JsonKafkaSource.java
@@ -80,17 +80,17 @@ public class JsonKafkaSource extends KafkaSource<String> {
         List<String> stringList = new LinkedList<>();
         ObjectMapper om = new ObjectMapper();
         partitionIterator.forEachRemaining(consumerRecord -> {
-          String record = consumerRecord.value().toString();
-          String recordKey = (String) consumerRecord.key();
+          String recordValue = consumerRecord.value().toString();
+          String recordKey = consumerRecord.key().toString();
           try {
-            ObjectNode jsonNode = (ObjectNode) om.readTree(record);
+            ObjectNode jsonNode = (ObjectNode) om.readTree(recordValue);
             jsonNode.put(KAFKA_SOURCE_OFFSET_COLUMN, consumerRecord.offset());
             jsonNode.put(KAFKA_SOURCE_PARTITION_COLUMN, consumerRecord.partition());
             jsonNode.put(KAFKA_SOURCE_TIMESTAMP_COLUMN, consumerRecord.timestamp());
             jsonNode.put(KAFKA_SOURCE_KEY_COLUMN, recordKey);
             stringList.add(om.writeValueAsString(jsonNode));
           } catch (Throwable e) {
-            stringList.add(record);
+            stringList.add(recordValue);
           }
         });
         return stringList.iterator();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroConvertor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/AvroConvertor.java
@@ -180,7 +180,7 @@ public class AvroConvertor implements Serializable {
     recordBuilder.set(KAFKA_SOURCE_OFFSET_COLUMN, consumerRecord.offset());
     recordBuilder.set(KAFKA_SOURCE_PARTITION_COLUMN, consumerRecord.partition());
     recordBuilder.set(KAFKA_SOURCE_TIMESTAMP_COLUMN, consumerRecord.timestamp());
-    recordBuilder.set(KAFKA_SOURCE_KEY_COLUMN, String.valueOf(consumerRecord.key()));
+    recordBuilder.set(KAFKA_SOURCE_KEY_COLUMN, consumerRecord.key().toString());
     return recordBuilder.build();
   }
 


### PR DESCRIPTION
### Change Logs

This PR update the variable `record` name to `recordValue` to make the code more readable, and replace the cast to string and the usage of `String.valueOf` by `toString`.

related: #9403

### Impact

_Describe any public API or user-facing feature change or any performance impact: NA

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks: None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change: None

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
