### PR TITLE
[HUDI-6832]  Ensure other table services with correct path are not affect…

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/HoodieMultiTableServicesMain.java
@@ -116,7 +116,7 @@ public class HoodieMultiTableServicesMain {
           .flatMap(p -> MultiTableServiceUtils.findHoodieTablesUnderPath(jsc, p).stream())
           .collect(Collectors.toList());
     } else {
-      tablePaths = MultiTableServiceUtils.getTablesToBeServedFromProps(props);
+      tablePaths = MultiTableServiceUtils.getTablesToBeServedFromProps(jsc, props);
     }
     LOG.info("All table paths: " + String.join(",", tablePaths));
     if (cfg.batch) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,22 +46,43 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME
  * Utils for executing multi-table services.
  */
 public class MultiTableServiceUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTableServiceUtils.class);
 
   public static class Constants {
     public static final String TABLES_TO_BE_SERVED_PROP = "hoodie.tableservice.tablesToServe";
+
+    public static final String TABLES_SKIP_WRONG_PATH = "hoodie.tableservice.skip.wrong.path";
 
     public static final String COMMA_SEPARATOR = ",";
 
     private static final int DEFAULT_LISTING_PARALLELISM = 1500;
   }
 
-  public static List<String> getTablesToBeServedFromProps(TypedProperties properties) {
+  public static List<String> getTablesToBeServedFromProps(JavaSparkContext jsc, TypedProperties properties) {
+    SerializableConfiguration conf = new SerializableConfiguration(jsc.hadoopConfiguration());
     String combinedTablesString = properties.getString(Constants.TABLES_TO_BE_SERVED_PROP);
+    boolean skipWrongPath = properties.getBoolean(Constants.TABLES_SKIP_WRONG_PATH, false);
     if (combinedTablesString == null) {
       return new ArrayList<>();
     }
     String[] tablesArray = combinedTablesString.split(Constants.COMMA_SEPARATOR);
-    return Arrays.asList(tablesArray);
+
+    List<String> tablePaths;
+    if (skipWrongPath) {
+      tablePaths = Arrays.stream(tablesArray)
+          .filter(tablePath -> {
+            if (isHoodieTable(new Path(tablePath), conf.get())) {
+              return true;
+            } else {
+              // Log the wrong path in console.
+              LOG.error("Hoodie table not found in path " + tablePath);
+              return false;
+            }
+          }).collect(Collectors.toList());
+    } else {
+      tablePaths = Arrays.asList(tablesArray);
+    }
+    return tablePaths;
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -51,7 +51,7 @@ public class MultiTableServiceUtils {
   public static class Constants {
     public static final String TABLES_TO_BE_SERVED_PROP = "hoodie.tableservice.tablesToServe";
 
-    public static final String TABLES_SKIP_WRONG_PATH = "hoodie.tableservice.skip.wrong.path";
+    public static final String TABLES_SKIP_WRONG_PATH = "hoodie.tableservice.skipNonHudiTable";
 
     public static final String COMMA_SEPARATOR = ",";
 
@@ -75,7 +75,7 @@ public class MultiTableServiceUtils {
               return true;
             } else {
               // Log the wrong path in console.
-              LOG.error("Hoodie table not found in path " + tablePath);
+              LOG.warn("Hoodie table not found in path {}, skip", tablePath);
               return false;
             }
           }).collect(Collectors.toList());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/multitable/MultiTableServiceUtils.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.TableNotFoundException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -81,6 +82,12 @@ public class MultiTableServiceUtils {
           }).collect(Collectors.toList());
     } else {
       tablePaths = Arrays.asList(tablesArray);
+      tablePaths.stream()
+          .filter(tablePath -> !isHoodieTable(new Path(tablePath), conf.get()))
+          .findFirst()
+          .ifPresent(tablePath -> {
+            throw new TableNotFoundException("Table not found: " + tablePath);
+          });
     }
     return tablePaths;
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -176,6 +176,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     cfg.autoDiscovery = false;
     cfg.batch = true;
     HoodieTableMetaClient metaClient1 = getMetaClient("table1");
+    cfg.configs.add(String.format("%s=%s", TABLES_SKIP_WRONG_PATH, "true"));
     cfg.configs.add(String.format("%s=%s", TABLES_TO_BE_SERVED_PROP, metaClient1.getBasePathV2() + ",file:///fakepath"));
     HoodieMultiTableServicesMain main = new HoodieMultiTableServicesMain(jsc, cfg);
     try {


### PR DESCRIPTION
…ed by table with wrong path.

### Change Logs

Filtering tables with incorrect paths in the multi table service.

The current multi table service supports executing table service for multiple tables by specifying them through `hoodie.tableservice.tablesToServe`. When an incorrect path is provided for a table or a table is deleted but the asynchronous table service is not yet aware of it, the current implementation causes the entire Spark job to fail, impacting the execution of other tables. It is expected that this should not impact the table service of other tables with correctly configured paths. The parameter `hoodie.tableservice.skip.wrong.path` is used to determine whether to ignore incorrect table path.

In order to address this issue, I will introduce a check to skip such cases and log the details of tables that do not conform to Hudi's requirements using `Log.error`.

A question for discussion: What kind of exceptions do you think should impact the table service of other tables in the same batch, and what kind should not? Alternatively, we can set a flag to choose whether to enable interference-free mode or not.

### Impact

None

### Risk level (write none, low medium or high below)

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
