### PR TITLE
fix(sec): upgrade com.google.code.gson:gson to 2.8.9

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -303,7 +303,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.6.2</version>
+      <version>2.8.9</version>
     </dependency>
 
     <!-- Test -->

--- a/packaging/hudi-cli-bundle/pom.xml
+++ b/packaging/hudi-cli-bundle/pom.xml
@@ -34,7 +34,7 @@
     <jakarta.el.version>3.0.3</jakarta.el.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jline.version>3.21.0</jline.version>
-    <hudi.cli.gson.version>2.6.2</hudi.cli.gson.version>
+    <hudi.cli.gson.version>2.8.9</hudi.cli.gson.version>
     <commons-configuration-2.version>2.8.0</commons-configuration-2.version>
   </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.code.gson:gson 2.6.2
- [CVE-2022-25647](https://www.oscs1024.com/hd/CVE-2022-25647)


### What did I do？
Upgrade com.google.code.gson:gson from 2.6.2 to 2.8.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS