### PR TITLE
[HUDI-6894] ReflectionUtils is not thread safe

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -32,10 +32,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 /**
@@ -45,7 +45,7 @@ public class ReflectionUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReflectionUtils.class);
 
-  private static final Map<String, Class<?>> CLAZZ_CACHE = new HashMap<>();
+  private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<>();
 
   public static Class<?> getClass(String clazzName) {
     if (!CLAZZ_CACHE.containsKey(clazzName)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -48,19 +48,13 @@ public class ReflectionUtils {
   private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<>();
 
   public static Class<?> getClass(String clazzName) {
-    if (!CLAZZ_CACHE.containsKey(clazzName)) {
-      synchronized (CLAZZ_CACHE) {
-        if (!CLAZZ_CACHE.containsKey(clazzName)) {
-          try {
-            Class<?> clazz = Class.forName(clazzName);
-            CLAZZ_CACHE.put(clazzName, clazz);
-          } catch (ClassNotFoundException e) {
-            throw new HoodieException("Unable to load class", e);
-          }
-        }
+    return CLAZZ_CACHE.computeIfAbsent(clazzName, c -> {
+      try {
+        return Class.forName(c);
+      } catch (ClassNotFoundException e) {
+        throw new HoodieException("Unable to load class", e);
       }
-    }
-    return CLAZZ_CACHE.get(clazzName);
+    });
   }
 
   public static <T> T loadClass(String className) {


### PR DESCRIPTION
### Change Logs

Method ReflectionUtils.getClass is not thread safe, and in our union all stream read & stream write scenario, will throw null pointer exception.

<img width="676" alt="image" src="https://github.com/apache/hudi/assets/34104400/595d5b4c-4482-4534-9612-222c9c5e8924">


code:

<img width="783" alt="image" src="https://github.com/apache/hudi/assets/34104400/3365067b-ee13-49e9-aacf-07384412e7a8">


### Impact

None.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
