### PR TITLE
[HUDI-6990] Configurable clustering task parallelism 

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -161,6 +161,13 @@ public class HoodieClusteringConfig extends HoodieConfig {
           + "value will let the clustering job run faster, while it will give additional pressure to the "
           + "execution engines to manage more concurrent running jobs.");
 
+  public static final ConfigProperty<Integer> CLUSTERING_READ_RECORDS_PARALLELISM = ConfigProperty
+      .key("hoodie.clustering.read.records.parallelism")
+      .defaultValue(20)
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Maximum number of parallelism when Spark read records from clustering group.");
+
   public static final ConfigProperty<String> PLAN_STRATEGY_SKIP_PARTITIONS_FROM_LATEST = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "daybased.skipfromlatest.partitions")
       .defaultValue("0")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -161,8 +161,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
           + "value will let the clustering job run faster, while it will give additional pressure to the "
           + "execution engines to manage more concurrent running jobs.");
 
-  public static final ConfigProperty<Integer> CLUSTERING_RDD_READ_PARALLELISM = ConfigProperty
-      .key("hoodie.clustering.rdd.read.parallelism")
+  public static final ConfigProperty<Integer> CLUSTERING_GROUP_READ_PARALLELISM = ConfigProperty
+      .key("hoodie.clustering.group.read.parallelism")
       .defaultValue(20)
       .markAdvanced()
       .sinceVersion("1.0.0")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -161,8 +161,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
           + "value will let the clustering job run faster, while it will give additional pressure to the "
           + "execution engines to manage more concurrent running jobs.");
 
-  public static final ConfigProperty<Integer> CLUSTERING_PARALLELISM = ConfigProperty
-      .key("hoodie.clustering.parallelism")
+  public static final ConfigProperty<Integer> CLUSTERING_RDD_READ_PARALLELISM = ConfigProperty
+      .key("hoodie.clustering.rdd.read.parallelism")
       .defaultValue(20)
       .markAdvanced()
       .sinceVersion("1.0.0")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -161,8 +161,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
           + "value will let the clustering job run faster, while it will give additional pressure to the "
           + "execution engines to manage more concurrent running jobs.");
 
-  public static final ConfigProperty<Integer> CLUSTERING_READ_RECORDS_PARALLELISM = ConfigProperty
-      .key("hoodie.clustering.read.records.parallelism")
+  public static final ConfigProperty<Integer> CLUSTERING_PARALLELISM = ConfigProperty
+      .key("hoodie.clustering.parallelism")
       .defaultValue(20)
       .markAdvanced()
       .sinceVersion("1.0.0")

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1795,8 +1795,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.LAYOUT_OPTIMIZE_BUILD_CURVE_SAMPLE_SIZE);
   }
 
-  public int getClusteringReadRecordsParallelism() {
-    return getInt(HoodieClusteringConfig.CLUSTERING_READ_RECORDS_PARALLELISM);
+  public int getClusteringParallelism() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_PARALLELISM);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1795,6 +1795,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.LAYOUT_OPTIMIZE_BUILD_CURVE_SAMPLE_SIZE);
   }
 
