### PR TITLE
[HUDI-5210] Implement functional indexes

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieFunctionalIndexConfig;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieMetaserverConfig;
@@ -773,7 +774,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   /**
    * An internal config referring to fileID encoding. 0 refers to UUID based encoding and 1 refers to raw string format(random string).
    */
-  public static final String WRITES_FILEID_ENCODING =  "_hoodie.writes.fileid.encoding";
+  public static final String WRITES_FILEID_ENCODING = "_hoodie.writes.fileid.encoding";
 
   private ConsistencyGuardConfig consistencyGuardConfig;
   private FileSystemRetryConfig fileSystemRetryConfig;
@@ -789,6 +790,7 @@ public class HoodieWriteConfig extends HoodieConfig {
   private HoodieCommonConfig commonConfig;
   private HoodieStorageConfig storageConfig;
   private HoodieTimeGeneratorConfig timeGeneratorConfig;
+  private HoodieFunctionalIndexConfig functionalIndexConfig;
   private EngineType engineType;
 
   /**
@@ -1185,6 +1187,7 @@ public class HoodieWriteConfig extends HoodieConfig {
     this.storageConfig = HoodieStorageConfig.newBuilder().fromProperties(props).build();
     this.timeGeneratorConfig = HoodieTimeGeneratorConfig.newBuilder().fromProperties(props)
         .withDefaultLockProvider(!isLockRequired()).build();
+    this.functionalIndexConfig = HoodieFunctionalIndexConfig.newBuilder().fromProperties(props).build();
   }
 
   public static HoodieWriteConfig.Builder newBuilder() {
@@ -2378,6 +2381,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return timeGeneratorConfig;
   }
 
+  public HoodieFunctionalIndexConfig getFunctionalIndexConfig() {
+    return functionalIndexConfig;
+  }
+
   /**
    * Commit call back configs.
    */
@@ -2798,7 +2805,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       return this;
     }
 
-    public  Builder withFailureOnInlineTableServiceException(boolean fail) {
+    public Builder withFailureOnInlineTableServiceException(boolean fail) {
       writeConfig.setValue(FAIL_ON_INLINE_TABLE_SERVICE_EXCEPTION, String.valueOf(fail));
       return this;
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieIndexPartitionInfo;
 import org.apache.hudi.avro.model.HoodieIndexPlan;
@@ -39,6 +40,8 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroup;
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
+import org.apache.hudi.common.model.HoodieFunctionalIndexMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -48,6 +51,7 @@ import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
@@ -72,6 +76,7 @@ import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.hadoop.SerializablePath;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
+import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -110,6 +115,11 @@ import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.createRollbackTimestamp;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.readRecordKeysFromBaseFiles;
+import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
+import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
+import static org.apache.hudi.metadata.MetadataPartitionType.FILES;
+import static org.apache.hudi.metadata.MetadataPartitionType.FUNCTIONAL_INDEX;
+import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 
 /**
  * Writer implementation backed by an internal hudi table. Partition and file listing are saved within an internal MOR table
@@ -205,17 +215,20 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
    */
   private void enablePartitions() {
     final HoodieMetadataConfig metadataConfig = dataWriteConfig.getMetadataConfig();
-    if (dataWriteConfig.isMetadataTableEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.FILES)) {
-      this.enabledPartitionTypes.add(MetadataPartitionType.FILES);
+    if (dataWriteConfig.isMetadataTableEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(FILES)) {
+      this.enabledPartitionTypes.add(FILES);
     }
-    if (metadataConfig.isBloomFilterIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.BLOOM_FILTERS)) {
-      this.enabledPartitionTypes.add(MetadataPartitionType.BLOOM_FILTERS);
+    if (metadataConfig.isBloomFilterIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(BLOOM_FILTERS)) {
+      this.enabledPartitionTypes.add(BLOOM_FILTERS);
     }
-    if (metadataConfig.isColumnStatsIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.COLUMN_STATS)) {
-      this.enabledPartitionTypes.add(MetadataPartitionType.COLUMN_STATS);
+    if (metadataConfig.isColumnStatsIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(COLUMN_STATS)) {
+      this.enabledPartitionTypes.add(COLUMN_STATS);
     }
-    if (dataWriteConfig.isRecordIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)) {
-      this.enabledPartitionTypes.add(MetadataPartitionType.RECORD_INDEX);
+    if (dataWriteConfig.isRecordIndexEnabled() || dataMetaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX)) {
+      this.enabledPartitionTypes.add(RECORD_INDEX);
+    }
+    if (dataMetaClient.getFunctionalIndexMetadata().isPresent()) {
+      this.enabledPartitionTypes.add(FUNCTIONAL_INDEX);
     }
   }
 
@@ -249,7 +262,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       boolean exists = metadataTableExists(dataMetaClient);
       if (!exists) {
         // FILES partition is always required
-        partitionsToInit.add(MetadataPartitionType.FILES);
+        partitionsToInit.add(FILES);
       }
 
       // check if any of the enabled partition types needs to be initialized
@@ -257,8 +270,10 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       if (!dataWriteConfig.isMetadataAsyncIndex()) {
         Set<String> completedPartitions = dataMetaClient.getTableConfig().getMetadataPartitions();
         LOG.info("Async metadata indexing disabled and following partitions already initialized: " + completedPartitions);
+        // TODO: fix the filter to check for exact partition name, e.g. completedPartitions could have func_index_datestr,
+        //       but now the user is trying to initialize the func_index_dayhour partition.
         this.enabledPartitionTypes.stream()
-            .filter(p -> !completedPartitions.contains(p.getPartitionPath()) && !MetadataPartitionType.FILES.equals(p))
+            .filter(p -> !completedPartitions.contains(p.getPartitionPath()) && !FILES.equals(p))
             .forEach(partitionsToInit::add);
       }
 
@@ -360,10 +375,10 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     }
 
     // FILES partition is always required and is initialized first
-    boolean filesPartitionAvailable = dataMetaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.FILES);
+    boolean filesPartitionAvailable = dataMetaClient.getTableConfig().isMetadataPartitionAvailable(FILES);
     if (!filesPartitionAvailable) {
-      partitionsToInit.remove(MetadataPartitionType.FILES);
-      partitionsToInit.add(0, MetadataPartitionType.FILES);
+      partitionsToInit.remove(FILES);
+      partitionsToInit.add(0, FILES);
       // Initialize the metadata table for the first time
       metadataMetaClient = initializeMetaClient();
     } else {
@@ -421,6 +436,9 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
             break;
           case RECORD_INDEX:
             fileGroupCountAndRecordsPair = initializeRecordIndexPartition();
+            break;
+          case FUNCTIONAL_INDEX:
+            fileGroupCountAndRecordsPair = initializeFunctionalIndexPartition();
             break;
           default:
             throw new HoodieMetadataException("Unsupported MDT partition type: " + partitionType);
@@ -498,6 +516,40 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     return Pair.of(fileGroupCount, records);
   }
 
+  protected abstract HoodieData<HoodieRecord> getFunctionalIndexRecords(List<Pair<String, FileSlice>> partitionFileSlicePairs,
+                                                                        HoodieFunctionalIndexDefinition indexDefinition,
+                                                                        HoodieTableMetaClient metaClient,
+                                                                        int parallelism, Schema readerSchema,
+                                                                        SerializableConfiguration hadoopConf);
+
+  private Pair<Integer, HoodieData<HoodieRecord>> initializeFunctionalIndexPartition() throws Exception {
+    HoodieMetadataFileSystemView fsView = new HoodieMetadataFileSystemView(dataMetaClient, dataMetaClient.getActiveTimeline(), metadata);
+    String indexName = dataWriteConfig.getFunctionalIndexConfig().getIndexName();
+    HoodieFunctionalIndexDefinition indexDefinition = getFunctionalIndexDefinition(indexName);
+    // Collect the list of latest file slices present in each partition
+    List<String> partitions = metadata.getAllPartitionPaths();
+    fsView.loadAllPartitions();
+    final List<Pair<String, FileSlice>> partitionFileSlicePairs = new ArrayList<>();
+    for (String partition : partitions) {
+      fsView.getLatestFileSlices(partition).forEach(fs -> partitionFileSlicePairs.add(Pair.of(partition, fs)));
+    }
+    TableSchemaResolver schemaResolver = new TableSchemaResolver(dataMetaClient);
+    Schema tableSchema = schemaResolver.getTableAvroSchema();
+    Schema readerSchema = HoodieAvroUtils.getSchemaForFields(tableSchema, indexDefinition.getSourceFields());
+    int fileGroupCount = dataWriteConfig.getMetadataConfig().getFunctionalIndexFileGroupCount();
+    int parallelism = Math.min(partitionFileSlicePairs.size(), dataWriteConfig.getMetadataConfig().getFunctionalIndexParallelism());
+    return Pair.of(fileGroupCount, getFunctionalIndexRecords(partitionFileSlicePairs, indexDefinition, dataMetaClient, parallelism, readerSchema, hadoopConf));
+  }
+
+  private HoodieFunctionalIndexDefinition getFunctionalIndexDefinition(String indexName) {
+    Option<HoodieFunctionalIndexMetadata> functionalIndexMetadata = dataMetaClient.getFunctionalIndexMetadata();
+    if (functionalIndexMetadata.isPresent()) {
+      return functionalIndexMetadata.get().getIndexDefinitions().get(indexName);
+    } else {
+      throw new HoodieIndexException("Functional Index definition is not present");
+    }
+  }
+
   private Pair<Integer, HoodieData<HoodieRecord>> initializeRecordIndexPartition() throws IOException {
     final HoodieMetadataFileSystemView fsView = new HoodieMetadataFileSystemView(dataMetaClient,
         dataMetaClient.getActiveTimeline(), metadata);
@@ -527,7 +579,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     final long recordCount = records.count();
 
     // Initialize the file groups
-    final int fileGroupCount = HoodieTableMetadataUtil.estimateFileGroupCount(MetadataPartitionType.RECORD_INDEX, recordCount,
+    final int fileGroupCount = HoodieTableMetadataUtil.estimateFileGroupCount(RECORD_INDEX, recordCount,
         RECORD_INDEX_AVERAGE_RECORD_SIZE, dataWriteConfig.getRecordIndexMinFileGroupCount(),
         dataWriteConfig.getRecordIndexMaxFileGroupCount(), dataWriteConfig.getRecordIndexGrowthFactor(),
         dataWriteConfig.getRecordIndexMaxFileGroupSizeBytes());
@@ -858,7 +910,8 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
           relativePartitionPath, metadataWriteConfig.getBasePath(), indexUptoInstantTime));
 
       // return early and populate enabledPartitionTypes correctly (check in initialCommit)
-      MetadataPartitionType partitionType = MetadataPartitionType.valueOf(relativePartitionPath.toUpperCase(Locale.ROOT));
+      MetadataPartitionType partitionType = relativePartitionPath.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX) ? FUNCTIONAL_INDEX :
+          MetadataPartitionType.valueOf(relativePartitionPath.toUpperCase(Locale.ROOT));
       if (!enabledPartitionTypes.contains(partitionType)) {
         throw new HoodieIndexException(String.format("Indexing for metadata partition: %s is not enabled", partitionType));
       }
@@ -888,7 +941,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       // to the HoodieTableMetadataUtil class in hudi-common.
       HoodieData<HoodieRecord> updatesFromWriteStatuses = getRecordIndexUpdates(writeStatus);
       HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpdates(updatesFromWriteStatuses, commitMetadata);
-      partitionToRecordMap.put(MetadataPartitionType.RECORD_INDEX, updatesFromWriteStatuses.union(additionalUpdates));
+      partitionToRecordMap.put(RECORD_INDEX, updatesFromWriteStatuses.union(additionalUpdates));
 
       return partitionToRecordMap;
     });
@@ -901,7 +954,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
       Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordMap =
           HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, commitMetadata, instantTime, getRecordsGenerationParams());
       HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpdates(records, commitMetadata);
-      partitionToRecordMap.put(MetadataPartitionType.RECORD_INDEX, records.union(additionalUpdates));
+      partitionToRecordMap.put(RECORD_INDEX, records.union(additionalUpdates));
 
       return partitionToRecordMap;
     });
@@ -945,7 +998,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
     LOG.info("Triggering restore to " + restoreToInstantTime + " in metadata table");
 
     // fetch the earliest commit to retain and ensure the base file prior to the time to restore is present
-    List<HoodieFileGroup> filesGroups = metadata.getMetadataFileSystemView().getAllFileGroups(MetadataPartitionType.FILES.getPartitionPath()).collect(Collectors.toList());
+    List<HoodieFileGroup> filesGroups = metadata.getMetadataFileSystemView().getAllFileGroups(FILES.getPartitionPath()).collect(Collectors.toList());
 
     boolean cannotRestore = filesGroups.stream().map(fileGroup -> fileGroup.getAllFileSlices().map(fileSlice -> fileSlice.getBaseInstantTime()).anyMatch(
         instantTime1 -> HoodieTimeline.compareTimestamps(instantTime1, LESSER_THAN_OR_EQUALS, restoreToInstantTime))).anyMatch(canRestore -> !canRestore);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -101,6 +101,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.avro.HoodieAvroUtils.addMetadataFields;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.ARCHIVELOG_FOLDER;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
