### PR TITLE
[HUDI-6719]Fix data inconsistency issues caused by concurrent clustering and delete partition.

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ReplaceCommitValidateUtil.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/ReplaceCommitValidateUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.cluster;
+
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.JsonUtils;
+import org.apache.hudi.exception.HoodieException;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.util.FileIOUtils.LOG;
+
+public class ReplaceCommitValidateUtil {
+  public static final String REPLACE_COMMIT_FILE_IDS = "replaceCommitFileIds";
+  public static void validateReplaceCommit(HoodieTableMetaClient metaClient) {
+    metaClient.reloadActiveTimeline();
+    Set<String> replaceFileids = new HashSet<>();
+
+    // Verify pending and completed replace commit
+    Stream.concat(metaClient.getActiveTimeline().getCompletedReplaceTimeline().getInstantsAsStream(),
+        metaClient.getActiveTimeline().filterInflights().filterPendingReplaceTimeline().getInstantsAsStream()).map(instant -> {
+          try {
+            HoodieReplaceCommitMetadata replaceCommitMetadata =
+                HoodieReplaceCommitMetadata.fromBytes(metaClient.getActiveTimeline().getInstantDetails(instant).get(),
+                HoodieReplaceCommitMetadata.class);
+            if (!instant.isCompleted()) {
+              return JsonUtils.getObjectMapper().readValue(replaceCommitMetadata.getExtraMetadata().get(REPLACE_COMMIT_FILE_IDS), String[].class);
+            } else {
+              return replaceCommitMetadata.getPartitionToReplaceFileIds().values().stream()
+                  .flatMap(List::stream)
+                  .toArray(String[]::new);
+            }
+          } catch (Exception e) {
+            // If the key does not exist or there is a JSON parsing error, LOG reports an error and ignores it.
+            LOG.error("Error when reading REPLACECOMMIT meta", e);
+            return null;
+          }
+        }).filter(Objects::nonNull)
+        .flatMap(Arrays::stream)
+        .filter(fileId -> !replaceFileids.add(fileId))
+        .findFirst()
+        .ifPresent(s -> {
+          throw new HoodieException("REPLACECOMMIT involves duplicate file ID " + s + ", which will cause the table status to be abnormal. The REPLACECOMMIT has been terminated.");
+        });
+  }
+}


### PR DESCRIPTION
### Change Logs
Implemented a solution to prevent duplicate key errors in concurrent replace commit operations.
Registered the replace file ID information to the timeline for each replace commit, whether it is submitted or not.
Saved the pending replace commit's partitionToReplaceFileIds information to the inflight commit's extra metadata.
Updated drop partition and clustering operations to read the partitionToReplaceFileIds information in the timeline to ensure no duplicate file IDs.
Removed the modification involved in the related issue for compaction commit.

### Impact

No public API or user-facing feature changes.

### Risk level (write none, low medium or high below)

low

### Documentation Update

Related issue: https://issues.apache.org/jira/browse/HUDI-5553

The specific problem is that when concurrent replace commit operations are executed, two replace commits may point to the same file ID, resulting in a duplicate key error. The existing issue solved the problem of scheduling delete partition while there are pending clustering or compaction operations, which will be prevented in this case. However, this solution is not perfect and may still cause data inconsistency if a clustering plan is scheduled before the delete partition is committed. Because validation is one-way.In this case, both replace commits will still contain duplicate keys, and the table will become inconsistent when both plans are committed. This is very fatal, and there are other similar scenarios that may bypass the validation of the existing issue. Moreover, the existing issue is at the partition level and is not precise enough.

Here is my solution:
![image](https://github.com/apache/hudi/assets/47964462/6d8a3134-96a5-45ec-8ed0-ed2776b7ed24)

As shown in the figure, both drop partition and clustering will go through a period of time that is not registered to the timeline, which is the scenario that the previous issue did not solve. Here, I register the replace file IDs involved in each replace commit to the active timeline (the replace commit timeline that has been submitted has saved partitionToReplaceFileIds, and only pending requests need to be processed). Since in the case of Spark SQL, delete partition creates a requested commit in advance during write, which is inconvenient to handle, I save the pending replace commit's partitionToReplaceFileIds information to the inflight commit's extra metadata. Therefore, each time drop partition or clustering is executed, it only needs to read the partitionToReplaceFileIds information in the timeline after ensuring that the inflight commit information has been saved to the timeline to ensure that there are no duplicate file IDs and prevent this kind of error from occurring.

In simple terms, each replace commit will register the replace file ID information to the timeline whether it is submitted or not, at the same time, each submission will check this information to ensure that it will not be repeated, so that any replace commit containing this file ID will be prevented, ensuring that there are no duplicate keys.

When this idea is also implemented on the compaction commit, the modification involved in the related issue can be removed.


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
