### PR TITLE
[MINOR] Fix npe for get internal schema

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/InternalSchemaCache.java
@@ -217,7 +217,11 @@ public class InternalSchemaCache {
     }
     InternalSchema fileSchema = InternalSchemaUtils.searchSchema(versionId, SerDeHelper.parseSchemas(latestHistorySchema));
     // step3:
-    return fileSchema.isEmptySchema() ? AvroInternalSchemaConverter.convert(HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(avroSchema))) : fileSchema;
+    return fileSchema.isEmptySchema()
+            ? StringUtils.isNullOrEmpty(avroSchema)
+              ? InternalSchema.getEmptyInternalSchema()
+              : AvroInternalSchemaConverter.convert(HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(avroSchema)))
+            : fileSchema;
   }
 
   public static InternalSchema getInternalSchemaByVersionId(long versionId, HoodieTableMetaClient metaClient) {


### PR DESCRIPTION
### Change Logs
related issue: https://github.com/apache/hudi/issues/9902
get internal schema maybe meet  npe when parse avroSchema. So, we need to return InternalSchema.getEmptyInternalSchema() when avroSchema is null or empty.
### Impact

none

### Risk level (write none, low medium or high below)

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
