### PR TITLE
[HUDI-7031] CopyToTempView support cache for improving perfermance

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CopyToTempViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/CopyToTempViewProcedure.scala
@@ -34,7 +34,8 @@ class CopyToTempViewProcedure extends BaseProcedure with ProcedureBuilder with L
     ProcedureParameter.optional(4, "end_instance_time", DataTypes.StringType, ""),
     ProcedureParameter.optional(5, "as_of_instant", DataTypes.StringType, ""),
     ProcedureParameter.optional(6, "replace", DataTypes.BooleanType, false),
-    ProcedureParameter.optional(7, "global", DataTypes.BooleanType, false)
+    ProcedureParameter.optional(7, "global", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(8, "cache", DataTypes.BooleanType, false)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -56,6 +57,7 @@ class CopyToTempViewProcedure extends BaseProcedure with ProcedureBuilder with L
     val asOfInstant = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[String]
     val replace = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[Boolean]
     val global = getArgValueOrDefault(args, PARAMETERS(7)).get.asInstanceOf[Boolean]
+    val cache = getArgValueOrDefault(args, PARAMETERS(8)).get.asInstanceOf[Boolean]
 
     val tablePath = getBasePath(tableName)
 
@@ -85,6 +87,9 @@ class CopyToTempViewProcedure extends BaseProcedure with ProcedureBuilder with L
           .format("org.apache.hudi")
           .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
           .load(tablePath)
+    }
+    if (cache) {
+      sourceDataFrame.cache
     }
     if (global) {
       if (replace) {


### PR DESCRIPTION
### Change Logs

when user in sparksql session mode，can not cache tempview for read_optimized or snapshot，so we need support it for improving sql in query or join scene，copyToTempView support cache for improving perfermance

### Impact

none

### Risk level (write none, low medium or high below)

low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
