### PR TITLE
[HUDI-6893] Copy the trino bundle to override the one in the image

### DIFF
--- a/docker/hoodie/hadoop/trinobase/scripts/trino.sh
+++ b/docker/hoodie/hadoop/trinobase/scripts/trino.sh
@@ -18,4 +18,8 @@
 # under the License.
 #
 
+# Copy the trino bundle at run time so that locally built bundle overrides the one that is present in the image
+echo "Copying trino bundle to ${TRINO_HOME}/plugin/hive/"
+cp ${HUDI_TRINO_BUNDLE} ${TRINO_HOME}/plugin/hive/
+
 /usr/local/trino/bin/launcher run


### PR DESCRIPTION
### Change Logs

Copy the trino bundle at run time so that locally built bundle overrides the one that is present in the image.

### Impact

Docker-based integ test to use snapshot version of hudi-trino-bundle.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
