### PR TITLE
[HUDI-6998] Fix drop table failure when load table as spark v2 table whose path is delete

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -319,7 +319,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
 
   private def loadTableSchemaByMetaClient(): Option[StructType] = {
     val resolver = spark.sessionState.conf.resolver
-    getTableSqlSchema(metaClient, includeMetadataFields = true).map(originSchema => {
+    try getTableSqlSchema(metaClient, includeMetadataFields = true).map(originSchema => {
       // Load table schema from meta on filesystem, and fill in 'comment'
       // information from Spark catalog.
       // Hoodie newly added columns are positioned after partition columns,
@@ -335,6 +335,11 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
       }.partition(f => partitionFields.contains(f.name))
       StructType(dataFields ++ partFields)
     })
+    catch {
+      case cause: Throwable =>
+        logWarning("Failed to load table schema from meta client.", cause)
+        None
+    }
   }
 
   // This code is forked from org.apache.spark.sql.hive.HiveExternalCatalog#verifyDataSchema


### PR DESCRIPTION

### Change Logs
We will first try to load schema from hoodie meta client since [HUDI-6219](https://issues.apache.org/jira/browse/HUDI-6219), it will throw exception if table directory does not exists, in which case we are unable to drop this hudi table.
```bash
20887 [ScalaTest-run-running-TestDropTable] WARN  org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable [] - Failed to load table schema from meta client.
org.apache.hudi.exception.TableNotFoundException: Hoodie table not found in path file:/private/var/folders/6j/vkbrdtgd0x34sqjzgv7s8ckh0000gy/T/spark-8a41e162-dfab-4843-afcd-bb672628747d/h0/.hoodie
	at org.apache.hudi.exception.TableNotFoundException.checkTableValidity(TableNotFoundException.java:57) ~[classes/:?]
	at org.apache.hudi.common.table.HoodieTableMetaClient.<init>(HoodieTableMetaClient.java:149) ~[classes/:?]
	at org.apache.hudi.common.table.HoodieTableMetaClient.newMetaClient(HoodieTableMetaClient.java:734) ~[classes/:?]
	at org.apache.hudi.common.table.HoodieTableMetaClient.access$000(HoodieTableMetaClient.java:91) ~[classes/:?]
	at org.apache.hudi.common.table.HoodieTableMetaClient$Builder.build(HoodieTableMetaClient.java:825) ~[classes/:?]
	at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.metaClient$lzycompute(HoodieCatalogTable.scala:85) ~[classes/:3.2.3]
	at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.metaClient(HoodieCatalogTable.scala:83) ~[classes/:3.2.3]
	at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.loadTableSchemaByMetaClient(HoodieCatalogTable.scala:322) ~[classes/:3.2.3]
	at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.tableSchema$lzycompute(HoodieCatalogTable.scala:138) ~[classes/:3.2.3]
	at org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable.tableSchema(HoodieCatalogTable.scala:137) ~[classes/:3.2.3]
	at org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table.tableSchema$lzycompute(HoodieInternalV2Table.scala:57) ~[classes/:?]
	at org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table.tableSchema(HoodieInternalV2Table.scala:57) ~[classes/:?]
	at org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table.schema(HoodieInternalV2Table.scala:61) ~[classes/:?]
	at org.apache.spark.sql.catalyst.analysis.ResolvedTable$.create(v2ResolutionPlans.scala:156) ~[spark-catalyst_2.12-3.2.3.jar:3.2.3]
	at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveRelations$.$anonfun$lookupTableOrView$1(Analyzer.scala:1232) ~[spark-catalyst_2.12-3.2.3.jar:3.2.3]
...
```
To prevent this issue, we produce catch and log exception when load table schema by meta client. 

### Impact
Fix drop table error.

### Risk level (write none, low medium or high below)

None.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
