### PR TITLE
[MINOR] Avoiding warn log for succeeding in first attempt

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -130,7 +130,9 @@ object HoodieSparkSqlWriter {
     while (counter <= maxRetry && !succeeded) {
       try {
         toReturn = writeInternal(sqlContext, mode, optParams, sourceDf, streamingWritesParamsOpt, hoodieWriteClient)
-        log.warn(s"Succeeded with attempt no $counter")
+        if ( counter > 0) {
+          log.warn(s"Succeeded with attempt no $counter")
+        }
         succeeded = true
       } catch {
         case e: HoodieWriteConflictException =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -130,7 +130,7 @@ object HoodieSparkSqlWriter {
     while (counter <= maxRetry && !succeeded) {
       try {
         toReturn = writeInternal(sqlContext, mode, optParams, sourceDf, streamingWritesParamsOpt, hoodieWriteClient)
-        if ( counter > 0) {
+        if (counter > 0) {
           log.warn(s"Succeeded with attempt no $counter")
         }
         succeeded = true


### PR DESCRIPTION
### Change Logs

Avoiding warn log for succeeding in first attempt

### Impact

Avoiding warn log for succeeding in first attempt

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
