### PR TITLE
Add detail exception when instant transition state

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -599,7 +599,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
 
   protected void transitionState(HoodieInstant fromInstant, HoodieInstant toInstant, Option<byte[]> data,
        boolean allowRedundantTransitions) {
-    ValidationUtils.checkArgument(fromInstant.getTimestamp().equals(toInstant.getTimestamp()));
+    ValidationUtils.checkArgument(fromInstant.getTimestamp().equals(toInstant.getTimestamp()), String.format("%s and %s are not consistent when transition state.", fromInstant, toInstant));
     try {
       if (metaClient.getTimelineLayoutVersion().isNullVersion()) {
         // Re-create the .inflight file by opening a new file and write the commit metadata in


### PR DESCRIPTION
### Change Logs

Add detail exception when instant transition state
```java

2023-08-18 10:40:53.643 ERROR [pool-21-thread-1:1-thread-1] org.apache.hudi.sink.StreamWriteOperatorCoordinator - Executor executes action [handle end input event for instant 20230818104027208] error
java.lang.IllegalArgumentException: null
	at org.apache.hudi.common.util.ValidationUtils.checkArgument(ValidationUtils.java:31)
	at org.apache.hudi.common.table.timeline.HoodieActiveTimeline.transitionState(HoodieActiveTimeline.java:577)
	at org.apache.hudi.common.table.timeline.HoodieActiveTimeline.transitionState(HoodieActiveTimeline.java:558)
	at 
```

