### PR TITLE
[HUDI-6822] Fix deletes handling in hbase index when partition path is updated

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -323,6 +323,7 @@ public class HoodieIndexUtils {
           } else {
             // merged record has a different partition: issue a delete to the old partition and insert the merged record to the new partition
             HoodieRecord<R> deleteRecord = createDeleteRecord(config, existing.getKey());
+            deleteRecord.setIgnoreFlag(true);
             return Arrays.asList(tagRecord(deleteRecord, existing.getCurrentLocation()), merged).iterator();
           }
         });

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -323,7 +323,7 @@ public class HoodieIndexUtils {
           } else {
             // merged record has a different partition: issue a delete to the old partition and insert the merged record to the new partition
             HoodieRecord<R> deleteRecord = createDeleteRecord(config, existing.getKey());
-            deleteRecord.setIgnoreFlag(true);
+            deleteRecord.setIgnoreIndexUpdate(true);
             return Arrays.asList(tagRecord(deleteRecord, existing.getCurrentLocation()), merged).iterator();
           }
         });

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1487,7 +1487,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       List<HoodieRecord> recordList = new LinkedList<>();
       for (HoodieRecordDelegate recordDelegate : writeStatus.getWrittenRecordDelegates()) {
         if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
-          if (recordDelegate.getIgnoreFlag()) {
+          if (recordDelegate.getIgnoreIndexUpdate()) {
             continue;
           }
           HoodieRecord hoodieRecord;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -29,10 +29,9 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.data.HoodieData;
-import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.function.SerializableFunction;
+import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -89,17 +88,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.apache.hudi.avro.HoodieAvroUtils.addMetadataFields;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
@@ -1488,39 +1484,14 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
    * @param writeStatuses {@code WriteStatus} from the write operation
    */
   private HoodieData<HoodieRecord> getRecordIndexUpdates(HoodieData<WriteStatus> writeStatuses) {
-    HoodiePairData<String, HoodieRecordDelegate> recordKeyDelegatePairs = null;
-    // if update partition path is true, chances that we might get two records (1 delete in older partition and 1 insert to new partition)
-    // and hence we might have to do reduce By key before ingesting to RLI partition.
-    if (dataWriteConfig.getRecordIndexUpdatePartitionPath()) {
-      recordKeyDelegatePairs = writeStatuses.map(writeStatus -> writeStatus.getWrittenRecordDelegates().stream()
-              .map(recordDelegate -> Pair.of(recordDelegate.getRecordKey(), recordDelegate)))
-          .flatMapToPair(Stream::iterator)
-          .reduceByKey((recordDelegate1, recordDelegate2) -> {
-            if (recordDelegate1.getRecordKey().equals(recordDelegate2.getRecordKey())) {
-              if (!recordDelegate1.getNewLocation().isPresent() && !recordDelegate2.getNewLocation().isPresent()) {
-                throw new HoodieIOException("Both version of records do not have location set. Record V1 " + recordDelegate1.toString()
-                    + ", Record V2 " + recordDelegate2.toString());
-              }
-              if (recordDelegate1.getNewLocation().isPresent()) {
-                return recordDelegate1;
-              } else {
-                // if record delegate 1 does not have location set, record delegate 2 should have location set.
-                return recordDelegate2;
-              }
-            } else {
-              return recordDelegate1;
-            }
-          }, Math.max(1, writeStatuses.getNumPartitions()));
-    } else {
-      // if update partition path = false, we should get only one entry per record key.
-      recordKeyDelegatePairs = writeStatuses.flatMapToPair(
-          (SerializableFunction<WriteStatus, Iterator<? extends Pair<String, HoodieRecordDelegate>>>) writeStatus
-              -> writeStatus.getWrittenRecordDelegates().stream().map(rec -> Pair.of(rec.getRecordKey(), rec)).iterator());
-    }
-    return recordKeyDelegatePairs
-        .map(writeStatusRecordDelegate -> {
-          HoodieRecordDelegate recordDelegate = writeStatusRecordDelegate.getValue();
-          HoodieRecord hoodieRecord = null;
+    return writeStatuses.flatMap(writeStatus -> {
+      List<HoodieRecord> recordList = new LinkedList<>();
+      for (HoodieRecordDelegate recordDelegate : writeStatus.getWrittenRecordDelegates()) {
+        if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
+          if (recordDelegate.getIgnoreFlag()) {
+            continue;
+          }
+          HoodieRecord hoodieRecord;
           Option<HoodieRecordLocation> newLocation = recordDelegate.getNewLocation();
           if (newLocation.isPresent()) {
             if (recordDelegate.getCurrentLocation().isPresent()) {
@@ -1540,13 +1511,18 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
                   recordDelegate.getRecordKey(), recordDelegate.getPartitionPath(),
                   newLocation.get().getFileId(), newLocation.get().getInstantTime(), dataWriteConfig.getWritesFileIdEncoding());
             }
+            hoodieRecord = HoodieMetadataPayload.createRecordIndexUpdate(
+                recordDelegate.getRecordKey(), recordDelegate.getPartitionPath(),
+                newLocation.get().getFileId(), newLocation.get().getInstantTime(), dataWriteConfig.getWritesFileIdEncoding());
           } else {
             // Delete existing index for a deleted record
             hoodieRecord = HoodieMetadataPayload.createRecordIndexDelete(recordDelegate.getRecordKey());
           }
-          return hoodieRecord;
-        })
-        .filter(Objects::nonNull);
+          recordList.add(hoodieRecord);
+        }
+      }
+      return recordList.iterator();
+    });
   }
 
   private HoodieData<HoodieRecord> getRecordIndexReplacedRecords(HoodieReplaceCommitMetadata replaceCommitMetadata) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
