### PR TITLE
[HUDI-6950] Query should process listed partitions to avoid driver oom due to large number files in table first partition

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -157,52 +157,66 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
       // TODO: Get the parallelism from HoodieWriteConfig
       int listingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, pathsToList.size());
 
-      // List all directories in parallel:
-      // if current dictionary contains PartitionMetadata, add it to result
-      // if current dictionary does not contain PartitionMetadata, add its subdirectory to queue to be processed.
+      // List all directories in parallel
       engineContext.setJobStatus(this.getClass().getSimpleName(), "Listing all partitions with prefix " + relativePathPrefix);
-      // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
-      // and second entry holds optionally a directory path to be processed further.
-      List<Pair<Option<String>, Option<Path>>> result = engineContext.flatMap(pathsToList, path -> {
+      List<FileStatus> dirToFileListing = engineContext.flatMap(pathsToList, path -> {
         FileSystem fileSystem = path.getFileSystem(hadoopConf.get());
-        if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, path)) {
-          return Stream.of(Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), path)), Option.empty()));
-        }
-        return Arrays.stream(fileSystem.listStatus(path))
-                .filter(status -> status.isDirectory() && !status.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME))
-                .map(status -> Pair.of(Option.empty(), Option.of(status.getPath())));
+        return Arrays.stream(fileSystem.listStatus(path));
       }, listingParallelism);
       pathsToList.clear();
 
-      partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
-              .map(entry -> entry.getKey().get())
-              .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
-                      || (Boolean) fullBoundExpr.eval(
-                      extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
-              .collect(Collectors.toList()));
+      // if current dictionary contains PartitionMetadata, add it to result
+      // if current dictionary does not contain PartitionMetadata, add it to queue to be processed.
+      int fileListingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, dirToFileListing.size());
+      if (!dirToFileListing.isEmpty()) {
+        // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
+        // and second entry holds optionally a directory path to be processed further.
+        engineContext.setJobStatus(this.getClass().getSimpleName(), "Processing listed partitions");
+        List<Pair<Option<String>, Option<Path>>> result = engineContext.map(dirToFileListing, fileStatus -> {
+          FileSystem fileSystem = fileStatus.getPath().getFileSystem(hadoopConf.get());
+          if (fileStatus.isDirectory()) {
+            if (HoodiePartitionMetadata.hasPartitionMetadata(fileSystem, fileStatus.getPath())) {
+              return Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), fileStatus.getPath())), Option.empty());
+            } else if (!fileStatus.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
+              return Pair.of(Option.empty(), Option.of(fileStatus.getPath()));
+            }
+          } else if (fileStatus.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX)) {
+            String partitionName = FSUtils.getRelativePartitionPath(dataBasePath.get(), fileStatus.getPath().getParent());
+            return Pair.of(Option.of(partitionName), Option.empty());
+          }
+          return Pair.of(Option.empty(), Option.empty());
+        }, fileListingParallelism);
 
-      Expression partialBoundExpr;
-      // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
-      // are filtered already.
-      if (needPushDownExpressions && partitionPaths.isEmpty()) {
-        // Here we assume the path level matches the number of partition columns, so we'll rebuild
-        // new schema based on current path level.
-        // e.g. partition columns are <region, date, hh>, if we're listing the second level, then
-        // currentSchema would be <region, date>
-        // `PartialBindVisitor` will bind reference if it can be found from `currentSchema`, otherwise
-        // will change the expression to `alwaysTrue`. Can see `PartialBindVisitor` for details.
-        Types.RecordType currentSchema = Types.RecordType.get(partitionFields.fields().subList(0, ++currentPartitionLevel));
-        PartialBindVisitor partialBindVisitor = new PartialBindVisitor(currentSchema, caseSensitive);
-        partialBoundExpr = pushedExpr.accept(partialBindVisitor);
-      } else {
-        partialBoundExpr = Predicates.alwaysTrue();
+        partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
+                .map(entry -> entry.getKey().get())
+                .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
+                        || (Boolean) fullBoundExpr.eval(
+                        extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
+                .collect(Collectors.toList()));
+
+        Expression partialBoundExpr;
+        // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
+        // are filtered already.
+        if (needPushDownExpressions && partitionPaths.isEmpty()) {
+          // Here we assume the path level matches the number of partition columns, so we'll rebuild
+          // new schema based on current path level.
+          // e.g. partition columns are <region, date, hh>, if we're listing the second level, then
+          // currentSchema would be <region, date>
+          // `PartialBindVisitor` will bind reference if it can be found from `currentSchema`, otherwise
+          // will change the expression to `alwaysTrue`. Can see `PartialBindVisitor` for details.
+          Types.RecordType currentSchema = Types.RecordType.get(partitionFields.fields().subList(0, ++currentPartitionLevel));
+          PartialBindVisitor partialBindVisitor = new PartialBindVisitor(currentSchema, caseSensitive);
+          partialBoundExpr = pushedExpr.accept(partialBindVisitor);
+        } else {
+          partialBoundExpr = Predicates.alwaysTrue();
+        }
+
+        pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
+                .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+                        || (Boolean) partialBoundExpr.eval(
+                        extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+                .collect(Collectors.toList()));
       }