@@ -536,7 +537,7 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
 
     int fileGroupCount = dataWriteConfig.getMetadataConfig().getFunctionalIndexFileGroupCount();
     int parallelism = Math.min(partitionFileSlicePairs.size(), dataWriteConfig.getMetadataConfig().getFunctionalIndexParallelism());
-    Schema readerSchema = getProjectedSchemaForFunctionalIndex(indexDefinition, dataMetaClient);
+    Schema readerSchema = addMetadataFields(getProjectedSchemaForFunctionalIndex(indexDefinition, dataMetaClient), dataWriteConfig.allowOperationMetadataField());
     return Pair.of(fileGroupCount, getFunctionalIndexRecords(partitionFileSlicePairs, indexDefinition, dataMetaClient, parallelism, readerSchema, hadoopConf));
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -170,7 +171,8 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
               .map(info -> new HoodieIndexPartitionInfo(
                   info.getVersion(),
                   info.getMetadataPartitionPath(),
-                  currentCaughtupInstant))
+                  currentCaughtupInstant,
+                  Collections.emptyMap()))
               .collect(Collectors.toList());
         } catch (Exception e) {
           throw new HoodieMetadataException("Failed to index partition " + Arrays.toString(indexPartitionInfos.stream()
@@ -187,7 +189,8 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
             .map(info -> new HoodieIndexPartitionInfo(
                 info.getVersion(),
                 info.getMetadataPartitionPath(),
-                indexUptoInstant))
+                indexUptoInstant,
+                Collections.emptyMap()))
             .collect(Collectors.toList());
       }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -72,6 +72,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.RESTORE_ACTIO
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.config.HoodieWriteConfig.WRITE_CONCURRENCY_MODE;
 import static org.apache.hudi.metadata.HoodieTableMetadata.getMetadataTableBasePath;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.deleteMetadataPartition;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightAndCompletedMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
