### PR TITLE
[HUDI-7016] Fix bundling of RoaringBitmap dependency

### DIFF
--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -91,6 +91,7 @@
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
+                  <include>org.roaringbitmap:RoaringBitmap</include>
                   <!-- Bundle Jackson JSR310 library since it is not present in spark 2.x. For spark 3.x this will
                        bundle the same JSR310 version that is included in spark runtime -->
                   <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
@@ -194,6 +195,10 @@
                 <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.roaringbitmap.</pattern>
+                  <shadedPattern>org.apache.hudi.org.roaringbitmap.</shadedPattern>
                 </relocation>
               </relocations>
               <filters>


### PR DESCRIPTION
### Change Logs

This PR fixes the bundling of RoaringBitmap dependency in Hudi bundles by including it in the shade rules and shading the classes, to avoid dependency conflict with engine-provided jars, e.g., Spark.

Before this fix, with Hudi Spark bundle, the following exception is thrown by Spark 3.2:
```
Caused by: java.lang.NoSuchMethodError: org.roaringbitmap.longlong.Roaring64NavigableMap.serializePortable(Ljava/io/DataOutput;)V
	at org.apache.hudi.common.table.log.LogReaderUtils.encodePositions(LogReaderUtils.java:128)
	at org.apache.hudi.common.table.log.LogReaderUtils.encodePositions(LogReaderUtils.java:109)
	at org.apache.hudi.common.table.log.block.HoodieLogBlock.addRecordPositionsToHeader(HoodieLogBlock.java:147)
	at org.apache.hudi.common.table.log.block.HoodieDeleteBlock.<init>(HoodieDeleteBlock.java:88)
	at org.apache.hudi.io.HoodieAppendHandle.appendDataAndDeleteBlocks(HoodieAppendHandle.java:480)
	at org.apache.hudi.io.HoodieAppendHandle.doAppend(HoodieAppendHandle.java:454)
	at org.apache.hudi.table.action.deltacommit.BaseSparkDeltaCommitActionExecutor.handleUpdate(BaseSparkDeltaCommitActionExecutor.java:83)
	at org.apache.hudi.table.action.commit.BaseSparkCommitActionExecutor.handleUpsertPartition(BaseSparkCommitActionExecutor.java:313)
	... 28 more 
```

### Impact

Fix the bundling of RoaringBitmap dependency.

The bundle size is only slightly increased (~400KB):
Before
```
   24069469 Oct 31 14:45 hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT-sources.jar
  104788296 Oct 31 14:45 hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT.jar
      10535 Oct 31 14:44 original-hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT-sources.jar
      14600 Oct 31 14:44 original-hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT.jar
```
After
```
   24345617 Oct 31 15:13 hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT-sources.jar
  105241434 Oct 31 15:13 hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT.jar
      10535 Oct 31 15:12 original-hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT-sources.jar
      14627 Oct 31 15:12 original-hudi-spark3.3-bundle_2.12-1.0.0-SNAPSHOT.jar
```

### Risk level

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
