### PR TITLE
[HUDI-6718] Check Timeline Before Transitioning Inflight Clean in Multiwriter Scenario

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -264,7 +264,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
           } catch (HoodieIOException e) {
             checkIfOtherWriterCommitted(hoodieInstant, e);
           } catch (Exception e) {
-            LOG.warn("Failed to perform previous clean operation, instant: " + hoodieInstant, e);
+            LOG.error("Failed to perform previous clean operation, instant: " + hoodieInstant, e);
             throw e;
           }
         }
@@ -286,7 +286,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     if (table.getCleanTimeline().filterCompletedInstants().containsInstant(hoodieInstant.getTimestamp())) {
       LOG.warn("Clean operation was completed by another writer for instant: " + hoodieInstant);
     } else {
-      LOG.warn("Failed to perform previous clean operation, instant: " + hoodieInstant, e);
+      LOG.error("Failed to perform previous clean operation, instant: " + hoodieInstant, e);
       throw e;
     }
   }


### PR DESCRIPTION
### Change Logs

If two cleans start at nearly the same time, they will both attempt to execute the same clean instances. This does not cause any data corruption, but will cause a writer to fail when they attempt to create the commit in the timeline. This is because the commit will have already been written by the first writer. Now, we check the timeline before transitioning state.

### Impact

No writers will fail in this scenario now

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
