### PR TITLE
[HUDI-6812]Fix bootstrap operator null point exception while lastInst…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/BootstrapOperator.java
@@ -106,7 +106,9 @@ public class BootstrapOperator<I, O extends HoodieRecord<?>>
   @Override
   public void snapshotState(StateSnapshotContext context) throws Exception {
     lastInstantTime = this.ckpMetadata.lastPendingInstant();
-    instantState.update(Collections.singletonList(lastInstantTime));
+    if (null != lastInstantTime) {
+      instantState.update(Collections.singletonList(lastInstantTime));
+    }
   }
 
   @Override


### PR DESCRIPTION
…antTime is null

### Change Logs

Fix bootstrap operator nullPointException while lastInstantTime is null
#9598

### Impact

there is no impact here,just hot fix

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._
NO

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._
NO

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
