### PR TITLE
[HUDI-6908] Confirm e2e flow of the spark record

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetStreamWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetStreamWriter.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.io.storage;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -37,6 +39,8 @@ public class HoodieSparkParquetStreamWriter implements HoodieSparkFileWriter, Au
   private final ParquetWriter<InternalRow> writer;
   private final HoodieRowParquetWriteSupport writeSupport;
 
+  private BufferedWriter writer1;
+
   public HoodieSparkParquetStreamWriter(FSDataOutputStream outputStream,
       HoodieRowParquetConfig parquetConfig) throws IOException {
     this.writeSupport = parquetConfig.getWriteSupport();
@@ -50,6 +54,7 @@ public class HoodieSparkParquetStreamWriter implements HoodieSparkFileWriter, Au
         .withWriterVersion(ParquetWriter.DEFAULT_WRITER_VERSION)
         .withConf(parquetConfig.getHadoopConf())
         .build();
+    writer1 = new BufferedWriter(new FileWriter("/Users/linliu/projects/hudi/log/stream.txt", true));
   }
 
   @Override
@@ -61,6 +66,9 @@ public class HoodieSparkParquetStreamWriter implements HoodieSparkFileWriter, Au
   public void writeRow(String key, InternalRow record) throws IOException {
     writer.write(record);
     writeSupport.add(UTF8String.fromString(key));
+    writer1.write("Using SparkParquetStreamWriter for: " + key);
+    writer1.newLine();
+    writer1.flush();
   }
 
   @Override
@@ -72,6 +80,7 @@ public class HoodieSparkParquetStreamWriter implements HoodieSparkFileWriter, Au
   @Override
   public void close() throws IOException {
     writer.close();
+    writer1.close();
   }
 
   private static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
@@ -27,6 +27,8 @@ import org.apache.hudi.io.storage.row.HoodieRowParquetWriteSupport;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.util.function.Function;
 
@@ -46,6 +48,7 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
   private final HoodieRowParquetWriteSupport writeSupport;
 
   private final Function<Long, String> seqIdGenerator;
+  private BufferedWriter writer;
 
   public HoodieSparkParquetWriter(Path file,
                                   HoodieRowParquetConfig parquetConfig,
@@ -61,6 +64,7 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
       Integer partitionId = taskContextSupplier.getPartitionIdSupplier().get();
       return HoodieRecord.generateSequenceId(instantTime, partitionId, recordIndex);
     };
+    writer = new BufferedWriter(new FileWriter("/Users/linliu/projects/hudi/log/parquet.txt", true));
   }
 
   @Override
@@ -71,14 +75,22 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
 
       super.write(row);
       writeSupport.add(recordKey);
