### PR TITLE
[HUDI-6478] Deduce op as upsert for INSERT INTO

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi
 
+import org.apache.hudi.AutoRecordKeyGenerationUtils.shouldAutoGenerateRecordKeys
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieConversionUtils.toProperties
@@ -28,7 +29,6 @@ import org.apache.hudi.config.{HoodieIndexConfig, HoodieInternalConfig, HoodieWr
 import org.apache.hudi.hive.ddl.HiveSyncMode
 import org.apache.hudi.hive.{HiveSyncConfig, HiveSyncConfigHolder, MultiPartKeysValueExtractor}
 import org.apache.hudi.keygen.ComplexKeyGenerator
-import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 import org.apache.hudi.sql.InsertMode
 import org.apache.hudi.sync.common.HoodieSyncConfig
 import org.apache.spark.internal.Logging
@@ -96,7 +96,7 @@ trait ProvidesHoodieConfig extends Logging {
       // TODO use HoodieSparkValidateDuplicateKeyRecordMerger when SparkRecordMerger is default
       classOf[ValidateDuplicateKeyPayload].getCanonicalName
     } else if (operation == INSERT_OPERATION_OPT_VAL && tableType == COW_TABLE_TYPE_OPT_VAL &&
-      insertMode == InsertMode.STRICT){
+      insertMode == InsertMode.STRICT) {
       // Validate duplicate key for inserts to COW table when using strict insert mode.
       classOf[ValidateDuplicateKeyPayload].getCanonicalName
     } else {
@@ -108,11 +108,14 @@ trait ProvidesHoodieConfig extends Logging {
    * Deduce the sql write operation for INSERT_INTO
    */
   private def deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition: Boolean, isOverwriteTable: Boolean,
-                                                    sqlWriteOperation: String): String = {
+                                                     shouldAutoKeyGen: Boolean, preCombineField: String,
+                                                     sqlWriteOperation: String): String = {
     if (isOverwriteTable) {
       INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL
     } else if (isOverwritePartition) {
       INSERT_OVERWRITE_OPERATION_OPT_VAL
+    } else if (!shouldAutoKeyGen && preCombineField.nonEmpty) {
+      UPSERT_OPERATION_OPT_VAL
     } else {
       sqlWriteOperation
     }
@@ -145,7 +148,7 @@ trait ProvidesHoodieConfig extends Logging {
       // if table is pk table and has enableBulkInsert use bulk insert for non-strict mode.
       case (true, false, false, _, true, _, _) => BULK_INSERT_OPERATION_OPT_VAL
       // if auto record key generation is enabled, use bulk_insert
-      case (_, _, _, _, _,_,true) => BULK_INSERT_OPERATION_OPT_VAL
+      case (_, _, _, _, _, _, true) => BULK_INSERT_OPERATION_OPT_VAL
       // for the rest case, use the insert operation
       case _ => INSERT_OPERATION_OPT_VAL
     }
@@ -193,7 +196,7 @@ trait ProvidesHoodieConfig extends Logging {
       DataSourceWriteOptions.SQL_ENABLE_BULK_INSERT.defaultValue()).toBoolean
     val dropDuplicate = sparkSession.conf
       .getOption(INSERT_DROP_DUPS.key).getOrElse(INSERT_DROP_DUPS.defaultValue).toBoolean
-    val autoGenerateRecordKeys : Boolean = !combinedOpts.contains(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key());
+    val shouldAutoKeyGen: Boolean = shouldAutoGenerateRecordKeys(combinedOpts)
 
     val insertMode = InsertMode.of(combinedOpts.getOrElse(DataSourceWriteOptions.SQL_INSERT_MODE.key,
       DataSourceWriteOptions.SQL_INSERT_MODE.defaultValue()))
@@ -208,19 +211,22 @@ trait ProvidesHoodieConfig extends Logging {
     val isPartitionedTable = hoodieCatalogTable.partitionFields.nonEmpty
     val combineBeforeInsert = hoodieCatalogTable.preCombineKey.nonEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
 
-    // try to use sql write operation instead of legacy insert mode. If only insert mode is explicitly specified, w/o specifying
-    // any value for sql write operation, leagcy configs will be honored. But on all other cases (i.e when neither of the configs is set,
-    // or when both configs are set, or when only sql write operation is set), we honor sql write operation and ignore
-    // the insert mode.
+    /*
+     * The sql write operation has higher precedence than the legacy insert mode.
+     * Only when the legacy insert mode is explicitly set, without setting sql write operation,
+     * legacy configs will be honored. On all other cases (i.e when both are set, either is set,
+     * or when only the sql write operation is set), we honor the sql write operation.
+     */
     val useLegacyInsertModeFlow = insertModeSet && !sqlWriteOperationSet
     var operation = combinedOpts.getOrElse(OPERATION.key,
       if (useLegacyInsertModeFlow) {
         // NOTE: Target operation could be overridden by the user, therefore if it has been provided as an input
         //       we'd prefer that value over auto-deduced operation. Otherwise, we deduce target operation type
         deduceOperation(enableBulkInsert, isOverwritePartition, isOverwriteTable, dropDuplicate,
-          isNonStrictMode, isPartitionedTable, combineBeforeInsert, insertMode, autoGenerateRecordKeys)
+          isNonStrictMode, isPartitionedTable, combineBeforeInsert, insertMode, shouldAutoKeyGen)
       } else {
-        deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition, isOverwriteTable, sqlWriteOperation)
+        deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition, isOverwriteTable,
+          shouldAutoKeyGen, preCombineField, sqlWriteOperation)
       }
     )
 
@@ -254,7 +260,7 @@ trait ProvidesHoodieConfig extends Logging {
     // w/o specifying any value for insert dup policy, legacy configs will be honored. But on all other cases (i.e when neither of the configs is set,
     // or when both configs are set, or when only insert dup policy is set), we honor insert dup policy and ignore the insert mode.
     val useLegacyInsertDropDupFlow = insertModeSet && !insertDupPolicySet
-    val payloadClassName =  if (useLegacyInsertDropDupFlow) {
+    val payloadClassName = if (useLegacyInsertDropDupFlow) {
       deducePayloadClassNameLegacy(operation, tableType, insertMode)
     } else {
       if (insertDupPolicy == FAIL_INSERT_DUP_POLICY) {
@@ -304,7 +310,7 @@ trait ProvidesHoodieConfig extends Logging {
       defaultOpts = defaultOpts, overridingOpts = overridingOpts)
   }
 
-  def getDropDupsConfig(useLegacyInsertModeFlow: Boolean, incomingParams : Map[String, String]): Map[String, String] = {
+  def getDropDupsConfig(useLegacyInsertModeFlow: Boolean, incomingParams: Map[String, String]): Map[String, String] = {
     if (!useLegacyInsertModeFlow) {
       Map(DataSourceWriteOptions.INSERT_DUP_POLICY.key() -> incomingParams.getOrElse(DataSourceWriteOptions.INSERT_DUP_POLICY.key(),
         DataSourceWriteOptions.INSERT_DUP_POLICY.defaultValue()),

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -185,7 +185,7 @@ trait ProvidesHoodieConfig extends Logging {
     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
     // default value ("ts")
     // TODO(HUDI-3456) clean up
-    val preCombineField = hoodieCatalogTable.preCombineKey.getOrElse("")
+    val preCombineField = combinedOpts.getOrElse(PRECOMBINE_FIELD.key, "")
 
     val hiveStylePartitioningEnable = Option(tableConfig.getHiveStylePartitioningEnable).getOrElse("true")
     val urlEncodePartitioning = Option(tableConfig.getUrlEncodePartitioning).getOrElse("false")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -109,12 +109,12 @@ trait ProvidesHoodieConfig extends Logging {
    */
   private def deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition: Boolean, isOverwriteTable: Boolean,
                                                      shouldAutoKeyGen: Boolean, preCombineField: String,
-                                                     sqlWriteOperation: String): String = {
+                                                     sqlWriteOperationSet: Boolean, sqlWriteOperation: String): String = {
     if (isOverwriteTable) {
       INSERT_OVERWRITE_TABLE_OPERATION_OPT_VAL
     } else if (isOverwritePartition) {
       INSERT_OVERWRITE_OPERATION_OPT_VAL
-    } else if (!shouldAutoKeyGen && preCombineField.nonEmpty) {
+    } else if (!sqlWriteOperationSet && !shouldAutoKeyGen && preCombineField.nonEmpty) {
       UPSERT_OPERATION_OPT_VAL
     } else {
       sqlWriteOperation
@@ -226,7 +226,7 @@ trait ProvidesHoodieConfig extends Logging {
           isNonStrictMode, isPartitionedTable, combineBeforeInsert, insertMode, shouldAutoKeyGen)
       } else {
         deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition, isOverwriteTable,
-          shouldAutoKeyGen, preCombineField, sqlWriteOperation)
+          shouldAutoKeyGen, preCombineField, sqlWriteOperationSet, sqlWriteOperation)
       }
     )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestAlterTableDropPartition.scala
@@ -417,7 +417,6 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
         spark.sql(s"""insert into $tableName values (2, "l4", "v1", "2021", "10", "02")""")
 
         checkAnswer(s"select id, name, ts, year, month, day from $tableName")(
-          Seq(2, "l4", "v1", "2021", "10", "02"),
           Seq(2, "l4", "v1", "2021", "10", "02")
         )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestTimeTravelTable.scala
@@ -41,24 +41,24 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
              | location '${tmp.getCanonicalPath}/$tableName1'
        """.stripMargin)
 
+        // 1st commit instant
         spark.sql(s"insert into $tableName1 values(1, 'a1', 10, 1000)")
 
         val metaClient1 = HoodieTableMetaClient.builder()
           .setBasePath(s"${tmp.getCanonicalPath}/$tableName1")
           .setConf(spark.sessionState.newHadoopConf())
           .build()
-
         val instant1 = metaClient1.getActiveTimeline.getAllCommitsTimeline
           .lastInstant().get().getTimestamp
 
+        // 2nd commit instant
         spark.sql(s"insert into $tableName1 values(1, 'a2', 20, 2000)")
 
         checkAnswer(s"select id, name, price, ts from $tableName1")(
-          Seq(1, "a1", 10.0, 1000),
           Seq(1, "a2", 20.0, 2000)
         )
 
-        // time travel from instant1
+        // time travel as of instant 1
         checkAnswer(
           s"select id, name, price, ts from $tableName1 TIMESTAMP AS OF '$instant1'")(
           Seq(1, "a1", 10.0, 1000)
@@ -194,11 +194,6 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
             Seq(2, "a2", 20.0, 1000)
           )
 
-          checkAnswer(s"select id, name, price, ts from $tableName1")(
-            Seq(1, "a1", 10.0, 1000),
-            Seq(2, "a2", 20.0, 1000)
-          )
-
           spark.sql(s"insert into $tableName2 values(3, 'a3', 10, 1000)")
           spark.sql(s"insert into $tableName2 values(4, 'a4', 20, 1000)")
 
@@ -272,25 +267,26 @@ class TestTimeTravelTable extends HoodieSparkSqlTestBase {
              | location '${tmp.getCanonicalPath}/$tableName'
        """.stripMargin)
 
+        // 1st commit instant
         spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
 
         val metaClient = HoodieTableMetaClient.builder()
           .setBasePath(s"${tmp.getCanonicalPath}/$tableName")
           .setConf(spark.sessionState.newHadoopConf())
           .build()
-
-        val instant = metaClient.getActiveTimeline.getAllCommitsTimeline
+        val instant1 = metaClient.getActiveTimeline.getAllCommitsTimeline
           .lastInstant().get().getTimestamp
+
+        // 2nd commit instant
         spark.sql(s"insert into $tableName values(1, 'a2', 20, 2000)")
 
         checkAnswer(s"select id, name, price, ts from $tableName distribute by cast(rand() * 2 as int)")(
-          Seq(1, "a1", 10.0, 1000),
           Seq(1, "a2", 20.0, 2000)
         )
 
-        // time travel from instant
+        // time travel as of instant 1
         checkAnswer(
-          s"select id, name, price, ts from $tableName TIMESTAMP AS OF '$instant' distribute by cast(rand() * 2 as int)")(
+          s"select id, name, price, ts from $tableName TIMESTAMP AS OF '$instant1' distribute by cast(rand() * 2 as int)")(
           Seq(1, "a1", 10.0, 1000)
         )
       })


### PR DESCRIPTION
### Change Logs

When users explicitly defines primaryKey and preCombineField when `CREATE TABLE`, subsequent `INSERT INTO` will deduce the operation as `UPSERT`.

### Impact

Spark `INSERT INTO` semantics.

### Risk level

Medium

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
