### PR TITLE
[HUDI-6917] Fix docker integ tests

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -455,4 +455,6 @@ jobs:
           mkdir /tmp/spark-events/
           SPARK_ARCHIVE_BASENAME=$(basename $SPARK_ARCHIVE)
           export SPARK_HOME=$GITHUB_WORKSPACE/${SPARK_ARCHIVE_BASENAME%.*}
+          rm -f $GITHUB_WORKSPACE/$SPARK_ARCHIVE
+          docker system prune --all --force
           mvn verify $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests -pl !hudi-flink-datasource/hudi-flink $MVN_ARGS

--- a/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -62,7 +62,6 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.CorruptedLogFileException;
-import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -458,22 +457,6 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     }
     assertEquals(logBlockWrittenNum, logBlockReadNum, "All written log should be correctly found");
     reader.close();
-
-    // test writing oversize data block which should be rejected
-    Writer oversizeWriter =
-        HoodieLogFormat.newWriterBuilder().onParentPath(partitionPath).withFileExtension(HoodieLogFile.DELTA_EXTENSION)
-            .withFileId("test-fileid1").withDeltaCommit("100").withSizeThreshold(3L * 1024 * 1024 * 1024).withFs(fs)
-            .build();
-    // write to the existing file
-    ((HoodieLogFormatWriter) writer).withOutputStream(fs.append(writer.getLogFile().getPath()));
-    List<HoodieLogBlock> dataBlocks = new ArrayList<>(logBlockWrittenNum + 1);
-    for (int i = 0; i < logBlockWrittenNum + 1; i++) {
-      dataBlocks.add(reusableDataBlock);
-    }
-    assertThrows(HoodieIOException.class, () -> {
-      oversizeWriter.appendBlocks(dataBlocks);
-    }, "Blocks appended may overflow. Please decrease log block size or log block amount");
-    oversizeWriter.close();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Change Logs

There are two issues with tests that are fixed by this PR:
1. `TestHoodieLogFormat#testHugeLogFileWrite` is trying to write a big log file which was frequently leading to namenode going down. PR removes the superfluous overflow testing.
2. Some unused docker images remained. So those images are pruned to reclaim space to avoid failure due to lack of space.

### Impact

Fix docker integ tests.

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
