### PR TITLE
[HUDI-7010] Build clustering group reduces redundant traversals

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -79,6 +79,11 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
         fileSliceGroups.add(Pair.of(currentGroup, numOutputGroups));
         currentGroup = new ArrayList<>();
         totalSizeSoFar = 0;
+
+        // if fileSliceGroups's size reach the max group, stop loop
+        if (fileSliceGroups.size() >= writeConfig.getClusteringMaxNumGroups()) {
+          break;
+        }
       }
 
       // Add to the current file-group

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestSparkBuildClusteringGroupsForPartition.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestSparkBuildClusteringGroupsForPartition.java
@@ -90,12 +90,11 @@ public class TestSparkBuildClusteringGroupsForPartition {
     List<FileSlice> fileSliceGroups = new ArrayList<>();
     String partition = "par0";
     String fileId;
-    for (int i = 1 ; i <= 4; i++) {
+    for (int i = 1; i <= 4; i++) {
       fileId = "fg-" + i;
       fileSliceGroups.add(generateFileSliceWithLen(partition, fileId, String.valueOf(i), 100));
     }
-    HoodieWriteConfig writeConfig = hoodieWriteConfigBuilder.
-        withClusteringConfig(
+    HoodieWriteConfig writeConfig = hoodieWriteConfigBuilder.withClusteringConfig(
             HoodieClusteringConfig.newBuilder()
                 .withClusteringPlanPartitionFilterMode(ClusteringPlanPartitionFilterMode.NONE)
                 .withClusteringMaxNumGroups(2)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestSparkBuildClusteringGroupsForPartition.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestSparkBuildClusteringGroupsForPartition.java
@@ -85,9 +85,40 @@ public class TestSparkBuildClusteringGroupsForPartition {
     assertEquals(0, groupStreamWithOutSort.count());
   }
 
+  @Test
+  public void testBuildClusteringGroupsWithLimitScan() {
+    List<FileSlice> fileSliceGroups = new ArrayList<>();
+    String partition = "par0";
+    String fileId;
+    for (int i = 1 ; i <= 4; i++) {
+      fileId = "fg-" + i;
+      fileSliceGroups.add(generateFileSliceWithLen(partition, fileId, String.valueOf(i), 100));
+    }
+    HoodieWriteConfig writeConfig = hoodieWriteConfigBuilder.
+        withClusteringConfig(
+            HoodieClusteringConfig.newBuilder()
+                .withClusteringPlanPartitionFilterMode(ClusteringPlanPartitionFilterMode.NONE)
+                .withClusteringMaxNumGroups(2)
+                .withClusteringTargetFileMaxBytes(100)
+                .withClusteringMaxBytesInGroup(100)
+                .build())
+        .build();
+    PartitionAwareClusteringPlanStrategy clusteringPlanStrategy = new SparkSizeBasedClusteringPlanStrategy(table, context, writeConfig);
+    Stream<HoodieClusteringGroup> groups = clusteringPlanStrategy.buildClusteringGroupsForPartition(partition,fileSliceGroups);
+    assertEquals(2, groups.count());
+  }
+
   private FileSlice generateFileSlice(String partitionPath, String fileId, String baseInstant) {
     FileSlice fs = new FileSlice(new HoodieFileGroupId(partitionPath, fileId), baseInstant);
     fs.setBaseFile(new HoodieBaseFile(FSUtils.makeBaseFileName(baseInstant, "1-0-1", fileId)));
+    return fs;
+  }
+
+  private FileSlice generateFileSliceWithLen(String partitionPath, String fileId, String baseInstant, long fileLen) {
+    FileSlice fs = new FileSlice(new HoodieFileGroupId(partitionPath, fileId), baseInstant);
+    HoodieBaseFile hoodieBaseFile = new HoodieBaseFile(FSUtils.makeBaseFileName(baseInstant, "1-0-1", fileId));
+    hoodieBaseFile.setFileLen(fileLen);
+    fs.setBaseFile(hoodieBaseFile);
     return fs;
   }
 }


### PR DESCRIPTION
### Change Logs

We build clustering group and get the final clustering plan with `getWriteConfig().getClusteringMaxNumGroups()` size. So there is no need to travel all FileSlices in `buildClusteringGroupsForPartition` method in some cases.

```
// PartitionAwareClusteringPlanStrategy
List<HoodieClusteringGroup> clusteringGroups = getEngineContext()
        .flatMap(
            partitionPaths,
            partitionPath -> {
              List<FileSlice> fileSlicesEligible = getFileSlicesEligibleForClustering(partitionPath).collect(Collectors.toList());
              return buildClusteringGroupsForPartition(partitionPath, fileSlicesEligible).limit(getWriteConfig().getClusteringMaxNumGroups());
            },
            partitionPaths.size())
        .stream()
        .limit(getWriteConfig().getClusteringMaxNumGroups())
        .collect(Collectors.toList());
```

### Impact

none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
