### PR TITLE
[HUDI-6997] A new WriteConcurrencyMode type for non-blocking concurrency control

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -383,7 +383,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    */
   public void bootstrap(Option<Map<String, String>> extraMetadata) {
     // TODO : MULTIWRITER -> check if failed bootstrap files can be cleaned later
-    if (config.getWriteConcurrencyMode().supportsConcurrencyControl()) {
+    if (config.getWriteConcurrencyMode().supportsMultiWriter()) {
       throw new HoodieException("Cannot bootstrap the table in multi-writer mode");
     }
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UPSERT, Option.ofNullable(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -383,7 +383,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    */
   public void bootstrap(Option<Map<String, String>> extraMetadata) {
     // TODO : MULTIWRITER -> check if failed bootstrap files can be cleaned later
-    if (config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+    if (config.getWriteConcurrencyMode().supportsConcurrencyControl()) {
       throw new HoodieException("Cannot bootstrap the table in multi-writer mode");
     }
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UPSERT, Option.ofNullable(HoodieTimeline.METADATA_BOOTSTRAP_INSTANT_TS));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -142,11 +142,16 @@ public class HoodieCleanConfig extends HoodieConfig {
       .defaultValue(HoodieFailedWritesCleaningPolicy.EAGER.name())
       .withInferFunction(cfg -> {
         Option<String> writeConcurrencyModeOpt = Option.ofNullable(cfg.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE));
-        if (!writeConcurrencyModeOpt.isPresent()
-            || !writeConcurrencyModeOpt.get().equalsIgnoreCase(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name())) {
+        if (!writeConcurrencyModeOpt.isPresent()) {
           return Option.empty();
+        } else {
+          WriteConcurrencyMode writeConcurrencyMode = WriteConcurrencyMode.valueOf(writeConcurrencyModeOpt.get().toUpperCase());
+          if (writeConcurrencyMode.supportsConcurrencyControl()) {
+            return Option.of(HoodieFailedWritesCleaningPolicy.LAZY.name());
+          } else {
+            return Option.empty();
+          }
         }
-        return Option.of(HoodieFailedWritesCleaningPolicy.LAZY.name());
       })
       .markAdvanced()
       .withDocumentation(HoodieFailedWritesCleaningPolicy.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -142,16 +142,11 @@ public class HoodieCleanConfig extends HoodieConfig {
       .defaultValue(HoodieFailedWritesCleaningPolicy.EAGER.name())
       .withInferFunction(cfg -> {
         Option<String> writeConcurrencyModeOpt = Option.ofNullable(cfg.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE));
-        if (!writeConcurrencyModeOpt.isPresent()) {
+        if (!writeConcurrencyModeOpt.isPresent()
+            || !WriteConcurrencyMode.supportsMultiWriter(writeConcurrencyModeOpt.get())) {
           return Option.empty();
-        } else {
-          WriteConcurrencyMode writeConcurrencyMode = WriteConcurrencyMode.valueOf(writeConcurrencyModeOpt.get().toUpperCase());
-          if (writeConcurrencyMode.supportsConcurrencyControl()) {
-            return Option.of(HoodieFailedWritesCleaningPolicy.LAZY.name());
-          } else {
-            return Option.empty();
-          }
         }
+        return Option.of(HoodieFailedWritesCleaningPolicy.LAZY.name());
       })
       .markAdvanced()
       .withDocumentation(HoodieFailedWritesCleaningPolicy.class);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3255,7 +3255,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       Objects.requireNonNull(writeConfig.getString(BASE_PATH));
       WriteConcurrencyMode writeConcurrencyMode = writeConfig.getWriteConcurrencyMode();
       if (writeConfig.isEarlyConflictDetectionEnable()) {
-        checkArgument(writeConcurrencyMode == WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL,
+        checkArgument(writeConcurrencyMode.isOptimisticConcurrencyControl(),
             "To use early conflict detection, set hoodie.write.concurrency.mode=OPTIMISTIC_CONCURRENCY_CONTROL");
       }
       if (writeConcurrencyMode.supportsMultiWriter()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3235,7 +3235,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       }
 
       // We check if "hoodie.cleaner.policy.failed.writes"
-      // is properly set to LAZY for optimistic concurrency control
+      // is properly set to LAZY for multi-writers
       WriteConcurrencyMode writeConcurrencyMode = writeConfig.getWriteConcurrencyMode();
       if (writeConcurrencyMode.supportsMultiWriter()) {
         // In this case, we assume that the user takes care of setting the lock provider used

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -247,7 +247,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
 
   private HoodieInstant validateAndGetIndexInstant() {
     // ensure lock provider configured
-    if (!config.getWriteConcurrencyMode().supportsConcurrencyControl() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
+    if (!config.getWriteConcurrencyMode().supportsMultiWriter() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
       throw new HoodieIndexException(String.format("Need to set %s as %s or %s and configure lock provider class",
           WRITE_CONCURRENCY_MODE.key(), OPTIMISTIC_CONCURRENCY_CONTROL.name(), NON_BLOCKING_CONCURRENCY_CONTROL.name()));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -59,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.model.WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL;
 import static org.apache.hudi.common.model.WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL;
 import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_METADATA_PARTITIONS;
 import static org.apache.hudi.common.table.HoodieTableConfig.TABLE_METADATA_PARTITIONS_INFLIGHT;
@@ -246,9 +247,9 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
 
   private HoodieInstant validateAndGetIndexInstant() {
     // ensure lock provider configured
-    if (!config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
-      throw new HoodieIndexException(String.format("Need to set %s as %s and configure lock provider class",
-          WRITE_CONCURRENCY_MODE.key(), OPTIMISTIC_CONCURRENCY_CONTROL.name()));
+    if (!config.getWriteConcurrencyMode().supportsConcurrencyControl() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
+      throw new HoodieIndexException(String.format("Need to set %s as %s or %s and configure lock provider class",
+          WRITE_CONCURRENCY_MODE.key(), OPTIMISTIC_CONCURRENCY_CONTROL.name(), NON_BLOCKING_CONCURRENCY_CONTROL.name()));
     }
 
     return table.getActiveTimeline()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.model.WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL;
 import static org.apache.hudi.common.model.WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL;
 import static org.apache.hudi.config.HoodieWriteConfig.WRITE_CONCURRENCY_MODE;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.deleteMetadataPartition;
@@ -125,9 +126,9 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
       throw new HoodieIndexException("Not all index types are valid: " + partitionIndexTypes);
     }
     // ensure lock provider configured
-    if (!config.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
-      throw new HoodieIndexException(String.format("Need to set %s as %s and configure lock provider class",
-          WRITE_CONCURRENCY_MODE.key(), OPTIMISTIC_CONCURRENCY_CONTROL.name()));
+    if (!config.getWriteConcurrencyMode().supportsConcurrencyControl() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
+      throw new HoodieIndexException(String.format("Need to set %s as %s or %s and configure lock provider class",
+          WRITE_CONCURRENCY_MODE.key(), OPTIMISTIC_CONCURRENCY_CONTROL.name(), NON_BLOCKING_CONCURRENCY_CONTROL.name()));
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/ScheduleIndexActionExecutor.java
@@ -126,7 +126,7 @@ public class ScheduleIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<
       throw new HoodieIndexException("Not all index types are valid: " + partitionIndexTypes);
     }
     // ensure lock provider configured
-    if (!config.getWriteConcurrencyMode().supportsConcurrencyControl() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
+    if (!config.getWriteConcurrencyMode().supportsMultiWriter() || StringUtils.isNullOrEmpty(config.getLockProviderClass())) {
       throw new HoodieIndexException(String.format("Need to set %s as %s or %s and configure lock provider class",
           WRITE_CONCURRENCY_MODE.key(), OPTIMISTIC_CONCURRENCY_CONTROL.name(), NON_BLOCKING_CONCURRENCY_CONTROL.name()));
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
@@ -81,7 +81,7 @@ public abstract class WriteMarkers implements Serializable {
    */
   public Option<Path> create(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
-    if (writeConfig.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()
+    if (writeConfig.getWriteConcurrencyMode().supportsConcurrencyControl()
         && writeConfig.isEarlyConflictDetectionEnable()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
@@ -122,7 +122,7 @@ public abstract class WriteMarkers implements Serializable {
   public Option<Path> createIfNotExists(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
     if (writeConfig.isEarlyConflictDetectionEnable()
-        && writeConfig.getWriteConcurrencyMode().supportsOptimisticConcurrencyControl()) {
+        && writeConfig.getWriteConcurrencyMode().supportsConcurrencyControl()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
@@ -81,7 +81,7 @@ public abstract class WriteMarkers implements Serializable {
    */
   public Option<Path> create(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
-    if (writeConfig.getWriteConcurrencyMode().supportsConcurrencyControl()
+    if (writeConfig.getWriteConcurrencyMode().supportsMultiWriter()
         && writeConfig.isEarlyConflictDetectionEnable()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
@@ -122,7 +122,7 @@ public abstract class WriteMarkers implements Serializable {
   public Option<Path> createIfNotExists(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
     if (writeConfig.isEarlyConflictDetectionEnable()
-        && writeConfig.getWriteConcurrencyMode().supportsConcurrencyControl()) {
+        && writeConfig.getWriteConcurrencyMode().supportsMultiWriter()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
@@ -21,7 +21,6 @@ package org.apache.hudi.table.marker;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.IOType;
-import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -82,8 +81,7 @@ public abstract class WriteMarkers implements Serializable {
    */
   public Option<Path> create(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
-    if (writeConfig.getWriteConcurrencyMode() == WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL
-        && writeConfig.isEarlyConflictDetectionEnable()) {
+    if (writeConfig.getWriteConcurrencyMode().isOptimisticConcurrencyControl() && writeConfig.isEarlyConflictDetectionEnable()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.
@@ -123,7 +121,7 @@ public abstract class WriteMarkers implements Serializable {
   public Option<Path> createIfNotExists(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
     if (writeConfig.isEarlyConflictDetectionEnable()
-        && writeConfig.getWriteConcurrencyMode() == WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL) {
+        && writeConfig.getWriteConcurrencyMode().isOptimisticConcurrencyControl()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkers.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.marker;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.IOType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -81,7 +82,7 @@ public abstract class WriteMarkers implements Serializable {
    */
   public Option<Path> create(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
-    if (writeConfig.getWriteConcurrencyMode().supportsMultiWriter()
+    if (writeConfig.getWriteConcurrencyMode() == WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL
         && writeConfig.isEarlyConflictDetectionEnable()) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
@@ -122,7 +123,7 @@ public abstract class WriteMarkers implements Serializable {
   public Option<Path> createIfNotExists(String partitionPath, String fileName, IOType type, HoodieWriteConfig writeConfig,
                              String fileId, HoodieActiveTimeline activeTimeline) {
     if (writeConfig.isEarlyConflictDetectionEnable()
-        && writeConfig.getWriteConcurrencyMode().supportsMultiWriter()) {
+        && writeConfig.getWriteConcurrencyMode() == WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL) {
       HoodieTimeline pendingCompactionTimeline = activeTimeline.filterPendingCompactionTimeline();
       HoodieTimeline pendingReplaceTimeline = activeTimeline.filterPendingReplaceTimeline();
       // TODO If current is compact or clustering then create marker directly without early conflict detection.

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -500,6 +500,68 @@ public class TestHoodieWriteConfig {
     assertEquals("org.apache.hudi.table.action.commit.UpsertPartitioner", overwritePartitioner.getString(HoodieLayoutConfig.LAYOUT_PARTITIONER_CLASS_NAME));
   }
 
+  @Test
+  public void testAutoAdjustCleanPolicyForNonBlockingConcurrencyControl() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieTableConfig.TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withIndexConfig(
+            HoodieIndexConfig.newBuilder()
+                .fromProperties(props)
+                .withIndexType(HoodieIndex.IndexType.BUCKET)
+                .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.SIMPLE)
+                .build())
+        .withWriteConcurrencyMode(WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL)
+        .build();
+
+    // Verify automatically set hoodie.cleaner.policy.failed.writes=LAZY for non-blocking concurrency control
+    verifyConcurrencyControlRelatedConfigs(writeConfig,
+        true, true, true,
+        WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL, HoodieFailedWritesCleaningPolicy.LAZY,
+        HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.defaultValue());
+  }
+
+  @Test
+  public void testNonBlockingConcurrencyControlInvalidEarlyConflictDetection() {
+    Properties props = new Properties();
+    props.put(HoodieTableConfig.TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    HoodieWriteConfig.Builder writeConfigBuilder = HoodieWriteConfig.newBuilder().withPath("/tmp");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> writeConfigBuilder.withIndexConfig(
+            HoodieIndexConfig.newBuilder()
+                .fromProperties(props)
+                .withIndexType(HoodieIndex.IndexType.BUCKET)
+                .withBucketIndexEngineType(HoodieIndex.BucketIndexEngineType.SIMPLE)
+                .build())
+            .withWriteConcurrencyMode(WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL)
+            .withEarlyConflictDetectionEnable(true)
+            .build(),
+        "To use early conflict detection, set hoodie.write.concurrency.mode=OPTIMISTIC_CONCURRENCY_CONTROL");
+  }
+
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testNonBlockingConcurrencyControlInvalidTableTypeOrIndexType(HoodieTableType tableType) {
+    TypedProperties props = new TypedProperties();
+    props.put(HoodieTableConfig.TYPE.key(), tableType.name());
+    props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid");
+    HoodieWriteConfig.Builder writeConfigBuilder = HoodieWriteConfig.newBuilder().withPath("/tmp");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> writeConfigBuilder.withIndexConfig(
+            HoodieIndexConfig.newBuilder()
+                .fromProperties(props)
+                .withIndexType(HoodieIndex.IndexType.SIMPLE)
+                .build())
+            .withWriteConcurrencyMode(WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL)
+            .build(),
+        "Non-blocking concurrency control requires the MOR table with simple bucket index");
+  }
+
   private HoodieWriteConfig createWriteConfig(Map<String, String> configs) {
     final Properties properties = new Properties();
     configs.forEach(properties::setProperty);

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteConcurrencyMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteConcurrencyMode.java
@@ -21,6 +21,8 @@ package org.apache.hudi.common.model;
 import org.apache.hudi.common.config.EnumDescription;
 import org.apache.hudi.common.config.EnumFieldDescription;
 
+import java.util.Locale;
+
 /**
  * Different concurrency modes for write operations.
  */
@@ -37,13 +39,17 @@ public enum WriteConcurrencyMode {
       + "same file group.")
   OPTIMISTIC_CONCURRENCY_CONTROL,
 
-  // Multiple writer can perform write ops on a MOR table with simple bucket index, and defer conflict
-  // resolution to compaction phase
-  @EnumFieldDescription("Multiple writer can perform write ops on a MOR table with simple bucket index, "
-      + "and defer conflict resolution to compaction phase.")
+  // Multiple writer can perform write ops on a MOR table with non-blocking conflict resolution
+  @EnumFieldDescription("Multiple writers can operate on the table with non-blocking conflict resolution. "
+      + "The writers can write into the same file group with the conflicts resolved automatically "
+      + "by the query reader and the compactor.")
   NON_BLOCKING_CONCURRENCY_CONTROL;
 
-  public boolean supportsConcurrencyControl() {
+  public boolean supportsMultiWriter() {
     return this == OPTIMISTIC_CONCURRENCY_CONTROL || this == NON_BLOCKING_CONCURRENCY_CONTROL;
+  }
+
+  public static boolean supportsMultiWriter(String name) {
+    return WriteConcurrencyMode.valueOf(name.toUpperCase(Locale.ROOT)).supportsMultiWriter();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteConcurrencyMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteConcurrencyMode.java
@@ -52,4 +52,8 @@ public enum WriteConcurrencyMode {
   public static boolean supportsMultiWriter(String name) {
     return WriteConcurrencyMode.valueOf(name.toUpperCase(Locale.ROOT)).supportsMultiWriter();
   }
+
+  public boolean isOptimisticConcurrencyControl() {
+    return this == OPTIMISTIC_CONCURRENCY_CONTROL;
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteConcurrencyMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteConcurrencyMode.java
@@ -35,9 +35,15 @@ public enum WriteConcurrencyMode {
   @EnumFieldDescription("Multiple writers can operate on the table with lazy conflict resolution "
       + "using locks. This means that only one writer succeeds if multiple writers write to the "
       + "same file group.")
-  OPTIMISTIC_CONCURRENCY_CONTROL;
+  OPTIMISTIC_CONCURRENCY_CONTROL,
 
-  public boolean supportsOptimisticConcurrencyControl() {
-    return this == OPTIMISTIC_CONCURRENCY_CONTROL;
+  // Multiple writer can perform write ops on a MOR table with simple bucket index, and defer conflict
+  // resolution to compaction phase
+  @EnumFieldDescription("Multiple writer can perform write ops on a MOR table with simple bucket index, "
+      + "and defer conflict resolution to compaction phase.")
+  NON_BLOCKING_CONCURRENCY_CONTROL;
+
+  public boolean supportsConcurrencyControl() {
+    return this == OPTIMISTIC_CONCURRENCY_CONTROL || this == NON_BLOCKING_CONCURRENCY_CONTROL;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsInference.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsInference.java
@@ -80,7 +80,7 @@ public class OptionsInference {
    * @see ClientIds
    */
   public static void setupClientId(Configuration conf) {
-    if (OptionsResolver.isOptimisticConcurrencyControl(conf)) {
+    if (OptionsResolver.isConcurrencyControl(conf)) {
       // explicit client id always has higher priority
       if (!conf.contains(FlinkOptions.WRITE_CLIENT_ID)) {
         try (ClientIds clientIds = ClientIds.builder().conf(conf).build()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsInference.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsInference.java
@@ -80,7 +80,7 @@ public class OptionsInference {
    * @see ClientIds
    */
   public static void setupClientId(Configuration conf) {
-    if (OptionsResolver.isConcurrencyControl(conf)) {
+    if (OptionsResolver.isMultiWriter(conf)) {
       // explicit client id always has higher priority
       if (!conf.contains(FlinkOptions.WRITE_CLIENT_ID)) {
         try (ClientIds clientIds = ClientIds.builder().conf(conf).build()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -306,15 +306,14 @@ public class OptionsResolver {
    * Returns whether the writer txn should be guarded by lock.
    */
   public static boolean isLockRequired(Configuration conf) {
-    return conf.getBoolean(FlinkOptions.METADATA_ENABLED) || isConcurrencyControl(conf);
+    return conf.getBoolean(FlinkOptions.METADATA_ENABLED) || isMultiWriter(conf);
   }
 
   /**
-   * Returns whether CC is enabled, including OCC and NB-CC.
+   * Returns whether multi-writer is enabled.
    */
-  public static boolean isConcurrencyControl(Configuration conf) {
-    WriteConcurrencyMode mode = WriteConcurrencyMode.valueOf(conf.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue()).toUpperCase());
-    return mode.supportsConcurrencyControl();
+  public static boolean isMultiWriter(Configuration conf) {
+    return WriteConcurrencyMode.supportsMultiWriter(conf.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue()));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -306,15 +306,15 @@ public class OptionsResolver {
    * Returns whether the writer txn should be guarded by lock.
    */
   public static boolean isLockRequired(Configuration conf) {
-    return conf.getBoolean(FlinkOptions.METADATA_ENABLED) || isOptimisticConcurrencyControl(conf);
+    return conf.getBoolean(FlinkOptions.METADATA_ENABLED) || isConcurrencyControl(conf);
   }
 
   /**
-   * Returns whether OCC is enabled.
+   * Returns whether CC is enabled, including OCC and NB-CC.
    */
-  public static boolean isOptimisticConcurrencyControl(Configuration conf) {
-    return conf.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue())
-        .equalsIgnoreCase(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+  public static boolean isConcurrencyControl(Configuration conf) {
+    WriteConcurrencyMode mode = WriteConcurrencyMode.valueOf(conf.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue()).toUpperCase());
+    return mode.supportsConcurrencyControl();
   }
 
   /**
@@ -371,7 +371,8 @@ public class OptionsResolver {
    * Returns whether this is non-blocking concurrency control.
    */
   public static boolean isNonBlockingConcurrencyControl(Configuration config) {
-    return isMorTable(config) && isSimpleBucketIndexType(config) && isOptimisticConcurrencyControl(config);
+    return config.getString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue())
+        .equalsIgnoreCase(WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
   }
 
   public static boolean isLazyFailedWritesCleanPolicy(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -202,7 +202,7 @@ public class StreamWriteOperatorCoordinator
       initHiveSync();
     }
     // start client id heartbeats for optimistic concurrency control
-    if (OptionsResolver.isOptimisticConcurrencyControl(conf)) {
+    if (OptionsResolver.isConcurrencyControl(conf)) {
       initClientIds(conf);
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -202,7 +202,7 @@ public class StreamWriteOperatorCoordinator
       initHiveSync();
     }
     // start client id heartbeats for optimistic concurrency control
-    if (OptionsResolver.isConcurrencyControl(conf)) {
+    if (OptionsResolver.isMultiWriter(conf)) {
       initClientIds(conf);
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -22,6 +22,7 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.config.HoodieCleanConfig;
@@ -41,14 +42,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -524,9 +524,9 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   //      |----------- txn1 -----------|
   //              | ----- txn2 ----- |
   @ParameterizedTest
-  @ValueSource(strings = {"OPTIMISTIC_CONCURRENCY_CONTROL", "NON_BLOCKING_CONCURRENCY_CONTROL"})
-  public void testWriteMultiWriterInvolved(String writeConcurrencyMode) throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), writeConcurrencyMode);
+  @EnumSource(value = WriteConcurrencyMode.class, names = {"OPTIMISTIC_CONCURRENCY_CONTROL", "NON_BLOCKING_CONCURRENCY_CONTROL"})
+  public void testWriteMultiWriterInvolved(WriteConcurrencyMode writeConcurrencyMode) throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), writeConcurrencyMode.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
@@ -578,9 +578,9 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   //      |----------- txn1 -----------|
   //                       | ----- txn2 ----- |
   @ParameterizedTest
-  @ValueSource(strings = {"OPTIMISTIC_CONCURRENCY_CONTROL", "NON_BLOCKING_CONCURRENCY_CONTROL"})
-  public void testWriteMultiWriterPartialOverlapping(String writeConcurrencyMode) throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), writeConcurrencyMode);
+  @EnumSource(value = WriteConcurrencyMode.class, names = {"OPTIMISTIC_CONCURRENCY_CONTROL", "NON_BLOCKING_CONCURRENCY_CONTROL"})
+  public void testWriteMultiWriterPartialOverlapping(WriteConcurrencyMode writeConcurrencyMode) throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), writeConcurrencyMode.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
@@ -659,6 +659,6 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   }
 
   protected HoodieTableType getTableType() {
-    return COPY_ON_WRITE;
+    return HoodieTableType.COPY_ON_WRITE;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -530,7 +530,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
-    if (isCowAndNonBlockingConcurrencyControl(writeConcurrencyMode)) {
+    if (OptionsResolver.isCowTable(conf) && OptionsResolver.isNonBlockingConcurrencyControl(conf)) {
       validateNonBlockingConcurrencyControlConditions();
     } else {
       TestHarness pipeline1 = preparePipeline(conf)
@@ -584,7 +584,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
-    if (isCowAndNonBlockingConcurrencyControl(writeConcurrencyMode)) {
+    if (OptionsResolver.isCowTable(conf) && OptionsResolver.isNonBlockingConcurrencyControl(conf)) {
       validateNonBlockingConcurrencyControlConditions();
     } else {
       TestHarness pipeline1 = preparePipeline(conf)
@@ -660,9 +660,5 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
 
   protected HoodieTableType getTableType() {
     return COPY_ON_WRITE;
-  }
-
-  private boolean isCowAndNonBlockingConcurrencyControl(String writeConcurrencyMode) {
-    return getTableType() == COPY_ON_WRITE && writeConcurrencyMode.equals("NON_BLOCKING_CONCURRENCY_CONTROL");
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -22,7 +22,6 @@ import org.apache.hudi.client.HoodieFlinkWriteClient;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieTableType;
-import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.config.HoodieCleanConfig;
@@ -41,14 +40,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test cases for stream write.
@@ -520,27 +523,39 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   // case1: txn2's time range is involved in txn1
   //      |----------- txn1 -----------|
   //              | ----- txn2 ----- |
-  @Test
-  public void testWriteMultiWriterInvolved() throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+  @ParameterizedTest
+  @ValueSource(strings = {"OPTIMISTIC_CONCURRENCY_CONTROL", "NON_BLOCKING_CONCURRENCY_CONTROL"})
+  public void testWriteMultiWriterInvolved(String writeConcurrencyMode) throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), writeConcurrencyMode);
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
-    TestHarness pipeline1 = preparePipeline(conf)
-        .consume(TestData.DATA_SET_INSERT_DUPLICATES)
-        .assertEmptyDataFiles();
-    // now start pipeline2 and commit the txn
-    Configuration conf2 = conf.clone();
-    conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
-    preparePipeline(conf2)
-        .consume(TestData.DATA_SET_INSERT_DUPLICATES)
-        .assertEmptyDataFiles()
-        .checkpoint(1)
-        .assertNextEvent()
-        .checkpointComplete(1)
-        .checkWrittenData(EXPECTED3, 1);
-    // step to commit the 2nd txn
-    validateConcurrentCommit(pipeline1);
+    if (isCowAndNonBlockingConcurrencyControl(writeConcurrencyMode)) {
+      validateNonBlockingConcurrencyControlConditions();
+    } else {
+      TestHarness pipeline1 = preparePipeline(conf)
+          .consume(TestData.DATA_SET_INSERT_DUPLICATES)
+          .assertEmptyDataFiles();
+      // now start pipeline2 and commit the txn
+      Configuration conf2 = conf.clone();
+      conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
+      preparePipeline(conf2)
+          .consume(TestData.DATA_SET_INSERT_DUPLICATES)
+          .assertEmptyDataFiles()
+          .checkpoint(1)
+          .assertNextEvent()
+          .checkpointComplete(1)
+          .checkWrittenData(EXPECTED3, 1);
+      // step to commit the 2nd txn
+      validateConcurrentCommit(pipeline1);
+    }
+  }
+
+  protected void validateNonBlockingConcurrencyControlConditions() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> preparePipeline(conf),
+        "Non-blocking concurrency control requires the MOR table with simple bucket index");
   }
 
   private void validateConcurrentCommit(TestHarness pipeline) throws Exception {
@@ -562,32 +577,37 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   // case2: txn2's time range has partial overlap with txn1
   //      |----------- txn1 -----------|
   //                       | ----- txn2 ----- |
-  @Test
-  public void testWriteMultiWriterPartialOverlapping() throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+  @ParameterizedTest
+  @ValueSource(strings = {"OPTIMISTIC_CONCURRENCY_CONTROL", "NON_BLOCKING_CONCURRENCY_CONTROL"})
+  public void testWriteMultiWriterPartialOverlapping(String writeConcurrencyMode) throws Exception {
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), writeConcurrencyMode);
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setBoolean(FlinkOptions.PRE_COMBINE, true);
 
-    TestHarness pipeline1 = preparePipeline(conf)
-        .consume(TestData.DATA_SET_INSERT_DUPLICATES)
-        .assertEmptyDataFiles();
-    // now start pipeline2 and suspend the txn commit
-    Configuration conf2 = conf.clone();
-    conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
-    TestHarness pipeline2 = preparePipeline(conf2)
-        .consume(TestData.DATA_SET_INSERT_DUPLICATES)
-        .assertEmptyDataFiles();
+    if (isCowAndNonBlockingConcurrencyControl(writeConcurrencyMode)) {
+      validateNonBlockingConcurrencyControlConditions();
+    } else {
+      TestHarness pipeline1 = preparePipeline(conf)
+          .consume(TestData.DATA_SET_INSERT_DUPLICATES)
+          .assertEmptyDataFiles();
+      // now start pipeline2 and suspend the txn commit
+      Configuration conf2 = conf.clone();
+      conf2.setString(FlinkOptions.WRITE_CLIENT_ID, "2");
+      TestHarness pipeline2 = preparePipeline(conf2)
+          .consume(TestData.DATA_SET_INSERT_DUPLICATES)
+          .assertEmptyDataFiles();
 
-    // step to commit the 1st txn, should succeed
-    pipeline1.checkpoint(1)
-        .assertNextEvent()
-        .checkpointComplete(1)
-        .checkWrittenData(EXPECTED3, 1);
+      // step to commit the 1st txn, should succeed
+      pipeline1.checkpoint(1)
+          .assertNextEvent()
+          .checkpointComplete(1)
+          .checkWrittenData(EXPECTED3, 1);
 
-    // step to commit the 2nd txn
-    // should success for concurrent modification of same fileGroups if using non-blocking concurrency control
-    // should throw exception otherwise
-    validateConcurrentCommit(pipeline2);
+      // step to commit the 2nd txn
+      // should success for concurrent modification of same fileGroups if using non-blocking concurrency control
+      // should throw exception otherwise
+      validateConcurrentCommit(pipeline2);
+    }
   }
 
   @Test
@@ -639,6 +659,10 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
   }
 
   protected HoodieTableType getTableType() {
-    return HoodieTableType.COPY_ON_WRITE;
+    return COPY_ON_WRITE;
+  }
+
+  private boolean isCowAndNonBlockingConcurrencyControl(String writeConcurrencyMode) {
+    return getTableType() == COPY_ON_WRITE && writeConcurrencyMode.equals("NON_BLOCKING_CONCURRENCY_CONTROL");
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -133,7 +133,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     // There is no base file in partition dir because there is no compaction yet.
     pipeline1.assertEmptyDataFiles();
 
-    // schedule compaction outside of all writers
+    // schedule compaction outside all writers
     try (HoodieFlinkWriteClient writeClient = FlinkWriteClients.createWriteClient(conf)) {
       Option<String> scheduleInstant = writeClient.scheduleCompaction(Option.empty());
       assertNotNull(scheduleInstant.get());
@@ -199,7 +199,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     pipeline2.checkpoint(1)
         .assertNextEvent();
 
-    // schedule compaction outside of all writers
+    // schedule compaction outside all writers
     try (HoodieFlinkWriteClient writeClient = FlinkWriteClients.createWriteClient(conf)) {
       Option<String> scheduleInstant = writeClient.scheduleCompaction(Option.empty());
       assertNotNull(scheduleInstant.get());
@@ -234,7 +234,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   //                       |----- txn2 ------|
   // the txn2 would fail to commit caused by conflict
   @Test
-  public void testBulkInsertInMultiWriter() throws Exception {
+  public void testBulkInsertWithNonBlockingConcurrencyControl() throws Exception {
     conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
@@ -276,7 +276,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   //      |----------- txn2 -----------|
   // both two txn would success to commit
   @Test
-  public void testBulkInsertInSequence() throws Exception {
+  public void testBulkInsertInSequenceWithNonBlockingConcurrencyControl() throws Exception {
     conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
@@ -316,7 +316,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
     Map<String, String> tmpSnapshotResult = Collections.singletonMap("par1", "[id1,par1,id1,Danny,23,2,par1]");
     pipeline2.checkWrittenData(tmpSnapshotResult, 1);
 
-    // schedule compaction outside of all writers
+    // schedule compaction outside all writers
     try (HoodieFlinkWriteClient writeClient = FlinkWriteClients.createWriteClient(conf)) {
       Option<String> scheduleInstant = writeClient.scheduleCompaction(Option.empty());
       assertNotNull(scheduleInstant.get());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnReadWithCompact.java
@@ -89,7 +89,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
 
   @Test
   public void testNonBlockingConcurrencyControlWithPartialUpdatePayload() throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
     // disable schedule compaction in writers
@@ -163,7 +163,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
 
   @Test
   public void testNonBlockingConcurrencyControlWithInflightInstant() throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     // disable schedule compaction in writers
     conf.setBoolean(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, false);
@@ -235,7 +235,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   // the txn2 would fail to commit caused by conflict
   @Test
   public void testBulkInsertInMultiWriter() throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
     // disable schedule compaction in writers
@@ -277,7 +277,7 @@ public class TestWriteMergeOnReadWithCompact extends TestWriteCopyOnWrite {
   // both two txn would success to commit
   @Test
   public void testBulkInsertInSequence() throws Exception {
-    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    conf.setString(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
     conf.setString(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.setString(FlinkOptions.PAYLOAD_CLASS_NAME, PartialUpdateAvroPayload.class.getName());
     // disable schedule compaction in writers

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -551,7 +551,7 @@ public class TestWriteBase {
     protected String lastCompleteInstant() {
       // If using optimistic concurrency control, fetch last complete instant of current writer from ckp metadata
       // because there are multiple write clients commit to the timeline.
-      if (OptionsResolver.isConcurrencyControl(conf)) {
+      if (OptionsResolver.isMultiWriter(conf)) {
         return this.ckpMetadata.lastCompleteInstant();
       } else {
         // fetch the instant from timeline.

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -551,7 +551,7 @@ public class TestWriteBase {
     protected String lastCompleteInstant() {
       // If using optimistic concurrency control, fetch last complete instant of current writer from ckp metadata
       // because there are multiple write clients commit to the timeline.
-      if (OptionsResolver.isOptimisticConcurrencyControl(conf)) {
+      if (OptionsResolver.isConcurrencyControl(conf)) {
         return this.ckpMetadata.lastCompleteInstant();
       } else {
         // fetch the instant from timeline.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -165,7 +165,7 @@ class DefaultSource extends RelationProvider
 
   def validateMultiWriterConfigs(options: Map[String, String]) : Unit = {
     if (ConfigUtils.resolveEnum(classOf[WriteConcurrencyMode], options.getOrDefault(WRITE_CONCURRENCY_MODE.key(),
-      WRITE_CONCURRENCY_MODE.defaultValue())) == WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL) {
+      WRITE_CONCURRENCY_MODE.defaultValue())).supportsConcurrencyControl()) {
       // ensure some valid value is set for identifier
       checkState(options.contains(STREAMING_CHECKPOINT_IDENTIFIER.key()), "For multi-writer scenarios, please set "
         + STREAMING_CHECKPOINT_IDENTIFIER.key() + ". Each writer should set different values for this identifier")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -165,7 +165,7 @@ class DefaultSource extends RelationProvider
 
   def validateMultiWriterConfigs(options: Map[String, String]) : Unit = {
     if (ConfigUtils.resolveEnum(classOf[WriteConcurrencyMode], options.getOrDefault(WRITE_CONCURRENCY_MODE.key(),
-      WRITE_CONCURRENCY_MODE.defaultValue())).supportsConcurrencyControl()) {
+      WRITE_CONCURRENCY_MODE.defaultValue())).supportsMultiWriter()) {
       // ensure some valid value is set for identifier
       checkState(options.contains(STREAMING_CHECKPOINT_IDENTIFIER.key()), "For multi-writer scenarios, please set "
         + STREAMING_CHECKPOINT_IDENTIFIER.key() + ". Each writer should set different values for this identifier")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -181,7 +181,7 @@ class HoodieSparkSqlWriterInternal {
       } catch {
         case e: HoodieWriteConflictException =>
           val writeConcurrencyMode = optParams.getOrElse(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue()).toUpperCase
-          if (WriteConcurrencyMode.valueOf(writeConcurrencyMode).supportsConcurrencyControl() && counter < maxRetry) {
+          if (WriteConcurrencyMode.valueOf(writeConcurrencyMode).supportsMultiWriter() && counter < maxRetry) {
             counter += 1
             log.warn(s"Conflict found. Retrying again for attempt no $counter")
           } else {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -180,8 +180,8 @@ class HoodieSparkSqlWriterInternal {
         succeeded = true
       } catch {
         case e: HoodieWriteConflictException =>
-          val writeConcurrencyMode = optParams.getOrElse(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue()).toUpperCase
-          if (WriteConcurrencyMode.valueOf(writeConcurrencyMode).supportsMultiWriter() && counter < maxRetry) {
+          val writeConcurrencyMode = optParams.getOrElse(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue())
+          if (WriteConcurrencyMode.supportsMultiWriter(writeConcurrencyMode) && counter < maxRetry) {
             counter += 1
             log.warn(s"Conflict found. Retrying again for attempt no $counter")
           } else {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -180,8 +180,8 @@ class HoodieSparkSqlWriterInternal {
         succeeded = true
       } catch {
         case e: HoodieWriteConflictException =>
-          val writeConcurrencyMode = optParams.getOrElse(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue())
-          if (writeConcurrencyMode.equalsIgnoreCase(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name()) && counter < maxRetry) {
+          val writeConcurrencyMode = optParams.getOrElse(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), HoodieWriteConfig.WRITE_CONCURRENCY_MODE.defaultValue()).toUpperCase
+          if (WriteConcurrencyMode.valueOf(writeConcurrencyMode).supportsConcurrencyControl() && counter < maxRetry) {
             counter += 1
             log.warn(s"Conflict found. Retrying again for attempt no $counter")
           } else {


### PR DESCRIPTION
### Change Logs

Currently, non-blocking concurrency control is enabled if a job config satisfy 'OCC + MOR + simple bucket index'.
It's a litter confusing and might lead to unexpected behavior under some cases.
It's better to create a new `WriteConcurrencyMode` type for non-blocking concurrency control .

### Impact

NA

### Risk level (write none, low medium or high below)

NA

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
