### PR TITLE
[HUDI-7022] RunClusteringProcedure support limit parameter

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureUtils.scala
@@ -99,7 +99,8 @@ object HoodieProcedureUtils {
     }
   }
 
-  def filterPendingInstantsAndGetOperation(pendingInstants: Seq[String], specificInstants: Option[String], op: Option[String]): (Seq[String], Operation) = {
+  def filterPendingInstantsAndGetOperation(pendingInstants: Seq[String], specificInstants: Option[String],
+                                           op: Option[String], limit: Option[Int] = None): (Seq[String], Operation) = {
     specificInstants match {
       case Some(inst) =>
         if (op.exists(o => !Execute.value.equalsIgnoreCase(o))) {
@@ -109,7 +110,11 @@ object HoodieProcedureUtils {
         (HoodieProcedureUtils.checkAndFilterPendingInstants(pendingInstants, inst), Execute)
       case _ =>
         // No op specified, set it as 'scheduleAndExecute' default
-        (pendingInstants, op.map(o => Operation.fromValue(o.toLowerCase)).getOrElse(ScheduleAndExecute))
+        if (limit.isDefined) {
+          (pendingInstants.take(limit.get), op.map(o => Operation.fromValue(o.toLowerCase)).getOrElse(ScheduleAndExecute))
+        } else {
+          (pendingInstants, op.map(o => Operation.fromValue(o.toLowerCase)).getOrElse(ScheduleAndExecute))
+        }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -56,7 +56,8 @@ class RunClusteringProcedure extends BaseProcedure
     // params => key=value, key2=value2
     ProcedureParameter.optional(7, "options", DataTypes.StringType),
     ProcedureParameter.optional(8, "instants", DataTypes.StringType),
-    ProcedureParameter.optional(9, "selected_partitions", DataTypes.StringType)
+    ProcedureParameter.optional(9, "selected_partitions", DataTypes.StringType),
+    ProcedureParameter.optional(10, "limit", DataTypes.IntegerType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -83,6 +84,7 @@ class RunClusteringProcedure extends BaseProcedure
     val options = getArgValueOrDefault(args, PARAMETERS(7))
     val specificInstants = getArgValueOrDefault(args, PARAMETERS(8))
     val parts = getArgValueOrDefault(args, PARAMETERS(9))
+    val limit = getArgValueOrDefault(args, PARAMETERS(10))
 
     val basePath: String = getBasePath(tableName, tablePath)
     val metaClient = HoodieTableMetaClient.builder.setConf(jsc.hadoopConfiguration()).setBasePath(basePath).build
@@ -149,7 +151,7 @@ class RunClusteringProcedure extends BaseProcedure
       .iterator().asScala.map(_.getLeft.getTimestamp).toSeq.sortBy(f => f)
 
     var (filteredPendingClusteringInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
-      pendingClusteringInstants, specificInstants.asInstanceOf[Option[String]], op.asInstanceOf[Option[String]])
+      pendingClusteringInstants, specificInstants.asInstanceOf[Option[String]], op.asInstanceOf[Option[String]], limit.asInstanceOf[Option[Int]])
 
     var client: SparkRDDWriteClient[_] = null
     try {


### PR DESCRIPTION
### Change Logs

Since clustering plan generation is non-blocking, all generated pending clustering plans will be executed at once when using `call run_clustering(table => '$table', op => 'execute')` in default. Adding limit parameter to execute these plans in batches by `call run_clustering(table => '$table', op => 'execute', limit => 10)`. Limit parameter is optional and has no default value.

### Impact

Support new parameter.

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
