### PR TITLE
[HUDI-6896] HoodieAvroHFileReader.RecordIterator iteration never terminates

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroHFileReader.java
@@ -672,6 +672,7 @@ public class HoodieAvroHFileReader extends HoodieAvroFileReaderBase implements H
     private final Schema readerSchema;
 
     private IndexedRecord next = null;
+    private boolean eof = false;
 
     RecordIterator(HFile.Reader reader, HFileScanner scanner, Schema writerSchema, Schema readerSchema) {
       this.reader = reader;
@@ -684,6 +685,10 @@ public class HoodieAvroHFileReader extends HoodieAvroFileReaderBase implements H
     public boolean hasNext() {
       try {
         // NOTE: This is required for idempotency
+        if (eof) {
+          return false;
+        }
+
         if (next != null) {
           return true;
         }
@@ -696,6 +701,7 @@ public class HoodieAvroHFileReader extends HoodieAvroFileReaderBase implements H
         }
 
         if (!hasRecords) {
+          eof = true;
           return false;
         }
 


### PR DESCRIPTION
### Change Logs

org.apache.hudi.io.storage.HoodieAvroHFileReader.RecordIterator#hasNext uses org.apache.hadoop.hbase.io.hfile.HFileScanner#isSeeked to seek to the first line of the file.
```
        if (!scanner.isSeeked()) {
          hasRecords = scanner.seekTo();
        }
```
if isSeeked returns false, scanner seeks to start of file.

After end of file is reached, isSeeked would still return false and the next time hasNext is called it seeks to start of file again leading to an infinite loop.

Documentation for HFileScanner#isSeeked
True is scanner has had one of the seek calls invoked; i.e. seekBefore(Cell) or seekTo() or seekTo(Cell). Otherwise returns false.

The PR adds a flag(eof) so that false is returned for hasNext if the flag is true.

### Impact

NA

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
