### PR TITLE
[HUDI-6725] Support efficient completion time queries on the timeline

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/CompletionTimeQueryView.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/CompletionTimeQueryView.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.timeline;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.generic.GenericRecord;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.hudi.common.table.timeline.HoodieArchivedTimeline.COMPLETION_TIME_ARCHIVED_META_FIELD;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.EQUALS;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.GREATER_THAN;
+
+/**
+ * Query view for instant completion time.
+ */
+public class CompletionTimeQueryView implements AutoCloseable {
+  private final HoodieTableMetaClient metaClient;
+
+  /**
+   * Mapping from instant start time -> completion time.
+   * Should be thread-safe data structure.
+   */
+  private final Map<String, String> startToCompletionInstantTimeMap;
+
+  /**
+   * The start instant time to eagerly load from, by default load last N days of completed instants.
+   */
+  private final String startInstant;
+
+  /**
+   * The first instant on the active timeline, used for query optimization.
+   */
+  private final String firstInstantOnActiveTimeline;
+
+  /**
+   * The constructor.
+   *
+   * @param metaClient   The table meta client.
+   * @param startInstant The earliest instant time to eagerly load from, by default load last N days of completed instants.
+   */
+  public CompletionTimeQueryView(HoodieTableMetaClient metaClient, String startInstant) {
+    this.metaClient = metaClient;
+    this.startToCompletionInstantTimeMap = new ConcurrentHashMap<>();
+    this.startInstant = startInstant;
+    this.firstInstantOnActiveTimeline = metaClient.getActiveTimeline().firstInstant().map(HoodieInstant::getTimestamp).orElse("");
+    load();
+  }
+
+  /**
+   * Queries the instant completion time with given start time.
+   *
+   * @param startTime The start time.
+   *
+   * @return The completion time if the instant finished or empty if it is still pending.
+   */
+  public Option<String> getCompletionTime(String startTime) {
+    String completionTime = this.startToCompletionInstantTimeMap.get(startTime);
+    if (completionTime != null) {
+      return Option.of(completionTime);
+    }
+    if (HoodieTimeline.compareTimestamps(startTime, GREATER_THAN, this.firstInstantOnActiveTimeline)) {
+      // the instant is still pending
+      return Option.empty();
+    }
+    // the 'startTime' should be out of the eager loading range, switch to a lazy loading.
+    // This operation is resource costly.
+    HoodieArchivedTimeline.loadInstants(metaClient,
+        new EqualsTimestampFilter(startTime),
+        HoodieArchivedTimeline.LoadMode.SLIM,
+        r -> true,
+        this::readCompletionTime);
+    return Option.ofNullable(this.startToCompletionInstantTimeMap.get(startTime));
+  }
+
+  /**
+   * This is method to read instant completion time.
+   * This would also update 'startToCompletionInstantTimeMap' map with start time/completion time pairs.
+   * Only instants starts from 'startInstant' (inclusive) are considered.
+   */
+  private void load() {
+    // load active instants first.
+    this.metaClient.getActiveTimeline()
+        .filterCompletedInstants().getInstantsAsStream()
+        .forEach(instant -> setCompletionTime(instant.getTimestamp(), instant.getStateTransitionTime()));
+    // then load the archived instants.
+    HoodieArchivedTimeline.loadInstants(metaClient,
+        new HoodieArchivedTimeline.StartTsFilter(this.startInstant),
+        HoodieArchivedTimeline.LoadMode.SLIM,
+        r -> true,
+        this::readCompletionTime);
+  }
+
+  private void readCompletionTime(String instantTime, GenericRecord record) {
+    final String completionTime = record.get(COMPLETION_TIME_ARCHIVED_META_FIELD).toString();
+    setCompletionTime(instantTime, completionTime);
+  }
+
+  private void setCompletionTime(String instantTime, String completionTime) {
+    this.startToCompletionInstantTimeMap.putIfAbsent(instantTime, completionTime);
+  }
+
+  @Override
+  public void close() throws Exception {
+    this.startToCompletionInstantTimeMap.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  //  Inner class
+  // -------------------------------------------------------------------------
+
+  /**
+   * A time based filter with equality of specified timestamp.
+   */
+  public static class EqualsTimestampFilter extends HoodieArchivedTimeline.TimeRangeFilter {
+    private final String ts;
+
+    public EqualsTimestampFilter(String ts) {
+      super(ts, ts); // endTs is never used
+      this.ts = ts;
+    }
+
+    public boolean isInRange(String instantTime) {
+      return HoodieTimeline.compareTimestamps(instantTime, EQUALS, ts);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.timeline;
+
+import org.apache.hudi.DummyActiveAction;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.table.HoodieTable;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link org.apache.hudi.client.timeline.CompletionTimeQueryView}.
+ */
+public class TestCompletionTimeQueryView {
+  @TempDir
+  File tempFile;
+
+  @Test
+  void testReadCompletionTime() throws Exception {
+    String tableName = "testTable";
+    String tablePath = tempFile.getAbsolutePath() + Path.SEPARATOR + tableName;
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(new Configuration(), tablePath, HoodieTableType.COPY_ON_WRITE, tableName);
+    prepareTimeline(tablePath, metaClient);
+    try (CompletionTimeQueryView view = new CompletionTimeQueryView(metaClient, String.format("%08d", 3))) {
+      // query completion time from LSM timeline
+      for (int i = 3; i < 7; i++) {
+        assertThat(view.getCompletionTime(String.format("%08d", i)).orElse(""), is(String.format("%08d", i + 1000)));
+      }
+      // query completion time from active timeline
+      for (int i = 7; i < 11; i++) {
+        assertTrue(view.getCompletionTime(String.format("%08d", i)).isPresent());
+      }
+      // lazy loading
+      for (int i = 1; i < 3; i++) {
+        assertThat(view.getCompletionTime(String.format("%08d", i)).orElse(""), is(String.format("%08d", i + 1000)));
+      }
+      // query with inflight start time
+      assertFalse(view.getCompletionTime(String.format("%08d", 11)).isPresent());
+      // query with non-exist start time
+      assertFalse(view.getCompletionTime(String.format("%08d", 12)).isPresent());
+    }
+  }
+
+  private void prepareTimeline(String tablePath, HoodieTableMetaClient metaClient) throws Exception {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(tablePath)
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+        .withMarkersType("DIRECT")
+        .build();
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    List<ActiveAction> activeActions = new ArrayList<>();
+    for (int i = 1; i < 11; i++) {
+      String instantTime = String.format("%08d", i);
+      String completionTime = String.format("%08d", i + 1000);
+      HoodieCommitMetadata metadata = testTable.createCommitMetadata(instantTime, WriteOperationType.INSERT, Arrays.asList("par1", "par2"), 10, false);
+      testTable.addCommit(instantTime, Option.of(metadata));
+      activeActions.add(new DummyActiveAction(new HoodieInstant(HoodieInstant.State.COMPLETED, "commit", instantTime, completionTime), metadata.toJsonString().getBytes()));
+    }
+    testTable.addRequestedCommit(String.format("%08d", 11));
+    List<HoodieInstant> instants = new HoodieActiveTimeline(metaClient, false).getInstantsAsStream().sorted().collect(Collectors.toList());
+    LSMTimelineWriter writer = LSMTimelineWriter.getInstance(writeConfig, getMockHoodieTable(metaClient));
+    // archive [1,2], [3,4], [5,6] separately
+    writer.write(activeActions.subList(0, 2), Option.empty(), Option.empty());
+    writer.write(activeActions.subList(2, 4), Option.empty(), Option.empty());
+    writer.write(activeActions.subList(4, 6), Option.empty(), Option.empty());
+    // reconcile the active timeline
+    instants.subList(0, 3 * 6).forEach(instant -> HoodieActiveTimeline.deleteInstantFile(metaClient.getFs(), metaClient.getMetaPath(), instant));
+    ValidationUtils.checkState(metaClient.reloadActiveTimeline().filterCompletedInstants().countInstants() == 4, "should archive 6 instants with 4 as active");
+  }
+
+  @SuppressWarnings("rawtypes")
+  private HoodieTable getMockHoodieTable(HoodieTableMetaClient metaClient) {
+    HoodieTable hoodieTable = mock(HoodieTable.class);
+    TaskContextSupplier taskContextSupplier = mock(TaskContextSupplier.class);
+    when(taskContextSupplier.getPartitionIdSupplier()).thenReturn(() -> 1);
+    when(hoodieTable.getTaskContextSupplier()).thenReturn(taskContextSupplier);
+    when(hoodieTable.getMetaClient()).thenReturn(metaClient);
+    return hoodieTable;
+  }
+}


### PR DESCRIPTION
### Change Logs

 Add a tool to query completion time efficiently on both active & archived timeline.

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
