### PR TITLE
[MINOR][DOCS] Fix supported type changes in doc site

### DIFF
--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -313,7 +313,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.11.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.11.0/schema_evolution.md
@@ -122,7 +122,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.11.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.11.1/schema_evolution.md
@@ -122,7 +122,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.12.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.0/schema_evolution.md
@@ -123,7 +123,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.12.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.1/schema_evolution.md
@@ -123,7 +123,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.12.2/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.2/schema_evolution.md
@@ -123,7 +123,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.12.3/schema_evolution.md
+++ b/website/versioned_docs/version-0.12.3/schema_evolution.md
@@ -123,7 +123,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.13.0/schema_evolution.md
+++ b/website/versioned_docs/version-0.13.0/schema_evolution.md
@@ -123,7 +123,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |

--- a/website/versioned_docs/version-0.13.1/schema_evolution.md
+++ b/website/versioned_docs/version-0.13.1/schema_evolution.md
@@ -123,7 +123,7 @@ ALTER TABLE table1 ALTER COLUMN a.b.c DROP NOT NULL
 | Source\Target      | long  | float | double | string | decimal | date | int |
 |--------------------|-------|-------|--------|--------|---------|------|-----|
 | int                |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  Y  |
-| long               |   Y   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
+| long               |   Y   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | float              |   N   |   Y   |    Y   |    Y   |    Y    |   N  |  N  |
 | double             |   N   |   N   |    Y   |    Y   |    Y    |   N  |  N  |
 | decimal            |   N   |   N   |    N   |    Y   |    Y    |   N  |  N  |


### PR DESCRIPTION
### Change Logs

LONG -> FLOAT is supported, but doc-site says it is not. This PR fixes this discrepancy.

https://github.com/apache/hudi/blob/c1062ff75be2ea9f6febc64ca3865e84c7e6c66d/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/SchemaChangeUtils.java#L39-L53

### Impact

None

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