@@ -318,7 +319,10 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
   }
 
   private void updateMetadataPartitionsTableConfig(HoodieTableMetaClient metaClient, Set<String> metadataPartitions) {
-    metadataPartitions.forEach(metadataPartition -> metaClient.getTableConfig().setMetadataPartitionState(
-        metaClient, MetadataPartitionType.valueOf(metadataPartition.toUpperCase(Locale.ROOT)), true));
+    metadataPartitions.forEach(metadataPartition -> {
+      MetadataPartitionType partitionType = metadataPartition.startsWith(PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX) ? MetadataPartitionType.FUNCTIONAL_INDEX :
+          MetadataPartitionType.valueOf(metadataPartition.toUpperCase(Locale.ROOT));
+      metaClient.getTableConfig().setMetadataPartitionState(metaClient, partitionType, true);
+    });
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/functional/BaseHoodieFunctionalIndexClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/functional/BaseHoodieFunctionalIndexClient.java
@@ -37,6 +37,10 @@ public abstract class BaseHoodieFunctionalIndexClient {
 
   /**
    * Register a functional index.
+   * Index definitions are stored in user-specified path or, by default, in .hoodie/.index_defs/index.json.
+   * For the first time, the index definition file will be created if not exists.
+   * For the second time, the index definition file will be updated if exists.
+   * Table Config is updated if necessary.
    */
   public void register(HoodieTableMetaClient metaClient, String indexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options) {
     LOG.info("Registering index {} of using {}", indexName, indexType);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/functional/BaseHoodieFunctionalIndexClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/functional/BaseHoodieFunctionalIndexClient.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.action.index.functional;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public abstract class BaseHoodieFunctionalIndexClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseHoodieFunctionalIndexClient.class);
+
+  public BaseHoodieFunctionalIndexClient() {
+  }
+
+  /**
+   * Register a functional index.
+   */
+  public void register(HoodieTableMetaClient metaClient, String indexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options) {
+    LOG.info("Registering index {} of using {}", indexName, indexType);
+    String indexMetaPath = metaClient.getTableConfig().getIndexDefinitionPath()
+        .orElse(metaClient.getMetaPath() + Path.SEPARATOR + HoodieTableMetaClient.INDEX_DEFINITION_FOLDER_NAME + Path.SEPARATOR + HoodieTableMetaClient.INDEX_DEFINITION_FILE_NAME);
+    // build HoodieFunctionalIndexMetadata and then add to index definition file
+    metaClient.buildFunctionalIndexDefinition(indexMetaPath, indexName, indexType, columns, options);
+    // update table config if necessary
+    if (!metaClient.getTableConfig().getProps().containsKey(HoodieTableConfig.INDEX_DEFINITION_PATH) || !metaClient.getTableConfig().getIndexDefinitionPath().isPresent()) {
+      metaClient.getTableConfig().setValue(HoodieTableConfig.INDEX_DEFINITION_PATH, indexMetaPath);
+      HoodieTableConfig.update(metaClient.getFs(), new Path(metaClient.getMetaPath()), metaClient.getTableConfig().getProps());
+    }
+  }
+
+  /**
+   * Create a functional index.
+   */
+  public abstract void create(HoodieTableMetaClient metaClient, String indexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options);
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -21,10 +21,13 @@ package org.apache.hudi.metadata;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.metrics.Registry;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
@@ -32,11 +35,13 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
+import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,5 +203,11 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   protected void preWrite(String instantTime) {
     metadataMetaClient.getActiveTimeline().transitionRequestedToInflight(HoodieActiveTimeline.DELTA_COMMIT_ACTION, instantTime);
+  }
+
+  @Override
+  protected HoodieData<HoodieRecord> getFunctionalIndexRecords(List<Pair<String, FileSlice>> partitionFileSlicePairs, HoodieFunctionalIndexDefinition indexDefinition, HoodieTableMetaClient metaClient,
+                                                               int parallelism, Schema readerSchema, SerializableConfiguration hadoopConf) {
+    throw new HoodieNotSupportedException("Flink metadata table does not support functional index yet.");
   }
 }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -20,16 +20,22 @@ package org.apache.hudi.metadata;
 
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.metrics.Registry;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 
+import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 
 import java.util.Collections;
@@ -109,5 +115,11 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   @Override
   protected void preWrite(String instantTime) {
     metadataMetaClient.getActiveTimeline().transitionRequestedToInflight(HoodieActiveTimeline.DELTA_COMMIT_ACTION, instantTime);
+  }
+
+  @Override
+  protected HoodieData<HoodieRecord> getFunctionalIndexRecords(List<Pair<String, FileSlice>> partitionFileSlicePairs, HoodieFunctionalIndexDefinition indexDefinition, HoodieTableMetaClient metaClient,
+                                                               int parallelism, Schema readerSchema, SerializableConfiguration hadoopConf) {
+    throw new HoodieNotSupportedException("Functional index not supported for Java metadata table writer yet.");
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -102,13 +102,13 @@ public class SparkMetadataWriterUtils {
     return sqlContext.baseRelationToDataFrame(relation);
   }
 
-  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<Comparable> computeColumnRangeMetadata(Dataset<Row> baseFileDf,
+  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<Comparable> computeColumnRangeMetadata(Dataset<Row> rowDataset,
                                                                                                            String columnName,
                                                                                                            String filePath,
                                                                                                            long fileSize) {
     long totalSize = fileSize;
     // Get nullCount, minValue, and maxValue
-    Dataset<Row> aggregated = baseFileDf.agg(
+    Dataset<Row> aggregated = rowDataset.agg(
         functions.count(functions.when(functions.col(columnName).isNull(), 1)).alias("nullCount"),
         functions.min(columnName).alias("minValue"),
         functions.max(columnName).alias("maxValue"),

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.utils;
+
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.functional.HoodieFunctionalIndex;
+import org.apache.hudi.io.storage.HoodieFileWriterFactory;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.sources.BaseRelation;
+
+import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+
+/**
+ * Utility methods for writing metadata for functional index.
+ */
+public class SparkMetadataWriterUtils {
+
+  /**
+   * Configs required to load records from paths as a dataframe
+   */
+  private static final String QUERY_TYPE_CONFIG = "hoodie.datasource.query.type";
+  private static final String QUERY_TYPE_SNAPSHOT = "snapshot";
+  private static final String READ_PATHS_CONFIG = "hoodie.datasource.read.paths";
+  private static final String GLOB_PATHS_CONFIG = "glob.paths";
+
+  public static void buildColumnRangeMetadata(HoodieTableMetaClient metaClient, Schema readerSchema,
+                                              HoodieFunctionalIndex<Column, Column> functionalIndex, String columnToIndex, SQLContext sqlContext,
+                                              List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList, long fileSize, Path filePath) {
+    Dataset<Row> fileDf = readRecordsAsRow(new Path[] {filePath}, sqlContext, metaClient, readerSchema);
+    Column indexedColumn = functionalIndex.apply(Arrays.asList(fileDf.col(columnToIndex)));
+    fileDf = fileDf.withColumn(columnToIndex, indexedColumn);
+    HoodieColumnRangeMetadata<Comparable> columnRangeMetadata = computeColumnRangeMetadata(fileDf, columnToIndex, filePath.toString(), fileSize);
+    columnRangeMetadataList.add(columnRangeMetadata);
+  }
+
+  public static void buildBloomFilterMetadata(HoodieTableMetaClient metaClient, Schema readerSchema,
+                                              HoodieFunctionalIndex<Column, Column> functionalIndex, String columnToIndex,
+                                              SQLContext sqlContext, List<HoodieRecord> bloomFilterMetadataList,
+                                              Path filePath, HoodieWriteConfig writeConfig, String partitionName, String instantTime) {
+    Dataset<Row> fileDf = readRecordsAsRow(new Path[] {filePath}, sqlContext, metaClient, readerSchema);
+    Column indexedColumn = functionalIndex.apply(Arrays.asList(fileDf.col(columnToIndex)));
+    fileDf = fileDf.withColumn(columnToIndex, indexedColumn);
+    BloomFilter bloomFilter = HoodieFileWriterFactory.createBloomFilter(writeConfig);
+    fileDf.foreach(row -> {
+      byte[] key = row.getAs(columnToIndex).toString().getBytes();
+      bloomFilter.add(key);
+    });
+    ByteBuffer bloomByteBuffer = ByteBuffer.wrap(getUTF8Bytes(bloomFilter.serializeToString()));
+    HoodieRecord<HoodieMetadataPayload> bloomFilterMetadataRecord = HoodieMetadataPayload.createBloomFilterMetadataRecord(
+        partitionName, filePath.toString(), instantTime, writeConfig.getBloomFilterType(), bloomByteBuffer, false);
+    bloomFilterMetadataList.add(bloomFilterMetadataRecord);
+  }
+
+  public static Dataset<Row> readRecordsAsRow(Path[] paths, SQLContext sqlContext, HoodieTableMetaClient metaClient, Schema schema) {
+    String readPathString = String.join(",", Arrays.stream(paths).map(Path::toString).toArray(String[]::new));
+    HashMap<String, String> params = new HashMap<>();
+    params.put(QUERY_TYPE_CONFIG, QUERY_TYPE_SNAPSHOT);
+    params.put(READ_PATHS_CONFIG, readPathString);
+    // Building HoodieFileIndex needs this param to decide query path
+    params.put(GLOB_PATHS_CONFIG, readPathString);
+    // Let Hudi relations to fetch the schema from the table itself
+    BaseRelation relation = SparkAdapterSupport$.MODULE$.sparkAdapter()
+        .createRelation(sqlContext, metaClient, schema, paths, params);
+
+    return sqlContext.baseRelationToDataFrame(relation);
+  }
+
+  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<Comparable> computeColumnRangeMetadata(Dataset<Row> baseFileDf,
+                                                                                                           String columnName,
+                                                                                                           String filePath,
+                                                                                                           long fileSize) {
+    long totalSize = fileSize;
+    // Get nullCount, minValue, and maxValue
+    Dataset<Row> aggregated = baseFileDf.agg(
+        functions.count(functions.when(functions.col(columnName).isNull(), 1)).alias("nullCount"),
+        functions.min(columnName).alias("minValue"),
+        functions.max(columnName).alias("maxValue"),
+        functions.count(columnName).alias("valueCount")
+    );
+
+    Row result = aggregated.collectAsList().get(0);
+    long nullCount = result.getLong(0);
+    @Nullable T minValue = (T) result.get(1);
+    @Nullable T maxValue = (T) result.get(2);
+    long valueCount = result.getLong(3);
+
+    // Total uncompressed size is harder to get directly. This is just an approximation to maintain the order.
+    long totalUncompressedSize = totalSize * 2;
+
+    return HoodieColumnRangeMetadata.<Comparable>create(
+        filePath,
+        columnName,
+        minValue,
+        maxValue,
+        nullCount,
+        valueCount,
+        totalSize,
+        totalUncompressedSize
+    );
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -20,14 +20,17 @@
 package org.apache.hudi.client.utils;
 
 import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.index.functional.HoodieFunctionalIndex;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
-import org.apache.hudi.metadata.HoodieMetadataPayload;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.Path;
@@ -41,11 +44,16 @@ import org.apache.spark.sql.sources.BaseRelation;
 import javax.annotation.Nullable;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.metadata.HoodieMetadataPayload.createBloomFilterMetadataRecord;
+import static org.apache.hudi.metadata.HoodieMetadataPayload.createColumnStatsRecords;
 
 /**
  * Utility methods for writing metadata for functional index.
@@ -60,9 +68,92 @@ public class SparkMetadataWriterUtils {
   private static final String READ_PATHS_CONFIG = "hoodie.datasource.read.paths";
   private static final String GLOB_PATHS_CONFIG = "glob.paths";
 
-  public static void buildColumnRangeMetadata(HoodieTableMetaClient metaClient, Schema readerSchema,
-                                              HoodieFunctionalIndex<Column, Column> functionalIndex, String columnToIndex, SQLContext sqlContext,
-                                              List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList, long fileSize, Path filePath) {
+  public static HoodieJavaRDD<HoodieRecord> getFunctionalIndexRecordsUsingColumnStats(
+      HoodieTableMetaClient metaClient,
+      int parallelism,
+      Schema readerSchema,
+      FileSlice fileSlice,
+      String basePath,
+      String partition,
+      HoodieFunctionalIndex<Column, Column> functionalIndex,
+      String columnToIndex,
+      SQLContext sqlContext,
+      HoodieSparkEngineContext sparkEngineContext) {
+    List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList = new ArrayList<>();
+    if (fileSlice.getBaseFile().isPresent()) {
+      HoodieBaseFile baseFile = fileSlice.getBaseFile().get();
+      String filename = baseFile.getFileName();
+      long fileSize = baseFile.getFileSize();
+      Path baseFilePath = new Path(basePath, partition + Path.SEPARATOR + filename);
+      buildColumnRangeMetadata(metaClient, readerSchema, functionalIndex, columnToIndex, sqlContext, columnRangeMetadataList, fileSize, baseFilePath);
+    }
+    // Handle log files
+    fileSlice.getLogFiles().forEach(logFile -> {
+      String fileName = logFile.getFileName();
+      Path logFilePath = new Path(basePath, partition + Path.SEPARATOR + fileName);
+      long fileSize = logFile.getFileSize();
+      buildColumnRangeMetadata(metaClient, readerSchema, functionalIndex, columnToIndex, sqlContext, columnRangeMetadataList, fileSize, logFilePath);
+    });
+    return HoodieJavaRDD.of(createColumnStatsRecords(partition, columnRangeMetadataList, false).collect(Collectors.toList()), sparkEngineContext, parallelism);
+  }
+
+  public static HoodieJavaRDD<HoodieRecord> getFunctionalIndexRecordsUsingBloomFilter(
+      HoodieTableMetaClient metaClient,
+      int parallelism,
+      Schema readerSchema,
+      FileSlice fileSlice,
+      String basePath,
+      String partition,
+      HoodieFunctionalIndex<Column, Column> functionalIndex,
+      String columnToIndex,
+      SQLContext sqlContext,
+      HoodieSparkEngineContext sparkEngineContext,
+      HoodieWriteConfig metadataWriteConfig) {
+    List<HoodieRecord> bloomFilterMetadataList = new ArrayList<>();
+    if (fileSlice.getBaseFile().isPresent()) {
+      HoodieBaseFile baseFile = fileSlice.getBaseFile().get();
+      String filename = baseFile.getFileName();
+      Path baseFilePath = new Path(basePath, partition + Path.SEPARATOR + filename);
+      buildBloomFilterMetadata(
+          metaClient,
+          readerSchema,
+          functionalIndex,
+          columnToIndex,
+          sqlContext,
+          bloomFilterMetadataList,
+          baseFilePath,
+          metadataWriteConfig,
+          partition,
+          baseFile.getCommitTime());
+    }
+    // Handle log files
+    fileSlice.getLogFiles().forEach(logFile -> {
+      String fileName = logFile.getFileName();
+      Path logFilePath = new Path(basePath, partition + Path.SEPARATOR + fileName);
+      buildBloomFilterMetadata(
+          metaClient,
+          readerSchema,
+          functionalIndex,
+          columnToIndex,
+          sqlContext,
+          bloomFilterMetadataList,
+          logFilePath,
+          metadataWriteConfig,
+          partition,
+          logFile.getDeltaCommitTime());
+    });
+    return HoodieJavaRDD.of(bloomFilterMetadataList, sparkEngineContext, parallelism);
+  }
+
+  private static void buildColumnRangeMetadata(
+      HoodieTableMetaClient metaClient,
+      Schema readerSchema,
+      HoodieFunctionalIndex<Column, Column> functionalIndex,
+      String columnToIndex,
+      SQLContext sqlContext,
+      List<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList,
+      long fileSize,
+      Path filePath) {
     Dataset<Row> fileDf = readRecordsAsRow(new Path[] {filePath}, sqlContext, metaClient, readerSchema);
     Column indexedColumn = functionalIndex.apply(Arrays.asList(fileDf.col(columnToIndex)));
     fileDf = fileDf.withColumn(columnToIndex, indexedColumn);
@@ -70,10 +161,17 @@ public class SparkMetadataWriterUtils {
     columnRangeMetadataList.add(columnRangeMetadata);
   }
 
-  public static void buildBloomFilterMetadata(HoodieTableMetaClient metaClient, Schema readerSchema,
-                                              HoodieFunctionalIndex<Column, Column> functionalIndex, String columnToIndex,
-                                              SQLContext sqlContext, List<HoodieRecord> bloomFilterMetadataList,
-                                              Path filePath, HoodieWriteConfig writeConfig, String partitionName, String instantTime) {
+  private static void buildBloomFilterMetadata(
+      HoodieTableMetaClient metaClient,
+      Schema readerSchema,
+      HoodieFunctionalIndex<Column, Column> functionalIndex,
+      String columnToIndex,
+      SQLContext sqlContext,
+      List<HoodieRecord> bloomFilterMetadataList,
+      Path filePath,
+      HoodieWriteConfig writeConfig,
+      String partitionName,
+      String instantTime) {
     Dataset<Row> fileDf = readRecordsAsRow(new Path[] {filePath}, sqlContext, metaClient, readerSchema);
     Column indexedColumn = functionalIndex.apply(Arrays.asList(fileDf.col(columnToIndex)));
     fileDf = fileDf.withColumn(columnToIndex, indexedColumn);
@@ -83,12 +181,11 @@ public class SparkMetadataWriterUtils {
       bloomFilter.add(key);
     });
     ByteBuffer bloomByteBuffer = ByteBuffer.wrap(getUTF8Bytes(bloomFilter.serializeToString()));
-    HoodieRecord<HoodieMetadataPayload> bloomFilterMetadataRecord = HoodieMetadataPayload.createBloomFilterMetadataRecord(
-        partitionName, filePath.toString(), instantTime, writeConfig.getBloomFilterType(), bloomByteBuffer, false);
-    bloomFilterMetadataList.add(bloomFilterMetadataRecord);
+    bloomFilterMetadataList.add(createBloomFilterMetadataRecord(
+        partitionName, filePath.toString(), instantTime, writeConfig.getBloomFilterType(), bloomByteBuffer, false));
   }
 
-  public static Dataset<Row> readRecordsAsRow(Path[] paths, SQLContext sqlContext, HoodieTableMetaClient metaClient, Schema schema) {
+  private static Dataset<Row> readRecordsAsRow(Path[] paths, SQLContext sqlContext, HoodieTableMetaClient metaClient, Schema schema) {
     String readPathString = String.join(",", Arrays.stream(paths).map(Path::toString).toArray(String[]::new));
     HashMap<String, String> params = new HashMap<>();
     params.put(QUERY_TYPE_CONFIG, QUERY_TYPE_SNAPSHOT);
@@ -99,13 +196,13 @@ public class SparkMetadataWriterUtils {
     BaseRelation relation = SparkAdapterSupport$.MODULE$.sparkAdapter()
         .createRelation(sqlContext, metaClient, schema, paths, params);
 
-    return sqlContext.baseRelationToDataFrame(relation);
+    return dropMetaFields(sqlContext.baseRelationToDataFrame(relation));
   }
 
-  public static <T extends Comparable<T>> HoodieColumnRangeMetadata<Comparable> computeColumnRangeMetadata(Dataset<Row> rowDataset,
-                                                                                                           String columnName,
-                                                                                                           String filePath,
-                                                                                                           long fileSize) {
+  private static <T extends Comparable<T>> HoodieColumnRangeMetadata<Comparable> computeColumnRangeMetadata(Dataset<Row> rowDataset,
+                                                                                                            String columnName,
+                                                                                                            String filePath,
+                                                                                                            long fileSize) {
     long totalSize = fileSize;
     // Get nullCount, minValue, and maxValue
     Dataset<Row> aggregated = rowDataset.agg(
@@ -134,5 +231,12 @@ public class SparkMetadataWriterUtils {
         totalSize,
         totalUncompressedSize
     );
+  }
+
+  private static Dataset<Row> dropMetaFields(Dataset<Row> df) {
+    return df.select(
+        Arrays.stream(df.columns())
+            .filter(c -> !HOODIE_META_COLUMNS.contains(c))
+            .map(df::col).toArray(Column[]::new));
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/functional/HoodieSparkFunctionalIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/functional/HoodieSparkFunctionalIndex.java
@@ -179,6 +179,12 @@ public class HoodieSparkFunctionalIndex implements HoodieFunctionalIndex<Column,
           throw new IllegalArgumentException("SPLIT requires 1 column");
         }
         return functions.split(columns.get(0), options.get("pattern"));
+      }),
+      Pair.of("identity", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("IDENTITY requires 1 column");
+        }
+        return columns.get(0);
       })
   );
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/functional/HoodieSparkFunctionalIndex.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/functional/HoodieSparkFunctionalIndex.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.functional;
+
+import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.functions;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+public class HoodieSparkFunctionalIndex implements HoodieFunctionalIndex<Column, Column>, Serializable {
+
+  /**
+   * Custom interface to support Spark functions
+   */
+  @FunctionalInterface
+  interface SparkFunction extends Serializable {
+    Column apply(List<Column> columns, Map<String, String> options);
+  }
+
+  /**
+   * Map of Spark functions to their implementations.
+   * NOTE: This is not an exhaustive list of spark-sql functions. Only the common date/timestamp and string functions have been added.
+   * Add more functions as needed. However, keep the key should match the exact spark-sql function name in lowercase.
+   */
+  private static final Map<String, SparkFunction> SPARK_FUNCTION_MAP = CollectionUtils.createImmutableMap(
+      // Date/Timestamp functions
+      Pair.of("date_format", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("DATE_FORMAT requires 1 column");
+        }
+        return functions.date_format(columns.get(0), options.get("format"));
+      }),
+      Pair.of("day", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("DAY requires 1 column");
+        }
+        return functions.dayofmonth(columns.get(0));
+      }),
+      Pair.of("year", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("YEAR requires 1 column");
+        }
+        return functions.year(columns.get(0));
+      }),
+      Pair.of("month", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("MONTH requires 1 column");
+        }
+        return functions.month(columns.get(0));
+      }),
+      Pair.of("hour", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("HOUR requires 1 column");
+        }
+        return functions.hour(columns.get(0));
+      }),
+      Pair.of("from_unixtime", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("FROM_UNIXTIME requires 1 column");
+        }
+        return functions.from_unixtime(columns.get(0), options.get("format"));
+      }),
+      Pair.of("unix_timestamp", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("UNIX_TIMESTAMP requires 1 column");
+        }
+        return functions.unix_timestamp(columns.get(0), options.get("format"));
+      }),
+      Pair.of("to_date", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("TO_DATE requires 1 column");
+        }
+        return functions.to_date(columns.get(0));
+      }),
+      Pair.of("to_timestamp", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("TO_TIMESTAMP requires 1 column");
+        }
+        return functions.to_timestamp(columns.get(0));
+      }),
+      Pair.of("date_add", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("DATE_ADD requires 1 column");
+        }
+        return functions.date_add(columns.get(0), Integer.parseInt(options.get("days")));
+      }),
+      Pair.of("date_sub", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("DATE_SUB requires 1 column");
+        }
+        return functions.date_sub(columns.get(0), Integer.parseInt(options.get("days")));
+      }),
+
+      // String functions
+      Pair.of("concat", (columns, options) -> {
+        if (columns.size() < 2) {
+          throw new IllegalArgumentException("CONCAT requires at least 2 columns");
+        }
+        return functions.concat(columns.toArray(new Column[0]));
+      }),
+      Pair.of("substring", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("SUBSTRING requires 1 column");
+        }
+        return functions.substring(columns.get(0), Integer.parseInt(options.get("pos")), Integer.parseInt(options.get("len")));
+      }),
+      Pair.of("lower", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("LOWER requires 1 column");
+        }
+        return functions.lower(columns.get(0));
+      }),
+      Pair.of("upper", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("UPPER requires 1 column");
+        }
+        return functions.upper(columns.get(0));
+      }),
+      Pair.of("trim", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("TRIM requires 1 column");
+        }
+        return functions.trim(columns.get(0));
+      }),
+      Pair.of("ltrim", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("LTRIM requires 1 column");
+        }
+        return functions.ltrim(columns.get(0));
+      }),
+      Pair.of("rtrim", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("RTRIM requires 1 column");
+        }
+        return functions.rtrim(columns.get(0));
+      }),
+      Pair.of("length", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("LENGTH requires 1 column");
+        }
+        return functions.length(columns.get(0));
+      }),
+      Pair.of("regexp_replace", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("REGEXP_REPLACE requires 1 column");
+        }
+        return functions.regexp_replace(columns.get(0), options.get("pattern"), options.get("replacement"));
+      }),
+      Pair.of("regexp_extract", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("REGEXP_EXTRACT requires 1 column");
+        }
+        return functions.regexp_extract(columns.get(0), options.get("pattern"), Integer.parseInt(options.get("idx")));
+      }),
+      Pair.of("split", (columns, options) -> {
+        if (columns.size() != 1) {
+          throw new IllegalArgumentException("SPLIT requires 1 column");
+        }
+        return functions.split(columns.get(0), options.get("pattern"));
+      })
+  );
+
+  private String indexName;
+  private String indexFunction;
+  private List<String> orderedSourceFields;
+  private Map<String, String> options;
+  private SparkFunction sparkFunction;
+
+  public HoodieSparkFunctionalIndex() {
+  }
+
+  public HoodieSparkFunctionalIndex(String indexName, String indexFunction, List<String> orderedSourceFields, Map<String, String> options) {
+    this.indexName = indexName;
+    this.indexFunction = indexFunction;
+    this.orderedSourceFields = orderedSourceFields;
+    this.options = options;
+
+    // Check if the function from the expression exists in our map
+    this.sparkFunction = SPARK_FUNCTION_MAP.get(indexFunction);
+    if (this.sparkFunction == null) {
+      throw new IllegalArgumentException("Unsupported Spark function: " + indexFunction);
+    }
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @Override
+  public String getIndexFunction() {
+    return indexFunction;
+  }
+
+  @Override
+  public List<String> getOrderedSourceFields() {
+    return orderedSourceFields;
+  }
+
+  @Override
+  public Column apply(List<Column> orderedSourceValues) {
+    if (orderedSourceValues.size() != orderedSourceFields.size()) {
+      throw new IllegalArgumentException("Mismatch in number of source values and fields in the expression");
+    }
+    return sparkFunction.apply(orderedSourceValues, options);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/functional/TestHoodieSparkFunctionalIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/functional/TestHoodieSparkFunctionalIndex.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.functional;
+
+import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.spark.sql.functions.col;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestHoodieSparkFunctionalIndex extends HoodieSparkClientTestHarness {
+
+  @BeforeEach
+  public void setup() {
+    initSparkContexts("TestHoodieSparkFunctionalIndex");
+  }
+
+  @AfterEach
+  public void tearDown() {
+    cleanupSparkContexts();
+  }
+
+  @Test
+  public void testYearFunction() {
+    // Create a test DataFrame
+    Dataset<Row> df = sparkSession.createDataFrame(Arrays.asList(
+        RowFactory.create(Timestamp.valueOf("2021-03-15 12:34:56")),
+        RowFactory.create(Timestamp.valueOf("2022-07-10 23:45:01"))
+    ), DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("timestampColumn", DataTypes.TimestampType, false)
+    )));
+
+    // Register the DataFrame as a temp view so we can query it
+    df.createOrReplaceTempView("testData");
+
+    // Initialize the HoodieSparkFunctionalIndex with the year function
+    HoodieSparkFunctionalIndex index = new HoodieSparkFunctionalIndex(
+        "yearIndex",
+        "year",
+        Arrays.asList("timestampColumn"),
+        new HashMap<>()
+    );
+
+    // Apply the function using the index
+    Column yearColumn = index.apply(Arrays.asList(col("timestampColumn")));
+
+    // Add the result as a new column to the DataFrame
+    Dataset<Row> resultDf = df.withColumn("year", yearColumn);
+
+    // Collect and assert the results
+    List<Row> results = resultDf.select("year").collectAsList();
+
+    assertEquals("2021", results.get(0).getAs("year").toString());
+    assertEquals("2022", results.get(1).getAs("year").toString());
+  }
+
+  @Test
+  public void testHourFunction() {
+    // Create a test DataFrame
+    Dataset<Row> df = sparkSession.createDataFrame(Arrays.asList(
+        RowFactory.create(Timestamp.valueOf("2021-03-15 12:34:56")),
+        RowFactory.create(Timestamp.valueOf("2022-07-10 23:45:01"))
+    ), DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("timestampColumn", DataTypes.TimestampType, false)
+    )));
+
+    // Register the DataFrame as a temp view so we can query it
+    df.createOrReplaceTempView("testData");
+
+    // Initialize the HoodieSparkFunctionalIndex with the hour function
+    HoodieSparkFunctionalIndex index = new HoodieSparkFunctionalIndex(
+        "hourIndex",
+        "hour",
+        Arrays.asList("timestampColumn"),
+        new HashMap<>()
+    );
+
+    // Apply the function using the index
+    Column hourColumn = index.apply(Arrays.asList(col("timestampColumn")));
+
+    // Add the result as a new column to the DataFrame
+    Dataset<Row> resultDf = df.withColumn("hour", hourColumn);
+
+    // Collect and assert the results
+    List<Row> results = resultDf.select("hour").collectAsList();
+
+    assertEquals("12", results.get(0).getAs("hour").toString());
+    assertEquals("23", results.get(1).getAs("hour").toString());
+  }
+
+  @Test
+  public void testApplyYearFunctionWithWrongNumberOfArguments() {
+    // Setup index with the wrong number of source fields
+    List<Column> sourceColumns = Arrays.asList(col("timestampColumn"), col("extraColumn"));
+    HoodieSparkFunctionalIndex index = new HoodieSparkFunctionalIndex(
+        "yearIndex",
+        "year",
+        Arrays.asList("timestampColumn", "extraColumn"),
+        Collections.emptyMap()
+    );
+    assertThrows(IllegalArgumentException.class, () -> index.apply(sourceColumns));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/upgrade/TestUpgradeDowngrade.java
@@ -101,6 +101,7 @@ import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEPRECATED_DE
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_FILES;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
@@ -555,7 +556,8 @@ public class TestUpgradeDowngrade extends HoodieClientTestBase {
         PARTITION_NAME_FILES,
         PARTITION_NAME_COLUMN_STATS,
         PARTITION_NAME_BLOOM_FILTERS,
-        PARTITION_NAME_RECORD_INDEX
+        PARTITION_NAME_RECORD_INDEX,
+        PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX
     );
     assertTrue(Files.exists(recordIndexPartitionPath), "record index partition should exist.");
     assertEquals(allPartitions, metaClient.getTableConfig().getMetadataPartitions(),

--- a/hudi-common/src/main/avro/HoodieIndexPartitionInfo.avsc
+++ b/hudi-common/src/main/avro/HoodieIndexPartitionInfo.avsc
@@ -43,6 +43,17 @@
         "string"
       ],
       "default": null
+    },
+    {
+      "name": "extraMetadata",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
     }
   ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -40,7 +40,8 @@ public class ConfigGroups {
     RECORD_PAYLOAD("Record Payload Config"),
     KAFKA_CONNECT("Kafka Connect Configs"),
     AWS("Amazon Web Services Configs"),
-    HUDI_STREAMER("Hudi Streamer Configs");
+    HUDI_STREAMER("Hudi Streamer Configs"),
+    INDEXING("Indexing Configs");
 
     public final String name;
 
@@ -76,7 +77,10 @@ public class ConfigGroups {
         "Configurations controlling the behavior of reading source data."),
     NONE(
         "None",
-        "No subgroup. This description should be hidden.");
+        "No subgroup. This description should be hidden."),
+    FUNCTIONAL_INDEX(
+        "Functional Index Configs",
+        "Configurations controlling the behavior of functional index.");
 
     public final String name;
     private final String description;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieConfig.java
