### PR TITLE
[HUDI-6826] Port BloomFilter related classes from Hadoop library

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/BloomFilterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/BloomFilterFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.common.bloom;
 
-import org.apache.hadoop.util.hash.Hash;
+import org.apache.hudi.common.util.hash.Hash;
 
 /**
  * A Factory class to generate different versions of {@link BloomFilter}.

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/HashFunction.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/HashFunction.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.bloom;
+
+import org.apache.hudi.common.util.hash.Hash;
+
+/**
+ * Implements a hash object that returns a certain number of hashed values.
+ *
+ * @see Key The general behavior of a key being stored in a bloom filter
+ * @see InternalBloomFilter The general behavior of a bloom filter
+ */
+public class HashFunction {
+  /**
+   * The number of hashed values.
+   */
+  private int nbHash;
+
+  /**
+   * The maximum highest returned value.
+   */
+  private int maxValue;
+
+  /**
+   * Hashing algorithm to use.
+   */
+  private Hash hashFunction;
+
+  /**
+   * Constructor.
+   * <p>
+   * Builds a hash function that must obey to a given maximum number of returned values and a highest value.
+   *
+   * @param maxValue The maximum highest returned value.
+   * @param nbHash   The number of resulting hashed values.
+   * @param hashType type of the hashing function (see {@link Hash}).
+   */
+  public HashFunction(int maxValue, int nbHash, int hashType) {
+    if (maxValue <= 0) {
+      throw new IllegalArgumentException("maxValue must be > 0");
+    }
+
+    if (nbHash <= 0) {
+      throw new IllegalArgumentException("nbHash must be > 0");
+    }
+
+    this.maxValue = maxValue;
+    this.nbHash = nbHash;
+    this.hashFunction = Hash.getInstance(hashType);
+    if (this.hashFunction == null) {
+      throw new IllegalArgumentException("hashType must be known");
+    }
+  }
+
+  /**
+   * Clears <i>this</i> hash function. A NOOP
+   */
+  public void clear() {
+  }
+
+  /**
+   * Hashes a specified key into several integers.
+   *
+   * @param k The specified key.
+   * @return The array of hashed values.
+   */
+  public int[] hash(Key k) {
+    byte[] b = k.getBytes();
+    if (b == null) {
+      throw new NullPointerException("buffer reference is null");
+    }
+    if (b.length == 0) {
+      throw new IllegalArgumentException("key length must be > 0");
+    }
+    int[] result = new int[nbHash];
+    for (int i = 0, initval = 0; i < nbHash; i++) {
+      initval = hashFunction.hash(b, initval);
+      result[i] = Math.abs(initval % maxValue);
+    }
+    return result;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/HoodieDynamicBoundedBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/HoodieDynamicBoundedBloomFilter.java
@@ -21,8 +21,6 @@ package org.apache.hudi.common.bloom;
 import org.apache.hudi.common.util.Base64CodecUtil;
 import org.apache.hudi.exception.HoodieIndexException;
 
-import org.apache.hadoop.util.bloom.Key;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -45,7 +43,7 @@ public class HoodieDynamicBoundedBloomFilter implements BloomFilter {
    *
    * @param numEntries The total number of entries.
    * @param errorRate  maximum allowable error rate.
-   * @param hashType   type of the hashing function (see {@link org.apache.hadoop.util.hash.Hash}).
+   * @param hashType   type of the hashing function (see {@link org.apache.hudi.common.util.hash.Hash}).
    * @return the {@link HoodieDynamicBoundedBloomFilter} thus created
    */
   HoodieDynamicBoundedBloomFilter(int numEntries, double errorRate, int hashType, int maxNoOfEntries) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/InternalBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/InternalBloomFilter.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (c) 2005, European Commission project OneLab under contract 034819 (http://www.one-lab.org)
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the University Catholique de Louvain - UCL
+ * nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior
+ * written permission.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.apache.hudi.common.bloom;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.BitSet;
+
+/**
+ * Implements a <i>Bloom filter</i>, as defined by Bloom in 1970.
+ * <p>
+ * The code in class is adapted from {@link org.apache.hadoop.util.bloom.BloomFilter} in Apache Hadoop.
+ * <p>
+ * Hudi serializes bloom filter(s) and write them to Parquet file footers and metadata table's
+ * bloom filter partition containing bloom filters for all data files.  We want to maintain the
+ * serde of a bloom filter and thus the code in Hudi repo to avoid breaking changes in storage
+ * format and bytes.
+ * <p>
+ * The Bloom filter is a data structure that was introduced in 1970 and that has been adopted by
+ * the networking research community in the past decade thanks to the bandwidth efficiencies that it
+ * offers for the transmission of set membership information between networked hosts.  A sender encodes
+ * the information into a bit vector, the Bloom filter, that is more compact than a conventional
+ * representation. Computation and space costs for construction are linear in the number of elements.
+ * The receiver uses the filter to test whether various elements are members of the set. Though the
+ * filter will occasionally return a false positive, it will never return a false negative. When creating
+ * the filter, the sender can choose its desired point in a trade-off between the false positive rate and the size.
+ *
+ * <p>
+ * Originally created by
+ * <a href="http://www.one-lab.org">European Commission One-Lab Project 034819</a>.
+ *
+ * @see <a href="http://portal.acm.org/citation.cfm?id=362692&dl=ACM&coll=portal">Space/Time Trade-Offs in Hash Coding with Allowable Errors</a>
+ */
+public class InternalBloomFilter extends InternalFilter {
+  private static final byte[] BIT_VALUES = new byte[] {
+      (byte) 0x01,
+      (byte) 0x02,
+      (byte) 0x04,
+      (byte) 0x08,
+      (byte) 0x10,
+      (byte) 0x20,
+      (byte) 0x40,
+      (byte) 0x80
+  };
+
+  /**
+   * The bit vector.
+   */
+  BitSet bits;
+
+  /**
+   * Default constructor - use with readFields
+   */
+  public InternalBloomFilter() {
+    super();
+  }
+
+  /**
+   * Constructor
+   *
+   * @param vectorSize The vector size of <i>this</i> filter.
+   * @param nbHash     The number of hash function to consider.
+   * @param hashType   type of the hashing function (see
+   *                   {@link org.apache.hudi.common.util.hash.Hash}).
+   */
+  public InternalBloomFilter(int vectorSize, int nbHash, int hashType) {
+    super(vectorSize, nbHash, hashType);
+
+    bits = new BitSet(this.vectorSize);
+  }
+
+  /**
+   * Adds a key to <i>this</i> filter.
+   *
+   * @param key The key to add.
+   */
+  @Override
+  public void add(Key key) {
+    if (key == null) {
+      throw new NullPointerException("key cannot be null");
+    }
+
+    int[] h = hash.hash(key);
+    hash.clear();
+
+    for (int i = 0; i < nbHash; i++) {
+      bits.set(h[i]);
+    }
+  }
+
+  @Override
+  public void and(InternalFilter filter) {
+    if (filter == null
+        || !(filter instanceof InternalBloomFilter)
+        || filter.vectorSize != this.vectorSize
+        || filter.nbHash != this.nbHash) {
+      throw new IllegalArgumentException("filters cannot be and-ed");
+    }
+
+    this.bits.and(((InternalBloomFilter) filter).bits);
+  }
+
+  @Override
+  public boolean membershipTest(Key key) {
+    if (key == null) {
+      throw new NullPointerException("key cannot be null");
+    }
+
+    int[] h = hash.hash(key);
+    hash.clear();
+    for (int i = 0; i < nbHash; i++) {
+      if (!bits.get(h[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void not() {
+    bits.flip(0, vectorSize);
+  }
+
+  @Override
+  public void or(InternalFilter filter) {
+    if (filter == null
+        || !(filter instanceof InternalBloomFilter)
+        || filter.vectorSize != this.vectorSize
+        || filter.nbHash != this.nbHash) {
+      throw new IllegalArgumentException("filters cannot be or-ed");
+    }
+    bits.or(((InternalBloomFilter) filter).bits);
+  }
+
+  @Override
+  public void xor(InternalFilter filter) {
+    if (filter == null
+        || !(filter instanceof InternalBloomFilter)
+        || filter.vectorSize != this.vectorSize
+        || filter.nbHash != this.nbHash) {
+      throw new IllegalArgumentException("filters cannot be xor-ed");
+    }
+    bits.xor(((InternalBloomFilter) filter).bits);
+  }
+
+  @Override
+  public String toString() {
+    return bits.toString();
+  }
+
+  /**
+   * @return size of the the bloomfilter
+   */
+  public int getVectorSize() {
+    return this.vectorSize;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    byte[] bytes = new byte[getNBytes()];
+    for (int i = 0, byteIndex = 0, bitIndex = 0; i < vectorSize; i++, bitIndex++) {
+      if (bitIndex == 8) {
+        bitIndex = 0;
+        byteIndex++;
+      }
+      if (bitIndex == 0) {
+        bytes[byteIndex] = 0;
+      }
+      if (bits.get(i)) {
+        bytes[byteIndex] |= BIT_VALUES[bitIndex];
+      }
+    }
+    out.write(bytes);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    bits = new BitSet(this.vectorSize);
+    byte[] bytes = new byte[getNBytes()];
+    in.readFully(bytes);
+    for (int i = 0, byteIndex = 0, bitIndex = 0; i < vectorSize; i++, bitIndex++) {
+      if (bitIndex == 8) {
+        bitIndex = 0;
+        byteIndex++;
+      }
+      if ((bytes[byteIndex] & BIT_VALUES[bitIndex]) != 0) {
+        bits.set(i);
+      }
+    }
+  }
+
+  /* @return number of bytes needed to hold bit vector */
+  private int getNBytes() {
+    return (int) (((long) vectorSize + 7) / 8);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/InternalDynamicBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/InternalDynamicBloomFilter.java
@@ -18,9 +18,6 @@
 
 package org.apache.hudi.common.bloom;
 
-import org.apache.hadoop.util.bloom.BloomFilter;
-import org.apache.hadoop.util.bloom.Key;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -48,7 +45,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
   /**
    * The matrix of Bloom filter.
    */
-  private org.apache.hadoop.util.bloom.BloomFilter[] matrix;
+  private InternalBloomFilter[] matrix;
 
   /**
    * Zero-args constructor for the serialization.
@@ -63,7 +60,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
    *
    * @param vectorSize The number of bits in the vector.
    * @param nbHash     The number of hash function to consider.
-   * @param hashType   type of the hashing function (see {@link org.apache.hadoop.util.hash.Hash}).
+   * @param hashType   type of the hashing function (see {@link org.apache.hudi.common.util.hash.Hash}).
    * @param nr         The threshold for the maximum number of keys to record in a dynamic Bloom filter row.
    */
   public InternalDynamicBloomFilter(int vectorSize, int nbHash, int hashType, int nr, int maxNr) {
@@ -73,8 +70,8 @@ class InternalDynamicBloomFilter extends InternalFilter {
     this.currentNbRecord = 0;
     this.maxNr = maxNr;
 
-    matrix = new org.apache.hadoop.util.bloom.BloomFilter[1];
-    matrix[0] = new org.apache.hadoop.util.bloom.BloomFilter(this.vectorSize, this.nbHash, this.hashType);
+    matrix = new InternalBloomFilter[1];
+    matrix[0] = new InternalBloomFilter(this.vectorSize, this.nbHash, this.hashType);
   }
 
   @Override
@@ -83,7 +80,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
       throw new NullPointerException("Key can not be null");
     }
 
-    org.apache.hadoop.util.bloom.BloomFilter bf = getActiveStandardBF();
+    InternalBloomFilter bf = getActiveStandardBF();
 
     if (bf == null) {
       addRow();
@@ -121,7 +118,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
       return true;
     }
 
-    for (BloomFilter bloomFilter : matrix) {
+    for (InternalBloomFilter bloomFilter : matrix) {
       if (bloomFilter.membershipTest(key)) {
         return true;
       }
@@ -132,7 +129,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
 
   @Override
   public void not() {
-    for (BloomFilter bloomFilter : matrix) {
+    for (InternalBloomFilter bloomFilter : matrix) {
       bloomFilter.not();
     }
   }
@@ -177,7 +174,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
   public String toString() {
     StringBuilder res = new StringBuilder();
 
-    for (BloomFilter bloomFilter : matrix) {
+    for (InternalBloomFilter bloomFilter : matrix) {
       res.append(bloomFilter);
       res.append(Character.LINE_SEPARATOR);
     }
@@ -192,7 +189,7 @@ class InternalDynamicBloomFilter extends InternalFilter {
     out.writeInt(nr);
     out.writeInt(currentNbRecord);
     out.writeInt(matrix.length);
-    for (BloomFilter bloomFilter : matrix) {
+    for (InternalBloomFilter bloomFilter : matrix) {
       bloomFilter.write(out);
     }
   }
@@ -203,9 +200,9 @@ class InternalDynamicBloomFilter extends InternalFilter {
     nr = in.readInt();
     currentNbRecord = in.readInt();
     int len = in.readInt();
-    matrix = new org.apache.hadoop.util.bloom.BloomFilter[len];
+    matrix = new InternalBloomFilter[len];
     for (int i = 0; i < matrix.length; i++) {
-      matrix[i] = new org.apache.hadoop.util.bloom.BloomFilter();
+      matrix[i] = new InternalBloomFilter();
       matrix[i].readFields(in);
     }
   }
@@ -214,19 +211,19 @@ class InternalDynamicBloomFilter extends InternalFilter {
    * Adds a new row to <i>this</i> dynamic Bloom filter.
    */
   private void addRow() {
-    BloomFilter[] tmp = new BloomFilter[matrix.length + 1];
+    InternalBloomFilter[] tmp = new InternalBloomFilter[matrix.length + 1];
     System.arraycopy(matrix, 0, tmp, 0, matrix.length);
-    tmp[tmp.length - 1] = new BloomFilter(vectorSize, nbHash, hashType);
+    tmp[tmp.length - 1] = new InternalBloomFilter(vectorSize, nbHash, hashType);
     matrix = tmp;
   }
 
   /**
    * Returns the active standard Bloom filter in <i>this</i> dynamic Bloom filter.
    *
-   * @return BloomFilter The active standard Bloom filter.
+   * @return SingleBloomFilter The active standard Bloom filter.
    * <code>Null</code> otherwise.
    */
-  private BloomFilter getActiveStandardBF() {
+  private InternalBloomFilter getActiveStandardBF() {
     if (reachedMax) {
       return matrix[curMatrixIndex++ % matrix.length];
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/InternalFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/InternalFilter.java
@@ -18,10 +18,7 @@
 
 package org.apache.hudi.common.bloom;
 
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.util.bloom.HashFunction;
-import org.apache.hadoop.util.bloom.Key;
-import org.apache.hadoop.util.hash.Hash;
+import org.apache.hudi.common.util.hash.Hash;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -30,15 +27,28 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Copied from {@link org.apache.hadoop.util.bloom.Filter}. {@link InternalDynamicBloomFilter} needs access to some of
- * protected members of {@link org.apache.hadoop.util.bloom.Filter} and hence had to copy it locally.
+ * Ported from {@link org.apache.hadoop.util.bloom.Filter}.
  */
-abstract class InternalFilter implements Writable {
-
+abstract class InternalFilter {
   private static final int VERSION = -1; // negative to accommodate for old format
+  /**
+   * The vector size of <i>this</i> filter.
+   */
   protected int vectorSize;
+
+  /**
+   * The hash function used to map a key to several positions in the vector.
+   */
   protected HashFunction hash;
+
+  /**
+   * The number of hash function to consider.
+   */
   protected int nbHash;
+
+  /**
+   * Type of hashing function to use.
+   */
   protected int hashType;
 
   protected InternalFilter() {
@@ -150,9 +160,6 @@ abstract class InternalFilter implements Writable {
     }
   } //end add()
 
-  // Writable interface
-
-  @Override
   public void write(DataOutput out) throws IOException {
     out.writeInt(VERSION);
     out.writeInt(this.nbHash);
@@ -160,7 +167,6 @@ abstract class InternalFilter implements Writable {
     out.writeInt(this.vectorSize);
   }
 
-  @Override
   public void readFields(DataInput in) throws IOException {
     int ver = in.readInt();
     if (ver > 0) { // old non-versioned format

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/Key.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/Key.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.bloom;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * The general behavior of a key that must be stored in a bloom filter.
+ *
+ * @see InternalBloomFilter The general behavior of a bloom filter and how the key is used.
+ */
+public final class Key implements Comparable<Key> {
+  /**
+   * Byte value of key
+   */
+  byte[] bytes;
+
+  /**
+   * The weight associated to <i>this</i> key.
+   * <p>
+   * <b>Invariant</b>: if it is not specified, each instance of
+   * <code>Key</code> will have a default weight of 1.0
+   */
+  double weight;
+
+  /**
+   * default constructor - use with readFields
+   */
+  public Key() {
+  }
+
+  /**
+   * Constructor.
+   * <p>
+   * Builds a key with a default weight.
+   *
+   * @param value The byte value of <i>this</i> key.
+   */
+  public Key(byte[] value) {
+    this(value, 1.0);
+  }
+
+  /**
+   * Constructor.
+   * <p>
+   * Builds a key with a specified weight.
+   *
+   * @param value  The value of <i>this</i> key.
+   * @param weight The weight associated to <i>this</i> key.
+   */
+  public Key(byte[] value, double weight) {
+    set(value, weight);
+  }
+
+  /**
+   * @param value
+   * @param weight
+   */
+  public void set(byte[] value, double weight) {
+    if (value == null) {
+      throw new IllegalArgumentException("value can not be null");
+    }
+    this.bytes = value;
+    this.weight = weight;
+  }
+
+  /**
+   * @return byte[] The value of <i>this</i> key.
+   */
+  public byte[] getBytes() {
+    return this.bytes;
+  }
+
+  /**
+   * @return Returns the weight associated to <i>this</i> key.
+   */
+  public double getWeight() {
+    return weight;
+  }
+
+  /**
+   * Increments the weight of <i>this</i> key with a specified value.
+   *
+   * @param weight The increment.
+   */
+  public void incrementWeight(double weight) {
+    this.weight += weight;
+  }
+
+  /**
+   * Increments the weight of <i>this</i> key by one.
+   */
+  public void incrementWeight() {
+    this.weight++;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Key)) {
+      return false;
+    }
+    return this.compareTo((Key) o) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 0;
+    for (int i = 0; i < bytes.length; i++) {
+      result ^= Byte.valueOf(bytes[i]).hashCode();
+    }
+    result ^= Double.valueOf(weight).hashCode();
+    return result;
+  }
+
+  /**
+   * Serialize the fields of this object to <code>out</code>.
+   *
+   * @param out <code>DataOuput</code> to serialize this object into.
+   * @throws IOException
+   */
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(bytes.length);
+    out.write(bytes);
+    out.writeDouble(weight);
+  }
+
+  /**
+   * Deserialize the fields of this object from <code>in</code>.
+   *
+   * <p>For efficiency, implementations should attempt to re-use storage in the
+   * existing object where possible.</p>
+   *
+   * @param in <code>DataInput</code> to deseriablize this object from.
+   * @throws IOException
+   */
+  public void readFields(DataInput in) throws IOException {
+    this.bytes = new byte[in.readInt()];
+    in.readFully(this.bytes);
+    weight = in.readDouble();
+  }
+
+  // Comparable
+  @Override
+  public int compareTo(Key other) {
+    int result = this.bytes.length - other.getBytes().length;
+    for (int i = 0; result == 0 && i < bytes.length; i++) {
+      result = this.bytes[i] - other.bytes[i];
+    }
+
+    if (result == 0) {
+      result = (int) (this.weight - other.weight);
+    }
+    return result;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/SimpleBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/SimpleBloomFilter.java
@@ -21,8 +21,6 @@ package org.apache.hudi.common.bloom;
 import org.apache.hudi.common.util.Base64CodecUtil;
 import org.apache.hudi.exception.HoodieIndexException;
 
-import org.apache.hadoop.util.bloom.Key;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -35,19 +33,19 @@ import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 
 /**
- * A Simple Bloom filter implementation built on top of {@link org.apache.hadoop.util.bloom.BloomFilter}.
+ * A Simple Bloom filter implementation built on top of {@link InternalBloomFilter}.
  */
 
 public class SimpleBloomFilter implements BloomFilter {
 
-  private org.apache.hadoop.util.bloom.BloomFilter filter;
+  private InternalBloomFilter filter;
 
   /**
    * Create a new Bloom filter with the given configurations.
    *
    * @param numEntries The total number of entries.
    * @param errorRate  maximum allowable error rate.
-   * @param hashType   type of the hashing function (see {@link org.apache.hadoop.util.hash.Hash}).
+   * @param hashType   type of the hashing function (see {@link org.apache.hudi.common.util.hash.Hash}).
    */
   public SimpleBloomFilter(int numEntries, double errorRate, int hashType) {
     // Bit size
@@ -55,7 +53,7 @@ public class SimpleBloomFilter implements BloomFilter {
     // Number of the hash functions
     int numHashs = BloomFilterUtils.getNumHashes(bitSize, numEntries);
     // The filter
-    this.filter = new org.apache.hadoop.util.bloom.BloomFilter(bitSize, numHashs, hashType);
+    this.filter = new InternalBloomFilter(bitSize, numHashs, hashType);
   }
 
   /**
@@ -64,7 +62,7 @@ public class SimpleBloomFilter implements BloomFilter {
    * @param serString serialized string which represents the {@link SimpleBloomFilter}
    */
   public SimpleBloomFilter(String serString) {
-    this.filter = new org.apache.hadoop.util.bloom.BloomFilter();
+    this.filter = new InternalBloomFilter();
     byte[] bytes = Base64CodecUtil.decode(serString);
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
     try {
@@ -119,7 +117,7 @@ public class SimpleBloomFilter implements BloomFilter {
   }
 
   private void readObject(ObjectInputStream is) throws IOException {
-    filter = new org.apache.hadoop.util.bloom.BloomFilter();
+    filter = new InternalBloomFilter();
     filter.readFields(is);
   }
 
@@ -130,7 +128,7 @@ public class SimpleBloomFilter implements BloomFilter {
 
   //@Override
   public void readFields(DataInput in) throws IOException {
-    filter = new org.apache.hadoop.util.bloom.BloomFilter();
+    filter = new InternalBloomFilter();
     filter.readFields(in);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/Hash.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/Hash.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util.hash;
+
+import org.apache.hudi.common.bloom.InternalBloomFilter;
+
+/**
+ * This class represents a common API for hashing functions used by
+ * {@link InternalBloomFilter}.
+ */
+public abstract class Hash {
+  /**
+   * Constant to denote invalid hash type.
+   */
+  public static final int INVALID_HASH = -1;
+  /**
+   * Constant to denote {@link JenkinsHash}.
+   */
+  public static final int JENKINS_HASH = 0;
+  /**
+   * Constant to denote {@link MurmurHash}.
+   */
+  public static final int MURMUR_HASH = 1;
+
+  /**
+   * This utility method converts String representation of hash function name
+   * to a symbolic constant. Currently two function types are supported,
+   * "jenkins" and "murmur".
+   *
+   * @param name hash function name
+   * @return one of the predefined constants
+   */
+  public static int parseHashType(String name) {
+    if ("jenkins".equalsIgnoreCase(name)) {
+      return JENKINS_HASH;
+    } else if ("murmur".equalsIgnoreCase(name)) {
+      return MURMUR_HASH;
+    } else {
+      return INVALID_HASH;
+    }
+  }
+
+  /**
+   * Get a singleton instance of hash function of a given type.
+   *
+   * @param type predefined hash type
+   * @return hash function instance, or null if type is invalid
+   */
+  public static Hash getInstance(int type) {
+    switch (type) {
+      case JENKINS_HASH:
+        return JenkinsHash.getInstance();
+      case MURMUR_HASH:
+        return MurmurHash.getInstance();
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Calculate a hash using all bytes from the input argument, and
+   * a seed of -1.
+   *
+   * @param bytes input bytes
+   * @return hash value
+   */
+  public int hash(byte[] bytes) {
+    return hash(bytes, bytes.length, -1);
+  }
+
+  /**
+   * Calculate a hash using all bytes from the input argument,
+   * and a provided seed value.
+   *
+   * @param bytes   input bytes
+   * @param initval seed value
+   * @return hash value
+   */
+  public int hash(byte[] bytes, int initval) {
+    return hash(bytes, bytes.length, initval);
+  }
+
+  /**
+   * Calculate a hash using bytes from 0 to <code>length</code>, and
+   * the provided seed value
+   *
+   * @param bytes   input bytes
+   * @param length  length of the valid bytes to consider
+   * @param initval seed value
+   * @return hash value
+   */
+  public abstract int hash(byte[] bytes, int length, int initval);
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/JenkinsHash.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/JenkinsHash.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util.hash;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Produces 32-bit hash for hash table lookup.
+ *
+ * <pre>lookup3.c, by Bob Jenkins, May 2006, Public Domain.
+ *
+ * You can use this free for any purpose.  It's in the public domain.
+ * It has no warranty.
+ * </pre>
+ *
+ * @see <a href="http://burtleburtle.net/bob/c/lookup3.c">lookup3.c</a>
+ * @see <a href="http://www.ddj.com/184410284">Hash Functions (and how this
+ * function compares to others such as CRC, MD?, etc</a>
+ * @see <a href="http://burtleburtle.net/bob/hash/doobs.html">Has update on the
+ * Dr. Dobbs Article</a>
+ */
+public class JenkinsHash extends Hash {
+  private static long INT_MASK = 0x00000000ffffffffL;
+  private static long BYTE_MASK = 0x00000000000000ffL;
+
+  private static JenkinsHash _instance = new JenkinsHash();
+
+  public static Hash getInstance() {
+    return _instance;
+  }
+
+  private static long rot(long val, int pos) {
+    return ((Integer.rotateLeft(
+        (int) (val & INT_MASK), pos)) & INT_MASK);
+  }
+
+  /**
+   * taken from  hashlittle() -- hash a variable-length key into a 32-bit value
+   *
+   * @param key     the key (the unaligned variable-length array of bytes)
+   * @param nbytes  number of bytes to include in hash
+   * @param initval can be any integer value
+   * @return a 32-bit value.  Every bit of the key affects every bit of the
+   * return value.  Two keys differing by one or two bits will have totally
+   * different hash values.
+   *
+   * <p>The best hash table sizes are powers of 2.  There is no need to do mod
+   * a prime (mod is sooo slow!).  If you need less than 32 bits, use a bitmask.
+   * For example, if you need only 10 bits, do
+   * <code>h = (h & hashmask(10));</code>
+   * In which case, the hash table should have hashsize(10) elements.
+   *
+   * <p>If you are hashing n strings byte[][] k, do it like this:
+   * for (int i = 0, h = 0; i < n; ++i) h = hash( k[i], h);
+   *
+   * <p>By Bob Jenkins, 2006.  bob_jenkins@burtleburtle.net.  You may use this
+   * code any way you wish, private, educational, or commercial.  It's free.
+   *
+   * <p>Use for hash table lookup, or anything where one collision in 2^^32 is
+   * acceptable.  Do NOT use for cryptographic purposes.
+   */
+  @Override
+  @SuppressWarnings("fallthrough")
+  public int hash(byte[] key, int nbytes, int initval) {
+    int length = nbytes;
+    long a;
+    long b;
+    long c;       // We use longs because we don't have unsigned ints
+    a = b = c = (0x00000000deadbeefL + length + initval) & INT_MASK;
+    int offset = 0;
+    for (; length > 12; offset += 12, length -= 12) {
+      a = (a + (key[offset + 0] & BYTE_MASK)) & INT_MASK;
+      a = (a + (((key[offset + 1] & BYTE_MASK) << 8) & INT_MASK)) & INT_MASK;
+      a = (a + (((key[offset + 2] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      a = (a + (((key[offset + 3] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      b = (b + (key[offset + 4] & BYTE_MASK)) & INT_MASK;
+      b = (b + (((key[offset + 5] & BYTE_MASK) << 8) & INT_MASK)) & INT_MASK;
+      b = (b + (((key[offset + 6] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      b = (b + (((key[offset + 7] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      c = (c + (key[offset + 8] & BYTE_MASK)) & INT_MASK;
+      c = (c + (((key[offset + 9] & BYTE_MASK) << 8) & INT_MASK)) & INT_MASK;
+      c = (c + (((key[offset + 10] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      c = (c + (((key[offset + 11] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+
+      /*
+       * mix -- mix 3 32-bit values reversibly.
+       * This is reversible, so any information in (a,b,c) before mix() is
+       * still in (a,b,c) after mix().
+       *
+       * If four pairs of (a,b,c) inputs are run through mix(), or through
+       * mix() in reverse, there are at least 32 bits of the output that
+       * are sometimes the same for one pair and different for another pair.
+       *
+       * This was tested for:
+       * - pairs that differed by one bit, by two bits, in any combination
+       *   of top bits of (a,b,c), or in any combination of bottom bits of
+       *   (a,b,c).
+       * - "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+       *   the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+       *    is commonly produced by subtraction) look like a single 1-bit
+       *    difference.
+       * - the base values were pseudorandom, all zero but one bit set, or
+       *   all zero plus a counter that starts at zero.
+       *
+       * Some k values for my "a-=c; a^=rot(c,k); c+=b;" arrangement that
+       * satisfy this are
+       *     4  6  8 16 19  4
+       *     9 15  3 18 27 15
+       *    14  9  3  7 17  3
+       * Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing for
+       * "differ" defined as + with a one-bit base and a two-bit delta.  I
+       * used http://burtleburtle.net/bob/hash/avalanche.html to choose
+       * the operations, constants, and arrangements of the variables.
+       *
+       * This does not achieve avalanche.  There are input bits of (a,b,c)
+       * that fail to affect some output bits of (a,b,c), especially of a.
+       * The most thoroughly mixed value is c, but it doesn't really even
+       * achieve avalanche in c.
+       *
+       * This allows some parallelism.  Read-after-writes are good at doubling
+       * the number of bits affected, so the goal of mixing pulls in the
+       * opposite direction as the goal of parallelism.  I did what I could.
+       * Rotates seem to cost as much as shifts on every machine I could lay
+       * my hands on, and rotates are much kinder to the top and bottom bits,
+       * so I used rotates.
+       *
+       * #define mix(a,b,c) \
+       * { \
+       *   a -= c;  a ^= rot(c, 4);  c += b; \
+       *   b -= a;  b ^= rot(a, 6);  a += c; \
+       *   c -= b;  c ^= rot(b, 8);  b += a; \
+       *   a -= c;  a ^= rot(c,16);  c += b; \
+       *   b -= a;  b ^= rot(a,19);  a += c; \
+       *   c -= b;  c ^= rot(b, 4);  b += a; \
+       * }
+       *
+       * mix(a,b,c);
+       */
+      a = (a - c) & INT_MASK;
+      a ^= rot(c, 4);
+      c = (c + b) & INT_MASK;
+      b = (b - a) & INT_MASK;
+      b ^= rot(a, 6);
+      a = (a + c) & INT_MASK;
+      c = (c - b) & INT_MASK;
+      c ^= rot(b, 8);
+      b = (b + a) & INT_MASK;
+      a = (a - c) & INT_MASK;
+      a ^= rot(c, 16);
+      c = (c + b) & INT_MASK;
+      b = (b - a) & INT_MASK;
+      b ^= rot(a, 19);
+      a = (a + c) & INT_MASK;
+      c = (c - b) & INT_MASK;
+      c ^= rot(b, 4);
+      b = (b + a) & INT_MASK;
+    }
+
+    //-------------------------------- last block: affect all 32 bits of (c)
+    // all the case statements fall through
+    switch (length) {
+      case 12:
+        c = (c + (((key[offset + 11] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      case 11:
+        c = (c + (((key[offset + 10] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      case 10:
+        c = (c + (((key[offset + 9] & BYTE_MASK) << 8) & INT_MASK)) & INT_MASK;
+      case 9:
+        c = (c + (key[offset + 8] & BYTE_MASK)) & INT_MASK;
+      case 8:
+        b = (b + (((key[offset + 7] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      case 7:
+        b = (b + (((key[offset + 6] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      case 6:
+        b = (b + (((key[offset + 5] & BYTE_MASK) << 8) & INT_MASK)) & INT_MASK;
+      case 5:
+        b = (b + (key[offset + 4] & BYTE_MASK)) & INT_MASK;
+      case 4:
+        a = (a + (((key[offset + 3] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      case 3:
+        a = (a + (((key[offset + 2] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      case 2:
+        a = (a + (((key[offset + 1] & BYTE_MASK) << 8) & INT_MASK)) & INT_MASK;
+      case 1:
+        a = (a + (key[offset + 0] & BYTE_MASK)) & INT_MASK;
+        break;
+      case 0:
+        return (int) (c & INT_MASK);
+      default:
+    }
+    /*
+     * final -- final mixing of 3 32-bit values (a,b,c) into c
+     *
+     * Pairs of (a,b,c) values differing in only a few bits will usually
+     * produce values of c that look totally different.  This was tested for
+     * - pairs that differed by one bit, by two bits, in any combination
+     *   of top bits of (a,b,c), or in any combination of bottom bits of
+     *   (a,b,c).
+     *
+     * - "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+     *   the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+     *   is commonly produced by subtraction) look like a single 1-bit
+     *   difference.
+     *
+     * - the base values were pseudorandom, all zero but one bit set, or
+     *   all zero plus a counter that starts at zero.
+     *
+     * These constants passed:
+     *   14 11 25 16 4 14 24
+     *   12 14 25 16 4 14 24
+     * and these came close:
+     *    4  8 15 26 3 22 24
+     *   10  8 15 26 3 22 24
+     *   11  8 15 26 3 22 24
+     *
+     * #define final(a,b,c) \
+     * {
+     *   c ^= b; c -= rot(b,14); \
+     *   a ^= c; a -= rot(c,11); \
+     *   b ^= a; b -= rot(a,25); \
+     *   c ^= b; c -= rot(b,16); \
+     *   a ^= c; a -= rot(c,4);  \
+     *   b ^= a; b -= rot(a,14); \
+     *   c ^= b; c -= rot(b,24); \
+     * }
+     *
+     */
+    c ^= b;
+    c = (c - rot(b, 14)) & INT_MASK;
+    a ^= c;
+    a = (a - rot(c, 11)) & INT_MASK;
+    b ^= a;
+    b = (b - rot(a, 25)) & INT_MASK;
+    c ^= b;
+    c = (c - rot(b, 16)) & INT_MASK;
+    a ^= c;
+    a = (a - rot(c, 4)) & INT_MASK;
+    b ^= a;
+    b = (b - rot(a, 14)) & INT_MASK;
+    c ^= b;
+    c = (c - rot(b, 24)) & INT_MASK;
+
+    return (int) (c & INT_MASK);
+  }
+
+  /**
+   * Compute the hash of the specified file
+   *
+   * @param args name of file to compute hash of.
+   * @throws IOException
+   */
+  public static void main(String[] args) throws IOException {
+    if (args.length != 1) {
+      System.err.println("Usage: JenkinsHash filename");
+      System.exit(-1);
+    }
+    try (FileInputStream in = new FileInputStream(args[0])) {
+      byte[] bytes = new byte[512];
+      int value = 0;
+      JenkinsHash hash = new JenkinsHash();
+      for (int length = in.read(bytes); length > 0; length = in.read(bytes)) {
+        value = hash.hash(bytes, length, value);
+      }
+      System.out.println(Math.abs(value));
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/MurmurHash.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/MurmurHash.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util.hash;
+
+/**
+ * This is a very fast, non-cryptographic hash suitable for general hash-based
+ * lookup.  See http://murmurhash.googlepages.com/ for more details.
+ *
+ * <p>The C version of MurmurHash 2.0 found at that site was ported
+ * to Java by Andrzej Bialecki (ab at getopt org).</p>
+ */
+public class MurmurHash extends Hash {
+  private static MurmurHash _instance = new MurmurHash();
+
+  public static Hash getInstance() {
+    return _instance;
+  }
+
+  @Override
+  public int hash(byte[] data, int length, int seed) {
+    return hash(data, 0, length, seed);
+  }
+
+  public int hash(byte[] data, int offset, int length, int seed) {
+    int m = 0x5bd1e995;
+    int r = 24;
+
+    int h = seed ^ length;
+
+    int len4 = length >> 2;
+
+    for (int i = 0; i < len4; i++) {
+      int i4 = offset + (i << 2);
+      int k = data[i4 + 3];
+      k = k << 8;
+      k = k | (data[i4 + 2] & 0xff);
+      k = k << 8;
+      k = k | (data[i4 + 1] & 0xff);
+      k = k << 8;
+      k = k | (data[i4 + 0] & 0xff);
+      k *= m;
+      k ^= k >>> r;
+      k *= m;
+      h *= m;
+      h ^= k;
+    }
+
+    // avoid calculating modulo
+    int lenM = len4 << 2;
+    int left = length - lenM;
+
+    if (left != 0) {
+      length += offset;
+      if (left >= 3) {
+        h ^= (int) data[length - 3] << 16;
+      }
+      if (left >= 2) {
+        h ^= (int) data[length - 2] << 8;
+      }
+      if (left >= 1) {
+        h ^= (int) data[length - 1];
+      }
+
+      h *= m;
+    }
+
+    h ^= h >>> 13;
+    h *= m;
+    h ^= h >>> 15;
+
+    return h;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/bloom/TestInternalDynamicBloomFilter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/bloom/TestInternalDynamicBloomFilter.java
@@ -18,7 +18,8 @@
 
 package org.apache.hudi.common.bloom;
 
-import org.apache.hadoop.util.hash.Hash;
+import org.apache.hudi.common.util.hash.Hash;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;


### PR DESCRIPTION
### Change Logs

Port `BloomFilter` related classes from Hadoop library. This has been done to remove Hadoop library dependency as part of HUDI-6824.

### Impact

No change in public APIs. All functionalities should behave as is. 

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
