### PR TITLE
[HUDI-6480] Flink support non-blocking concurrency control

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -67,8 +67,8 @@ public class TransactionUtils {
       Option<HoodieInstant> lastCompletedTxnOwnerInstant,
       boolean reloadActiveTimeline,
       Set<String> pendingInstants) throws HoodieWriteConflictException {
-    // Skip to resolve conflict if there are multiple writers working on the same MOR table with simple bucket index
-    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl() && !config.isLocklessMultiWriter()) {
+    // Skip to resolve conflict if using non-blocking concurrency control
+    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl() && !config.isNonBlockingConcurrencyControl()) {
       // deal with pendingInstants
       Stream<HoodieInstant> completedInstantsDuringCurrentWriteOperation = getCompletedInstantsDuringCurrentWriteOperation(table.getMetaClient(), pendingInstants);
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -67,7 +67,8 @@ public class TransactionUtils {
       Option<HoodieInstant> lastCompletedTxnOwnerInstant,
       boolean reloadActiveTimeline,
       Set<String> pendingInstants) throws HoodieWriteConflictException {
-    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+    // Skip to resolve conflict if there are multiple writers working on the same MOR table with simple bucket index
+    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl() && !config.isLocklessMultiWriter()) {
       // deal with pendingInstants
       Stream<HoodieInstant> completedInstantsDuringCurrentWriteOperation = getCompletedInstantsDuringCurrentWriteOperation(table.getMetaClient(), pendingInstants);
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2616,7 +2616,7 @@ public class HoodieWriteConfig extends HoodieConfig {
     return props.getInteger(WRITES_FILEID_ENCODING, HoodieMetadataPayload.RECORD_INDEX_FIELD_FILEID_ENCODING_UUID);
   }
 
-  public boolean isLocklessMultiWriter() {
+  public boolean isNonBlockingConcurrencyControl() {
     return getTableType().equals(HoodieTableType.MERGE_ON_READ)
         && getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()
         && isSimpleBucketIndex();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1289,6 +1289,11 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getIndexType() == HoodieIndex.IndexType.BUCKET && getBucketIndexEngineType() == HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING;
   }
 
+  public boolean isSimpleBucketIndex() {
+    return HoodieIndex.IndexType.BUCKET.equals(getIndexType())
+        && HoodieIndex.BucketIndexEngineType.SIMPLE.equals(getBucketIndexEngineType());
+  }
+
   public boolean isConsistentLogicalTimestampEnabled() {
     return getBooleanOrDefault(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED);
   }
@@ -2609,6 +2614,12 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public Integer getWritesFileIdEncoding() {
     return props.getInteger(WRITES_FILEID_ENCODING, HoodieMetadataPayload.RECORD_INDEX_FIELD_FILEID_ENCODING_UUID);
+  }
+
+  public boolean isLocklessMultiWriter() {
+    return getTableType().equals(HoodieTableType.MERGE_ON_READ)
+        && getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()
+        && isSimpleBucketIndex();
   }
 
   public static class Builder {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -33,6 +33,9 @@ public class BucketIdentifier implements Serializable {
   // Compatible with the spark bucket name
   private static final Pattern BUCKET_NAME = Pattern.compile(".*_(\\d+)(?:\\..*)?$");
 
+  // Ensure the same records keys from different writers are desired to be distributed into the same bucket
+  private static final String CONSTANT_FILE_ID_SUFFIX = "-0000-0000-0000-000000000000";
+
   public static int getBucketId(HoodieRecord record, String indexKeyFields, int numBuckets) {
     return getBucketId(record.getKey(), indexKeyFields, numBuckets);
   }
@@ -97,6 +100,10 @@ public class BucketIdentifier implements Serializable {
 
   public static String newBucketFileIdPrefix(String bucketId) {
     return FSUtils.createNewFileIdPfx().replaceFirst(".{8}", bucketId);
+  }
+
+  public static String newBucketFileIdFixedSuffix(int bucketId) {
+    return bucketIdStr(bucketId) + CONSTANT_FILE_ID_SUFFIX;
   }
 
   public static boolean isBucketFileName(String name) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -303,7 +303,7 @@ public class HoodieFlinkWriteClient<T> extends
    * should be called before the Driver starts a new transaction.
    */
   public void preTxn(HoodieTableMetaClient metaClient) {
-    if (txnManager.isLockRequired()) {
+    if (txnManager.isLockRequired() && !config.isNonBlockingConcurrencyControl()) {
       // refresh the meta client which is reused
       metaClient.reloadActiveTimeline();
       this.lastCompletedTxnAndMetadata = TransactionUtils.getLastCompletedTxnInstantAndMetadata(metaClient);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -159,6 +159,13 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns whether the table index is simple bucket index.
+   */
+  public static boolean isSimpleBucketIndexType(Configuration conf) {
+    return isBucketIndexType(conf) && getBucketEngineType(conf).equals(HoodieIndex.BucketIndexEngineType.SIMPLE);
+  }
+
+  /**
    * Returns the default plan strategy class.
    */
   public static String getDefaultPlanStrategyClassName(Configuration conf) {
@@ -358,6 +365,13 @@ public class OptionsResolver {
    */
   public static boolean allowCommitOnEmptyBatch(Configuration conf) {
     return conf.getBoolean(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false);
+  }
+
+  /**
+   * Returns whether this is lockless multi-writer ingestion.
+   */
+  public static boolean isLocklessMultiWriter(Configuration config) {
+    return isMorTable(config) && isSimpleBucketIndexType(config) && isOptimisticConcurrencyControl(config);
   }
 
   public static boolean isLazyFailedWritesCleanPolicy(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -368,9 +368,9 @@ public class OptionsResolver {
   }
 
   /**
-   * Returns whether this is lockless multi-writer ingestion.
+   * Returns whether this is non-blocking concurrency control.
    */
-  public static boolean isLocklessMultiWriter(Configuration config) {
+  public static boolean isNonBlockingConcurrencyControl(Configuration config) {
     return isMorTable(config) && isSimpleBucketIndexType(config) && isOptimisticConcurrencyControl(config);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -460,7 +460,7 @@ public class StreamWriteOperatorCoordinator
   private void scheduleTableServices(Boolean committed) {
     // if compaction is on, schedule the compaction
     if (tableState.scheduleCompaction) {
-      CompactionUtil.scheduleCompaction(metaClient, writeClient, tableState.isDeltaTimeCompaction, committed);
+      CompactionUtil.scheduleCompaction(writeClient, tableState.isDeltaTimeCompaction, committed);
     }
     // if clustering is on, schedule the clustering
     if (tableState.scheduleClustering) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -58,7 +58,7 @@ public class BucketStreamWriteFunction<I> extends StreamWriteFunction<I> {
 
   private String indexKeyFields;
 
-  private boolean isLocklessMultiWriter;
+  private boolean isNonBlockingConcurrencyControl;
 
   /**
    * BucketID to file group mapping in each partition.
@@ -87,7 +87,7 @@ public class BucketStreamWriteFunction<I> extends StreamWriteFunction<I> {
     super.open(parameters);
     this.bucketNum = config.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS);
     this.indexKeyFields = OptionsResolver.getIndexKeyField(config);
-    this.isLocklessMultiWriter = OptionsResolver.isLocklessMultiWriter(config);
+    this.isNonBlockingConcurrencyControl = OptionsResolver.isNonBlockingConcurrencyControl(config);
     this.taskID = getRuntimeContext().getIndexOfThisSubtask();
     this.parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
     this.bucketIndex = new HashMap<>();
@@ -122,7 +122,7 @@ public class BucketStreamWriteFunction<I> extends StreamWriteFunction<I> {
     } else if (bucketToFileId.containsKey(bucketNum)) {
       location = new HoodieRecordLocation("U", bucketToFileId.get(bucketNum));
     } else {
-      String newFileId = isLocklessMultiWriter
+      String newFileId = isNonBlockingConcurrencyControl
           ? BucketIdentifier.newBucketFileIdFixedSuffix(bucketNum)
           : BucketIdentifier.newBucketFileIdPrefix(bucketNum);
       location = new HoodieRecordLocation("I", newFileId);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
@@ -221,16 +221,13 @@ public class HoodieFlinkCompactor {
 
       // checks the compaction plan and do compaction.
       if (cfg.schedule) {
-        Option<String> compactionInstantTimeOption = CompactionUtil.getCompactionInstantTime(table.getMetaClient());
-        if (compactionInstantTimeOption.isPresent()) {
-          boolean scheduled = writeClient.scheduleCompactionAtInstant(compactionInstantTimeOption.get(), Option.empty());
-          if (!scheduled) {
-            // do nothing.
-            LOG.info("No compaction plan for this job ");
-            return;
-          }
-          table.getMetaClient().reloadActiveTimeline();
+        boolean scheduled = writeClient.scheduleCompaction(Option.empty()).isPresent();
+        if (!scheduled) {
+          // do nothing.
+          LOG.info("No compaction plan for this job ");
+          return;
         }
+        table.getMetaClient().reloadActiveTimeline();
       }
 
       // fetch the instant based on the configured execution sequence

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -200,6 +200,19 @@ public class CkpMetadata implements Serializable, AutoCloseable {
     return this.instantCache;
   }
 
+  @Nullable
+  @VisibleForTesting
+  public String lastCompleteInstant() {
+    load();
+    for (int i = this.messages.size() - 1; i >= 0; i--) {
+      CkpMessage ckpMsg = this.messages.get(i);
+      if (ckpMsg.isComplete()) {
+        return ckpMsg.getInstant();
+      }
+    }
+    return null;
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -213,12 +213,6 @@ public class CkpMetadata implements Serializable, AutoCloseable {
     return null;
   }
 
-  @Nullable
-  @VisibleForTesting
-  public boolean isEmpty() {
-    return messages.isEmpty();
-  }
-
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/meta/CkpMetadata.java
@@ -213,6 +213,12 @@ public class CkpMetadata implements Serializable, AutoCloseable {
     return null;
   }
 
+  @Nullable
+  @VisibleForTesting
+  public boolean isEmpty() {
+    return messages.isEmpty();
+  }
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -216,6 +216,7 @@ public class StreamerUtil {
         properties.put(option.key(), option.defaultValue());
       }
     }
+    properties.put(HoodieTableConfig.TYPE.key(), conf.getString(FlinkOptions.TABLE_TYPE));
     return new TypedProperties(properties);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -543,8 +543,8 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
     pipeline1 = pipeline1
         .checkpoint(1)
         .assertNextEvent();
-    if (OptionsResolver.isLocklessMultiWriter(conf)) {
-      // should success for concurrent modification of same fileGroups if using lockless multi writers
+    if (OptionsResolver.isNonBlockingConcurrencyControl(conf)) {
+      // should success for concurrent modification of same fileGroups if using non-blocking concurrency control
       pipeline1
           .checkpointComplete(1)
           .checkWrittenData(EXPECTED3, 1);
@@ -581,12 +581,12 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
         .checkWrittenData(EXPECTED3, 1);
 
     // step to commit the 2nd txn
-    // should success for concurrent modification of same fileGroups if using lockless multi writers
+    // should success for concurrent modification of same fileGroups if using non-blocking concurrency control
     // should throw exception otherwise
     pipeline2 = pipeline2
         .checkpoint(1)
         .assertNextEvent();
-    if (OptionsResolver.isLocklessMultiWriter(conf)) {
+    if (OptionsResolver.isNonBlockingConcurrencyControl(conf)) {
       pipeline2
           .checkpointComplete(1)
           .checkWrittenData(EXPECTED3, 1);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
@@ -214,14 +214,6 @@ public class TestWriteMergeOnRead extends TestWriteCopyOnWrite {
   }
 
   @Override
-  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
-    pipeline.checkpoint(1)
-        .assertNextEvent()
-        .checkpointComplete(1)
-        .checkWrittenData(EXPECTED3, 1);
-  }
-
-  @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
@@ -214,6 +214,14 @@ public class TestWriteMergeOnRead extends TestWriteCopyOnWrite {
   }
 
   @Override
+  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
+    pipeline.checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1)
+        .checkWrittenData(EXPECTED3, 1);
+  }
+
+  @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -18,14 +18,30 @@
 
 package org.apache.hudi.sink;
 
+import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.PartialUpdateAvroPayload;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.util.FlinkWriteClients;
+import org.apache.hudi.utils.TestData;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static org.apache.hudi.utils.TestData.insertRow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test cases for delta stream write with compaction.
@@ -70,12 +86,78 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     return expected;
   }
 
-  @Override
-  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
-    pipeline.checkpoint(1)
+  @Test
+  public void testLocklessMultiWriterWithPartialUpdatePayload() throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
+    // disable schedule compaction in writers
+    conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
+    conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
+
+    // start pipeline1 and insert record: [id1,par1,id1,Danny,null,1,par1], suspend the tx commit
+    List<RowData> dataset1 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id1"), StringData.fromString("Danny"), null,
+            TimestampData.fromEpochMillis(1), StringData.fromString("par1")));
+    TestHarness pipeline1 = preparePipeline(conf)
+        .consume(dataset1)
+        .assertEmptyDataFiles();
+
+    // start pipeline2 and insert record: [id1,par1,id1,null,23,1,par1], suspend the tx commit
+    Configuration conf2 = conf.clone();
+    conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
+    List<RowData> dataset2 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id1"), null, 23,
+            TimestampData.fromEpochMillis(2), StringData.fromString("par1")));
+    TestHarness pipeline2 = preparePipeline(conf2)
+        .consume(dataset2)
+        .assertEmptyDataFiles();
+
+    // step to commit the 1st txn
+    pipeline1.checkpoint(1)
         .assertNextEvent()
-        .checkpointComplete(1)
-        .checkWrittenData(EXPECTED3, 1);
+        .checkpointComplete(1);
+
+    // step to commit the 2nd txn
+    pipeline2.checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1);
+
+    // snapshot result is [(id1,Danny,23,2,par1)] after two writers finish to commit
+    Map<String, String> tmpSnapshotResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
+    pipeline2.checkWrittenData(tmpSnapshotResult, 1);
+
+    // There is no base file in partition dir because there is no compaction yet.
+    pipeline1.assertEmptyDataFiles();
+
+    // schedule compaction outside of all writers
+    try (HoodieFlinkWriteClient writeClient = FlinkWriteClients.createWriteClient(conf)) {
+      Option<String> scheduleInstant = writeClient.scheduleCompaction(Option.empty());
+      assertNotNull(scheduleInstant.get());
+    }
+
+    // step to commit the 3nd txn
+    // it would also trigger inline compactor
+    List<RowData> dataset3 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id3"), StringData.fromString("Julian"), 53,
+            TimestampData.fromEpochMillis(4), StringData.fromString("par1")));
+    pipeline1.consume(dataset3)
+        .checkpoint(2)
+        .assertNextEvent()
+        .checkpointComplete(2);
+
+    // snapshot read result is [(id1,Danny,23,2,par1), (id3,Julian,53,4,par1)] after three writers finish to commit
+    Map<String, String> finalSnapshotResult = Collections.singletonMap(
+        "par1",
+        "[id1,par1,id1,Danny,23,2,par1, id3,par1,id3,Julian,53,4,par1]");
+    pipeline1.checkWrittenData(finalSnapshotResult, 1);
+    // read optimized read result is [(id1,Danny,23,2,par1)]
+    // because the data of third commit is not included in the last compaction.
+    Map<String, String> readOptimizedResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
+    TestData.checkWrittenData(tempFile, readOptimizedResult, 1);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -71,6 +71,14 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   }
 
   @Override
+  protected void testConcurrentCommit(TestHarness pipeline) throws Exception {
+    pipeline.checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1)
+        .checkWrittenData(EXPECTED3, 1);
+  }
+
+  @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -524,13 +524,12 @@ public class TestWriteBase {
     }
 
     protected String lastCompleteInstant() {
-      // If using non-blocking concurrency control, fetch last complete instant of current writer from ckp metadata
-      // because the writer started first might finish later, similarly, the writer started later might finish first.
-      String lastCommitFromCkpMeta = this.ckpMetadata.lastCompleteInstant();
-      if (lastCommitFromCkpMeta != null || this.ckpMetadata.isEmpty()) {
-        return lastCommitFromCkpMeta;
+      // If using optimistic concurrency control, fetch last complete instant of current writer from ckp metadata
+      // because there are multiple write clients commit to the timeline.
+      if (OptionsResolver.isOptimisticConcurrencyControl(conf)) {
+        return this.ckpMetadata.lastCompleteInstant();
       } else {
-        // The ckp meta has been cleaned because of the failover, fetch the instant from timeline.
+        // fetch the instant from timeline.
         return OptionsResolver.isMorTable(conf)
             ? TestUtils.getLastDeltaCompleteInstant(basePath)
             : TestUtils.getLastCompleteInstant(basePath, HoodieTimeline.COMMIT_ACTION);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -479,7 +479,11 @@ public class TestWriteBase {
     }
 
     public TestHarness checkLastPendingInstantCompleted() {
-      checkInstantState(HoodieInstant.State.COMPLETED, this.lastPending);
+      // the ckp meta has been cleaned because of the failover, fetch the instant from timeline.
+      String lastCompleteInstant = OptionsResolver.isMorTable(conf)
+          ? TestUtils.getLastDeltaCompleteInstant(basePath)
+          : TestUtils.getLastCompleteInstant(basePath, HoodieTimeline.COMMIT_ACTION);
+      assertThat(lastCompleteInstant, is(this.lastPending));
       this.lastComplete = lastPending;
       this.lastPending = lastPendingInstant();
       return this;
@@ -524,9 +528,7 @@ public class TestWriteBase {
     }
 
     protected String lastCompleteInstant() {
-      return OptionsResolver.isMorTable(conf)
-          ? TestUtils.getLastDeltaCompleteInstant(basePath)
-          : TestUtils.getLastCompleteInstant(basePath, HoodieTimeline.COMMIT_ACTION);
+      return this.ckpMetadata.lastCompleteInstant();
     }
 
     public TestHarness checkCompletedInstantCount(int count) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
@@ -140,7 +140,7 @@ public class TestCompactionUtil {
     TestData.writeDataAsBatch(TestData.DATA_SET_SINGLE_INSERT, conf);
 
     try (HoodieFlinkWriteClient<?> writeClient = FlinkWriteClients.createWriteClient(conf)) {
-      CompactionUtil.scheduleCompaction(metaClient, writeClient, true, true);
+      CompactionUtil.scheduleCompaction(writeClient, true, true);
 
       Option<HoodieInstant> pendingCompactionInstant = metaClient.reloadActiveTimeline().filterPendingCompactionTimeline().lastInstant();
       assertTrue(pendingCompactionInstant.isPresent(), "A compaction plan expects to be scheduled");
@@ -150,7 +150,7 @@ public class TestCompactionUtil {
       TimeUnit.SECONDS.sleep(3); // in case the instant time interval is too close
       writeClient.startCommit();
 
-      CompactionUtil.scheduleCompaction(metaClient, writeClient, true, false);
+      CompactionUtil.scheduleCompaction(writeClient, true, false);
       int numCompactionCommits = metaClient.reloadActiveTimeline().filterPendingCompactionTimeline().countInstants();
       assertThat("Two compaction plan expects to be scheduled", numCompactionCommits, is(2));
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -964,14 +964,22 @@ public class TestData {
    */
   private static String filterOutVariables(GenericRecord genericRecord) {
     List<String> fields = new ArrayList<>();
-    fields.add(genericRecord.get("_hoodie_record_key").toString());
-    fields.add(genericRecord.get("_hoodie_partition_path").toString());
-    fields.add(genericRecord.get("uuid").toString());
-    fields.add(genericRecord.get("name").toString());
-    fields.add(genericRecord.get("age").toString());
+    fields.add(getFieldValue(genericRecord, "_hoodie_record_key"));
+    fields.add(getFieldValue(genericRecord, "_hoodie_partition_path"));
+    fields.add(getFieldValue(genericRecord, "uuid"));
+    fields.add(getFieldValue(genericRecord, "name"));
+    fields.add(getFieldValue(genericRecord, "age"));
     fields.add(genericRecord.get("ts").toString());
     fields.add(genericRecord.get("partition").toString());
     return String.join(",", fields);
+  }
+
+  private static String getFieldValue(GenericRecord genericRecord, String fieldName) {
+    if (genericRecord.get(fieldName) != null) {
+      return genericRecord.get(fieldName).toString();
+    } else {
+      return null;
+    }
   }
 
   public static BinaryRowData insertRow(Object... fields) {


### PR DESCRIPTION
### Change Logs

Since [#9776](https://github.com/apache/hudi/pull/9776) is merged, this pr aims to support multiple streaming writers into the same MOR table with simple bucket index.

Set the following configure to enable this feature:  
* table.type=MERGE_ON_READ
* hoodie.write.concurrency.mode=OPTIMISTIC_CONCURRENCY_CONTROL
* index.type=BUCKET
* hoodie.index.bucket.engine=SIMPLE
* hoodie.cleaner.policy.failed.writes=LAZY
Besides, only enable async cleaning for one writer (by default, they are all enabled).

ps: This work is follow up of [#9125](https://github.com/apache/hudi/pull/9125). Thanks for contribution @danny0405 

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

Would be add in a separate PR.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