-
-      pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-              .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-                      || (Boolean) partialBoundExpr.eval(
-                      extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-              .collect(Collectors.toList()));
     }
     return partitionPaths;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -132,19 +132,19 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
                                                                            Expression pushedExpr) throws IOException {
     List<Path> pathsToList = new CopyOnWriteArrayList<>();
     pathsToList.add(StringUtils.isNullOrEmpty(relativePathPrefix)
-        ? dataBasePath.get() : new Path(dataBasePath.get(), relativePathPrefix));
+            ? dataBasePath.get() : new Path(dataBasePath.get(), relativePathPrefix));
     List<String> partitionPaths = new CopyOnWriteArrayList<>();
 
     int currentPartitionLevel = -1;
     boolean needPushDownExpressions;
     Expression fullBoundExpr;
-    // Not like `HoodieBackedTableMetadata`, since we don't know the exact partition levels here
+    // Not like `HoodieBackedTableMetadata`, since we don't know the exact partition levels here,
     // given it's possible that partition values contains `/`, which could affect
     // the result to get right `partitionValue` when listing paths, here we have
     // to make it more strict that `urlEncodePartitioningEnabled` must be enabled.
     // TODO better enable urlEncodePartitioningEnabled if hiveStylePartitioningEnabled is enabled?
     if (hiveStylePartitioningEnabled && urlEncodePartitioningEnabled
-        && pushedExpr != null && partitionFields != null) {
+            && pushedExpr != null && partitionFields != null) {
       currentPartitionLevel = getPathPartitionLevel(partitionFields, relativePathPrefix);
       needPushDownExpressions = true;
       fullBoundExpr = pushedExpr.accept(new BindVisitor(partitionFields, caseSensitive));
@@ -169,17 +169,17 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
           return Stream.of(Pair.of(Option.of(FSUtils.getRelativePartitionPath(dataBasePath.get(), path)), Option.empty()));
         }
         return Arrays.stream(fileSystem.listStatus(path))
-            .filter(status -> status.isDirectory() && !status.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME))
-            .map(status -> Pair.of(Option.empty(), Option.of(status.getPath())));
+                .filter(status -> status.isDirectory() && !status.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME))
+                .map(status -> Pair.of(Option.empty(), Option.of(status.getPath())));
       }, listingParallelism);
       pathsToList.clear();
 
       partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
-          .map(entry -> entry.getKey().get())
-          .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
-              || (Boolean) fullBoundExpr.eval(
-              extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
-          .collect(Collectors.toList()));
+              .map(entry -> entry.getKey().get())
+              .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
+                      || (Boolean) fullBoundExpr.eval(
+                      extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
+              .collect(Collectors.toList()));
 
       Expression partialBoundExpr;
       // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
@@ -199,10 +199,10 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
       }
 
       pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-          .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-              || (Boolean) partialBoundExpr.eval(
-                  extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-          .collect(Collectors.toList()));
+              .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+                      || (Boolean) partialBoundExpr.eval(
+                      extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+              .collect(Collectors.toList()));
     }
     return partitionPaths;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -210,11 +210,11 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
           partialBoundExpr = Predicates.alwaysTrue();
         }
 
-      pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-          .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-              || (Boolean) partialBoundExpr.eval(
-                  extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-          .collect(Collectors.toList()));
+        pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
+            .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+                || (Boolean) partialBoundExpr.eval(
+                    extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+            .collect(Collectors.toList()));
       }
     }
     return partitionPaths;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -210,11 +210,11 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
           partialBoundExpr = Predicates.alwaysTrue();
         }
 
-        pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-            .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-                || (Boolean) partialBoundExpr.eval(
-                extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-            .collect(Collectors.toList()));
+      pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
+          .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+              || (Boolean) partialBoundExpr.eval(
+                  extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+          .collect(Collectors.toList()));
       }
     }
     return partitionPaths;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -138,7 +138,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
     int currentPartitionLevel = -1;
     boolean needPushDownExpressions;
     Expression fullBoundExpr;
