### PR TITLE
[HUDI-6813] Support table name for meta sync in bootstrap

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -73,6 +73,7 @@ import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.URL_ENCODE_PAR
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 
 /**
  * Performs bootstrap from a non-hudi source.
@@ -194,6 +195,7 @@ public class BootstrapExecutorUtils implements Serializable {
       TypedProperties metaProps = new TypedProperties();
       metaProps.putAll(props);
       metaProps.put(META_SYNC_DATABASE_NAME.key(), cfg.database);
+      metaProps.put(META_SYNC_TABLE_NAME.key(), cfg.tableName);
       metaProps.put(META_SYNC_BASE_PATH.key(), cfg.basePath);
       metaProps.put(META_SYNC_BASE_FILE_FORMAT.key(), cfg.baseFileFormat);
       if (props.getBoolean(HIVE_SYNC_BUCKET_SYNC.key(), HIVE_SYNC_BUCKET_SYNC.defaultValue())) {


### PR DESCRIPTION
### Change Logs

Support table name for meta sync in bootstrap.
Using bootstrap procedure to migrate an existing table into a Hudi table.
```
call run_bootstrap(
  table=> "test_db.test_hudi_table",
  table_type=>"COPY_ON_WRITE",
  bootstrap_path=>"XXX",
  base_path=>"XXX",
  rowKey_field=>"device_id",
  partition_path_field=>"p_date,product",
  key_generator_class=>"org.apache.hudi.keygen.ComplexKeyGenerator",
  enable_hive_sync=>true,
  options => 'hoodie.datasource.hive_sync.mode=hms'
);
```

After sync to HMS, I get a hudi table which stored as `test_db. unknown ` instead of `test_db.test_hudi_table` in HMS. 
The root cause is not set table configure 'META_SYNC_TABLE_NAME' before start hive sync.
The pr aims to fix this bug.

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
