### PR TITLE
[HUDI-6892] ExternalSpillableMap may cause data duplication when flink compaction

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -213,6 +213,8 @@ public class ExternalSpillableMap<T extends Serializable, R extends Serializable
 
     if (this.inMemoryMap.containsKey(key)) {
       this.inMemoryMap.put(key, value);
+    } else if (inDiskContainsKey(key)) {
+      getDiskBasedMap().put(key, value);
     } else if (this.currentInMemoryMapSize < this.maxInMemorySizeInBytes) {
       this.currentInMemoryMapSize += this.estimatedPayloadSize;
       this.inMemoryMap.put(key, value);

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -31,6 +32,7 @@ import org.apache.hudi.common.testutils.SpillableMapTestUtils;
 import org.apache.hudi.common.util.DefaultSizeEstimator;
 import org.apache.hudi.common.util.HoodieRecordSizeEstimator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.SizeEstimator;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -47,6 +49,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -379,6 +382,53 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
       }, "ExternalSpillableMap put() should not throw exception!");
       recordKeys.add(hoodieRecord.getRecordKey());
     });
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArguments")
+  public void testDataCorrectnessWithUpsertToDiskMap(ExternalSpillableMap.DiskMapType diskMapType,
+                                                  boolean isCompressionEnabled) throws IOException, URISyntaxException {
+    Schema schema = HoodieAvroUtils.addMetadataFields(SchemaTestUtil.getSimpleSchema());
+
+    SizeEstimator keyEstimator = new DefaultSizeEstimator();
+    SizeEstimator valEstimator = new HoodieRecordSizeEstimator(schema);
+    SchemaTestUtil testUtil = new SchemaTestUtil();
+    List<IndexedRecord> iRecords = testUtil.generateHoodieTestRecords(0, 100);
+
+    // Get the first record
+    IndexedRecord firstRecord = iRecords.get(0);
+    String key = ((GenericRecord) firstRecord).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
+    String partitionPath = ((GenericRecord) firstRecord).get(HoodieRecord.PARTITION_PATH_METADATA_FIELD).toString();
+    HoodieRecord record =
+        new HoodieAvroRecord<>(new HoodieKey(key, partitionPath), new HoodieAvroPayload(Option.of((GenericRecord) firstRecord)));
+    record.setCurrentLocation(new HoodieRecordLocation(SpillableMapTestUtils.DUMMY_COMMIT_TIME, SpillableMapTestUtils.DUMMY_FILE_ID));
+    record.seal();
+
+    // Estimate the first record size and calculate the total memory size that the in-memory map can only contain 100 records.
+    long estimatedPayloadSize = keyEstimator.sizeEstimate(key) + valEstimator.sizeEstimate(record);
+    long totalEstimatedSizeWith100Records = (long) ((estimatedPayloadSize * 100) / 0.8);
+    ExternalSpillableMap<String, HoodieRecord<? extends HoodieRecordPayload>> records =
+        new ExternalSpillableMap<>(totalEstimatedSizeWith100Records, basePath, new DefaultSizeEstimator(),
+            new HoodieRecordSizeEstimator(schema), diskMapType, isCompressionEnabled);
+
+    // Insert 100 records and then in-memory map will contain 100 records.
+    SpillableMapTestUtils.upsertRecords(iRecords, records);
+
+    // Generate one record and it will be spilled to disk
+    List<IndexedRecord> singleRecord = testUtil.generateHoodieTestRecords(0, 1);
+    List<String> singleRecordKey = SpillableMapTestUtils.upsertRecords(singleRecord, records);
+
+    // Get the field we want to update
+    String fieldName = schema.getFields().stream().filter(field -> field.schema().getType() == Schema.Type.STRING).findAny()
+        .get().name();
+    HoodieRecord hoodieRecord = records.get(singleRecordKey.get(0));
+    // Use a new value to update this field, the estimate size of this record will be less than the first record.
+    String newValue = "";
+    HoodieRecord updatedRecord =
+        SchemaTestUtil.updateHoodieTestRecordsWithoutHoodieMetadata(Arrays.asList(hoodieRecord), schema, fieldName, newValue).get(0);
+    records.put(updatedRecord.getRecordKey(), updatedRecord);
+
+    assertEquals(records.size(), 101);
   }
 
   private static Stream<Arguments> testArguments() {


### PR DESCRIPTION
### Change Logs
ExternalSpillableMap may cause data duplication when flink compaction. 
see: [https://issues.apache.org/jira/browse/HUDI-6892](https://issues.apache.org/jira/browse/HUDI-6892)

### Impact
none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