@@ -288,6 +288,7 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
                   new EmptyHoodieRecordPayload());
               emptyRecord.unseal();
               emptyRecord.setCurrentLocation(new HoodieRecordLocation(commitTs, fileId));
+              emptyRecord.setIgnoreFlag(true);
               emptyRecord.seal();
               // insert partition new data record
               currentRecord = new HoodieAvroRecord(new HoodieKey(currentRecord.getRecordKey(), currentRecord.getPartitionPath()),
@@ -359,6 +360,9 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
             // Any calls beyond `multiPutBatchSize` within a second will be rate limited
             for (HoodieRecordDelegate recordDelegate : writeStatus.getWrittenRecordDelegates()) {
               if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
+                if (recordDelegate.getIgnoreFlag()) {
+                  continue;
+                }
                 Option<HoodieRecordLocation> loc = recordDelegate.getNewLocation();
                 if (loc.isPresent()) {
                   if (recordDelegate.getCurrentLocation().isPresent()) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java
@@ -288,7 +288,7 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
                   new EmptyHoodieRecordPayload());
               emptyRecord.unseal();
               emptyRecord.setCurrentLocation(new HoodieRecordLocation(commitTs, fileId));
-              emptyRecord.setIgnoreFlag(true);
+              emptyRecord.setIgnoreIndexUpdate(true);
               emptyRecord.seal();
               // insert partition new data record
               currentRecord = new HoodieAvroRecord(new HoodieKey(currentRecord.getRecordKey(), currentRecord.getPartitionPath()),
@@ -360,7 +360,7 @@ public class SparkHoodieHBaseIndex extends HoodieIndex<Object, Object> {
             // Any calls beyond `multiPutBatchSize` within a second will be rate limited
             for (HoodieRecordDelegate recordDelegate : writeStatus.getWrittenRecordDelegates()) {
               if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
-                if (recordDelegate.getIgnoreFlag()) {
+                if (recordDelegate.getIgnoreIndexUpdate()) {
                   continue;
                 }
                 Option<HoodieRecordLocation> loc = recordDelegate.getNewLocation();

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -284,7 +284,8 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     }
     HoodieRecord that = (HoodieRecord) o;
     return Objects.equals(key, that.key) && Objects.equals(data, that.data)
-        && Objects.equals(currentLocation, that.currentLocation) && Objects.equals(newLocation, that.newLocation);
+        && Objects.equals(currentLocation, that.currentLocation) && Objects.equals(newLocation, that.newLocation)
+        && Objects.equals(ignored, that.ignored);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -137,7 +137,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   /**
    * If set, not update index after written.
    */
-  protected boolean ignored;
+  protected boolean ignoreIndexUpdate;
 
   /**
    * Indicates whether the object is sealed.
@@ -164,7 +164,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     this.currentLocation = null;
     this.newLocation = null;
     this.sealed = false;
-    this.ignored = false;
+    this.ignoreIndexUpdate = false;
     this.operation = operation;
     this.metaData = metaData;
   }
@@ -187,7 +187,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     this.currentLocation = record.currentLocation;
     this.newLocation = record.newLocation;
     this.sealed = record.sealed;
-    this.ignored = record.ignored;
+    this.ignoreIndexUpdate = record.ignoreIndexUpdate;
   }
 
   public HoodieRecord() {}
@@ -266,12 +266,12 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   /**
    * Sets the ignore flag.
    */
-  public void setIgnoreFlag(boolean ignoreFlag) {
-    this.ignored = ignoreFlag;
+  public void setIgnoreIndexUpdate(boolean ignoreFlag) {
+    this.ignoreIndexUpdate = ignoreFlag;
   }
 
-  public boolean getIgnoreFlag() {
-    return this.ignored;
+  public boolean getIgnoreIndexUpdate() {
+    return this.ignoreIndexUpdate;
   }
 
   @Override
@@ -285,7 +285,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     HoodieRecord that = (HoodieRecord) o;
     return Objects.equals(key, that.key) && Objects.equals(data, that.data)
         && Objects.equals(currentLocation, that.currentLocation) && Objects.equals(newLocation, that.newLocation)
-        && Objects.equals(ignored, that.ignored);
+        && Objects.equals(ignoreIndexUpdate, that.ignoreIndexUpdate);
   }
 
   @Override
@@ -362,7 +362,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     // NOTE: Writing out actual record payload is relegated to the actual
     //       implementation
     writeRecordPayload(data, kryo, output);
-    kryo.writeObjectOrNull(output, ignored, Boolean.class);
+    kryo.writeObjectOrNull(output, ignoreIndexUpdate, Boolean.class);
   }
 
   /**
@@ -378,7 +378,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     // NOTE: Reading out actual record payload is relegated to the actual
     //       implementation
     this.data = readRecordPayload(kryo, input);
-    this.ignored = kryo.readObjectOrNull(input, Boolean.class);
+    this.ignoreIndexUpdate = kryo.readObjectOrNull(input, Boolean.class);
 
     // NOTE: We're always seal object after deserialization
     this.sealed = true;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -135,6 +135,11 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
   protected HoodieRecordLocation newLocation;
 
   /**
+   * If set, not update index after written.
+   */
+  protected boolean ignored;
+
+  /**
    * Indicates whether the object is sealed.
    */
   private boolean sealed;
@@ -159,6 +164,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     this.currentLocation = null;
     this.newLocation = null;
     this.sealed = false;
+    this.ignored = false;
     this.operation = operation;
     this.metaData = metaData;
   }
@@ -181,6 +187,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     this.currentLocation = record.currentLocation;
     this.newLocation = record.newLocation;
     this.sealed = record.sealed;
+    this.ignored = record.ignored;
   }
 
   public HoodieRecord() {}
@@ -254,6 +261,17 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
       return this.currentLocation.getPosition();
     }
     return HoodieRecordLocation.INVALID_POSITION;
+  }
+
+  /**
+   * Sets the ignore flag.
+   */
+  public void setIgnoreFlag(boolean ignoreFlag) {
+    this.ignored = ignoreFlag;
+  }
+
+  public boolean getIgnoreFlag() {
+    return this.ignored;
   }
 
   @Override
@@ -343,6 +361,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     // NOTE: Writing out actual record payload is relegated to the actual
     //       implementation
     writeRecordPayload(data, kryo, output);
+    kryo.writeObjectOrNull(output, ignored, Boolean.class);
   }
 
   /**
@@ -358,6 +377,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     // NOTE: Reading out actual record payload is relegated to the actual
     //       implementation
     this.data = readRecordPayload(kryo, input);
+    this.ignored = kryo.readObjectOrNull(input, Boolean.class);
 
     // NOTE: We're always seal object after deserialization
     this.sealed = true;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordDelegate.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordDelegate.java
@@ -52,52 +52,59 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
    */
   private Option<HoodieRecordLocation> newLocation;
 