+  public int getClusteringReadRecordsParallelism() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_READ_RECORDS_PARALLELISM);
+  }
+
   /**
    * index properties.
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1795,8 +1795,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.LAYOUT_OPTIMIZE_BUILD_CURVE_SAMPLE_SIZE);
   }
 
-  public int getClusteringParallelism() {
-    return getInt(HoodieClusteringConfig.CLUSTERING_PARALLELISM);
+  public int getClusteringRddReadParallelism() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_RDD_READ_PARALLELISM);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1795,8 +1795,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieClusteringConfig.LAYOUT_OPTIMIZE_BUILD_CURVE_SAMPLE_SIZE);
   }
 
-  public int getClusteringRddReadParallelism() {
-    return getInt(HoodieClusteringConfig.CLUSTERING_RDD_READ_PARALLELISM);
+  public int getClusteringGroupReadParallelism() {
+    return getInt(HoodieClusteringConfig.CLUSTERING_GROUP_READ_PARALLELISM);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -296,7 +296,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    int readParallelism = Math.min(writeConfig.getClusteringParallelism(), clusteringOps.size());
+    int readParallelism = Math.min(writeConfig.getClusteringRddReadParallelism(), clusteringOps.size());
 
     return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism).mapPartitions(clusteringOpsPartition -> {
       List<Iterator<HoodieRecord<T>>> recordIterators = new ArrayList<>();
@@ -354,7 +354,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    int readParallelism = Math.min(writeConfig.getClusteringParallelism(), clusteringOps.size());
+    int readParallelism = Math.min(writeConfig.getClusteringRddReadParallelism(), clusteringOps.size());
 
     return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism)
         .mapPartitions(clusteringOpsPartition -> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -296,7 +296,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    int readParallelism = Math.min(writeConfig.getClusteringRddReadParallelism(), clusteringOps.size());
+    int readParallelism = Math.min(writeConfig.getClusteringGroupReadParallelism(), clusteringOps.size());
 
     return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism).mapPartitions(clusteringOpsPartition -> {
       List<Iterator<HoodieRecord<T>>> recordIterators = new ArrayList<>();
@@ -354,7 +354,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    int readParallelism = Math.min(writeConfig.getClusteringRddReadParallelism(), clusteringOps.size());
+    int readParallelism = Math.min(writeConfig.getClusteringGroupReadParallelism(), clusteringOps.size());
 
     return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism)
         .mapPartitions(clusteringOpsPartition -> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -296,7 +296,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    int readParallelism = Math.min(writeConfig.getClusteringReadRecordsParallelism(), clusteringOps.size());
+    int readParallelism = Math.min(writeConfig.getClusteringParallelism(), clusteringOps.size());
 
     return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism).mapPartitions(clusteringOpsPartition -> {
       List<Iterator<HoodieRecord<T>>> recordIterators = new ArrayList<>();
@@ -354,7 +354,7 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    int readParallelism = Math.min(writeConfig.getClusteringReadRecordsParallelism(), clusteringOps.size());
+    int readParallelism = Math.min(writeConfig.getClusteringParallelism(), clusteringOps.size());
 
     return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism)
         .mapPartitions(clusteringOpsPartition -> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -296,7 +296,9 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, clusteringOps.size()).mapPartitions(clusteringOpsPartition -> {
+    int readParallelism = Math.min(writeConfig.getClusteringReadRecordsParallelism(), clusteringOps.size());
+
+    return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism).mapPartitions(clusteringOpsPartition -> {
       List<Iterator<HoodieRecord<T>>> recordIterators = new ArrayList<>();
       clusteringOpsPartition.forEachRemaining(clusteringOp -> {
         long maxMemoryPerCompaction = IOUtils.getMaxMemoryPerCompaction(new SparkTaskContextSupplier(), config);
@@ -352,7 +354,9 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     String bootstrapBasePath = tableConfig.getBootstrapBasePath().orElse(null);
     Option<String[]> partitionFields = tableConfig.getPartitionFields();
 
-    return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, clusteringOps.size())
+    int readParallelism = Math.min(writeConfig.getClusteringReadRecordsParallelism(), clusteringOps.size());
+
+    return HoodieJavaRDD.of(jsc.parallelize(clusteringOps, readParallelism)
         .mapPartitions(clusteringOpsPartition -> {
           List<Iterator<HoodieRecord<T>>> iteratorsForPartition = new ArrayList<>();
           clusteringOpsPartition.forEachRemaining(clusteringOp -> {


### PR DESCRIPTION
### Change Logs

Spark executes clustering will generate too many tasks which is equal to the the number of files in clustering plan. Support config it when read files.
![image](https://github.com/apache/hudi/assets/135721692/92e4b88a-a581-43c5-8776-3df060c726a5)

### Impact

None

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
