### PR TITLE
[HUDI-6732] Allow wildcards from Spark-SQL entrypoints for drop parti…

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -576,7 +576,8 @@ object HoodieSparkSqlWriter {
    */
   private def resolvePartitionWildcards(partitions: List[String], jsc: JavaSparkContext, cfg: HoodieConfig, basePath: String): List[String] = {
     //find out if any of the input partitions have wildcards
-    var (wildcardPartitions, fullPartitions) = partitions.partition(partition => partition.contains("*"))
+    //note:spark-sql may url-encode special characters (* -> %2A)
+    var (wildcardPartitions, fullPartitions) = partitions.partition(partition => partition.matches(".*(\\*|%2A).*"))
 
     if (wildcardPartitions.nonEmpty) {
       //get list of all partitions
@@ -591,7 +592,8 @@ object HoodieSparkSqlWriter {
         //prevent that from happening. Any text inbetween \\Q and \\E is considered literal
         //So we start the string with \\Q and end with \\E and then whenever we find a * we add \\E before
         //and \\Q after so all other characters besides .* will be enclosed between a set of \\Q \\E
-        val regexPartition = "^\\Q" + partition.replace("*", "\\E.*\\Q") + "\\E$"
+        val wildcardToken: String = if (partition.contains("*")) "*" else "%2A"
+        val regexPartition = "^\\Q" + partition.replace(wildcardToken, "\\E.*\\Q") + "\\E$"
 
         //filter all partitions with the regex and append the result to the list of full partitions
         fullPartitions = List.concat(fullPartitions,allPartitions.filter(_.matches(regexPartition)))


### PR DESCRIPTION
…tion DDL

### Change Logs

The drop partition DDL is not handling wildcards properly, specifically, for partitions with wildcards that are submitted via the Spark-SQL entry point.

```sql
ALTER TABLE table_x DROP PARTITION(partition_col="*")  
```

The Spark-SQL entrypoint will url-encode special characters, causing the * character to be url-encoded to %2A, as such, we will need to handle that too.

![image](https://github.com/apache/hudi/assets/6312314/76f2ff91-7572-406f-83ad-bdf52375c3c9)


### Impact

Wildcards can be used via Spark-SQL entrypoints.

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