@@ -42,6 +42,10 @@ public class HoodieConfig implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieConfig.class);
 
   protected static final String CONFIG_VALUES_DELIMITER = ",";
+  // Number of retries while reading the properties file to deal with parallel updates
+  protected static final int MAX_READ_RETRIES = 5;
+  // Delay between retries while reading the properties file
+  protected static final int READ_RETRY_DELAY_MSEC = 1000;
 
   protected TypedProperties props;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieFunctionalIndexConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieFunctionalIndexConfig.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
+import org.apache.hudi.common.util.BinaryUtil;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.index.secondary.SecondaryIndexType;
+import org.apache.hudi.metadata.MetadataPartitionType;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static org.apache.hudi.common.util.ConfigUtils.fetchConfigs;
+import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+
+@Immutable
+@ConfigClassProperty(name = "Common Index Configs",
+    groupName = ConfigGroups.Names.INDEXING,
+    subGroupName = ConfigGroups.SubGroupNames.FUNCTIONAL_INDEX,
+    areCommonConfigs = true,
+    description = "")
+public class HoodieFunctionalIndexConfig extends HoodieConfig {
+
+  public static final String INDEX_DEFINITION_FILE = "index.properties";
+  public static final String INDEX_DEFINITION_FILE_BACKUP = "index.properties.backup";
+  public static final ConfigProperty<String> INDEX_NAME = ConfigProperty
+      .key("hoodie.functional.index.name")
+      .noDefaultValue()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Name of the functional index. This is also used for the partition name in the metadata table.");
+
+  public static final ConfigProperty<String> INDEX_TYPE = ConfigProperty
+      .key("hoodie.functional.index.type")
+      .defaultValue(MetadataPartitionType.COLUMN_STATS.name())
+      .withValidValues(
+          MetadataPartitionType.COLUMN_STATS.name(),
+          MetadataPartitionType.BLOOM_FILTERS.name()
+      )
+      .sinceVersion("1.0.0")
+      .withDocumentation("Type of the functional index. Default is `column_stats` if there are no functions and expressions in the command. "
+          + "Valid options could be BITMAP, COLUMN_STATS, LUCENE, etc. If index_type is not provided, "
+          + "and there are functions or expressions in the command then a functional index using column stats will be created.");
+
+  public static final ConfigProperty<String> INDEX_FUNCTION = ConfigProperty
+      .key("hoodie.functional.index.function")
+      .noDefaultValue()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Function to be used for building the functional index.");
+
+  public static final ConfigProperty<String> INDEX_DEFINITION_CHECKSUM = ConfigProperty
+      .key("hoodie.table.checksum")
+      .noDefaultValue()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Index definition checksum is used to guard against partial writes in HDFS. "
+          + "It is added as the last entry in index.properties and then used to validate while reading table config.");
+
+  private static final String INDEX_DEFINITION_CHECKSUM_FORMAT = "%s.%s"; // <index_name>.<index_type>
+
+  public HoodieFunctionalIndexConfig() {
+    super();
+  }
+
+  public static void create(FileSystem fs, Path metadataFolder, Properties properties)
+      throws IOException {
+    if (!fs.exists(metadataFolder)) {
+      fs.mkdirs(metadataFolder);
+    }
+    HoodieConfig hoodieConfig = new HoodieConfig(properties);
+    Path propertyPath = new Path(metadataFolder, INDEX_DEFINITION_FILE);
+    try (FSDataOutputStream outputStream = fs.create(propertyPath)) {
+      if (!hoodieConfig.contains(INDEX_NAME)) {
+        throw new IllegalArgumentException(INDEX_NAME.key() + " property needs to be specified");
+      }
+      hoodieConfig.setDefaultValue(INDEX_TYPE);
+      storeProperties(hoodieConfig.getProps(), outputStream);
+    }
+  }
+
+  public static void update(FileSystem fs, Path metadataFolder, Properties updatedProps) {
+    modify(fs, metadataFolder, updatedProps, ConfigUtils::upsertProperties);
+  }
+
+  public static void delete(FileSystem fs, Path metadataFolder, Set<String> deletedProps) {
+    Properties props = new Properties();
+    deletedProps.forEach(p -> props.setProperty(p, ""));
+    modify(fs, metadataFolder, props, ConfigUtils::deleteProperties);
+  }
+
+  public static void recover(FileSystem fs, Path metadataFolder) throws IOException {
+    Path cfgPath = new Path(metadataFolder, INDEX_DEFINITION_FILE);
+    Path backupCfgPath = new Path(metadataFolder, INDEX_DEFINITION_FILE_BACKUP);
+    recoverIfNeeded(fs, cfgPath, backupCfgPath);
+  }
+
+  private static void modify(FileSystem fs, Path metadataFolder, Properties modifyProps, BiConsumer<Properties, Properties> modifyFn) {
+    Path cfgPath = new Path(metadataFolder, INDEX_DEFINITION_FILE);
+    Path backupCfgPath = new Path(metadataFolder, INDEX_DEFINITION_FILE_BACKUP);
+    try {
+      // 0. do any recovery from prior attempts.
+      recoverIfNeeded(fs, cfgPath, backupCfgPath);
+
+      // 1. Read the existing config
+      TypedProperties props = fetchConfigs(fs, metadataFolder.toString(), INDEX_DEFINITION_FILE, INDEX_DEFINITION_FILE_BACKUP, MAX_READ_RETRIES, READ_RETRY_DELAY_MSEC);
+
+      // 2. backup the existing properties.
+      try (FSDataOutputStream out = fs.create(backupCfgPath, false)) {
+        storeProperties(props, out);
+      }
+
+      // 3. delete the properties file, reads will go to the backup, until we are done.
+      fs.delete(cfgPath, false);
+
+      // 4. Upsert and save back.
+      String checksum;
+      try (FSDataOutputStream out = fs.create(cfgPath, true)) {
+        modifyFn.accept(props, modifyProps);
+        checksum = storeProperties(props, out);
+      }
+
+      // 4. verify and remove backup.
+      try (FSDataInputStream in = fs.open(cfgPath)) {
+        props.clear();
+        props.load(in);
+        if (!props.containsKey(INDEX_DEFINITION_CHECKSUM.key()) || !props.getProperty(INDEX_DEFINITION_CHECKSUM.key()).equals(checksum)) {
+          // delete the properties file and throw exception indicating update failure
+          // subsequent writes will recover and update, reads will go to the backup until then
+          fs.delete(cfgPath, false);
+          throw new HoodieIOException("Checksum property missing or does not match.");
+        }
+      }
+
+      // 5. delete the backup properties file
+      fs.delete(backupCfgPath, false);
+    } catch (IOException e) {
+      throw new HoodieIOException("Error updating table configs.", e);
+    }
+  }
+
+  private static Properties getOrderedPropertiesWithTableChecksum(Properties props) {
+    Properties orderedProps = new OrderedProperties(props);
+    orderedProps.put(INDEX_DEFINITION_CHECKSUM.key(), String.valueOf(generateChecksum(props)));
+    return orderedProps;
+  }
+
+  /**
+   * Write the properties to the given output stream and return the table checksum.
+   *
+   * @param props        - properties to be written
+   * @param outputStream - output stream to which properties will be written
+   * @return return the table checksum
+   */
+  private static String storeProperties(Properties props, FSDataOutputStream outputStream) throws IOException {
+    final String checksum;
+    if (isValidChecksum(props)) {
+      checksum = props.getProperty(INDEX_DEFINITION_CHECKSUM.key());
+      props.store(outputStream, "Updated at " + Instant.now());
+    } else {
+      Properties propsWithChecksum = getOrderedPropertiesWithTableChecksum(props);
+      propsWithChecksum.store(outputStream, "Properties saved on " + Instant.now());
+      checksum = propsWithChecksum.getProperty(INDEX_DEFINITION_CHECKSUM.key());
+      props.setProperty(INDEX_DEFINITION_CHECKSUM.key(), checksum);
+    }
+    return checksum;
+  }
+
+  private static boolean isValidChecksum(Properties props) {
+    return props.containsKey(INDEX_DEFINITION_CHECKSUM.key()) && validateChecksum(props);
+  }
+
+  public static long generateChecksum(Properties props) {
+    if (!props.containsKey(INDEX_NAME.key())) {
+      throw new IllegalArgumentException(INDEX_NAME.key() + " property needs to be specified");
+    }
+    String table = props.getProperty(INDEX_NAME.key());
+    String database = props.getProperty(INDEX_TYPE.key(), "");
+    return BinaryUtil.generateChecksum(getUTF8Bytes(String.format(INDEX_DEFINITION_CHECKSUM_FORMAT, database, table)));
+  }
+
+  public static boolean validateChecksum(Properties props) {
+    return Long.parseLong(props.getProperty(INDEX_DEFINITION_CHECKSUM.key())) == generateChecksum(props);
+  }
+
+  public static HoodieFunctionalIndexConfig.Builder newBuilder() {
+    return new HoodieFunctionalIndexConfig.Builder();
+  }
+
+  public static class Builder {
+    private final HoodieFunctionalIndexConfig functionalIndexConfig = new HoodieFunctionalIndexConfig();
+
+    public Builder fromFile(File propertiesFile) throws IOException {
+      try (FileReader reader = new FileReader(propertiesFile)) {
+        this.functionalIndexConfig.getProps().load(reader);
+        return this;
+      }
+    }
+
+    public Builder fromProperties(Properties props) {
+      this.functionalIndexConfig.getProps().putAll(props);
+      return this;
+    }
+
+    public Builder fromIndexConfig(HoodieFunctionalIndexConfig functionalIndexConfig) {
+      this.functionalIndexConfig.getProps().putAll(functionalIndexConfig.getProps());
+      return this;
+    }
+
+    public Builder withIndexName(String indexName) {
+      functionalIndexConfig.setValue(INDEX_NAME, indexName);
+      return this;
+    }
+
+    public Builder withIndexType(String indexType) {
+      functionalIndexConfig.setValue(INDEX_TYPE, indexType);
+      return this;
+    }
+
+    public Builder withIndexFunction(String indexFunction) {
+      functionalIndexConfig.setValue(INDEX_FUNCTION, indexFunction);
+      return this;
+    }
+
+    public HoodieFunctionalIndexConfig build() {
+      functionalIndexConfig.setDefaults(HoodieFunctionalIndexConfig.class.getName());
+      return functionalIndexConfig;
+    }
+  }
+
+  public static HoodieFunctionalIndexConfig copy(HoodieFunctionalIndexConfig functionalIndexConfig) {
+    return newBuilder().fromIndexConfig(functionalIndexConfig).build();
+  }
+
+  public static HoodieFunctionalIndexConfig merge(HoodieFunctionalIndexConfig functionalIndexConfig1, HoodieFunctionalIndexConfig functionalIndexConfig2) {
+    return newBuilder().fromIndexConfig(functionalIndexConfig1).fromIndexConfig(functionalIndexConfig2).build();
+  }
+
+  public static HoodieFunctionalIndexConfig fromIndexDefinition(HoodieFunctionalIndexDefinition indexDefinition) {
+    return newBuilder().withIndexName(indexDefinition.getIndexName())
+        .withIndexType(indexDefinition.getIndexType())
+        .withIndexFunction(indexDefinition.getIndexFunction())
+        .build();
+  }
+
+  public String getIndexName() {
+    return getString(INDEX_NAME);
+  }
+
+  public String getIndexType() {
+    return getString(INDEX_TYPE);
+  }
+
+  public String getIndexFunction() {
+    return getString(INDEX_FUNCTION);
+  }
+
+  public boolean isIndexUsingBloomFilter() {
+    return getIndexType().equalsIgnoreCase(MetadataPartitionType.BLOOM_FILTERS.name());
+  }
+
+  public boolean isIndexUsingLucene() {
+    return getIndexType().equalsIgnoreCase(SecondaryIndexType.LUCENE.name());
+  }
+
+  public boolean isIndexUsingColumnStats() {
+    return getIndexType().equalsIgnoreCase(MetadataPartitionType.COLUMN_STATS.name());
+  }
+
+  public boolean isIndexUsingRecordIndex() {
+    return getIndexType().equalsIgnoreCase(MetadataPartitionType.RECORD_INDEX.name());
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -320,7 +320,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".index.functional.file.group.count")
       .defaultValue(2)
       .markAdvanced()
