### PR TITLE
[HUDI-6962] Fix the conflicts resolution for bulk insert under NB-CC

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -21,6 +21,7 @@ package org.apache.hudi.client.utils;
 import org.apache.hudi.client.transaction.ConcurrentOperation;
 import org.apache.hudi.client.transaction.ConflictResolutionStrategy;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -67,8 +68,9 @@ public class TransactionUtils {
       Option<HoodieInstant> lastCompletedTxnOwnerInstant,
       boolean reloadActiveTimeline,
       Set<String> pendingInstants) throws HoodieWriteConflictException {
-    // Skip to resolve conflict if using non-blocking concurrency control
-    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl() && !config.isNonBlockingConcurrencyControl()) {
+    // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
+    WriteOperationType operationType = thisCommitMetadata.orElse(new HoodieCommitMetadata()).getOperationType();
+    if (config.needResolveWriteConflict(operationType)) {
       // deal with pendingInstants
       Stream<HoodieInstant> completedInstantsDuringCurrentWriteOperation = getCompletedInstantsDuringCurrentWriteOperation(table.getMetaClient(), pendingInstants);
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -68,7 +68,7 @@ public class TransactionUtils {
       Option<HoodieInstant> lastCompletedTxnOwnerInstant,
       boolean reloadActiveTimeline,
       Set<String> pendingInstants) throws HoodieWriteConflictException {
-    WriteOperationType operationType = thisCommitMetadata.map(HoodieCommitMetadata::getOperationType).orElse(WriteOperationType.UNKNOWN);
+    Option<WriteOperationType> operationType = thisCommitMetadata.map(HoodieCommitMetadata::getOperationType);
     if (config.needResolveWriteConflict(operationType)) {
       // deal with pendingInstants
       Stream<HoodieInstant> completedInstantsDuringCurrentWriteOperation = getCompletedInstantsDuringCurrentWriteOperation(table.getMetaClient(), pendingInstants);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -68,7 +68,7 @@ public class TransactionUtils {
       Option<HoodieInstant> lastCompletedTxnOwnerInstant,
       boolean reloadActiveTimeline,
       Set<String> pendingInstants) throws HoodieWriteConflictException {
-    Option<WriteOperationType> operationType = thisCommitMetadata.map(HoodieCommitMetadata::getOperationType);
+    WriteOperationType operationType = thisCommitMetadata.map(HoodieCommitMetadata::getOperationType).orElse(null);
     if (config.needResolveWriteConflict(operationType)) {
       // deal with pendingInstants
       Stream<HoodieInstant> completedInstantsDuringCurrentWriteOperation = getCompletedInstantsDuringCurrentWriteOperation(table.getMetaClient(), pendingInstants);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -68,8 +68,7 @@ public class TransactionUtils {
       Option<HoodieInstant> lastCompletedTxnOwnerInstant,
       boolean reloadActiveTimeline,
       Set<String> pendingInstants) throws HoodieWriteConflictException {
-    // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
-    WriteOperationType operationType = thisCommitMetadata.orElse(new HoodieCommitMetadata()).getOperationType();
+    WriteOperationType operationType = thisCommitMetadata.map(HoodieCommitMetadata::getOperationType).orElse(WriteOperationType.UNKNOWN);
     if (config.needResolveWriteConflict(operationType)) {
       // deal with pendingInstants
       Stream<HoodieInstant> completedInstantsDuringCurrentWriteOperation = getCompletedInstantsDuringCurrentWriteOperation(table.getMetaClient(), pendingInstants);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2619,15 +2619,21 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean needResolveWriteConflict(WriteOperationType operationType) {
     if (getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
-      if (getTableType().equals(HoodieTableType.MERGE_ON_READ) && isSimpleBucketIndex()) {
-        // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
-        return operationType == WriteOperationType.UNKNOWN || operationType == WriteOperationType.BULK_INSERT;
-      } else {
-        return true;
-      }
+      // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
+      return !isNonBlockingConcurrencyControl() || maybeBulkInsert(operationType);
     } else {
       return false;
     }
+  }
+
+  private boolean maybeBulkInsert(WriteOperationType operationType) {
+    return operationType == WriteOperationType.UNKNOWN || operationType == WriteOperationType.BULK_INSERT;
+  }
+
+  public boolean isNonBlockingConcurrencyControl() {
+    return getTableType().equals(HoodieTableType.MERGE_ON_READ)
+        && getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()
+        && isSimpleBucketIndex();
   }
 
   public static class Builder {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2617,20 +2617,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return props.getInteger(WRITES_FILEID_ENCODING, HoodieMetadataPayload.RECORD_INDEX_FIELD_FILEID_ENCODING_UUID);
   }
 
-  public boolean needResolveWriteConflict(Option<WriteOperationType> operationType) {
-    if (getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
-      // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
-      // TODO: skip resolve conflict if the option is empty or the inner operation type is UNKNOWN ?
-      return !isNonBlockingConcurrencyControl() || mayBeBulkInsert(operationType);
-    } else {
-      return false;
-    }
-  }
-
-  private boolean mayBeBulkInsert(Option<WriteOperationType> operationType) {
-    // If the option is empty or the inner operation type is UNKNOWN, it may be bulk insert
-    return operationType.map(type -> type == WriteOperationType.BULK_INSERT || type == WriteOperationType.UNKNOWN)
-        .orElse(true);
+  public boolean needResolveWriteConflict(WriteOperationType operationType) {
+    return WriteOperationType.BULK_INSERT == operationType || !isNonBlockingConcurrencyControl();
   }
 
   public boolean isNonBlockingConcurrencyControl() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2618,7 +2618,13 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public boolean needResolveWriteConflict(WriteOperationType operationType) {
-    return WriteOperationType.BULK_INSERT == operationType || !isNonBlockingConcurrencyControl();
+    if (getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+      // NB-CC don't need to resolve write conflict except bulk insert operation
+      return WriteOperationType.BULK_INSERT == operationType || !isNonBlockingConcurrencyControl();
+    } else {
+      // SINGLE_WRITER case don't need to resolve write conflict
+      return false;
+    }
   }
 
   public boolean isNonBlockingConcurrencyControl() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2618,9 +2618,9 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   public boolean needResolveWriteConflict(WriteOperationType operationType) {
-    // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
     if (getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
       if (getTableType().equals(HoodieTableType.MERGE_ON_READ) && isSimpleBucketIndex()) {
+        // Skip to resolve conflict for non bulk_insert operation if using non-blocking concurrency control
         return operationType == WriteOperationType.UNKNOWN || operationType == WriteOperationType.BULK_INSERT;
       } else {
         return true;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -302,8 +302,8 @@ public class HoodieFlinkWriteClient<T> extends
    * Refresh the last transaction metadata,
    * should be called before the Driver starts a new transaction.
    */
-  public void preTxn(HoodieTableMetaClient metaClient) {
-    if (txnManager.isLockRequired() && !config.isNonBlockingConcurrencyControl()) {
+  public void preTxn(WriteOperationType operationType, HoodieTableMetaClient metaClient) {
+    if (txnManager.isLockRequired() && config.needResolveWriteConflict(operationType)) {
       // refresh the meta client which is reused
       metaClient.reloadActiveTimeline();
       this.lastCompletedTxnAndMetadata = TransactionUtils.getLastCompletedTxnInstantAndMetadata(metaClient);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -303,7 +303,7 @@ public class HoodieFlinkWriteClient<T> extends
    * should be called before the Driver starts a new transaction.
    */
   public void preTxn(WriteOperationType operationType, HoodieTableMetaClient metaClient) {
-    if (txnManager.isLockRequired() && config.needResolveWriteConflict(operationType)) {
+    if (txnManager.isLockRequired() && config.needResolveWriteConflict(Option.of(operationType))) {
       // refresh the meta client which is reused
       metaClient.reloadActiveTimeline();
       this.lastCompletedTxnAndMetadata = TransactionUtils.getLastCompletedTxnInstantAndMetadata(metaClient);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -303,7 +303,7 @@ public class HoodieFlinkWriteClient<T> extends
    * should be called before the Driver starts a new transaction.
    */
   public void preTxn(WriteOperationType operationType, HoodieTableMetaClient metaClient) {
-    if (txnManager.isLockRequired() && config.needResolveWriteConflict(Option.of(operationType))) {
+    if (txnManager.isLockRequired() && config.needResolveWriteConflict(operationType)) {
       // refresh the meta client which is reused
       metaClient.reloadActiveTimeline();
       this.lastCompletedTxnAndMetadata = TransactionUtils.getLastCompletedTxnInstantAndMetadata(metaClient);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -387,7 +387,7 @@ public class StreamWriteOperatorCoordinator
 
   private void startInstant() {
     // refresh the last txn metadata
-    this.writeClient.preTxn(WriteOperationType.fromValue(conf.getString(FlinkOptions.OPERATION)), this.metaClient);
+    this.writeClient.preTxn(tableState.operationType, this.metaClient);
     // put the assignment in front of metadata generation,
     // because the instant request from write task is asynchronous.
     this.instant = this.writeClient.startCommit(tableState.commitAction, this.metaClient);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -387,7 +387,7 @@ public class StreamWriteOperatorCoordinator
 
   private void startInstant() {
     // refresh the last txn metadata
-    this.writeClient.preTxn(this.metaClient);
+    this.writeClient.preTxn(WriteOperationType.fromValue(conf.getString(FlinkOptions.OPERATION)), this.metaClient);
     // put the assignment in front of metadata generation,
     // because the instant request from write task is asynchronous.
     this.instant = this.writeClient.startCommit(tableState.commitAction, this.metaClient);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -92,16 +92,22 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
     return new SortOperatorGen(rowType, new String[] {FILE_GROUP_META_FIELD});
   }
 
-  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, String indexKeys, int numBuckets) {
+  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, String indexKeys, int numBuckets, boolean needFixedFileIdSuffix) {
     String recordKey = keyGen.getRecordKey(record);
     String partition = keyGen.getPartitionPath(record);
     final int bucketNum = BucketIdentifier.getBucketId(recordKey, indexKeys, numBuckets);
     String bucketId = partition + bucketNum;
-    return bucketIdToFileId.computeIfAbsent(bucketId, k -> BucketIdentifier.newBucketFileIdPrefix(bucketNum));
+    return bucketIdToFileId.computeIfAbsent(bucketId, k -> {
+      if (needFixedFileIdSuffix) {
+        return BucketIdentifier.newBucketFileIdFixedSuffix(bucketNum);
+      } else {
+        return BucketIdentifier.newBucketFileIdPrefix(bucketNum);
+      }
+    });
   }
 
-  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, String indexKeys, int numBuckets) {
-    final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeys, numBuckets);
+  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, String indexKeys, int numBuckets, boolean needFixedFileIdSuffix) {
+    final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeys, numBuckets, needFixedFileIdSuffix);
     return GenericRowData.of(StringData.fromString(fileId), record);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriteFunction.java
@@ -121,7 +121,7 @@ public class BulkInsertWriteFunction<I>
 
   @Override
   public void processElement(I value, Context ctx, Collector<Object> out) throws IOException {
-    initWriterHelper();
+    initWriterHelperIfNeeded();
     this.writerHelper.write((RowData) value);
   }
 
@@ -136,6 +136,7 @@ public class BulkInsertWriteFunction<I>
    * End input action for batch source.
    */
   public void endInput() {
+    initWriterHelperIfNeeded();
     final List<WriteStatus> writeStatus = this.writerHelper.getWriteStatuses(this.taskID);
 
     final WriteMetadataEvent event = WriteMetadataEvent.builder()
@@ -165,7 +166,7 @@ public class BulkInsertWriteFunction<I>
   //  Utilities
   // -------------------------------------------------------------------------
 
-  private void initWriterHelper() {
+  private void initWriterHelperIfNeeded() {
     if (writerHelper == null) {
       String instant = instantToWrite();
       this.writerHelper = WriterHelpers.getWriterHelper(this.config, this.writeClient.getHoodieTable(), this.writeClient.getConfig(),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriteFunction.java
@@ -117,11 +117,11 @@ public class BulkInsertWriteFunction<I>
     this.ckpMetadata = CkpMetadataFactory.getCkpMetadata(writeClient.getConfig(), config);
     this.initInstant = lastPendingInstant();
     sendBootstrapEvent();
-    initWriterHelper();
   }
 
   @Override
   public void processElement(I value, Context ctx, Collector<Object> out) throws IOException {
+    initWriterHelper();
     this.writerHelper.write((RowData) value);
   }
 
@@ -166,10 +166,12 @@ public class BulkInsertWriteFunction<I>
   // -------------------------------------------------------------------------
 
   private void initWriterHelper() {
-    String instant = instantToWrite();
-    this.writerHelper = WriterHelpers.getWriterHelper(this.config, this.writeClient.getHoodieTable(), this.writeClient.getConfig(),
-        instant, this.taskID, getRuntimeContext().getNumberOfParallelSubtasks(), getRuntimeContext().getAttemptNumber(),
-        this.rowType);
+    if (writerHelper == null) {
+      String instant = instantToWrite();
+      this.writerHelper = WriterHelpers.getWriterHelper(this.config, this.writeClient.getHoodieTable(), this.writeClient.getConfig(),
+          instant, this.taskID, getRuntimeContext().getNumberOfParallelSubtasks(), getRuntimeContext().getAttemptNumber(),
+          this.rowType);
+    }
   }
 
   private void sendBootstrapEvent() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -124,10 +124,11 @@ public class Pipelines {
       RowDataKeyGen keyGen = RowDataKeyGen.instance(conf, rowType);
       RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
       InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(rowTypeWithFileId);
+      boolean needFixedFileIdSuffix = OptionsResolver.isNonBlockingConcurrencyControl(conf);
 
       Map<String, String> bucketIdToFileId = new HashMap<>();
       dataStream = dataStream.partitionCustom(partitioner, keyGen::getHoodieKey)
-          .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, record, indexKeys, numBuckets), typeInfo)
+          .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, record, indexKeys, numBuckets, needFixedFileIdSuffix), typeInfo)
           .setParallelism(conf.getInteger(FlinkOptions.WRITE_TASKS)); // same parallelism as write task to avoid shuffle
       if (conf.getBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT)) {
         SortOperatorGen sortOperatorGen = BucketBulkInsertWriterHelper.getFileIdSorterGen(rowTypeWithFileId);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieWriteConflictException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.utils.TestData;
@@ -225,6 +226,111 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // because 2nd commit is in inflight state and
     // the data files belongs 3rd commit is not included in the last compaction.
     Map<String, String> readOptimizedResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,1,par1]");
+    TestData.checkWrittenData(tempFile, readOptimizedResult, 1);
+  }
+
+  @Test
+  public void testBulkInsertInMultiWriter() throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
+    // disable schedule compaction in writers
+    conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
+    conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
+
+    // start pipeline1 and insert record: [id1,Danny,null,1,par1], suspend the tx commit
+    List<RowData> dataset1 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id1"), StringData.fromString("Danny"), null,
+            TimestampData.fromEpochMillis(1), StringData.fromString("par1")));
+    TestHarness pipeline1 = preparePipeline(conf)
+        .consume(dataset1)
+        .assertEmptyDataFiles();
+
+    // start pipeline2 and bulk insert record: [id1,null,23,1,par1], suspend the tx commit
+    Configuration conf2 = conf.clone();
+    conf2.setString(FlinkOptions.OPERATION, "BULK_INSERT");
+    conf2.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
+    conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
+    List<RowData> dataset2 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id1"), null, 23,
+            TimestampData.fromEpochMillis(2), StringData.fromString("par1")));
+    TestHarness pipeline2 = preparePipeline(conf2)
+        .consume(dataset2);
+
+    // step to commit the 1st txn
+    pipeline1.checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1);
+
+    // step to commit the 2nd txn, should throw exception
+    pipeline2.commitAsBatchThrows(HoodieWriteConflictException.class, "Cannot resolve conflicts");
+  }
+
+  @Test
+  public void testBulkInsertInSequence() throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
+    // disable schedule compaction in writers
+    conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
+    conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
+
+    Configuration conf1 = conf.clone();
+    conf1.setString(FlinkOptions.OPERATION, "BULK_INSERT");
+    conf1.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
+    // start pipeline1 and insert record: [id1,Danny,null,1,par1], commit the 1st tx
+    List<RowData> dataset1 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id1"), StringData.fromString("Danny"), null,
+            TimestampData.fromEpochMillis(1), StringData.fromString("par1")));
+    preparePipeline(conf1)
+        .consume(dataset1)
+        .commitAsBatch();
+
+    // start pipeline2 and bulk insert record: [id1,null,23,2,par1], commit the 2nd tx
+    Configuration conf2 = conf.clone();
+    conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
+    List<RowData> dataset2 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id1"), null, 23,
+            TimestampData.fromEpochMillis(2), StringData.fromString("par1")));
+    TestHarness pipeline2 = preparePipeline(conf2)
+        .consume(dataset2)
+        .checkpoint(1)
+        .assertNextEvent()
+        .checkpointComplete(1);
+
+    // snapshot result is [(id1,Danny,23,2,par1)] after two writers finish to commit
+    Map<String, String> tmpSnapshotResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
+    pipeline2.checkWrittenData(tmpSnapshotResult, 1);
+
+    // schedule compaction outside of all writers
+    try (HoodieFlinkWriteClient writeClient = FlinkWriteClients.createWriteClient(conf)) {
+      Option<String> scheduleInstant = writeClient.scheduleCompaction(Option.empty());
+      assertNotNull(scheduleInstant.get());
+    }
+
+    // step to commit the 3rd txn
+    // it also triggers inline compactor
+    List<RowData> dataset3 = Collections.singletonList(
+        insertRow(
+            StringData.fromString("id3"), StringData.fromString("Julian"), 53,
+            TimestampData.fromEpochMillis(4), StringData.fromString("par1")));
+    pipeline2.consume(dataset3)
+        .checkpoint(2)
+        .assertNextEvent()
+        .checkpointComplete(2);
+
+    // snapshot read result is [(id1,Danny,23,2,par1), (id3,Julian,53,4,par1)] after three writers finish to commit
+    Map<String, String> finalSnapshotResult = Collections.singletonMap(
+        "par1",
+        "[id1,par1,id1,Danny,23,2,par1, id3,par1,id3,Julian,53,4,par1]");
+    pipeline2.checkWrittenData(finalSnapshotResult, 1);
+    // read optimized read result is [(id1,Danny,23,2,par1)]
+    // because the data files belongs 3rd commit is not included in the last compaction.
+    Map<String, String> readOptimizedResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
     TestData.checkWrittenData(tempFile, readOptimizedResult, 1);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -254,7 +254,6 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // start pipeline2 and bulk insert record: [id1,null,23,1,par1], suspend the tx commit
     Configuration conf2 = conf.clone();
     conf2.setString(FlinkOptions.OPERATION, "BULK_INSERT");
-    conf2.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
     conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
     List<RowData> dataset2 = Collections.singletonList(
         insertRow(
@@ -269,7 +268,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
         .checkpointComplete(1);
 
     // step to commit the 2nd txn, should throw exception
-    pipeline2.commitAsBatchThrows(HoodieWriteConflictException.class, "Cannot resolve conflicts");
+    pipeline2.endInputThrows(HoodieWriteConflictException.class, "Cannot resolve conflicts");
   }
 
   // case1: txn1 is upsert writer, txn2 is bulk_insert writer.
@@ -287,7 +286,6 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
 
     Configuration conf1 = conf.clone();
     conf1.setString(FlinkOptions.OPERATION, "BULK_INSERT");
-    conf1.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
     // start pipeline1 and bulk insert record: [id1,Danny,null,1,par1], suspend the tx commit
     List<RowData> dataset1 = Collections.singletonList(
         insertRow(
@@ -307,7 +305,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
         .consume(dataset2);
 
     // step to commit the 1st txn
-    pipeline1.commitAsBatch();
+    pipeline1.endInput();
 
     // step to commit the 2nd data
     pipeline2.checkpoint(1)

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
+import org.apache.hudi.sink.bucket.BucketBulkInsertWriterHelper;
+import org.apache.hudi.sink.bulk.BulkInsertWriteFunction;
+import org.apache.hudi.sink.bulk.RowDataKeyGen;
+import org.apache.hudi.sink.event.WriteMetadataEvent;
+import org.apache.hudi.util.AvroSchemaConverter;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.collect.utils.MockOperatorEventGateway;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.util.MockStreamTaskBuilder;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A wrapper class to manipulate the {@link BulkInsertWriteFunction} instance for testing.
+ *
+ * @param <I> Input type
+ */
+public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
+  private final Configuration conf;
+  private final RowType rowType;
+  private final RowType rowTypeWithFileId;
+
+  private final MockStreamingRuntimeContext runtimeContext;
+  private final MockOperatorEventGateway gateway;
+  private final MockOperatorCoordinatorContext coordinatorContext;
+  private final StreamWriteOperatorCoordinator coordinator;
+  private final MockStateInitializationContext stateInitializationContext;
+
+  private final boolean asyncClustering;
+  private ClusteringFunctionWrapper clusteringFunctionWrapper;
+
+  /**
+   * Bulk insert write function.
+   */
+  private BulkInsertWriteFunction<RowData> writeFunction;
+  private MapFunction<RowData, RowData> mapFunction;
+  private Map<String, String> bucketIdToFileId;
+
+  public BulkInsertFunctionWrapper(String tablePath, Configuration conf) throws Exception {
+    IOManager ioManager = new IOManagerAsync();
+    MockEnvironment environment = new MockEnvironmentBuilder()
+        .setTaskName("mockTask")
+        .setManagedMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
+        .setIOManager(ioManager)
+        .build();
+    this.runtimeContext = new MockStreamingRuntimeContext(false, 1, 0, environment);
+    this.gateway = new MockOperatorEventGateway();
+    this.conf = conf;
+    this.rowType = (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
+    this.rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
+    // one function
+    this.coordinatorContext = new MockOperatorCoordinatorContext(new OperatorID(), 1);
+    this.coordinator = new StreamWriteOperatorCoordinator(conf, this.coordinatorContext);
+    this.stateInitializationContext = new MockStateInitializationContext();
+    this.asyncClustering = OptionsResolver.needsAsyncClustering(conf);
+    StreamConfig streamConfig = new StreamConfig(conf);
+    streamConfig.setOperatorID(new OperatorID());
+    StreamTask<?, ?> streamTask = new MockStreamTaskBuilder(environment)
+        .setConfig(new StreamConfig(conf))
+        .setExecutionConfig(new ExecutionConfig().enableObjectReuse())
+        .build();
+    this.clusteringFunctionWrapper = new ClusteringFunctionWrapper(this.conf, streamTask, streamConfig);
+  }
+
+  public void openFunction() throws Exception {
+    this.coordinator.start();
+    this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+    setupWriteFunction();
+    RowDataKeyGen keyGen = RowDataKeyGen.instance(conf, rowType);
+    String indexKeys = OptionsResolver.getIndexKeyField(conf);
+    int numBuckets = conf.getInteger(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS);
+    boolean needFixedFileIdSuffix = OptionsResolver.isNonBlockingConcurrencyControl(conf);
+    this.bucketIdToFileId = new HashMap<>();
+    this.mapFunction = r -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, r, indexKeys, numBuckets, needFixedFileIdSuffix);
+    if (asyncClustering) {
+      clusteringFunctionWrapper.openFunction();
+    }
+  }
+
+  public void invoke(I record) throws Exception {
+    RowData recordWithFileId = mapFunction.map((RowData) record);
+    writeFunction.processElement(recordWithFileId, null, null);
+  }
+
+  public WriteMetadataEvent[] getEventBuffer() {
+    return this.coordinator.getEventBuffer();
+  }
+
+  public OperatorEvent getNextEvent() {
+    return this.gateway.getNextEvent();
+  }
+
+  public void checkpointFunction(long checkpointId) {
+    // Do nothing
+  }
+
+  @Override
+  public void endInput() {
+    writeFunction.endInput();
+    if (bucketIdToFileId != null) {
+      this.bucketIdToFileId.clear();
+    }
+  }
+
+  public void checkpointComplete(long checkpointId) {
+    stateInitializationContext.getOperatorStateStore().checkpointSuccess(checkpointId);
+    coordinator.notifyCheckpointComplete(checkpointId);
+    if (asyncClustering) {
+      try {
+        clusteringFunctionWrapper.cluster(checkpointId);
+      } catch (Exception e) {
+        throw new HoodieException(e);
+      }
+    }
+  }
+
+  public void coordinatorFails() throws Exception {
+    this.coordinator.close();
+    this.coordinator.start();
+    this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+  }
+
+  public void checkpointFails(long checkpointId) {
+    coordinator.notifyCheckpointAborted(checkpointId);
+  }
+
+  public StreamWriteOperatorCoordinator getCoordinator() {
+    return coordinator;
+  }
+
+  public MockOperatorCoordinatorContext getCoordinatorContext() {
+    return coordinatorContext;
+  }
+
+  @Override
+  public void close() throws Exception {
+    this.coordinator.close();
+    if (clusteringFunctionWrapper != null) {
+      clusteringFunctionWrapper.close();
+    }
+    if (bucketIdToFileId != null) {
+      this.bucketIdToFileId.clear();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  //  Utilities
+  // -------------------------------------------------------------------------
+
+  private void setupWriteFunction() {
+    ExecutorService executors = Executors.newFixedThreadPool(2);
+    Runnable writeFunctionInitializer = () -> {
+      try {
+        writeFunction = new BulkInsertWriteFunction<>(conf, rowType);
+        writeFunction.setRuntimeContext(runtimeContext);
+        writeFunction.setOperatorEventGateway(gateway);
+        writeFunction.open(conf);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+    executors.submit(writeFunctionInitializer);
+    Runnable coordinatorInitializer = () -> {
+      while (true) {
+        try {
+          OperatorEvent initializeEvent = getNextEvent();
+          // handle the bootstrap event
+          coordinator.handleEventFromOperator(0, initializeEvent);
+          break;
+        } catch (NoSuchElementException e) {
+          try {
+            // sleep and retry
+            TimeUnit.SECONDS.sleep(1);
+          } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+          }
+        }
+      }
+    };
+    executors.submit(coordinatorInitializer);
+    executors.shutdown();
+    try {
+      executors.awaitTermination(5, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      // ignore
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink.utils;
 
+import org.apache.hudi.adapter.TestStreamConfigs;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
@@ -92,7 +93,6 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     this.conf = conf;
     this.rowType = (RowType) AvroSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
     this.rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
-    // one function
     this.coordinatorContext = new MockOperatorCoordinatorContext(new OperatorID(), 1);
     this.coordinator = new StreamWriteOperatorCoordinator(conf, this.coordinatorContext);
     this.stateInitializationContext = new MockStateInitializationContext();
@@ -221,10 +221,9 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     this.output = new CollectorOutput<>();
     StreamConfig streamConfig = new StreamConfig(conf);
     streamConfig.setOperatorID(new OperatorID());
-    streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, .99);
     RowDataSerializer inputSerializer = new RowDataSerializer(rowTypeWithFileId);
-    streamConfig.setupNetworkInputs(inputSerializer);
-    streamConfig.serializeAllConfigs();
+    TestStreamConfigs.setupNetworkInputs(streamConfig, inputSerializer);
+    streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, .99);
     this.sortOperator.setup(streamTask, streamConfig, output);
     this.sortOperator.open();
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -327,9 +327,6 @@ public class TestWriteBase {
       this.pipeline.endInput();
       final OperatorEvent nextEvent = this.pipeline.getNextEvent();
       this.pipeline.getCoordinator().handleEventFromOperator(0, nextEvent);
-      if (this.pipeline.getCoordinatorContext().isJobFailed()) {
-        System.err.println(this.pipeline.getCoordinatorContext().getJobFailureReason().getCause());
-      }
       return this;
     }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -306,6 +306,34 @@ public class TestWriteBase {
     }
 
     /**
+     * Flush data using endInput. Asserts the commit would fail.
+     */
+    public void commitAsBatchThrows(Class<?> cause, String msg) {
+      // this triggers the data write and event send
+      this.pipeline.endInput();
+      final OperatorEvent nextEvent = this.pipeline.getNextEvent();
+      this.pipeline.getCoordinator().handleEventFromOperator(0, nextEvent);
+      assertTrue(this.pipeline.getCoordinatorContext().isJobFailed(), "Job should have been failed");
+      Throwable throwable = this.pipeline.getCoordinatorContext().getJobFailureReason().getCause();
+      assertThat(throwable, instanceOf(cause));
+      assertThat(throwable.getMessage(), containsString(msg));
+    }
+
+    /**
+     * Flush data using endInput. Asserts the commit would fail.
+     */
+    public TestHarness commitAsBatch() {
+      // this triggers the data write and event send
+      this.pipeline.endInput();
+      final OperatorEvent nextEvent = this.pipeline.getNextEvent();
+      this.pipeline.getCoordinator().handleEventFromOperator(0, nextEvent);
+      if (this.pipeline.getCoordinatorContext().isJobFailed()) {
+        System.err.println(this.pipeline.getCoordinatorContext().getJobFailureReason().getCause());
+      }
+      return this;
+    }
+
+    /**
      * Asserts the checkpoint with id {@code checkpointId} throws when completes .
      */
     public TestHarness checkpointCompleteThrows(long checkpointId, Class<?> cause, String msg) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -306,7 +306,7 @@ public class TestWriteBase {
     }
 
     /**
-     * Flush data using endInput. Asserts the commit would fail.
+     * Flush data and commit using endInput. Asserts the commit would fail.
      */
     public void endInputThrows(Class<?> cause, String msg) {
       // this triggers the data write and event send
@@ -320,7 +320,7 @@ public class TestWriteBase {
     }
 
     /**
-     * Flush data using endInput. Asserts the commit would fail.
+     * Flush data and commit using endInput.
      */
     public TestHarness endInput() {
       // this triggers the data write and event send

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -308,7 +308,7 @@ public class TestWriteBase {
     /**
      * Flush data using endInput. Asserts the commit would fail.
      */
-    public void commitAsBatchThrows(Class<?> cause, String msg) {
+    public void endInputThrows(Class<?> cause, String msg) {
       // this triggers the data write and event send
       this.pipeline.endInput();
       final OperatorEvent nextEvent = this.pipeline.getNextEvent();
@@ -322,7 +322,7 @@ public class TestWriteBase {
     /**
      * Flush data using endInput. Asserts the commit would fail.
      */
-    public TestHarness commitAsBatch() {
+    public TestHarness endInput() {
       // this triggers the data write and event send
       this.pipeline.endInput();
       final OperatorEvent nextEvent = this.pipeline.getNextEvent();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -555,9 +555,6 @@ public class TestData {
    */
   public static TestFunctionWrapper<RowData> getWritePipeline(String basePath, Configuration conf) throws Exception {
     if (OptionsResolver.isBulkInsertOperation(conf)) {
-      if (conf.getBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT)) {
-        throw new UnsupportedOperationException("Harness test does not support bulk insert sort yet");
-      }
       return new BulkInsertFunctionWrapper<>(basePath, conf);
     } else if (OptionsResolver.isAppendMode(conf)) {
       return new InsertFunctionWrapper<>(basePath, conf);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestData.java
@@ -34,6 +34,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.sink.utils.BucketStreamWriteFunctionWrapper;
+import org.apache.hudi.sink.utils.BulkInsertFunctionWrapper;
 import org.apache.hudi.sink.utils.ConsistentBucketStreamWriteFunctionWrapper;
 import org.apache.hudi.sink.utils.InsertFunctionWrapper;
 import org.apache.hudi.sink.utils.StreamWriteFunctionWrapper;
@@ -553,7 +554,12 @@ public class TestData {
    * Initializes a writing pipeline with given configuration.
    */
   public static TestFunctionWrapper<RowData> getWritePipeline(String basePath, Configuration conf) throws Exception {
-    if (OptionsResolver.isAppendMode(conf)) {
+    if (OptionsResolver.isBulkInsertOperation(conf)) {
+      if (conf.getBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT)) {
+        throw new UnsupportedOperationException("Harness test does not support bulk insert sort yet");
+      }
+      return new BulkInsertFunctionWrapper<>(basePath, conf);
+    } else if (OptionsResolver.isAppendMode(conf)) {
       return new InsertFunctionWrapper<>(basePath, conf);
     } else if (OptionsResolver.isBucketIndexType(conf)) {
       if (OptionsResolver.isConsistentHashingBucketIndexType(conf)) {

--- a/hudi-flink-datasource/hudi-flink1.13.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
+++ b/hudi-flink-datasource/hudi-flink1.13.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+
+/**
+ * StreamConfig for test goals.
+ */
+public class TestStreamConfigs {
+
+  public static void setupNetworkInputs(StreamConfig streamConfig, TypeSerializer<?>... inputSerializers) {
+    streamConfig.setupNetworkInputs(inputSerializers);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.14.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
+++ b/hudi-flink-datasource/hudi-flink1.14.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+
+/**
+ * StreamConfig for test goals.
+ */
+public class TestStreamConfigs {
+
+  public static void setupNetworkInputs(StreamConfig streamConfig, TypeSerializer<?>... inputSerializers) {
+    streamConfig.setupNetworkInputs(inputSerializers);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.15.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
+++ b/hudi-flink-datasource/hudi-flink1.15.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+
+/**
+ * StreamConfig for test goals.
+ */
+public class TestStreamConfigs {
+
+  public static void setupNetworkInputs(StreamConfig streamConfig, TypeSerializer<?>... inputSerializers) {
+    streamConfig.setupNetworkInputs(inputSerializers);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.16.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
+++ b/hudi-flink-datasource/hudi-flink1.16.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+
+/**
+ * StreamConfig for test goals.
+ */
+public class TestStreamConfigs {
+
+  public static void setupNetworkInputs(StreamConfig streamConfig, TypeSerializer<?>... inputSerializers) {
+    streamConfig.setupNetworkInputs(inputSerializers);
+    // Since Flink 1.16, need call serializeAllConfigs to serialize all object configs synchronously.
+    // See https://issues.apache.org/jira/browse/FLINK-26675.
+    streamConfig.serializeAllConfigs();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.17.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
+++ b/hudi-flink-datasource/hudi-flink1.17.x/src/test/java/org/apache/hudi/adapter/TestStreamConfigs.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.adapter;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+
+/**
+ * StreamConfig for test goals.
+ */
+public class TestStreamConfigs {
+
+  public static void setupNetworkInputs(StreamConfig streamConfig, TypeSerializer<?>... inputSerializers) {
+    streamConfig.setupNetworkInputs(inputSerializers);
+    // Since Flink 1.16, need call serializeAllConfigs to serialize all object configs synchronously.
+    // See https://issues.apache.org/jira/browse/FLINK-26675.
+    streamConfig.serializeAllConfigs();
+  }
+}


### PR DESCRIPTION
### Change Logs

In the previous [PR#9850](https://github.com/apache/hudi/pull/9850), I forget to take `bulk insert` into consideration.
How to handle the case if the multiple writer contains a job with bulk insert operation?
* Generated file group id: Generate a fixed file group ID because other jobs will use the fixed file group id suffix instead of random uuid suffix. The behavior needs to be consistent to prevent later writer jobs from writing the records with same primary key to different file groups.
* Deal with the transaction: The conflict resolution of bulk insert could not defer to the compaction phase. Because bulk insert writers flush data into base files, if there are multiple bulk insert job, there might exists multiple base files in the same bucket.

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
