### PR TITLE
Row writer optimization for bulk insert

### DIFF
--- a/docker/demo/config/hoodie-schema.avsc
+++ b/docker/demo/config/hoodie-schema.avsc
@@ -88,7 +88,7 @@
                 "name": "abc",
                 "size": 5,
                 "logicalType": "decimal",
-                "precision": 10,
+                "precision": 12,
                 "scale": 6
             }
         },

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -130,7 +130,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
       + "{\"name\": \"nation\", \"type\": \"bytes\"},"
       + "{\"name\":\"current_date\",\"type\": {\"type\": \"int\", \"logicalType\": \"date\"}},"
       + "{\"name\":\"current_ts\",\"type\": {\"type\": \"long\"}},"
-      + "{\"name\":\"height\",\"type\":{\"type\":\"fixed\",\"name\":\"abc\",\"size\":5,\"logicalType\":\"decimal\",\"precision\":10,\"scale\":6}},";
+      + "{\"name\":\"height\",\"type\":{\"type\":\"fixed\",\"name\":\"abc\",\"size\":5,\"logicalType\":\"decimal\",\"precision\":12,\"scale\":6}},";
 
   public static final String TRIP_EXAMPLE_SCHEMA =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
@@ -148,7 +148,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
       + "{\"name\":\"driver\",\"type\":\"string\"},{\"name\":\"fare\",\"type\":\"double\"},{\"name\": \"_hoodie_is_deleted\", \"type\": \"boolean\", \"default\": false}]}";
 
   public static final String NULL_SCHEMA = Schema.create(Schema.Type.NULL).toString();
-  public static final String TRIP_HIVE_COLUMN_TYPES = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
+  public static final String TRIP_HIVE_COLUMN_TYPES = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(12,6),"
       + "map<string,string>,struct<amount:double,currency:string>,array<struct<amount:double,currency:string>>,boolean";
 
 
@@ -397,7 +397,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     BigDecimal bigDecimal = new BigDecimal(String.format(Locale.ENGLISH, "%5f", rand.nextFloat()));
     Schema decimalSchema = AVRO_SCHEMA.getField("height").schema();
     Conversions.DecimalConversion decimalConversions = new Conversions.DecimalConversion();
