### PR TITLE
[HUDI-7002] Fixing initializing RLI MDT partition for non-partitioned dataset

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1738,7 +1738,7 @@ public class HoodieTableMetadataUtil {
       final String partition = partitionAndBaseFile.getKey();
       final HoodieBaseFile baseFile = partitionAndBaseFile.getValue();
       final String filename = baseFile.getFileName();
-      Path dataFilePath = new Path(basePath, partition + Path.SEPARATOR + filename);
+      Path dataFilePath = new Path(basePath, StringUtils.isNullOrEmpty(partition) ? filename : (partition + Path.SEPARATOR) + filename);
 
       final String fileId = baseFile.getFileId();
       final String instantTime = baseFile.getCommitTime();


### PR DESCRIPTION
### Change Logs

Initializing RLI for an existing table had a minor bug for non-partitioned dataset. Fixing as part of the patch. 

### Impact

Opens up RLI for non partitioned dataset. 

### Risk level (write none, low medium or high below)

low.

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
