### PR TITLE
[HUDI-6895][WIP] Change default timeline timezone from local to UTC

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ClusteringCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ClusteringCommand.java
@@ -59,7 +59,7 @@ public class ClusteringCommand {
     SparkLauncher sparkLauncher = SparkUtil.initLauncher(sparkPropertiesPath);
 
     // First get a clustering instant time and pass it to spark launcher for scheduling clustering
-    String clusteringInstantTime = HoodieActiveTimeline.createNewInstantTime();
+    String clusteringInstantTime = HoodieActiveTimeline.createNewInstantTimeInTimeZone(client.getTableConfig().getTimelineTimezone());
 
     sparkLauncher.addAppArgs(SparkCommand.CLUSTERING_SCHEDULE.toString(), master, sparkMemory,
         client.getBasePath(), client.getTableConfig().getTableName(), clusteringInstantTime, propsFilePath);

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
@@ -197,7 +197,7 @@ public class CompactionCommand {
     HoodieCLI.initFS(initialized);
 
     // First get a compaction instant time and pass it to spark launcher for scheduling compaction
-    String compactionInstantTime = HoodieActiveTimeline.createNewInstantTime();
+    String compactionInstantTime = HoodieActiveTimeline.createNewInstantTimeInTimeZone(client.getTableConfig().getTimelineTimezone());
 
     String sparkPropertiesPath =
         Utils.getDefaultPropertiesFile(scala.collection.JavaConversions.propertiesAsScalaMap(System.getProperties()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -172,8 +172,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    * Performs a compaction operation on a table, serially before or after an insert/upsert action.
    * Scheduling and execution is done inline.
    */
-  protected Option<String> inlineCompaction(Option<Map<String, String>> extraMetadata) {
-    Option<String> compactionInstantTimeOpt = inlineScheduleCompaction(extraMetadata);
+  protected Option<String> inlineCompaction(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) {
+    Option<String> compactionInstantTimeOpt = inlineScheduleCompaction(extraMetadata, metaClient);
     compactionInstantTimeOpt.ifPresent(compactInstantTime -> {
       // inline compaction should auto commit as the user is never given control
       compact(compactInstantTime, true);
@@ -183,10 +183,10 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
 
   private void inlineCompaction(HoodieTable table, Option<Map<String, String>> extraMetadata) {
     if (shouldDelegateToTableServiceManager(config, ActionType.compaction)) {
-      scheduleCompaction(extraMetadata);
+      scheduleCompaction(extraMetadata, table.getMetaClient());
     } else {
       runAnyPendingCompactions(table);
-      inlineCompaction(extraMetadata);
+      inlineCompaction(extraMetadata, table.getMetaClient());
     }
   }
 
@@ -235,8 +235,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
   /**
    * Performs a log compaction operation on a table, serially before or after an insert/upsert action.
    */
-  protected Option<String> inlineLogCompact(Option<Map<String, String>> extraMetadata) {
-    Option<String> logCompactionInstantTimeOpt = scheduleLogCompaction(extraMetadata);
+  protected Option<String> inlineLogCompact(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) {
+    Option<String> logCompactionInstantTimeOpt = scheduleLogCompaction(extraMetadata, metaClient);
     logCompactionInstantTimeOpt.ifPresent(logCompactInstantTime -> {
       // inline log compaction should auto commit as the user is never given control
       logCompact(logCompactInstantTime, true);
@@ -266,8 +266,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    * @param extraMetadata extra metadata to be used.
    * @return compaction instant if scheduled.
    */
-  protected Option<String> inlineScheduleCompaction(Option<Map<String, String>> extraMetadata) {
-    return scheduleCompaction(extraMetadata);
+  protected Option<String> inlineScheduleCompaction(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) {
+    return scheduleCompaction(extraMetadata, metaClient);
   }
 
   /**
@@ -275,8 +275,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    *
    * @param extraMetadata Extra Metadata to be stored
    */
-  public Option<String> scheduleCompaction(Option<Map<String, String>> extraMetadata) throws HoodieIOException {
-    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+  public Option<String> scheduleCompaction(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) throws HoodieIOException {
+    String instantTime = HoodieActiveTimeline.createNewInstantTimeInTimeZone(metaClient.getTableConfig().getTimelineTimezone());
     return scheduleCompactionAtInstant(instantTime, extraMetadata) ? Option.of(instantTime) : Option.empty();
   }
 
@@ -349,8 +349,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    *
    * @param extraMetadata Extra Metadata to be stored
    */
-  public Option<String> scheduleLogCompaction(Option<Map<String, String>> extraMetadata) throws HoodieIOException {
-    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+  public Option<String> scheduleLogCompaction(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) throws HoodieIOException {
+    String instantTime = HoodieActiveTimeline.createNewInstantTimeInTimeZone(metaClient.getTableConfig().getTimelineTimezone());
     return scheduleLogCompactionAtInstant(instantTime, extraMetadata) ? Option.of(instantTime) : Option.empty();
   }
 
@@ -419,8 +419,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    *
    * @param extraMetadata Extra Metadata to be stored
    */
-  public Option<String> scheduleClustering(Option<Map<String, String>> extraMetadata) throws HoodieIOException {
-    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+  public Option<String> scheduleClustering(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) throws HoodieIOException {
+    String instantTime = HoodieActiveTimeline.createNewInstantTimeInTimeZone(metaClient.getTableConfig().getTimelineTimezone());
     return scheduleClusteringAtInstant(instantTime, extraMetadata) ? Option.of(instantTime) : Option.empty();
   }
 
@@ -542,14 +542,14 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
         && table.getActiveTimeline().getWriteTimeline().filterPendingCompactionTimeline().empty()) {
       // proceed only if there are no pending compactions
       metadata.addMetadata(HoodieCompactionConfig.SCHEDULE_INLINE_COMPACT.key(), "true");
-      inlineScheduleCompaction(extraMetadata);
+      inlineScheduleCompaction(extraMetadata, table.getMetaClient());
     }
 
     // Do an inline log compaction if enabled
     if (config.inlineLogCompactionEnabled()) {
       runAnyPendingLogCompactions(table);
       metadata.addMetadata(HoodieCompactionConfig.INLINE_LOG_COMPACT.key(), "true");
-      inlineLogCompact(extraMetadata);
+      inlineLogCompact(extraMetadata, table.getMetaClient());
     } else {
       metadata.addMetadata(HoodieCompactionConfig.INLINE_LOG_COMPACT.key(), "false");
     }
@@ -567,7 +567,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
         && table.getActiveTimeline().filterPendingReplaceTimeline().empty()) {
       // proceed only if there are no pending clustering
       metadata.addMetadata(HoodieClusteringConfig.SCHEDULE_INLINE_CLUSTERING.key(), "true");
-      inlineScheduleClustering(extraMetadata);
+      inlineScheduleClustering(extraMetadata, table.getMetaClient());
     }
   }
 
@@ -647,8 +647,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    * Executes a clustering plan on a table, serially before or after an insert/upsert action.
    * Schedules and executes clustering inline.
    */
-  protected Option<String> inlineClustering(Option<Map<String, String>> extraMetadata) {
-    Option<String> clusteringInstantOpt = inlineScheduleClustering(extraMetadata);
+  protected Option<String> inlineClustering(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) {
+    Option<String> clusteringInstantOpt = inlineScheduleClustering(extraMetadata, metaClient);
     clusteringInstantOpt.ifPresent(clusteringInstant -> {
       // inline cluster should auto commit as the user is never given control
       cluster(clusteringInstant, true);
@@ -658,10 +658,10 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
 
   private void inlineClustering(HoodieTable table, Option<Map<String, String>> extraMetadata) {
     if (shouldDelegateToTableServiceManager(config, ActionType.replacecommit)) {
-      scheduleClustering(extraMetadata);
+      scheduleClustering(extraMetadata, table.getMetaClient());
     } else {
       runAnyPendingClustering(table);
-      inlineClustering(extraMetadata);
+      inlineClustering(extraMetadata, table.getMetaClient());
     }
   }
 
@@ -671,8 +671,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    * @param extraMetadata extra metadata to use.
    * @return clustering instant if scheduled.
    */
-  protected Option<String> inlineScheduleClustering(Option<Map<String, String>> extraMetadata) {
-    return scheduleClustering(extraMetadata);
+  protected Option<String> inlineScheduleClustering(Option<Map<String, String>> extraMetadata, HoodieTableMetaClient metaClient) {
+    return scheduleClustering(extraMetadata, metaClient);
   }
 
   protected void runAnyPendingClustering(HoodieTable table) {
@@ -1078,7 +1078,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
     if (instant.isPresent() && HoodieTimeline.compareTimestamps(instant.get(), HoodieTimeline.LESSER_THAN_OR_EQUALS,
         HoodieTimeline.FULL_BOOTSTRAP_INSTANT_TS)) {
       LOG.info("Found pending bootstrap instants. Rolling them back");
-      table.rollbackBootstrap(context, HoodieActiveTimeline.createNewInstantTime());
+      table.rollbackBootstrap(context, HoodieActiveTimeline.createNewInstantTimeInTimeZone(table.getMetaClient().getTableConfig().getTimelineTimezone()));
       LOG.info("Finished rolling back pending bootstrap");
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -822,7 +822,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     if (failedRestore.isPresent() && savepointToRestoreTimestamp.equals(RestoreUtils.getSavepointToRestoreTimestamp(table, failedRestore.get()))) {
       return Pair.of(failedRestore.get().getTimestamp(), Option.of(RestoreUtils.getRestorePlan(table.getMetaClient(), failedRestore.get())));
     }
-    final String restoreInstantTimestamp = HoodieActiveTimeline.createNewInstantTime();
+    final String restoreInstantTimestamp = HoodieActiveTimeline.createNewInstantTimeInTimeZone(table.getMetaClient().getTableConfig().getTimelineTimezone());
     return Pair.of(restoreInstantTimestamp, table.scheduleRestore(context, restoreInstantTimestamp, savepointToRestoreTimestamp));
   }
 
@@ -911,7 +911,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     CleanerUtils.rollbackFailedWrites(config.getFailedWritesCleanPolicy(),
         HoodieTimeline.COMMIT_ACTION, () -> tableServiceClient.rollbackFailedWrites());
 
-    String instantTime = HoodieActiveTimeline.createNewInstantTime();
+    String instantTime = HoodieActiveTimeline.createNewInstantTimeInTimeZone(metaClient.getTableConfig().getTimelineTimezone());
     startCommit(instantTime, actionType, metaClient);
     return instantTime;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -229,7 +229,7 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public static final ConfigProperty<HoodieTimelineTimeZone> TIMELINE_TIMEZONE = ConfigProperty
       .key("hoodie.table.timeline.timezone")
-      .defaultValue(HoodieTimelineTimeZone.LOCAL)
+      .defaultValue(HoodieTimelineTimeZone.UTC)
       .withDocumentation("User can set hoodie commit timeline timezone, such as utc, local and so on. local is default");
 
   public static final ConfigProperty<Boolean> PARTITION_METAFILE_USE_BASE_FORMAT = ConfigProperty

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieTimelineTimeZone;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.util.FileIOUtils;
@@ -135,9 +136,18 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
 
   /**
    * Returns next instant time in the correct format.
-   * Ensures each instant time is atleast 1 second apart since we create instant times at second granularity
+   * Ensures each instant time is at least 1 second apart since we create instant times at second granularity
    */
   public static String createNewInstantTime() {
+    return HoodieInstantTimeGenerator.createNewInstantTime(0);
+  }
+
+  /**
+   * Returns next instant time in the correct format in the timezone specified.
+   * Ensures each instant time is at least 1 second apart since we create instant times at second granularity
+   */
+  public static String createNewInstantTimeInTimeZone(HoodieTimelineTimeZone timelineTimeZone) {
+    HoodieInstantTimeGenerator.setCommitTimeZone(timelineTimeZone);
     return HoodieInstantTimeGenerator.createNewInstantTime(0);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -57,7 +57,7 @@ public class HoodieInstantTimeGenerator {
   // when performing comparisons such as LESS_THAN_OR_EQUAL_TO
   public static final String DEFAULT_MILLIS_EXT = "999";
 
-  private static HoodieTimelineTimeZone commitTimeZone = HoodieTimelineTimeZone.LOCAL;
+  private static HoodieTimelineTimeZone commitTimeZone = HoodieTimelineTimeZone.UTC;
 
   /**
    * Returns next instant time that adds N milliseconds to the current time.


### PR DESCRIPTION
### Change Logs

Change default timeline timezone from local to UTC.

TODO: Replace usages of `HoodieActiveTimeline.createNewInstantTime` by `HoodieActiveTimeline.createNewInstantTimeInTimeZone`.

### Impact

Default will be UTC. However, when creating new instant time, the timezone in the table config will be honored.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
