### PR TITLE
[HUDI-6925] Do not list all partitions for 'alter table drop partition'

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -326,23 +326,7 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
   def getPartitionPathToDrop(
                               hoodieCatalogTable: HoodieCatalogTable,
                               normalizedSpecs: Seq[Map[String, String]]): String = {
-    val (enableHiveStylePartitioning, enableEncodeUrl) = {
-      val tableConfig = hoodieCatalogTable.tableConfig
-      val enableHiveStylePartitioning = Option(tableConfig.getHiveStylePartitioningEnable)
-      val enableEncodeUrl = Option(tableConfig.getUrlEncodePartitioning)
-      if (enableHiveStylePartitioning.isDefined && enableEncodeUrl.isDefined) {
-        (enableHiveStylePartitioning.get.toBoolean, enableEncodeUrl.get.toBoolean)
-      } else {
-        val table = hoodieCatalogTable.table
-        val allPartitionPaths = hoodieCatalogTable.getPartitionPaths
-        (isHiveStyledPartitioning(allPartitionPaths, table), isUrlEncodeEnabled(allPartitionPaths, table))
-      }
-    }
-    val partitionFields = hoodieCatalogTable.partitionFields
-    val partitionsToDrop = normalizedSpecs.map(
-      makePartitionPath(partitionFields, _, enableEncodeUrl, enableHiveStylePartitioning)
-    ).mkString(",")
-    partitionsToDrop
+    normalizedSpecs.map(makePartitionPath(hoodieCatalogTable, _)).mkString(",")
   }
 
   private def makePartitionPath(partitionFields: Seq[String],


### PR DESCRIPTION
### Change Logs

Currently we will list all partitions paths when calling 'alter table drop partition' to check if the table is hive style partitions and URL encoded. Listing all partitions path is expensive and we can  get these configs from table config instead. 


This behavior is aligh with 'insert into table', see `org.apache.spark.sql.hudi.ProvidesHoodieConfig#buildHoodieInsertConfig`. 


### Impact

Get `hiveStylePartitioningEnable` and `urlEncodePartitioning` from table config when 'alter table drop partition'.

### Risk level (write none, low medium or high below)

low


### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
