### PR TITLE
[MINOR] CLAZZ_CACHE get should be synchonized avoid thread safe problem

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -53,11 +53,11 @@ public class ReflectionUtils {
         try {
           Class<?> clazz = Class.forName(clazzName);
           CLAZZ_CACHE.put(clazzName, clazz);
-          return CLAZZ_CACHE.get(clazzName);
         } catch (ClassNotFoundException e) {
           throw new HoodieException("Unable to load class", e);
         }
       }
+      return CLAZZ_CACHE.get(clazzName);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -48,19 +48,17 @@ public class ReflectionUtils {
   private static final Map<String, Class<?>> CLAZZ_CACHE = new HashMap<>();
 
   public static Class<?> getClass(String clazzName) {
-    if (!CLAZZ_CACHE.containsKey(clazzName)) {
-      synchronized (CLAZZ_CACHE) {
-        if (!CLAZZ_CACHE.containsKey(clazzName)) {
-          try {
-            Class<?> clazz = Class.forName(clazzName);
-            CLAZZ_CACHE.put(clazzName, clazz);
-          } catch (ClassNotFoundException e) {
-            throw new HoodieException("Unable to load class", e);
-          }
+    synchronized (CLAZZ_CACHE) {
+      if (!CLAZZ_CACHE.containsKey(clazzName)) {
+        try {
+          Class<?> clazz = Class.forName(clazzName);
+          CLAZZ_CACHE.put(clazzName, clazz);
+          return CLAZZ_CACHE.get(clazzName);
+        } catch (ClassNotFoundException e) {
+          throw new HoodieException("Unable to load class", e);
         }
       }
     }
-    return CLAZZ_CACHE.get(clazzName);
   }
 
   public static <T> T loadClass(String className) {


### PR DESCRIPTION
### Change Logs

CLAZZ_CACHE get should be synchonized avoid thread safe problem such as npe when put is called at the same time，because get method in Map is not use CAS

### Impact

none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
