### PR TITLE
[HUDI-6847] Improve the incremental clean fallback logic

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -63,7 +63,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.client.utils.MetadataTableUtils.shouldUseBatchLookup;
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 
 /**
  * Cleaner is responsible for garbage collecting older files in a given partition path. Such that
@@ -195,7 +194,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
     return hoodieTable.getCompletedCommitsTimeline().getInstantsAsStream().filter(
         instant -> HoodieTimeline.compareTimestamps(instant.getTimestamp(), HoodieTimeline.GREATER_THAN_OR_EQUALS,
             cleanMetadata.getEarliestCommitToRetain()) && HoodieTimeline.compareTimestamps(instant.getTimestamp(),
-            LESSER_THAN, newInstantToRetain.get().getTimestamp())).flatMap(instant -> {
+            HoodieTimeline.LESSER_THAN, newInstantToRetain.get().getTimestamp())).flatMap(instant -> {
               try {
                 if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())) {
                   HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.client.utils.MetadataTableUtils.shouldUseBatchLookup;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.LESSER_THAN;
 
 /**
  * Cleaner is responsible for garbage collecting older files in a given partition path. Such that
@@ -171,7 +172,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
                   .deserializeHoodieCleanMetadata(hoodieTable.getActiveTimeline().getInstantDetails(lastClean.get()).get());
           if ((cleanMetadata.getEarliestCommitToRetain() != null)
                   && (cleanMetadata.getEarliestCommitToRetain().length() > 0)
-                  && !hoodieTable.getActiveTimeline().isBeforeTimelineStarts(cleanMetadata.getEarliestCommitToRetain())) {
+                  && !hoodieTable.getActiveTimeline().getCommitsTimeline().isBeforeTimelineStarts(cleanMetadata.getEarliestCommitToRetain())) {
             return getPartitionPathsForIncrementalCleaning(cleanMetadata, instantToRetain);
           }
         }
@@ -194,7 +195,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
     return hoodieTable.getCompletedCommitsTimeline().getInstantsAsStream().filter(
         instant -> HoodieTimeline.compareTimestamps(instant.getTimestamp(), HoodieTimeline.GREATER_THAN_OR_EQUALS,
             cleanMetadata.getEarliestCommitToRetain()) && HoodieTimeline.compareTimestamps(instant.getTimestamp(),
-            HoodieTimeline.LESSER_THAN, newInstantToRetain.get().getTimestamp())).flatMap(instant -> {
+            LESSER_THAN, newInstantToRetain.get().getTimestamp())).flatMap(instant -> {
               try {
                 if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(instant.getAction())) {
                   HoodieReplaceCommitMetadata replaceCommitMetadata = HoodieReplaceCommitMetadata.fromBytes(

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -1124,15 +1124,16 @@ public class TestCleaner extends HoodieCleanerTestBase {
         put(p1, CollectionUtils.createImmutableList(file1P1, file2P1));
       }
     });
-    commitWithMdt("1", part1ToFileId, testTable, metadataWriter);
-    commitWithMdt("2", part1ToFileId, testTable, metadataWriter);
+    commitWithMdt("10", part1ToFileId, testTable, metadataWriter);
+    testTable.addClean("15");
+    commitWithMdt("20", part1ToFileId, testTable, metadataWriter);
 
     // add clean instant
     HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan(new HoodieActionInstant("", "", ""),
         "", "", new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>(), new ArrayList<>());
     HoodieCleanMetadata cleanMeta = new HoodieCleanMetadata("", 0L, 0,
-        "2", "", new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>());
-    testTable.addClean("3", cleanerPlan, cleanMeta);
+        "20", "", new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>());
+    testTable.addClean("30", cleanerPlan, cleanMeta);
 
     // add file in partition "part_2"
     String file3P2 = UUID.randomUUID().toString();
@@ -1142,8 +1143,8 @@ public class TestCleaner extends HoodieCleanerTestBase {
         put(p2, CollectionUtils.createImmutableList(file3P2, file4P2));
       }
     });
-    commitWithMdt("3", part2ToFileId, testTable, metadataWriter);
-    commitWithMdt("4", part2ToFileId, testTable, metadataWriter);
+    commitWithMdt("30", part2ToFileId, testTable, metadataWriter);
+    commitWithMdt("40", part2ToFileId, testTable, metadataWriter);
 
     // empty commits
     String file5P2 = UUID.randomUUID().toString();
@@ -1153,25 +1154,25 @@ public class TestCleaner extends HoodieCleanerTestBase {
         put(p2, CollectionUtils.createImmutableList(file5P2, file6P2));
       }
     });
-    commitWithMdt("5", part2ToFileId, testTable, metadataWriter);
-    commitWithMdt("6", part2ToFileId, testTable, metadataWriter);
+    commitWithMdt("50", part2ToFileId, testTable, metadataWriter);
+    commitWithMdt("60", part2ToFileId, testTable, metadataWriter);
 
     // archive commit 1, 2
     new HoodieTimelineArchiver<>(config, HoodieSparkTable.create(config, context, metaClient))
         .archiveIfRequired(context, false);
     metaClient = HoodieTableMetaClient.reload(metaClient);
-    assertFalse(metaClient.getActiveTimeline().containsInstant("1"));
-    assertFalse(metaClient.getActiveTimeline().containsInstant("2"));
+    assertFalse(metaClient.getActiveTimeline().containsInstant("10"));
+    assertFalse(metaClient.getActiveTimeline().containsInstant("20"));
 
     runCleaner(config);
-    assertFalse(testTable.baseFileExists(p1, "1", file1P1), "Clean old FileSlice in p1 by fallback to full clean");
-    assertFalse(testTable.baseFileExists(p1, "1", file2P1), "Clean old FileSlice in p1 by fallback to full clean");
-    assertFalse(testTable.baseFileExists(p2, "3", file3P2), "Clean old FileSlice in p2");
-    assertFalse(testTable.baseFileExists(p2, "3", file4P2), "Clean old FileSlice in p2");
-    assertTrue(testTable.baseFileExists(p1, "2", file1P1), "Latest FileSlice exists");
-    assertTrue(testTable.baseFileExists(p1, "2", file2P1), "Latest FileSlice exists");
-    assertTrue(testTable.baseFileExists(p2, "4", file3P2), "Latest FileSlice exists");
-    assertTrue(testTable.baseFileExists(p2, "4", file4P2), "Latest FileSlice exists");
+    assertFalse(testTable.baseFileExists(p1, "10", file1P1), "Clean old FileSlice in p1 by fallback to full clean");
+    assertFalse(testTable.baseFileExists(p1, "10", file2P1), "Clean old FileSlice in p1 by fallback to full clean");
+    assertFalse(testTable.baseFileExists(p2, "30", file3P2), "Clean old FileSlice in p2");
+    assertFalse(testTable.baseFileExists(p2, "30", file4P2), "Clean old FileSlice in p2");
+    assertTrue(testTable.baseFileExists(p1, "20", file1P1), "Latest FileSlice exists");
+    assertTrue(testTable.baseFileExists(p1, "20", file2P1), "Latest FileSlice exists");
+    assertTrue(testTable.baseFileExists(p2, "40", file3P2), "Latest FileSlice exists");
+    assertTrue(testTable.baseFileExists(p2, "40", file4P2), "Latest FileSlice exists");
   }
 
   /**


### PR DESCRIPTION
### Change Logs

current incremental clean include clean instants when deciding if should fallback to full clean. This pr change to only include commits instants only, because incremental clean only use commits instants to decide which partition should clean.

### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
