### PR TITLE
[HUDI-6785] Introduce a new File Group Reader

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/HoodieSparkRecordMerger.java
@@ -7,18 +7,18 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hudi;
 
-import org.apache.avro.Schema;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
@@ -27,6 +27,8 @@ import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
 
 import java.io.IOException;
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRowReaderContext.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieSparkRecord;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.spark.sql.HoodieInternalRowUtils;
+import org.apache.spark.sql.HoodieUnsafeRowUtils;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.Map;
+
+import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecordMerger.DEFAULT_MERGER_STRATEGY_UUID;
+
+/**
+ * An abstract class implementing {@link HoodieReaderContext} to handle {@link InternalRow}s.
+ * Subclasses need to implement {@link #getFileRecordIterator} with the reader logic.
+ */
+public abstract class BaseSparkInternalRowReaderContext extends HoodieReaderContext<InternalRow> {
+  @Override
+  public FileSystem getFs(String path, Configuration conf) {
+    return FSUtils.getFs(path, conf);
+  }
+
+  @Override
+  public HoodieRecordMerger getRecordMerger(String mergerStrategy) {
+    switch (mergerStrategy) {
+      case DEFAULT_MERGER_STRATEGY_UUID:
+        return new HoodieSparkRecordMerger();
+      default:
+        throw new HoodieException("The merger strategy UUID is not supported: " + mergerStrategy);
+    }
+  }
+
+  @Override
+  public Object getValue(InternalRow row, Schema schema, String fieldName) {
+    return getFieldValueFromInternalRow(row, schema, fieldName);
+  }
+
+  @Override
+  public String getRecordKey(InternalRow row, Schema schema) {
+    return getFieldValueFromInternalRow(row, schema, RECORD_KEY_METADATA_FIELD).toString();
+  }
+
+  @Override
+  public Comparable getOrderingValue(Option<InternalRow> rowOption,
+                                     Map<String, Object> metadataMap,
+                                     Schema schema,
+                                     TypedProperties props) {
+    if (metadataMap.containsKey(INTERNAL_META_ORDERING_FIELD)) {
+      return (Comparable) metadataMap.get(INTERNAL_META_ORDERING_FIELD);
+    }
+
+    if (!rowOption.isPresent()) {
+      return 0;
+    }
+
+    String orderingFieldName = ConfigUtils.getOrderingField(props);
+    Object value = getFieldValueFromInternalRow(rowOption.get(), schema, orderingFieldName);
+    return value != null ? (Comparable) value : 0;
+  }
+
+  @Override
+  public HoodieRecord<InternalRow> constructHoodieRecord(Option<InternalRow> rowOption,
+                                                         Map<String, Object> metadataMap,
+                                                         Schema schema) {
+    if (!rowOption.isPresent()) {
+      return new HoodieEmptyRecord<>(
+          new HoodieKey((String) metadataMap.get(INTERNAL_META_RECORD_KEY),
+              (String) metadataMap.get(INTERNAL_META_PARTITION_PATH)),
+          HoodieRecord.HoodieRecordType.SPARK);
+    }
+
+    InternalRow row = rowOption.get();
+    return new HoodieSparkRecord(row, HoodieInternalRowUtils.getCachedSchema(schema));
+  }
+
+  @Override
+  public InternalRow seal(InternalRow internalRow) {
+    return internalRow.copy();
+  }
+
+  private Object getFieldValueFromInternalRow(InternalRow row, Schema recordSchema, String fieldName) {
+    StructType structType = HoodieInternalRowUtils.getCachedSchema(recordSchema);
+    scala.Option<HoodieUnsafeRowUtils.NestedFieldPath> cachedNestedFieldPath =
+        HoodieInternalRowUtils.getCachedPosList(structType, fieldName);
+    if (cachedNestedFieldPath.isDefined()) {
+      HoodieUnsafeRowUtils.NestedFieldPath nestedFieldPath = cachedNestedFieldPath.get();
+      return HoodieUnsafeRowUtils.getNestedInternalRowValue(row, nestedFieldPath);
+    } else {
+      return null;
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.avro.Schema
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hudi.common.engine.HoodieReaderContext
+import org.apache.hudi.common.util.collection.ClosableIterator
+import org.apache.hudi.util.CloseableInternalRowIterator
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{HoodieInternalRowUtils, SparkSession}
+
+/**
+ * Implementation of {@link HoodieReaderContext} to read {@link InternalRow}s with
+ * {@link ParquetFileFormat} on Spark.
+ *
+ * This uses Spark parquet reader to read parquet data files or parquet log blocks.
+ *
+ * @param sparkSession      {@link SparkSession} instance.
+ * @param parquetFileFormat {@link ParquetFileFormat} instance for parquet file format in Spark.
+ * @param hadoopConf        Hadoop configuration.
+ */
+class SparkFileFormatInternalRowReaderContext(sparkSession: SparkSession,
+                                              parquetFileFormat: ParquetFileFormat,
+                                              hadoopConf: Configuration) extends BaseSparkInternalRowReaderContext {
+  lazy val sparkAdapter = SparkAdapterSupport.sparkAdapter
+
+  override def getFileRecordIterator(filePath: Path,
+                                     start: Long,
+                                     length: Long,
+                                     dataSchema: Schema,
+                                     requiredSchema: Schema,
+                                     conf: Configuration): ClosableIterator[InternalRow] = {
+    val fileInfo = sparkAdapter.getSparkPartitionedFileUtils.createPartitionedFile(
+      InternalRow.empty, filePath, 0, length)
+
+    val dataStructSchema = HoodieInternalRowUtils.getCachedSchema(dataSchema)
+    val requiredStructSchema = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
+    new CloseableInternalRowIterator(parquetFileFormat.buildReaderWithPartitionValues(
+      sparkSession, dataStructSchema, StructType(Seq.empty), requiredStructSchema, Seq.empty,
+      Map(), conf
+    ).apply(fileInfo))
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/CloseableInternalRowIterator.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/CloseableInternalRowIterator.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.util
+
+import org.apache.hudi.common.util.collection.ClosableIterator
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * A [[ClosableIterator]] returning [[InternalRow]] by iterating through the entries returned
+ * by a Spark reader.
+ *
+ * @param iterator the input iterator that can either contain [[InternalRow]] (non-vectorized)
+ *                 or [[ColumnarBatch]] (vectorized), as returned by the Spark reader.
+ */
+class CloseableInternalRowIterator(iterator: Iterator[_]) extends ClosableIterator[InternalRow] {
+  private var entryTypeKnown = false
+  private var isColumnarBatch = false
+  private var nextBatch: ColumnarBatch = _
+  private var seqInBatch: Int = -1
+
+  override def close(): Unit = {
+    // No op
+  }
+
+  override def hasNext: Boolean = {
+    seqInBatch >= 0 || iterator.hasNext
+  }
+
+  override def next: InternalRow = {
+    if (!entryTypeKnown) {
+      // First entry
+      val nextVal = iterator.next
+      seqInBatch = 0
+      nextVal match {
+        case _: ColumnarBatch =>
+          isColumnarBatch = true
+          nextBatch = nextVal.asInstanceOf[ColumnarBatch]
+          val result = nextBatch.getRow(seqInBatch)
+          seqInBatch += 1
+          if (seqInBatch >= nextBatch.numRows()) {
+            seqInBatch = -1
+          }
+          result
+        case _ =>
+          seqInBatch = -1
+          nextVal.asInstanceOf[InternalRow]
+      }
+    } else {
+      if (isColumnarBatch) {
+        val result = nextBatch.getRow(seqInBatch)
+        seqInBatch += 1
+        if (seqInBatch >= nextBatch.numRows()) {
+          seqInBatch = -1
+        }
+        result
+      } else {
+        iterator.next.asInstanceOf[InternalRow]
+      }
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/CloseableScalaIterator.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/CloseableScalaIterator.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.util
+
+import org.apache.hudi.common.util.collection.ClosableIterator
+
+/**
+ * A [[ClosableIterator]] wrapping a Scala [[Iterator]] of the same type.
+ *
+ * @param iterator Scala [[Iterator]].
+ * @tparam T The type of entry.
+ */
+class CloseableScalaIterator[T](iterator: Iterator[T]) extends ClosableIterator[T] {
+  override def close(): Unit = {
+  }
+
+  override def hasNext: Boolean = {
+    iterator.hasNext
+  }
+
+  override def next: T = {
+    iterator.next
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.engine;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An abstract reader context class for {@code HoodieFileGroupReader} to use, containing APIs for
+ * engine-specific implementation on reading data files, getting field values from a record,
+ * transforming a record, etc.
+ * <p>
+ * For each query engine, this class should be extended and plugged into {@code HoodieFileGroupReader}
+ * to realize the file group reading.
+ *
+ * @param <T> The type of engine-specific record representation, e.g.,{@code InternalRow} in Spark
+ *            and {@code RowData} in Flink.
+ */
+public abstract class HoodieReaderContext<T> {
+  // These internal key names are only used in memory for record metadata and merging,
+  // and should not be persisted to storage.
+  public static final String INTERNAL_META_RECORD_KEY = "_0";
+  public static final String INTERNAL_META_PARTITION_PATH = "_1";
+  public static final String INTERNAL_META_ORDERING_FIELD = "_2";
+  public static final String INTERNAL_META_OPERATION = "_3";
+  public static final String INTERNAL_META_INSTANT_TIME = "_4";
+
+  /**
+   * Gets the file system based on the file path and configuration.
+   *
+   * @param path File path to get the file system.
+   * @param conf Hadoop {@link Configuration} instance.
+   * @return The {@link FileSystem} instance to use.
+   */
+  public abstract FileSystem getFs(String path, Configuration conf);
+
+  /**
+   * Gets the record iterator based on the type of engine-specific record representation from the
+   * file.
+   *
+   * @param filePath       {@link Path} instance of a file.
+   * @param start          Starting byte to start reading.
+   * @param length         Bytes to read.
+   * @param dataSchema     Schema of records in the file in {@link Schema}.
+   * @param requiredSchema Schema containing required fields to read in {@link Schema} for projection.
+   * @param conf           {@link Configuration} for reading records.
+   * @return {@link ClosableIterator<T>} that can return all records through iteration.
+   */
+  public abstract ClosableIterator<T> getFileRecordIterator(
+      Path filePath, long start, long length, Schema dataSchema, Schema requiredSchema, Configuration conf);
+
+  /**
+   * @param mergerStrategy Merger strategy UUID.
+   * @return {@link HoodieRecordMerger} to use.
+   */
+  public abstract HoodieRecordMerger getRecordMerger(String mergerStrategy);
+
+  /**
+   * Gets the field value.
+   *
+   * @param record    The record in engine-specific type.
+   * @param schema    The Avro schema of the record.
+   * @param fieldName The field name.
+   * @return The field value.
+   */
+  public abstract Object getValue(T record, Schema schema, String fieldName);
+
+  /**
+   * Gets the record key in String.
+   *
+   * @param record The record in engine-specific type.
+   * @param schema The Avro schema of the record.
+   * @return The record key in String.
+   */
+  public abstract String getRecordKey(T record, Schema schema);
+
+  /**
+   * Gets the ordering value in particular type.
+   *
+   * @param recordOption An option of record.
+   * @param metadataMap  A map containing the record metadata.
+   * @param schema       The Avro schema of the record.
+   * @param props        Properties.
+   * @return The ordering value.
+   */
+  public abstract Comparable getOrderingValue(Option<T> recordOption,
+                                              Map<String, Object> metadataMap,
+                                              Schema schema,
+                                              TypedProperties props);
+
+  /**
+   * Constructs a new {@link HoodieRecord} based on the record of engine-specific type and metadata for merging.
+   *
+   * @param recordOption An option of the record in engine-specific type if exists.
+   * @param metadataMap  The record metadata.
+   * @param schema       The Avro schema of the record.
+   * @return A new instance of {@link HoodieRecord}.
+   */
+  public abstract HoodieRecord<T> constructHoodieRecord(Option<T> recordOption,
+                                                        Map<String, Object> metadataMap,
+                                                        Schema schema);
+
+  /**
+   * Seals the engine-specific record to make sure the data referenced in memory do not change.
+   *
+   * @param record The record.
+   * @return The record containing the same data that do not change in memory over time.
+   */
+  public abstract T seal(T record);
+
+  /**
+   * Generates metadata map based on the information.
+   *
+   * @param recordKey     Record key in String.
+   * @param partitionPath Partition path in String.
+   * @param orderingVal   Ordering value in String.
+   * @return A mapping containing the metadata.
+   */
+  public Map<String, Object> generateMetadataForRecord(
+      String recordKey, String partitionPath, Comparable orderingVal) {
+    Map<String, Object> meta = new HashMap<>();
+    meta.put(INTERNAL_META_RECORD_KEY, recordKey);
+    meta.put(INTERNAL_META_PARTITION_PATH, partitionPath);
+    meta.put(INTERNAL_META_ORDERING_FIELD, orderingVal);
+    return meta;
+  }
+
+  /**
+   * Generates metadata of the record. Only fetches record key that is necessary for merging.
+   *
+   * @param record The record.
+   * @param schema The Avro schema of the record.
+   * @return A mapping containing the metadata.
+   */
+  public Map<String, Object> generateMetadataForRecord(T record, Schema schema) {
+    Map<String, Object> meta = new HashMap<>();
+    meta.put(INTERNAL_META_RECORD_KEY, getRecordKey(record, schema));
+    return meta;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
@@ -1,0 +1,972 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.DeleteRecord;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodiePayloadProps;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
+import org.apache.hudi.common.table.log.block.HoodieDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.CachingPath;
+import org.apache.hudi.internal.schema.InternalSchema;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.log.block.HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_BLOCK;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.BLOCK_IDENTIFIER;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.COMPACTED_BLOCK_TIMES;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.INSTANT_TIME;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.COMMAND_BLOCK;
+import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.CORRUPT_BLOCK;
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+
+/**
+ * A new abstract log record reader, returning records in the type of engine-specific
+ * record representation.
+ *
+ * @param <T> type of engine-specific record representation.
+ */
+public abstract class BaseHoodieLogRecordReader<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseHoodieLogRecordReader.class);
+
+  // Reader schema for the records
+  protected final Schema readerSchema;
+  // Latest valid instant time
+  // Log-Blocks belonging to inflight delta-instants are filtered-out using this high-watermark.
+  private final String latestInstantTime;
+  protected final HoodieReaderContext<T> readerContext;
+  protected final HoodieTableMetaClient hoodieTableMetaClient;
+  // Merge strategy to use when combining records from log
+  private final String payloadClassFQN;
+  // Record's key/partition-path fields
+  private final String recordKeyField;
+  private final Option<String> partitionPathFieldOpt;
+  // Partition name override
+  private final Option<String> partitionNameOverrideOpt;
+  // Pre-combining field
+  protected final String preCombineField;
+  // Stateless component for merging records
+  protected final HoodieRecordMerger recordMerger;
+  private final TypedProperties payloadProps;
+  // Log File Paths
+  protected final List<String> logFilePaths;
+  // Reverse reader - Not implemented yet (NA -> Why do we need ?)
+  // but present here for plumbing for future implementation
+  private final boolean reverseReader;
+  // Buffer Size for log file reader
+  private final int bufferSize;
+  // optional instant range for incremental block filtering
+  private final Option<InstantRange> instantRange;
+  // Read the operation metadata field from the avro record
+  private final boolean withOperationField;
+  // FileSystem
+  private final FileSystem fs;
+  // Total log files read - for metrics
+  private AtomicLong totalLogFiles = new AtomicLong(0);
+  // Internal schema, used to support full schema evolution.
+  private final InternalSchema internalSchema;
+  // Total log blocks read - for metrics
+  private AtomicLong totalLogBlocks = new AtomicLong(0);
+  // Total log records read - for metrics
+  private AtomicLong totalLogRecords = new AtomicLong(0);
+  // Total number of rollbacks written across all log files
+  private AtomicLong totalRollbacks = new AtomicLong(0);
+  // Total number of corrupt blocks written across all log files
+  private AtomicLong totalCorruptBlocks = new AtomicLong(0);
+  // Store the last instant log blocks (needed to implement rollback)
+  private Deque<HoodieLogBlock> currentInstantLogBlocks = new ArrayDeque<>();
+  // Enables full scan of log records
+  protected final boolean forceFullScan;
+  // Progress
+  private float progress = 0.0f;
+  // Populate meta fields for the records
+  private final boolean populateMetaFields;
+  // Record type read from log block
+  protected final HoodieRecord.HoodieRecordType recordType;
+  // Collect all the block instants after scanning all the log files.
+  private final List<String> validBlockInstants = new ArrayList<>();
+  // Use scanV2 method.
+  private final boolean enableOptimizedLogBlocksScan;
+
+  protected BaseHoodieLogRecordReader(HoodieReaderContext readerContext,
+                                      FileSystem fs, String basePath, List<String> logFilePaths,
+                                      Schema readerSchema, String latestInstantTime, boolean readBlocksLazily,
+                                      boolean reverseReader, int bufferSize, Option<InstantRange> instantRange,
+                                      boolean withOperationField, boolean forceFullScan,
+                                      Option<String> partitionNameOverride,
+                                      InternalSchema internalSchema,
+                                      Option<String> keyFieldOverride,
+                                      boolean enableOptimizedLogBlocksScan,
+                                      HoodieRecordMerger recordMerger) {
+    this.readerContext = readerContext;
+    this.readerSchema = readerSchema;
+    this.latestInstantTime = latestInstantTime;
+    this.hoodieTableMetaClient = HoodieTableMetaClient.builder().setConf(fs.getConf()).setBasePath(basePath).build();
+    // load class from the payload fully qualified class name
+    HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
+    this.payloadClassFQN = tableConfig.getPayloadClass();
+    this.preCombineField = tableConfig.getPreCombineField();
+    // Log scanner merge log with precombine
+    TypedProperties props = new TypedProperties();
+    if (this.preCombineField != null) {
+      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, this.preCombineField);
+    }
+    this.payloadProps = props;
+    this.recordMerger = recordMerger;
+    this.totalLogFiles.addAndGet(logFilePaths.size());
+    this.logFilePaths = logFilePaths;
+    this.reverseReader = reverseReader;
+    this.fs = fs;
+    this.bufferSize = bufferSize;
+    this.instantRange = instantRange;
+    this.withOperationField = withOperationField;
+    this.forceFullScan = forceFullScan;
+    this.internalSchema = internalSchema == null ? InternalSchema.getEmptyInternalSchema() : internalSchema;
+    this.enableOptimizedLogBlocksScan = enableOptimizedLogBlocksScan;
+
+    if (keyFieldOverride.isPresent()) {
+      // NOTE: This branch specifically is leveraged handling Metadata Table
+      //       log-block merging sequence. Here we do
+      //         - Override the record-key field (which isn't configured t/h table-config)
+      //         - Override partition-path value w/ static "partition-name" (in MT all partitions
+      //         are static, like "files", "col_stats", etc)
+      checkState(partitionNameOverride.isPresent());
+
+      this.populateMetaFields = false;
+      this.recordKeyField = keyFieldOverride.get();
+      this.partitionPathFieldOpt = Option.empty();
+    } else if (tableConfig.populateMetaFields()) {
+      this.populateMetaFields = true;
+      this.recordKeyField = HoodieRecord.RECORD_KEY_METADATA_FIELD;
+      this.partitionPathFieldOpt = Option.of(HoodieRecord.PARTITION_PATH_METADATA_FIELD);
+    } else {
+      this.populateMetaFields = false;
+      this.recordKeyField = tableConfig.getRecordKeyFieldProp();
+      this.partitionPathFieldOpt = Option.of(tableConfig.getPartitionFieldProp());
+    }
+
+    this.partitionNameOverrideOpt = partitionNameOverride;
+    this.recordType = recordMerger.getRecordType();
+  }
+
+  /**
+   * @param keySpecOpt           specifies target set of keys to be scanned
+   * @param skipProcessingBlocks controls, whether (delta) blocks have to actually be processed
+   */
+  protected final void scanInternal(Option<KeySpec> keySpecOpt, boolean skipProcessingBlocks) {
+    synchronized (this) {
+      if (enableOptimizedLogBlocksScan) {
+        scanInternalV2(keySpecOpt, skipProcessingBlocks);
+      } else {
+        scanInternalV1(keySpecOpt);
+      }
+    }
+  }
+
+  private void scanInternalV1(Option<KeySpec> keySpecOpt) {
+    currentInstantLogBlocks = new ArrayDeque<>();
+    List<HoodieLogBlock> validLogBlockInstants = new ArrayList<>();
+    Map<String, Map<Long, List<Pair<Integer, HoodieLogBlock>>>> blockSequenceMapPerCommit = new HashMap<>();
+
+    progress = 0.0f;
+    totalLogFiles = new AtomicLong(0);
+    totalRollbacks = new AtomicLong(0);
+    totalCorruptBlocks = new AtomicLong(0);
+    totalLogBlocks = new AtomicLong(0);
+    totalLogRecords = new AtomicLong(0);
+    HoodieLogFormatReverseReader logFormatReaderWrapper = null;
+    HoodieTimeline commitsTimeline = this.hoodieTableMetaClient.getCommitsTimeline();
+    HoodieTimeline completedInstantsTimeline = commitsTimeline.filterCompletedInstants();
+    HoodieTimeline inflightInstantsTimeline = commitsTimeline.filterInflights();
+    try {
+      // Iterate over the paths
+      logFormatReaderWrapper = new HoodieLogFormatReverseReader(fs,
+          logFilePaths.stream().map(logFile -> new HoodieLogFile(new CachingPath(logFile))).collect(Collectors.toList()),
+          readerSchema, true, reverseReader, bufferSize, shouldLookupRecords(), recordKeyField, internalSchema);
+
+      Set<HoodieLogFile> scannedLogFiles = new HashSet<>();
+      while (logFormatReaderWrapper.hasNext()) {
+        HoodieLogFile logFile = logFormatReaderWrapper.getLogFile();
+        LOG.info("Scanning log file " + logFile);
+        scannedLogFiles.add(logFile);
+        totalLogFiles.set(scannedLogFiles.size());
+        // Use the HoodieLogFileReader to iterate through the blocks in the log file
+        HoodieLogBlock logBlock = logFormatReaderWrapper.next();
+        final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
+        final String blockSequenceNumberStr = logBlock.getLogBlockHeader().getOrDefault(BLOCK_IDENTIFIER, "");
+        int blockSeqNo = -1;
+        long attemptNo = -1L;
+        if (!StringUtils.isNullOrEmpty(blockSequenceNumberStr)) {
+          String[] parts = blockSequenceNumberStr.split(",");
+          attemptNo = Long.parseLong(parts[0]);
+          blockSeqNo = Integer.parseInt(parts[1]);
+        }
+        totalLogBlocks.incrementAndGet();
+        if (logBlock.getBlockType() != CORRUPT_BLOCK
+            && !HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME), HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime
+        )) {
+          // hit a block with instant time greater than should be processed, stop processing further
+          break;
+        }
+        if (logBlock.getBlockType() != CORRUPT_BLOCK && logBlock.getBlockType() != COMMAND_BLOCK) {
+          if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
+              || inflightInstantsTimeline.containsInstant(instantTime)) {
+            // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
+            continue;
+          }
+          if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {
+            // filter the log block by instant range
+            continue;
+          }
+        }
+        switch (logBlock.getBlockType()) {
+          case HFILE_DATA_BLOCK:
+          case AVRO_DATA_BLOCK:
+          case PARQUET_DATA_BLOCK:
+            LOG.info("Reading a data block from file " + logFile.getPath() + " at instant " + instantTime);
+            // store the current block
+            currentInstantLogBlocks.push(logBlock);
+            validLogBlockInstants.add(logBlock);
+            updateBlockSequenceTracker(logBlock, instantTime, blockSeqNo, attemptNo, blockSequenceMapPerCommit);
+            break;
+          case DELETE_BLOCK:
+            LOG.info("Reading a delete block from file " + logFile.getPath());
+            // store deletes so can be rolled back
+            currentInstantLogBlocks.push(logBlock);
+            validLogBlockInstants.add(logBlock);
+            updateBlockSequenceTracker(logBlock, instantTime, blockSeqNo, attemptNo, blockSequenceMapPerCommit);
+            break;
+          case COMMAND_BLOCK:
+            // Consider the following scenario
+            // (Time 0, C1, Task T1) -> Running
+            // (Time 1, C1, Task T1) -> Failed (Wrote either a corrupt block or a correct
+            // DataBlock (B1) with commitTime C1
+            // (Time 2, C1, Task T1.2) -> Running (Task T1 was retried and the attempt number is 2)
+            // (Time 3, C1, Task T1.2) -> Finished (Wrote a correct DataBlock B2)
+            // Now a logFile L1 can have 2 correct Datablocks (B1 and B2) which are the same.
+            // Say, commit C1 eventually failed and a rollback is triggered.
+            // Rollback will write only 1 rollback block (R1) since it assumes one block is
+            // written per ingestion batch for a file but in reality we need to rollback (B1 & B2)
+            // The following code ensures the same rollback block (R1) is used to rollback
+            // both B1 & B2
+            // This is a command block - take appropriate action based on the command
+            HoodieCommandBlock commandBlock = (HoodieCommandBlock) logBlock;
+            String targetInstantForCommandBlock =
+                logBlock.getLogBlockHeader().get(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME);
+            LOG.info(String.format("Reading a command block %s with targetInstantTime %s from file %s", commandBlock.getType(), targetInstantForCommandBlock,
+                logFile.getPath()));
+            switch (commandBlock.getType()) { // there can be different types of command blocks
+              case ROLLBACK_BLOCK:
+                // Rollback older read log block(s)
+                // Get commit time from older record blocks, compare with targetCommitTime,
+                // rollback only if equal, this is required in scenarios of invalid/extra
+                // rollback blocks written due to failures during the rollback operation itself
+                // and ensures the same rollback block (R1) is used to rollback both B1 & B2 with
+                // same instant_time.
+                final int instantLogBlockSizeBeforeRollback = currentInstantLogBlocks.size();
+                currentInstantLogBlocks.removeIf(block -> {
+                  // handle corrupt blocks separately since they may not have metadata
+                  if (block.getBlockType() == CORRUPT_BLOCK) {
+                    LOG.info("Rolling back the last corrupted log block read in " + logFile.getPath());
+                    return true;
+                  }
+                  if (targetInstantForCommandBlock.contentEquals(block.getLogBlockHeader().get(INSTANT_TIME))) {
+                    // rollback older data block or delete block
+                    LOG.info(String.format("Rolling back an older log block read from %s with instantTime %s",
+                        logFile.getPath(), targetInstantForCommandBlock));
+                    return true;
+                  }
+                  return false;
+                });
+
+                // remove entire entry from blockSequenceTracker
+                blockSequenceMapPerCommit.remove(targetInstantForCommandBlock);
+
+                /// remove all matching log blocks from valid list tracked so far
+                validLogBlockInstants = validLogBlockInstants.stream().filter(block -> {
+                  // handle corrupt blocks separately since they may not have metadata
+                  if (block.getBlockType() == CORRUPT_BLOCK) {
+                    LOG.info("Rolling back the last corrupted log block read in " + logFile.getPath());
+                    return true;
+                  }
+                  if (targetInstantForCommandBlock.contentEquals(block.getLogBlockHeader().get(INSTANT_TIME))) {
+                    // rollback older data block or delete block
+                    LOG.info(String.format("Rolling back an older log block read from %s with instantTime %s",
+                        logFile.getPath(), targetInstantForCommandBlock));
+                    return false;
+                  }
+                  return true;
+                }).collect(Collectors.toList());
+
+                final int numBlocksRolledBack = instantLogBlockSizeBeforeRollback - currentInstantLogBlocks.size();
+                totalRollbacks.addAndGet(numBlocksRolledBack);
+                LOG.info("Number of applied rollback blocks " + numBlocksRolledBack);
+                if (numBlocksRolledBack == 0) {
+                  LOG.warn(String.format("TargetInstantTime %s invalid or extra rollback command block in %s",
+                      targetInstantForCommandBlock, logFile.getPath()));
+                }
+                break;
+              default:
+                throw new UnsupportedOperationException("Command type not yet supported.");
+            }
+            break;
+          case CORRUPT_BLOCK:
+            LOG.info("Found a corrupt block in " + logFile.getPath());
+            totalCorruptBlocks.incrementAndGet();
+            // If there is a corrupt block - we will assume that this was the next data block
+            currentInstantLogBlocks.push(logBlock);
+            validLogBlockInstants.add(logBlock);
+            // we don't need to update the block sequence tracker here, since the block sequence tracker is meant to remove additional/spurious valid logblocks.
+            // anyway, contents of corrupt blocks are not read.
+            break;
+          default:
+            throw new UnsupportedOperationException("Block type not supported yet");
+        }
+      }
+      // merge the last read block when all the blocks are done reading
+      if (!currentInstantLogBlocks.isEmpty()) {
+        Pair<Boolean, List<HoodieLogBlock>> dedupedLogBlocksInfo = reconcileSpuriousBlocksAndGetValidOnes(validLogBlockInstants, blockSequenceMapPerCommit);
+        if (dedupedLogBlocksInfo.getKey()) {
+          // if there are duplicate log blocks that needs to be removed, we re-create the queue for valid log blocks from dedupedLogBlocks
+          currentInstantLogBlocks = new ArrayDeque<>();
+          dedupedLogBlocksInfo.getValue().forEach(block -> currentInstantLogBlocks.push(block));
+          LOG.info("Merging the final data blocks");
+          processQueuedBlocksForInstant(currentInstantLogBlocks, scannedLogFiles.size(), keySpecOpt);
+        } else {
+          // if there are no dups, we can take currentInstantLogBlocks as is.
+          LOG.info("Merging the final data blocks");
+          processQueuedBlocksForInstant(currentInstantLogBlocks, scannedLogFiles.size(), keySpecOpt);
+        }
+      }
+
+      // Done
+      progress = 1.0f;
+    } catch (IOException e) {
+      LOG.error("Got IOException when reading log file", e);
+      throw new HoodieIOException("IOException when reading log file ", e);
+    } catch (Exception e) {
+      LOG.error("Got exception when reading log file", e);
+      throw new HoodieException("Exception when reading log file ", e);
+    } finally {
+      try {
+        if (null != logFormatReaderWrapper) {
+          logFormatReaderWrapper.close();
+        }
+      } catch (IOException ioe) {
+        // Eat exception as we do not want to mask the original exception that can happen
+        LOG.error("Unable to close log format reader", ioe);
+      }
+    }
+  }
+
+  /**
+   * There could be spurious log blocks due to spark task retries. So, we will use BLOCK_SEQUENCE_NUMBER in the log block header to deduce such spurious log blocks and return
+   * a deduped set of log blocks.
+   *
+   * @param allValidLogBlocks         all valid log blocks parsed so far.
+   * @param blockSequenceMapPerCommit map containing block sequence numbers for every commit.
+   * @return a Pair of boolean and list of deduped valid block blocks, where boolean of true means, there have been dups detected.
+   */
+  private Pair<Boolean, List<HoodieLogBlock>> reconcileSpuriousBlocksAndGetValidOnes(List<HoodieLogBlock> allValidLogBlocks,
+                                                                                     Map<String, Map<Long, List<Pair<Integer, HoodieLogBlock>>>> blockSequenceMapPerCommit) {
+
+    boolean dupsFound = blockSequenceMapPerCommit.values().stream().anyMatch(perCommitBlockList -> perCommitBlockList.size() > 1);
+    if (dupsFound) {
+      // duplicates are found. we need to remove duplicate log blocks.
+      for (Map.Entry<String, Map<Long, List<Pair<Integer, HoodieLogBlock>>>> entry : blockSequenceMapPerCommit.entrySet()) {
+        Map<Long, List<Pair<Integer, HoodieLogBlock>>> perCommitBlockSequences = entry.getValue();
+        if (perCommitBlockSequences.size() > 1) {
+          // only those that have more than 1 sequence needs deduping.
+          int maxSequenceCount = -1;
+          int maxAttemptNo = -1;
+          int totalSequences = perCommitBlockSequences.size();
+          int counter = 0;
+          for (Map.Entry<Long, List<Pair<Integer, HoodieLogBlock>>> perAttemptEntries : perCommitBlockSequences.entrySet()) {
+            Long attemptNo = perAttemptEntries.getKey();
+            int size = perAttemptEntries.getValue().size();
+            if (maxSequenceCount < size) {
+              maxSequenceCount = size;
+              maxAttemptNo = Math.toIntExact(attemptNo);
+            }
+            counter++;
+          }
+          // for other sequence (!= maxSequenceIndex), we need to remove the corresponding logBlocks from allValidLogBlocks
+          for (Map.Entry<Long, List<Pair<Integer, HoodieLogBlock>>> perAttemptEntries : perCommitBlockSequences.entrySet()) {
+            Long attemptNo = perAttemptEntries.getKey();
+            if (maxAttemptNo != attemptNo) {
+              List<HoodieLogBlock> logBlocksToRemove = perCommitBlockSequences.get(attemptNo).stream().map(pair -> pair.getValue()).collect(Collectors.toList());
+              logBlocksToRemove.forEach(logBlockToRemove -> allValidLogBlocks.remove(logBlocksToRemove));
+            }
+          }
+        }
+      }
+      return Pair.of(true, allValidLogBlocks);
+    } else {
+      return Pair.of(false, allValidLogBlocks);
+    }
+  }
+
+  /**
+   * Updates map tracking block seq no.
+   * Here is the map structure.
+   * Map<String, Map<Long, List<Pair<Integer, HoodieLogBlock>>>> blockSequenceMapPerCommit
+   * Key: Commit time.
+   * Value: Map<Long, List<Pair<Integer, HoodieLogBlock>>>>
+   * Value refers to a Map of different attempts for the commit of interest. List contains the block seq number and the resp HoodieLogBlock.
+   * <p>
+   * For eg, if there were two attempts for a file slice while writing(due to spark task retries), here is how the map might look like
+   * key: commit1
+   * value : {
+   * 0L = List = { {0, lb1}, {1, lb2} },
+   * 1L = List = { {0, lb3}, {1, lb4}, {2, lb5}}
+   * }
+   * Meaning: for commit1, there was two attempts with Append Handle while writing. In first attempt, lb1 and lb2 was added. And in 2nd attempt lb3, lb4 and lb5 was added.
+   * We keep populating this entire map and finally detect spurious log blocks and ignore them.
+   * In most cases, we might just see one set of sequence for a given commit.
+   *
+   * @param logBlock                  log block of interest to be added.
+   * @param instantTime               commit time of interest.
+   * @param blockSeqNo                block sequence number.
+   * @param blockSequenceMapPerCommit map tracking per commit block sequences.
+   */
+  private void updateBlockSequenceTracker(HoodieLogBlock logBlock, String instantTime, int blockSeqNo, long attemptNo,
+                                          Map<String, Map<Long, List<Pair<Integer, HoodieLogBlock>>>> blockSequenceMapPerCommit) {
+    if (blockSeqNo != -1 && attemptNo != -1) { // update the block sequence tracker for log blocks containing the same.
+      blockSequenceMapPerCommit.computeIfAbsent(instantTime, entry -> new HashMap<>());
+      Map<Long, List<Pair<Integer, HoodieLogBlock>>> curCommitBlockMap = blockSequenceMapPerCommit.get(instantTime);
+      if (curCommitBlockMap.containsKey(attemptNo)) {
+        // append to existing map entry
+        curCommitBlockMap.get(attemptNo).add(Pair.of(blockSeqNo, logBlock));
+      } else {
+        // create a new map entry
+        curCommitBlockMap.put(attemptNo, new ArrayList<>());
+        curCommitBlockMap.get(attemptNo).add(Pair.of(blockSeqNo, logBlock));
+      }
+      // update the latest to block sequence tracker
+      blockSequenceMapPerCommit.put(instantTime, curCommitBlockMap);
+    } else {
+      // all of older blocks are considered valid. there should be only one list for older commits where block sequence number is not present.
+      blockSequenceMapPerCommit.computeIfAbsent(instantTime, entry -> new HashMap<>());
+      Map<Long, List<Pair<Integer, HoodieLogBlock>>> curCommitBlockMap = blockSequenceMapPerCommit.get(instantTime);
+      curCommitBlockMap.put(0L, new ArrayList<>());
+      curCommitBlockMap.get(0L).add(Pair.of(blockSeqNo, logBlock));
+      // update the latest to block sequence tracker
+      blockSequenceMapPerCommit.put(instantTime, curCommitBlockMap);
+    }
+  }
+
+  private void scanInternalV2(Option<KeySpec> keySpecOption, boolean skipProcessingBlocks) {
+    currentInstantLogBlocks = new ArrayDeque<>();
+    progress = 0.0f;
+    totalLogFiles = new AtomicLong(0);
+    totalRollbacks = new AtomicLong(0);
+    totalCorruptBlocks = new AtomicLong(0);
+    totalLogBlocks = new AtomicLong(0);
+    totalLogRecords = new AtomicLong(0);
+    HoodieLogFormatReader logFormatReaderWrapper = null;
+    HoodieTimeline commitsTimeline = this.hoodieTableMetaClient.getCommitsTimeline();
+    HoodieTimeline completedInstantsTimeline = commitsTimeline.filterCompletedInstants();
+    HoodieTimeline inflightInstantsTimeline = commitsTimeline.filterInflights();
+    try {
+      // Iterate over the paths
+      logFormatReaderWrapper = new HoodieLogFormatReader(fs,
+          logFilePaths.stream().map(logFile -> new HoodieLogFile(new CachingPath(logFile))).collect(Collectors.toList()),
+          readerSchema, true, reverseReader, bufferSize, shouldLookupRecords(), recordKeyField, internalSchema);
+
+      /**
+       * Scanning log blocks and placing the compacted blocks at the right place require two traversals.
+       * First traversal to identify the rollback blocks and valid data and compacted blocks.
+       *
+       * Scanning blocks is easy to do in single writer mode, where the rollback block is right after the effected data blocks.
+       * With multi-writer mode the blocks can be out of sync. An example scenario.
+       * B1, B2, B3, B4, R1(B3), B5
+       * In this case, rollback block R1 is invalidating the B3 which is not the previous block.
+       * This becomes more complicated if we have compacted blocks, which are data blocks created using log compaction.
+       *
+       * To solve this, run a single traversal, collect all the valid blocks that are not corrupted
+       * along with the block instant times and rollback block's target instant times.
+       *
+       * As part of second traversal iterate block instant times in reverse order.
+       * While iterating in reverse order keep a track of final compacted instant times for each block.
+       * In doing so, when a data block is seen include the final compacted block if it is not already added.
+       *
+       * find the final compacted block which contains the merged contents.
+       * For example B1 and B2 are merged and created a compacted block called M1 and now M1, B3 and B4 are merged and
+       * created another compacted block called M2. So, now M2 is the final block which contains all the changes of B1,B2,B3,B4.
+       * So, blockTimeToCompactionBlockTimeMap will look like
+       * (B1 -> M2), (B2 -> M2), (B3 -> M2), (B4 -> M2), (M1 -> M2)
+       * This map is updated while iterating and is used to place the compacted blocks in the correct position.
+       * This way we can have multiple layers of merge blocks and still be able to find the correct positions of merged blocks.
+       */
+
+      // Collect targetRollbackInstants, using which we can determine which blocks are invalid.
+      Set<String> targetRollbackInstants = new HashSet<>();
+
+      // This holds block instant time to list of blocks. Note here the log blocks can be normal data blocks or compacted log blocks.
+      Map<String, List<HoodieLogBlock>> instantToBlocksMap = new HashMap<>();
+
+      // Order of Instants.
+      List<String> orderedInstantsList = new ArrayList<>();
+
+      Set<HoodieLogFile> scannedLogFiles = new HashSet<>();
+
+      /*
+       * 1. First step to traverse in forward direction. While traversing the log blocks collect following,
+       *    a. instant times
+       *    b. instant to logblocks map.
+       *    c. targetRollbackInstants.
+       */
+      while (logFormatReaderWrapper.hasNext()) {
+        HoodieLogFile logFile = logFormatReaderWrapper.getLogFile();
+        LOG.info("Scanning log file " + logFile);
+        scannedLogFiles.add(logFile);
+        totalLogFiles.set(scannedLogFiles.size());
+        // Use the HoodieLogFileReader to iterate through the blocks in the log file
+        HoodieLogBlock logBlock = logFormatReaderWrapper.next();
+        final String instantTime = logBlock.getLogBlockHeader().get(INSTANT_TIME);
+        totalLogBlocks.incrementAndGet();
+        // Ignore the corrupt blocks. No further handling is required for them.
+        if (logBlock.getBlockType().equals(CORRUPT_BLOCK)) {
+          LOG.info("Found a corrupt block in " + logFile.getPath());
+          totalCorruptBlocks.incrementAndGet();
+          continue;
+        }
+        if (!HoodieTimeline.compareTimestamps(logBlock.getLogBlockHeader().get(INSTANT_TIME),
+            HoodieTimeline.LESSER_THAN_OR_EQUALS, this.latestInstantTime)) {
+          // hit a block with instant time greater than should be processed, stop processing further
+          break;
+        }
+        if (logBlock.getBlockType() != COMMAND_BLOCK) {
+          if (!completedInstantsTimeline.containsOrBeforeTimelineStarts(instantTime)
+              || inflightInstantsTimeline.containsInstant(instantTime)) {
+            // hit an uncommitted block possibly from a failed write, move to the next one and skip processing this one
+            continue;
+          }
+          if (instantRange.isPresent() && !instantRange.get().isInRange(instantTime)) {
+            // filter the log block by instant range
+            continue;
+          }
+        }
+
+        switch (logBlock.getBlockType()) {
+          case HFILE_DATA_BLOCK:
+          case AVRO_DATA_BLOCK:
+          case PARQUET_DATA_BLOCK:
+          case DELETE_BLOCK:
+            List<HoodieLogBlock> logBlocksList = instantToBlocksMap.getOrDefault(instantTime, new ArrayList<>());
+            if (logBlocksList.size() == 0) {
+              // Keep a track of instant Times in the order of arrival.
+              orderedInstantsList.add(instantTime);
+            }
+            logBlocksList.add(logBlock);
+            instantToBlocksMap.put(instantTime, logBlocksList);
+            break;
+          case COMMAND_BLOCK:
+            LOG.info("Reading a command block from file " + logFile.getPath());
+            // This is a command block - take appropriate action based on the command
+            HoodieCommandBlock commandBlock = (HoodieCommandBlock) logBlock;
+
+            // Rollback blocks contain information of instants that are failed, collect them in a set..
+            if (commandBlock.getType().equals(ROLLBACK_BLOCK)) {
+              totalRollbacks.incrementAndGet();
+              String targetInstantForCommandBlock =
+                  logBlock.getLogBlockHeader().get(TARGET_INSTANT_TIME);
+              targetRollbackInstants.add(targetInstantForCommandBlock);
+              orderedInstantsList.remove(targetInstantForCommandBlock);
+              instantToBlocksMap.remove(targetInstantForCommandBlock);
+            } else {
+              throw new UnsupportedOperationException("Command type not yet supported.");
+            }
+            break;
+          default:
+            throw new UnsupportedOperationException("Block type not yet supported.");
+        }
+      }
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Ordered instant times seen " + orderedInstantsList);
+      }
+
+      int numBlocksRolledBack = 0;
+
+      // All the block's instants time that are added to the queue are collected in this set.
+      Set<String> instantTimesIncluded = new HashSet<>();
+
+      // Key will have details related to instant time and value will be empty if that instant is not compacted.
+      // Ex: B1(i1), B2(i2), CB(i3,[i1,i2]) entries will be like i1 -> i3, i2 -> i3.
+      Map<String, String> blockTimeToCompactionBlockTimeMap = new HashMap<>();
+
+      /*
+       * 2. Iterate the instants list in reverse order to get the latest instants first.
+       *    While iterating update the blockTimeToCompactionBlockTimesMap and include the compacted blocks in right position.
+       */
+      for (int i = orderedInstantsList.size() - 1; i >= 0; i--) {
+        String instantTime = orderedInstantsList.get(i);
+        List<HoodieLogBlock> instantsBlocks = instantToBlocksMap.get(instantTime);
+        if (instantsBlocks.size() == 0) {
+          throw new HoodieException("Data corrupted while writing. Found zero blocks for an instant " + instantTime);
+        }
+        HoodieLogBlock firstBlock = instantsBlocks.get(0);
+
+        // For compacted blocks COMPACTED_BLOCK_TIMES entry is present under its headers.
+        if (firstBlock.getLogBlockHeader().containsKey(COMPACTED_BLOCK_TIMES)) {
+          // When compacted blocks are seen update the blockTimeToCompactionBlockTimeMap.
+          Arrays.stream(firstBlock.getLogBlockHeader().get(COMPACTED_BLOCK_TIMES).split(","))
+              .forEach(originalInstant -> {
+                String finalInstant = blockTimeToCompactionBlockTimeMap.getOrDefault(instantTime, instantTime);
+                blockTimeToCompactionBlockTimeMap.put(originalInstant, finalInstant);
+              });
+        } else {
+          // When a data block is found check if it is already compacted.
+          String compactedFinalInstantTime = blockTimeToCompactionBlockTimeMap.get(instantTime);
+          if (compactedFinalInstantTime == null) {
+            // If it is not compacted then add the blocks related to the instant time at the end of the queue and continue.
+            List<HoodieLogBlock> logBlocks = instantToBlocksMap.get(instantTime);
+            Collections.reverse(logBlocks);
+            logBlocks.forEach(block -> currentInstantLogBlocks.addLast(block));
+            instantTimesIncluded.add(instantTime);
+            validBlockInstants.add(instantTime);
+            continue;
+          }
+          // If the compacted block exists and it is already included in the dequeue then ignore and continue.
+          if (instantTimesIncluded.contains(compactedFinalInstantTime)) {
+            continue;
+          }
+          // If the compacted block exists and it is not already added then add all the blocks related to that instant time.
+          List<HoodieLogBlock> logBlocks = instantToBlocksMap.get(compactedFinalInstantTime);
+          Collections.reverse(logBlocks);
+          logBlocks.forEach(block -> currentInstantLogBlocks.addLast(block));
+          instantTimesIncluded.add(compactedFinalInstantTime);
+          validBlockInstants.add(compactedFinalInstantTime);
+        }
+      }
+      LOG.info("Number of applied rollback blocks " + numBlocksRolledBack);
+
+      if (LOG.isDebugEnabled()) {
+        LOG.info("Final view of the Block time to compactionBlockMap " + blockTimeToCompactionBlockTimeMap);
+      }
+
+      // merge the last read block when all the blocks are done reading
+      if (!currentInstantLogBlocks.isEmpty() && !skipProcessingBlocks) {
+        LOG.info("Merging the final data blocks");
+        processQueuedBlocksForInstant(currentInstantLogBlocks, scannedLogFiles.size(), keySpecOption);
+      }
+      // Done
+      progress = 1.0f;
+    } catch (IOException e) {
+      LOG.error("Got IOException when reading log file", e);
+      throw new HoodieIOException("IOException when reading log file ", e);
+    } catch (Exception e) {
+      LOG.error("Got exception when reading log file", e);
+      throw new HoodieException("Exception when reading log file ", e);
+    } finally {
+      try {
+        if (null != logFormatReaderWrapper) {
+          logFormatReaderWrapper.close();
+        }
+      } catch (IOException ioe) {
+        // Eat exception as we do not want to mask the original exception that can happen
+        LOG.error("Unable to close log format reader", ioe);
+      }
+    }
+  }
+
+  /**
+   * Checks if the current logblock belongs to a later instant.
+   */
+  private boolean isNewInstantBlock(HoodieLogBlock logBlock) {
+    return currentInstantLogBlocks.size() > 0 && currentInstantLogBlocks.peek().getBlockType() != CORRUPT_BLOCK
+        && !logBlock.getLogBlockHeader().get(INSTANT_TIME)
+        .contentEquals(currentInstantLogBlocks.peek().getLogBlockHeader().get(INSTANT_TIME));
+  }
+
+  /**
+   * Iterate over the GenericRecord in the block, read the hoodie key and partition path and call subclass processors to
+   * handle it.
+   */
+  private void processDataBlock(HoodieDataBlock dataBlock, Option<KeySpec> keySpecOpt) throws Exception {
+    checkState(partitionNameOverrideOpt.isPresent() || partitionPathFieldOpt.isPresent(),
+        "Either partition-name override or partition-path field had to be present");
+
+    Option<Pair<String, String>> recordKeyPartitionPathFieldPair = populateMetaFields
+        ? Option.empty()
+        : Option.of(Pair.of(recordKeyField, partitionPathFieldOpt.orElse(null)));
+
+    Pair<ClosableIterator<T>, Schema> recordsIteratorSchemaPair =
+        getRecordsIterator(dataBlock, keySpecOpt);
+
+    try (ClosableIterator<T> recordIterator = recordsIteratorSchemaPair.getLeft()) {
+      while (recordIterator.hasNext()) {
+        T nextRecord = recordIterator.next();
+        processNextRecord(nextRecord,
+            readerContext.generateMetadataForRecord(nextRecord, readerSchema));
+        totalLogRecords.incrementAndGet();
+      }
+    }
+  }
+
+  /**
+   * Process next record.
+   *
+   * @param record   The next record in engine-specific representation.
+   * @param metadata The metadata of the record.
+   * @throws Exception
+   */
+  public abstract void processNextRecord(T record, Map<String, Object> metadata) throws Exception;
+
+  /**
+   * Process next deleted record.
+   *
+   * @param deleteRecord Deleted record(hoodie key and ordering value)
+   */
+  protected abstract void processNextDeletedRecord(DeleteRecord deleteRecord);
+
+  /**
+   * Process the set of log blocks belonging to the last instant which is read fully.
+   */
+  private void processQueuedBlocksForInstant(Deque<HoodieLogBlock> logBlocks, int numLogFilesSeen,
+                                             Option<KeySpec> keySpecOpt) throws Exception {
+    while (!logBlocks.isEmpty()) {
+      LOG.info("Number of remaining logblocks to merge " + logBlocks.size());
+      // poll the element at the bottom of the stack since that's the order it was inserted
+      HoodieLogBlock lastBlock = logBlocks.pollLast();
+      switch (lastBlock.getBlockType()) {
+        case AVRO_DATA_BLOCK:
+        case HFILE_DATA_BLOCK:
+        case PARQUET_DATA_BLOCK:
+          processDataBlock((HoodieDataBlock) lastBlock, keySpecOpt);
+          break;
+        case DELETE_BLOCK:
+          Arrays.stream(((HoodieDeleteBlock) lastBlock).getRecordsToDelete()).forEach(this::processNextDeletedRecord);
+          break;
+        case CORRUPT_BLOCK:
+          LOG.warn("Found a corrupt block which was not rolled back");
+          break;
+        default:
+          break;
+      }
+    }
+    // At this step the lastBlocks are consumed. We track approximate progress by number of log-files seen
+    progress = (numLogFilesSeen - 1) / logFilePaths.size();
+  }
+
+  private boolean shouldLookupRecords() {
+    // NOTE: Point-wise record lookups are only enabled when scanner is not in
+    //       a full-scan mode
+    return !forceFullScan;
+  }
+
+  /**
+   * Return progress of scanning as a float between 0.0 to 1.0.
+   */
+  public float getProgress() {
+    return progress;
+  }
+
+  public long getTotalLogFiles() {
+    return totalLogFiles.get();
+  }
+
+  public long getTotalLogRecords() {
+    return totalLogRecords.get();
+  }
+
+  public long getTotalLogBlocks() {
+    return totalLogBlocks.get();
+  }
+
+  protected String getPayloadClassFQN() {
+    return payloadClassFQN;
+  }
+
+  public Option<String> getPartitionNameOverride() {
+    return partitionNameOverrideOpt;
+  }
+
+  public long getTotalRollbacks() {
+    return totalRollbacks.get();
+  }
+
+  public long getTotalCorruptBlocks() {
+    return totalCorruptBlocks.get();
+  }
+
+  public boolean isWithOperationField() {
+    return withOperationField;
+  }
+
+  protected TypedProperties getPayloadProps() {
+    return payloadProps;
+  }
+
+  /**
+   * Key specification with a list of column names.
+   */
+  protected interface KeySpec {
+    List<String> getKeys();
+
+    boolean isFullKey();
+
+    static KeySpec fullKeySpec(List<String> keys) {
+      return new FullKeySpec(keys);
+    }
+
+    static KeySpec prefixKeySpec(List<String> keyPrefixes) {
+      return new PrefixKeySpec(keyPrefixes);
+    }
+  }
+
+  private static class FullKeySpec implements KeySpec {
+    private final List<String> keys;
+
+    private FullKeySpec(List<String> keys) {
+      this.keys = keys;
+    }
+
+    @Override
+    public List<String> getKeys() {
+      return keys;
+    }
+
+    @Override
+    public boolean isFullKey() {
+      return true;
+    }
+  }
+
+  private static class PrefixKeySpec implements KeySpec {
+    private final List<String> keysPrefixes;
+
+    private PrefixKeySpec(List<String> keysPrefixes) {
+      this.keysPrefixes = keysPrefixes;
+    }
+
+    @Override
+    public List<String> getKeys() {
+      return keysPrefixes;
+    }
+
+    @Override
+    public boolean isFullKey() {
+      return false;
+    }
+  }
+
+  public Deque<HoodieLogBlock> getCurrentInstantLogBlocks() {
+    return currentInstantLogBlocks;
+  }
+
+  public List<String> getValidBlockInstants() {
+    return validBlockInstants;
+  }
+
+  private Pair<ClosableIterator<T>, Schema> getRecordsIterator(
+      HoodieDataBlock dataBlock, Option<KeySpec> keySpecOpt) throws IOException {
+    ClosableIterator<T> blockRecordsIterator;
+    if (keySpecOpt.isPresent()) {
+      KeySpec keySpec = keySpecOpt.get();
+      blockRecordsIterator = dataBlock.getEngineRecordIterator(readerContext, keySpec.getKeys(), keySpec.isFullKey());
+    } else {
+      blockRecordsIterator = dataBlock.getEngineRecordIterator(readerContext);
+    }
+    return Pair.of(blockRecordsIterator, dataBlock.getSchema());
+  }
+
+  /**
+   * Builder used to build {@code AbstractHoodieLogRecordScanner}.
+   */
+  public abstract static class Builder<T> {
+    public abstract Builder withHoodieReaderContext(HoodieReaderContext<T> readerContext);
+
+    public abstract Builder withFileSystem(FileSystem fs);
+
+    public abstract Builder withBasePath(String basePath);
+
+    public abstract Builder withLogFilePaths(List<String> logFilePaths);
+
+    public abstract Builder withReaderSchema(Schema schema);
+
+    public abstract Builder withInternalSchema(InternalSchema internalSchema);
+
+    public abstract Builder withLatestInstantTime(String latestInstantTime);
+
+    public abstract Builder withReadBlocksLazily(boolean readBlocksLazily);
+
+    public abstract Builder withReverseReader(boolean reverseReader);
+
+    public abstract Builder withBufferSize(int bufferSize);
+
+    public Builder withPartition(String partitionName) {
+      throw new UnsupportedOperationException();
+    }
+
+    public Builder withInstantRange(Option<InstantRange> instantRange) {
+      throw new UnsupportedOperationException();
+    }
+
+    public Builder withOperationField(boolean withOperationField) {
+      throw new UnsupportedOperationException();
+    }
+
+    public Builder withRecordMerger(HoodieRecordMerger recordMerger) {
+      throw new UnsupportedOperationException();
+    }
+
+    public Builder withOptimizedLogBlocksScan(boolean enableOptimizedLogBlocksScan) {
+      throw new UnsupportedOperationException();
+    }
+
+    public abstract BaseHoodieLogRecordReader build();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReverseReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatReverseReader.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.internal.schema.InternalSchema;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A log format reader by reading log files and blocks in reserve order.
+ * This reader assumes that each log file only has one log block.
+ */
+public class HoodieLogFormatReverseReader implements HoodieLogFormat.Reader {
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieLogFormatReader.class);
+  private final List<HoodieLogFile> logFiles;
+  // Readers for previously scanned log-files that are still open
+  private final List<HoodieLogFileReader> prevReadersInOpenState;
+  private HoodieLogFileReader currentReader;
+  private final FileSystem fs;
+  private final Schema readerSchema;
+  private InternalSchema internalSchema = InternalSchema.getEmptyInternalSchema();
+  private final boolean readBlocksLazily;
+  private final boolean reverseLogReader;
+  private final String recordKeyField;
+  private final boolean enableInlineReading;
+  private int bufferSize;
+  private int logFilePos = -1;
+
+  HoodieLogFormatReverseReader(FileSystem fs, List<HoodieLogFile> logFiles, Schema readerSchema, boolean readBlocksLazily,
+                               boolean reverseLogReader, int bufferSize, boolean enableRecordLookups,
+                               String recordKeyField, InternalSchema internalSchema) throws IOException {
+    this.logFiles = logFiles;
+    this.fs = fs;
+    this.readerSchema = readerSchema;
+    this.readBlocksLazily = readBlocksLazily;
+    this.reverseLogReader = reverseLogReader;
+    this.bufferSize = bufferSize;
+    this.prevReadersInOpenState = new ArrayList<>();
+    this.recordKeyField = recordKeyField;
+    this.enableInlineReading = enableRecordLookups;
+    this.internalSchema = internalSchema == null ? InternalSchema.getEmptyInternalSchema() : internalSchema;
+    logFilePos = logFiles.size() - 1;
+    if (logFilePos >= 0) {
+      HoodieLogFile nextLogFile = logFiles.get(logFilePos);
+      logFilePos--;
+      this.currentReader = new HoodieLogFileReader(fs, nextLogFile, readerSchema, bufferSize, readBlocksLazily, false,
+          enableRecordLookups, recordKeyField, internalSchema);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    for (HoodieLogFileReader reader : prevReadersInOpenState) {
+      reader.close();
+    }
+
+    prevReadersInOpenState.clear();
+
+    if (currentReader != null) {
+      currentReader.close();
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (currentReader == null) {
+      return false;
+    } else if (currentReader.hasNext()) {
+      return true;
+    } else if (logFilePos >= 0) {
+      try {
+        HoodieLogFile nextLogFile = logFiles.get(logFilePos);
+        logFilePos--;
+        // First close previous reader only if readBlockLazily is false
+        if (!readBlocksLazily) {
+          this.currentReader.close();
+        } else {
+          this.prevReadersInOpenState.add(currentReader);
+        }
+        this.currentReader = new HoodieLogFileReader(fs, nextLogFile, readerSchema, bufferSize, readBlocksLazily, false,
+            enableInlineReading, recordKeyField, internalSchema);
+      } catch (IOException io) {
+        throw new HoodieIOException("unable to initialize read with log file ", io);
+      }
+      LOG.info("Moving to the next reader for logfile " + currentReader.getLogFile());
+      return hasNext();
+    }
+    return false;
+  }
+
+  @Override
+  public HoodieLogBlock next() {
+    return currentReader.next();
+  }
+
+  @Override
+  public HoodieLogFile getLogFile() {
+    return currentReader.getLogFile();
+  }
+
+  @Override
+  public void remove() {
+  }
+
+  @Override
+  public boolean hasPrev() {
+    return this.currentReader.hasPrev();
+  }
+
+  @Override
+  public HoodieLogBlock prev() throws IOException {
+    return this.currentReader.prev();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordReader.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.DeleteRecord;
+import org.apache.hudi.common.model.HoodiePreCombineAvroRecordMerger;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.cdc.HoodieCDCUtils;
+import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.HoodieRecordUtils;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.internal.schema.InternalSchema;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.fs.FSUtils.getRelativePartitionPath;
+
+/**
+ * A log record reader that merges the records with the same record key.
+ *
+ * @param <T> type of engine-specific record representation.
+ */
+public class HoodieMergedLogRecordReader<T> extends BaseHoodieLogRecordReader<T>
+    implements Iterable<Pair<Option<T>, Map<String, Object>>>, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieMergedLogRecordReader.class);
+  // A timer for calculating elapsed time in millis
+  public final HoodieTimer timer = HoodieTimer.create();
+  // Map of compacted/merged records with metadata
+  private final Map<String, Pair<Option<T>, Map<String, Object>>> records;
+  // Set of already scanned prefixes allowing us to avoid scanning same prefixes again
+  private final Set<String> scannedPrefixes;
+  // count of merged records in log
+  private long numMergedRecordsInLog;
+  // Stores the total time taken to perform reading and merging of log blocks
+  private long totalTimeTakenToReadAndMergeBlocks;
+
+  @SuppressWarnings("unchecked")
+  private HoodieMergedLogRecordReader(HoodieReaderContext<T> readerContext,
+                                      FileSystem fs, String basePath, List<String> logFilePaths, Schema readerSchema,
+                                      String latestInstantTime, boolean readBlocksLazily,
+                                      boolean reverseReader, int bufferSize, Option<InstantRange> instantRange,
+                                      boolean withOperationField, boolean forceFullScan,
+                                      Option<String> partitionName,
+                                      InternalSchema internalSchema,
+                                      Option<String> keyFieldOverride,
+                                      boolean enableOptimizedLogBlocksScan, HoodieRecordMerger recordMerger) {
+    super(readerContext, fs, basePath, logFilePaths, readerSchema, latestInstantTime, readBlocksLazily, reverseReader, bufferSize,
+        instantRange, withOperationField, forceFullScan, partitionName, internalSchema, keyFieldOverride, enableOptimizedLogBlocksScan, recordMerger);
+    this.records = new HashMap<>();
+    this.scannedPrefixes = new HashSet<>();
+    if (forceFullScan) {
+      performScan();
+    }
+  }
+
+  /**
+   * Scans delta-log files processing blocks
+   */
+  public final void scan() {
+    scan(false);
+  }
+
+  public final void scan(boolean skipProcessingBlocks) {
+    if (forceFullScan) {
+      // NOTE: When full-scan is enforced, scanning is invoked upfront (during initialization)
+      return;
+    }
+
+    scanInternal(Option.empty(), skipProcessingBlocks);
+  }
+
+  /**
+   * Provides incremental scanning capability where only provided keys will be looked
+   * up in the delta-log files, scanned and subsequently materialized into the internal
+   * cache
+   *
+   * @param keys to be looked up
+   */
+  public void scanByFullKeys(List<String> keys) {
+    // We can skip scanning in case reader is in full-scan mode, in which case all blocks
+    // are processed upfront (no additional scanning is necessary)
+    if (forceFullScan) {
+      return; // no-op
+    }
+
+    List<String> missingKeys = keys.stream()
+        .filter(key -> !records.containsKey(key))
+        .collect(Collectors.toList());
+
+    if (missingKeys.isEmpty()) {
+      // All the required records are already fetched, no-op
+      return;
+    }
+
+    scanInternal(Option.of(KeySpec.fullKeySpec(missingKeys)), false);
+  }
+
+  /**
+   * Provides incremental scanning capability where only keys matching provided key-prefixes
+   * will be looked up in the delta-log files, scanned and subsequently materialized into
+   * the internal cache
+   *
+   * @param keyPrefixes to be looked up
+   */
+  public void scanByKeyPrefixes(List<String> keyPrefixes) {
+    // We can skip scanning in case reader is in full-scan mode, in which case all blocks
+    // are processed upfront (no additional scanning is necessary)
+    if (forceFullScan) {
+      return;
+    }
+
+    List<String> missingKeyPrefixes = keyPrefixes.stream()
+        .filter(keyPrefix ->
+            // NOTE: We can skip scanning the prefixes that have already
+            //       been covered by the previous scans
+            scannedPrefixes.stream().noneMatch(keyPrefix::startsWith))
+        .collect(Collectors.toList());
+
+    if (missingKeyPrefixes.isEmpty()) {
+      // All the required records are already fetched, no-op
+      return;
+    }
+
+    // NOTE: When looking up by key-prefixes unfortunately we can't short-circuit
+    //       and will have to scan every time as we can't know (based on just
+    //       the records cached) whether particular prefix was scanned or just records
+    //       matching the prefix looked up (by [[scanByFullKeys]] API)
+    scanInternal(Option.of(KeySpec.prefixKeySpec(missingKeyPrefixes)), false);
+    scannedPrefixes.addAll(missingKeyPrefixes);
+  }
+
+  private void performScan() {
+    // Do the scan and merge
+    timer.startTimer();
+
+    scanInternal(Option.empty(), false);
+
+    this.totalTimeTakenToReadAndMergeBlocks = timer.endTimer();
+    this.numMergedRecordsInLog = records.size();
+
+    LOG.info("Number of log files scanned => " + logFilePaths.size());
+    LOG.info("Number of entries in Map => " + records.size());
+  }
+
+  @Override
+  public Iterator<Pair<Option<T>, Map<String, Object>>> iterator() {
+    return records.values().iterator();
+  }
+
+  public Map<String, Pair<Option<T>, Map<String, Object>>> getRecords() {
+    return records;
+  }
+
+  public HoodieRecord.HoodieRecordType getRecordType() {
+    return recordMerger.getRecordType();
+  }
+
+  public long getNumMergedRecordsInLog() {
+    return numMergedRecordsInLog;
+  }
+
+  /**
+   * Returns the builder for {@code HoodieMergedLogRecordReader}.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  @Override
+  public void processNextRecord(T record, Map<String, Object> metadata) throws IOException {
+    String key = (String) metadata.get(HoodieReaderContext.INTERNAL_META_RECORD_KEY);
+    Pair<Option<T>, Map<String, Object>> existingRecordMetadataPair = records.get(key);
+
+    if (existingRecordMetadataPair != null) {
+      // Merge and store the combined record
+      // Note that the incoming `record` is from an older commit, so it should be put as
+      // the `older` in the merge API
+      HoodieRecord<T> combinedRecord = (HoodieRecord<T>) recordMerger.merge(
+          readerContext.constructHoodieRecord(Option.of(record), metadata, readerSchema), readerSchema,
+          readerContext.constructHoodieRecord(existingRecordMetadataPair.getLeft(), existingRecordMetadataPair.getRight(), readerSchema),
+          readerSchema, this.getPayloadProps()).get().getLeft();
+      // If pre-combine returns existing record, no need to update it
+      if (combinedRecord.getData() != existingRecordMetadataPair.getLeft().get()) {
+        records.put(key, Pair.of(Option.ofNullable(readerContext.seal(combinedRecord.getData())), metadata));
+      }
+    } else {
+      // Put the record as is
+      // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
+      //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
+      //       it since these records will be put into records(Map).
+      records.put(key, Pair.of(Option.of(readerContext.seal(record)), metadata));
+    }
+  }
+
+  @Override
+  protected void processNextDeletedRecord(DeleteRecord deleteRecord) {
+    String key = deleteRecord.getRecordKey();
+    Pair<Option<T>, Map<String, Object>> existingRecordMetadataPair = records.get(key);
+    if (existingRecordMetadataPair != null) {
+      // Merge and store the merged record. The ordering val is taken to decide whether the same key record
+      // should be deleted or be kept. The old record is kept only if the DELETE record has smaller ordering val.
+      // For same ordering values, uses the natural order(arrival time semantics).
+
+      Comparable existingOrderingVal = readerContext.getOrderingValue(
+          existingRecordMetadataPair.getLeft(), existingRecordMetadataPair.getRight(), readerSchema,
+          this.hoodieTableMetaClient.getTableConfig().getProps());
+      Comparable deleteOrderingVal = deleteRecord.getOrderingValue();
+      // Checks the ordering value does not equal to 0
+      // because we use 0 as the default value which means natural order
+      boolean chooseExisting = !deleteOrderingVal.equals(0)
+          && ReflectionUtils.isSameClass(existingOrderingVal, deleteOrderingVal)
+          && existingOrderingVal.compareTo(deleteOrderingVal) > 0;
+      if (chooseExisting) {
+        // The DELETE message is obsolete if the old message has greater orderingVal.
+        return;
+      }
+    }
+    // Put the DELETE record
+    records.put(key, Pair.of(Option.empty(),
+        readerContext.generateMetadataForRecord(key, deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue())));
+  }
+
+  public long getTotalTimeTakenToReadAndMergeBlocks() {
+    return totalTimeTakenToReadAndMergeBlocks;
+  }
+
+  @Override
+  public void close() {
+    if (records != null) {
+      records.clear();
+    }
+  }
+
+  /**
+   * Builder used to build {@code HoodieUnMergedLogRecordScanner}.
+   */
+  public static class Builder<T> extends BaseHoodieLogRecordReader.Builder<T> {
+    private HoodieReaderContext<T> readerContext;
+    private FileSystem fs;
+    private String basePath;
+    private List<String> logFilePaths;
+    private Schema readerSchema;
+    private InternalSchema internalSchema = InternalSchema.getEmptyInternalSchema();
+    private String latestInstantTime;
+    private boolean readBlocksLazily;
+    private boolean reverseReader;
+    private int bufferSize;
+    // specific configurations
+    private Long maxMemorySizeInBytes;
+    // incremental filtering
+    private Option<InstantRange> instantRange = Option.empty();
+    private String partitionName;
+    // operation field default false
+    private boolean withOperationField = false;
+    private String keyFieldOverride;
+    // By default, we're doing a full-scan
+    private boolean forceFullScan = true;
+    private boolean enableOptimizedLogBlocksScan = false;
+    private HoodieRecordMerger recordMerger = HoodiePreCombineAvroRecordMerger.INSTANCE;
+
+    @Override
+    public Builder<T> withHoodieReaderContext(HoodieReaderContext<T> readerContext) {
+      this.readerContext = readerContext;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withFileSystem(FileSystem fs) {
+      this.fs = fs;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withBasePath(String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withLogFilePaths(List<String> logFilePaths) {
+      this.logFilePaths = logFilePaths.stream()
+          .filter(p -> !p.endsWith(HoodieCDCUtils.CDC_LOGFILE_SUFFIX))
+          .collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    public Builder<T> withReaderSchema(Schema schema) {
+      this.readerSchema = schema;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withLatestInstantTime(String latestInstantTime) {
+      this.latestInstantTime = latestInstantTime;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withReadBlocksLazily(boolean readBlocksLazily) {
+      this.readBlocksLazily = readBlocksLazily;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withReverseReader(boolean reverseReader) {
+      this.reverseReader = reverseReader;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withBufferSize(int bufferSize) {
+      this.bufferSize = bufferSize;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withInstantRange(Option<InstantRange> instantRange) {
+      this.instantRange = instantRange;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withInternalSchema(InternalSchema internalSchema) {
+      this.internalSchema = internalSchema;
+      return this;
+    }
+
+    public Builder<T> withOperationField(boolean withOperationField) {
+      this.withOperationField = withOperationField;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withPartition(String partitionName) {
+      this.partitionName = partitionName;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withOptimizedLogBlocksScan(boolean enableOptimizedLogBlocksScan) {
+      this.enableOptimizedLogBlocksScan = enableOptimizedLogBlocksScan;
+      return this;
+    }
+
+    @Override
+    public Builder<T> withRecordMerger(HoodieRecordMerger recordMerger) {
+      this.recordMerger = HoodieRecordUtils.mergerToPreCombineMode(recordMerger);
+      return this;
+    }
+
+    public Builder<T> withKeyFiledOverride(String keyFieldOverride) {
+      this.keyFieldOverride = Objects.requireNonNull(keyFieldOverride);
+      return this;
+    }
+
+    public Builder<T> withForceFullScan(boolean forceFullScan) {
+      this.forceFullScan = forceFullScan;
+      return this;
+    }
+
+    @Override
+    public HoodieMergedLogRecordReader<T> build() {
+      if (this.partitionName == null && CollectionUtils.nonEmpty(this.logFilePaths)) {
+        this.partitionName = getRelativePartitionPath(new Path(basePath), new Path(this.logFilePaths.get(0)).getParent());
+      }
+      ValidationUtils.checkArgument(recordMerger != null);
+
+      return new HoodieMergedLogRecordReader<>(readerContext, fs, basePath, logFilePaths, readerSchema,
+          latestInstantTime, readBlocksLazily, reverseReader,
+          bufferSize, instantRange,
+          withOperationField, forceFullScan,
+          Option.ofNullable(partitionName), internalSchema, Option.ofNullable(keyFieldOverride), enableOptimizedLogBlocksScan, recordMerger);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.log.block;
 
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.SizeAwareDataInputStream;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -142,6 +143,13 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
     // TODO AvroSparkReader need
     RecordIterator iterator = RecordIterator.getInstance(this, content);
     return new CloseableMappingIterator<>(iterator, data -> (HoodieRecord<T>) new HoodieAvroIndexedRecord(data));
+  }
+
+  @Override
+  protected <T> ClosableIterator<T> deserializeRecords(HoodieReaderContext<T> readerContext, byte[] content) throws IOException {
+    checkState(this.readerSchema != null, "Reader's schema has to be non-null");
+    RecordIterator iterator = RecordIterator.getInstance(this, content);
+    return new CloseableMappingIterator<>(iterator, data -> (T) data);
   }
 
   private static class RecordIterator implements ClosableIterator<IndexedRecord> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieHFileDataBlock.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.table.log.block;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.fs.inline.InLineFSUtils;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -177,8 +178,21 @@ public class HoodieHFileDataBlock extends HoodieDataBlock {
     FileSystem fs = FSUtils.getFs(pathForReader.toString(), hadoopConf);
     // Read the content
     try (HoodieAvroHFileReader reader = new HoodieAvroHFileReader(hadoopConf, pathForReader, new CacheConfig(hadoopConf),
-                                                             fs, content, Option.of(getSchemaFromHeader()))) {
+        fs, content, Option.of(getSchemaFromHeader()))) {
       return unsafeCast(reader.getRecordIterator(readerSchema));
+    }
+  }
+
+  @Override
+  protected <T> ClosableIterator<T> deserializeRecords(HoodieReaderContext<T> readerContext, byte[] content) throws IOException {
+    checkState(readerSchema != null, "Reader's schema has to be non-null");
+
+    Configuration hadoopConf = FSUtils.buildInlineConf(getBlockContentLocation().get().getHadoopConf());
+    FileSystem fs = FSUtils.getFs(pathForReader.toString(), hadoopConf);
+    // Read the content
+    try (HoodieAvroHFileReader reader = new HoodieAvroHFileReader(hadoopConf, pathForReader, new CacheConfig(hadoopConf),
+        fs, content, Option.of(getSchemaFromHeader()))) {
+      return unsafeCast(reader.getIndexedRecordIterator(readerSchema, readerSchema));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieParquetDataBlock.java
@@ -19,13 +19,14 @@
 package org.apache.hudi.common.table.log.block;
 
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.fs.inline.InLineFSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
-import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieFileWriter;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
@@ -163,7 +164,32 @@ public class HoodieParquetDataBlock extends HoodieDataBlock {
   }
 
   @Override
+  protected <T> ClosableIterator<T> readRecordsFromBlockPayload(HoodieReaderContext<T> readerContext) throws IOException {
+    HoodieLogBlockContentLocation blockContentLoc = getBlockContentLocation().get();
+
+    // NOTE: It's important to extend Hadoop configuration here to make sure configuration
+    //       is appropriately carried over
+    Configuration inlineConf = FSUtils.buildInlineConf(blockContentLoc.getHadoopConf());
+
+    Path inlineLogFilePath = InLineFSUtils.getInlineFilePath(
+        blockContentLoc.getLogFile().getPath(),
+        blockContentLoc.getLogFile().getPath().toUri().getScheme(),
+        blockContentLoc.getContentPositionInLogFile(),
+        blockContentLoc.getBlockSize());
+
+    Schema writerSchema = new Schema.Parser().parse(this.getLogBlockHeader().get(HeaderMetadataType.SCHEMA));
+
+    return readerContext.getFileRecordIterator(
+        inlineLogFilePath, 0, blockContentLoc.getBlockSize(), writerSchema, readerSchema, inlineConf);
+  }
+
+  @Override
   protected <T> ClosableIterator<HoodieRecord<T>> deserializeRecords(byte[] content, HoodieRecordType type) throws IOException {
+    throw new UnsupportedOperationException("Should not be invoked");
+  }
+
+  @Override
+  protected <T> ClosableIterator<T> deserializeRecords(HoodieReaderContext<T> readerContext, byte[] content) throws IOException {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderState.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderState.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.apache.avro.Schema;
+
+/**
+ * A class holding the state that is needed by {@code HoodieFileGroupReader},
+ * e.g., schema, merging strategy, etc.
+ */
+public class FileGroupReaderState {
+  public String tablePath;
+  public String latestCommitTime;
+  public Schema baseFileAvroSchema;
+  public Schema logRecordAvroSchema;
+  public TypedProperties mergeProps = new TypedProperties();
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -73,13 +73,13 @@ public final class HoodieFileGroupReader<T> implements Closeable {
   private final long start;
   // Length of bytes to read from the base file
   private final long length;
+  // Key to record and metadata mapping from log files
+  private final Map<String, Pair<Option<T>, Map<String, Object>>> logFileRecordMapping = new HashMap<>();
+  private final FileGroupReaderState readerState = new FileGroupReaderState();
   private ClosableIterator<T> baseFileIterator;
   // This is only initialized and used after all records from the base file are iterated
   private Iterator<Pair<Option<T>, Map<String, Object>>> logRecordIterator;
   private HoodieRecordMerger recordMerger;
-  // Key to record and metadata mapping from log files
-  private final Map<String, Pair<Option<T>, Map<String, Object>>> logFileRecordMapping = new HashMap<>();
-  private final FileGroupReaderState readerState = new FileGroupReaderState();
 
   T nextRecord;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.config.HoodieMemoryConfig;
+import org.apache.hudi.common.config.HoodieReaderConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieTableQueryType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.HoodieMergedLogRecordReader;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.EmptyIterator;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.fs.FSUtils.getRelativePartitionPath;
+import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGER_STRATEGY;
+import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
+import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
+import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+
+/**
+ * A file group reader that iterates through the records in a single file group.
+ * <p>
+ * This should be used by the every engine integration, by plugging in a
+ * {@link HoodieReaderContext<T>} implementation.
+ *
+ * @param <T> The type of engine-specific record representation, e.g.,{@code InternalRow}
+ *            in Spark and {@code RowData} in Flink.
+ */
+public final class HoodieFileGroupReader<T> implements Closeable {
+  private final HoodieReaderContext<T> readerContext;
+  private final Option<HoodieBaseFile> baseFilePath;
+  private final Option<List<String>> logFilePathList;
+  private final Configuration hadoopConf;
+  private final TypedProperties props;
+  // Byte offset to start reading from the base file
+  private final long start;
+  // Length of bytes to read from the base file
+  private final long length;
+  private ClosableIterator<T> baseFileIterator;
+  // This is only initialized and used after all records from the base file are iterated
+  private Iterator<Pair<Option<T>, Map<String, Object>>> logRecordIterator;
+  private HoodieRecordMerger recordMerger;
+  // Key to record and metadata mapping from log files
+  private final Map<String, Pair<Option<T>, Map<String, Object>>> logFileRecordMapping = new HashMap<>();
+  private final FileGroupReaderState readerState = new FileGroupReaderState();
+
+  T nextRecord;
+
+  public HoodieFileGroupReader(HoodieReaderContext<T> readerContext,
+                               HoodieTableMetaClient metaClient,
+                               String fileGroupId,
+                               TypedProperties props,
+                               HoodieTimeline timeline,
+                               HoodieTableQueryType queryType,
+                               Option<String> instantTime,
+                               Option<String> startInstantTime) {
+    // This constructor is a placeholder now to allow automatically fetching the correct list of
+    // base and log files for a file group.
+    // Derive base and log files and call the corresponding constructor.
+    this.readerContext = readerContext;
+    this.hadoopConf = metaClient.getHadoopConf();
+    this.baseFilePath = Option.empty();
+    this.logFilePathList = Option.empty();
+    this.props = props;
+    this.start = 0;
+    this.length = Long.MAX_VALUE;
+    this.baseFileIterator = new EmptyIterator<>();
+  }
+
+  public HoodieFileGroupReader(HoodieReaderContext<T> readerContext,
+                               Configuration hadoopConf,
+                               String tablePath,
+                               String latestCommitTime,
+                               Option<HoodieBaseFile> baseFilePath,
+                               Option<List<String>> logFilePathList,
+                               Schema avroSchema,
+                               TypedProperties props,
+                               long start,
+                               long length) {
+    this.readerContext = readerContext;
+    this.hadoopConf = hadoopConf;
+    this.baseFilePath = baseFilePath;
+    this.logFilePathList = logFilePathList;
+    this.props = props;
+    this.start = start;
+    this.length = length;
+    this.recordMerger = readerContext.getRecordMerger(
+        getStringWithAltKeys(props, RECORD_MERGER_STRATEGY, RECORD_MERGER_STRATEGY.defaultValue()));
+    this.readerState.tablePath = tablePath;
+    this.readerState.latestCommitTime = latestCommitTime;
+    this.readerState.baseFileAvroSchema = avroSchema;
+    this.readerState.logRecordAvroSchema = avroSchema;
+    this.readerState.mergeProps.putAll(props);
+  }
+
+  /**
+   * Initialize internal iterators on the base and log files.
+   */
+  public void initRecordIterators() {
+    this.baseFileIterator = baseFilePath.isPresent()
+        ? readerContext.getFileRecordIterator(
+        baseFilePath.get().getHadoopPath(), 0, baseFilePath.get().getFileLen(),
+        readerState.baseFileAvroSchema, readerState.baseFileAvroSchema, hadoopConf)
+        : new EmptyIterator<>();
+    scanLogFiles();
+  }
+
+  /**
+   * @return {@code true} if the next record exists; {@code false} otherwise.
+   * @throws IOException on reader error.
+   */
+  public boolean hasNext() throws IOException {
+    while (baseFileIterator.hasNext()) {
+      T baseRecord = baseFileIterator.next();
+      String recordKey = readerContext.getRecordKey(baseRecord, readerState.baseFileAvroSchema);
+      Pair<Option<T>, Map<String, Object>> logRecordInfo = logFileRecordMapping.remove(recordKey);
+      Option<T> resultRecord = logRecordInfo != null
+          ? merge(Option.of(baseRecord), Collections.emptyMap(), logRecordInfo.getLeft(), logRecordInfo.getRight())
+          : merge(Option.empty(), Collections.emptyMap(), Option.of(baseRecord), Collections.emptyMap());
+      if (resultRecord.isPresent()) {
+        nextRecord = readerContext.seal(resultRecord.get());
+        return true;
+      }
+    }
+
+    if (logRecordIterator == null) {
+      logRecordIterator = logFileRecordMapping.values().iterator();
+    }
+
+    while (logRecordIterator.hasNext()) {
+      Pair<Option<T>, Map<String, Object>> nextRecordInfo = logRecordIterator.next();
+      Option<T> resultRecord = merge(Option.empty(), Collections.emptyMap(),
+          nextRecordInfo.getLeft(), nextRecordInfo.getRight());
+      if (resultRecord.isPresent()) {
+        nextRecord = readerContext.seal(resultRecord.get());
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @return The next record after calling {@link #hasNext}.
+   */
+  public T next() {
+    T result = nextRecord;
+    nextRecord = null;
+    return result;
+  }
+
+  private void scanLogFiles() {
+    if (logFilePathList.isPresent()) {
+      FileSystem fs = readerContext.getFs(logFilePathList.get().get(0), hadoopConf);
+      HoodieMergedLogRecordReader<T> logRecordReader = HoodieMergedLogRecordReader.newBuilder()
+          .withHoodieReaderContext(readerContext)
+          .withFileSystem(fs)
+          .withBasePath(readerState.tablePath)
+          .withLogFilePaths(logFilePathList.get())
+          .withLatestInstantTime(readerState.latestCommitTime)
+          .withReaderSchema(readerState.logRecordAvroSchema)
+          .withReadBlocksLazily(getBooleanWithAltKeys(props, HoodieReaderConfig.COMPACTION_LAZY_BLOCK_READ_ENABLE))
+          .withReverseReader(false)
+          .withBufferSize(getIntWithAltKeys(props, HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE))
+          .withPartition(getRelativePartitionPath(
+              new Path(readerState.tablePath), new Path(logFilePathList.get().get(0)).getParent()
+          ))
+          .withRecordMerger(recordMerger)
+          .build();
+      logFileRecordMapping.putAll(logRecordReader.getRecords());
+      logRecordReader.close();
+    }
+  }
+
+  private Option<T> merge(Option<T> older, Map<String, Object> olderInfoMap,
+                          Option<T> newer, Map<String, Object> newerInfoMap) throws IOException {
+    if (!older.isPresent()) {
+      return newer;
+    }
+
+    Option<Pair<HoodieRecord, Schema>> mergedRecord = recordMerger.merge(
+        readerContext.constructHoodieRecord(older, olderInfoMap, readerState.baseFileAvroSchema), readerState.baseFileAvroSchema,
+        readerContext.constructHoodieRecord(newer, newerInfoMap, readerState.logRecordAvroSchema), readerState.logRecordAvroSchema, props);
+    if (mergedRecord.isPresent()) {
+      return Option.ofNullable((T) mergedRecord.get().getLeft().getData());
+    }
+    return Option.empty();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (baseFileIterator != null) {
+      baseFileIterator.close();
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/EmptyIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/EmptyIterator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+/**
+ * A {@link ClosableIterator} that does not contain any record.
+ *
+ * @param <R> The type of entry as a placeholder.
+ */
+public class EmptyIterator<R> implements ClosableIterator<R> {
+  @Override
+  public void close() {
+    // No-op
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+
+  @Override
+  public R next() {
+    return null;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.table.view.SyncableFileSystemView;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.model.WriteOperationType.INSERT;
+import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getLogFileListFromFileSlice;
+import static org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests {@link HoodieFileGroupReader} with different engines
+ */
+public abstract class TestHoodieFileGroupReaderBase<T> {
+  @TempDir
+  protected java.nio.file.Path tempDir;
+
+  public abstract Configuration getHadoopConf();
+
+  public abstract String getBasePath();
+
+  public abstract HoodieReaderContext<T> getHoodieReaderContext();
+
+  public abstract void commitToTable(List<String> recordList, String operation,
+                                     Map<String, String> writeConfigs);
+
+  public abstract void validateRecordsInFileGroup(List<T> actualRecordList,
+                                                  Schema schema,
+                                                  String fileGroupId);
+
+  @Test
+  public void testReadFileGroupInMergeOnReadTable() throws Exception {
+    Map<String, String> writeConfigs = new HashMap<>();
+    writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
+    writeConfigs.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    writeConfigs.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
+    writeConfigs.put("hoodie.datasource.write.precombine.field", "timestamp");
+    writeConfigs.put(HoodieTableConfig.HOODIE_TABLE_NAME_KEY, "hoodie_test");
+    writeConfigs.put("hoodie.insert.shuffle.parallelism", "4");
+    writeConfigs.put("hoodie.upsert.shuffle.parallelism", "4");
+    writeConfigs.put("hoodie.bulkinsert.shuffle.parallelism", "2");
+    writeConfigs.put("hoodie.delete.shuffle.parallelism", "1");
+    writeConfigs.put("hoodie.merge.small.file.group.candidates.limit", "0");
+    writeConfigs.put(HoodieMetadataConfig.ENABLE.key(), "false");
+
+    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF)) {
+      // One commit; reading one file group containing a base file only
+      commitToTable(recordsToStrings(dataGen.generateInserts("001", 100)), INSERT.value(), writeConfigs);
+      validateOutputFromFileGroupReader(getHadoopConf(), getBasePath(), dataGen.getPartitionPaths(), 0);
+
+      // Two commits; reading one file group containing a base file and a log file
+      commitToTable(recordsToStrings(dataGen.generateUpdates("002", 100)), UPSERT.value(), writeConfigs);
+      validateOutputFromFileGroupReader(getHadoopConf(), getBasePath(), dataGen.getPartitionPaths(), 1);
+
+      // Three commits; reading one file group containing a base file and two log files
+      commitToTable(recordsToStrings(dataGen.generateUpdates("003", 100)), UPSERT.value(), writeConfigs);
+      validateOutputFromFileGroupReader(getHadoopConf(), getBasePath(), dataGen.getPartitionPaths(), 2);
+    }
+  }
+
+  private void validateOutputFromFileGroupReader(Configuration hadoopConf,
+                                                 String basePath,
+                                                 String[] partitionPaths,
+                                                 int expectedLogFileNum) throws Exception {
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+        .setConf(hadoopConf).setBasePath(basePath).build();
+    Schema avroSchema = new TableSchemaResolver(metaClient).getTableAvroSchema();
+    FileSystemViewManager viewManager = FileSystemViewManager.createViewManager(
+        new HoodieLocalEngineContext(hadoopConf), HoodieMetadataConfig.newBuilder().build(),
+        FileSystemViewStorageConfig.newBuilder().build(),
+        HoodieCommonConfig.newBuilder().build());
+    SyncableFileSystemView fsView = viewManager.getFileSystemView(metaClient);
+    FileSlice fileSlice = fsView.getAllFileSlices(partitionPaths[0]).findFirst().get();
+    List<String> logFilePathList = getLogFileListFromFileSlice(fileSlice);
+    Collections.sort(logFilePathList);
+    assertEquals(expectedLogFileNum, logFilePathList.size());
+
+    List<T> actualRecordList = new ArrayList<>();
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.datasource.write.precombine.field", "timestamp");
+    props.setProperty(HoodieTableConfig.RECORD_MERGER_STRATEGY.key(),
+        HoodieTableConfig.RECORD_MERGER_STRATEGY.defaultValue());
+    HoodieFileGroupReader<T> fileGroupReader = new HoodieFileGroupReader<T>(
+        getHoodieReaderContext(),
+        hadoopConf,
+        basePath,
+        metaClient.getActiveTimeline().lastInstant().get().getTimestamp(),
+        fileSlice.getBaseFile(),
+        logFilePathList.isEmpty() ? Option.empty() : Option.of(logFilePathList),
+        avroSchema,
+        props,
+        -1,
+        -1);
+    fileGroupReader.initRecordIterators();
+    while (fileGroupReader.hasNext()) {
+      actualRecordList.add(fileGroupReader.next());
+    }
+    fileGroupReader.close();
+
+    validateRecordsInFileGroup(actualRecordList, avroSchema, fileSlice.getFileId());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.testutils;
 
 import org.apache.hudi.common.fs.HoodieWrapperFileSystem;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * A utility class for testing.
@@ -246,5 +248,10 @@ public class HoodieTestUtils {
     conf.set("fs.defaultFS", "hdfs://localhost:9000");
     conf.set("dfs.replication", "3");
     return (DistributedFileSystem) DistributedFileSystem.get(conf);
+  }
+
+  public static List<String> getLogFileListFromFileSlice(FileSlice fileSlice) {
+    return fileSlice.getLogFiles().map(logFile -> logFile.getPath().toString())
+        .collect(Collectors.toList());
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read
+
+import org.apache.avro.Schema
+import org.apache.hadoop.conf.Configuration
+import org.apache.hudi.common.engine.HoodieReaderContext
+import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
+import org.apache.hudi.{SparkAdapterSupport, SparkFileFormatInternalRowReaderContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.{Dataset, HoodieInternalRowUtils, HoodieUnsafeUtils, Row, SaveMode, SparkSession}
+import org.apache.spark.{HoodieSparkKryoRegistrar, SparkConf}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+
+import java.util
+import scala.collection.JavaConversions._
+
+/**
+ * Tests {@link HoodieFileGroupReader} with {@link SparkFileFormatInternalRowReaderContext}
+ * on Spark
+ */
+class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[InternalRow] {
+  var spark: SparkSession = _
+
+  @BeforeEach
+  def setup() {
+    val sparkConf = new SparkConf
+    sparkConf.set("spark.app.name", getClass.getName)
+    sparkConf.set("spark.master", "local[*]")
+    sparkConf.set("spark.default.parallelism", "4")
+    sparkConf.set("spark.sql.shuffle.partitions", "4")
+    sparkConf.set("spark.driver.maxResultSize", "2g")
+    sparkConf.set("spark.hadoop.mapred.output.compress", "true")
+    sparkConf.set("spark.hadoop.mapred.output.compression.codec", "true")
+    sparkConf.set("spark.hadoop.mapred.output.compression.codec", "org.apache.hadoop.io.compress.GzipCodec")
+    sparkConf.set("spark.hadoop.mapred.output.compression.type", "BLOCK")
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    sparkConf.set("spark.kryo.registrator", "org.apache.spark.HoodieSparkKryoRegistrar")
+    HoodieSparkKryoRegistrar.register(sparkConf)
+    spark = SparkSession.builder.config(sparkConf).getOrCreate
+  }
+
+  override def getHadoopConf: Configuration = {
+    new Configuration()
+  }
+
+  override def getBasePath: String = {
+    tempDir.toAbsolutePath.toUri.toString
+  }
+
+  override def getHoodieReaderContext: HoodieReaderContext[InternalRow] = {
+    new SparkFileFormatInternalRowReaderContext(spark,
+      SparkAdapterSupport.sparkAdapter.createLegacyHoodieParquetFileFormat(false).get,
+      getHadoopConf)
+  }
+
+  override def commitToTable(recordList: util.List[String], operation: String, options: util.Map[String, String]): Unit = {
+    val inputDF: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(recordList.toList, 2))
+    inputDF.write.format("hudi")
+      .options(options)
+      .option("hoodie.compact.inline", "false") // else fails due to compaction & deltacommit instant times being same
+      .option("hoodie.datasource.write.operation", operation)
+      .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
+      .mode(if (operation.equalsIgnoreCase(WriteOperationType.INSERT.value())) SaveMode.Overwrite
+      else SaveMode.Append)
+      .save(getBasePath)
+  }
+
+  override def validateRecordsInFileGroup(actualRecordList: util.List[InternalRow],
+                                          schema: Schema,
+                                          fileGroupId: String): Unit = {
+    val expectedDf = spark.read.format("hudi")
+      .load(getBasePath)
+      .where(col(HoodieRecord.FILENAME_METADATA_FIELD).contains(fileGroupId))
+    assertEquals(expectedDf.count, actualRecordList.size)
+    val actualDf = HoodieUnsafeUtils.createDataFrameFromInternalRows(
+      spark, actualRecordList, HoodieInternalRowUtils.getCachedSchema(schema))
+    assertEquals(expectedDf.count, expectedDf.intersect(actualDf).count)
+  }
+}


### PR DESCRIPTION
### Change Logs

This PR introduces a new File Group Reader, `HoodieFileGroupReader<T>`, to unify Hudi-specific reader logic across all query types in a single class, while allowing plug-in `HoodieReaderContext<T>` for engine-specific implementation on reading data files, getting field values from a record, transforming a record, etc.  The type argument `T` denotes the type of engine-specific record representation, e.g., `InternalRow` in Spark, `RowData` in Flink, and `ArrayWritable` in Hive, etc.

The reader operates on the engine-specific record representation for reading and merging.  This includes reading the base file and log blocks into `ClosableIterator<T>`.  When merging, the engine-specific records are converted to `HoodieRecord<T>` and passed to `HoodieRecordMerger#merge` API.

This PR covers the basic file group reading logic with merging base and log files of parquet format.  Features including schema evolution across base and log files, different base and log file format, de-hadooping, etc., will be addressed as follow-ups.

This PR serves as a first step towards a public Hudi file group reader across engines.  There will be follow-ups to make sure the engine integration with Spark, Hive, and Flink can work on the new File Group Reader.  The goal is to remove Hudi-speicific query and merging logic as much as possible from the engine integration and have them in the common file group reader in the format layer.
- Spark: replaces the read and merging logic in `NewHoodieParquetFileFormat` and `Iterators`
- Flink: replaces the read and merging logic in `MergeOnReadInputFormat` and `RecordIterators`
- Hive: replaces the read and merging logic in different implementation of `AbstractRealtimeRecordReader` (e.g., `RealtimeCompactedRecordReader`, `RealtimeUnmergedRecordReader`,  `HoodieMergeOnReadSnapshotReader`) 

A detailed RFC will be put up once all details are figured out.

### Impact

The new File Group Reader, `HoodieFileGroupReader`, aims to unify Hudi-specific reader logic across all query types in a single class, while allowing plug-in `HoodieReaderContext<T>` for engine-specific implementation on reading data files, getting field values from a record, transforming a record, etc.

There is no impact on existing readers as the new File Group Reader is not integrated in this PR.

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
