### PR TITLE
[HUDI-6549] Adding support for comma separated path format for spark.read.load

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudStoreIngestionConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudStoreIngestionConfig.java
@@ -102,4 +102,16 @@ public class CloudStoreIngestionConfig {
    */
   @Deprecated
   public static final String DATAFILE_FORMAT = CloudSourceConfig.DATAFILE_FORMAT.key();
+
+  /**
+   * A comma delimited list of path-based partition fields in the source file structure
+   */
+  public static final String PATH_BASED_PARTITION_FIELDS = "hoodie.deltastreamer.source.cloud.data.partition.fields.from.path";
+
+  /**
+   * boolean value for specifying path format in load args of spark.read.format("..").load("a.xml,b.xml,c.xml"),
+   * set true if path format needs to be comma separated string value, if false it's passed as array of strings like
+   * spark.read.format("..").load(new String[]{a.xml,b.xml,c.xml})
+   */
+  public static final String SPARK_DATASOURCE_READER_COMMA_SEPARATED_PATH_FORMAT = "hoodie.deltastreamer.source.cloud.data.reader.comma.separated.path.format";
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -79,6 +79,7 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
   public void partitionKeyNotPresentInPath() {
     List<CloudObjectMetadata> input = Collections.singletonList(new CloudObjectMetadata("src/test/resources/data/partitioned/country=US/state=CA/data.json", 1));
     TypedProperties properties = new TypedProperties();
+    properties.put("hoodie.deltastreamer.source.cloud.data.reader.comma.separated.path.format", "false");
     properties.put("hoodie.deltastreamer.source.cloud.data.partition.fields.from.path", "unknown");
     Option<Dataset<Row>> result = CloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, properties, "json");
     Assertions.assertTrue(result.isPresent());


### PR DESCRIPTION
### Change Logs
CloudObjectsSelectorCommon adds config `SPARK_DATASOURCE_READER_COMMA_SEPARATED_PATH_FORMAT` for comma separated path . 

### Impact
For file formats like xml does not support array of strings in spark.read.load() .  
comma separated path formats are supported for loading data from more than 1 file . 
So this pr adds support for  comma separated path

### Risk level (write none, low medium or high below)

low
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
