### PR TITLE
[HUDI-6969] Add speed limit for stream read

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -343,18 +343,13 @@ public class FlinkOptions extends HoodieConfig {
       .noDefaultValue()
       .withDescription("End commit instant for reading, the commit time format should be 'yyyyMMddHHmmss'");
 
-  public static final ConfigOption<Boolean> READ_SPEED_LIMIT_ENABLED = ConfigOptions
-      .key("read.speed.limit.enabled")
-      .booleanType()
-      .defaultValue(false)
-      .withDescription("Enable stream read speed limit, avoiding the risk of oom caused by the streamReadMonitor "
-          + " loading too many metadata at once");
-
-  public static final ConfigOption<Integer> READ_SPEED_LIMIT_COMMITS = ConfigOptions
-      .key("read.speed.limit.commits")
+  public static final ConfigOption<Integer> READ_COMMITS_LIMIT = ConfigOptions
+      .key("read.commits.limit")
       .intType()
-      .defaultValue(5)
-      .withDescription("The maximum number of commits allowed streamReadMonitor to read in each poll");
+      .noDefaultValue()
+      .withDescription("The maximum number of commits allowed to read in each instant check, if it is streaming read, "
+          + "the avg read instants number per-second would be 'read.commits.limit'/'read.streaming.check-interval', by "
+          + "default no limit");
 
   @AdvancedConfig
   public static final ConfigOption<Boolean> READ_DATA_SKIPPING_ENABLED = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -343,12 +343,25 @@ public class FlinkOptions extends HoodieConfig {
       .noDefaultValue()
       .withDescription("End commit instant for reading, the commit time format should be 'yyyyMMddHHmmss'");
 
+  public static final ConfigOption<Boolean> READ_SPEED_LIMIT_ENABLED = ConfigOptions
+      .key("read.speed.limit.enabled")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Enable stream read speed limit, avoiding the risk of oom caused by the streamReadMonitor "
+          + " loading too many metadata at once");
+
+  public static final ConfigOption<Integer> READ_SPEED_LIMIT_COMMITS = ConfigOptions
+      .key("read.speed.limit.commits")
+      .intType()
+      .defaultValue(5)
+      .withDescription("The maximum number of commits allowed streamReadMonitor to read in each poll");
+
   @AdvancedConfig
   public static final ConfigOption<Boolean> READ_DATA_SKIPPING_ENABLED = ConfigOptions
       .key("read.data.skipping.enabled")
       .booleanType()
       .defaultValue(false)
-      .withDescription("Enables data-skipping allowing queries to leverage indexes to reduce the search space by"
+      .withDescription("Enables data-skipping allowing queries to leverage indexes to reduce the search space by "
           + "skipping over files");
 
   // ------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -273,6 +273,13 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns whether the read commits limit is specified.
+   */
+  public static boolean hasReadCommitsLimit(Configuration conf) {
+    return conf.contains(FlinkOptions.READ_COMMITS_LIMIT);
+  }
+
+  /**
    * Returns the supplemental logging mode.
    */
   public static HoodieCDCSupplementalLoggingMode getCDCSupplementalLoggingMode(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/IncrementalInputSplits.java
@@ -269,9 +269,9 @@ public class IncrementalInputSplits implements Serializable {
     Result hollowSplits = getHollowInputSplits(metaClient, metaClient.getHadoopConf(), issuedInstant, issuedOffset, commitTimeline, cdcEnabled);
 
     List<HoodieInstant> instants = filterInstantsWithRange(commitTimeline, issuedInstant);
-    // read speed limit, avoid OOM caused by loading too many data at once
-    if (this.conf.getBoolean(FlinkOptions.READ_SPEED_LIMIT_ENABLED)) {
-      int readLimit = this.conf.getInteger(FlinkOptions.READ_SPEED_LIMIT_COMMITS);
+    // streaming read speed limit, limits the maximum number of commits allowed to read in each instant check
+    if (OptionsResolver.hasReadCommitsLimit(conf)) {
+      int readLimit = this.conf.getInteger(FlinkOptions.READ_COMMITS_LIMIT);
       instants = instants.subList(0, Math.min(readLimit, instants.size()));
     }
 


### PR DESCRIPTION
### Change Logs

Currently, there is no speed limit for stream read, and regardless of the instantranges, they will be read at once. It is easy to cause GC of monitor operator.
Add a configuration to limit the number of commits read per round in stream read mode.

### Impact

stream read.

### Risk level (write none, low medium or high below)

low.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
