### PR TITLE
[HUDI-6926] Disable DROP_PARTITION_COLUMNS when upsert MOR table

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -1194,8 +1194,9 @@ object HoodieSparkSqlWriter {
       && !optParams.containsKey(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE.key)) {
       mergedParams.put(HoodieCompactionConfig.INLINE_COMPACT.key(), "true")
     }
-    // disallow drop partition columns when upsert MOR table
-    if (mergedParams.get(OPERATION.key).get == UPSERT_OPERATION_OPT_VAL && tableConfig.getTableType == MERGE_ON_READ) {
+    // disable drop partition columns when upsert MOR table
+    if (mergedParams.get(OPERATION.key).get == UPSERT_OPERATION_OPT_VAL
+      && mergedParams.getOrElse(DataSourceWriteOptions.TABLE_TYPE.key, COPY_ON_WRITE.name) == MERGE_ON_READ.name) {
       mergedParams.put(HoodieTableConfig.DROP_PARTITION_COLUMNS.key, "false")
     }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -1194,6 +1194,11 @@ object HoodieSparkSqlWriter {
       && !optParams.containsKey(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE.key)) {
       mergedParams.put(HoodieCompactionConfig.INLINE_COMPACT.key(), "true")
     }
+    // disallow drop partition columns when upsert MOR table
+    if (mergedParams.get(OPERATION.key).get == UPSERT_OPERATION_OPT_VAL && tableConfig.getTableType == MERGE_ON_READ) {
+      mergedParams.put(HoodieTableConfig.DROP_PARTITION_COLUMNS.key, "false")
+    }
+
     val params = mergedParams.toMap
     (params, HoodieWriterUtils.convertMapToHoodieConfig(params))
   }


### PR DESCRIPTION
### Change Logs
When merge the log files for MOR table, it can not generate partition values if we drop partition columns while upsert data. As a result, the updated rows in log files will get null for partition columns.

To prevent this issue, we suggest disable `DROP_PARTITION_COLUMNS` while upsert MOR table.

### Impact
Fix bug in get partition values from path in MOR log files.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
