### PR TITLE
[MINOR] HFileBootstrapIndex: use try-with-resources in two places

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBootstrapIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bootstrap/index/HFileBootstrapIndex.java
@@ -322,8 +322,7 @@ public class HFileBootstrapIndex extends BootstrapIndex {
 
     @Override
     public List<BootstrapFileMapping> getSourceFileMappingForPartition(String partition) {
-      try {
-        HFileScanner scanner = partitionIndexReader().getScanner(true, false);
+      try (HFileScanner scanner = partitionIndexReader().getScanner(true, false)) {
         KeyValue keyValue = new KeyValue(Bytes.toBytes(getPartitionKey(partition)), new byte[0], new byte[0],
             HConstants.LATEST_TIMESTAMP, KeyValue.Type.Put, new byte[0]);
         if (scanner.seekTo(keyValue) == 0) {
@@ -355,8 +354,7 @@ public class HFileBootstrapIndex extends BootstrapIndex {
       // Arrange input Keys in sorted order for 1 pass scan
       List<HoodieFileGroupId> fileGroupIds = new ArrayList<>(ids);
       Collections.sort(fileGroupIds);
-      try {
-        HFileScanner scanner = fileIdIndexReader().getScanner(true, false);
+      try (HFileScanner scanner = fileIdIndexReader().getScanner(true, false)) {
         for (HoodieFileGroupId fileGroupId : fileGroupIds) {
           KeyValue keyValue = new KeyValue(Bytes.toBytes(getFileGroupKey(fileGroupId)), new byte[0], new byte[0],
               HConstants.LATEST_TIMESTAMP, KeyValue.Type.Put, new byte[0]);


### PR DESCRIPTION
### Change Logs

Updates two spots in the code to use try-with-resources to properly close the scanner

### Impact

Closes resource

### Risk level (write none, low medium or high below)

None

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
