### PR TITLE
[HUDI-6481] Support run multi tables services in a single spark job

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
@@ -64,6 +64,13 @@ public class HoodieCleaner {
     LOG.info("Creating Cleaner with configs : " + props.toString());
   }
 
+  public HoodieCleaner(Config cfg, TypedProperties props, JavaSparkContext jssc) {
+    this.cfg = cfg;
+    this.jssc = jssc;
+    this.props = props;
+    LOG.info("Creating Cleaner with configs : " + props.toString());
+  }
+
   public void run() {
     HoodieWriteConfig hoodieCfg = getHoodieClientConfig();
     try (SparkRDDWriteClient client = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jssc), hoodieCfg)) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java
@@ -54,17 +54,10 @@ public class HoodieCleaner {
   private TypedProperties props;
 
   public HoodieCleaner(Config cfg, JavaSparkContext jssc) {
-    this.cfg = cfg;
-    this.jssc = jssc;
-    /*
-     * Filesystem used.
-     */
-    this.props = cfg.propsFilePath == null ? UtilHelpers.buildProperties(cfg.configs)
-        : UtilHelpers.readConfig(jssc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs).getProps(true);
-    LOG.info("Creating Cleaner with configs : " + props.toString());
+    this(cfg, jssc, UtilHelpers.buildProperties(jssc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs));
   }
 
-  public HoodieCleaner(Config cfg, TypedProperties props, JavaSparkContext jssc) {
+  public HoodieCleaner(Config cfg, JavaSparkContext jssc, TypedProperties props) {
     this.cfg = cfg;
     this.jssc = jssc;
     this.props = props;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -71,6 +71,13 @@ public class HoodieClusteringJob {
     }
   }
 
+  public HoodieClusteringJob(JavaSparkContext jsc, Config cfg, TypedProperties props) {
+    this.cfg = cfg;
+    this.jsc = jsc;
+    this.props = props;
+    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+  }
+
   private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {
     return UtilHelpers.readConfig(jsc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs)
         .getProps(true);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieClusteringJob.java
@@ -76,6 +76,13 @@ public class HoodieClusteringJob {
     this.jsc = jsc;
     this.props = props;
     this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+    // Disable async cleaning, will trigger synchronous cleaning manually.
+    this.props.put(HoodieCleanConfig.ASYNC_CLEAN.key(), false);
+    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+    if (this.metaClient.getTableConfig().isMetadataTableAvailable()) {
+      // add default lock config options if MDT is enabled.
+      UtilHelpers.addLockOptions(cfg.basePath, this.props);
+    }
   }
 
   private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -36,7 +36,6 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
@@ -60,18 +59,7 @@ public class HoodieCompactor {
   private final HoodieTableMetaClient metaClient;
 
   public HoodieCompactor(JavaSparkContext jsc, Config cfg) {
-    this.cfg = cfg;
-    this.jsc = jsc;
-    this.props = cfg.propsFilePath == null
-        ? UtilHelpers.buildProperties(cfg.configs)
-        : readConfigFromFileSystem(jsc, cfg);
-    // Disable async cleaning, will trigger synchronous cleaning manually.
-    this.props.put(HoodieCleanConfig.ASYNC_CLEAN.key(), false);
-    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
-    if (this.metaClient.getTableConfig().isMetadataTableAvailable()) {
-      // add default lock config options if MDT is enabled.
-      UtilHelpers.addLockOptions(cfg.basePath, this.props);
-    }
+    this(jsc, cfg, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs));
   }
 
   public HoodieCompactor(JavaSparkContext jsc, Config cfg, TypedProperties props) {
@@ -85,11 +73,6 @@ public class HoodieCompactor {
       // add default lock config options if MDT is enabled.
       UtilHelpers.addLockOptions(cfg.basePath, this.props);
     }
-  }
-
-  private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {
-    return UtilHelpers.readConfig(jsc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs)
-        .getProps(true);
   }
 
   public static class Config implements Serializable {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -79,6 +79,12 @@ public class HoodieCompactor {
     this.jsc = jsc;
     this.props = props;
     this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+    // Disable async cleaning, will trigger synchronous cleaning manually.
+    this.props.put(HoodieCleanConfig.ASYNC_CLEAN.key(), false);
+    if (this.metaClient.getTableConfig().isMetadataTableAvailable()) {
+      // add default lock config options if MDT is enabled.
+      UtilHelpers.addLockOptions(cfg.basePath, this.props);
+    }
   }
 
   private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java
@@ -74,6 +74,13 @@ public class HoodieCompactor {
     }
   }
 
+  public HoodieCompactor(JavaSparkContext jsc, Config cfg, TypedProperties props) {
+    this.cfg = cfg;
+    this.jsc = jsc;
+    this.props = props;
+    this.metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
+  }
+
   private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {
     return UtilHelpers.readConfig(jsc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs)
         .getProps(true);
@@ -261,8 +268,7 @@ public class HoodieCompactor {
       // instant from the active timeline
       if (StringUtils.isNullOrEmpty(cfg.compactionInstantTime)) {
         HoodieTableMetaClient metaClient = UtilHelpers.createMetaClient(jsc, cfg.basePath, true);
-        Option<HoodieInstant> firstCompactionInstant =
-            metaClient.getActiveTimeline().filterPendingCompactionTimeline().firstInstant();
+        Option<HoodieInstant> firstCompactionInstant = metaClient.getActiveTimeline().filterPendingCompactionTimeline().firstInstant();
         if (firstCompactionInstant.isPresent()) {
           cfg.compactionInstantTime = firstCompactionInstant.get().getTimestamp();
           LOG.info("Found the earliest scheduled compaction instant which will be executed: "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/UtilHelpers.java
@@ -256,6 +256,13 @@ public class UtilHelpers {
     return conf;
   }
 
+  public static TypedProperties buildProperties(Configuration hadoopConf, String propsFilePath, List<String> props) {
+    return StringUtils.isNullOrEmpty(propsFilePath)
+        ? UtilHelpers.buildProperties(props)
+        : UtilHelpers.readConfig(hadoopConf, new Path(propsFilePath), props)
+        .getProps(true);
+  }
+
   public static TypedProperties buildProperties(List<String> props) {
     TypedProperties properties = DFSPropertiesConfiguration.getGlobalProps();
     props.forEach(x -> {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ArchiveTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ArchiveTask.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -29,6 +29,10 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Archive task to run in TableServicePipeline
+ * @see HoodieMultiTableServicesMain
+ */
 class ArchiveTask extends TableServiceTask {
   private static final Logger LOG = LoggerFactory.getLogger(ArchiveTask.class);
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ArchiveTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ArchiveTask.java
@@ -30,7 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Archive task to run in TableServicePipeline
+ * Archive task to run in TableServicePipeline.
+ *
  * @see HoodieMultiTableServicesMain
  */
 class ArchiveTask extends TableServiceTask {
@@ -48,15 +49,38 @@ class ArchiveTask extends TableServiceTask {
     }
   }
 
+  /**
+   * Utility to create builder for {@link ArchiveTask}.
+   *
+   * @return Builder for {@link ArchiveTask}.
+   */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /**
+   * Builder class for {@link ArchiveTask}.
+   */
   public static final class Builder {
+    /**
+     * Properties for running archive task which are already consolidated w/ CLI provided config-overrides.
+     */
     private TypedProperties props;
+
+    /**
+     * Hoodie table path for running archive task.
+     */
     private String basePath;
-    private JavaSparkContext jsc;
+
+    /**
+     * Number of retries.
+     */
     private int retry;
+
+    /**
+     * JavaSparkContext to run spark job.
+     */
+    private JavaSparkContext jsc;
 
     public Builder withProps(TypedProperties props) {
       this.props = props;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ArchiveTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ArchiveTask.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.utilities.UtilHelpers;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ArchiveTask extends TableServiceTask {
+  private static final Logger LOG = LoggerFactory.getLogger(ArchiveTask.class);
+
+  @Override
+  void run() {
+    LOG.info("Run Archive with props: " + props);
+    HoodieWriteConfig hoodieCfg = HoodieWriteConfig.newBuilder().withPath(basePath).withProps(props).build();
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jsc), hoodieCfg)) {
+      UtilHelpers.retry(retry, () -> {
+        client.archive();
+        return 0;
+      }, "Archive Failed");
+    }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private TypedProperties props;
+    private String basePath;
+    private JavaSparkContext jsc;
+    private int retry;
+
+    public Builder withProps(TypedProperties props) {
+      this.props = props;
+      return this;
+    }
+
+    public Builder withBasePath(String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
+    public Builder withJsc(JavaSparkContext jsc) {
+      this.jsc = jsc;
+      return this;
+    }
+
+    public Builder withRetry(int retry) {
+      this.retry = retry;
+      return this;
+    }
+
+    public ArchiveTask build() {
+      ArchiveTask archiveTask = new ArchiveTask();
+      archiveTask.jsc = this.jsc;
+      archiveTask.retry = this.retry;
+      archiveTask.props = this.props;
+      archiveTask.basePath = this.basePath;
+      return archiveTask;
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -25,6 +25,10 @@ import org.apache.hudi.utilities.UtilHelpers;
 
 import org.apache.spark.api.java.JavaSparkContext;
 
+/**
+ * Clean task to run in TableServicePipeline
+ * @see HoodieMultiTableServicesMain
+ */
 class CleanTask extends TableServiceTask {
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
@@ -26,7 +26,8 @@ import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.spark.api.java.JavaSparkContext;
 
 /**
- * Clean task to run in TableServicePipeline
+ * Clean task to run in TableServicePipeline.
+ *
  * @see HoodieMultiTableServicesMain
  */
 class CleanTask extends TableServiceTask {
@@ -41,15 +42,38 @@ class CleanTask extends TableServiceTask {
     }, "Clean Failed");
   }
 
+  /**
+   * Utility to create builder for {@link CleanTask}.
+   *
+   * @return Builder for {@link CleanTask}.
+   */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /**
+   * Builder class for {@link CleanTask}.
+   */
   public static final class Builder {
+    /**
+     * Properties for running clean task which are already consolidated w/ CLI provided config-overrides.
+     */
     private TypedProperties props;
+
+    /**
+     * Hoodie table path for running clean task.
+     */
     private String basePath;
-    private JavaSparkContext jsc;
+
+    /**
+     * Number of retries.
+     */
     private int retry;
+
+    /**
+     * JavaSparkContext to run spark job.
+     */
+    private JavaSparkContext jsc;
 
     public Builder withProps(TypedProperties props) {
       this.props = props;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
@@ -37,7 +37,7 @@ class CleanTask extends TableServiceTask {
     HoodieCleaner.Config cleanConfig = new HoodieCleaner.Config();
     cleanConfig.basePath = basePath;
     UtilHelpers.retry(retry, () -> {
-      new HoodieCleaner(cleanConfig, props, jsc).run();
+      new HoodieCleaner(cleanConfig, jsc, props).run();
       return 0;
     }, "Clean Failed");
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CleanTask.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.HoodieCleaner;
+import org.apache.hudi.utilities.UtilHelpers;
+
+import org.apache.spark.api.java.JavaSparkContext;
+
+class CleanTask extends TableServiceTask {
+
+  @Override
+  void run() {
+    HoodieCleaner.Config cleanConfig = new HoodieCleaner.Config();
+    cleanConfig.basePath = basePath;
+    UtilHelpers.retry(retry, () -> {
+      new HoodieCleaner(cleanConfig, props, jsc).run();
+      return 0;
+    }, "Clean Failed");
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private TypedProperties props;
+    private String basePath;
+    private JavaSparkContext jsc;
+    private int retry;
+
+    public Builder withProps(TypedProperties props) {
+      this.props = props;
+      return this;
+    }
+
+    public Builder withBasePath(String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
+    public Builder withJsc(JavaSparkContext jsc) {
+      this.jsc = jsc;
+      return this;
+    }
+
+    public Builder withRetry(int retry) {
+      this.retry = retry;
+      return this;
+    }
+
+    public CleanTask build() {
+      CleanTask cleanTask = new CleanTask();
+      cleanTask.jsc = this.jsc;
+      cleanTask.retry = this.retry;
+      cleanTask.basePath = this.basePath;
+      cleanTask.props = this.props;
+      return cleanTask;
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
@@ -25,12 +25,22 @@ import org.apache.hudi.utilities.HoodieClusteringJob;
 import org.apache.spark.api.java.JavaSparkContext;
 
 /**
- * Clustering task to run in TableServicePipeline
+ * Clustering task to run in TableServicePipeline.
+ *
  * @see HoodieMultiTableServicesMain
  */
 class ClusteringTask extends TableServiceTask {
 
+  /**
+   * Parallelism for hoodie clustering.
+   */
   private int parallelism;
+
+  /**
+   * Mode for running clustering.
+   *
+   * @see HoodieClusteringJob.Config#runningMode
+   */
   private String clusteringMode;
 
   @Override
@@ -42,16 +52,50 @@ class ClusteringTask extends TableServiceTask {
     new HoodieClusteringJob(jsc, clusteringConfig, props).cluster(retry);
   }
 
+  /**
+   * Utility to create builder for {@link ClusteringTask}.
+   *
+   * @return Builder for {@link ClusteringTask}.
+   */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /**
+   * Builder class for {@link ClusteringTask}.
+   */
   public static final class Builder {
+
+    /**
+     * Properties for running clustering task which are already consolidated w/ CLI provided config-overrides.
+     */
     private TypedProperties props;
+
+    /**
+     * Parallelism for hoodie clustering.
+     */
     private int parallelism;
+
+    /**
+     * Clustering mode for running clustering.
+     *
+     * @see HoodieClusteringJob.Config#runningMode
+     */
     private String clusteringMode;
+
+    /**
+     * Hoodie table path for running clustering task.
+     */
     private String basePath;
+
+    /**
+     * JavaSparkContext to run spark job.
+     */
     private JavaSparkContext jsc;
+
+    /**
+     * Number of retries.
+     */
     private int retry;
 
     private Builder() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -24,6 +24,10 @@ import org.apache.hudi.utilities.HoodieClusteringJob;
 
 import org.apache.spark.api.java.JavaSparkContext;
 
+/**
+ * Clustering task to run in TableServicePipeline
+ * @see HoodieMultiTableServicesMain
+ */
 class ClusteringTask extends TableServiceTask {
 
   private int parallelism;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/ClusteringTask.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.HoodieClusteringJob;
+
+import org.apache.spark.api.java.JavaSparkContext;
+
+class ClusteringTask extends TableServiceTask {
+
+  private int parallelism;
+  private String clusteringMode;
+
+  @Override
+  void run() {
+    HoodieClusteringJob.Config clusteringConfig = new HoodieClusteringJob.Config();
+    clusteringConfig.basePath = basePath;
+    clusteringConfig.parallelism = parallelism;
+    clusteringConfig.runningMode = clusteringMode;
+    new HoodieClusteringJob(jsc, clusteringConfig, props).cluster(retry);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private TypedProperties props;
+    private int parallelism;
+    private String clusteringMode;
+    private String basePath;
+    private JavaSparkContext jsc;
+    private int retry;
+
+    private Builder() {
+    }
+
+    public Builder withProps(TypedProperties props) {
+      this.props = props;
+      return this;
+    }
+
+    public Builder withParallelism(int parallelism) {
+      this.parallelism = parallelism;
+      return this;
+    }
+
+    public Builder withClusteringRunningMode(String clusteringRunningMode) {
+      this.clusteringMode = clusteringRunningMode;
+      return this;
+    }
+
+    public Builder withBasePath(String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
+    public Builder withJsc(JavaSparkContext jsc) {
+      this.jsc = jsc;
+      return this;
+    }
+
+    public Builder withRetry(int retry) {
+      this.retry = retry;
+      return this;
+    }
+
+    public ClusteringTask build() {
+      ClusteringTask clusteringTask = new ClusteringTask();
+      clusteringTask.jsc = this.jsc;
+      clusteringTask.parallelism = this.parallelism;
+      clusteringTask.clusteringMode = this.clusteringMode;
+      clusteringTask.retry = this.retry;
+      clusteringTask.basePath = this.basePath;
+      clusteringTask.props = this.props;
+      return clusteringTask;
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -25,6 +25,10 @@ import org.apache.hudi.utilities.HoodieCompactor;
 
 import org.apache.spark.api.java.JavaSparkContext;
 
+/**
+ * Compaction task to run in TableServicePipeline
+ * @see HoodieMultiTableServicesMain
+ */
 class CompactionTask extends TableServiceTask {
 
   public String compactionRunningMode = HoodieCompactor.EXECUTE;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
@@ -20,21 +20,32 @@
 package org.apache.hudi.utilities.multitable;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
 import org.apache.hudi.utilities.HoodieCompactor;
 
 import org.apache.spark.api.java.JavaSparkContext;
 
 /**
- * Compaction task to run in TableServicePipeline
+ * Compaction task to run in TableServicePipeline.
+ *
  * @see HoodieMultiTableServicesMain
  */
 class CompactionTask extends TableServiceTask {
 
-  public String compactionRunningMode = HoodieCompactor.EXECUTE;
+  /**
+   * Mode for running compaction.
+   *
+   * @see HoodieCompactor.Config#runningMode
+   */
+  public String compactionRunningMode;
 
-  public String compactionStrategyName = LogFileSizeBasedCompactionStrategy.class.getName();
+  /**
+   * Strategy Class of compaction.
+   */
+  public String compactionStrategyName;
 
+  /**
+   * Parallelism for hoodie clustering.
+   */
   private int parallelism;
 
   @Override
@@ -48,16 +59,54 @@ class CompactionTask extends TableServiceTask {
     new HoodieCompactor(jsc, compactionCfg, props).compact(retry);
   }
 
+  /**
+   * Utility to create builder for {@link CompactionTask}.
+   *
+   * @return Builder for {@link CompactionTask}.
+   */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /**
+   * Builder class for {@link CompactionTask}.
+   */
   public static final class Builder {
+    /**
+     * Properties for running compaction task which are already consolidated w/ CLI provided config-overrides.
+     */
     private TypedProperties props;
+
+    /**
+     * Mode for running compaction.
+     *
+     * @see HoodieCompactor.Config#runningMode
+     */
     private String compactionRunningMode;
+
+    /**
+     * Strategy Class of compaction.
+     */
+    public String compactionStrategyName;
+
+    /**
+     * Parallelism for hoodie compaction.
+     */
     private int parallelism;
+
+    /**
+     * Number of retries.
+     */
     private int retry;
+
+    /**
+     * Hoodie table path for running compaction task.
+     */
     private String basePath;
+
+    /**
+     * JavaSparkContext to run spark job.
+     */
     private JavaSparkContext jsc;
 
     public Builder withProps(TypedProperties props) {
@@ -67,6 +116,11 @@ class CompactionTask extends TableServiceTask {
 
     public Builder withCompactionRunningMode(String compactionRunningMode) {
       this.compactionRunningMode = compactionRunningMode;
+      return this;
+    }
+
+    public Builder withCompactionStrategyName(String compactionStrategyName) {
+      this.compactionStrategyName = compactionStrategyName;
       return this;
     }
 
@@ -96,6 +150,7 @@ class CompactionTask extends TableServiceTask {
       compactionTask.jsc = this.jsc;
       compactionTask.parallelism = this.parallelism;
       compactionTask.compactionRunningMode = this.compactionRunningMode;
+      compactionTask.compactionStrategyName = this.compactionStrategyName;
       compactionTask.retry = this.retry;
       compactionTask.props = this.props;
       return compactionTask;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/CompactionTask.java
@@ -1,0 +1,100 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
+import org.apache.hudi.utilities.HoodieCompactor;
+
+import org.apache.spark.api.java.JavaSparkContext;
+
+class CompactionTask extends TableServiceTask {
+
+  public String compactionRunningMode = HoodieCompactor.EXECUTE;
+
+  public String compactionStrategyName = LogFileSizeBasedCompactionStrategy.class.getName();
+
+  private int parallelism;
+
+  @Override
+  void run() {
+    HoodieCompactor.Config compactionCfg = new HoodieCompactor.Config();
+    compactionCfg.basePath = basePath;
+    compactionCfg.strategyClassName = compactionStrategyName;
+    compactionCfg.runningMode = compactionRunningMode;
+    compactionCfg.parallelism = parallelism;
+    compactionCfg.retry = retry;
+    new HoodieCompactor(jsc, compactionCfg, props).compact(retry);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private TypedProperties props;
+    private String compactionRunningMode;
+    private int parallelism;
+    private int retry;
+    private String basePath;
+    private JavaSparkContext jsc;
+
+    public Builder withProps(TypedProperties props) {
+      this.props = props;
+      return this;
+    }
+
+    public Builder withCompactionRunningMode(String compactionRunningMode) {
+      this.compactionRunningMode = compactionRunningMode;
+      return this;
+    }
+
+    public Builder withParallelism(int parallelism) {
+      this.parallelism = parallelism;
+      return this;
+    }
+
+    public Builder withRetry(int retry) {
+      this.retry = retry;
+      return this;
+    }
+
+    public Builder withBasePath(String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
+    public Builder withJsc(JavaSparkContext jsc) {
+      this.jsc = jsc;
+      return this;
+    }
+
+    public CompactionTask build() {
+      CompactionTask compactionTask = new CompactionTask();
+      compactionTask.basePath = this.basePath;
+      compactionTask.jsc = this.jsc;
+      compactionTask.parallelism = this.parallelism;
+      compactionTask.compactionRunningMode = this.compactionRunningMode;
+      compactionTask.retry = this.retry;
+      compactionTask.props = this.props;
+      return compactionTask;
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  * Main function for executing multi-table services
  */
 public class HoodieMultiTableServicesMain {
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieStreamer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieMultiTableServicesMain.class);
   final Config cfg;
   final TypedProperties props;
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
@@ -1,0 +1,249 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.utilities.HoodieCompactor;
+import org.apache.hudi.utilities.IdentitySplitter;
+import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.hudi.utilities.streamer.HoodieStreamer;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.utilities.multitable.MultiTableServiceUtils.Constants.LOCAL_SPARK_MASTER;
+
+public class HoodieMultiTableServicesMain {
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieStreamer.class);
+  final Config cfg;
+  final TypedProperties props;
+
+  private final JavaSparkContext jsc;
+
+  private ScheduledExecutorService executorService;
+
+  private void batchRunTableServices(List<String> tablePaths) throws InterruptedException, ExecutionException {
+    ExecutorService executorService = Executors.newFixedThreadPool(cfg.poolSize);
+    List<CompletableFuture<Void>> futures = tablePaths.stream()
+        .map(basePath -> CompletableFuture.runAsync(
+            () -> MultiTableServiceUtils.buildTableServicePipeline(jsc, basePath, cfg, props).execute(),
+            executorService))
+        .collect(Collectors.toList());
+    CompletableFuture<?> allComplete =
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    CompletableFuture<?> anyException = new CompletableFuture<>();
+    for (CompletableFuture<?> future : futures) {
+      future.exceptionally((e) -> {
+        anyException.completeExceptionally(e);
+        return null;
+      });
+    }
+    try {
+      CompletableFuture.anyOf(allComplete, anyException).get();
+    } catch (ExecutionException ee) {
+      throw new ExecutionException("some table service failed", ee);
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  private void streamRunTableServices(List<String> tablePaths) throws InterruptedException {
+    executorService = Executors.newScheduledThreadPool(cfg.poolSize);
+    for (String tablePath : tablePaths) {
+      TableServicePipeline pipeline = MultiTableServiceUtils.buildTableServicePipeline(jsc, tablePath, cfg, props);
+      executorService.scheduleAtFixedRate(pipeline::execute, 0, cfg.scheduleDelay, TimeUnit.MILLISECONDS);
+    }
+    executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.MINUTES);
+  }
+
+  public void cancel() {
+    if (executorService != null) {
+      executorService.shutdown();
+    }
+  }
+
+  public HoodieMultiTableServicesMain(JavaSparkContext jsc, Config cfg) {
+    this.cfg = cfg;
+    this.jsc = jsc;
+    this.props = cfg.propsFilePath == null ? UtilHelpers.buildProperties(cfg.configs) : readConfigFromFileSystem(jsc, cfg);
+  }
+
+  public void startServices() throws ExecutionException, InterruptedException {
+    LOG.info("StartServices Config: " + cfg);
+    List<String> tablePaths;
+    if (cfg.autoDiscovering) {
+      // We support defining multi base paths
+      tablePaths = cfg.basePath.stream()
+          .filter(this::pathExists)
+          .flatMap(p -> MultiTableServiceUtils.findHoodieTablesUnderPath(jsc, p).stream())
+          .collect(Collectors.toList());
+    } else {
+      tablePaths = MultiTableServiceUtils.getTablesToBeIngestedFromProps(props);
+    }
+    LOG.info("All table paths: " + String.join(",", tablePaths));
+    if (cfg.batch) {
+      batchRunTableServices(tablePaths);
+    } else {
+      streamRunTableServices(tablePaths);
+    }
+  }
+
+  private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {
+    return UtilHelpers.readConfig(jsc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs).getProps(true);
+  }
+
+  private boolean pathExists(String path) {
+    try {
+      Path p = new Path(path);
+      FileSystem fs = p.getFileSystem(jsc.hadoopConfiguration());
+      return fs.exists(p);
+    } catch (IOException e) {
+      throw new HoodieIOException("Error checking path existing:", e);
+    }
+  }
+
+  /**
+   * Command line configs to run table services
+   */
+  public static class Config implements Serializable {
+    @Parameter(names = {"--base-path"}, description = "Base path for all the tables, this can be repeated",
+        required = true, splitter = IdentitySplitter.class)
+    public List<String> basePath = Collections.emptyList();
+
+    @Parameter(names = {"--auto", "-a"}, description = "Whether to discover hudi tables in the base path")
+    public boolean autoDiscovering = false;
+
+    @Parameter(names = {"--parallelism"}, description = "Parallelism for hoodie table service")
+    public int parallelism = 200;
+
+    @Parameter(names = {"--batch", "-b"}, description = "Run services in batch or streaming mode")
+    public boolean batch = false;
+
+    @Parameter(names = {"--schedule-delay", "-d"}, description = "Table services schedule delay")
+    public int scheduleDelay = 2000;
+
+    @Parameter(names = {"--retry", "-r"}, description = "Table service retry count")
+    public int retry = 1;
+
+    @Parameter(names = {"--poolSize", "-p"}, description = "thread pool size")
+    public int poolSize = Runtime.getRuntime().availableProcessors();
+
+    @Parameter(names = {"--name", "-n"}, description = "Spark APP name")
+    public String appName = "Hudi Table Service";
+
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
+
+    @Parameter(names = {"--enable-compaction"}, help = true)
+    public Boolean enableCompaction = false;
+
+    @Parameter(names = {"--enable-clustering"}, help = true)
+    public Boolean enableClustering = false;
+
+    @Parameter(names = {"--enable-clean"}, help = true)
+    public Boolean enableClean = false;
+
+    @Parameter(names = {"--enable-archive"}, help = true)
+    public Boolean enableArchive = false;
+
+    @Parameter(names = {"--compaction-mode"}, description = "Set job mode: Set \"schedule\" means make a compact plan; "
+        + "Set \"execute\" means execute a compact plan at given instant which means --instant-time is needed here; "
+        + "Set \"scheduleAndExecute\" means make a compact plan first and execute that plan immediately")
+    public String compactionRunningMode = HoodieCompactor.EXECUTE;
+
+    @Parameter(names = {"--clustering-mode"}, description = "Set job mode: Set \"schedule\" means make a clustering plan; "
+        + "Set \"execute\" means execute a clustering plan at given instant which means --instant-time is needed here; "
+        + "Set \"scheduleAndExecute\" means make a clustering plan first and execute that plan immediately")
+    public String clusteringRunningMode = HoodieCompactor.SCHEDULE_AND_EXECUTE;
+
+    @Parameter(names = {"--props"}, description = "path to properties file on localfs or dfs, with configurations for "
+        + "hoodie client for table service")
+    public String propsFilePath = null;
+
+    @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
+        + "(using the CLI parameter \"--props\") can also be passed command line using this parameter. This can be repeated",
+        splitter = IdentitySplitter.class)
+    public List<String> configs = new ArrayList<>();
+
+    @Override
+    public String toString() {
+      return "Config{"
+          + "basePath=" + basePath
+          + ", autoDiscovering=" + autoDiscovering
+          + ", parallelism=" + parallelism
+          + ", batch=" + batch
+          + ", scheduleDelay=" + scheduleDelay
+          + ", retry=" + retry
+          + ", poolSize=" + poolSize
+          + ", appName='" + appName + '\''
+          + ", help=" + help
+          + ", enableCompaction=" + enableCompaction
+          + ", enableClustering=" + enableClustering
+          + ", enableClean=" + enableClean
+          + ", enableArchive=" + enableArchive
+          + ", compactionRunningMode='" + compactionRunningMode + '\''
+          + ", clusteringRunningMode='" + clusteringRunningMode + '\''
+          + ", propsFilePath='" + propsFilePath + '\''
+          + ", configs=" + configs
+          + '}';
+    }
+
+  }
+
+  public static void main(String[] args) {
+    final HoodieMultiTableServicesMain.Config cfg = new HoodieMultiTableServicesMain.Config();
+    JCommander cmd = new JCommander(cfg, null, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+    Map<String, String> config = new HashMap<>();
+    JavaSparkContext jsc = UtilHelpers.buildSparkContext(cfg.appName, LOCAL_SPARK_MASTER, config);
+    try {
+      new HoodieMultiTableServicesMain(jsc, cfg).startServices();
+    } catch (Throwable throwable) {
+      LOG.error("Fail to run table services, ", throwable);
+    } finally {
+      jsc.stop();
+    }
+  }
+
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.multitable;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
 import org.apache.hudi.utilities.HoodieCompactor;
 import org.apache.hudi.utilities.IdentitySplitter;
 import org.apache.hudi.utilities.UtilHelpers;
@@ -48,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * Main function for executing multi-table services
+ * Main function for executing multi-table services.
  */
 public class HoodieMultiTableServicesMain {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieMultiTableServicesMain.class);
@@ -188,6 +189,9 @@ public class HoodieMultiTableServicesMain {
         + "Set \"scheduleAndExecute\" means make a compact plan first and execute that plan immediately")
     public String compactionRunningMode = HoodieCompactor.EXECUTE;
 
+    @Parameter(names = {"--strategy", "-st"}, description = "Strategy Class")
+    public String compactionStrategyClassName = LogFileSizeBasedCompactionStrategy.class.getName();
+
     @Parameter(names = {"--clustering-mode"}, description = "Set job mode: Set \"schedule\" means make a clustering plan; "
         + "Set \"execute\" means execute a clustering plan at given instant which means --instant-time is needed here; "
         + "Set \"scheduleAndExecute\" means make a clustering plan first and execute that plan immediately")
@@ -225,6 +229,7 @@ public class HoodieMultiTableServicesMain {
           .add("enableClean=" + enableClean)
           .add("enableArchive=" + enableArchive)
           .add("compactionRunningMode='" + compactionRunningMode + "'")
+          .add("compactionStrategyClassName='" + compactionStrategyClassName + "'")
           .add("clusteringRunningMode='" + clusteringRunningMode + "'")
           .add("sparkMaster='" + sparkMaster + "'")
           .add("sparkMemory='" + sparkMemory + "'")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
@@ -24,7 +24,6 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.utilities.HoodieCompactor;
 import org.apache.hudi.utilities.IdentitySplitter;
 import org.apache.hudi.utilities.UtilHelpers;
-import org.apache.hudi.utilities.streamer.HoodieStreamer;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 
 /**
- * Utils for executing multi-table services
+ * Utils for executing multi-table services.
  */
 public class MultiTableServiceUtils {
 
@@ -63,7 +63,7 @@ public class MultiTableServiceUtils {
   }
 
   /**
-   * Type of directories when searching hoodie tables under path
+   * Type of directories when searching hoodie tables under path.
    */
   enum DirType {
     HOODIE_TABLE,
@@ -142,6 +142,7 @@ public class MultiTableServiceUtils {
           .withBasePath(basePath)
           .withParallelism(cfg.parallelism)
           .withCompactionRunningMode(cfg.compactionRunningMode)
+          .withCompactionStrategyName(cfg.compactionStrategyClassName)
           .withProps(props)
           .withRetry(cfg.retry)
           .build());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -40,20 +40,21 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 
+/**
+ * Utils for executing multi-table services
+ */
 public class MultiTableServiceUtils {
 
   public static class Constants {
-    public static final String TABLES_TO_BE_INGESTED_PROP = "hoodie.tableservice.tablesToServe";
+    public static final String TABLES_TO_BE_SERVED_PROP = "hoodie.tableservice.tablesToServe";
 
     public static final String COMMA_SEPARATOR = ",";
-
-    public static final String LOCAL_SPARK_MASTER = "local[2]";
 
     private static final int DEFAULT_LISTING_PARALLELISM = 1500;
   }
 
-  public static List<String> getTablesToBeIngestedFromProps(TypedProperties properties) {
-    String combinedTablesString = properties.getString(Constants.TABLES_TO_BE_INGESTED_PROP);
+  public static List<String> getTablesToBeServedFromProps(TypedProperties properties) {
+    String combinedTablesString = properties.getString(Constants.TABLES_TO_BE_SERVED_PROP);
     if (combinedTablesString == null) {
       return new ArrayList<>();
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -1,0 +1,166 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
+
+public class MultiTableServiceUtils {
+
+  public static class Constants {
+    public static final String TABLES_TO_BE_INGESTED_PROP = "hoodie.tableservice.tablesToServe";
+
+    public static final String COMMA_SEPARATOR = ",";
+
+    public static final String LOCAL_SPARK_MASTER = "local[2]";
+
+    private static final int DEFAULT_LISTING_PARALLELISM = 1500;
+  }
+
+  public static List<String> getTablesToBeIngestedFromProps(TypedProperties properties) {
+    String combinedTablesString = properties.getString(Constants.TABLES_TO_BE_INGESTED_PROP);
+    if (combinedTablesString == null) {
+      return new ArrayList<>();
+    }
+    String[] tablesArray = combinedTablesString.split(Constants.COMMA_SEPARATOR);
+    return Arrays.asList(tablesArray);
+  }
+
+  public static List<String> findHoodieTablesUnderPath(JavaSparkContext jsc, String pathStr) {
+    Path rootPath = new Path(pathStr);
+    SerializableConfiguration conf = new SerializableConfiguration(jsc.hadoopConfiguration());
+    if (isHoodieTable(rootPath, conf.get())) {
+      return Collections.singletonList(pathStr);
+    }
+
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    List<String> hoodieTablePaths = new CopyOnWriteArrayList<>();
+    List<Path> pathsToList = new CopyOnWriteArrayList<>();
+    pathsToList.add(rootPath);
+    int listingParallelism = Math.min(Constants.DEFAULT_LISTING_PARALLELISM, pathsToList.size());
+
+    while (!pathsToList.isEmpty()) {
+      // List all directories in parallel
+      List<FileStatus[]> dirToFileListing = engineContext.map(pathsToList, path -> {
+        FileSystem fileSystem = path.getFileSystem(conf.get());
+        return fileSystem.listStatus(path);
+      }, listingParallelism);
+      pathsToList.clear();
+
+      // if current dictionary contains meta folder(.hoodie), add it to result. Otherwise, add it to queue
+      List<FileStatus> dirs = dirToFileListing.stream().flatMap(Arrays::stream)
+          .filter(FileStatus::isDirectory)
+          .collect(Collectors.toList());
+
+      if (!dirs.isEmpty()) {
+        List<Pair<FileStatus, Integer>> dirResults = engineContext.map(dirs, fileStatus -> {
+          if (isHoodieTable(fileStatus.getPath(), conf.get())) {
+            return Pair.of(fileStatus, 0);
+          } else if (!fileStatus.getPath().getName().equals(METAFOLDER_NAME)) {
+            return Pair.of(fileStatus, 1);
+          }
+          return Pair.of(fileStatus, 2);
+        }, Math.min(Constants.DEFAULT_LISTING_PARALLELISM, dirs.size()));
+
+        dirResults.stream().parallel().forEach(dirResult -> {
+          FileStatus fileStatus = dirResult.getLeft();
+          if (dirResult.getRight() == 0) {
+            hoodieTablePaths.add(fileStatus.getPath().toString());
+          } else if (dirResult.getRight() == 1) {
+            pathsToList.add(fileStatus.getPath());
+          }
+        });
+      }
+    }
+
+    return hoodieTablePaths;
+  }
+
+  private static boolean isHoodieTable(Path path, Configuration conf) {
+    try {
+      FileSystem fs = path.getFileSystem(conf);
+      return fs.exists(path) && fs.exists(new Path(path, METAFOLDER_NAME));
+    } catch (Exception e) {
+      throw new HoodieException("Error checking presence of partition meta file for " + path, e);
+    }
+  }
+
+  public static TableServicePipeline buildTableServicePipeline(JavaSparkContext jsc,
+                                                               String basePath,
+                                                               HoodieMultiTableServicesMain.Config cfg,
+                                                               TypedProperties props) {
+    TableServicePipeline pipeline = new TableServicePipeline();
+    if (cfg.enableCompaction) {
+      pipeline.add(CompactionTask.newBuilder()
+          .withJsc(jsc)
+          .withBasePath(basePath)
+          .withParallelism(cfg.parallelism)
+          .withCompactionRunningMode(cfg.compactionRunningMode)
+          .withProps(props)
+          .withRetry(cfg.retry)
+          .build());
+    }
+    if (cfg.enableClustering) {
+      pipeline.add(ClusteringTask.newBuilder()
+          .withBasePath(basePath)
+          .withJsc(jsc)
+          .withParallelism(cfg.parallelism)
+          .withClusteringRunningMode(cfg.clusteringRunningMode)
+          .withProps(props)
+          .withRetry(cfg.retry)
+          .build());
+    }
+    if (cfg.enableClean) {
+      pipeline.add(CleanTask.newBuilder()
+          .withBasePath(basePath)
+          .withJsc(jsc)
+          .withRetry(cfg.retry)
+          .withProps(props)
+          .build());
+    }
+    if (cfg.enableArchive) {
+      pipeline.add(ArchiveTask.newBuilder()
+          .withBasePath(basePath)
+          .withJsc(jsc)
+          .withProps(props)
+          .withRetry(cfg.retry)
+          .build());
+    }
+    return pipeline;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServicePipeline.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServicePipeline.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -22,6 +22,9 @@ package org.apache.hudi.utilities.multitable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * TableServicePipeline is a container holding all table services task to execute for a specific hoodie table
+ */
 public class TableServicePipeline {
 
   private final List<TableServiceTask> tableServiceTasks;
@@ -30,10 +33,18 @@ public class TableServicePipeline {
     this.tableServiceTasks = new ArrayList<>();
   }
 
+  /**
+   * Add a table service task to the end of table service pipe. The task will be executed in FIFO manner
+   *
+   * @param task table service task to run in pipeline
+   */
   public void add(TableServiceTask task) {
     tableServiceTasks.add(task);
   }
 
+  /**
+   * Run all table services task sequentially
+   */
   public void execute() {
     tableServiceTasks.forEach(TableServiceTask::run);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServicePipeline.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServicePipeline.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableServicePipeline {
+
+  private final List<TableServiceTask> tableServiceTasks;
+
+  public TableServicePipeline() {
+    this.tableServiceTasks = new ArrayList<>();
+  }
+
+  public void add(TableServiceTask task) {
+    tableServiceTasks.add(task);
+  }
+
+  public void execute() {
+    tableServiceTasks.forEach(TableServiceTask::run);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServicePipeline.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServicePipeline.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * TableServicePipeline is a container holding all table services task to execute for a specific hoodie table
+ * TableServicePipeline is a container holding all table services task to execute for a specific hoodie table.
  */
 public class TableServicePipeline {
 
@@ -34,16 +34,16 @@ public class TableServicePipeline {
   }
 
   /**
-   * Add a table service task to the end of table service pipe. The task will be executed in FIFO manner
+   * Add a table service task to the end of table service pipe. The task will be executed in FIFO manner.
    *
-   * @param task table service task to run in pipeline
+   * @param task table service task to run in pipeline.
    */
   public void add(TableServiceTask task) {
     tableServiceTasks.add(task);
   }
 
   /**
-   * Run all table services task sequentially
+   * Run all table services task sequentially.
    */
   public void execute() {
     tableServiceTasks.forEach(TableServiceTask::run);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServiceTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServiceTask.java
@@ -24,18 +24,31 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.spark.api.java.JavaSparkContext;
 
 /**
- * Abstract class for defining a task running in TableService pipeline
+ * Abstract class for defining a task running in TableService pipeline.
+ *
  * @see TableServicePipeline
  */
 public abstract class TableServiceTask {
 
+  /**
+   * Hoodie table path for running table service
+   */
   protected String basePath;
 
-  protected JavaSparkContext jsc;
-
+  /**
+   * Properties for running clean task which are already consolidated w/ CLI provided config-overrides.
+   */
   protected TypedProperties props;
 
+  /**
+   * Number of retries when running table services
+   */
   protected int retry;
+
+  /**
+   * JavaSparkContext to run spark job.
+   */
+  protected JavaSparkContext jsc;
 
   abstract void run();
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServiceTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServiceTask.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.apache.spark.api.java.JavaSparkContext;
+
+public abstract class TableServiceTask {
+
+  protected String basePath;
+
+  protected JavaSparkContext jsc;
+
+  protected TypedProperties props;
+
+  protected int retry;
+
+  abstract void run();
+
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServiceTask.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/TableServiceTask.java
@@ -1,20 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi.utilities.multitable;
@@ -23,6 +23,10 @@ import org.apache.hudi.common.config.TypedProperties;
 
 import org.apache.spark.api.java.JavaSparkContext;
 
+/**
+ * Abstract class for defining a task running in TableService pipeline
+ * @see TableServicePipeline
+ */
 public abstract class TableServiceTask {
 
   protected String basePath;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -74,7 +74,7 @@ import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
  */
 class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implements SparkProvider {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ArchiveTask.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieMultiTableServicesMain.class);
 
   protected boolean initialized = false;
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -1,0 +1,304 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi.utilities.multitable;
+
+import org.apache.hudi.client.SparkRDDReadClient;
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCleaningPolicy;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieLayoutConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner;
+import org.apache.hudi.table.storage.HoodieStorageLayout;
+import org.apache.hudi.testutils.providers.SparkProvider;
+import org.apache.hudi.utilities.HoodieCompactor;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.HoodieSparkKryoRegistrar$;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+
+class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implements SparkProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ArchiveTask.class);
+
+  protected boolean initialized = false;
+
+  private static SparkSession spark;
+  private static SQLContext sqlContext;
+  private static JavaSparkContext jsc;
+  private static HoodieSparkEngineContext context;
+
+  protected transient HoodieTestDataGenerator dataGen = null;
+
+  @BeforeEach
+  public void init() throws IOException, ExecutionException, InterruptedException {
+    boolean initialized = spark != null;
+    if (!initialized) {
+      SparkConf sparkConf = conf();
+      HoodieSparkKryoRegistrar$.MODULE$.register(sparkConf);
+      SparkRDDReadClient.addHoodieSupport(sparkConf);
+      spark = SparkSession.builder().config(sparkConf).getOrCreate();
+      sqlContext = spark.sqlContext();
+      jsc = new JavaSparkContext(spark.sparkContext());
+      context = new HoodieSparkEngineContext(jsc);
+    }
+    initPath();
+    prepareData();
+  }
+
+  @Test
+  public void testRunAllServices() throws IOException, ExecutionException, InterruptedException {
+    HoodieMultiTableServicesMain.Config cfg = getHoodieMultiServiceConfig();
+    cfg.batch = true;
+    HoodieTableMetaClient metaClient1 = getMetaClient("table1");
+    HoodieTableMetaClient metaClient2 = getMetaClient("table2");
+    HoodieMultiTableServicesMain main = new HoodieMultiTableServicesMain(jsc, cfg);
+    main.startServices();
+    // Verify cleans
+    Assertions.assertEquals(1, metaClient1.reloadActiveTimeline().getCleanerTimeline().countInstants());
+    Assertions.assertEquals(1, metaClient2.reloadActiveTimeline().getCleanerTimeline().countInstants());
+    // Verify delta commits
+    Assertions.assertEquals(2, metaClient1.reloadActiveTimeline().getDeltaCommitTimeline().countInstants());
+    Assertions.assertEquals(2, metaClient2.reloadActiveTimeline().getDeltaCommitTimeline().countInstants());
+    // Verify replace commits
+    Assertions.assertEquals(1, metaClient1.reloadActiveTimeline().getCompletedReplaceTimeline().countInstants());
+    Assertions.assertEquals(1, metaClient2.reloadActiveTimeline().getCompletedReplaceTimeline().countInstants());
+    // Verify compactions, delta commits and replace commits
+    Assertions.assertEquals(4, metaClient1.reloadActiveTimeline().getCommitsTimeline().countInstants());
+    Assertions.assertEquals(4, metaClient2.reloadActiveTimeline().getCommitsTimeline().countInstants());
+  }
+
+  @Test
+  public void testRunAllServicesForSingleTable() throws IOException, ExecutionException, InterruptedException {
+    HoodieMultiTableServicesMain.Config cfg = getHoodieMultiServiceConfig();
+    HoodieTableMetaClient metaClient1 = getMetaClient("table1");
+    cfg.batch = true;
+    cfg.basePath = Collections.singletonList(metaClient1.getBasePath());
+    HoodieMultiTableServicesMain main = new HoodieMultiTableServicesMain(jsc, cfg);
+    main.startServices();
+    // Verify cleans
+    Assertions.assertEquals(1, metaClient1.reloadActiveTimeline().getCleanerTimeline().countInstants());
+    // Verify delta commits
+    Assertions.assertEquals(2, metaClient1.reloadActiveTimeline().getDeltaCommitTimeline().countInstants());
+    // Verify replace commits
+    Assertions.assertEquals(1, metaClient1.reloadActiveTimeline().getCompletedReplaceTimeline().countInstants());
+    // Verify compactions, delta commits and replace commits
+    Assertions.assertEquals(4, metaClient1.reloadActiveTimeline().getCommitsTimeline().countInstants());
+  }
+
+  @Test
+  public void testStreamRunAllServices() throws IOException, ExecutionException, InterruptedException {
+    HoodieMultiTableServicesMain.Config cfg = getHoodieMultiServiceConfig();
+    HoodieMultiTableServicesMain main = new HoodieMultiTableServicesMain(jsc, cfg);
+    new Thread(() -> {
+      try {
+        Thread.sleep(10000);
+        LOG.info("Shutdown the table services");
+        main.cancel();
+      } catch (InterruptedException e) {
+        //
+      }
+    }).start();
+    main.startServices();
+    HoodieTableMetaClient metaClient1 = getMetaClient("table1");
+    HoodieTableMetaClient metaClient2 = getMetaClient("table2");
+    // Verify cleans
+    Assertions.assertEquals(1, metaClient1.reloadActiveTimeline().getCleanerTimeline().countInstants());
+    Assertions.assertEquals(1, metaClient2.reloadActiveTimeline().getCleanerTimeline().countInstants());
+    // Verify compactions, delta commits and replace commits
+    Assertions.assertEquals(4, metaClient1.reloadActiveTimeline().getCommitsTimeline().countInstants());
+    Assertions.assertEquals(4, metaClient2.reloadActiveTimeline().getCommitsTimeline().countInstants());
+  }
+
+  private void prepareData() throws IOException {
+    initTestDataGenerator();
+    HoodieTableMetaClient metaClient1 = getMetaClient("table1");
+    HoodieTableMetaClient metaClient2 = getMetaClient("table2");
+    String instant1 = HoodieInstantTimeGenerator.createNewInstantTime(0);
+    writeToTable(metaClient1.getBasePath(), instant1, false);
+    writeToTable(metaClient2.getBasePath(), instant1, false);
+    String instant2 = HoodieInstantTimeGenerator.createNewInstantTime(1);
+    writeToTable(metaClient1.getBasePath(), instant2, true);
+    writeToTable(metaClient2.getBasePath(), instant2, true);
+    Assertions.assertEquals(0, metaClient1.reloadActiveTimeline().getCleanerTimeline().countInstants());
+    Assertions.assertEquals(0, metaClient2.reloadActiveTimeline().getCleanerTimeline().countInstants());
+  }
+
+  private void writeToTable(String basePath, String instant, boolean update) throws IOException {
+    String tableName = "test";
+    HoodieWriteConfig.Builder writeConfigBuilder = getWriteConfigBuilder(basePath, tableName);
+    // enable files and bloom_filters on the regular write client
+    HoodieWriteConfig writeConfig = writeConfigBuilder.build();
+    // do one upsert with synchronous metadata update
+    SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context, writeConfig);
+    List<HoodieRecord> records;
+    writeClient.startCommitWithTime(instant);
+    if (update) {
+      records = dataGen.generateUpdates(instant, 100);
+    } else {
+      records = dataGen.generateInserts(instant, 100);
+    }
+    JavaRDD<WriteStatus> result = writeClient.upsert(jsc.parallelize(records, 8), instant);
+    List<WriteStatus> statuses = result.collect();
+    assertNoWriteErrors(statuses);
+  }
+
+  private HoodieWriteConfig.Builder getWriteConfigBuilder(String basePath, String tableName) {
+    Properties properties = new Properties();
+    properties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    return HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withParallelism(4, 4)
+        .withBulkInsertParallelism(4)
+        .withFinalizeWriteParallelism(2)
+        .withProps(makeIndexConfig(HoodieIndex.IndexType.BUCKET))
+        .withTableServicesEnabled(false)
+        .withLayoutConfig(HoodieLayoutConfig.newBuilder()
+            .withLayoutType(HoodieStorageLayout.LayoutType.BUCKET.name())
+            .withLayoutPartitioner("org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner")
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .forTable(tableName);
+  }
+
+  protected HoodieTableMetaClient getMetaClient(String tableName) throws IOException {
+    String rootPathStr = "file://" + tempDir.toAbsolutePath() + "/" + tableName;
+    Path rootPath = new Path(rootPathStr);
+    rootPath.getFileSystem(jsc.hadoopConfiguration()).mkdirs(rootPath);
+    Properties props = new Properties();
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    props.setProperty(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "_row_key");
+    return HoodieTestUtils.init(jsc.hadoopConfiguration(), rootPathStr, getTableType(), props);
+  }
+
+  private Properties makeIndexConfig(HoodieIndex.IndexType indexType) {
+    Properties props = new Properties();
+    HoodieIndexConfig.Builder indexConfig = HoodieIndexConfig.newBuilder()
+        .withIndexType(indexType);
+    if (indexType.equals(HoodieIndex.IndexType.BUCKET)) {
+      props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+      indexConfig.fromProperties(props)
+          .withIndexKeyField("_row_key")
+          .withBucketNum("1")
+          .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.SIMPLE);
+      props.putAll(indexConfig.build().getProps());
+      props.putAll(HoodieLayoutConfig.newBuilder().fromProperties(props)
+          .withLayoutType(HoodieStorageLayout.LayoutType.BUCKET.name())
+          .withLayoutPartitioner(SparkBucketIndexPartitioner.class.getName()).build().getProps());
+    }
+    return props;
+  }
+
+  @Override
+  protected HoodieTableType getTableType() {
+    return HoodieTableType.MERGE_ON_READ;
+  }
+
+  private HoodieMultiTableServicesMain.Config getHoodieMultiServiceConfig() {
+    HoodieMultiTableServicesMain.Config cfg = new HoodieMultiTableServicesMain.Config();
+    cfg.autoDiscovering = true;
+    cfg.enableCompaction = true;
+    cfg.enableClustering = true;
+    cfg.enableClean = true;
+    cfg.enableArchive = true;
+    List<String> configs = new ArrayList<>();
+    configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_POLICY.key(), HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS));
+    configs.add(String.format("%s=%s", HoodieCleanConfig.AUTO_CLEAN.key(), "false"));
+    configs.add(String.format("%s=%s", HoodieCleanConfig.CLEANER_FILE_VERSIONS_RETAINED.key(), "1"));
+    configs.add(String.format("%s=%s", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "0"));
+    cfg.configs = configs;
+    cfg.compactionRunningMode = HoodieCompactor.SCHEDULE_AND_EXECUTE;
+    cfg.clusteringRunningMode = HoodieCompactor.SCHEDULE_AND_EXECUTE;
+    cfg.basePath = Collections.singletonList(tempDir.toAbsolutePath().toString());
+    cfg.scheduleDelay = 50000;
+    return cfg;
+  }
+
+  /**
+   * Initializes a test data generator which used to generate test datas.
+   */
+  protected void initTestDataGenerator() {
+    dataGen = new HoodieTestDataGenerator();
+  }
+
+  @Override
+  public HoodieEngineContext context() {
+    return context;
+  }
+
+  @Override
+  public SparkSession spark() {
+    return spark;
+  }
+
+  @Override
+  public SQLContext sqlContext() {
+    return sqlContext;
+  }
+
+  @Override
+  public JavaSparkContext jsc() {
+    return jsc;
+  }
+
+  @AfterAll
+  public static synchronized void cleanUpAfterAll() {
+    if (spark != null) {
+      spark.close();
+      spark = null;
+    }
+  }
+
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -68,6 +68,10 @@ import java.util.concurrent.ExecutionException;
 
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 
+/**
+ * Tests for HoodieMultiTableServicesMain
+ * @see HoodieMultiTableServicesMain
+ */
 class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implements SparkProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArchiveTask.class);
@@ -147,7 +151,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
         LOG.info("Shutdown the table services");
         main.cancel();
       } catch (InterruptedException e) {
-        //
+        LOG.warn("InterruptedException: ", e);
       }
     }).start();
     main.startServices();
@@ -248,7 +252,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
 
   private HoodieMultiTableServicesMain.Config getHoodieMultiServiceConfig() {
     HoodieMultiTableServicesMain.Config cfg = new HoodieMultiTableServicesMain.Config();
-    cfg.autoDiscovering = true;
+    cfg.autoDiscovery = true;
     cfg.enableCompaction = true;
     cfg.enableClustering = true;
     cfg.enableClean = true;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -41,6 +41,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner;
+import org.apache.hudi.table.action.compact.strategy.LogFileSizeBasedCompactionStrategy;
 import org.apache.hudi.table.storage.HoodieStorageLayout;
 import org.apache.hudi.testutils.providers.SparkProvider;
 import org.apache.hudi.utilities.HoodieCompactor;
@@ -264,6 +265,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     configs.add(String.format("%s=%s", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "0"));
     cfg.configs = configs;
     cfg.compactionRunningMode = HoodieCompactor.SCHEDULE_AND_EXECUTE;
+    cfg.compactionStrategyClassName = LogFileSizeBasedCompactionStrategy.class.getName();
     cfg.clusteringRunningMode = HoodieCompactor.SCHEDULE_AND_EXECUTE;
     cfg.basePath = Collections.singletonList(tempDir.toAbsolutePath().toString());
     cfg.scheduleDelay = 50000;


### PR DESCRIPTION
### Change Logs

Origin Issue: https://github.com/apache/hudi/issues/8960

Now we have HoodieMultiTableDeltaStreamer using spark to ingest multi tables into hudi, and we can also ingest multi tables using a single flink in some platforms like alicloud vvp. In such scenario we may want to run all tables services outside of the ingestion job to improve stability.

Currently, hudi provides a bunch of offline table service jobs but we still need to run them manually or through some schedule tools. This Pr provides a tool to run all table services in a single spark job


### Impact

provides a tool to run all table services in a single spark job

### Risk level (write none, low medium or high below)

none

### Documentation Update

Will update document after merge

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
