### PR TITLE
[HUDI-6858] Fix checkpoint reading in Spark structured streaming

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCommitUtils.java
@@ -18,20 +18,37 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieCompactionStrategy;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_SCHEMA;
+import static org.apache.hudi.common.util.CommitUtils.getCheckpointValueAsString;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,6 +57,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests {@link CommitUtils}.
  */
 public class TestCommitUtils {
+  private static final String SINK_CHECKPOINT_KEY = "_hudi_streaming_sink_checkpoint";
+  private static final String ID1 = "id1";
+  private static final String ID2 = "id2";
+  private static final String ID3 = "id3";
+  @TempDir
+  public java.nio.file.Path tempDir;
 
   @Test
   public void testCommitMetadataCreation() {
@@ -78,7 +101,7 @@ public class TestCommitUtils {
         Option.empty(),
         WriteOperationType.INSERT,
         TRIP_SCHEMA,
-        HoodieTimeline.REPLACE_COMMIT_ACTION);
+        REPLACE_COMMIT_ACTION);
 
     assertTrue(commitMetadata instanceof HoodieReplaceCommitMetadata);
     HoodieReplaceCommitMetadata replaceCommitMetadata = (HoodieReplaceCommitMetadata) commitMetadata;
@@ -91,10 +114,103 @@ public class TestCommitUtils {
     assertEquals(TRIP_SCHEMA, commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY));
   }
 
+  @Test
+  public void testGetValidCheckpointForCurrentWriter() throws IOException {
+    java.nio.file.Path basePath = tempDir.resolve("dataset");
+    java.nio.file.Files.createDirectories(basePath);
+    String basePathStr = basePath.toAbsolutePath().toString();
+    HoodieTableMetaClient metaClient =
+        HoodieTestUtils.init(basePathStr, HoodieTableType.MERGE_ON_READ);
+    HoodieActiveTimeline timeline = new HoodieActiveTimeline(metaClient);
+
+    // Deltacommit 1 completed: (id1, 3)
+    addDeltaCommit(timeline, "20230913001000000", ID1, "3", true);
+    // Deltacommit 2 completed: (id2, 4)
+    addDeltaCommit(timeline, "20230913002000000", ID2, "4", true);
+    // Deltacommit 3 completed: (id1, 5)
+    addDeltaCommit(timeline, "20230913003000000", ID1, "5", true);
+    // Request compaction:
+    addRequestedCompaction(timeline, "20230913003800000");
+    // Deltacommit 4 completed: (id2, 6)
+    addDeltaCommit(timeline, "20230913004000000", ID2, "6", true);
+    // Requested replacecommit (clustering):
+    addRequestedReplaceCommit(timeline, "20230913004800000");
+    // Deltacommit 5 inflight: (id2, 7)
+    addDeltaCommit(timeline, "20230913005000000", ID2, "7", false);
+    // Commit 6 completed without checkpoints (e.g., compaction that does not affect checkpointing)
+    addCommit(timeline, "20230913006000000");
+
+    timeline = timeline.reload();
+    assertEquals(Option.of("5"), CommitUtils.getValidCheckpointForCurrentWriter(timeline, SINK_CHECKPOINT_KEY, ID1));
+    assertEquals(Option.of("6"), CommitUtils.getValidCheckpointForCurrentWriter(timeline, SINK_CHECKPOINT_KEY, ID2));
+    assertEquals(Option.empty(), CommitUtils.getValidCheckpointForCurrentWriter(timeline, SINK_CHECKPOINT_KEY, ID3));
+  }
+
   private HoodieWriteStat createWriteStat(String partition, String fileId) {
     HoodieWriteStat writeStat1 = new HoodieWriteStat();
     writeStat1.setPartitionPath(partition);
     writeStat1.setFileId(fileId);
     return writeStat1;
+  }
+
+  private void addDeltaCommit(HoodieActiveTimeline timeline,
+                              String ts, String id, String batchId,
+                              boolean isCompleted) throws IOException {
+    HoodieInstant instant = new HoodieInstant(
+        HoodieInstant.State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, ts);
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UPSERT);
+    commitMetadata.addMetadata(SINK_CHECKPOINT_KEY,
+        getCheckpointValueAsString(id, batchId));
+    timeline.createNewInstant(instant);
+    timeline.transitionRequestedToInflight(
+        instant, Option.of(getUTF8Bytes(commitMetadata.toJsonString())));
+    if (isCompleted) {
+      timeline.saveAsComplete(new HoodieInstant(
+              true, instant.getAction(), instant.getTimestamp()),
+          Option.of(getUTF8Bytes(commitMetadata.toJsonString())));
+    }
+  }
+
+  private void addCommit(HoodieActiveTimeline timeline,
+                         String ts) throws IOException {
+    HoodieInstant instant = new HoodieInstant(
+        HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, ts);
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.COMPACT);
+    timeline.createNewInstant(instant);
+    timeline.transitionRequestedToInflight(
+        instant, Option.of(getUTF8Bytes(commitMetadata.toJsonString())));
+    timeline.saveAsComplete(new HoodieInstant(
+            true, instant.getAction(), instant.getTimestamp()),
+        Option.of(getUTF8Bytes(commitMetadata.toJsonString())));
+  }
+
+  private void addRequestedCompaction(HoodieActiveTimeline timeline,
+                                      String ts) throws IOException {
+    HoodieCompactionPlan compactionPlan = HoodieCompactionPlan.newBuilder()
+        .setOperations(Collections.emptyList())
+        .setVersion(CompactionUtils.LATEST_COMPACTION_METADATA_VERSION)
+        .setStrategy(HoodieCompactionStrategy.newBuilder().build())
+        .setPreserveHoodieMetadata(true)
+        .build();
+    timeline.saveToCompactionRequested(
+        new HoodieInstant(HoodieInstant.State.REQUESTED, COMPACTION_ACTION, ts),
+        TimelineMetadataUtils.serializeCompactionPlan(compactionPlan)
+    );
+  }
+
+  private void addRequestedReplaceCommit(HoodieActiveTimeline timeline,
+                                         String ts) throws IOException {
+    HoodieRequestedReplaceMetadata requestedReplaceMetadata =
+        HoodieRequestedReplaceMetadata.newBuilder()
+            .setOperationType(WriteOperationType.CLUSTER.name())
+            .setExtraMetadata(Collections.emptyMap())
+            .setClusteringPlan(new HoodieClusteringPlan())
+            .build();
+    timeline.saveToPendingReplaceCommit(
+        new HoodieInstant(HoodieInstant.State.REQUESTED, REPLACE_COMMIT_ACTION, ts),
+        TimelineMetadataUtils.serializeRequestedReplaceMetadata(requestedReplaceMetadata)
+    );
   }
 }


### PR DESCRIPTION
### Change Logs

This PR fixes the checkpoint reading in Hudi streaming sink in Spark structured streaming.  The fix avoids reading the requested compaction or clustering plan which is serialized in Avro, causing the deserialization to fail and only scan the commit metadata of completed commits, which are serialized in JSON. Without the fix, the Avro serialized plan throws exceptions (see below).  A new test is added to validate the correctness of reading checkpoint for Hudi streaming sink in Spark structured streaming.

```
org.apache.hudi.exception.HoodieIOException: Failed to parse HoodieCommitMetadata for [==>20230913003800000__compaction__REQUESTED__20230913155321000]

	at org.apache.hudi.common.util.CommitUtils.lambda$getValidCheckpointForCurrentWriter$3(CommitUtils.java:180)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
...
Caused by: java.io.IOException: unable to read commit metadata
	at org.apache.hudi.common.model.HoodieCommitMetadata.fromBytes(HoodieCommitMetadata.java:514)
	at org.apache.hudi.common.util.CommitUtils.lambda$getValidCheckpointForCurrentWriter$3(CommitUtils.java:170)
	... 77 more
Caused by: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'Objavro': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"Obj\u0001\u0002\u0016avro.schema� {"type":"record","name":"HoodieCompactionPlan","namespace":"org.apache.hudi.avro.model","fields":[{"name":"operations","type":["null",{"type":"array","items":{"type":"record","name":"HoodieCompactionOperation","fields":[{"name":"baseInstantTime","type":["null",{"type":"string","avro.java.string":"String"}]},{"name":"deltaFilePaths","type":["null",{"type":"array","items":{"type":"string","avro.java.string":"String"}}],"default":null},{"name":"dataFilePath","type":["null",{"type"[truncated 1614 chars]; line: 1, column: 11]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2391)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:745)
```
```
org.apache.hudi.exception.HoodieIOException: Failed to parse HoodieCommitMetadata for [==>20230913004800000__replacecommit__REQUESTED__20230913155245000]
	at org.apache.hudi.common.util.CommitUtils.lambda$getValidCheckpointForCurrentWriter$3(CommitUtils.java:180)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
Caused by: java.io.IOException: unable to read commit metadata
	at org.apache.hudi.common.model.HoodieCommitMetadata.fromBytes(HoodieCommitMetadata.java:514)
	at org.apache.hudi.common.util.CommitUtils.lambda$getValidCheckpointForCurrentWriter$3(CommitUtils.java:170)
	... 77 more
Caused by: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'Objavro': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"Obj\u0001\u0002\u0016avro.schema�&{"type":"record","name":"HoodieRequestedReplaceMetadata","namespace":"org.apache.hudi.avro.model","fields":[{"name":"operationType","type":["null",{"type":"string","avro.java.string":"String"}],"default":null},{"name":"clusteringPlan","type":["null",{"type":"record","name":"HoodieClusteringPlan","fields":[{"name":"inputGroups","type":["null",{"type":"array","items":{"type":"record","name":"HoodieClusteringGroup","fields":[{"name":"slices","type":["null",{"type":"array","items""[truncated 2037 chars]; line: 1, column: 11]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2391)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:745)
```

### Impact

Bug fix

### Risk level

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
