### PR TITLE
[HUDI-6766] Fixing mysql debezium data loss 

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -91,6 +91,6 @@ public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
     Long currentPos = Long.valueOf(currentFilePos[1]);
     Long insertPos = Long.valueOf(insertFilePos[1]);
 
-    return insertPos.compareTo(currentPos) <= 0;
+    return insertPos <= currentPos;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -66,8 +66,31 @@ public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
             new HoodieDebeziumAvroPayloadException(String.format("%s cannot be null in insert record: %s",
                 DebeziumConstants.ADDED_SEQ_COL_NAME, insertRecord)));
     Option<String> currentSourceSeqOpt = extractSeq(currentRecord);
-    // Pick the current value in storage only if its Seq (file+pos) is latest
-    // compared to the Seq (file+pos) of the insert value
-    return currentSourceSeqOpt.isPresent() && insertSourceSeq.compareTo(currentSourceSeqOpt.get()) < 0;
+
+    // handle bootstrap case
+    if (!currentSourceSeqOpt.isPresent()) {
+      return false;
+    }
+
+    // Seq is file+pos string like "001.000010", getting [001,000010] from it
+    String[] currentFilePos = currentSourceSeqOpt.get().split("\\.");
+    String[] insertFilePos = insertSourceSeq.split("\\.");
+
+    long currentFileNum = Long.valueOf(currentFilePos[0]);
+    long insertFileNum = Long.valueOf(insertFilePos[0]);
+
+    if (insertFileNum < currentFileNum) {
+      // pick the current value
+      return true;
+    } else if (insertFileNum > currentFileNum) {
+      // pick the insert value
+      return false;
+    }
+
+    // file name is the same, compare the position in the file
+    Long currentPos = Long.valueOf(currentFilePos[1]);
+    Long insertPos = Long.valueOf(insertFilePos[1]);
+
+    return insertPos.compareTo(currentPos) <= 0;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -96,6 +96,12 @@ public class TestMySqlDebeziumAvroPayload {
     payload = new MySqlDebeziumAvroPayload(lateRecord, "00000.222");
     mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema);
     validateRecord(mergedRecord, 1, Operation.INSERT, "00001.111");
+
+    GenericRecord originalRecord = createRecord(1, Operation.INSERT, "00000.23");
+    payload = new MySqlDebeziumAvroPayload(originalRecord, "00000.23");
+    updateRecord = createRecord(1, Operation.UPDATE, "00000.123");
+    mergedRecord = payload.combineAndGetUpdateValue(updateRecord, avroSchema);
+    validateRecord(mergedRecord, 1, Operation.UPDATE, "00000.123");
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

In our end-to-end testing, found some mysql debezium records are ignored by Deltastreamer and we lose these updates in hudi tables. e.g. 

```
Existing record in hudi table has _event_seq "00000.23"
For the same record, new update comes with  _event_seq "00000.123" (same binlog file, higher position)

```
However, current implementation ignores the update "00000.123" since it is using string comparison. This PR fixes the issue by comparing binlog file number and position within binlog file for the record separately. 

Unit test added which fails without the fix included in this PR.

### Impact

Fixes the data loss issue for mysql debezium

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
