### PR TITLE
[HUDI-6975] Optimize the code of DayBasedCompactionStrategy

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/strategy/DayBasedCompactionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/strategy/DayBasedCompactionStrategy.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.table.action.compact.strategy;
 
-import org.apache.hudi.avro.model.HoodieCompactionOperation;
-import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 
@@ -29,7 +27,6 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -64,20 +61,8 @@ public class DayBasedCompactionStrategy extends CompactionStrategy {
   }
 
   @Override
-  public List<HoodieCompactionOperation> orderAndFilter(HoodieWriteConfig writeConfig,
-      List<HoodieCompactionOperation> operations, List<HoodieCompactionPlan> pendingCompactionPlans) {
-    // Iterate through the operations and accept operations as long as we are within the configured target partitions
-    // limit
-    return operations.stream()
-        .collect(Collectors.groupingBy(HoodieCompactionOperation::getPartitionPath)).entrySet().stream()
-        .sorted(Map.Entry.comparingByKey(comparator)).limit(writeConfig.getTargetPartitionsPerDayBasedCompaction())
-        .flatMap(e -> e.getValue().stream()).collect(Collectors.toList());
-  }
-
-  @Override
   public List<String> filterPartitionPaths(HoodieWriteConfig writeConfig, List<String> allPartitionPaths) {
-    return allPartitionPaths.stream().map(partition -> partition.replace("/", "-"))
-        .sorted(Comparator.reverseOrder()).map(partitionPath -> partitionPath.replace("-", "/"))
+    return allPartitionPaths.stream().sorted(comparator)
         .collect(Collectors.toList()).subList(0, Math.min(allPartitionPaths.size(),
             writeConfig.getTargetPartitionsPerDayBasedCompaction()));
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
@@ -139,9 +139,12 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap, keyToPartitionMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
-    assertTrue(returned.size() < operations.size(),
-        "DayBasedCompactionStrategy should have resulted in fewer compactions");
-    assertEquals(2, returned.size(), "DayBasedCompactionStrategy should have resulted in fewer compactions");
+    assertTrue(returned.size() == operations.size(),
+        "DayBasedCompactionStrategy should have resulted same compactions");
+    assertEquals(4, returned.size(), "DayBasedCompactionStrategy should have resulted same compactions");
+
+    List<String> filterPartitions = strategy.filterPartitionPaths(writeConfig, Arrays.asList(partitionPaths));
+    assertEquals(1, filterPartitions.size(), "DayBasedCompactionStrategy should have resulted in fewer partitions");
 
     int comparison = strategy.getComparator().compare(returned.get(returned.size() - 1).getPartitionPath(),
         returned.get(0).getPartitionPath());

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
@@ -136,18 +136,21 @@ public class TestHoodieCompactionStrategy {
     HoodieWriteConfig writeConfig =
         HoodieWriteConfig.newBuilder().withPath("/tmp").withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .withCompactionStrategy(strategy).withTargetPartitionsPerDayBasedCompaction(1).build()).build();
-    List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap, keyToPartitionMap);
-    List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
-
-    assertTrue(returned.size() == operations.size(),
-        "DayBasedCompactionStrategy should have resulted same compactions");
-    assertEquals(4, returned.size(), "DayBasedCompactionStrategy should have resulted same compactions");
 
     List<String> filterPartitions = strategy.filterPartitionPaths(writeConfig, Arrays.asList(partitionPaths));
     assertEquals(1, filterPartitions.size(), "DayBasedCompactionStrategy should have resulted in fewer partitions");
 
