### PR TITLE
[HUDI-6916] Improve performance of Custom Key Generators

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/CustomAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/CustomAvroKeyGenerator.java
@@ -18,16 +18,18 @@
 
 package org.apache.hudi.keygen;
 
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieKeyException;
 import org.apache.hudi.exception.HoodieKeyGeneratorException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
+import org.apache.avro.generic.GenericRecord;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -47,6 +49,8 @@ public class CustomAvroKeyGenerator extends BaseKeyGenerator {
 
   public static final String DEFAULT_PARTITION_PATH_SEPARATOR = "/";
   public static final String SPLIT_REGEX = ":";
+  private final List<BaseKeyGenerator> partitionKeyGenerators;
+  private final BaseKeyGenerator recordKeyGenerator;
 
   /**
    * Used as a part of config in CustomKeyGenerator.java.
@@ -63,6 +67,35 @@ public class CustomAvroKeyGenerator extends BaseKeyGenerator {
                 .map(String::trim).collect(Collectors.toList())
         ).orElse(Collections.emptyList());
     this.partitionPathFields = Arrays.stream(props.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()).split(",")).map(String::trim).collect(Collectors.toList());
+    this.recordKeyGenerator = getRecordKeyFieldNames().size() == 1 ? new SimpleAvroKeyGenerator(config) : new ComplexAvroKeyGenerator(config);
+    this.partitionKeyGenerators = getPartitionKeyGenerators(this.partitionPathFields, config);
+  }
+
+  private static List<BaseKeyGenerator> getPartitionKeyGenerators(List<String> partitionPathFields, TypedProperties config) {
+    if (partitionPathFields.size() == 1 && partitionPathFields.get(0).isEmpty()) {
+      return Collections.emptyList(); // Corresponds to no partition case
+    } else {
+      return partitionPathFields.stream().map(field -> {
+        String[] fieldWithType = field.split(SPLIT_REGEX);
+        if (fieldWithType.length != 2) {
+          throw new HoodieKeyException("Unable to find field names for partition path in proper format");
+        }
+        String partitionPathField = fieldWithType[0];
+        PartitionKeyType keyType = PartitionKeyType.valueOf(fieldWithType[1].toUpperCase());
+        switch (keyType) {
+          case SIMPLE:
+            return new SimpleAvroKeyGenerator(config, partitionPathField);
+          case TIMESTAMP:
+            try {
+              return new TimestampBasedAvroKeyGenerator(config, partitionPathField);
+            } catch (IOException e) {
+              throw new HoodieKeyGeneratorException("Unable to initialise TimestampBasedKeyGenerator class", e);
+            }
+          default:
+            throw new HoodieKeyGeneratorException("Please provide valid PartitionKeyType with fields! You provided: " + keyType);
+        }
+      }).collect(Collectors.toList());
+    }
   }
 
   @Override
@@ -70,48 +103,25 @@ public class CustomAvroKeyGenerator extends BaseKeyGenerator {
     if (getPartitionPathFields() == null) {
       throw new HoodieKeyException("Unable to find field names for partition path in cfg");
     }
-
-    String partitionPathField;
-    StringBuilder partitionPath = new StringBuilder();
-
-    //Corresponds to no partition case
-    if (getPartitionPathFields().size() == 1 && getPartitionPathFields().get(0).isEmpty()) {
+    // Corresponds to no partition case
+    if (partitionKeyGenerators.isEmpty()) {
       return "";
     }
-    for (String field : getPartitionPathFields()) {
-      String[] fieldWithType = field.split(SPLIT_REGEX);
-      if (fieldWithType.length != 2) {
-        throw new HoodieKeyException("Unable to find field names for partition path in proper format");
+    StringBuilder partitionPath = new StringBuilder();
+    for (int i = 0; i < partitionKeyGenerators.size(); i++) {
+      BaseKeyGenerator partitionKeyGenerator = partitionKeyGenerators.get(i);
+      partitionPath.append(partitionKeyGenerator.getPartitionPath(record));
+      if (i != partitionKeyGenerators.size() - 1) {
+        partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
       }
-
-      partitionPathField = fieldWithType[0];
-      PartitionKeyType keyType = PartitionKeyType.valueOf(fieldWithType[1].toUpperCase());
-      switch (keyType) {
-        case SIMPLE:
-          partitionPath.append(new SimpleAvroKeyGenerator(config, partitionPathField).getPartitionPath(record));
-          break;
-        case TIMESTAMP:
-          try {
-            partitionPath.append(new TimestampBasedAvroKeyGenerator(config, partitionPathField).getPartitionPath(record));
-          } catch (IOException e) {
-            throw new HoodieKeyGeneratorException("Unable to initialise TimestampBasedKeyGenerator class", e);
-          }
-          break;
-        default:
-          throw new HoodieKeyGeneratorException("Please provide valid PartitionKeyType with fields! You provided: " + keyType);
-      }
-      partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
     }
-    partitionPath.deleteCharAt(partitionPath.length() - 1);
     return partitionPath.toString();
   }
 
   @Override
   public String getRecordKey(GenericRecord record) {
     validateRecordKeyFields();
-    return getRecordKeyFieldNames().size() == 1
-        ? new SimpleAvroKeyGenerator(config).getRecordKey(record)
-        : new ComplexAvroKeyGenerator(config).getRecordKey(record);
+    return recordKeyGenerator.getRecordKey(record);
   }
 
   private void validateRecordKeyFields() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/factory/TestCreateAvroKeyGeneratorByTypeWithFactory.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/keygen/factory/TestCreateAvroKeyGeneratorByTypeWithFactory.java
@@ -75,7 +75,10 @@ public class TestCreateAvroKeyGeneratorByTypeWithFactory {
   public void testKeyGeneratorTypes(String keyGenType) throws IOException {
     props.put(HoodieWriteConfig.KEYGENERATOR_TYPE.key(), keyGenType);
     KeyGeneratorType keyType = KeyGeneratorType.valueOf(keyGenType);
-
+    if (keyType == KeyGeneratorType.CUSTOM) {
+      // input needs to be properly formatted
+      props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "timestamp:timestamp");
+    }
     KeyGenerator keyGenerator = HoodieAvroKeyGeneratorFactory.createKeyGenerator(props);
     switch (keyType) {
       case SIMPLE:

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/CustomKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/CustomKeyGenerator.java
@@ -34,6 +34,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -55,6 +56,8 @@ import java.util.stream.Collectors;
 public class CustomKeyGenerator extends BuiltinKeyGenerator {
 
   private final CustomAvroKeyGenerator customAvroKeyGenerator;
+  private final List<BuiltinKeyGenerator> partitionKeyGenerators;
+  private final BuiltinKeyGenerator recordKeyGenerator;
 
   public CustomKeyGenerator(TypedProperties props) {
     // NOTE: We have to strip partition-path configuration, since it could only be interpreted by
@@ -71,6 +74,37 @@ public class CustomKeyGenerator extends BuiltinKeyGenerator {
         ? Collections.emptyList()
         : Arrays.stream(partitionPathFields.split(",")).map(String::trim).collect(Collectors.toList());
     this.customAvroKeyGenerator = new CustomAvroKeyGenerator(props);
+    this.recordKeyGenerator = getRecordKeyFieldNames().size() == 1
+        ? new SimpleKeyGenerator(config, Option.ofNullable(config.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key())), null)
+        : new ComplexKeyGenerator(config);
+    this.partitionKeyGenerators = getPartitionKeyGenerators(this.partitionPathFields, config);
+  }
+
+  private static List<BuiltinKeyGenerator> getPartitionKeyGenerators(List<String> partitionPathFields, TypedProperties config) {
+    if (partitionPathFields.size() == 1 && partitionPathFields.get(0).isEmpty()) {
+      return Collections.emptyList();
+    } else {
+      return partitionPathFields.stream().map(field -> {
+        String[] fieldWithType = field.split(CustomAvroKeyGenerator.SPLIT_REGEX);
+        if (fieldWithType.length != 2) {
+          throw new HoodieKeyGeneratorException("Unable to find field names for partition path in proper format");
+        }
+        String partitionPathField = fieldWithType[0];
+        CustomAvroKeyGenerator.PartitionKeyType keyType = CustomAvroKeyGenerator.PartitionKeyType.valueOf(fieldWithType[1].toUpperCase());
+        switch (keyType) {
+          case SIMPLE:
+            return new SimpleKeyGenerator(config, partitionPathField);
+          case TIMESTAMP:
+            try {
+              return new TimestampBasedKeyGenerator(config, partitionPathField);
+            } catch (IOException ioe) {
+              throw new HoodieKeyGeneratorException("Unable to initialise TimestampBasedKeyGenerator class", ioe);
+            }
+          default:
+            throw new HoodieKeyGeneratorException("Please provide valid PartitionKeyType with fields! You provided: " + keyType);
+        }
+      }).collect(Collectors.toList());
+    }
   }
 
   @Override
@@ -85,9 +119,7 @@ public class CustomKeyGenerator extends BuiltinKeyGenerator {
 
   @Override
   public String getRecordKey(Row row) {
-    return getRecordKeyFieldNames().size() == 1
-        ? new SimpleKeyGenerator(config, Option.ofNullable(config.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key())), null).getRecordKey(row)
-        : new ComplexKeyGenerator(config).getRecordKey(row);
+    return recordKeyGenerator.getRecordKey(row);
   }
 
   @Override
@@ -104,54 +136,25 @@ public class CustomKeyGenerator extends BuiltinKeyGenerator {
     if (getPartitionPathFields() == null) {
       throw new HoodieKeyException("Unable to find field names for partition path in cfg");
     }
-
-    String partitionPathField;
-    StringBuilder partitionPath = new StringBuilder();
-
-    //Corresponds to no partition case
-    if (getPartitionPathFields().size() == 1 && getPartitionPathFields().get(0).isEmpty()) {
+    // Corresponds to no partition case
+    if (partitionKeyGenerators.isEmpty()) {
       return "";
     }
-    for (String field : getPartitionPathFields()) {
-      String[] fieldWithType = field.split(CustomAvroKeyGenerator.SPLIT_REGEX);
-      if (fieldWithType.length != 2) {
-        throw new HoodieKeyGeneratorException("Unable to find field names for partition path in proper format");
+    StringBuilder partitionPath = new StringBuilder();
+    for (int i = 0; i < partitionKeyGenerators.size(); i++) {
+      BuiltinKeyGenerator keyGenerator = partitionKeyGenerators.get(i);
+      if (record.isPresent()) {
+        partitionPath.append(keyGenerator.getPartitionPath(record.get()));
+      } else if (row.isPresent()) {
+        partitionPath.append(keyGenerator.getPartitionPath(row.get()));
+      } else {
+        partitionPath.append(keyGenerator.getPartitionPath(internalRowStructTypePair.get().getKey(),
+            internalRowStructTypePair.get().getValue()));
       }
-
-      partitionPathField = fieldWithType[0];
-      CustomAvroKeyGenerator.PartitionKeyType keyType = CustomAvroKeyGenerator.PartitionKeyType.valueOf(fieldWithType[1].toUpperCase());
-      switch (keyType) {
-        case SIMPLE:
-          if (record.isPresent()) {
-            partitionPath.append(new SimpleKeyGenerator(config, partitionPathField).getPartitionPath(record.get()));
-          } else if (row.isPresent()) {
-            partitionPath.append(new SimpleKeyGenerator(config, partitionPathField).getPartitionPath(row.get()));
-          } else {
-            partitionPath.append(new SimpleKeyGenerator(config, partitionPathField).getPartitionPath(internalRowStructTypePair.get().getKey(),
-                internalRowStructTypePair.get().getValue()));
-          }
-          break;
-        case TIMESTAMP:
-          try {
-            if (record.isPresent()) {
-              partitionPath.append(new TimestampBasedKeyGenerator(config, partitionPathField).getPartitionPath(record.get()));
-            } else if (row.isPresent()) {
-              partitionPath.append(new TimestampBasedKeyGenerator(config, partitionPathField).getPartitionPath(row.get()));
-            } else {
-              partitionPath.append(new TimestampBasedKeyGenerator(config, partitionPathField).getPartitionPath(internalRowStructTypePair.get().getKey(),
-                  internalRowStructTypePair.get().getValue()));
-            }
-          } catch (IOException ioe) {
-            throw new HoodieKeyGeneratorException("Unable to initialise TimestampBasedKeyGenerator class", ioe);
-          }
-          break;
-        default:
-          throw new HoodieKeyGeneratorException("Please provide valid PartitionKeyType with fields! You provided: " + keyType);
+      if (i != partitionKeyGenerators.size() - 1) {
+        partitionPath.append(customAvroKeyGenerator.getDefaultPartitionPathSeparator());
       }
-
-      partitionPath.append(customAvroKeyGenerator.getDefaultPartitionPathSeparator());
     }
-    partitionPath.deleteCharAt(partitionPath.length() - 1);
     return partitionPath.toString();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/CustomKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/CustomKeyGenerator.java
@@ -50,9 +50,7 @@ import java.util.stream.Collectors;
  *
  * RecordKey is internally generated using either SimpleKeyGenerator or ComplexKeyGenerator.
  *
- * @deprecated
  */
-@Deprecated
 public class CustomKeyGenerator extends BuiltinKeyGenerator {
 
   private final CustomAvroKeyGenerator customAvroKeyGenerator;

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/factory/TestCreateKeyGeneratorByTypeWithFactory.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/factory/TestCreateKeyGeneratorByTypeWithFactory.java
@@ -77,6 +77,10 @@ public class TestCreateKeyGeneratorByTypeWithFactory {
     props.put(HoodieWriteConfig.KEYGENERATOR_TYPE.key(), keyGenType);
     KeyGeneratorType keyType = KeyGeneratorType.valueOf(keyGenType);
 
+    if (keyType == KeyGeneratorType.CUSTOM) {
+      // input needs to be properly formatted
+      props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "timestamp:timestamp");
+    }
     KeyGenerator keyGenerator = HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
     switch (keyType) {
       case SIMPLE:

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/factory/TestHoodieSparkKeyGeneratorFactory.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/keygen/factory/TestHoodieSparkKeyGeneratorFactory.java
@@ -72,6 +72,7 @@ public class TestHoodieSparkKeyGeneratorFactory {
 
     // set KeyGenerator type only
     props.put(KEYGENERATOR_TYPE.key(), KeyGeneratorType.CUSTOM.name());
+    props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "field:simple");
     KeyGenerator keyGenerator = HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
     assertEquals(CustomKeyGenerator.class.getName(), keyGenerator.getClass().getName());
 


### PR DESCRIPTION
### Change Logs

Fixes an issue in the custom key generators where we are creating objects per record/row instead of reusing them. This leads to excess object creation which in turn creates more objects to garbage collect.

### Impact

Improves performance for users using custom key generator

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
