### PR TITLE
[HUDI-6621] Fix downgrade handler for 0.14.0

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SixToFiveDowngradeHandler.java
@@ -69,8 +69,9 @@ public class SixToFiveDowngradeHandler implements DowngradeHandler {
 
     syncCompactionRequestedFileToAuxiliaryFolder(table);
 
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.reload(table.getMetaClient());
     Map<ConfigProperty, String> updatedTableProps = new HashMap<>();
-    HoodieTableConfig tableConfig = table.getMetaClient().getTableConfig();
+    HoodieTableConfig tableConfig = metaClient.getTableConfig();
     Option.ofNullable(tableConfig.getString(TABLE_METADATA_PARTITIONS))
         .ifPresent(v -> updatedTableProps.put(TABLE_METADATA_PARTITIONS, v));
     Option.ofNullable(tableConfig.getString(TABLE_METADATA_PARTITIONS_INFLIGHT))

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SupportsUpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SupportsUpgradeDowngrade.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.table.upgrade;
 
+import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
@@ -41,4 +42,6 @@ public interface SupportsUpgradeDowngrade extends Serializable {
    * @return partition columns in String.
    */
   String getPartitionColumns(HoodieWriteConfig config);
+
+  BaseHoodieWriteClient getWriteClient(HoodieWriteConfig config, HoodieEngineContext context);
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/upgrade/FlinkUpgradeDowngradeHelper.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/upgrade/FlinkUpgradeDowngradeHelper.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.table.upgrade;
 
+import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -49,5 +51,10 @@ public class FlinkUpgradeDowngradeHelper implements SupportsUpgradeDowngrade {
   @Override
   public String getPartitionColumns(HoodieWriteConfig config) {
     return config.getProps().getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key());
+  }
+
+  @Override
+  public BaseHoodieWriteClient getWriteClient(HoodieWriteConfig config, HoodieEngineContext context) {
+    return new HoodieFlinkWriteClient(context, config);
   }
 }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/upgrade/JavaUpgradeDowngradeHelper.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/upgrade/JavaUpgradeDowngradeHelper.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.table.upgrade;
 
+import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.client.HoodieJavaWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
@@ -47,5 +49,10 @@ public class JavaUpgradeDowngradeHelper implements SupportsUpgradeDowngrade {
   @Override
   public String getPartitionColumns(HoodieWriteConfig config) {
     return config.getProps().getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key());
+  }
+
+  @Override
+  public BaseHoodieWriteClient getWriteClient(HoodieWriteConfig config, HoodieEngineContext context) {
+    return new HoodieJavaWriteClient(context, config);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/upgrade/SparkUpgradeDowngradeHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/upgrade/SparkUpgradeDowngradeHelper.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.table.upgrade;
 
+import org.apache.hudi.client.BaseHoodieWriteClient;
+import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieSparkTable;
@@ -48,5 +50,10 @@ public class SparkUpgradeDowngradeHelper implements SupportsUpgradeDowngrade {
   @Override
   public String getPartitionColumns(HoodieWriteConfig config) {
     return SparkKeyGenUtils.getPartitionColumns(config.getProps());
+  }
+
+  @Override
+  public BaseHoodieWriteClient getWriteClient(HoodieWriteConfig config, HoodieEngineContext context) {
+    return new SparkRDDWriteClient(context, config);
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -75,6 +75,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -553,11 +554,6 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
         PARTITION_NAME_BLOOM_FILTERS,
         PARTITION_NAME_RECORD_INDEX
     );
-    Set<String> allPartitionsExceptRecordIndex = CollectionUtils.createImmutableSet(
-        PARTITION_NAME_FILES,
-        PARTITION_NAME_COLUMN_STATS,
-        PARTITION_NAME_BLOOM_FILTERS
-    );
     assertTrue(Files.exists(recordIndexPartitionPath), "record index partition should exist.");
     assertEquals(allPartitions, metaClient.getTableConfig().getMetadataPartitions(),
         TABLE_METADATA_PARTITIONS.key() + " should contain all partitions.");
@@ -571,9 +567,9 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     // validate the relevant table states after downgrade
     assertFalse(Files.exists(recordIndexPartitionPath), "record index partition should be deleted.");
-    assertEquals(allPartitionsExceptRecordIndex, metaClient.getTableConfig().getMetadataPartitions(),
+    assertEquals(Collections.emptySet(), metaClient.getTableConfig().getMetadataPartitions(),
         TABLE_METADATA_PARTITIONS.key() + " should contain all partitions except record_index.");
-    assertEquals(allPartitionsExceptRecordIndex, metaClient.getTableConfig().getMetadataPartitionsInflight(),
+    assertEquals(Collections.emptySet(), metaClient.getTableConfig().getMetadataPartitionsInflight(),
         TABLE_METADATA_PARTITIONS_INFLIGHT.key() + " should contain all partitions except record_index.");
 
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSixToFiveDowngradeHandler.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSixToFiveDowngradeHandler.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hadoop.fs.Path
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView
+import org.apache.hudi.config.HoodieCompactionConfig
+import org.apache.hudi.metadata.HoodieMetadataFileSystemView
+import org.apache.hudi.table.upgrade.{SixToFiveDowngradeHandler, SparkUpgradeDowngradeHelper}
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+import scala.jdk.CollectionConverters.{asScalaIteratorConverter, collectionAsScalaIterableConverter}
+
+class TestSixToFiveDowngradeHandler extends RecordLevelIndexTestBase {
+
+  private var partitionPaths: java.util.List[Path] = null
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testDowngradeWithMDTAndLogFiles(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts + (
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+      HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key() -> "0")
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite,
+      validate = false)
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append,
+      validate = false)
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertTrue(metaClient.getTableConfig.isMetadataTableAvailable)
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      assertTrue(getLogFilesCount(hudiOpts) > 0)
+    }
+
+    val downgradeHandler = new SixToFiveDowngradeHandler()
+    downgradeHandler.downgrade(getWriteConfig(hudiOpts), context, null, SparkUpgradeDowngradeHelper.getInstance())
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    // Ensure file slices have been compacted and the MDT table has been deleted
+    assertFalse(metaClient.getTableConfig.isMetadataTableAvailable)
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      assertEquals(0, getLogFilesCount(hudiOpts))
+    }
+  }
+
+  @Test
+  def testDowngradeWithoutLogFiles(): Unit = {
+    val hudiOpts = commonOpts + (
+      DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name(),
+      HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key() -> "0")
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite,
+      validate = false)
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertEquals(0, getLogFilesCount(hudiOpts))
+
+    val downgradeHandler = new SixToFiveDowngradeHandler()
+    downgradeHandler.downgrade(getWriteConfig(hudiOpts), context, null, SparkUpgradeDowngradeHelper.getInstance())
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertEquals(0, getLogFilesCount(hudiOpts))
+  }
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testDowngradeWithoutMDT(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts + (
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+      HoodieMetadataConfig.ENABLE.key() -> "false")
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite,
+      validate = false)
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertFalse(metaClient.getTableConfig.isMetadataTableAvailable)
+
+    val downgradeHandler = new SixToFiveDowngradeHandler()
+    downgradeHandler.downgrade(getWriteConfig(hudiOpts), context, null, SparkUpgradeDowngradeHelper.getInstance())
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertFalse(metaClient.getTableConfig.isMetadataTableAvailable)
+  }
+
+  private def getLogFilesCount(opts: Map[String, String]) = {
+    var numFileSlicesWithLogFiles = 0L
+    val fsView = getTableFileSystemView(opts)
+    getAllPartititonPaths(fsView).asScala.flatMap { partitionPath =>
+      val relativePath = FSUtils.getRelativePartitionPath(metaClient.getBasePathV2, partitionPath)
+      fsView.getLatestMergedFileSlicesBeforeOrOn(relativePath, getLatestMetaClient(false)
+        .getActiveTimeline.lastInstant().get().getTimestamp).iterator().asScala.toSeq
+    }.foreach(
+      slice => if (slice.getLogFiles.count() > 0) {
+        numFileSlicesWithLogFiles += 1
+      })
+    numFileSlicesWithLogFiles
+  }
+
+  private def getTableFileSystemView(opts: Map[String, String]): HoodieTableFileSystemView = {
+    if (metaClient.getTableConfig.isMetadataTableAvailable) {
+      new HoodieMetadataFileSystemView(metaClient, metaClient.getActiveTimeline, metadataWriter(getWriteConfig(opts)).getTableMetadata)
+    } else {
+      new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline)
+    }
+  }
+
+  private def getAllPartititonPaths(fsView: HoodieTableFileSystemView): java.util.List[Path] = {
+    if (partitionPaths == null) {
+      fsView.loadAllPartitions()
+      partitionPaths = fsView.getPartitionPaths
+    }
+    partitionPaths
+  }
+}


### PR DESCRIPTION
### Change Logs

Since the log block version (due to delete block change) has been upgraded in 0.14.0, the delete blocks can not be read in 0.13.0 or earlier.
Similarly the addition of record level index field in metadata table leads to column drop error on downgrade. The Jira aims to fix the downgrade handler to trigger compaction and delete metadata table if user wishes to downgrade from version six (0.14.0) to version 5 (0.13.0).

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
