### PR TITLE
[HUDI-7030] update containsInstant without containsOrBeforeTimelineStarts to fix data lost

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieIndex.java
@@ -553,6 +553,27 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
     assertFalse(timeline.empty());
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestamp));
     assertFalse(HoodieIndexUtils.checkIfValidCommit(timeline, instantTimestampSec));
+
+    // Check the completed delta commit instant which is end with DEFAULT_MILLIS_EXT timestamp
+    // Timestamp not contain in inflight timeline, checkContainsInstant() should return false
+    // Timestamp contain in inflight timeline, checkContainsInstant() should return true
+    String checkInstantTimestampSec = instantTimestamp.substring(0, instantTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
+    String checkInstantTimestamp = checkInstantTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT;
+    Thread.sleep(2000); // sleep required so that new timestamp differs in the seconds rather than msec
+    String newTimestamp = writeClient.createNewInstantTime();
+    String newTimestampSec = newTimestamp.substring(0, newTimestamp.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
+    final HoodieInstant instant5 = new HoodieInstant(true, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestamp);
+    timeline = new HoodieDefaultTimeline(Stream.of(instant5), metaClient.getActiveTimeline()::getInstantDetails);
+    assertFalse(timeline.empty());
+    assertFalse(timeline.containsInstant(checkInstantTimestamp));
+    assertFalse(timeline.containsInstant(checkInstantTimestampSec));
+
+    final HoodieInstant instant6 = new HoodieInstant(true, HoodieTimeline.DELTA_COMMIT_ACTION, newTimestampSec + HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT);
+    timeline = new HoodieDefaultTimeline(Stream.of(instant6), metaClient.getActiveTimeline()::getInstantDetails);
+    assertFalse(timeline.empty());
+    assertFalse(timeline.containsInstant(newTimestamp));
+    assertFalse(timeline.containsInstant(checkInstantTimestamp));
+    assertTrue(timeline.containsInstant(instant6.getTimestamp()));
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -439,7 +439,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
     // Check for older timestamp which have sec granularity and an extension of DEFAULT_MILLIS_EXT may have been added via Timeline operations
     if (ts.length() == HoodieInstantTimeGenerator.MILLIS_INSTANT_TIMESTAMP_FORMAT_LENGTH && ts.endsWith(HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT)) {
       final String actualOlderFormatTs = ts.substring(0, ts.length() - HoodieInstantTimeGenerator.DEFAULT_MILLIS_EXT.length());
-      return containsOrBeforeTimelineStarts(actualOlderFormatTs);
+      return containsInstant(actualOlderFormatTs);
     }
 
     return false;


### PR DESCRIPTION
### Change Logs

update containsInstant without containsOrBeforeTimelineStarts to fix data lost

jira：https://issues.apache.org/jira/browse/HUDI-7030

### Impact

update containsInstant without containsOrBeforeTimelineStarts to fix data lost

### Risk level (write none, low medium or high below)

high

### Documentation Update

Describe any necessary documentation update if there is any new feature, config, or user-facing change

The config description must be updated if new configs are added or the default value of the configs are changed
Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
changes to the website.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
