### PR TITLE
[HUDI-6959] Bulk insert V2 do not rollback failed instant on abort

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/internal/DataSourceInternalWriterHelper.java
@@ -97,7 +97,6 @@ public class DataSourceInternalWriterHelper {
 
   public void abort() {
     LOG.error("Commit " + instantTime + " aborted ");
-    writeClient.rollback(instantTime);
     writeClient.close();
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestInsertTable.scala
@@ -1714,8 +1714,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
     }
   }
 
-  // [HUDI-6900] TestInsertTable "Test Bulk Insert Into Consistent Hashing Bucket Index Table" is failing continuously
-  ignore("Test Bulk Insert Into Consistent Hashing Bucket Index Table") {
+  test("Test Bulk Insert Into Consistent Hashing Bucket Index Table") {
     withSQLConf("hoodie.datasource.write.operation" -> "bulk_insert") {
       Seq("false", "true").foreach { bulkInsertAsRow =>
         withTempDir { tmp =>


### PR DESCRIPTION
### Change Logs

TestInsertTable#Test Bulk Insert Into Consistent Hashing Bucket Index Table failed continuously in #9776, I enabled it again and reproduced it locally. 

The test will cause the write job to abort, and when `org.apache.hudi.spark3.internal.HoodieDataSourceInternalBatchWrite#abort` is called, all the subtasks may not have already been canceled. So if we roll back the current instant immediately, new files may still be written after rollback scheduled, which will cause dirty data.  This bug exists before #9776,  but only after  #9776 the test will fail. 

We don't need to rollback the failed instant immediately, so to avoid this problem, I remove the line that rollback the instant in `org.apache.hudi.spark3.internal.HoodieDataSourceInternalBatchWrite#abort `. 

### Impact

Bulk insert as row do not rollback failed instant on abort

### Risk level (write none, low medium or high below)

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
