### PR TITLE
[HUDI-6845] Upgrade org.apache.pulsar:pulsar-client to 2.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <fasterxml.jackson.dataformat.yaml.version>${fasterxml.spark3.version}</fasterxml.jackson.dataformat.yaml.version>
     <kafka.version>2.0.0</kafka.version>
     <kafka.spark3.version>2.8.0</kafka.spark3.version>
-    <pulsar.version>2.8.1</pulsar.version>
+    <pulsar.version>2.10.2</pulsar.version>
     <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
     <pulsar.spark.scala11.version>2.4.5</pulsar.spark.scala11.version>
     <pulsar.spark.scala12.version>3.1.1.4</pulsar.spark.scala12.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.pulsar:pulsar-client 2.8.1
- [CVE-2022-33684](https://www.oscs1024.com/hd/CVE-2022-33684)


### What did I do？
Upgrade org.apache.pulsar:pulsar-client from 2.8.1 to 2.10.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS