### PR TITLE
[HUDI-6848] Fix non-unique uid for hudi operators

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -73,12 +73,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
  * Utilities to generate all kinds of sub-pipelines.
  */
 public class Pipelines {
+
+  // The counter of operators, avoiding duplicate uids caused by the same operator
+  private static final ConcurrentHashMap<String,Integer> OPERATOR_COUNTERS = new ConcurrentHashMap<>();
 
   /**
    * Bulk insert the input dataset at once.
@@ -482,7 +486,8 @@ public class Pipelines {
   }
 
   public static String opUID(String operatorN, Configuration conf) {
-    return "uid_" + operatorN + "_" + getTablePath(conf);
+    Integer operatorCount = OPERATOR_COUNTERS.merge(operatorN, 1, (oldValue, value) -> oldValue + value);
+    return "uid_" + operatorN + (operatorCount == 1 ? "" : "_" + (operatorCount - 1)) + "_" + getTablePath(conf);
   }
 
   public static String getTablePath(Configuration conf) {


### PR DESCRIPTION
### Change Logs


If multiple source operators in flink task belong to the same table, it will cause duplicate uids.

![image](https://github.com/apache/hudi/assets/34104400/6abe767f-8af8-4da9-9994-d789f7e7873f)


![image](https://github.com/apache/hudi/assets/34104400/615d7e29-aa8f-4722-9eb0-fbc597a1935b)


### Impact

bug fix

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
