### PR TITLE
[MINOR] StreamerUtil#getTableConfig should check whether hoodie.properties exists

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -312,7 +312,7 @@ public class StreamerUtil {
     FileSystem fs = FSUtils.getFs(basePath, hadoopConf);
     Path metaPath = new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME);
     try {
-      if (fs.exists(metaPath)) {
+      if (fs.exists(new Path(metaPath, HoodieTableConfig.HOODIE_PROPERTIES_FILE))) {
         return Option.of(new HoodieTableConfig(fs, metaPath.toString(), null, null));
       }
     } catch (IOException e) {


### PR DESCRIPTION
### Change Logs

`StreamerUtil#getTableConfig` only checks whether .hoodie exists at present. Because `HoodieTableSink#getSinkRuntimeProvider` would create `.hoodie/.aux/ids` directory for auto client id. Therefore `StreamerUtil#getTableConfig` should check whether hoodie.properties exists, then get table config via `hoodie.properties`.

### Impact

`StreamerUtil#getTableConfig` checks whether hoodie.properties exists when getting table config.

### Risk level (write none, low medium or high below)

none.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed