### PR TITLE
[MINOR] Add timeout for github check test-hudi-hadoop-mr-and-hudi-java-client

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -114,6 +114,7 @@ jobs:
 
   test-hudi-hadoop-mr-and-hudi-java-client:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         include:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -16,7 +16,6 @@ on:
       - '**.png'
       - '**.svg'
       - '**.yaml'
-      - '**.yml'
       - '.gitignore'
     branches:
       - master


### PR DESCRIPTION
### Change Logs

Adds 40 minute timeout for github check test-hudi-hadoop-mr-and-hudi-java-client

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
