### PR TITLE
[HUDI-6830] Fix downgrade from version six for partially failed commits

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -223,7 +223,7 @@ class RecordLevelIndexTestBase extends HoodieSparkClientTestBase {
     }
   }
 
-  private def getInstantTime(): String = {
+  protected def getInstantTime(): String = {
     String.format("%03d", new Integer(instantTime.incrementAndGet()))
   }
 


### PR DESCRIPTION
### Change Logs

With the new version six, if table has pending commits then these commits should be rolled back during downgrade so that files created using the new format are cleaned up properly. The Jira aims to fix the downgrade handler to support this step.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
