### PR TITLE
[HUDI-6731] BigQuerySyncTool: add flag to allow for read optimized sync for MoR tables

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
@@ -128,6 +128,12 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       .withDocumentation("Assume standard yyyy/mm/dd partitioning, this"
           + " exists to support backward compatibility. If you use hoodie 0.3.x, do not set this parameter");
 
+  public static final ConfigProperty<Boolean> BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC = ConfigProperty
+      .key("hoodie.gcp.bigquery.sync.allow_read_optimized_sync")
+      .defaultValue(false)
+      .withDocumentation("If true, allows read-optimized queries on Merge-on-Read tables. It is important to note that BigQuery cannot currently read the log "
+        + "files of an MoR table so the completeness and accuracy of the data queried will be dependent on when and how the table was last compacted.");
+
   public BigQuerySyncConfig(Properties props) {
     super(props);
     setDefaults(BigQuerySyncConfig.class.getName());
@@ -154,6 +160,10 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
     @Parameter(names = {"--source-uri-prefix"}, description = "Name of the source uri gcs path prefix of the table", required = false)
     public String sourceUriPrefix;
 
+    @Parameter(names = {"--allow-read-optimized-sync"}, description = "If true, allows read-optimized queries on Merge-on-Read tables. It is important to note that BigQuery cannot currently read the "
+        + "log files of an MoR table so the completeness and accuracy of the data queried will be dependent on when and how the table was last compacted.")
+    public boolean allowReadOptimizedSync;
+
     public boolean isHelp() {
       return hoodieSyncConfigParams.isHelp();
     }
@@ -171,6 +181,7 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       props.setPropertyIfNonNull(BIGQUERY_SYNC_PARTITION_FIELDS.key(), String.join(",", hoodieSyncConfigParams.partitionFields));
       props.setPropertyIfNonNull(BIGQUERY_SYNC_USE_FILE_LISTING_FROM_METADATA.key(), hoodieSyncConfigParams.useFileListingFromMetadata);
       props.setPropertyIfNonNull(BIGQUERY_SYNC_ASSUME_DATE_PARTITIONING.key(), hoodieSyncConfigParams.assumeDatePartitioning);
+      props.setPropertyIfNonNull(BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC.key(), allowReadOptimizedSync);
       return props;
     }
   }

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
@@ -128,12 +128,6 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       .withDocumentation("Assume standard yyyy/mm/dd partitioning, this"
           + " exists to support backward compatibility. If you use hoodie 0.3.x, do not set this parameter");
 
-  public static final ConfigProperty<Boolean> BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC = ConfigProperty
-      .key("hoodie.gcp.bigquery.sync.allow_read_optimized_sync")
-      .defaultValue(false)
-      .withDocumentation("If true, allows read-optimized queries on Merge-on-Read tables. It is important to note that BigQuery cannot currently read the log "
-        + "files of an MoR table so the completeness and accuracy of the data queried will be dependent on when and how the table was last compacted.");
-
   public BigQuerySyncConfig(Properties props) {
     super(props);
     setDefaults(BigQuerySyncConfig.class.getName());
@@ -160,10 +154,6 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
     @Parameter(names = {"--source-uri-prefix"}, description = "Name of the source uri gcs path prefix of the table", required = false)
     public String sourceUriPrefix;
 
-    @Parameter(names = {"--allow-read-optimized-sync"}, description = "If true, allows read-optimized queries on Merge-on-Read tables. It is important to note that BigQuery cannot currently read the "
-        + "log files of an MoR table so the completeness and accuracy of the data queried will be dependent on when and how the table was last compacted.")
-    public boolean allowReadOptimizedSync;
-
     public boolean isHelp() {
       return hoodieSyncConfigParams.isHelp();
     }
@@ -181,7 +171,6 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       props.setPropertyIfNonNull(BIGQUERY_SYNC_PARTITION_FIELDS.key(), String.join(",", hoodieSyncConfigParams.partitionFields));
       props.setPropertyIfNonNull(BIGQUERY_SYNC_USE_FILE_LISTING_FROM_METADATA.key(), hoodieSyncConfigParams.useFileListingFromMetadata);
       props.setPropertyIfNonNull(BIGQUERY_SYNC_ASSUME_DATE_PARTITIONING.key(), hoodieSyncConfigParams.assumeDatePartitioning);
-      props.setPropertyIfNonNull(BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC.key(), allowReadOptimizedSync);
       return props;
     }
   }

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncTool.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
-import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC;
 import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_ASSUME_DATE_PARTITIONING;
 import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_DATASET_NAME;
 import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_PARTITION_FIELDS;
@@ -73,14 +72,8 @@ public class BigQuerySyncTool extends HoodieSyncTool {
     try (HoodieBigQuerySyncClient bqSyncClient = new HoodieBigQuerySyncClient(config)) {
       switch (bqSyncClient.getTableType()) {
         case COPY_ON_WRITE:
-          syncTable(bqSyncClient);
-          break;
         case MERGE_ON_READ:
-          if (config.getBoolean(BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC)) {
-            syncTable(bqSyncClient);
-          } else {
-            throw new UnsupportedOperationException("Set " + BIGQUERY_SYNC_ALLOW_READ_OPTIMIZED_SYNC.key() + " to true to sync a Read-Optimized version of the table.");
-          }
+          syncTable(bqSyncClient);
           break;
         default:
           throw new UnsupportedOperationException(bqSyncClient.getTableType() + " table type is not supported yet.");


### PR DESCRIPTION
### Change Logs

Adds support for syncing the base files of an MoR table to BigQuery so users to can query the table in a "Read Optimized" way like they can do with other query engines.

### Impact

Allows users to query base files of MoR tables from BigQuery.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
