### PR TITLE
[HUDI-7011] a metric to indicate whether rollback has occurred in final compaction state

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkCompactionMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkCompactionMetrics.java
@@ -70,7 +70,7 @@ public class FlinkCompactionMetrics extends FlinkWriteMetrics {
    * Flag saying whether the compaction is completed or been rolled back.
    *
    */
-  private long compactionFailedState;
+  private long compactionStateSignal;
 
   public FlinkCompactionMetrics(MetricGroup metricGroup) {
     super(metricGroup, HoodieTimeline.COMPACTION_ACTION);
@@ -82,7 +82,7 @@ public class FlinkCompactionMetrics extends FlinkWriteMetrics {
     metricGroup.gauge(getMetricsName(actionType, "pendingCompactionCount"), () -> pendingCompactionCount);
     metricGroup.gauge(getMetricsName(actionType, "compactionDelay"), () -> compactionDelay);
     metricGroup.gauge(getMetricsName(actionType, "compactionCost"), () -> compactionCost);
-    metricGroup.gauge(getMetricsName(actionType, "compactionFailedState"), () -> compactionFailedState);
+    metricGroup.gauge(getMetricsName(actionType, "compactionStateSignal"), () -> compactionStateSignal);
   }
 
   public void setPendingCompactionCount(int pendingCompactionCount) {
@@ -111,11 +111,11 @@ public class FlinkCompactionMetrics extends FlinkWriteMetrics {
   }
 
   public void markCompactionCompleted() {
-    this.compactionFailedState = 0L;
+    this.compactionStateSignal = 0L;
   }
 
   public void markCompactionRolledBack() {
-    this.compactionFailedState = 1L;
+    this.compactionStateSignal = 1L;
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkCompactionMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkCompactionMetrics.java
@@ -66,6 +66,12 @@ public class FlinkCompactionMetrics extends FlinkWriteMetrics {
    */
   private long compactionCost;
 
+  /**
+   * Flag saying whether the compaction is completed or been rolled back.
+   *
+   */
+  private long compactionFailedState;
+
   public FlinkCompactionMetrics(MetricGroup metricGroup) {
     super(metricGroup, HoodieTimeline.COMPACTION_ACTION);
   }
@@ -76,6 +82,7 @@ public class FlinkCompactionMetrics extends FlinkWriteMetrics {
     metricGroup.gauge(getMetricsName(actionType, "pendingCompactionCount"), () -> pendingCompactionCount);
     metricGroup.gauge(getMetricsName(actionType, "compactionDelay"), () -> compactionDelay);
     metricGroup.gauge(getMetricsName(actionType, "compactionCost"), () -> compactionCost);
+    metricGroup.gauge(getMetricsName(actionType, "compactionFailedState"), () -> compactionFailedState);
   }
 
   public void setPendingCompactionCount(int pendingCompactionCount) {
@@ -101,6 +108,14 @@ public class FlinkCompactionMetrics extends FlinkWriteMetrics {
 
   public void endCompaction() {
     this.compactionCost = stopTimer(COMPACTION_KEY);
+  }
+
+  public void markCompactionCompleted() {
+    this.compactionFailedState = 0L;
+  }
+
+  public void markCompactionRolledBack() {
+    this.compactionFailedState = 1L;
   }
 
 }


### PR DESCRIPTION
currently, when flink job start async compaction on a mor table, the metrics in org.apache.hudi.metrics.FlinkCompactionMetrics 
will update including pendingCompactionCount,compactionDelay,compactionCost. However, when a compaction failed need a metric to
help user to know specific instant whether the final compaction has occured rollback.
so attemp to add a metric named compactionFailedState in org.apache.hudi.sink.compact.CompactionCommitSink to record the instance
happend rollback, which also means the current compaction failed in current time

### Change Logs

add a metric named compactionFailedState in org.apache.hudi.sink.compact.CompactionCommitSink to record the instance
happend rollback, which also means the current compaction failed in current time

### Impact

no impact

### Risk level (write none, low medium or high below)

low medium

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
