### PR TITLE
[HUDI-6899] Fix hive read schema evolution table with partition field

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
@@ -110,6 +110,9 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
       return createBootstrappingRecordReader(split, job, reporter);
     }
 
+    // add partition fields to hive job conf
+    HoodieRealtimeInputFormatUtils.addProjectionField(job, job.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
+
     // adapt schema evolution
     new SchemaEvolutionContext(split, job).doEvolutionForParquetFormat();
 
@@ -117,7 +120,6 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
       LOG.debug("EMPLOYING DEFAULT RECORD READER - " + split);
     }
 
-    HoodieRealtimeInputFormatUtils.addProjectionField(job, job.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
     return getRecordReaderInternal(split, job, reporter);
   }
 


### PR DESCRIPTION
### Change Logs

Steps to reproduce

```sql
-- spark
set hoodie.schema.on.read.enable=true;

create table hudi_cow_test_tbl (
  id bigint,
  name string,
  ts int,
  dt string,
  hh string
) using hudi
tblproperties (
  type = 'cow',
  primaryKey = 'id',
  preCombineField = 'ts'
)
partitioned by (dt, hh);

insert into hudi_cow_test_tbl values (1, 'a1', 1001, '2021-12-09', '10');
ALTER TABLE hudi_cow_test_tbl ALTER COLUMN ts TYPE bigint;
insert into hudi_cow_test_tbl values (2, 'a2', 1001, '2021-12-09', '11');

-- hive
select id, dt from xinyu_test.hudi_cow_test_tbl;

Failed with exception java.io.IOException:org.apache.hudi.exception.HoodieException: 
The size of hive.io.file.readcolumn.ids: 5,8,9 is not equal to projection columns: id
```
The core reason is we need to modify the conf first (by https://github.com/apache/hudi/pull/7355) and then execute `new SchemaEvolutionContext(split, job).doEvolutionForParquetFormat();`

### Impact

Fix above

### Risk level (write none, low medium or high below)

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
