### PR TITLE
[HUDI-7009] Filtering out null values from avro kafka source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/AvroKafkaSource.java
@@ -103,14 +103,14 @@ public class AvroKafkaSource extends KafkaSource<GenericRecord> {
       //Don't want kafka offsets here so we use originalSchemaProvider
       AvroConvertor convertor = new AvroConvertor(originalSchemaProvider.getSourceSchema());
       kafkaRDD = KafkaUtils.<String, byte[]>createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges,
-          LocationStrategies.PreferConsistent()).map(obj ->
+          LocationStrategies.PreferConsistent()).filter(obj -> obj.value() != null).map(obj ->
           new ConsumerRecord<>(obj.topic(), obj.partition(), obj.offset(),
               obj.key(), convertor.fromAvroBinary(obj.value())));
     } else {
       kafkaRDD = KafkaUtils.createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges,
           LocationStrategies.PreferConsistent());
     }
-    return maybeAppendKafkaOffsets(kafkaRDD);
+    return maybeAppendKafkaOffsets(kafkaRDD.filter(consemerRec -> consemerRec.value() != null));
   }
 
   protected JavaRDD<GenericRecord> maybeAppendKafkaOffsets(JavaRDD<ConsumerRecord<Object, Object>> kafkaRDD) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestAvroKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestAvroKafkaSource.java
@@ -126,11 +126,10 @@ public class TestAvroKafkaSource extends SparkClientFunctionalTestHarness {
   }
 
   void sendMessagesToKafkaWithNullKafkaValue(String topic, int count, int numPartitions) {
-    List<GenericRecord> genericRecords = dataGen.generateGenericRecords(count);
     Properties config = getProducerProperties();
     try (Producer<String, byte[]> producer = new KafkaProducer<>(config)) {
-      for (int i = 0; i < genericRecords.size(); i++) {
-        // null kafka key
+      for (int i = 0; i < count; i++) {
+        // null kafka value
         producer.send(new ProducerRecord<>(topic, i % numPartitions, "key", null));
       }
     }


### PR DESCRIPTION
### Change Logs

- Filtering out null values from avro kafka source
- Tombstone records could have null values and hence filtering them out.

### Impact

- Will unblock pipelines having tombstone records in kafka (postgres debezium for eg)

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
