### PR TITLE
fix the use of spark parameters in website documents

### DIFF
--- a/website/versioned_docs/version-0.10.1/table_management.md
+++ b/website/versioned_docs/version-0.10.1/table_management.md
@@ -157,7 +157,7 @@ create table if not exists h3(
 options (
   primaryKey = 'id',
   type = 'mor',
-  ${hoodie.config.key1} = '${hoodie.config.value2}',
+  ${hoodie.config.key1} = '${hoodie.config.value1}',
   ${hoodie.config.key2} = '${hoodie.config.value2}',
   ....
 );


### PR DESCRIPTION
### Change Logs

fix the use of spark parameters in website documents

### Impact

fix the use of spark parameters in website documents

### Risk level (write none, low medium or high below)

none
