### PR TITLE
[MINOR] Re-enable a test that got fixed

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestWaitBasedTimeGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestWaitBasedTimeGenerator.java
@@ -26,7 +26,6 @@ import org.apache.hudi.exception.HoodieLockException;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -63,11 +62,11 @@ public class TestWaitBasedTimeGenerator {
           throw new HoodieLockException(e);
         }
       }
-      boolean locked = super.tryLock(time, unit);
-      if (locked) {
+      boolean isLocked = super.tryLock(time, unit);
+      if (isLocked) {
         SIGNAL.countDown();
       }
-      return locked;
+      return isLocked;
     }
   }
 
@@ -105,7 +104,6 @@ public class TestWaitBasedTimeGenerator {
    *    3> whereas t1's timestamp > t2's timestamp
    * So no matter which thread firstly acquires lock, the first acquired thread's timestamp should be earlier.
    */
-  @Disabled("This test is flaky, disable it for now. Fix in review -> https://github.com/apache/hudi/pull/9972")
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void testSlowerThreadLaterAcquiredLock(boolean slowerThreadAcquiredLockLater) throws InterruptedException {


### PR DESCRIPTION
### Change Logs

`testSlowerThreadLaterAcquiredLock` was disabled and got fixed by #9972. This PR simple enables it again.

### Impact

none - test change

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
