### PR TITLE
[MINOR] Mark a few new configs advanced and tag since version of 0.14.0

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -229,6 +229,7 @@ public class HoodieIndexConfig extends HoodieConfig {
       .key("hoodie.record.index.update.partition.path")
       .defaultValue("false")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Similar to " + BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE + ", but for record index.");
 
   public static final ConfigProperty<String> GLOBAL_INDEX_RECONCILE_PARALLELISM = ConfigProperty
@@ -320,6 +321,7 @@ public class HoodieIndexConfig extends HoodieConfig {
       .key("hoodie.record.index.use.caching")
       .defaultValue("true")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Only applies if index type is RECORD_INDEX."
           + "When true, the input RDD will be cached to speed up index lookup by reducing IO "
           + "for computing parallelism or affected partitions");
@@ -328,6 +330,7 @@ public class HoodieIndexConfig extends HoodieConfig {
       .key("hoodie.record.index.input.storage.level")
       .defaultValue("MEMORY_AND_DISK_SER")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Only applies when #recordIndexUseCaching is set. Determine what level of persistence is used to cache input RDDs. "
           + "Refer to org.apache.spark.storage.StorageLevel for different values");
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -713,6 +713,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       .key("hoodie.sensitive.config.keys")
       .defaultValue("ssl,tls,sasl,auth,credentials")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Comma separated list of filters for sensitive config keys. Hudi Streamer "
           + "will not print any configuration which contains the configured filter. For example with "
           + "a configured filter `ssl`, value for config `ssl.trustore.location` would be masked.");

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -66,6 +66,7 @@ public class HoodieCommonConfig extends HoodieConfig {
       .key("hoodie.datasource.write.new.columns.nullable")
       .defaultValue(false)
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("When a non-nullable column is added to datasource during a write operation, the write "
           + " operation will fail schema compatibility check. Set this option to true will make the newly added "
           + " column nullable to successfully complete the write operation.");
@@ -106,6 +107,7 @@ public class HoodieCommonConfig extends HoodieConfig {
       .key("hoodie.fs.atomic_creation.support")
       .defaultValue("")
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("This config is used to specify the file system which supports atomic file creation . "
           + "atomic means that an operation either succeeds and has an effect or has fails and has no effect;"
           + " now this feature is used by FileSystemLockProvider to guaranteeing that only one writer can create the lock file at a time."

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -100,6 +100,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".log.compaction.blocks.threshold")
       .defaultValue(5)
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Controls the criteria to log compacted files groups in metadata table.");
 
   // Regex to filter out matching directories during bootstrap

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/bigquery/BigQuerySyncConfig.java
@@ -83,6 +83,7 @@ public class BigQuerySyncConfig extends HoodieSyncConfig implements Serializable
       .key("hoodie.gcp.bigquery.sync.use_bq_manifest_file")
       .defaultValue(false)
       .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("If true, generate a manifest file with data file absolute paths and use BigQuery manifest file support to "
           + "directly create one external table over the Hudi table. If false (default), generate a manifest file with data file "
           + "names and create two external tables and one view in BigQuery. Query the view for the same results as querying the Hudi table");

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -457,6 +457,7 @@ object DataSourceWriteOptions {
   val SQL_INSERT_MODE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.sql.insert.mode")
     .defaultValue("upsert")
+    .markAdvanced()
     .deprecatedAfter("0.14.0")
     .withDocumentation("Insert mode when insert data to pk-table. The optional modes are: upsert, strict and non-strict." +
       "For upsert mode, insert statement do the upsert operation for the pk-table which will update the duplicate record." +
@@ -522,6 +523,7 @@ object DataSourceWriteOptions {
   val STREAMING_DISABLE_COMPACTION: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.write.streaming.disable.compaction")
     .defaultValue("false")
+    .markAdvanced()
     .sinceVersion("0.14.0")
     .withDocumentation("By default for MOR table, async compaction is enabled with spark streaming sink. "
       + "By setting this config to true, we can disable it and the expectation is that, users will schedule and execute "
@@ -542,6 +544,8 @@ object DataSourceWriteOptions {
     .key("hoodie.spark.sql.insert.into.operation")
     .defaultValue(WriteOperationType.INSERT.value())
     .withValidValues(WriteOperationType.BULK_INSERT.value(), WriteOperationType.INSERT.value(), WriteOperationType.UPSERT.value())
+    .markAdvanced()
+    .sinceVersion("0.14.0")
     .withDocumentation("Sql write operation to use with INSERT_INTO spark sql command. This comes with 3 possible values, bulk_insert, " +
       "insert and upsert. bulk_insert is generally meant for initial loads and is known to be performant compared to insert. But bulk_insert may not " +
       "do small file management. If you prefer hudi to automatically manage small files, then you can go with \"insert\". There is no precombine " +
@@ -557,6 +561,8 @@ object DataSourceWriteOptions {
     .key("hoodie.datasource.insert.dup.policy")
     .defaultValue(NONE_INSERT_DUP_POLICY)
     .withValidValues(NONE_INSERT_DUP_POLICY, DROP_INSERT_DUP_POLICY, FAIL_INSERT_DUP_POLICY)
+    .markAdvanced()
+    .sinceVersion("0.14.0")
     .withDocumentation("When operation type is set to \"insert\", users can optionally enforce a dedup policy. This policy will be employed "
       + " when records being ingested already exists in storage. Default policy is none and no action will be taken. Another option is to choose " +
       " \"drop\", on which matching records from incoming will be dropped and the rest will be ingested. Third option is \"fail\" which will " +

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieStreamerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieStreamerConfig.java
@@ -119,6 +119,8 @@ public class HoodieStreamerConfig extends HoodieConfig {
       .key(STREAMER_CONFIG_PREFIX + "sample.writes.enabled")
       .defaultValue(false)
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "sample.writes.enabled")
+      .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Set this to true to sample from the first batch of records and write to the auxiliary path, before writing to the table."
           + "The sampled records are used to calculate the average record size. The relevant write client will have `" + COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key()
           + "` being overwritten by the calculated result.");
@@ -126,6 +128,8 @@ public class HoodieStreamerConfig extends HoodieConfig {
       .key(STREAMER_CONFIG_PREFIX + "sample.writes.size")
       .defaultValue(5000)
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "sample.writes.size")
+      .markAdvanced()
+      .sinceVersion("0.14.0")
       .withDocumentation("Number of records to sample from the first write. To improve the estimation's accuracy, "
           + "for smaller or more compressable record size, set the sample size bigger. For bigger or less compressable record size, set smaller.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/KafkaSourceConfig.java
@@ -99,6 +99,7 @@ public class KafkaSourceConfig extends HoodieConfig {
       .defaultValue(0L)
       .withAlternatives(OLD_PREFIX + "minPartitions")
       .markAdvanced()
+      .sinceVersion("0.14.0")
           .withDocumentation("Desired minimum number of partitions to read from Kafka. "
               + "By default, Hudi has a 1-1 mapping of topicPartitions to Hudi partitions consuming from Kafka. "
               + "If set this option to a value greater than topicPartitions, "


### PR DESCRIPTION
### Change Logs

As above.

### Impact

Mark advanced configs and add since version of "0.14.0".

### Risk level

None

### Documentation Update

Make sure that a few configs that should be advanced do not show up in the basic configuration page and the configs have the right since version.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
