### PR TITLE
[HUDI-6740] Add 0.13.x to Spark 3 support matrix doc

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -2,7 +2,7 @@
 title: "Spark Guide"
 sidebar_position: 2
 toc: true
-last_modified_at: 2019-12-30T15:59:57-04:00
+last_modified_at: 2023-08-23T21:14:52+09:00
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -20,7 +20,7 @@ Hudi works with Spark-2.4.3+ & Spark 3.x versions. You can follow instructions [
 
 | Hudi            | Supported Spark 3 version                       |
 |:----------------|:------------------------------------------------|
-| 0.12.x          | 3.3.x (default build), 3.2.x, 3.1.x             |
+| 0.12.0 - 0.13.x | 3.3.x (default build), 3.2.x, 3.1.x             |
 | 0.11.x          | 3.2.x (default build, Spark bundle only), 3.1.x |
 | 0.10.x          | 3.1.x (default build), 3.0.x                    |
 | 0.7.0 - 0.9.0   | 3.0.x                                           |


### PR DESCRIPTION
### Change Logs

Add Hudi 0.13.x to the Spark 3 support matrix doc https://hudi.apache.org/docs/quick-start-guide/

https://issues.apache.org/jira/browse/HUDI-6740

### Impact

Doc only change

### Risk level (write none, low medium or high below)

low

### Documentation Update

This is documentation only update

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
