### PR TITLE
[HUDI-6870] Pass project ID to BigQuery job

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.gcp.bigquery.BigQuerySyncConfig.BIGQUERY_SYNC_DATASET_LOCATION;

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -118,11 +118,8 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
       QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)
           .setUseLegacySql(false)
           .build();
-      JobId jobId = JobId.of(UUID.randomUUID().toString());
-      Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig)
-                             .setJobId(jobId)
-                             .build()
-                             .setProjectId(projectId));
+      JobId jobId = JobId.newBuilder().setProject(projectId).setRandomJob().build();
+      Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
 
       queryJob = queryJob.waitFor();
 

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -119,7 +119,10 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
           .setUseLegacySql(false)
           .build();
       JobId jobId = JobId.of(UUID.randomUUID().toString());
-      Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
+      Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig)
+                             .setProjectId(projectId)
+                             .setJobId(jobId)
+                             .build());
 
       queryJob = queryJob.waitFor();
 

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/HoodieBigQuerySyncClient.java
@@ -120,9 +120,9 @@ public class HoodieBigQuerySyncClient extends HoodieSyncClient {
           .build();
       JobId jobId = JobId.of(UUID.randomUUID().toString());
       Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig)
-                             .setProjectId(projectId)
                              .setJobId(jobId)
-                             .build());
+                             .build()
+                             .setProjectId(projectId));
 
       queryJob = queryJob.waitFor();
 


### PR DESCRIPTION
### Change Logs

Use the project ID for the table when running the job.

### Impact

This will requires users have permissions to run jobs in the target project that they are creating the table in.

### Risk level (write none, low medium or high below)

Low, this feature is not yet released, and in general has relatively low usage.

### Documentation Update

N/A

### Contributor's checklist

- [ X ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ X ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
