### PR TITLE
[HUDI-6805] Print detailed error message in clustering

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -243,7 +243,7 @@ public class HoodieRowCreateHandle implements Serializable {
     stat.setFileSizeInBytes(fileSizeInBytes);
     stat.setTotalWriteErrors(writeStatus.getTotalErrorRecords());
     for (Pair<HoodieRecordDelegate, Throwable> pair : writeStatus.getFailedRecords()) {
-      LOG.info("Failed to write {}", pair.getLeft(), pair.getRight());
+      LOG.error("Failed to write {}", pair.getLeft(), pair.getRight());
     }
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalCreateTime(currTimer.endTimer());

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -241,6 +242,9 @@ public class HoodieRowCreateHandle implements Serializable {
     stat.setTotalWriteBytes(fileSizeInBytes);
     stat.setFileSizeInBytes(fileSizeInBytes);
     stat.setTotalWriteErrors(writeStatus.getTotalErrorRecords());
+    for (Pair<HoodieRecordDelegate, Throwable> pair : writeStatus.getFailedRecords()) {
+      LOG.info("Failed to write {}", pair.getLeft(), pair.getRight());
+    }
     HoodieWriteStat.RuntimeStats runtimeStats = new HoodieWriteStat.RuntimeStats();
     runtimeStats.setTotalCreateTime(currTimer.endTimer());
     stat.setRuntimeStats(runtimeStats);


### PR DESCRIPTION
### Change Logs

If clustering failed, it's not printing the detailed error reason. For example, in #9094, the error message contains the list of failed files but doesn't contain the reason or stacktrace why it failed to write the files.

The exceptions are once stored to `failedRecords` by `WriteStatus#markFailure` method, but they are never accessed or logged. After this change, the exceptions will be printed in the log.

JIRA: HUDI-6805

### Impact

Very little impact.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

No documentation changes required.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
