### PR TITLE
[HUDI-6913] Set default database name correctly

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -91,7 +91,7 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> DATABASE_NAME = ConfigProperty
       .key("hoodie.database.name")
-      .noDefaultValue()
+      .defaultValue("default")
       .withDocumentation("Database name that will be used for incremental query.If different databases have the same table name during incremental query, "
           + "we can set it to limit the table name under a specific database");
 
@@ -528,7 +528,7 @@ public class HoodieTableConfig extends HoodieConfig {
       throw new IllegalArgumentException(NAME.key() + " property needs to be specified");
     }
     String table = props.getProperty(NAME.key());
-    String database = props.getProperty(DATABASE_NAME.key(), "");
+    String database = props.getProperty(DATABASE_NAME.key(), DATABASE_NAME.defaultValue());
     return BinaryUtil.generateChecksum(getUTF8Bytes(String.format(TABLE_CHECKSUM_FORMAT, database, table)));
   }
 
@@ -663,7 +663,7 @@ public class HoodieTableConfig extends HoodieConfig {
    * Read the database name.
    */
   public String getDatabaseName() {
-    return getString(DATABASE_NAME);
+    return getStringOrDefault(DATABASE_NAME);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -91,7 +91,7 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> DATABASE_NAME = ConfigProperty
       .key("hoodie.database.name")
-      .defaultValue("default")
+      .noDefaultValue()
       .withDocumentation("Database name that will be used for incremental query.If different databases have the same table name during incremental query, "
           + "we can set it to limit the table name under a specific database");
 
@@ -528,7 +528,7 @@ public class HoodieTableConfig extends HoodieConfig {
       throw new IllegalArgumentException(NAME.key() + " property needs to be specified");
     }
     String table = props.getProperty(NAME.key());
-    String database = props.getProperty(DATABASE_NAME.key(), DATABASE_NAME.defaultValue());
+    String database = props.getProperty(DATABASE_NAME.key(), "");
     return BinaryUtil.generateChecksum(getUTF8Bytes(String.format(TABLE_CHECKSUM_FORMAT, database, table)));
   }
 
@@ -663,7 +663,7 @@ public class HoodieTableConfig extends HoodieConfig {
    * Read the database name.
    */
   public String getDatabaseName() {
-    return getStringOrDefault(DATABASE_NAME);
+    return getString(DATABASE_NAME);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -91,7 +91,7 @@ public class HoodieTableConfig extends HoodieConfig {
 
   public static final ConfigProperty<String> DATABASE_NAME = ConfigProperty
       .key("hoodie.database.name")
-      .noDefaultValue()
+      .noDefaultValue("Database name can't have default value as it's used to toggle Hive incremental query feature. See HUDI-2837")
       .withDocumentation("Database name that will be used for incremental query.If different databases have the same table name during incremental query, "
           + "we can set it to limit the table name under a specific database");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1120,7 +1120,7 @@ public class HoodieTableMetaClient implements Serializable {
 
       tableConfig.setAll(others);
 
-      if (!StringUtils.isNullOrEmpty(databaseName)) {
+      if (databaseName != null) {
         tableConfig.setValue(HoodieTableConfig.DATABASE_NAME, databaseName);
       }
       tableConfig.setValue(HoodieTableConfig.NAME, tableName);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1120,7 +1120,7 @@ public class HoodieTableMetaClient implements Serializable {
 
       tableConfig.setAll(others);
 
-      if (databaseName != null) {
+      if (!StringUtils.isNullOrEmpty(databaseName)) {
         tableConfig.setValue(HoodieTableConfig.DATABASE_NAME, databaseName);
       }
       tableConfig.setValue(HoodieTableConfig.NAME, tableName);

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -79,7 +79,13 @@ public class HoodieSyncConfig extends HoodieConfig {
   public static final ConfigProperty<String> META_SYNC_DATABASE_NAME = ConfigProperty
       .key("hoodie.datasource.hive_sync.database")
       .defaultValue("default")
-      .withInferFunction(cfg -> Option.ofNullable(cfg.getString(DATABASE_NAME)))
+      .withInferFunction(cfg -> {
+        String databaseName = cfg.getString(DATABASE_NAME);
+        // Need to check if database name is empty as Option won't check it
+        return StringUtils.isNullOrEmpty(databaseName)
+            ? Option.empty()
+            : Option.of(databaseName);
+      })
       .markAdvanced()
       .withDocumentation("The name of the destination database that we should sync the hudi table to.");
 


### PR DESCRIPTION
### Change Logs

Hudi can't infer default database name when running hive sync.

 
`hoodie.datasource.hive_sync.database` has a default value of `default` but it would use infer function to read `hoodie.database.name` before using default value.
 
And `hoodie.database.name` is set to an empty string by default and by mistake, which is considered non-null by java `Option` class so Hudi would continue to use the empty string instead of `default` to run hive sync, and cause exceptions below:
 
```
Caused by: org.apache.hudi.exception.HoodieException: Got runtime exception when hive syncing hudi_basic_test_mor51667
  at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:168)
  at org.apache.hudi.sync.common.util.SyncUtilHelpers.runHoodieMetaSync(SyncUtilHelpers.java:79)
  ... 90 more
Caused by: java.lang.IllegalArgumentException: databaseName cannot be null or empty
  at com.google.common.base.Preconditions.checkArgument(Preconditions.java:92)
  at com.amazonaws.glue.catalog.metastore.GlueMetastoreClientDelegate.tableExists(GlueMetastoreClientDelegate.java:417)
  at com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient.tableExists(AWSCatalogMetastoreClient.java:1644)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.apache.hadoop.hive.metastore.HiveMetaStoreClient$SynchronizedHandler.invoke(HiveMetaStoreClient.java:2350)
  at com.sun.proxy.$Proxy89.tableExists(Unknown Source)
  at org.apache.hudi.hive.HoodieHiveSyncClient.tableExists(HoodieHiveSyncClient.java:250)
  at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:241)
  at org.apache.hudi.hive.HiveSyncTool.doSync(HiveSyncTool.java:191)
  at org.apache.hudi.hive.HiveSyncTool.syncHoodieTable(HiveSyncTool.java:165) 
```

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