+  /**
+   * If set, not update index after written.
+   */
+  private boolean ignored;
+
   private HoodieRecordDelegate(HoodieKey hoodieKey,
                                @Nullable HoodieRecordLocation currentLocation,
-                               @Nullable HoodieRecordLocation newLocation) {
+                               @Nullable HoodieRecordLocation newLocation,
+                               boolean ignored) {
     this.hoodieKey = hoodieKey;
     this.currentLocation = Option.ofNullable(currentLocation);
     this.newLocation = Option.ofNullable(newLocation);
+    this.ignored = ignored;
   }
 
   public static HoodieRecordDelegate create(String recordKey, String partitionPath) {
-    return new HoodieRecordDelegate(new HoodieKey(recordKey, partitionPath), null, null);
+    return new HoodieRecordDelegate(new HoodieKey(recordKey, partitionPath), null, null, false);
   }
 
   public static HoodieRecordDelegate create(String recordKey,
                                             String partitionPath,
                                             HoodieRecordLocation currentLocation) {
-    return new HoodieRecordDelegate(new HoodieKey(recordKey, partitionPath), currentLocation, null);
+    return new HoodieRecordDelegate(new HoodieKey(recordKey, partitionPath), currentLocation, null, false);
   }
 
   public static HoodieRecordDelegate create(String recordKey,
                                             String partitionPath,
                                             HoodieRecordLocation currentLocation,
                                             HoodieRecordLocation newLocation) {
-    return new HoodieRecordDelegate(new HoodieKey(recordKey, partitionPath), currentLocation, newLocation);
+    return new HoodieRecordDelegate(new HoodieKey(recordKey, partitionPath), currentLocation, newLocation, false);
   }
 
   public static HoodieRecordDelegate create(HoodieKey key) {
-    return new HoodieRecordDelegate(key, null, null);
+    return new HoodieRecordDelegate(key, null, null, false);
   }
 
   public static HoodieRecordDelegate create(HoodieKey key, HoodieRecordLocation currentLocation) {
-    return new HoodieRecordDelegate(key, currentLocation, null);
+    return new HoodieRecordDelegate(key, currentLocation, null, false);
   }
 
   public static HoodieRecordDelegate create(HoodieKey key,
                                             HoodieRecordLocation currentLocation,
                                             HoodieRecordLocation newLocation) {
-    return new HoodieRecordDelegate(key, currentLocation, newLocation);
+    return new HoodieRecordDelegate(key, currentLocation, newLocation, false);
   }
 
   public static HoodieRecordDelegate fromHoodieRecord(HoodieRecord record) {
-    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), record.getNewLocation());
+    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), record.getNewLocation(), record.getIgnoreFlag());
   }
 
   public static HoodieRecordDelegate fromHoodieRecord(HoodieRecord record,
                                                       @Nullable HoodieRecordLocation newLocationOverride) {
-    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), newLocationOverride);
+    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), newLocationOverride, record.getIgnoreFlag());
   }
 
   public String getRecordKey() {
@@ -120,12 +127,17 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
     return newLocation;
   }
 
