### PR TITLE
[HUDI-6831] Add back missing project_id to query statement in BigQuerySyncTool

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -94,8 +94,9 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
       }
       String query =
           String.format(
-              "CREATE EXTERNAL TABLE `%s.%s` %s OPTIONS (%s "
+              "CREATE EXTERNAL TABLE `%s.%s.%s` %s OPTIONS (%s "
               + "uris=[\"%s\"], format=\"PARQUET\", file_set_spec_type=\"NEW_LINE_DELIMITED_MANIFEST\")",
+              projectId,
               datasetName,
               tableName,
               withClauses,


### PR DESCRIPTION
### Change Logs

This pr adds project id to the query statement: changing "create external table dataset.table" to "create external table project.dataset.table"

### Impact

Fix the bug where project id is missing.

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
