### PR TITLE
[HUDI-6871] BigQuery sync improvements

### DIFF
--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySchemaResolver.java
@@ -92,9 +92,9 @@ class BigQuerySchemaResolver {
       }
       String name = field.getName();
       if (field.getMode() == Field.Mode.REPEATED) {
-        return String.format("%s ARRAY<%s>", name, type);
+        return String.format("`%s` ARRAY<%s>", name, type);
       } else {
-        return String.format("%s %s%s", name, type, mode);
+        return String.format("`%s` %s%s", name, type, mode);
       }
     }).collect(Collectors.joining(", "));
   }

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySchemaResolver.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestBigQuerySchemaResolver.java
@@ -108,22 +108,22 @@ public class TestBigQuerySchemaResolver {
 
   @Test
   void convertSchemaToString_primitiveTypes() {
-    String expectedSqlSchema = "requiredBoolean BOOL NOT NULL, "
-        + "optionalBoolean BOOL, "
-        + "requiredInt INT64 NOT NULL, "
-        + "optionalInt INT64, "
-        + "requiredLong INT64 NOT NULL, "
-        + "optionalLong INT64, "
-        + "requiredDouble FLOAT64 NOT NULL, "
-        + "optionalDouble FLOAT64, "
-        + "requiredFloat FLOAT64 NOT NULL, "
-        + "optionalFloat FLOAT64, "
-        + "requiredString STRING NOT NULL, "
-        + "optionalString STRING, "
-        + "requiredBytes BYTES NOT NULL, "
-        + "optionalBytes BYTES, "
-        + "requiredEnum STRING NOT NULL, "
-        + "optionalEnum STRING";
+    String expectedSqlSchema = "`requiredBoolean` BOOL NOT NULL, "
+        + "`optionalBoolean` BOOL, "
+        + "`requiredInt` INT64 NOT NULL, "
+        + "`optionalInt` INT64, "
+        + "`requiredLong` INT64 NOT NULL, "
+        + "`optionalLong` INT64, "
+        + "`requiredDouble` FLOAT64 NOT NULL, "
+        + "`optionalDouble` FLOAT64, "
+        + "`requiredFloat` FLOAT64 NOT NULL, "
+        + "`optionalFloat` FLOAT64, "
+        + "`requiredString` STRING NOT NULL, "
+        + "`optionalString` STRING, "
+        + "`requiredBytes` BYTES NOT NULL, "
+        + "`optionalBytes` BYTES, "
+        + "`requiredEnum` STRING NOT NULL, "
+        + "`optionalEnum` STRING";
     Assertions.assertEquals(expectedSqlSchema, schemaToSqlString(SCHEMA_RESOLVER.convertSchema(PRIMITIVE_TYPES)));
   }
 
@@ -142,10 +142,10 @@ public class TestBigQuerySchemaResolver {
 
   @Test
   void convertSchemaToString_nestedFields() {
-    String expectedSqlSchema = "nestedOne STRUCT<"
-        + "nestedOptionalInt INT64, "
-        + "nestedRequiredDouble FLOAT64 NOT NULL, "
-        + "nestedTwo STRUCT<doublyNestedString STRING> NOT NULL>";
+    String expectedSqlSchema = "`nestedOne` STRUCT<"
+        + "`nestedOptionalInt` INT64, "
+        + "`nestedRequiredDouble` FLOAT64 NOT NULL, "
+        + "`nestedTwo` STRUCT<`doublyNestedString` STRING> NOT NULL>";
     Assertions.assertEquals(expectedSqlSchema, schemaToSqlString(SCHEMA_RESOLVER.convertSchema(NESTED_FIELDS)));
   }
 
@@ -170,8 +170,8 @@ public class TestBigQuerySchemaResolver {
 
   @Test
   void convertSchemaToString_lists() {
-    String expectedSqlSchema = "intList ARRAY<INT64>, "
-        + "recordList ARRAY<STRUCT<requiredDouble FLOAT64 NOT NULL, optionalString STRING>>";
+    String expectedSqlSchema = "`intList` ARRAY<INT64>, "
+        + "`recordList` ARRAY<STRUCT<`requiredDouble` FLOAT64 NOT NULL, `optionalString` STRING>>";
     Assertions.assertEquals(expectedSqlSchema, schemaToSqlString(SCHEMA_RESOLVER.convertSchema(LISTS)));
   }
 

--- a/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
+++ b/hudi-gcp/src/test/java/org/apache/hudi/gcp/bigquery/TestHoodieBigQuerySyncClient.java
@@ -94,7 +94,7 @@ public class TestHoodieBigQuerySyncClient {
 
     QueryJobConfiguration configuration = jobInfoCaptor.getValue().getConfiguration();
     assertEquals(configuration.getQuery(),
-        String.format("CREATE EXTERNAL TABLE `%s.%s.%s` ( field STRING ) WITH PARTITION COLUMNS OPTIONS (enable_list_inference=true, "
+        String.format("CREATE EXTERNAL TABLE `%s.%s.%s` ( `field` STRING ) WITH PARTITION COLUMNS OPTIONS (enable_list_inference=true, "
             + "hive_partition_uri_prefix=\"%s\", uris=[\"%s\"], format=\"PARQUET\", "
             + "file_set_spec_type=\"NEW_LINE_DELIMITED_MANIFEST\")", PROJECT_ID, TEST_DATASET, TEST_TABLE, SOURCE_PREFIX, MANIFEST_FILE_URI));
   }
@@ -114,7 +114,7 @@ public class TestHoodieBigQuerySyncClient {
 
     QueryJobConfiguration configuration = jobInfoCaptor.getValue().getConfiguration();
     assertEquals(configuration.getQuery(),
-        String.format("CREATE EXTERNAL TABLE `%s.%s.%s` ( field STRING ) OPTIONS (enable_list_inference=true, uris=[\"%s\"], format=\"PARQUET\", "
+        String.format("CREATE EXTERNAL TABLE `%s.%s.%s` ( `field` STRING ) OPTIONS (enable_list_inference=true, uris=[\"%s\"], format=\"PARQUET\", "
             + "file_set_spec_type=\"NEW_LINE_DELIMITED_MANIFEST\")", PROJECT_ID, TEST_DATASET, TEST_TABLE, MANIFEST_FILE_URI));
   }
 }


### PR DESCRIPTION
### Change Logs

- Removes overhead incurred per partition on manifest file writing to improve performance of sync
- Adds backticks (`) to field names to avoid issues with reserved keywords in BigQuery

### Impact

Lowers the time to sync the table and fixes bugs for some users

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