+      writer.write("Using SparkParquetWriter for: " + recordKey);
+      writer.newLine();
+      writer.flush();
     } else {
       super.write(row);
+      writer.write("Using SparkParquetWriter for: " + key.toString());
+      writer.newLine();
+      writer.flush();
     }
   }
 
   @Override
   public void writeRow(String recordKey, InternalRow row) throws IOException {
     super.write(row);
+    writer.write("Using SparkParquetWriter for: " + recordKey);
+    writer.newLine();
     if (populateMetaFields) {
       writeSupport.add(UTF8String.fromString(recordKey));
     }
@@ -86,6 +98,7 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
 
   @Override
   public void close() throws IOException {
+    writer.close();
     super.close();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowParquetWriter.java
@@ -24,31 +24,41 @@ import org.apache.hudi.io.storage.HoodieBaseParquetWriter;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 
 /**
  * Parquet's impl of {@link HoodieInternalRowFileWriter} to write {@link InternalRow}s.
  */
-public class HoodieInternalRowParquetWriter extends HoodieBaseParquetWriter<InternalRow>
+  public class HoodieInternalRowParquetWriter extends HoodieBaseParquetWriter<InternalRow>
     implements HoodieInternalRowFileWriter {
 
   private final HoodieRowParquetWriteSupport writeSupport;
+  private BufferedWriter writer;
 
   public HoodieInternalRowParquetWriter(Path file, HoodieParquetConfig<HoodieRowParquetWriteSupport> parquetConfig)
       throws IOException {
     super(file, parquetConfig);
 
     this.writeSupport = parquetConfig.getWriteSupport();
+    writer = new BufferedWriter(new FileWriter("/Users/linliu/projects/hudi/log/row.txt", true));
   }
 
   @Override
   public void writeRow(UTF8String key, InternalRow row) throws IOException {
     super.write(row);
     writeSupport.add(key);
+    writer.write("Using InternalRowParquetWriter for: " + key);
+    writer.newLine();
+    writer.flush();
   }
 
   @Override
   public void writeRow(InternalRow row) throws IOException {
     super.write(row);
+    writer.write("Using InternalRowParquetWriter for: " + row.getString(2));
+    writer.newLine();
+    writer.flush();
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.testutils;
 
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -118,6 +119,22 @@ public class SparkDatasetTestUtils {
   }
 
   /**
+   * Generate random Rows based on a set of given keys.
+   *
+   * @param
+   * @param keys A set of {@Link HoodieKey}
+   * @return the Dataset<Row>s thus generated.
+   */
+  public static Dataset<Row> getRandomRowsWithKeys(SQLContext sqlContext, List<HoodieKey> keys, boolean isError) {
+    List<Row> records = new ArrayList<>();
+    for (HoodieKey key : keys) {
+      records.add(getRandomValue(key.getRecordKey(), key.getPartitionPath(), isError));
+    }
+    return sqlContext.createDataFrame(records, isError ? ERROR_STRUCT_TYPE : STRUCT_TYPE);
+  }
+
+
+  /**
    * Generate random Row.
    *
    * @param partitionPath partition path to be set in the Row.
@@ -133,6 +150,36 @@ public class SparkDatasetTestUtils {
       values[1] = RANDOM.nextLong();
     }
     values[2] = UUID.randomUUID().toString();
+    values[3] = partitionPath;
+    values[4] = ""; // filename
+    values[5] = UUID.randomUUID().toString();
+    values[6] = partitionPath;
+    values[7] = RANDOM.nextInt();
+    if (!isError) {
+      values[8] = RANDOM.nextLong();
+    } else {
+      values[8] = UUID.randomUUID().toString();
+    }
+    return new GenericRow(values);
+  }
+
+  /**
+   * Generate random Row based on given record key and partition path.
+   *
+   * @param key the id of the Row.
+   * @param partitionPath partition path to be set in the Row.
+   * @return the Row thus generated.
+   */
+  public static Row getRandomValue(String key, String partitionPath, boolean isError) {
+    // order commit time, seq no, record key, partition path, file name
+    Object[] values = new Object[9];
+    values[0] = ""; //commit time
+    if (!isError) {
+      values[1] = ""; // commit seq no
+    } else {
+      values[1] = RANDOM.nextLong();
+    }
+    values[2] = key;
     values[3] = partitionPath;
     values[4] = ""; // filename
     values[5] = UUID.randomUUID().toString();

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroParquetWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieAvroParquetWriter.java
@@ -26,6 +26,8 @@ import org.apache.hudi.common.model.HoodieKey;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 
 /**
@@ -44,6 +46,7 @@ public class HoodieAvroParquetWriter
   private final TaskContextSupplier taskContextSupplier;
   private final boolean populateMetaFields;
   private final HoodieAvroWriteSupport writeSupport;
+  private BufferedWriter writer;
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   public HoodieAvroParquetWriter(Path file,
@@ -57,6 +60,7 @@ public class HoodieAvroParquetWriter
     this.instantTime = instantTime;
     this.taskContextSupplier = taskContextSupplier;
     this.populateMetaFields = populateMetaFields;
+    writer = new BufferedWriter(new FileWriter("/Users/linliu/projects/hudi/log/avroparquet.txt", true));
   }
 
   @Override
@@ -66,14 +70,23 @@ public class HoodieAvroParquetWriter
           taskContextSupplier.getPartitionIdSupplier().get(), getWrittenRecordCount(), fileName);
       super.write(avroRecord);
       writeSupport.add(key.getRecordKey());
+      writer.write("Using AvroParquetWriter for: " + key);
+      writer.newLine();
+      writer.flush();
     } else {
       super.write(avroRecord);
+      writer.write("Using AvroParquetWriter for: " + key);
+      writer.newLine();
+      writer.flush();
     }
   }
 
   @Override
   public void writeAvro(String key, IndexedRecord object) throws IOException {
     super.write(object);
+    writer.write("Using AvroParquetWriter for: " + key);
+    writer.newLine();
+    writer.flush();
     if (populateMetaFields) {
       writeSupport.add(key);
     }
@@ -82,5 +95,6 @@ public class HoodieAvroParquetWriter
   @Override
   public void close() throws IOException {
     super.close();
+    writer.close();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetStreamWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieParquetStreamWriter.java
@@ -31,6 +31,8 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.OutputFile;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 
 /**
@@ -42,6 +44,7 @@ public class HoodieParquetStreamWriter implements HoodieAvroFileWriter, AutoClos
 
   private final ParquetWriter<IndexedRecord> writer;
   private final HoodieAvroWriteSupport writeSupport;
+  private BufferedWriter writer1;
 
   public HoodieParquetStreamWriter(FSDataOutputStream outputStream,
                                    HoodieParquetConfig<HoodieAvroWriteSupport> parquetConfig) throws IOException {
@@ -56,6 +59,7 @@ public class HoodieParquetStreamWriter implements HoodieAvroFileWriter, AutoClos
         .withWriterVersion(ParquetWriter.DEFAULT_WRITER_VERSION)
         .withConf(parquetConfig.getHadoopConf())
         .build();
+    writer1 = new BufferedWriter(new FileWriter("/Users/linliu/projects/hudi/log/avrostream.txt", true));
   }
 
   @Override
@@ -67,6 +71,9 @@ public class HoodieParquetStreamWriter implements HoodieAvroFileWriter, AutoClos
   public void writeAvro(String key, IndexedRecord record) throws IOException {
     writer.write(record);
     writeSupport.add(key);
+    writer1.write("Using AvroParquetStreamWriter for: " + key);
+    writer1.newLine();
+    writer1.flush();
   }
 
   @Override

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieSparkRecordMergerWorkflow.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieSparkRecordMergerWorkflow.java
@@ -1,0 +1,281 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.hudi;
+
+import org.apache.avro.Schema;
+
+import org.apache.hudi.client.SparkRDDReadClient;
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieSparkRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.hadoop.realtime.HoodieMergeOnReadSnapshotReader;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+import org.apache.hudi.testutils.SparkDatasetTestUtils;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieSparkRecordMergerWorkflow extends SparkClientFunctionalTestHarness {
+  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieSparkRecordMergerWorkflow.class);
+  private static final String FILE = "/Users/linliu/projects/hudi/log/info.txt";
+  private BufferedWriter writer;
+
+  private HoodieTableMetaClient metaClient;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    Properties properties = new Properties();
+    properties.setProperty(
+        HoodieTableConfig.BASE_FILE_FORMAT.key(),
+        HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
+    properties.setProperty(
+        "hoodie.payload.ordering.field",
+        "_hoodie_record_key");
+    metaClient = getHoodieMetaClient(hadoopConf(), basePath(), HoodieTableType.MERGE_ON_READ, properties);
+    writer = new BufferedWriter(new FileWriter(FILE, true));
+  }
+
+  public static String getPartitionPath() {
+    return "2023-09-25";
+  }
+
+  public List<HoodieRecord> generateRecords(int numOfRecords) throws Exception {
+    Dataset<Row> rows = SparkDatasetTestUtils.getRandomRows(new SQLContext(jsc()), numOfRecords, getPartitionPath(), false);
+    List<InternalRow> internalRows = SparkDatasetTestUtils.toInternalRows(rows, SparkDatasetTestUtils.ENCODER);
+    return internalRows.stream()
+        .map(r -> new HoodieSparkRecord(new HoodieKey(r.getString(2), r.getString(3)),
+            r,
+            SparkDatasetTestUtils.STRUCT_TYPE,
+            false)).collect(Collectors.toList());
+  }
+
+  public List<HoodieRecord> generateRecordUpdates(List<HoodieKey> keys) throws Exception {
+    Dataset<Row> rows = SparkDatasetTestUtils.getRandomRowsWithKeys(new SQLContext(jsc()), keys, false);
+    List<InternalRow> internalRows = SparkDatasetTestUtils.toInternalRows(rows, SparkDatasetTestUtils.ENCODER);
+    return internalRows.stream()
+        .map(r -> new HoodieSparkRecord(new HoodieKey(r.getString(2), r.getString(3)),
+            r,
+            SparkDatasetTestUtils.STRUCT_TYPE,
+            false)).collect(Collectors.toList());
+  }
+
+  public static List<HoodieKey> getKeys(List<HoodieRecord> records) {
+    return records.stream().map(r -> r.getKey()).collect(Collectors.toList());
+  }
+
+  private static Schema getAvroSchema(String schemaName, String schemaNameSpace) {
+    return AvroConversionUtils.convertStructTypeToAvroSchema(SparkDatasetTestUtils.STRUCT_TYPE, schemaName, schemaNameSpace);
+  }
+
+  public HoodieWriteConfig getWriteConfig(Schema avroSchema) {
+    Properties extraProperties = new Properties();
+    extraProperties.setProperty(
+        "hoodie.datasource.write.record.merger.impls",
+        "org.apache.hudi.HoodieSparkRecordMerger");
+    extraProperties.setProperty(
+        "hoodie.logfile.data.block.format",
+        "parquet");
+    extraProperties.setProperty(
+        "hoodie.payload.ordering.field",
+        "_hoodie_record_key");
+    extraProperties.setProperty(
+        "hoodie.datasource.write.row.writer.enable",
+        "true");
+
+    return getConfigBuilder(true)
+        .withPath(basePath())
+        .withSchema(avroSchema.toString())
+        .withProperties(extraProperties)
+        .build();
+  }
+
+  public HoodieTableFileSystemView getFileSystemView() {
+    return new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
+  }
+
+  public List<FileSlice> getLatestFileSlices(String partitionPath) {
+    return getFileSystemView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
+  }
+
+  public Option<FileSlice> getLatestFileSlice(String partitionPath, String fileId) {
+    return getFileSystemView().getLatestFileSlice(partitionPath, fileId);
+  }
+
+  public Option<HoodieBaseFile> getLatestBaseFile(String partitionPath, String fileId) {
+    return getLatestFileSlice(partitionPath, fileId).map(fs -> fs.getBaseFile().get());
+  }
+
+  public List<HoodieLogFile> getLatestLogFiles(String partitionPath, String fileId) {
+    Option<FileSlice> fileSliceOpt = getLatestFileSlice(partitionPath, fileId);
+    if (fileSliceOpt.isPresent()) {
+      return fileSliceOpt.get().getLogFiles().collect(Collectors.toList());
+    }
+    return Collections.emptyList();
+  }
+
+  public Option<String> getOneFileId(String partitionPath) {
+    List<FileSlice> fileSlices = getLatestFileSlices(partitionPath);
+    if (fileSlices.isEmpty()) {
+      return Option.empty();
+    }
+    return Option.of(fileSlices.get(0).getFileId());
+  }
+
+  public void checkDataIntegrityUsingSnapshotReader(
+      String partitionPath, String fileId, String latestInstantTime, Schema schema, JobConf jobConf, List<HoodieRecord> records) throws IOException {
+    Option<FileSlice> fileSliceOption = getLatestFileSlice(partitionPath, fileId);
+    assertTrue(fileSliceOption.isPresent());
+
+    Option<HoodieBaseFile> baseFileOption = fileSliceOption.get().getBaseFile();
+    assertTrue(baseFileOption.isPresent());
+
+    List<HoodieLogFile> logFiles = fileSliceOption.get().getLogFiles().collect(Collectors.toList());
+
+    HoodieMergeOnReadSnapshotReader snapshotReader = new HoodieMergeOnReadSnapshotReader(
+        basePath(),
+        baseFileOption.get().getPath(),
+        logFiles,
+        latestInstantTime,
+        schema,
+        jobConf,
+        0,
+        10000000
+        );
+
+    Map<String, HoodieRecord> r = snapshotReader.getRecordsByKey();
+    List<HoodieRecord> obtainedRecords = r.values().stream().collect(Collectors.toList());
+    assertEquals(records.size(), obtainedRecords.size());
+
+    Set<HoodieKey> keys = records.stream().map(HoodieRecord::getKey).collect(Collectors.toSet());
+    Set<HoodieKey> obtainedKeys = obtainedRecords.stream().map(HoodieRecord::getKey).collect(Collectors.toSet());
+
+    Set<HoodieKey> allKeys = new HashSet<>(keys);
+    allKeys.retainAll(obtainedKeys);
+    assertEquals(keys.size(), allKeys.size());
+  }
+
+  public void checkDataIntegrityUsingROReader(List<HoodieRecord> records) {
+    SparkRDDReadClient readClient = new SparkRDDReadClient<>(context(), basePath(), sqlContext());
+    List<HoodieKey> keys = records.stream().map(HoodieRecord::getKey).collect(Collectors.toList());
+    JavaRDD<HoodieKey> keysRDD = jsc().parallelize(keys, 1);
+    List<Row> rows = readClient.readROView(keysRDD, 1).collectAsList();
+    assertEquals(records.size(), rows.size());
+  }
+
+  public void checkDataIntegrity(int numRecords) {
+    List<Row> rows = spark()
+        .read()
+        .format("org.apache.hudi")
+        .load(basePath() + "/" + getPartitionPath())
+        .collectAsList();
+    assertEquals(numRecords, rows.size());
+  }
+
+  @Test
+  public void testSparkRecordWorkflow() throws Exception {
+    Schema avroSchema = getAvroSchema("AvroSchema", "AvroSchemaNS");
+    HoodieWriteConfig writeConfig = getWriteConfig(avroSchema);
+
+    // Check if the merger is correct.
+    HoodieRecordMerger merger = writeConfig.getRecordMerger();
+    assertTrue(merger instanceof HoodieSparkRecordMerger);
+    writer.write("------------- Check merge type DONE");
+    writer.newLine();
+
+    // Check if the table type is correct.
+    HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieTable hoodieTable = HoodieSparkTable.create(writeConfig, context(), reloadedMetaClient);
+    assertEquals(hoodieTable.getMetaClient().getTableType(), HoodieTableType.MERGE_ON_READ);
+    LOG.error("------------- Check table type DONE");
+    writer.newLine();
+
+    // Write and read.
+    try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
+      List<HoodieRecord> records = generateRecords(10);
+
+      // (1) Write: insert.
+      String instantTime = "001";
+      writeClient.startCommitWithTime(instantTime);
+      insertRecordsToMORTable(
+          reloadedMetaClient, records, writeClient, writeConfig, instantTime);
+      writer.write("------------- Insert the first batch of data DONE");
+      writer.newLine();
+      checkDataIntegrity(records.size());
+
+      // (2) Write: new records.
+      instantTime = "002";
+      writeClient.startCommitWithTime(instantTime);
+
+      List<HoodieRecord> records2 = generateRecords(10);
+      updateRecordsInMORTable(
+          reloadedMetaClient, records2, writeClient, writeConfig, instantTime, false);
+      writer.write("------------- Insert the second batch of data DONE");
+      writer.newLine();
+      checkDataIntegrity(records.size() + records.size());
+
+      // (3) Write: append.
+      instantTime = "003";
+      writeClient.startCommitWithTime(instantTime);
+
+      List<HoodieRecord> records3 = generateRecordUpdates(getKeys(records2));
+      updateRecordsInMORTable(reloadedMetaClient, records3, writeClient, writeConfig, instantTime, false);
+      writer.write("------------- Update the first batch of data DONE");
+      writer.newLine();
+      checkDataIntegrity(records.size() + records2.size());
+    }
+    writer.close();
+  }
+}


### PR DESCRIPTION
### Change Logs

We created a functional test to write data and read data, meanwhile log the writers that are used to write data into local files.
We confirmed that only SparkParquetWriters are used to write internal rows into the disk.

This PR is used to confirm the e2e write paths of the internal rows. We will not try to land this PR into prod.

### Impact

No.

### Risk level (write none, low medium or high below)

No.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