-    // Not like `HoodieBackedTableMetadata`, since we don't know the exact partition levels here,
+    // Not like `HoodieBackedTableMetadata`, since we don't know the exact partition levels here
     // given it's possible that partition values contains `/`, which could affect
     // the result to get right `partitionValue` when listing paths, here we have
     // to make it more strict that `urlEncodePartitioningEnabled` must be enabled.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -144,7 +144,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
     // to make it more strict that `urlEncodePartitioningEnabled` must be enabled.
     // TODO better enable urlEncodePartitioningEnabled if hiveStylePartitioningEnabled is enabled?
     if (hiveStylePartitioningEnabled && urlEncodePartitioningEnabled
-            && pushedExpr != null && partitionFields != null) {
+        && pushedExpr != null && partitionFields != null) {
       currentPartitionLevel = getPathPartitionLevel(partitionFields, relativePathPrefix);
       needPushDownExpressions = true;
       fullBoundExpr = pushedExpr.accept(new BindVisitor(partitionFields, caseSensitive));
@@ -188,11 +188,11 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
         }, fileListingParallelism);
 
         partitionPaths.addAll(result.stream().filter(entry -> entry.getKey().isPresent())
-                .map(entry -> entry.getKey().get())
-                .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
-                        || (Boolean) fullBoundExpr.eval(
-                        extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
-                .collect(Collectors.toList()));
+            .map(entry -> entry.getKey().get())
+            .filter(relativePartitionPath -> fullBoundExpr instanceof Predicates.TrueExpression
+                || (Boolean) fullBoundExpr.eval(
+                extractPartitionValues(partitionFields, relativePartitionPath, urlEncodePartitioningEnabled)))
+            .collect(Collectors.toList()));
 
         Expression partialBoundExpr;
         // If partitionPaths is nonEmpty, we're already at the last path level, and all paths
@@ -212,10 +212,10 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
         }
 
         pathsToList.addAll(result.stream().filter(entry -> entry.getValue().isPresent()).map(entry -> entry.getValue().get())
-                .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
-                        || (Boolean) partialBoundExpr.eval(
-                        extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
-                .collect(Collectors.toList()));
+            .filter(path -> partialBoundExpr instanceof Predicates.TrueExpression
+                || (Boolean) partialBoundExpr.eval(
+                extractPartitionValues(partitionFields, FSUtils.getRelativePartitionPath(dataBasePath.get(), path), urlEncodePartitioningEnabled)))
+            .collect(Collectors.toList()));
       }
     }
     return partitionPaths;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Implementation of {@link HoodieTableMetadata} based file-system-backed table metadata.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -132,7 +132,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
                                                                            Expression pushedExpr) throws IOException {
     List<Path> pathsToList = new CopyOnWriteArrayList<>();
     pathsToList.add(StringUtils.isNullOrEmpty(relativePathPrefix)
-            ? dataBasePath.get() : new Path(dataBasePath.get(), relativePathPrefix));
+        ? dataBasePath.get() : new Path(dataBasePath.get(), relativePathPrefix));
     List<String> partitionPaths = new CopyOnWriteArrayList<>();
 
     int currentPartitionLevel = -1;


### PR DESCRIPTION
### Change Logs

query should process listed partitions avoid driver oom due to large number files in table first partition 
https://issues.apache.org/jira/browse/HUDI-6950

### Impact

currently if multiple partition table，would cause oom easy
eg:
CREATE TABLE `hudi_test`.`tmp_hudi_test_1` (
  `id` string,
  `name` string,
  `dt` bigint,
  `day` STRING COMMENT '日期分区',
  `hour` INT COMMENT '小时分区'
)using hudi
OPTIONS ('hoodie.datasource.write.hive_style_partitioning' 'false', 'hoodie.datasource.meta.sync.enable' 'false', 'hoodie.datasource.hive_sync.enable' 'false')
tblproperties (
  'primaryKey' = 'id',
  'type' = 'mor',
  'preCombineField'='dt',
  'hoodie.index.type' = 'BUCKET',
  'hoodie.bucket.index.hash.field' = 'id',
  'hoodie.bucket.index.num.buckets'=512
)
PARTITIONED BY (`day`,`hour`);

select count(1) from  `hudi_test`.`tmp_hudi_test_1` where day='2023-10-17'  would list much filestatus to driver，and driver would oom（such as table with hundreds billion records in a partition（day='2023-10-17'））

but table in hive can be queried rightly
so submit the pr to fix it

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
