### PR TITLE
[HUDI-6784] Support deletion logic in merger

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
@@ -148,7 +149,13 @@ public class HoodieIndexUtils {
       // separate filenames that the record is found in. This will result in setting
       // currentLocation 2 times and it will fail the second time. So creating a new in memory
       // copy of the hoodie record.
-      HoodieRecord<R> newRecord = record.newInstance();
+      HoodieRecord<R> newRecord = null;
+      if (record instanceof HoodieEmptyRecord) {
+        newRecord = record.newInstance(record.getKey(), record.getOperation());
+      } else {
+        newRecord = record.newInstance();
+      }
+
       newRecord.unseal();
       newRecord.setCurrentLocation(location.get());
       newRecord.seal();

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaWriteHelper.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaWriteHelper.java
@@ -72,7 +72,7 @@ public class JavaWriteHelper<T,R> extends BaseWriteHelper<T, List<HoodieRecord<T
     return keyedRecords.values().stream().map(x -> x.stream().map(Pair::getRight).reduce((rec1, rec2) -> {
       HoodieRecord<T> reducedRecord;
       try {
-        reducedRecord =  merger.merge(rec1, schema, rec2, schema, props).get().getLeft();
+        reducedRecord = merger.merge(rec1, schema, rec2, schema, props).get().getLeft();
       } catch (IOException e) {
         throw new HoodieException(String.format("Error to merge two records, %s, %s", rec1, rec2), e);
       }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -74,6 +74,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -318,8 +319,45 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
     assertFalse(commit.isPresent());
   }
 
+  protected void deleteRecordsFromMORTable(HoodieTableMetaClient metaClient, List<HoodieKey> keys, SparkRDDWriteClient client, HoodieWriteConfig cfg, String commitTime,
+                          boolean doExplicitCommit) throws IOException {
+    HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
+    JavaRDD<WriteStatus> statusesRdd = client.delete(jsc().parallelize(keys, 1), commitTime);
+    List<WriteStatus> statuses = statusesRdd.collect();
+    assertNoWriteErrors(statuses);
+    if (doExplicitCommit) {
+      client.commit(commitTime, statusesRdd);
+    }
+    assertFileSizesEqual(statuses, status -> FSUtils.getFileSize(reloadedMetaClient.getFs(), new Path(reloadedMetaClient.getBasePath(), status.getStat().getPath())));
+
+    Option<HoodieInstant> deltaCommit = reloadedMetaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
+    assertTrue(deltaCommit.isPresent());
+    assertEquals(commitTime, deltaCommit.get().getTimestamp(),
+        "Latest Delta commit should match specified time");
+
+    Option<HoodieInstant> commit = reloadedMetaClient.getActiveTimeline().getCommitTimeline().firstInstant();
+    assertFalse(commit.isPresent());
+  }
+
   protected FileStatus[] listAllBaseFilesInPath(HoodieTable table) throws IOException {
     return HoodieTestTable.of(table.getMetaClient()).listAllBaseFiles(table.getBaseFileExtension());
+  }
+
+  protected List<FileStatus> listAllFilesInPartition(HoodieTable table, String partitionPath) throws IOException {
+    return Arrays.asList(HoodieTestTable.of(table.getMetaClient()).listAllFilesInPartition(partitionPath));
+  }
+
+  protected List<FileStatus> listAllBaseFilesInPartition(HoodieTable table, String partitionPath) throws IOException {
+    String baseFileExtension = table.getBaseFileExtension();
+    return listAllFilesInPartition(table, partitionPath).stream()
+        .filter(status -> status.getPath().getName().endsWith(baseFileExtension))
+        .collect(Collectors.toList());
+  }
+
+  protected List<FileStatus> listAllLogFilesInPartition(HoodieTable table, String partitionPath) throws IOException {
+    String logFileExtension = table.getLogFileFormat().getFileExtension();
+    return listAllFilesInPartition(table, partitionPath).stream()
+        .filter(status -> status.getPath().getName().endsWith(logFileExtension)).collect(Collectors.toList());
   }
 
   protected Properties getPropertiesForKeyGen() {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.testutils;
 
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -118,6 +119,21 @@ public class SparkDatasetTestUtils {
   }
 
   /**
+   * Generate random Rows based on a set of given keys.
+   *
+   * @param
+   * @param keys A set of {@Link HoodieKey}
+   * @return the Dataset<Row>s thus generated.
+   */
+  public static Dataset<Row> getRandomRowsWithKeys(SQLContext sqlContext, List<HoodieKey> keys, boolean isError) {
+    List<Row> records = new ArrayList<>();
+    for (HoodieKey key : keys) {
+      records.add(getRandomValue(key.getRecordKey(), key.getPartitionPath(), isError));
+    }
+    return sqlContext.createDataFrame(records, isError ? ERROR_STRUCT_TYPE : STRUCT_TYPE);
+  }
+
+  /**
    * Generate random Row.
    *
    * @param partitionPath partition path to be set in the Row.
@@ -133,6 +149,36 @@ public class SparkDatasetTestUtils {
       values[1] = RANDOM.nextLong();
     }
     values[2] = UUID.randomUUID().toString();
+    values[3] = partitionPath;
+    values[4] = ""; // filename
+    values[5] = UUID.randomUUID().toString();
+    values[6] = partitionPath;
+    values[7] = RANDOM.nextInt();
+    if (!isError) {
+      values[8] = RANDOM.nextLong();
+    } else {
+      values[8] = UUID.randomUUID().toString();
+    }
+    return new GenericRow(values);
+  }
+
+  /**
+   * Generate random Row based on given record key and partition path.
+   *
+   * @param key the id of the Row.
+   * @param partitionPath partition path to be set in the Row.
+   * @return the Row thus generated.
+   */
+  public static Row getRandomValue(String key, String partitionPath, boolean isError) {
+    // order commit time, seq no, record key, partition path, file name
+    Object[] values = new Object[9];
+    values[0] = ""; //commit time
+    if (!isError) {
+      values[1] = ""; // commit seq no
+    } else {
+      values[1] = RANDOM.nextLong();
+    }
+    values[2] = key;
     values[3] = partitionPath;
     values[4] = ""; // filename
     values[5] = UUID.randomUUID().toString();

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -132,7 +132,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   public boolean isDelete(Schema recordSchema, Properties props) {
-    return false;
+    return data == null || data.equals(SENTINEL);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
@@ -43,8 +43,24 @@ public interface HoodieRecordMerger extends Serializable {
    * This method converges combineAndGetUpdateValue and precombine from HoodiePayload.
    * It'd be associative operation: f(a, f(b, c)) = f(f(a, b), c) (which we can translate as having 3 versions A, B, C
    * of the single record, both orders of operations applications have to yield the same result)
+   * <p>
+   * @Param older a {@link HoodieRecord} record that has lower timestamp.
+   * @Param oldSchema the schema for the {@code older}.
+   * @Param newer a {@link HoodieRecord} record that has higher timestamp.
+   * @Param newSchema the schema for the {@code newer}.
+   * @Return the merged record and its schema if any.
    */
-  Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException;
+  Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older,
+                                           Schema oldSchema,
+                                           HoodieRecord newer,
+                                           Schema newSchema,
+                                           TypedProperties props) throws IOException;
+
+  default Option<Pair<HoodieRecord, Schema>> insert(HoodieRecord record,
+                                                    Schema schema,
+                                                    TypedProperties props) throws IOException {
+    return Option.of(Pair.of(record, schema));
+  }
 
   /**
    * The record type handled by the current merger.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -241,8 +241,8 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordReader
     HoodieRecord<T> prevRecord = records.get(key);
     if (prevRecord != null) {
       // Merge and store the combined record
-      HoodieRecord<T> combinedRecord = (HoodieRecord<T>) recordMerger.merge(prevRecord, readerSchema,
-          newRecord, readerSchema, this.getPayloadProps()).get().getLeft();
+      HoodieRecord<T> combinedRecord = (HoodieRecord<T>) recordMerger.merge(
+          prevRecord, readerSchema, newRecord, readerSchema, this.getPayloadProps()).get().getLeft();
       // If pre-combine returns existing record, no need to update it
       if (combinedRecord.getData() != prevRecord.getData()) {
         HoodieRecord latestHoodieRecord =

--- a/hudi-common/src/test/java/org/apache/hudi/model/TestHoodieAvroRecordMerger.java
+++ b/hudi-common/src/test/java/org/apache/hudi/model/TestHoodieAvroRecordMerger.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.model;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieAvroRecordMerger;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.hudi.model.TestUtil.SCHEMA;
+import static org.apache.hudi.model.TestUtil.getFieldFromAvroRecord;
+import static org.apache.hudi.model.TestUtil.getFieldFromIndexedRecord;
+import static org.apache.hudi.model.TestUtil.generateData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieAvroRecordMerger {
+  private static final HoodieAvroRecordMerger MERGER = HoodieAvroRecordMerger.INSTANCE;
+
+  @Test
+  public void testMergeWhenBothSidesAreValid() throws IOException {
+    List<HoodieAvroRecord> olderRecords = generateData(10);
+    List<HoodieAvroRecord> newerRecords = generateData(10);
+
+    // Update case.
+    for (int i = 0; i < olderRecords.size(); ++i) {
+      Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+          olderRecords.get(i),
+          SCHEMA,
+          newerRecords.get(i),
+          SCHEMA,
+          new TypedProperties());
+      assertEquals(r.get().getRight(), SCHEMA);
+      assertEquals(
+          getFieldFromIndexedRecord(r.get().getLeft(), 0),
+          getFieldFromAvroRecord(newerRecords.get(i), SCHEMA, "valueId"));
+    }
+
+    // Delete case 1: EmptyHoodieRecordPayload.
+    Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+        olderRecords.get(0),
+        SCHEMA,
+        new HoodieAvroRecord(olderRecords.get(0).getKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        new TypedProperties());
+    assertFalse(r.isPresent());
+  }
+
+  @Test
+  public void testMergeWhenAtLeastOneSideIsInvalid() throws IOException {
+    HoodieAvroRecord record = generateData(1).get(0);
+
+    // Old record is a delete record.
+    Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+        new HoodieAvroRecord(record.getKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        record,
+        SCHEMA,
+        new TypedProperties());
+    assertTrue(r.isPresent());
+    assertEquals(
+        getFieldFromAvroRecord(record, SCHEMA, "valueId"),
+        getFieldFromIndexedRecord(r.get().getLeft(), 0));
+
+    // No meaningful new record.
+    r = MERGER.merge(
+        record,
+        SCHEMA,
+        new HoodieAvroRecord(record.getKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        new TypedProperties());
+    assertFalse(r.isPresent());
+
+    // No meaningful records are provided.
+    r = MERGER.merge(
+        new HoodieAvroRecord(new HoodieKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        new HoodieAvroRecord(new HoodieKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        new TypedProperties());
+    assertFalse(r.isPresent());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/model/TestHoodiePreCombineAvroRecordMerger.java
+++ b/hudi-common/src/test/java/org/apache/hudi/model/TestHoodiePreCombineAvroRecordMerger.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.model;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodiePreCombineAvroRecordMerger;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.hudi.model.TestUtil.SCHEMA;
+import static org.apache.hudi.model.TestUtil.generateData;
+import static org.apache.hudi.model.TestUtil.getFieldFromAvroRecord;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodiePreCombineAvroRecordMerger {
+  private static final HoodiePreCombineAvroRecordMerger MERGER = HoodiePreCombineAvroRecordMerger.INSTANCE;
+
+  @Test
+  public void testMergeWhenBothSidesAreGood() throws IOException {
+    List<HoodieAvroRecord> olderRecords = generateData(10);
+    List<HoodieAvroRecord> newerRecords = generateData(10);
+
+    for (int i = 0; i < olderRecords.size(); ++i) {
+      Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+          olderRecords.get(i),
+          SCHEMA,
+          newerRecords.get(i),
+          SCHEMA,
+          new TypedProperties());
+      assertEquals(r.get().getRight(), SCHEMA);
+      assertEquals(
+          getFieldFromAvroRecord((HoodieAvroRecord) r.get().getLeft(), SCHEMA, "valueId"),
+          getFieldFromAvroRecord(newerRecords.get(i), SCHEMA, "valueId"));
+    }
+  }
+
+  @Test
+  public void testMergeWhenBothSidesAreBad() throws IOException {
+    Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+        new HoodieAvroRecord(new HoodieKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        new HoodieAvroRecord(new HoodieKey(), new EmptyHoodieRecordPayload()),
+        SCHEMA,
+        new TypedProperties());
+    assertTrue(r.isPresent());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/model/TestUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/model/TestUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.model;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+public class TestUtil {
+  public static final Schema SCHEMA = SchemaBuilder.record("MetadataValue")
+      .fields()
+      .name("valueId").type().stringType().noDefault()
+      .name("extraInfo").type().stringType().noDefault()
+      .endRecord();
+  public static final Random RANDOM = new Random(TestHoodieAvroRecordMerger.class.hashCode());
+
+  public static String generateRandomString(int length) {
+    byte[] array = new byte[length];
+    RANDOM.nextBytes(array);
+    return new String(array, StandardCharsets.UTF_8);
+  }
+
+  public static List<HoodieAvroRecord> generateData(int numRecord) throws IOException {
+    List<HoodieAvroRecord> data = new ArrayList<>();
+    for (int i = 0; i < numRecord; i++) {
+      UUID uuid = UUID.randomUUID();
+      GenericRecord record = new GenericData.Record(SCHEMA);
+      record.put("valueId", uuid.toString());
+      record.put("extraInfo", new Utf8(generateRandomString(7)));
+      data.add(new HoodieAvroRecord<>(
+          new HoodieKey(String.valueOf(i), String.valueOf(i)),
+          new HoodieAvroPayload(record, 0)));
+    }
+    return data;
+  }
+
+  public static String getFieldFromAvroRecord(HoodieAvroRecord record,
+                                               Schema schema,
+                                               String fieldName) throws IOException {
+    return ((Utf8) HoodieAvroUtils.bytesToAvro(((HoodieAvroPayload) record.getData()).getRecordBytes(), schema)
+        .get(fieldName)).toString();
+  }
+
+  public static String getFieldFromIndexedRecord(HoodieRecord record, int fieldIndex) {
+    return ((Utf8) ((IndexedRecord) record.getData()).get(fieldIndex)).toString();
+  }
+}

--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
@@ -154,6 +154,7 @@ public final class HoodieSparkQuickstart {
                                HoodieExampleDataGenerator<HoodieAvroPayload> dataGen) {
     Dataset<Row> roViewDF = spark
         .read()
+        .option("hoodie.datasource.write.record.merger.impls", "org.apache.hudi.HoodieSparkRecordMerger")
         .format("hudi")
         .load(tablePath + "/*/*/*/*");
 
@@ -214,6 +215,7 @@ public final class HoodieSparkQuickstart {
         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
         .option(TBL_NAME.key(), tableName)
         .option("hoodie.datasource.write.operation", WriteOperationType.DELETE.value())
+        .option("hoodie.datasource.write.record.merger.impls", "org.apache.hudi.HoodieSparkRecordMerger")
         .mode(Append)
         .save(tablePath);
     return toBeDeletedDf;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -30,7 +30,6 @@ import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
@@ -837,7 +836,8 @@ public class MergeOnReadInputFormat
       GenericRecord historyAvroRecord = (GenericRecord) rowDataToAvroConverter.convert(tableSchema, curRow);
       HoodieAvroIndexedRecord hoodieAvroIndexedRecord = new HoodieAvroIndexedRecord(historyAvroRecord);
       try {
-        return recordMerger.merge(hoodieAvroIndexedRecord, tableSchema, record, tableSchema, payloadProps).map(Pair::getLeft);
+        return recordMerger.merge(
+            hoodieAvroIndexedRecord, tableSchema, record, tableSchema, payloadProps).map(r -> r.getLeft());
       } catch (IOException e) {
         throw new HoodieIOException("Merge base and delta payloads exception", e);
       }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
@@ -197,8 +197,8 @@ public class RealtimeCompactedRecordReader extends AbstractRealtimeRecordReader
     // once presto on hudi have its own mor reader, we can remove the rewrite logical.
     GenericRecord genericRecord = HiveAvroSerializer.rewriteRecordIgnoreResultCheck(oldRecord, getLogScannerReaderSchema());
     HoodieRecord record = new HoodieAvroIndexedRecord(genericRecord);
-    Option<Pair<HoodieRecord, Schema>> mergeResult = HoodieAvroRecordMerger.INSTANCE.merge(record,
-        genericRecord.getSchema(), newRecord, getLogScannerReaderSchema(), new TypedProperties(payloadProps));
+    Option<Pair<HoodieRecord, Schema>> mergeResult = HoodieAvroRecordMerger.INSTANCE.merge(
+        record, genericRecord.getSchema(), newRecord, getLogScannerReaderSchema(), new TypedProperties(payloadProps));
     return mergeResult.map(p -> (HoodieAvroIndexedRecord) p.getLeft());
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/Iterators.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/Iterators.scala
@@ -247,7 +247,7 @@ class RecordMergingFileIterator(logFiles: List[HoodieLogFile],
         nextRecord = requiredSchemaProjection(curRow)
         true
       } else {
-       val mergedRecordOpt = merge(curRow, updatedRecordOpt.get)
+        val mergedRecordOpt = merge(curRow, updatedRecordOpt.get)
         if (mergedRecordOpt.isEmpty) {
           // Record has been deleted, skipping
           this.hasNextInternal
@@ -270,7 +270,8 @@ class RecordMergingFileIterator(logFiles: List[HoodieLogFile],
     recordMerger.getRecordType match {
       case HoodieRecordType.SPARK =>
         val curRecord = new HoodieSparkRecord(curRow, readerSchema)
-        val result = recordMerger.merge(curRecord, baseFileReaderAvroSchema, newRecord, logFileReaderAvroSchema, payloadProps)
+        val result = recordMerger.merge(
+          curRecord, baseFileReaderAvroSchema, newRecord, logFileReaderAvroSchema, payloadProps)
         toScalaOption(result)
           .map { r =>
             val schema = HoodieInternalRowUtils.getCachedSchema(r.getRight)
@@ -279,7 +280,8 @@ class RecordMergingFileIterator(logFiles: List[HoodieLogFile],
           }
       case _ =>
         val curRecord = new HoodieAvroIndexedRecord(serialize(curRow))
-        val result = recordMerger.merge(curRecord, baseFileReaderAvroSchema, newRecord, logFileReaderAvroSchema, payloadProps)
+        val result = recordMerger.merge(
+          curRecord, baseFileReaderAvroSchema, newRecord, logFileReaderAvroSchema, payloadProps)
         toScalaOption(result)
           .map { r =>
             val avroRecord = r.getLeft.toIndexedRecord(r.getRight, payloadProps).get.getData.asInstanceOf[GenericRecord]

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkRecordMerger.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional;
+
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.HoodieSparkRecordMerger;
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.client.utils.SparkRowSerDe;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieSparkRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.testutils.DataSourceTestUtils;
+
+import org.apache.avro.Schema;
+import org.apache.spark.sql.Row;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieSparkRecordMerger {
+  private static HoodieSparkRecordMerger MERGER = new HoodieSparkRecordMerger();
+
+  private static InternalRow toInternalRow(Row row, StructType schema) {
+    SparkRowSerDe encoder = SparkAdapterSupport$.MODULE$.sparkAdapter().createSparkRowSerDe(schema);
+    return encoder.serializeRow(row);
+  }
+
+  private static HoodieRecord toHoodieRecord(InternalRow row, StructType schema, int i) {
+    HoodieKey key = new HoodieKey(String.valueOf(i), String.valueOf(i));
+    return new HoodieSparkRecord(key, row, schema, false);
+  }
+
+  @Test
+  public void testWhenBothSizesAvailable() throws IOException {
+    List<Row> oldData = DataSourceTestUtils.generateRandomRows(3);
+    List<Row> newData = DataSourceTestUtils.generateRandomRows(3);
+    Schema avroSchema = DataSourceTestUtils.getStructTypeExampleSchema();
+    StructType scalaSchema = AvroConversionUtils.convertAvroSchemaToStructType(avroSchema);
+
+    TypedProperties props = new TypedProperties();
+    props.setPropertyIfNonNull("hoodie.payload.ordering.field", "_row_key");
+    for (int i = 0; i < oldData.size(); i++) {
+      Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+          toHoodieRecord(toInternalRow(oldData.get(i), scalaSchema), scalaSchema, i),
+          avroSchema,
+          toHoodieRecord(toInternalRow(newData.get(i), scalaSchema), scalaSchema, i),
+          avroSchema,
+          props);
+      if (((String) oldData.get(i).get(0)).compareTo((String) newData.get(i).get(0)) > 0) {
+        assertEquals(r.get().getLeft().getData(), toInternalRow(oldData.get(i), scalaSchema));
+      } else {
+        assertEquals(r.get().getLeft().getData(), toInternalRow(newData.get(i), scalaSchema));
+      }
+    }
+  }
+
+  @Test
+  public void testWhenOneSideIsEmpty() throws IOException {
+    List<Row> data = DataSourceTestUtils.generateRandomRows(3);
+    Schema avroSchema = DataSourceTestUtils.getStructTypeExampleSchema();
+    StructType scalaSchema = AvroConversionUtils.convertAvroSchemaToStructType(avroSchema);
+
+    TypedProperties props = new TypedProperties();
+    props.setPropertyIfNonNull("hoodie.payload.ordering.field", "_row_key");
+
+    // When new data is not given, no data is returned.
+    for (int i = 0; i < data.size(); i++) {
+      HoodieRecord record = toHoodieRecord(toInternalRow(data.get(i), scalaSchema), scalaSchema, i);
+      HoodieRecord emptyRecord = new HoodieEmptyRecord(
+          record.getKey(), HoodieOperation.DELETE, 1, HoodieRecord.HoodieRecordType.SPARK);
+      Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+          emptyRecord,
+          avroSchema,
+          record,
+          avroSchema,
+          props);
+      assertTrue(r.isPresent());
+      assertEquals(record, r.get().getLeft());
+    }
+
+    // When a delete record is given, return value should be the delete record.
+    for (int i = 0; i < data.size(); i++) {
+      HoodieRecord record = toHoodieRecord(toInternalRow(data.get(i), scalaSchema), scalaSchema, i);
+      HoodieRecord emptyRecord = new HoodieEmptyRecord(
+          record.getKey(), HoodieOperation.DELETE, 1, HoodieRecord.HoodieRecordType.SPARK);
+      Option<Pair<HoodieRecord, Schema>> r = MERGER.merge(
+          record,
+          avroSchema,
+          emptyRecord,
+          avroSchema,
+          props);
+      assertTrue(r.isPresent());
+      assertTrue(r.get().getLeft().isDelete(avroSchema, props));
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

The goal of this PR is to support custom logic during data write through Merger API. Our current solution is to add Option wrapper for older and newer parameters in merge function. In such way, all of update, delete, combine logics are merged into one api. Meanwhile, we apply this merge function into HoodieMergeHandle to handle both update and insert write path.

TESTS:
Unit tests are added for existing merger implementations.

### Impact

Users could implement merge api to support their own logic about deletion now. Previously deletion is not supported.

### Risk level (write none, low medium or high below)

Low.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
