### PR TITLE
[HUDI-6703] StreamWriteOperatorCoordinator should refresh the last txn metadata firstly for recommit

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -51,6 +51,7 @@ import org.apache.hudi.table.upgrade.UpgradeDowngrade;
 import org.apache.hudi.util.WriteStatMerger;
 
 import com.codahale.metrics.Timer;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -61,6 +62,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -498,6 +500,11 @@ public class HoodieFlinkWriteClient<T> extends
   private List<String> getAllExistingFileIds(HoodieFlinkTable<T> table, String partitionPath) {
     // because new commit is not complete. it is safe to mark all existing file Ids as old files
     return table.getSliceView().getLatestFileSlices(partitionPath).map(FileSlice::getFileId).distinct().collect(Collectors.toList());
+  }
+
+  @VisibleForTesting
+  public Set<String> getPendingInflightAndRequestedInstants() {
+    return pendingInflightAndRequestedInstants;
   }
 
   private final class AutoCloseableWriteHandle implements AutoCloseable {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -416,6 +416,8 @@ public class StreamWriteOperatorCoordinator
         if (writeClient.getConfig().getFailedWritesCleanPolicy().isLazy()) {
           writeClient.getHeartbeatClient().start(instant);
         }
+        // Recommit should refresh the last txn metadata firstly to prepare resolution of write conflict.
+        this.writeClient.preTxn(this.metaClient);
         commitInstant(instant);
       }
       // starts a new instant


### PR DESCRIPTION
### Change Logs

`StreamWriteOperatorCoordinator` should refresh the last txn metadata firstly to prepare resolution of write conflict for recommit. Otherwise `HoodieFlinkWriteClient#preCommit` could not resolve write conflict with empty `pendingInflightAndRequestedInstants`.

### Impact

`StreamWriteOperatorCoordinator` refreshes the last txn metadata firstly to prepare resolution of write conflict for recommit.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed