### PR TITLE
[HUDI-6865] Fix InternalSchema schemaId when column is dropped

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/InternalSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/InternalSchema.java
@@ -158,12 +158,12 @@ public class InternalSchema implements Serializable {
   }
 
   /**
-   * Returns the {@link Type} of a sub-field identified by the field name.
+   * Returns the fully qualified name of the field corresponding to the given id.
    *
    * @param id a field id
-   * @return fullName of field of
+   * @return full name of field corresponding to id
    */
-  public String findfullName(int id) {
+  public String findFullName(int id) {
     if (idToName == null) {
       buildIdToName();
     }
@@ -272,8 +272,7 @@ public class InternalSchema implements Serializable {
   public String toString() {
     return String.format("table {\n%s\n}",
         StringUtils.join(record.fields().stream()
-            .map(f -> " " + f)
-            .collect(Collectors.toList()).toArray(new String[0]), "\n"));
+            .map(f -> " " + f).toArray(String[]::new), "\n"));
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/action/InternalSchemaMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/action/InternalSchemaMerger.java
@@ -116,9 +116,9 @@ public class InternalSchemaMerger {
       Type newType = newTypes.get(i);
       Types.Field oldField = oldFields.get(i);
       int fieldId = oldField.fieldId();
-      String fullName = querySchema.findfullName(fieldId);
+      String fullName = querySchema.findFullName(fieldId);
       if (fileSchema.findField(fieldId) != null) {
-        if (fileSchema.findfullName(fieldId).equals(fullName)) {
+        if (fileSchema.findFullName(fieldId).equals(fullName)) {
           // maybe col type changed, deal with it.
           newFields.add(Types.Field.get(oldField.fieldId(), oldField.isOptional(), oldField.name(), newType, oldField.doc()));
         } else {
@@ -173,7 +173,7 @@ public class InternalSchemaMerger {
       }
       String parentName = sb.toString();
       int parentFieldIdFromQuerySchema = querySchema.findIdByName(parentName);
-      String parentNameFromFileSchema = fileSchema.findfullName(parentFieldIdFromQuerySchema);
+      String parentNameFromFileSchema = fileSchema.findFullName(parentFieldIdFromQuerySchema);
       if (parentNameFromFileSchema.isEmpty()) {
         break;
       }

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/InternalSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/InternalSchemaUtils.java
@@ -184,13 +184,13 @@ public class InternalSchemaUtils {
       // the read file does not contain current col, so current colFilter is invalid
       return "";
     } else {
-      if (name.equals(fileSchema.findfullName(nameId))) {
+      if (name.equals(fileSchema.findFullName(nameId))) {
         // no change happened on current col
         return name;
       } else {
         // find rename operation on current col
         // return the name from fileSchema
-        return fileSchema.findfullName(nameId);
+        return fileSchema.findFullName(nameId);
       }
     }
   }
@@ -210,8 +210,8 @@ public class InternalSchemaUtils {
     Map<Integer, Pair<Type, Type>> result = new HashMap<>();
     ids.stream().filter(f -> otherIds.contains(f)).forEach(f -> {
       if (!schema.findType(f).equals(oldSchema.findType(f))) {
-        String[] fieldNameParts = schema.findfullName(f).split("\\.");
-        String[] otherFieldNameParts = oldSchema.findfullName(f).split("\\.");
+        String[] fieldNameParts = schema.findFullName(f).split("\\.");
+        String[] otherFieldNameParts = oldSchema.findFullName(f).split("\\.");
         String parentName = fieldNameParts[0];
         String otherParentName = otherFieldNameParts[0];
         if (fieldNameParts.length == otherFieldNameParts.length && schema.findIdByName(parentName) == oldSchema.findIdByName(otherParentName)) {
@@ -280,8 +280,8 @@ public class InternalSchemaUtils {
     return colNamesFromWriteSchema.stream().filter(f -> {
       int fieldIdFromWriteSchema = oldSchema.findIdByName(f);
       // try to find the cols which has the same id, but have different colName;
-      return newSchema.getAllIds().contains(fieldIdFromWriteSchema) && !newSchema.findfullName(fieldIdFromWriteSchema).equalsIgnoreCase(f);
-    }).collect(Collectors.toMap(e -> newSchema.findfullName(oldSchema.findIdByName(e)), e -> {
+      return newSchema.getAllIds().contains(fieldIdFromWriteSchema) && !newSchema.findFullName(fieldIdFromWriteSchema).equalsIgnoreCase(f);
+    }).collect(Collectors.toMap(e -> newSchema.findFullName(oldSchema.findIdByName(e)), e -> {
       int lastDotIndex = e.lastIndexOf(".");
       return e.substring(lastDotIndex == -1 ? 0 : lastDotIndex + 1);
     }));

--- a/hudi-common/src/test/java/org/apache/hudi/internal/schema/action/TestMergeSchema.java
+++ b/hudi-common/src/test/java/org/apache/hudi/internal/schema/action/TestMergeSchema.java
@@ -22,10 +22,11 @@ import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.Types;
 import org.apache.hudi.internal.schema.utils.SchemaChangeUtils;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests {@link InternalSchemaMerger}.
@@ -34,11 +35,11 @@ public class TestMergeSchema {
 
   @Test
   public void testPrimitiveMerge() {
-    Types.RecordType record = Types.RecordType.get(Arrays.asList(new Types.Field[] {
+    Types.RecordType record = Types.RecordType.get(Arrays.asList(
         Types.Field.get(0, "col1", Types.BooleanType.get()),
         Types.Field.get(1, "col2", Types.IntType.get()),
         Types.Field.get(2, "col3", Types.LongType.get()),
-        Types.Field.get(3, "col4", Types.FloatType.get())}));
+        Types.Field.get(3, "col4", Types.FloatType.get())));
 
     InternalSchema oldSchema = new InternalSchema(record);
     // add c1 after 'col1', and c2 before 'col3'
@@ -52,6 +53,7 @@ public class TestMergeSchema {
     deleteChange.deleteColumn("col1");
     deleteChange.deleteColumn("col3");
     InternalSchema newDeleteSchema = SchemaChangeUtils.applyTableChanges2Schema(newAddSchema, deleteChange);
+    assertEquals(newAddSchema.getMaxColumnId(), newDeleteSchema.getMaxColumnId());
 
     TableChanges.ColumnUpdateChange updateChange = TableChanges.ColumnUpdateChange.get(newDeleteSchema);
     updateChange.updateColumnType("col2", Types.LongType.get())
@@ -67,25 +69,23 @@ public class TestMergeSchema {
     // merge schema by using columnType from query schema
     InternalSchema mergeSchema = new InternalSchemaMerger(oldSchema, finalSchema, true, false).mergeSchema();
 
-    InternalSchema checkedSchema = new InternalSchema(Types.RecordType.get(Arrays.asList(new Types.Field[] {
-            Types.Field.get(4, true, "c1", Types.BooleanType.get(), "add c1 after col1"),
-            Types.Field.get(5, true, "c2", Types.IntType.get(), "add c2 before col3"),
-            Types.Field.get(3, true, "col4", Types.FloatType.get()),
-            Types.Field.get(1, true, "col2", Types.LongType.get(), "alter col2 comments"),
-            Types.Field.get(6, true, "col1suffix", Types.BooleanType.get(), "add new col1")
-        })));
-    Assertions.assertEquals(mergeSchema, checkedSchema);
+    InternalSchema checkedSchema = new InternalSchema(Types.RecordType.get(Arrays.asList(
+        Types.Field.get(4, true, "c1", Types.BooleanType.get(), "add c1 after col1"),
+        Types.Field.get(5, true, "c2", Types.IntType.get(), "add c2 before col3"),
+        Types.Field.get(3, true, "col4", Types.FloatType.get()),
+        Types.Field.get(1, true, "col2", Types.LongType.get(), "alter col2 comments"),
+        Types.Field.get(6, true, "col1suffix", Types.BooleanType.get(), "add new col1"))));
+    assertEquals(mergeSchema, checkedSchema);
 
     // merge schema by using columnType from file schema
     InternalSchema mergeSchema1 = new InternalSchemaMerger(oldSchema, finalSchema, true, true).mergeSchema();
-    InternalSchema checkedSchema1 = new InternalSchema(Types.RecordType.get(Arrays.asList(new Types.Field[] {
-            Types.Field.get(4, true, "c1", Types.BooleanType.get(), "add c1 after col1"),
-            Types.Field.get(5, true, "c2", Types.IntType.get(), "add c2 before col3"),
-            Types.Field.get(3, true, "col4", Types.FloatType.get()),
-            Types.Field.get(1, true, "col2", Types.IntType.get(), "alter col2 comments"),
-            Types.Field.get(6, true, "col1suffix", Types.BooleanType.get(), "add new col1")
-        })));
-    Assertions.assertEquals(mergeSchema1, checkedSchema1);
+    InternalSchema checkedSchema1 = new InternalSchema(Types.RecordType.get(Arrays.asList(
+        Types.Field.get(4, true, "c1", Types.BooleanType.get(), "add c1 after col1"),
+        Types.Field.get(5, true, "c2", Types.IntType.get(), "add c2 before col3"),
+        Types.Field.get(3, true, "col4", Types.FloatType.get()),
+        Types.Field.get(1, true, "col2", Types.IntType.get(), "alter col2 comments"),
+        Types.Field.get(6, true, "col1suffix", Types.BooleanType.get(), "add new col1"))));
+    assertEquals(mergeSchema1, checkedSchema1);
   }
 }
 


### PR DESCRIPTION
### Change Logs

When schema on read is enabled and user drops a column, then the commit goes through and column is dropped but `schemaId` is incorrecty set to `maxColumnId`. This is a bug. Firstly, drop column is a delete action which should not change the `maxColumnId`. Secondly, `schemaId` must always map to the commit time producing the schema change otherwise it breaks on the reader side or subsequent writes when schema on read is enabled.

### Impact

Bug fix.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