-      .sinceVersion("0.11.0")
+      .sinceVersion("1.0.0")
       .withDocumentation("Metadata functional index partition file group count.");
 
   public static final ConfigProperty<Integer> FUNCTIONAL_INDEX_PARALLELISM = ConfigProperty

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -316,6 +316,20 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("Initializes the metadata table by reading from the file system when the table is first created. Enabled by default. "
           + "Warning: This should only be disabled when manually constructing the metadata table outside of typical Hudi writer flows.");
 
+  public static final ConfigProperty<Integer> FUNCTIONAL_INDEX_FILE_GROUP_COUNT = ConfigProperty
+      .key(METADATA_PREFIX + ".index.functional.file.group.count")
+      .defaultValue(2)
+      .markAdvanced()
+      .sinceVersion("0.11.0")
+      .withDocumentation("Metadata functional index partition file group count.");
+
+  public static final ConfigProperty<Integer> FUNCTIONAL_INDEX_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".index.functional.parallelism")
+      .defaultValue(200)
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Parallelism to use, when generating functional index.");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -442,6 +456,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean shouldAutoInitialize() {
     return getBoolean(AUTO_INITIALIZE);
+  }
+
+  public int getFunctionalIndexFileGroupCount() {
+    return getInt(FUNCTIONAL_INDEX_FILE_GROUP_COUNT);
+  }
+
+  public int getFunctionalIndexParallelism() {
+    return getInt(FUNCTIONAL_INDEX_PARALLELISM);
   }
 
   public static class Builder {
@@ -614,6 +636,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withMaxLogFileSizeBytes(long sizeInBytes) {
       metadataConfig.setValue(MAX_LOG_FILE_SIZE_BYTES_PROP, String.valueOf(sizeInBytes));
+      return this;
+    }
+
+    public Builder withFunctionalIndexFileGroupCount(int fileGroupCount) {
+      metadataConfig.setValue(FUNCTIONAL_INDEX_FILE_GROUP_COUNT, String.valueOf(fileGroupCount));
+      return this;
+    }
+
+    public Builder withFunctionalIndexParallelism(int parallelism) {
+      metadataConfig.setValue(FUNCTIONAL_INDEX_PARALLELISM, String.valueOf(parallelism));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFunctionalIndexDefinition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFunctionalIndexDefinition.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class representing the metadata for a functional index in Hudi.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HoodieFunctionalIndexDefinition implements Serializable {
+
+  // Name of the index
+  private String indexName;
+
+  private String indexType;
+
+  // Expression used for the index, e.g., MONTH(ts)
+  private String indexFunction;
+
+  // Data fields the expression is derived from
+  private List<String> sourceFields;
+
+  // Any other configuration or properties specific to the index
+  private Map<String, String> indexOptions;
+
+  public HoodieFunctionalIndexDefinition() {
+  }
+
+  public HoodieFunctionalIndexDefinition(String indexName, String indexType, String indexFunction, List<String> sourceFields,
+                                         Map<String, String> indexOptions) {
+    this.indexName = indexName;
+    this.indexType = indexType;
+    this.indexFunction = indexFunction;
+    this.sourceFields = sourceFields;
+    this.indexOptions = indexOptions;
+  }
+
+  public String getIndexFunction() {
+    return indexFunction;
+  }
+
+  public List<String> getSourceFields() {
+    return sourceFields;
+  }
+
+  public Map<String, String> getIndexOptions() {
+    return indexOptions;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String getIndexType() {
+    return indexType;
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieFunctionalIndexDefinition{"
+        + "indexName='" + indexName + '\''
+        + ", indexType='" + indexType + '\''
+        + ", indexFunction='" + indexFunction + '\''
+        + ", sourceFields=" + sourceFields
+        + ", indexOptions=" + indexOptions
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFunctionalIndexMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFunctionalIndexMetadata.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.util.JsonUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents the metadata for all functional indexes in Hudi.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HoodieFunctionalIndexMetadata implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieFunctionalIndexMetadata.class);
+
+  // Map to hold the index definitions keyed by their names.
+  private Map<String, HoodieFunctionalIndexDefinition> indexDefinitions;
+
+  public HoodieFunctionalIndexMetadata() {
+    this.indexDefinitions = new HashMap<>();
+  }
+
+  public HoodieFunctionalIndexMetadata(Map<String, HoodieFunctionalIndexDefinition> indexDefinitions) {
+    this.indexDefinitions = indexDefinitions;
+  }
+
+  public Map<String, HoodieFunctionalIndexDefinition> getIndexDefinitions() {
+    return indexDefinitions;
+  }
+
+  public void setIndexDefinitions(Map<String, HoodieFunctionalIndexDefinition> indexDefinitions) {
+    this.indexDefinitions = indexDefinitions;
+  }
+
+  /**
+   * Serialize this object to JSON string.
+   *
+   * @return Serialized JSON string.
+   * @throws JsonProcessingException If any serialization errors occur.
+   */
+  public String toJson() throws JsonProcessingException {
+    if (indexDefinitions.containsKey(null)) {
+      LOG.info("null index name for the index definition " + indexDefinitions.get(null));
+      indexDefinitions.remove(null);
+    }
+    return JsonUtils.getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);
+  }
+
+  /**
+   * Deserialize from JSON string to create an instance of this class.
+   *
+   * @param json Input JSON string.
+   * @return Deserialized instance of HoodieFunctionalIndexMetadata.
+   * @throws IOException If any deserialization errors occur.
+   */
+  public static HoodieFunctionalIndexMetadata fromJson(String json) throws IOException {
+    if (json == null || json.isEmpty()) {
+      return new HoodieFunctionalIndexMetadata();
+    }
+    return JsonUtils.getObjectMapper().readValue(json, HoodieFunctionalIndexMetadata.class);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieFunctionalIndexMetadata{"
+        + "indexDefinitions=" + indexDefinitions
+        + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -35,7 +35,7 @@ import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.BinaryUtil;
-import org.apache.hudi.common.util.FileIOUtils;
+import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -71,6 +71,8 @@ import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAM
 import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT;
 import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_TIMEZONE_FORMAT;
 import static org.apache.hudi.common.config.TimestampKeyGeneratorConfig.TIMESTAMP_TIMEZONE_FORMAT;
+import static org.apache.hudi.common.util.ConfigUtils.fetchConfigs;
+import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -290,19 +292,20 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("0.13.0")
       .withDocumentation("The metadata of secondary indexes");
 
-  private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
+  public static final ConfigProperty<String> INDEX_DEFINITION_PATH = ConfigProperty
+      .key("hoodie.table.index.defs.path")
+      .noDefaultValue()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Absolute path where the index definitions are stored");
 
-  // Number of retries while reading the properties file to deal with parallel updates
-  private static final int MAX_READ_RETRIES = 5;
-  // Delay between retries while reading the properties file
-  private static final int READ_RETRY_DELAY_MSEC = 1000;
+  private static final String TABLE_CHECKSUM_FORMAT = "%s.%s"; // <database_name>.<table_name>
 
   public HoodieTableConfig(FileSystem fs, String metaPath, String payloadClassName, String recordMergerStrategyId) {
     super();
     Path propertyPath = new Path(metaPath, HOODIE_PROPERTIES_FILE);
     LOG.info("Loading table properties from " + propertyPath);
     try {
-      this.props = fetchConfigs(fs, metaPath);
+      this.props = fetchConfigs(fs, metaPath, HOODIE_PROPERTIES_FILE, HOODIE_PROPERTIES_FILE_BACKUP, MAX_READ_RETRIES, READ_RETRY_DELAY_MSEC);
       boolean needStore = false;
       if (contains(PAYLOAD_CLASS_NAME) && payloadClassName != null
           && !getString(PAYLOAD_CLASS_NAME).equals(payloadClassName)) {
@@ -369,69 +372,10 @@ public class HoodieTableConfig extends HoodieConfig {
     super();
   }
 
-  private static TypedProperties fetchConfigs(FileSystem fs, String metaPath) throws IOException {
-    Path cfgPath = new Path(metaPath, HOODIE_PROPERTIES_FILE);
-    Path backupCfgPath = new Path(metaPath, HOODIE_PROPERTIES_FILE_BACKUP);
-    int readRetryCount = 0;
-    boolean found = false;
-
-    TypedProperties props = new TypedProperties();
-    while (readRetryCount++ < MAX_READ_RETRIES) {
-      for (Path path : Arrays.asList(cfgPath, backupCfgPath)) {
-        // Read the properties and validate that it is a valid file
-        try (FSDataInputStream is = fs.open(path)) {
-          props.clear();
-          props.load(is);
-          found = true;
-          ValidationUtils.checkArgument(validateChecksum(props));
-          return props;
-        } catch (IOException e) {
-          LOG.warn(String.format("Could not read properties from %s: %s", path, e));
-        } catch (IllegalArgumentException e) {
-          LOG.warn(String.format("Invalid properties file %s: %s", path, props));
-        }
-      }
-
-      // Failed to read all files so wait before retrying. This can happen in cases of parallel updates to the properties.
-      try {
-        Thread.sleep(READ_RETRY_DELAY_MSEC);
-      } catch (InterruptedException e) {
-        LOG.warn("Interrupted while waiting");
-      }
-    }
-
-    // If we are here then after all retries either no hoodie.properties was found or only an invalid file was found.
-    if (found) {
-      throw new IllegalArgumentException("hoodie.properties file seems invalid. Please check for left over `.updated` files if any, manually copy it to hoodie.properties and retry");
-    } else {
-      throw new HoodieIOException("Could not load Hoodie properties from " + cfgPath);
-    }
-  }
-
   public static void recover(FileSystem fs, Path metadataFolder) throws IOException {
     Path cfgPath = new Path(metadataFolder, HOODIE_PROPERTIES_FILE);
     Path backupCfgPath = new Path(metadataFolder, HOODIE_PROPERTIES_FILE_BACKUP);
     recoverIfNeeded(fs, cfgPath, backupCfgPath);
-  }
-
-  static void recoverIfNeeded(FileSystem fs, Path cfgPath, Path backupCfgPath) throws IOException {
-    if (!fs.exists(cfgPath)) {
-      // copy over from backup
-      try (FSDataInputStream in = fs.open(backupCfgPath);
-           FSDataOutputStream out = fs.create(cfgPath, false)) {
-        FileIOUtils.copy(in, out);
-      }
-    }
-    // regardless, we don't need the backup anymore.
-    fs.delete(backupCfgPath, false);
-  }
-
-  private static void upsertProperties(Properties current, Properties updated) {
-    updated.forEach((k, v) -> current.setProperty(k.toString(), v.toString()));
-  }
-
-  private static void deleteProperties(Properties current, Properties deleted) {
-    deleted.forEach((k, v) -> current.remove(k.toString()));
   }
 
   private static void modify(FileSystem fs, Path metadataFolder, Properties modifyProps, BiConsumer<Properties, Properties> modifyFn) {
@@ -442,7 +386,7 @@ public class HoodieTableConfig extends HoodieConfig {
       recoverIfNeeded(fs, cfgPath, backupCfgPath);
 
       // 1. Read the existing config
-      TypedProperties props = fetchConfigs(fs, metadataFolder.toString());
+      TypedProperties props = fetchConfigs(fs, metadataFolder.toString(), HOODIE_PROPERTIES_FILE, HOODIE_PROPERTIES_FILE_BACKUP, MAX_READ_RETRIES, READ_RETRY_DELAY_MSEC);
 
       // 2. backup the existing properties.
       try (FSDataOutputStream out = fs.create(backupCfgPath, false)) {
@@ -483,13 +427,13 @@ public class HoodieTableConfig extends HoodieConfig {
    * here for safely updating with recovery and also ensuring the table config continues to be readable.
    */
   public static void update(FileSystem fs, Path metadataFolder, Properties updatedProps) {
-    modify(fs, metadataFolder, updatedProps, HoodieTableConfig::upsertProperties);
+    modify(fs, metadataFolder, updatedProps, ConfigUtils::upsertProperties);
   }
 
   public static void delete(FileSystem fs, Path metadataFolder, Set<String> deletedProps) {
     Properties props = new Properties();
     deletedProps.forEach(p -> props.setProperty(p, ""));
-    modify(fs, metadataFolder, props, HoodieTableConfig::deleteProperties);
+    modify(fs, metadataFolder, props, ConfigUtils::deleteProperties);
   }
 
   /**
@@ -774,6 +718,13 @@ public class HoodieTableConfig extends HoodieConfig {
     return new HashSet<>(
         StringUtils.split(getStringOrDefault(TABLE_METADATA_PARTITIONS, StringUtils.EMPTY_STRING),
             CONFIG_VALUES_DELIMITER));
+  }
+
+  /**
+   * @returns the index definition path.
+   */
+  public Option<String> getIndexDefinitionPath() {
+    return Option.ofNullable(getString(INDEX_DEFINITION_PATH));
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieFunctionalIndexException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieFunctionalIndexException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.exception;
+
+/**
+ * Exception for Hudi functional index.
+ */
+public class HoodieFunctionalIndexException extends HoodieException {
+
+  public HoodieFunctionalIndexException(String message) {
+    super(message);
+  }
+
+  public HoodieFunctionalIndexException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/index/functional/HoodieFunctionalIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/functional/HoodieFunctionalIndex.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.index.functional;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Interface representing a functional index in Hudi.
+ *
+ * @param <S> The source type of the values from the fields used in the functional index expression.
+ *            Note that this assumes than an expression is operating on fields of same type.
+ * @param <T> The target type after applying the transformation. Represents the type of the indexed value.
+ */
+public interface HoodieFunctionalIndex<S, T> extends Serializable {
+  /**
+   * Get the name of the index.
+   *
+   * @return Name of the index.
+   */
+  String getIndexName();
+
+  /**
+   * Get the expression associated with the index.
+   *
+   * @return Expression string.
+   */
+  String getIndexFunction();
+
+  /**
+   * Get the list of fields involved in the expression in order.
+   *
+   * @return List of fields.
+   */
+  List<String> getOrderedSourceFields();
+
+  /**
+   * Apply the transformation based on the source values and the expression.
+   *
+   * @param orderedSourceValues List of source values corresponding to fields in the expression.
+   * @return Transformed value.
+   */
+  T apply(List<S> orderedSourceValues);
+}

--- a/hudi-common/src/main/java/org/apache/hudi/index/secondary/HoodieSecondaryIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/secondary/HoodieSecondaryIndex.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi.secondary.index;
+package org.apache.hudi.index.secondary;
 
 import org.apache.hudi.exception.HoodieSecondaryIndexException;
 

--- a/hudi-common/src/main/java/org/apache/hudi/index/secondary/SecondaryIndexManager.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/secondary/SecondaryIndexManager.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi.secondary.index;
+package org.apache.hudi.index.secondary;
 
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -38,8 +38,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.apache.hudi.secondary.index.SecondaryIndexUtils.getSecondaryIndexes;
 
 /**
  * Manages secondary index.
@@ -84,7 +82,7 @@ public class SecondaryIndexManager {
       boolean ignoreIfExists,
       LinkedHashMap<String, Map<String, String>> columns,
       Map<String, String> options) {
-    Option<List<HoodieSecondaryIndex>> secondaryIndexes = getSecondaryIndexes(metaClient);
+    Option<List<HoodieSecondaryIndex>> secondaryIndexes = SecondaryIndexUtils.getSecondaryIndexes(metaClient);
     Set<String> colNames = columns.keySet();
     Schema avroSchema;
     try {
@@ -140,7 +138,7 @@ public class SecondaryIndexManager {
    * @param ignoreIfNotExists Whether ignore drop if the specific secondary index no exists
    */
   public void drop(HoodieTableMetaClient metaClient, String indexName, boolean ignoreIfNotExists) {
-    Option<List<HoodieSecondaryIndex>> secondaryIndexes = getSecondaryIndexes(metaClient);
+    Option<List<HoodieSecondaryIndex>> secondaryIndexes = SecondaryIndexUtils.getSecondaryIndexes(metaClient);
     if (!indexExists(secondaryIndexes, indexName, Option.empty(), Option.empty())) {
       if (ignoreIfNotExists) {
         return;
@@ -175,7 +173,7 @@ public class SecondaryIndexManager {
    * @return Indexes in this table
    */
   public Option<List<HoodieSecondaryIndex>> show(HoodieTableMetaClient metaClient) {
-    return getSecondaryIndexes(metaClient);
+    return SecondaryIndexUtils.getSecondaryIndexes(metaClient);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/index/secondary/SecondaryIndexType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/secondary/SecondaryIndexType.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi.secondary.index;
+package org.apache.hudi.index.secondary;
 
 import org.apache.hudi.exception.HoodieIndexException;
 

--- a/hudi-common/src/main/java/org/apache/hudi/index/secondary/SecondaryIndexUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/index/secondary/SecondaryIndexUtils.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.hudi.secondary.index;
+package org.apache.hudi.index.secondary;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -121,7 +121,7 @@ public class HoodieFileWriterFactory {
     throw new UnsupportedOperationException();
   }
 
-  protected BloomFilter createBloomFilter(HoodieConfig config) {
+  public static BloomFilter createBloomFilter(HoodieConfig config) {
     return BloomFilterFactory.createBloomFilter(
         config.getIntOrDefault(HoodieStorageConfig.BLOOM_FILTER_NUM_ENTRIES_VALUE),
         config.getDoubleOrDefault(HoodieStorageConfig.BLOOM_FILTER_FPP_VALUE),

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -135,6 +135,7 @@ public class HoodieTableMetadataUtil {
   public static final String PARTITION_NAME_COLUMN_STATS = "column_stats";
   public static final String PARTITION_NAME_BLOOM_FILTERS = "bloom_filters";
   public static final String PARTITION_NAME_RECORD_INDEX = "record_index";
+  public static final String PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX = "func_index_";
 
   // Suffix to use for various operations on MDT
   private enum OperationSuffix {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -41,6 +41,7 @@ import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
@@ -1856,5 +1857,11 @@ public class HoodieTableMetadataUtil {
         }
       };
     });
+  }
+
+  public static Schema getProjectedSchemaForFunctionalIndex(HoodieFunctionalIndexDefinition indexDefinition, HoodieTableMetaClient metaClient) throws Exception {
+    TableSchemaResolver schemaResolver = new TableSchemaResolver(metaClient);
+    Schema tableSchema = schemaResolver.getTableAvroSchema();
+    return HoodieAvroUtils.getSchemaForFields(tableSchema, indexDefinition.getSourceFields());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -29,7 +29,7 @@ public enum MetadataPartitionType {
   COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-"),
   BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-"),
   RECORD_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, "record-index-"),
-  FUNCTIONAL_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX, "func_index_");
+  FUNCTIONAL_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX, "func-index-");
 
   // Partition path in metadata table.
   private final String partitionPath;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -28,7 +28,8 @@ public enum MetadataPartitionType {
   FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-"),
   COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-"),
   BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-"),
-  RECORD_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, "record-index-");
+  RECORD_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, "record-index-"),
+  FUNCTIONAL_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX, "func_index_");
 
   // Partition path in metadata table.
   private final String partitionPath;

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.hudi.common.util.ConfigUtils.recoverIfNeeded;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -141,7 +142,7 @@ public class TestHoodieTableConfig extends HoodieCommonTestHarness {
       config.getProps().store(out, "");
     }
 
-    HoodieTableConfig.recoverIfNeeded(fs, cfgPath, backupCfgPath);
+    recoverIfNeeded(fs, cfgPath, backupCfgPath);
     assertTrue(fs.exists(cfgPath));
     assertFalse(fs.exists(backupCfgPath));
     config = new HoodieTableConfig(fs, metaPath.toString(), null, null);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestWaitBasedTimeGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestWaitBasedTimeGenerator.java
@@ -19,14 +19,14 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
-import org.apache.hudi.exception.HoodieLockException;
 import org.apache.hudi.common.config.HoodieTimeGeneratorConfig;
 import org.apache.hudi.common.config.LockConfiguration;
+import org.apache.hudi.exception.HoodieLockException;
 
 import org.apache.hadoop.conf.Configuration;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -103,6 +103,7 @@ public class TestWaitBasedTimeGenerator {
    *    3> whereas t1's timestamp > t2's timestamp
    * So no matter which thread firstly acquires lock, the first acquired thread's timestamp should be earlier.
    */
+  @Disabled("This test is flaky, disable it for now. Fix in review -> https://github.com/apache/hudi/pull/9972")
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testSlowerThreadLaterAcquiredLock(boolean slowerThreadAcquiredLockLater) throws InterruptedException {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkFunctionalIndexClient.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/HoodieSparkFunctionalIndexClient.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.config.HoodieFunctionalIndexConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieFunctionalIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieFunctionalIndexException;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.table.action.index.functional.BaseHoodieFunctionalIndexClient;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import scala.collection.JavaConverters;
+
+import static org.apache.hudi.HoodieConversionUtils.mapAsScalaImmutableMap;
+import static org.apache.hudi.HoodieConversionUtils.toScalaOption;
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
+public class HoodieSparkFunctionalIndexClient extends BaseHoodieFunctionalIndexClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieSparkFunctionalIndexClient.class);
+
+  private static volatile HoodieSparkFunctionalIndexClient _instance;
+
+  private final SparkSession sparkSession;
+
+  private HoodieSparkFunctionalIndexClient(SparkSession sparkSession) {
+    super();
+    this.sparkSession = sparkSession;
+  }
+
+  public static HoodieSparkFunctionalIndexClient getInstance(SparkSession sparkSession) {
+    if (_instance == null) {
+      synchronized (HoodieSparkFunctionalIndexClient.class) {
+        if (_instance == null) {
+          _instance = new HoodieSparkFunctionalIndexClient(sparkSession);
+        }
+      }
+    }
+    return _instance;
+  }
+
+  @Override
+  public void create(HoodieTableMetaClient metaClient, String indexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options) {
+    indexName = HoodieTableMetadataUtil.PARTITION_NAME_FUNCTIONAL_INDEX_PREFIX + indexName;
+    if (indexExists(metaClient, indexName)) {
+      throw new HoodieFunctionalIndexException("Index already exists: " + indexName);
+    }
+
+    if (!metaClient.getTableConfig().getIndexDefinitionPath().isPresent() || !metaClient.getFunctionalIndexMetadata().isPresent()) {
+      LOG.info("Index definition is not present. Registering the index first");
+      register(metaClient, indexName, indexType, columns, options);
+    }
+
+    ValidationUtils.checkState(metaClient.getFunctionalIndexMetadata().isPresent(), "Index definition is not present");
+
+    LOG.info("Creating index {} of using {}", indexName, indexType);
+    HoodieFunctionalIndexDefinition functionalIndexDefinition = metaClient.getFunctionalIndexMetadata().get().getIndexDefinitions().get(indexName);
+    try (SparkRDDWriteClient writeClient = HoodieCLIUtils.createHoodieWriteClient(
+        sparkSession, metaClient.getBasePathV2().toString(), mapAsScalaImmutableMap(buildWriteConfig(metaClient, functionalIndexDefinition)), toScalaOption(Option.empty()))) {
+      // generate index plan
+      Option<String> indexInstantTime = doSchedule(writeClient, metaClient);
+      if (indexInstantTime.isPresent()) {
+        // build index
+        writeClient.index(indexInstantTime.get());
+      } else {
+        throw new HoodieFunctionalIndexException("Scheduling of index action did not return any instant.");
+      }
+    }
+  }
+
+  private static SparkRDDWriteClient<HoodieRecordPayload> createHoodieClient(JavaSparkContext jsc, String basePath, String schemaStr,
+                                                                             int parallelism, Option<String> compactionStrategyClass, TypedProperties properties) {
+    HoodieCompactionConfig compactionConfig = compactionStrategyClass
+        .map(strategy -> HoodieCompactionConfig.newBuilder().withInlineCompaction(false)
+            .withCompactionStrategy(ReflectionUtils.loadClass(strategy)).build())
+        .orElse(HoodieCompactionConfig.newBuilder().withInlineCompaction(false).build());
+    HoodieWriteConfig config =
+        HoodieWriteConfig.newBuilder().withPath(basePath)
+            .withParallelism(parallelism, parallelism)
+            .withBulkInsertParallelism(parallelism)
+            .withDeleteParallelism(parallelism)
+            .withSchema(schemaStr).combineInput(true, true).withCompactionConfig(compactionConfig)
+            .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
+            .withProps(properties).build();
+    return new SparkRDDWriteClient<>(new HoodieSparkEngineContext(jsc), config);
+  }
+
+  private static Option<String> doSchedule(SparkRDDWriteClient<HoodieRecordPayload> client, HoodieTableMetaClient metaClient) {
+    List<MetadataPartitionType> partitionTypes = Collections.singletonList(MetadataPartitionType.FUNCTIONAL_INDEX);
+    checkArgument(partitionTypes.size() == 1, "Currently, only one index type can be scheduled at a time.");
+    if (metaClient.getTableConfig().getMetadataPartitions().isEmpty()) {
+      throw new HoodieException("Metadata table is not yet initialized. Initialize FILES partition before any other partition " + Arrays.toString(partitionTypes.toArray()));
+    }
+    return client.scheduleIndexing(partitionTypes);
+  }
+
+  private static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {
+    return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName));
+  }
+
+  private static Map<String, String> buildWriteConfig(HoodieTableMetaClient metaClient, HoodieFunctionalIndexDefinition indexDefinition) {
+    Map<String, String> writeConfig = new HashMap<>();
+    if (metaClient.getTableConfig().isMetadataTableAvailable()) {
+      if (!writeConfig.containsKey(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key())) {
+        writeConfig.put(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+        writeConfig.putAll(JavaConverters.mapAsJavaMap(HoodieCLIUtils.getLockOptions(metaClient.getBasePathV2().toString())));
+      }
+    }
+    HoodieFunctionalIndexConfig.fromIndexDefinition(indexDefinition).getProps().forEach((key, value) -> writeConfig.put(key.toString(), value.toString()));
+    return writeConfig;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/FunctionalIndexSupport.scala
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hudi.FunctionalIndexSupport._
+import org.apache.hudi.HoodieConversionUtils.toScalaOption
+import org.apache.hudi.avro.model.{HoodieMetadataColumnStats, HoodieMetadataRecord}
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.data.HoodieData
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.util.ValidationUtils.checkState
+import org.apache.hudi.common.util.hash.ColumnIndexID
+import org.apache.hudi.data.HoodieJavaRDD
+import org.apache.hudi.metadata.{HoodieMetadataPayload, HoodieTableMetadata, HoodieTableMetadataUtil}
+import org.apache.hudi.util.JFunction
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.HoodieUnsafeUtils.{createDataFrameFromInternalRows, createDataFrameFromRDD}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{And, Expression}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+class FunctionalIndexSupport(spark: SparkSession,
+                             metadataConfig: HoodieMetadataConfig,
+                             metaClient: HoodieTableMetaClient) {
+
+  @transient private lazy val engineCtx = new HoodieSparkEngineContext(new JavaSparkContext(spark.sparkContext))
+  @transient private lazy val metadataTable: HoodieTableMetadata =
+    HoodieTableMetadata.create(engineCtx, metadataConfig, metaClient.getBasePathV2.toString)
+
+  // NOTE: Since [[metadataConfig]] is transient this has to be eagerly persisted, before this will be passed on to the executor
+  private val inMemoryProjectionThreshold = metadataConfig.getColumnStatsIndexInMemoryProjectionThreshold
+
+  /**
+   * Determines whether it would be more optimal to read Column Stats Index a) in-memory of the invoking process,
+   * or b) executing it on-cluster via Spark [[Dataset]] and [[RDD]] APIs
+   */
+  def shouldReadInMemory(fileIndex: HoodieFileIndex, queryReferencedColumns: Seq[String]): Boolean = {
+    Option(metadataConfig.getColumnStatsIndexProcessingModeOverride) match {
+      case Some(mode) =>
+        mode == HoodieMetadataConfig.COLUMN_STATS_INDEX_PROCESSING_MODE_IN_MEMORY
+      case None =>
+        fileIndex.getFileSlicesCount * queryReferencedColumns.length < inMemoryProjectionThreshold
+    }
+  }
+
+  /**
+   * Return true if metadata table is enabled and functional index metadata partition is available.
+   */
+  def isIndexAvailable: Boolean = {
+    metadataConfig.enabled && metaClient.getFunctionalIndexMetadata.isPresent && !metaClient.getFunctionalIndexMetadata.get().getIndexDefinitions.isEmpty
+  }
+
+  def getPrunedCandidateFileNames(indexPartition: String,
+                                  shouldReadInMemory: Boolean,
+                                  queryFilters: Seq[Expression]): Set[String] = {
+    val indexDf = loadFunctionalIndexDataFrame(indexPartition, shouldReadInMemory)
+    val indexSchema = indexDf.schema
+    val indexFilter =
+      queryFilters.map(translateIntoColumnStatsIndexFilterExpr(_, indexSchema))
+        .reduce(And)
+
+    val prunedCandidateFileNames =
+      indexDf.where(new Column(indexFilter))
+        .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
+        .collect()
+        .map(_.getString(0))
+        .toSet
+
+    prunedCandidateFileNames
+  }
+
+  def load(indexPartition: String,
+           targetColumns: Seq[String],
+           shouldReadInMemory: Boolean): DataFrame = {
+    val metadataTablePath = HoodieTableMetadata.getMetadataTableBasePath(metaClient.getBasePathV2.toString)
+    // Read Metadata Table's Column Stats Index into Spark's [[DataFrame]]
+    val colStatsDF = spark.read.format("org.apache.hudi")
+      .options(metadataConfig.getProps.asScala)
+      .load(s"$metadataTablePath/$indexPartition")
+
+    val requiredIndexColumns =
+      targetColumnStatsIndexColumns.map(colName =>
+        col(s"${HoodieMetadataPayload.SCHEMA_FIELD_ID_COLUMN_STATS}.${colName}"))
+
+    colStatsDF.where(col(HoodieMetadataPayload.SCHEMA_FIELD_ID_COLUMN_STATS).isNotNull)
+      .select(requiredIndexColumns: _*)
+  }
+
+  def loadFunctionalIndexDataFrame(indexPartition: String,
+                                   shouldReadInMemory: Boolean): DataFrame = {
+    val colStatsDF = {
+      val indexDefinition = metaClient.getFunctionalIndexMetadata.get().getIndexDefinitions.get(indexPartition)
+      val indexType = indexDefinition.getIndexType
+      // NOTE: Currently only functional indexes created using column_stats is supported.
+      // HUDI-7007 tracks for adding support for other index types such as bloom filters.
+      checkState(indexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS),
+        s"Index type $indexType is not supported")
+      val colStatsRecords: HoodieData[HoodieMetadataColumnStats] = loadFunctionalIndexForColumnsInternal(
+        indexDefinition.getSourceFields.asScala, indexPartition, shouldReadInMemory)
+      // NOTE: Explicit conversion is required for Scala 2.11
+      val catalystRows: HoodieData[InternalRow] = colStatsRecords.mapPartitions(JFunction.toJavaSerializableFunction(it => {
+        val converter = AvroConversionUtils.createAvroToInternalRowConverter(HoodieMetadataColumnStats.SCHEMA$, columnStatsRecordStructType)
+        it.asScala.map(r => converter(r).orNull).asJava
+      }), false)
+
+      if (shouldReadInMemory) {
+        // NOTE: This will instantiate a [[Dataset]] backed by [[LocalRelation]] holding all of the rows
+        //       of the transposed table in memory, facilitating execution of the subsequently chained operations
+        //       on it locally (on the driver; all such operations are actually going to be performed by Spark's
+        //       Optimizer)
+        createDataFrameFromInternalRows(spark, catalystRows.collectAsList().asScala, columnStatsRecordStructType)
+      } else {
+        createDataFrameFromRDD(spark, HoodieJavaRDD.getJavaRDD(catalystRows), columnStatsRecordStructType)
+      }
+    }
+
+    colStatsDF.select(targetColumnStatsIndexColumns.map(col): _*)
+  }
+
+  private def loadFunctionalIndexForColumnsInternal(targetColumns: Seq[String],
+                                                    indexPartition: String,
+                                                    shouldReadInMemory: Boolean): HoodieData[HoodieMetadataColumnStats] = {
+    // Read Metadata Table's Functional Index records into [[HoodieData]] container by
+    //    - Fetching the records from CSI by key-prefixes (encoded column names)
+    //    - Extracting [[HoodieMetadataColumnStats]] records
+    //    - Filtering out nulls
+    checkState(targetColumns.nonEmpty)
+    val encodedTargetColumnNames = targetColumns.map(colName => new ColumnIndexID(colName).asBase64EncodedString())
+    val metadataRecords: HoodieData[HoodieRecord[HoodieMetadataPayload]] =
+      metadataTable.getRecordsByKeyPrefixes(encodedTargetColumnNames.asJava, indexPartition, shouldReadInMemory)
+    val columnStatsRecords: HoodieData[HoodieMetadataColumnStats] =
+    // NOTE: Explicit conversion is required for Scala 2.11
+      metadataRecords.map(JFunction.toJavaSerializableFunction(record => {
+          toScalaOption(record.getData.getInsertValue(null, null))
+            .map(metadataRecord => metadataRecord.asInstanceOf[HoodieMetadataRecord].getColumnStatsMetadata)
+            .orNull
+        }))
+        .filter(JFunction.toJavaSerializableFunction(columnStatsRecord => columnStatsRecord != null))
+
+    columnStatsRecords
+  }
+
+  /**
+   * Returns the list of candidate files which store the provided record keys based on Metadata Table Record Index.
+   *
+   * @param allFiles   - List of all files which needs to be considered for the query
+   * @param recordKeys - List of record keys.
+   * @return Sequence of file names which need to be queried
+   */
+  def getCandidateFiles(allFiles: Seq[FileStatus], recordKeys: List[String]): Set[String] = {
+    val recordKeyLocationsMap = metadataTable.readRecordIndex(seqAsJavaListConverter(recordKeys).asJava)
+    val fileIdToPartitionMap: mutable.Map[String, String] = mutable.Map.empty
+    val candidateFiles: mutable.Set[String] = mutable.Set.empty
+    for (location <- collectionAsScalaIterableConverter(recordKeyLocationsMap.values()).asScala) {
+      fileIdToPartitionMap.put(location.getFileId, location.getPartitionPath)
+    }
+    for (file <- allFiles) {
+      val fileId = FSUtils.getFileIdFromFilePath(file.getPath)
+      val partitionOpt = fileIdToPartitionMap.get(fileId)
+      if (partitionOpt.isDefined) {
+        candidateFiles += file.getPath.getName
+      }
+    }
+    candidateFiles.toSet
+  }
+}
+
+object FunctionalIndexSupport {
+
+  /**
+   * Target Column Stats Index columns which internally are mapped onto fields of the corresponding
+   * Column Stats record payload ([[HoodieMetadataColumnStats]]) persisted w/in Metadata Table
+   */
+  private val targetColumnStatsIndexColumns = Seq(
+    HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME,
+    HoodieMetadataPayload.COLUMN_STATS_FIELD_MIN_VALUE,
+    HoodieMetadataPayload.COLUMN_STATS_FIELD_MAX_VALUE,
+    HoodieMetadataPayload.COLUMN_STATS_FIELD_NULL_COUNT,
+    HoodieMetadataPayload.COLUMN_STATS_FIELD_VALUE_COUNT,
+    HoodieMetadataPayload.COLUMN_STATS_FIELD_COLUMN_NAME
+  )
+
+  private val columnStatsRecordStructType: StructType = AvroConversionUtils.convertAvroSchemaToStructType(HoodieMetadataColumnStats.SCHEMA$)
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4
+++ b/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4
@@ -107,6 +107,36 @@
     : parts+=identifier ('.' parts+=identifier)*
     ;
 
+ indexItem
+     :   indexExpressionItem                // For expressions
+     ;
+
+ indexExpressionItem
+     :   indexExpression (OPTIONS options=propertyList)?
+     ;
+
+ indexExpression
+     :   functionCall                     // Function calls like from_unixtime(ts, 'yyyy-MM-dd')
+     // Add more expressions as needed
+     ;
+
+ functionCall
+     :   functionName LEFT_PAREN functionArgs RIGHT_PAREN
+     ;
+
+ functionName
+     :   IDENTIFIER                       // Matches function names like "from_unixtime"
+     ;
+
+ functionArgs
+     :   functionArg (COMMA functionArg)* // A list of arguments separated by commas
+     ;
+
+ functionArg
+     :   STRING                           // Matches string literals like 'yyyy-MM-dd'
+     // Add more types of arguments as needed
+     ;
+
  identifier
     : IDENTIFIER              #unquotedIdentifier
     | quotedIdentifier        #quotedIdentifierAlternative
@@ -126,6 +156,31 @@
      | SCHEDULE
      | SHOW
      ;
+
+ propertyList
+     : LEFT_PAREN property (COMMA property)* RIGHT_PAREN
+     ;
+
+ property
+     : key=propertyKey (EQ? value=propertyValue)?
+     ;
+
+ propertyKey
+     : identifier (DOT identifier)*
+     | STRING
+     ;
+
+ propertyValue
+     : INTEGER_VALUE
+     | DECIMAL_VALUE
+     | booleanValue
+     | STRING
+     ;
+
+ LEFT_PAREN: '(';
+ RIGHT_PAREN: ')';
+ COMMA: ',';
+ DOT: '.';
 
  ALL: 'ALL';
  AT: 'AT';

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -64,7 +64,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
            | (3, 'a3', 30, 3000, "2021-01-07")
               """.stripMargin)
 
-      checkAnswer(s"select id, name, price, ts, dt from $tableName")(
+      checkAnswer(s"select id, name, price, ts, dt from $tableName where year(dt) > '2020' and lower(name) > 'a0'")(
         Seq(1, "a1", 10.0, 1000, "2021-01-05"),
         Seq(2, "a2", 20.0, 2000, "2021-01-06"),
         Seq(3, "a3", 30.0, 3000, "2021-01-07")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -70,7 +70,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
         assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
 
-        spark.sql(createIndexSql)
+        /*spark.sql(createIndexSql)
         val metaClient = HoodieTableMetaClient.builder()
           .setBasePath(tmp.getCanonicalPath)
           .setConf(spark.sessionState.newHadoopConf())
@@ -78,7 +78,7 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         assertTrue(metaClient.getFunctionalIndexMetadata.isPresent)
         val functionalIndexMetadata = metaClient.getFunctionalIndexMetadata.get()
         assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
-        assertEquals("idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("idx_datestr").getIndexName)
+        assertEquals("idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("idx_datestr").getIndexName)*/
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -19,6 +19,7 @@
 
 package org.apache.spark.sql.hudi.command.index
 
+import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -28,6 +29,60 @@ import org.apache.spark.sql.hudi.command.{CreateIndexCommand, ShowIndexesCommand
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 
 class TestFunctionalIndex extends HoodieSparkSqlTestBase {
+
+  test("Test Create Functional Index Syntax") {
+    if (HoodieSparkUtils.gteqSpark3_2) {
+      withTempDir { tmp =>
+        Seq("cow", "mor").foreach { tableType =>
+          val databaseName = "default"
+          val tableName = generateTableName
+          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  ts long
+               |) using hudi
+               | options (
+               |  primaryKey ='id',
+               |  type = '$tableType',
+               |  preCombineField = 'ts'
+               | )
+               | partitioned by(ts)
+               | location '$basePath'
+       """.stripMargin)
+          spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+          spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+          spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+
+          val sqlParser: ParserInterface = spark.sessionState.sqlParser
+          val analyzer: Analyzer = spark.sessionState.analyzer
+
+          var logicalPlan = sqlParser.parsePlan(s"show indexes from default.$tableName")
+          var resolvedLogicalPlan = analyzer.execute(logicalPlan)
+          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[ShowIndexesCommand].table, databaseName, tableName)
+
+          logicalPlan = sqlParser.parsePlan(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
+          resolvedLogicalPlan = analyzer.execute(logicalPlan)
+          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+          assertResult("idx_datestr")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+          assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+          assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
+          assertResult(Map("func" -> "from_unixtime", "format" -> "yyyy-MM-dd"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
+
+          logicalPlan = sqlParser.parsePlan(s"create index idx_name on $tableName using bloom_filters(name) options(func='lower')")
+          resolvedLogicalPlan = analyzer.execute(logicalPlan)
+          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+          assertResult("idx_name")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+          assertResult("bloom_filters")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+          assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
+          assertResult(Map("func" -> "lower"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
+        }
+      }
+    }
+  }
 
   test("Test Create Functional Index") {
     withTempDir { tmp =>
@@ -70,15 +125,15 @@ class TestFunctionalIndex extends HoodieSparkSqlTestBase {
         assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
         assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
 
-        /*spark.sql(createIndexSql)
+        spark.sql(createIndexSql)
         val metaClient = HoodieTableMetaClient.builder()
-          .setBasePath(tmp.getCanonicalPath)
+          .setBasePath(basePath)
           .setConf(spark.sessionState.newHadoopConf())
           .build()
         assertTrue(metaClient.getFunctionalIndexMetadata.isPresent)
         val functionalIndexMetadata = metaClient.getFunctionalIndexMetadata.get()
         assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
-        assertEquals("idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("idx_datestr").getIndexName)*/
+        assertEquals("func_index_idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("func_index_idx_datestr").getIndexName)
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestFunctionalIndex.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.index
+
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.spark.sql.catalyst.analysis.Analyzer
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.hudi.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.command.{CreateIndexCommand, ShowIndexesCommand}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+
+class TestFunctionalIndex extends HoodieSparkSqlTestBase {
+
+  test("Test Create Functional Index") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val databaseName = "default"
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts'
+             | )
+             | partitioned by(ts)
+             | location '$basePath'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+
+        val sqlParser: ParserInterface = spark.sessionState.sqlParser
+        val analyzer: Analyzer = spark.sessionState.analyzer
+
+        var logicalPlan = sqlParser.parsePlan(s"show indexes from default.$tableName")
+        var resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[ShowIndexesCommand].table, databaseName, tableName)
+
+        val createIndexSql = s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')"
+        logicalPlan = sqlParser.parsePlan(createIndexSql)
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+        assertResult("idx_datestr")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+        assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+        assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
+
+        spark.sql(createIndexSql)
+        val metaClient = HoodieTableMetaClient.builder()
+          .setBasePath(tmp.getCanonicalPath)
+          .setConf(spark.sessionState.newHadoopConf())
+          .build()
+        assertTrue(metaClient.getFunctionalIndexMetadata.isPresent)
+        val functionalIndexMetadata = metaClient.getFunctionalIndexMetadata.get()
+        assertEquals(1, functionalIndexMetadata.getIndexDefinitions.size())
+        assertEquals("idx_datestr", functionalIndexMetadata.getIndexDefinitions.get("idx_datestr").getIndexName)
+      }
+    }
+  }
+
+  private def assertTableIdentifier(catalogTable: CatalogTable,
+                                    expectedDatabaseName: String,
+                                    expectedTableName: String): Unit = {
+    assertResult(Some(expectedDatabaseName))(catalogTable.identifier.database)
+    assertResult(expectedTableName)(catalogTable.identifier.table)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
@@ -70,13 +70,6 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
           assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
           assertResult(Map("block_size" -> "1024"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
 
-          logicalPlan = sqlParser.parsePlan(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
-          resolvedLogicalPlan = analyzer.execute(logicalPlan)
-          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
-          assertResult("idx_datestr")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
-          assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
-          assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
-
           logicalPlan = sqlParser.parsePlan(s"create index if not exists idx_price on $tableName using lucene (price options(order='desc')) options(block_size=512)")
           resolvedLogicalPlan = analyzer.execute(logicalPlan)
           assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/index/TestIndexSyntax.scala
@@ -70,6 +70,13 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
           assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
           assertResult(Map("block_size" -> "1024"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
 
+          logicalPlan = sqlParser.parsePlan(s"create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')")
+          resolvedLogicalPlan = analyzer.execute(logicalPlan)
+          assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+          assertResult("idx_datestr")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+          assertResult("column_stats")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+          assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
+
           logicalPlan = sqlParser.parsePlan(s"create index if not exists idx_price on $tableName using lucene (price options(order='desc')) options(block_size=512)")
           resolvedLogicalPlan = analyzer.execute(logicalPlan)
           assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -118,7 +118,8 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
         .setIndexPartitionInfos(Arrays.asList(new HoodieIndexPartitionInfo(
             1,
             COLUMN_STATS.getPartitionPath(),
-            "0000")))
+            "0000",
+            Collections.emptyMap())))
         .build();
     assertFalse(indexer.isIndexBuiltForAllRequestedTypes(commitMetadata.getIndexPartitionInfos()));
 


### PR DESCRIPTION
### Change Logs

Support functional indexes. Full design in [RFC-63](https://github.com/apache/hudi/blob/08361606de1a8a4b1a5471c8186ea1c8aa79eb9a/rfc/rfc-63/rfc-63.md).

- Add `HoodieFunctionaIndex` interface and a concrete implementation for Spark `HoodieSparkFunctionalIndex` function.
- Add `BaseHoodieFunctionalIndexClient` and its Spark implementation to build indexes.
- Maintain a map of spark-sql functions in `HoodieSparkFunctionalIndex`, which is then applied on dataframe to build the index.
- Support building secondary index using identity function, and we can also use colstats and bloom filters over function of column.
- Index creation can be done using usual async indexer or by SQL: `create index idx_datestr on $tableName using column_stats(ts) options(func='from_unixtime', format='yyyy-MM-dd')`
- Each functional index will be a partition in metadata table and index definition is stored separately (`HoodieFunctionalIndexConfig` and `HoodieFunctionalIndexMetadata` classes added for index definition).
- Add new methods in `HoodieBackedTableMetadataWriter` to initialize and update functional index. Concrete implementation only for Spark.
- Add e2e tests.

### Impact

Users can now create indexes on not jsut columns but also functions based on columns, e.g. `DATE_FORMAT(ts, '%Y-%m-%d')`

### Risk level (write none, low medium or high below)

medium

New feature. Does not touch the core. Even the changes in metadata writer are guarded by metadata partition type.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
