### PR TITLE
[HUDI-6941] sparksql query perfermance cost more in hudi 0.14-rc

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -463,16 +463,6 @@ object HoodieFileIndex extends Logging {
     if (listingModeOverride != null) {
       properties.setProperty(DataSourceReadOptions.FILE_INDEX_LISTING_MODE_OVERRIDE.key, listingModeOverride)
     }
-    val partitionColumns = metaClient.getTableConfig.getPartitionFields
-    if (partitionColumns.isPresent) {
-      // NOTE: Multiple partition fields could have non-encoded slashes in the partition value.
-      //       We might not be able to properly parse partition-values from the listed partition-paths.
-      //       Fallback to eager listing in this case.
-      if (partitionColumns.get().length > 1
-        && (listingModeOverride == null || DataSourceReadOptions.FILE_INDEX_LISTING_MODE_LAZY.equals(listingModeOverride))) {
-        properties.setProperty(DataSourceReadOptions.FILE_INDEX_LISTING_MODE_OVERRIDE.key, DataSourceReadOptions.FILE_INDEX_LISTING_MODE_EAGER)
-      }
-    }
 
     properties
   }


### PR DESCRIPTION
### Change Logs

[_Describe context and summary for this change. Highlight if any code was copied._
](https://issues.apache.org/jira/browse/HUDI-6941)

quick fix for [HUDI-6941](https://github.com/apache/hudi/issues/9858)

### Impact

sparksql query perfermance cost more in hudi 0.14-rc

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