-    int comparison = strategy.getComparator().compare(returned.get(returned.size() - 1).getPartitionPath(),
-        returned.get(0).getPartitionPath());
+    List<HoodieCompactionOperation> operations = createCompactionOperationsForPartition(writeConfig, sizesMap, keyToPartitionMap, filterPartitions);
+    assertEquals(2, operations.size(),
+        "DayBasedCompactionStrategy should generate 2 HoodieCompactionOperation for partition 2017/01/03");
+
+    List<String> operationPartitions = operations.stream().collect(Collectors.groupingBy(HoodieCompactionOperation::getPartitionPath))
+        .entrySet().stream().map(e -> e.getKey()).collect(Collectors.toList());
+    assertTrue(operationPartitions.size() == filterPartitions.size(),
+        "DayBasedCompactionStrategy should have resulted same partitions");
+
+    int comparison = strategy.getComparator().compare(operations.get(operations.size() - 1).getPartitionPath(),
+        operations.get(0).getPartitionPath());
     // Either the partition paths are sorted in descending order or they are equal
     assertTrue(comparison >= 0, "DayBasedCompactionStrategy should sort partitions in descending order");
   }
@@ -307,6 +310,30 @@ public class TestHoodieCompactionStrategy {
           config.getCompactionStrategy().captureMetrics(config, slice),
           df.getBootstrapBaseFile().map(BaseFile::getPath).orElse(null))
       );
+    });
+    return operations;
+  }
+
+  private List<HoodieCompactionOperation> createCompactionOperationsForPartition(HoodieWriteConfig config,
+      Map<Long, List<Long>> sizesMap, Map<Long, String> keyToPartitionMap, List<String> filterPartitions) {
+    List<HoodieCompactionOperation> operations = new ArrayList<>(sizesMap.size());
+
+    sizesMap.forEach((k, v) -> {
+      HoodieBaseFile df = TestHoodieBaseFile.newDataFile(k);
+      String partitionPath = keyToPartitionMap.get(k);
+      // create operation for target partition
+      if (filterPartitions.contains(partitionPath)) {
+        List<HoodieLogFile> logFiles = v.stream().map(TestHoodieLogFile::newLogFile).collect(Collectors.toList());
+        FileSlice slice = new FileSlice(new HoodieFileGroupId(partitionPath, df.getFileId()), df.getCommitTime());
+        slice.setBaseFile(df);
+        logFiles.stream().forEach(f -> slice.addLogFile(f));
+        operations.add(new HoodieCompactionOperation(df.getCommitTime(),
+            logFiles.stream().map(s -> s.getPath().toString()).collect(Collectors.toList()), df.getPath(), df.getFileId(),
+            partitionPath,
+            config.getCompactionStrategy().captureMetrics(config, slice),
+            df.getBootstrapBaseFile().map(BaseFile::getPath).orElse(null))
+        );
+      }
     });
     return operations;
   }


### PR DESCRIPTION
### Change Logs

Remove redundant orderAndFilter method in DayBasedCompactionStrategy. 

For example, when partitionPaths = {"2017/01/01", "2017/01/02", "2017/01/03"}, hoodie.compaction.daybased.target.partitions = 1.

In filterPartitionPaths method, we will get the lastest partition "2017/01/03", we get the corresponding operations by scanning this partition.
```
  public List<String> filterPartitionPaths(HoodieWriteConfig writeConfig, List<String> allPartitionPaths) {
    return allPartitionPaths.stream().map(partition -> partition.replace("/", "-"))
        .sorted(Comparator.reverseOrder()).map(partitionPath -> partitionPath.replace("-", "/"))
        .collect(Collectors.toList()).subList(0, Math.min(allPartitionPaths.size(),
            writeConfig.getTargetPartitionsPerDayBasedCompaction()));
  }
```

But in orderAndFilter method, we also group by opertions's partition path to limit the partitions. 
```
  public List<HoodieCompactionOperation> orderAndFilter(HoodieWriteConfig writeConfig,
      List<HoodieCompactionOperation> operations, List<HoodieCompactionPlan> pendingCompactionPlans) {
    // Iterate through the operations and accept operations as long as we are within the configured target partitions
    // limit
    return operations.stream()
        .collect(Collectors.groupingBy(HoodieCompactionOperation::getPartitionPath)).entrySet().stream()
        .sorted(Map.Entry.comparingByKey(comparator)).limit(writeConfig.getTargetPartitionsPerDayBasedCompaction())
        .flatMap(e -> e.getValue().stream()).collect(Collectors.toList());
  }
```

It's no need to do this redundant action.

### Impact

None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