+  public boolean getIgnoreFlag() {
+    return ignored;
+  }
+
   @Override
   public String toString() {
     return "HoodieRecordDelegate{"
         + "hoodieKey=" + hoodieKey
         + ", currentLocation=" + currentLocation
         + ", newLocation=" + newLocation
+        + ", ignored=" + ignored
         + '}';
   }
 
@@ -135,6 +147,7 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
     kryo.writeObjectOrNull(output, hoodieKey, HoodieKey.class);
     kryo.writeClassAndObject(output, currentLocation.isPresent() ? currentLocation.get() : null);
     kryo.writeClassAndObject(output, newLocation.isPresent() ? newLocation.get() : null);
+    kryo.writeObjectOrNull(output, ignored, Boolean.class);
   }
 
   @VisibleForTesting
@@ -143,5 +156,6 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
     this.hoodieKey = kryo.readObjectOrNull(input, HoodieKey.class);
     this.currentLocation = Option.ofNullable((HoodieRecordLocation) kryo.readClassAndObject(input));
     this.newLocation = Option.ofNullable((HoodieRecordLocation) kryo.readClassAndObject(input));
+    this.ignored = kryo.readObjectOrNull(input, Boolean.class);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordDelegate.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordDelegate.java
@@ -55,16 +55,16 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
   /**
    * If set, not update index after written.
    */
