### PR TITLE
[MINOR] Fix sql core flow test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
@@ -19,7 +19,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE_INCREMENTAL_OPT_VAL, QUERY_TYPE_READ_OPTIMIZED_OPT_VAL}
+import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, QUERY_TYPE_SNAPSHOT_OPT_VAL}
 import org.apache.hudi.HoodieDataSourceHelpers.{hasNewCommits, latestCommit, listCommitsSince}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.fs.FSUtils
@@ -185,8 +185,8 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
 
   def doSnapshotRead(tableName: String, isMetadataEnabledOnRead: Boolean): sql.DataFrame = {
     try {
-      spark.sql("set hoodie.datasource.query.type=\"snapshot\"")
-      spark.sql(s"set hoodie.metadata.enable=${String.valueOf(isMetadataEnabledOnRead)}")
+      spark.sql(s"set hoodie.datasource.query.type=$QUERY_TYPE_SNAPSHOT_OPT_VAL")
+      spark.sql(s"set hoodie.metadata.enable=$isMetadataEnabledOnRead")
       spark.sql(s"select * from $tableName")
     } finally {
       spark.conf.unset("hoodie.datasource.query.type")


### PR DESCRIPTION
### Change Logs

Fix test failure caused by unnecessary quotes around query type value.

```
Caused by: org.apache.hudi.exception.HoodieException: Invalid query type : "snapshot" for tableType: COPY_ON_WRITE,isBootstrappedTable: false 
```

### Impact

Fix test only.

### Risk level

None.

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
