### PR TITLE
[HUDI-6808] SkipCompaction Config should not affect the stream read of the cow table

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -603,7 +603,7 @@ public class IncrementalInputSplits implements Serializable {
   @VisibleForTesting
   public HoodieTimeline filterInstantsAsPerUserConfigs(HoodieTimeline timeline) {
     final HoodieTimeline oriTimeline = timeline;
-    if (this.skipCompaction) {
+    if (OptionsResolver.isMorTable(this.conf) & this.skipCompaction) {
       // the compaction commit uses 'commit' as action which is tricky
       timeline = timeline.filter(instant -> !instant.getAction().equals(HoodieTimeline.COMMIT_ACTION));
     }


### PR DESCRIPTION
### Change Logs

The same action type(commit) is used after the completion of mor-compaction and cow-commit. If skipcompaction is configured, it will cause the stream read to skip the normal commit when reading the cow table. SkipCompaction Config should not affect the stream read of the cow table .

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