-  private boolean ignored;
+  private boolean ignoreIndexUpdate;
 
   private HoodieRecordDelegate(HoodieKey hoodieKey,
                                @Nullable HoodieRecordLocation currentLocation,
                                @Nullable HoodieRecordLocation newLocation,
-                               boolean ignored) {
+                               boolean ignoreIndexUpdate) {
     this.hoodieKey = hoodieKey;
     this.currentLocation = Option.ofNullable(currentLocation);
     this.newLocation = Option.ofNullable(newLocation);
-    this.ignored = ignored;
+    this.ignoreIndexUpdate = ignoreIndexUpdate;
   }
 
   public static HoodieRecordDelegate create(String recordKey, String partitionPath) {
@@ -99,12 +99,12 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
   }
 
   public static HoodieRecordDelegate fromHoodieRecord(HoodieRecord record) {
-    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), record.getNewLocation(), record.getIgnoreFlag());
+    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), record.getNewLocation(), record.getIgnoreIndexUpdate());
   }
 
   public static HoodieRecordDelegate fromHoodieRecord(HoodieRecord record,
                                                       @Nullable HoodieRecordLocation newLocationOverride) {
-    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), newLocationOverride, record.getIgnoreFlag());
+    return new HoodieRecordDelegate(record.getKey(), record.getCurrentLocation(), newLocationOverride, record.getIgnoreIndexUpdate());
   }
 
   public String getRecordKey() {
@@ -127,8 +127,8 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
     return newLocation;
   }
 
-  public boolean getIgnoreFlag() {
-    return ignored;
+  public boolean getIgnoreIndexUpdate() {
+    return ignoreIndexUpdate;
   }
 
   @Override
@@ -137,7 +137,7 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
         + "hoodieKey=" + hoodieKey
         + ", currentLocation=" + currentLocation
         + ", newLocation=" + newLocation
-        + ", ignored=" + ignored
+        + ", ignoreIndexUpdate=" + ignoreIndexUpdate
         + '}';
   }
 
@@ -147,7 +147,7 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
     kryo.writeObjectOrNull(output, hoodieKey, HoodieKey.class);
     kryo.writeClassAndObject(output, currentLocation.isPresent() ? currentLocation.get() : null);
     kryo.writeClassAndObject(output, newLocation.isPresent() ? newLocation.get() : null);
-    kryo.writeObjectOrNull(output, ignored, Boolean.class);
+    kryo.writeObjectOrNull(output, ignoreIndexUpdate, Boolean.class);
   }
 
   @VisibleForTesting
