### PR TITLE
[HUDI-6923] Fixing bug with sanitization for rowSource

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -53,7 +53,7 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     super(props, jssc);
     checkRequiredConfigProperties(props, Collections.singletonList(FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE));
     String sourceFile = getStringWithAltKeys(props, FilebasedSchemaProviderConfig.SOURCE_SCHEMA_FILE);
-    boolean shouldSanitize = SanitizationUtils.getShouldSanitize(props);
+    boolean shouldSanitize = SanitizationUtils.shouldSanitize(props);
     String invalidCharMask = SanitizationUtils.getInvalidCharMask(props);
     this.fs = FSUtils.getFs(sourceFile, jssc.hadoopConfiguration(), true);
     this.sourceSchema = readAvroSchemaFromFile(sourceFile, this.fs, shouldSanitize, invalidCharMask);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/SanitizationUtils.java
@@ -65,7 +65,7 @@ public class SanitizationUtils {
 
   private static final String AVRO_FIELD_NAME_KEY = "name";
 
-  public static boolean getShouldSanitize(TypedProperties props) {
+  public static boolean shouldSanitize(TypedProperties props) {
     return getBooleanWithAltKeys(props, HoodieStreamerConfig.SANITIZE_SCHEMA_FIELD_NAMES);
   }
 
@@ -118,6 +118,11 @@ public class SanitizationUtils {
       }
     }
     return targetDataset;
+  }
+
+  public static Dataset<Row> sanitizeColumnNamesForAvro(Dataset<Row> inputDataset, TypedProperties props) {
+    return shouldSanitize(props) ? sanitizeColumnNamesForAvro(inputDataset, getInvalidCharMask(props))
+        : inputDataset;
   }
 
   /*


### PR DESCRIPTION
### Change Logs

Moving sanitization from sourceFormatAdapter to RowSource , modifying unit tests to consider RowBasedSchemaProvider.
### Impact

`RowSource` schemaProvider is constructing RowBasedSchemaProvider . Which can be overwritten in `Source` if  external schemaProvider is not null . 
If we sanitize after we create RowBasedSchemaProvider , then schema mismatch is happening ( df.schema is not same as inputBatch.getSchemaProvider.schema)
This Fix will do Sanitization in RowSource 

### Risk level (write none, low medium or high below)

low
### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
