### PR TITLE
[HUDI-6846] fix a bug of consistent bucket index clustering

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIdentifier.java
@@ -115,6 +115,21 @@ public class ConsistentBucketIdentifier extends BucketIdentifier {
     return headMap.isEmpty() ? ring.lastEntry().getValue() : headMap.get(headMap.lastKey());
   }
 
+  /**
+   * Get the latter node of the given node (inferred from file id).
+   */
+  public ConsistentHashingNode getLatterBucket(String fileId) {
+    return getLatterBucket(getBucketByFileId(fileId).getValue());
+  }
+
+  /**
+   * Get the latter node of the given node (inferred from hash value).
+   */
+  public ConsistentHashingNode getLatterBucket(int hashValue) {
+    SortedMap<Integer, ConsistentHashingNode> tailMap = ring.tailMap(hashValue);
+    return tailMap.isEmpty() ? ring.firstEntry().getValue() : tailMap.get(tailMap.firstKey());
+  }
+
   public List<ConsistentHashingNode> mergeBucket(List<String> fileIds) {
     ValidationUtils.checkArgument(fileIds.size() >= 2, "At least two file groups should be provided for merging");
     // Get nodes using fileIds

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkConsistentBucketClusteringPlanStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/clustering/plan/strategy/TestSparkConsistentBucketClusteringPlanStrategy.java
@@ -169,6 +169,19 @@ public class TestSparkConsistentBucketClusteringPlanStrategy extends HoodieSpark
     Assertions.assertEquals(ConsistentHashingNode.NodeTag.DELETE, nodes.get(0).getTag());
     Assertions.assertEquals(ConsistentHashingNode.NodeTag.REPLACE, nodes.get(1).getTag());
     Assertions.assertEquals(metadata.getNodes().get(3).getValue(), nodes.get(1).getValue());
+
+    HoodieConsistentHashingMetadata metadata1 = new HoodieConsistentHashingMetadata("partition", 3);
+    ConsistentBucketIdentifier identifier1 = new ConsistentBucketIdentifier(metadata1);
+
+    int[] fsSize1 = {mergeSize / 4, maxFileSize, mergeSize / 4};
+    List<FileSlice> fileSlices1 = IntStream.range(0, metadata1.getNodes().size()).mapToObj(
+        i -> createFileSliceWithSize(metadata1.getNodes().get(i).getFileIdPrefix(), fsSize1[i] / 2, fsSize1[i] / 2)
+    ).collect(Collectors.toList());
+
+    Triple<List<HoodieClusteringGroup>, Integer, List<FileSlice>> res1 = planStrategy.buildMergeClusteringGroup(identifier1,
+        fileSlices1.stream().filter(fs -> fs.getTotalFileSize() < mergeSize).collect(Collectors.toList()), 4);
+    Assertions.assertEquals(1, res1.getLeft().size());
+    Assertions.assertEquals(2, res1.getLeft().get(0).getSlices().size());
   }
 
   private FileSlice createFileSliceWithSize(String fileIdPfx, long baseFileSize, long totalLogFileSize) {


### PR DESCRIPTION
### Change Logs

 fix a bug of clustering when using ConsistentBucketClusteringPlanStrategy.

current logic have bug when building merge clustering grouop.

more detail see [HUDI-6846](https://issues.apache.org/jira/projects/HUDI/issues/HUDI-6846?filter=allissues)

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
