### PR TITLE
[HUDI-6445] Triaging flaky tests attempt 1

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -106,6 +106,7 @@ stages:
   - stage: test
     jobs:
       - job: UT_FT_1
+        condition: false
         displayName: UT FT common & flink & UT client/spark-client
         timeoutInMinutes: '150'
         steps:
@@ -139,6 +140,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_2
+        condition: false
         displayName: FT client/spark-client
         timeoutInMinutes: '150'
         steps:
@@ -163,6 +165,7 @@ stages:
               grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
             displayName: Top 100 long-running testcases
       - job: UT_FT_3
+        condition: false
         displayName: UT spark-datasource
         timeoutInMinutes: '240'
         steps:

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/hive/TestHoodieCombineHiveInputFormat.java
@@ -69,7 +69,6 @@ import java.util.stream.Collectors;
 import static org.apache.hadoop.hive.ql.exec.Utilities.HAS_MAP_WORK;
 import static org.apache.hadoop.hive.ql.exec.Utilities.MAPRED_MAPPER_CLASS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
 
@@ -79,21 +78,21 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
   @BeforeAll
   public static void setUpClass() throws IOException, InterruptedException {
     // Append is not supported in LocalFileSystem. HDFS needs to be setup.
-    hdfsTestService = new HdfsTestService();
-    fs = hdfsTestService.start(true).getFileSystem();
+    // hdfsTestService = new HdfsTestService();
+    // fs = hdfsTestService.start(true).getFileSystem();
   }
 
   @AfterAll
   public static void tearDownClass() {
-    hdfsTestService.stop();
+    // hdfsTestService.stop();
   }
 
   @BeforeEach
   public void setUp() throws IOException, InterruptedException {
-    assertTrue(fs.mkdirs(new Path(tempDir.toAbsolutePath().toString())));
+    // assertTrue(fs.mkdirs(new Path(tempDir.toAbsolutePath().toString())));
   }
 
-  @Test
+  // @Test
   public void multiPartitionReadersRealtimeCombineHoodieInputFormat() throws Exception {
     // test for HUDI-1718
     Configuration conf = new Configuration();
@@ -176,7 +175,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     recordReader.close();
   }
 
-  @Test
+  // @Test
   public void multiLevelPartitionReadersRealtimeCombineHoodieInputFormat() throws Exception {
     // test for HUDI-1718
     Configuration conf = new Configuration();
@@ -248,7 +247,7 @@ public class TestHoodieCombineHiveInputFormat extends HoodieCommonTestHarness {
     recordReader.close();
   }
 
-  @Test
+  // @Test
   public void testMultiReaderRealtimeCombineHoodieInputFormat() throws Exception {
     // test for hudi-1722
     Configuration conf = new Configuration();


### PR DESCRIPTION
### Change Logs

Triaging flaky tests. 
Job4: UT module seems to be stuck just after running tests in TestHoodieCombineHiveInputFormat. So, I have disabled all tests in that class and checking for CI output. 
Concurrently, I am going to try and chase the actual flaky tests until I get the results from this run. 

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
