### PR TITLE
[HUDI-6827] Fix task failure when insert into empty dataset

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieEngineContext.java
@@ -67,7 +67,11 @@ public abstract class HoodieEngineContext {
   public abstract <T> HoodieData<T> emptyHoodieData();
 
   public <T> HoodieData<T> parallelize(List<T> data) {
-    return parallelize(data, data.size());
+    if (data.isEmpty()) {
+      return emptyHoodieData();
+    } else {
+      return parallelize(data, data.size());
+    }
   }
 
   public abstract <T> HoodieData<T> parallelize(List<T> data, int parallelism);


### PR DESCRIPTION
### Change Logs

If run a spark job to insert/insertOverWrite empty data into HUDI table using bulkInsert, the exceptions like 'java.lang.IllegalArgumentException: Positive number of partitions required' would be thrown out.
More detail in [HUDI-6827](https://issues.apache.org/jira/browse/HUDI-6827)

This pr aims to fix the bug.

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