@@ -156,6 +156,6 @@ public class HoodieRecordDelegate implements Serializable, KryoSerializable {
     this.hoodieKey = kryo.readObjectOrNull(input, HoodieKey.class);
     this.currentLocation = Option.ofNullable((HoodieRecordLocation) kryo.readClassAndObject(input));
     this.newLocation = Option.ofNullable((HoodieRecordLocation) kryo.readClassAndObject(input));
-    this.ignored = kryo.readObjectOrNull(input, Boolean.class);
+    this.ignoreIndexUpdate = kryo.readObjectOrNull(input, Boolean.class);
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
@@ -105,9 +105,9 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     val key = new HoodieKey("rec-key", "part-path")
 
     val legacyRecord = toLegacyAvroRecord(avroRecord, key)
-    legacyRecord.setIgnoreFlag(true)
+    legacyRecord.setIgnoreIndexUpdate(true)
     val avroIndexedRecord = new HoodieAvroIndexedRecord(key, avroRecord)
-    avroIndexedRecord.setIgnoreFlag(true)
+    avroIndexedRecord.setIgnoreIndexUpdate(true)
 
     val expectedLagacyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 536 else 530
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/model/TestHoodieRecordSerialization.scala
@@ -79,8 +79,8 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     val hoodieInternalRow = new HoodieInternalRow(new Array[UTF8String](5), unsafeRow, false)
 
     Seq(
-      (unsafeRow, rowSchema, 87),
-      (hoodieInternalRow, addMetaFields(rowSchema), 127)
+      (unsafeRow, rowSchema, 89),
+      (hoodieInternalRow, addMetaFields(rowSchema), 129)
     ) foreach { case (row, schema, expectedSize) => routine(row, schema, expectedSize) }
   }
 
@@ -105,13 +105,15 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     val key = new HoodieKey("rec-key", "part-path")
 
     val legacyRecord = toLegacyAvroRecord(avroRecord, key)
+    legacyRecord.setIgnoreFlag(true)
     val avroIndexedRecord = new HoodieAvroIndexedRecord(key, avroRecord)
+    avroIndexedRecord.setIgnoreFlag(true)
 
-    val expectedLagacyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 534 else 528
+    val expectedLagacyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 536 else 530
 
     Seq(
       (legacyRecord, expectedLagacyRecordSize),
-      (avroIndexedRecord, 389)
+      (avroIndexedRecord, 391)
     ) foreach { case (record, expectedSize) => routine(record, expectedSize) }
   }
 
@@ -130,7 +132,7 @@ class TestHoodieRecordSerialization extends SparkClientFunctionalTestHarness {
     }
 
     val key = new HoodieKey("rec-key", "part-path")
-    val expectedEmptyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 30 else 27
+    val expectedEmptyRecordSize = if (HoodieSparkUtils.gteqSpark3_4) 32 else 29
     Seq(
       (new HoodieEmptyRecord[GenericRecord](key, HoodieOperation.INSERT, 1, HoodieRecordType.AVRO),
         expectedEmptyRecordSize),


### PR DESCRIPTION
### Change Logs

Similar to https://github.com/apache/hudi/pull/9114, corner case when a record moves from 1 partition to another with partition path update set to true

### Impact
https://github.com/apache/hudi/blob/eab00d570fdc986d865b511cc0402069b4b9ce2b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/hbase/SparkHoodieHBaseIndex.java#L235-L242
1. Hbase index tagLocation is executed concurrently in different spark partitions, so the index delete operation may happen after index add operation, cause the undefined behavior as [codope](https://github.com/codope) said.
2. ReduceByKey can be a costly operation as https://github.com/apache/hudi/pull/9114#discussion_r1251177363 discussed
so add a flag to ignore this index delete operations in partitionPathUpdate condition
### Risk level (write none, low medium or high below)

N/A

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
