### PR TITLE
[HUDI-6881] Hudi configured spark.scheduler.allocation.file should include scheme since Spark3.2

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SchedulerConfGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SchedulerConfGenerator.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.streamer;
 
+import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.SparkConfigs;
 import org.apache.hudi.async.AsyncCompactService;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -133,7 +134,9 @@ public class SchedulerConfGenerator {
     BufferedWriter bw = new BufferedWriter(new FileWriter(tempConfigFile));
     bw.write(generateConfig(deltaSyncWeight, compactionWeight, deltaSyncMinShare, compactionMinShare, clusteringWeight, clusteringMinShare));
     bw.close();
-    LOG.info("Configs written to file" + tempConfigFile.getAbsolutePath());
-    return tempConfigFile.getAbsolutePath();
+    // SPARK-35083 introduces remote scheduler pool files, so the file must include scheme since Spark 3.2
+    String path = HoodieSparkUtils.gteqSpark3_2() ? tempConfigFile.toURI().toString() : tempConfigFile.getAbsolutePath();
+    LOG.info("Configs written to file " + path);
+    return path;
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSchedulerConfGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSchedulerConfGenerator.java
@@ -18,12 +18,15 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
+import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.SparkConfigs;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.utilities.streamer.HoodieStreamer;
 import org.apache.hudi.utilities.streamer.SchedulerConfGenerator;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +37,7 @@ public class TestSchedulerConfGenerator {
 
   @Test
   public void testGenerateSparkSchedulingConf() throws Exception {
-    HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
+    HoodieStreamer.Config cfg = new HoodieStreamer.Config();
     Map<String, String> configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
     assertNull(configs.get(SparkConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY()), "spark.scheduler.mode not set");
 
@@ -77,5 +80,21 @@ public class TestSchedulerConfGenerator {
             + "</allocations>";
     String generatedConfig = SchedulerConfGenerator.generateConfig(1, 3, 2, 4, 5, 6);
     assertEquals(targetConfig, generatedConfig);
+  }
+
+  @Test
+  public void testGeneratedConfigFileScheme() throws Exception {
+    System.setProperty(SchedulerConfGenerator.SPARK_SCHEDULER_MODE_KEY, "FAIR");
+    HoodieStreamer.Config cfg = new HoodieStreamer.Config();
+    cfg.continuousMode = true;
+    cfg.tableType = HoodieTableType.MERGE_ON_READ.name();
+    Map<String, String> configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
+
+    URI schedulerFile = URI.create(configs.get(SparkConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY()));
+    if (HoodieSparkUtils.gteqSpark3_2()) {
+      assertNotNull(schedulerFile.getScheme());
+    } else {
+      assertNull(schedulerFile.getScheme());
+    }
   }
 }


### PR DESCRIPTION


### Change Logs
Hudi `SchedulerConfGenerator` configure the generated local file name without scheme, for Spark3.2 or newer version, it could not find the config file:
```bash
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.FileNotFoundException): File does not exist: /mnt//yarn/nm-local-dir/usercache/user/appcache/application_1695109514894_0504/container_e2463_1695109514894_0504_01_000001/tmp/ad680d18-28ea-412e-84e0-51dd77d924bd8230486245389606996.xml
	at org.apache.hadoop.hdfs.server.namenode.INodeFile.valueOf(INodeFile.java:87)
	at org.apache.hadoop.hdfs.server.namenode.INodeFile.valueOf(INodeFile.java:77)
	at org.apache.hadoop.hdfs.server.namenode.FSDirStatAndListingOp.getBlockLocations(FSDirStatAndListingOp.java:169)
	at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getBlockLocations(FSNamesystem.java:2260)
```

### Impact

Fix bug.

### Risk level (write none, low medium or high below)

Low.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
