### PR TITLE
[HUDI-6735] Adding support for snapshotLoadQuerySplitter for incremental sources.

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -23,20 +23,23 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.config.HoodieIncrSourceConfig;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper;
 import org.apache.hudi.utilities.sources.helpers.QueryInfo;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+
+import static org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter.Config.SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME;
 
 import static org.apache.hudi.DataSourceReadOptions.BEGIN_INSTANTTIME;
 import static org.apache.hudi.DataSourceReadOptions.END_INSTANTTIME;
@@ -55,7 +58,8 @@ import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHoll
 
 public class HoodieIncrSource extends RowSource {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieIncrSource.class);
+  private static final Logger LOG = LogManager.getLogger(HoodieIncrSource.class);
+  private final Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitter;
 
   public static class Config {
 
@@ -128,6 +132,10 @@ public class HoodieIncrSource extends RowSource {
   public HoodieIncrSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
                           SchemaProvider schemaProvider) {
     super(props, sparkContext, sparkSession, schemaProvider);
+
+    this.snapshotLoadQuerySplitter = Option.ofNullable(props.getString(SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME, null))
+        .map(className -> (SnapshotLoadQuerySplitter) ReflectionUtils.loadClass(className,
+              new Class<?>[]{TypedProperties.class}, props));
   }
 
   @Override
@@ -184,9 +192,13 @@ public class HoodieIncrSource extends RowSource {
           .load(srcPath);
     } else {
       // if checkpoint is missing from source table, and if strategy is set to READ_UPTO_LATEST_COMMIT, we have to issue snapshot query
-      source = sparkSession.read().format("org.apache.hudi")
-          .option(QUERY_TYPE().key(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
-          .load(srcPath)
+      Dataset<Row> snapshot = sparkSession.read().format("org.apache.hudi")
+          .option(DataSourceReadOptions.QUERY_TYPE().key(), DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL())
+          .load(srcPath);
+      if (snapshotLoadQuerySplitter.isPresent()) {
+        queryInfo = snapshotLoadQuerySplitter.get().getNextCheckpoint(snapshot, queryInfo);
+      }
+      source = snapshot
           // add filtering so that only interested records are returned.
           .filter(String.format("%s > '%s'", HoodieRecord.COMMIT_TIME_METADATA_FIELD,
               queryInfo.getStartInstant()))

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -30,16 +30,14 @@ import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper;
 import org.apache.hudi.utilities.sources.helpers.QueryInfo;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-
-import static org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter.Config.SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME;
 
 import static org.apache.hudi.DataSourceReadOptions.BEGIN_INSTANTTIME;
 import static org.apache.hudi.DataSourceReadOptions.END_INSTANTTIME;
@@ -53,12 +51,13 @@ import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.utilities.UtilHelpers.createRecordMerger;
+import static org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter.Config.SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.generateQueryInfo;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.getHollowCommitHandleMode;
 
 public class HoodieIncrSource extends RowSource {
 
-  private static final Logger LOG = LogManager.getLogger(HoodieIncrSource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieIncrSource.class);
   private final Option<SnapshotLoadQuerySplitter> snapshotLoadQuerySplitter;
 
   public static class Config {
@@ -135,7 +134,7 @@ public class HoodieIncrSource extends RowSource {
 
     this.snapshotLoadQuerySplitter = Option.ofNullable(props.getString(SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME, null))
         .map(className -> (SnapshotLoadQuerySplitter) ReflectionUtils.loadClass(className,
-              new Class<?>[]{TypedProperties.class}, props));
+            new Class<?>[] {TypedProperties.class}, props));
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/SnapshotLoadQuerySplitter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.sources.helpers.QueryInfo;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+/**
+ * Abstract splitter responsible for managing the snapshot load query operations.
+ */
+public abstract class SnapshotLoadQuerySplitter {
+
+  /**
+   * Configuration properties for the splitter.
+   */
+  protected final TypedProperties properties;
+
+  /**
+   * Configurations for the SnapshotLoadQuerySplitter.
+   */
+  public static class Config {
+    /**
+     * Property for the snapshot load query splitter class name.
+     */
+    public static final String SNAPSHOT_LOAD_QUERY_SPLITTER_CLASS_NAME = "hoodie.deltastreamer.snapshotload.query.splitter.class.name";
+  }
+
+  /**
+   * Constructor initializing the properties.
+   *
+   * @param properties Configuration properties for the splitter.
+   */
+  public SnapshotLoadQuerySplitter(TypedProperties properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Abstract method to retrieve the next checkpoint.
+   *
+   * @param df The dataset to process.
+   * @param beginCheckpointStr The starting checkpoint string.
+   * @return The next checkpoint as an Option.
+   */
+  public abstract Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr);
+
+  /**
+   * Retrieves the next checkpoint based on query information.
+   *
+   * @param df The dataset to process.
+   * @param queryInfo The query information object.
+   * @return Updated query information with the next checkpoint, in case of empty checkpoint,
+   * returning endPoint same as queryInfo.getEndInstant().
+   */
+  public QueryInfo getNextCheckpoint(Dataset<Row> df, QueryInfo queryInfo) {
+    return getNextCheckpoint(df, queryInfo.getStartInstant())
+        .map(checkpoint -> queryInfo.withUpdatedEndInstant(checkpoint))
+        .orElse(queryInfo);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryInfo.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryInfo.java
@@ -97,6 +97,18 @@ public class QueryInfo {
     return orderByColumns;
   }
 
+  public QueryInfo withUpdatedEndInstant(String newEndInstant) {
+    return new QueryInfo(
+        this.queryType,
+        this.previousInstant,
+        this.startInstant,
+        newEndInstant,
+        this.orderColumn,
+        this.keyColumn,
+        this.limitColumn
+    );
+  }
+
   @Override
   public String toString() {
     return ("Query information for Incremental Source "

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSnapshotQuerySplitterImpl.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestSnapshotQuerySplitterImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.sources.SnapshotLoadQuerySplitter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import java.util.List;
+
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.lit;
+
+public class TestSnapshotQuerySplitterImpl extends SnapshotLoadQuerySplitter {
+
+  private static final String COMMIT_TIME_METADATA_FIELD = HoodieRecord.COMMIT_TIME_METADATA_FIELD;
+
+  /**
+   * Constructor initializing the properties.
+   *
+   * @param properties Configuration properties for the splitter.
+   */
+  public TestSnapshotQuerySplitterImpl(TypedProperties properties) {
+    super(properties);
+  }
+
+  @Override
+  public Option<String> getNextCheckpoint(Dataset<Row> df, String beginCheckpointStr) {
+    List<Row> row = df.filter(col(COMMIT_TIME_METADATA_FIELD).gt(lit(beginCheckpointStr)))
+        .orderBy(col(COMMIT_TIME_METADATA_FIELD)).limit(1).collectAsList();
+    return Option.ofNullable(row.size() > 0 ? row.get(0).getAs(COMMIT_TIME_METADATA_FIELD) : null);
+  }
+}


### PR DESCRIPTION
### Change Logs

Snapshot load scan of historical table ( having majority of data in archived timeline ) causes large batch processing . 
Adding interface to support breaking snapshotload query into batches which can have commitId as checkpoint . 
### Impact

Adding SnapshotLoadQuerySplitter interface and integrating that with HudiIncrSource for snapshotLoad . 

### Risk level (write none, low medium or high below)

low 
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
