### PR TITLE
[HUDI-6944] Fix Flink bootstrap concurrency issue causes job to keep rolling back

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -409,23 +409,21 @@ public class StreamWriteOperatorCoordinator
    */
   private void initInstant(String instant) {
     HoodieTimeline completedTimeline = this.metaClient.getActiveTimeline().filterCompletedInstants();
-    executor.execute(() -> {
-      if (instant.equals(WriteMetadataEvent.BOOTSTRAP_INSTANT) || completedTimeline.containsInstant(instant)) {
-        // the last instant committed successfully
-        reset();
-      } else {
-        LOG.info("Recommit instant {}", instant);
-        // Recommit should start heartbeat for lazy failed writes clean policy to avoid aborting for heartbeat expired.
-        if (writeClient.getConfig().getFailedWritesCleanPolicy().isLazy()) {
-          writeClient.getHeartbeatClient().start(instant);
-        }
-        commitInstant(instant);
+    if (instant.equals(WriteMetadataEvent.BOOTSTRAP_INSTANT) || completedTimeline.containsInstant(instant)) {
+      // the last instant committed successfully
+      reset();
+    } else {
+      LOG.info("Recommit instant {}", instant);
+      // Recommit should start heartbeat for lazy failed writes clean policy to avoid aborting for heartbeat expired.
+      if (writeClient.getConfig().getFailedWritesCleanPolicy().isLazy()) {
+        writeClient.getHeartbeatClient().start(instant);
       }
-      // starts a new instant
-      startInstant();
-      // upgrade downgrade
-      this.writeClient.upgradeDowngrade(this.instant, this.metaClient);
-    }, "initialize instant %s", instant);
+      commitInstant(instant);
+    }
+    // starts a new instant
+    startInstant();
+    // upgrade downgrade
+    this.writeClient.upgradeDowngrade(this.instant, this.metaClient);
   }
 
   private void handleBootstrapEvent(WriteMetadataEvent event) {


### PR DESCRIPTION
### Change Logs

There are some details
Commit 20231008185332158 start at 18:53:32.184 and Rolling back immediately after 20 milliseconds(18:53:32.212)
```
2023-10-08 18:53:32.155 INFO  [pool-20-thread-1:0-thread-1] o.a.hudi.table.action.rollback.BaseRollbackActionExecutor - Rollback of Commits [20231008185331924] is complete

.....

2023-10-08 18:53:32.184 INFO  [pool-20-thread-1:0-thread-1] org.apache.hudi.sink.StreamWriteOperatorCoordinator - Create instant [20231008185332158] for table [hudi_sss] with type [COPY_ON_WRITE]

..... 

2023-10-08 18:53:32.212 INFO  [pool-20-thread-1:0-thread-1] org.apache.hudi.client.BaseHoodieWriteClient - Begin rollback of instant 20231008185332158
```


```
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185533653.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185533653.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185533893.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185533893.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185533893.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534199.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534199.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534199.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534458.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534458.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534458.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534699.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534699.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185534699.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185535030.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185535030.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185535030.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185535295.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185535295.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185535295.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185536332.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185536332.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185536332.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185536674.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185536674.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185536674.rollback.requested
-rw-rw-rw-   3 xxx xxx       1408 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185537030.rollback
-rw-rw-rw-   3 xxx xxx          0 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185537030.rollback.inflight
-rw-rw-rw-   3 xxx xxx       1225 2023-10-08 18:55 hdfs://xxx/user/xxx/bdm_dev.db/hudi_xxx/.hoodie/20231008185537030.rollback.requested
```

### Impact

no

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
