### PR TITLE
[MINOR] change hive/adb tool not auto create database default

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -90,6 +90,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
           hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key, basePath)
           hiveSyncProps.setProperty(HIVE_USE_PRE_APACHE_INPUT_FORMAT.key, "false")
           hiveSyncProps.setProperty(META_SYNC_NO_PARTITION_METADATA.key, "true")
+          hiveSyncProps.setProperty(HIVE_AUTO_CREATE_DATABASE.key(), "true")
           HiveTestUtil.setUp(Option.of(hiveSyncProps), false)
           val tool = new HiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf)
           tool.syncHoodieTable()

--- a/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncConfig.java
+++ b/hudi-sync/hudi-adb-sync/src/main/java/org/apache/hudi/sync/adb/AdbSyncConfig.java
@@ -108,7 +108,7 @@ public class AdbSyncConfig extends HiveSyncConfig {
 
   public static final ConfigProperty<Boolean> ADB_SYNC_AUTO_CREATE_DATABASE = ConfigProperty
       .key("hoodie.datasource.adb.sync.auto_create_database")
-      .defaultValue(true)
+      .defaultValue(false)
       .markAdvanced()
       .withDocumentation("Whether auto create adb database");
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -72,7 +72,7 @@ public class HiveSyncConfigHolder {
       .withDocumentation("Hive metastore url");
   public static final ConfigProperty<String> HIVE_AUTO_CREATE_DATABASE = ConfigProperty
       .key("hoodie.datasource.hive_sync.auto_create_database")
-      .defaultValue("true")
+      .defaultValue("false")
       .markAdvanced()
       .withDocumentation("Auto create hive database if does not exists");
   public static final ConfigProperty<String> HIVE_IGNORE_EXCEPTIONS = ConfigProperty

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -100,6 +100,7 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeCommitMetadata;
 import static org.apache.hudi.common.table.timeline.TimelineMetadataUtils.serializeRollbackMetadata;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.hive.HiveSyncConfig.HIVE_AUTO_CREATE_DATABASE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_URL;
@@ -161,6 +162,7 @@ public class HiveTestUtil {
       hiveSyncProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "datestr");
       hiveSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), SlashEncodedDayPartitionValueExtractor.class.getName());
       hiveSyncProps.setProperty(HIVE_BATCH_SYNC_PARTITION_NUM.key(), "3");
+      hiveSyncProps.setProperty(HIVE_AUTO_CREATE_DATABASE.key(), "true");
     }
     hiveSyncConfig = new HiveSyncConfig(hiveSyncProps, hiveTestService.getHiveConf());
     fileSystem = hiveSyncConfig.getHadoopFileSystem();


### PR DESCRIPTION
### Change Logs

usually, `create database`  usually operate at a higher level, like `Project management platform`, and require higher permissions to create. It is usually not created by the etl task itself, do not meet common business needs.

### Impact

will not auto create database default

### Risk level (write none, low medium or high below)

low

### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
