### PR TITLE
[HUDI-7005] Fix hudi-aws-bundle relocation issue with avro

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -78,12 +78,9 @@ public class HiveSyncContext {
   public HiveSyncTool hiveSyncTool() {
     HiveSyncMode syncMode = HiveSyncMode.of(props.getProperty(HIVE_SYNC_MODE.key()));
     if (syncMode == HiveSyncMode.GLUE) {
-      if (ReflectionUtils.hasConstructor(AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
-          new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class})) {
-        return ((HiveSyncTool) ReflectionUtils.loadClass(AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
-            new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class},
-            props, hiveConf));
-      }
+      return ((HiveSyncTool) ReflectionUtils.loadClass(AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
+          new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class},
+          props, hiveConf));
     }
     return new HiveSyncTool(props, hiveConf);
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -18,9 +18,9 @@
 
 package org.apache.hudi.sink.utils;
 
-import org.apache.hudi.aws.sync.AwsGlueCatalogSyncTool;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.hive.HiveSyncTool;
@@ -67,6 +67,9 @@ public class HiveSyncContext {
   private final Properties props;
   private final HiveConf hiveConf;
 
+  public static final String AWS_GLUE_CATALOG_SYNC_TOOL_CLASS =
+      "org.apache.hudi.aws.sync.AwsGlueCatalogSyncTool";
+
   private HiveSyncContext(Properties props, HiveConf hiveConf) {
     this.props = props;
     this.hiveConf = hiveConf;
@@ -75,7 +78,12 @@ public class HiveSyncContext {
   public HiveSyncTool hiveSyncTool() {
     HiveSyncMode syncMode = HiveSyncMode.of(props.getProperty(HIVE_SYNC_MODE.key()));
     if (syncMode == HiveSyncMode.GLUE) {
-      return new AwsGlueCatalogSyncTool(props, hiveConf);
+      if (ReflectionUtils.hasConstructor(AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
+          new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class})) {
+        return ((HiveSyncTool) ReflectionUtils.loadClass(AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
+            new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class},
+            props, hiveConf));
+      }
     }
     return new HiveSyncTool(props, hiveConf);
   }

--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -72,12 +72,10 @@
                             </transformers>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>org.apache.hudi:hudi-common</include>
                                     <include>org.apache.hudi:hudi-hadoop-mr</include>
                                     <include>org.apache.hudi:hudi-sync-common</include>
                                     <include>org.apache.hudi:hudi-hive-sync</include>
                                     <include>org.apache.hudi:hudi-aws</include>
-                                    <include>org.apache.parquet:parquet-avro</include>
                                     <include>org.reactivestreams:reactive-streams</include>
                                     <include>com.amazonaws:dynamodb-lock-client</include>
                                     <include>org.apache.httpcomponents:httpclient</include>
@@ -88,7 +86,6 @@
                                     <include>com.beust:jcommander</include>
                                     <include>commons-io:commons-io</include>
                                     <include>org.openjdk.jol:jol-core</include>
-                                    <include>org.apache.avro:avro</include>
                                 </includes>
                             </artifactSet>
                             <relocations combine.children="append">
@@ -115,10 +112,6 @@
                                 <relocation>
                                     <pattern>org.apache.httpcomponents.</pattern>
                                     <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.avro.</pattern>
-                                    <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
                                 </relocation>
                             </relocations>
                             <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -88,6 +88,7 @@
                                     <include>com.beust:jcommander</include>
                                     <include>commons-io:commons-io</include>
                                     <include>org.openjdk.jol:jol-core</include>
+                                    <include>org.apache.avro:avro</include>
                                 </includes>
                             </artifactSet>
                             <relocations combine.children="append">
@@ -114,6 +115,10 @@
                                 <relocation>
                                     <pattern>org.apache.httpcomponents.</pattern>
                                     <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.avro.</pattern>
+                                    <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
                                 </relocation>
                             </relocations>
                             <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -84,7 +84,6 @@
                   <include>org.apache.hudi:hudi-sync-common</include>
                   <include>org.apache.hudi:hudi-hadoop-mr</include>
                   <include>org.apache.hudi:hudi-timeline-service</include>
-                  <include>org.apache.hudi:hudi-aws</include>
 
                   <!-- Kryo -->
                   <include>com.esotericsoftware:kryo-shaded</include>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -110,6 +110,10 @@
                   <pattern>org.objenesis.</pattern>
                   <shadedPattern>org.apache.hudi.org.objenesis.</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.avro.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
+                </relocation>
               </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -110,10 +110,6 @@
                   <pattern>org.objenesis.</pattern>
                   <shadedPattern>org.apache.hudi.org.objenesis.</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.apache.avro.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
-                </relocation>
               </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>


### PR DESCRIPTION
### Change Logs

Relocates org.apache.avro to org.apache.hudi.org.apache.avro while shading hudi-common classes in hudi-hive-sync-bundle and hudi-aws-bundle to avoid conflicts while working with hudi-flink-bundle and any other bundle where it is relocated already.

### Impact

Flink SQL Client Fixes.

### Risk level (write none, low medium or high below)

low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