-    GenericFixed genericFixed = decimalConversions.toFixed(bigDecimal, decimalSchema, LogicalTypes.decimal(10, 6));
+    GenericFixed genericFixed = decimalConversions.toFixed(bigDecimal, decimalSchema, LogicalTypes.decimal(12, 6));
     rec.put("height", genericFixed);
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSyncHelper.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSyncHelper.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.streamer;
+
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.DataSourceUtils;
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.config.SerializableSchema;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieSparkRecord;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.keygen.BuiltinKeyGenerator;
+import org.apache.hudi.keygen.KeyGenUtils;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory;
+import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.spark.TaskContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.HoodieInternalRowUtils;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hudi.utilities.UtilHelpers.createRecordMerger;
+import static org.apache.hudi.utilities.UtilHelpers.getPartitionColumns;
+
+/**
+ * Stream sync helper function that will APIs that help in fetching data from source, apply key gen etc.,
+ */
+public class StreamSyncHelper {
+
+  public static JavaRDD<HoodieRecord> applyKeyGeneration(HoodieStreamer.Config cfg, TypedProperties props, SchemaProvider schemaProvider,
+                                                         Option<JavaRDD<GenericRecord>> avroRDDOptional,
+                                                         Option<Dataset<Row>> rowDatasetOptional,
+                                                         boolean autoGenerateRecordKeys, String instantTime) {
+
+    HoodieRecordType recordType = createRecordMerger(props).getRecordType();
+    boolean shouldCombine = cfg.filterDupes || cfg.operation.equals(WriteOperationType.UPSERT);
+    Set<String> partitionColumns = getPartitionColumns(props);
+    JavaRDD<HoodieRecord> records = null;
+    SerializableSchema avroSchema = new SerializableSchema(schemaProvider.getTargetSchema());
+    SerializableSchema processedAvroSchema = new SerializableSchema(UtilHelpers.isDropPartitionColumns(props)
+        ? HoodieAvroUtils.removeMetadataFields(avroSchema.get()) : avroSchema.get());
+    try {
+      if (recordType == HoodieRecordType.SPARK) {
+        assert (rowDatasetOptional.isPresent());
+        StructType baseStructType = AvroConversionUtils.convertAvroSchemaToStructType(processedAvroSchema.get());
+        StructType targetStructType = UtilHelpers.isDropPartitionColumns(props) ? AvroConversionUtils
+            .convertAvroSchemaToStructType(HoodieAvroUtils.removeFields(processedAvroSchema.get(), partitionColumns)) : baseStructType;
+
+        Dataset<Row> df = rowDatasetOptional.get();
+        records = df.queryExecution().toRdd()
+            .toJavaRDD()
+            .mapPartitions(itr -> {
+              if (autoGenerateRecordKeys) {
+                props.setProperty(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, String.valueOf(TaskContext.getPartitionId()));
+                props.setProperty(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, instantTime);
+              }
+              BuiltinKeyGenerator builtinKeyGenerator = (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
+              return new CloseableMappingIterator<>(ClosableIterator.wrap(itr), rec -> {
+                String recordKey = builtinKeyGenerator.getRecordKey(rec, baseStructType).toString();
+                String partitionPath = builtinKeyGenerator.getPartitionPath(rec, baseStructType).toString();
+                return new HoodieSparkRecord(new HoodieKey(recordKey, partitionPath),
+                    HoodieInternalRowUtils.getCachedUnsafeProjection(baseStructType, targetStructType).apply(rec), targetStructType, false);
+              });
+            });
+      } else {
+        assert (avroRDDOptional.isPresent());
+        JavaRDD<GenericRecord> avroRDD = avroRDDOptional.get();
+        if (recordType == HoodieRecordType.AVRO) {
+          records = avroRDD.mapPartitions(
+              (FlatMapFunction<Iterator<GenericRecord>, HoodieRecord>) genericRecordIterator -> {
+                if (autoGenerateRecordKeys) {
+                  props.setProperty(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, String.valueOf(TaskContext.getPartitionId()));
+                  props.setProperty(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, instantTime);
+                }
+                BuiltinKeyGenerator builtinKeyGenerator = (BuiltinKeyGenerator) HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
+                List<HoodieRecord> avroRecords = new ArrayList<>();
+                while (genericRecordIterator.hasNext()) {
+                  GenericRecord genRec = genericRecordIterator.next();
+                  HoodieKey hoodieKey = new HoodieKey(builtinKeyGenerator.getRecordKey(genRec), builtinKeyGenerator.getPartitionPath(genRec));
+                  GenericRecord gr = UtilHelpers.isDropPartitionColumns(props) ? HoodieAvroUtils.removeFields(genRec, partitionColumns) : genRec;
+                  HoodieRecordPayload payload = shouldCombine ? DataSourceUtils.createPayload(cfg.payloadClassName, gr,
+                      (Comparable) HoodieAvroUtils.getNestedFieldVal(gr, cfg.sourceOrderingField, false, props.getBoolean(
+                          KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+                          Boolean.parseBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()))))
+                      : DataSourceUtils.createPayload(cfg.payloadClassName, gr);
+                  avroRecords.add(new HoodieAvroRecord<>(hoodieKey, payload));
+                }
+                return avroRecords.iterator();
+              });
+        } else {
+          throw new UnsupportedOperationException(recordType.name());
+        }
+      }
+    } catch (Exception e) {
+      throw new HoodieException("Error converting input data to hoodie records.", e);
+    }
+    return records;
+  }
+}

--- a/hudi-utilities/src/test/resources/streamer-config/source_evolved.avsc
+++ b/hudi-utilities/src/test/resources/streamer-config/source_evolved.avsc
@@ -93,7 +93,7 @@
         "name": "abc",
         "size": 5,
         "logicalType": "decimal",
-        "precision": 10,
+        "precision": 12,
         "scale": 6
       }
     },

--- a/hudi-utilities/src/test/resources/streamer-config/source_evolved_post_processed.avsc
+++ b/hudi-utilities/src/test/resources/streamer-config/source_evolved_post_processed.avsc
@@ -94,7 +94,7 @@
         "namespace": "triprec.height",
         "size": 5,
         "logicalType": "decimal",
-        "precision": 10,
+        "precision": 12,
         "scale": 6
       }
     },

--- a/hudi-utilities/src/test/resources/streamer-config/target.avsc
+++ b/hudi-utilities/src/test/resources/streamer-config/target.avsc
@@ -104,7 +104,7 @@
         "name": "abc",
         "size": 5,
         "logicalType": "decimal",
-        "precision": 10,
+        "precision": 12,
         "scale": 6
       }
     },


### PR DESCRIPTION
### Change Logs

We found inefficiencies with bulk insert use case where in delta streamer code path we were taking a performance hit for doing row to avro conversion when transformer is hooked on. This PR addresses to avoid these unnecessary conversions by directly passing hoodie spark record to the write client. 

### Impact

Initial testing of this PR shows the following benefits

master(without changes):
1550.62s user 268.99s system 496% cpu 6:06.20 total
1548.00s user 214.47s system 500% cpu 5:52.47 total
1530.54s user 205.70s system 507% cpu 5:42.22 total

row(with changes):
1398.94s user 16.19s system 560% cpu 4:12.48 total
1387.49s user 16.15s system 560% cpu 4:10.62 total
1386.58s user 39.09s system 540% cpu 4:23.62 total

### Risk level (write none, low medium or high below)

low, we are trying to enhance this performance boost only for row writer use case.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
