### PR TITLE
fix(sec): upgrade org.glassfish:jakarta.el to 3.0.4

### DIFF
--- a/packaging/hudi-cli-bundle/pom.xml
+++ b/packaging/hudi-cli-bundle/pom.xml
@@ -31,7 +31,7 @@
     <main.basedir>${project.parent.basedir}</main.basedir>
     <skipTests>true</skipTests>
     <!-- jakarta and jline version chosen based on hibernate validator https://mvnrepository.com/artifact/org.hibernate.validator/hibernate-validator/6.2.4.Final -->
-    <jakarta.el.version>3.0.3</jakarta.el.version>
+    <jakarta.el.version>3.0.4</jakarta.el.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jline.version>3.21.0</jline.version>
     <hudi.cli.gson.version>2.6.2</hudi.cli.gson.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.glassfish:jakarta.el 3.0.3
- [CVE-2021-28170](https://www.oscs1024.com/hd/CVE-2021-28170)


### What did I do？
Upgrade org.glassfish:jakarta.el from 3.0.3 to 3.0.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS