### PR TITLE
[MINOR] Hotfix in HdfsParquetImportProcedure for format parameter is not need to add

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HdfsParquetImportProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HdfsParquetImportProcedure.scala
@@ -58,10 +58,10 @@ class HdfsParquetImportProcedure extends BaseProcedure with ProcedureBuilder wit
     val rowKey = getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[String]
     val partitionKey = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[String]
     val schemaFilePath = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[String]
-    val command = getArgValueOrDefault(args, PARAMETERS(8)).get.asInstanceOf[String]
-    val retry = getArgValueOrDefault(args, PARAMETERS(9)).get.asInstanceOf[Int]
-    val parallelism = getArgValueOrDefault(args, PARAMETERS(10)).get.asInstanceOf[Int]
-    val propsFilePath = getArgValueOrDefault(args, PARAMETERS(11)).get.asInstanceOf[String]
+    val command = getArgValueOrDefault(args, PARAMETERS(7)).get.asInstanceOf[String]
+    val retry = getArgValueOrDefault(args, PARAMETERS(8)).get.asInstanceOf[Int]
+    val parallelism = getArgValueOrDefault(args, PARAMETERS(9)).get.asInstanceOf[Int]
+    val propsFilePath = getArgValueOrDefault(args, PARAMETERS(10)).get.asInstanceOf[String]
 
     val parquetImporterUtils: HDFSParquetImporterUtils = new HDFSParquetImporterUtils(command, srcPath, targetPath,
       tableName, tableType, rowKey, partitionKey, parallelism, schemaFilePath, retry, propsFilePath)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HdfsParquetImportProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HdfsParquetImportProcedure.scala
@@ -34,11 +34,10 @@ class HdfsParquetImportProcedure extends BaseProcedure with ProcedureBuilder wit
     ProcedureParameter.required(4, "row_key", DataTypes.StringType),
     ProcedureParameter.required(5, "partition_key", DataTypes.StringType),
     ProcedureParameter.required(6, "schema_file_path", DataTypes.StringType),
-    ProcedureParameter.optional(7, "format", DataTypes.StringType, "parquet"),
-    ProcedureParameter.optional(8, "command", DataTypes.StringType, "insert"),
-    ProcedureParameter.optional(9, "retry", DataTypes.IntegerType, 0),
-    ProcedureParameter.optional(10, "parallelism", DataTypes.IntegerType, jsc.defaultParallelism),
-    ProcedureParameter.optional(11, "props_file_path", DataTypes.StringType, "")
+    ProcedureParameter.optional(7, "command", DataTypes.StringType, "insert"),
+    ProcedureParameter.optional(8, "retry", DataTypes.IntegerType, 0),
+    ProcedureParameter.optional(9, "parallelism", DataTypes.IntegerType, jsc.defaultParallelism),
+    ProcedureParameter.optional(10, "props_file_path", DataTypes.StringType, "")
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -59,7 +58,6 @@ class HdfsParquetImportProcedure extends BaseProcedure with ProcedureBuilder wit
     val rowKey = getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[String]
     val partitionKey = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[String]
     val schemaFilePath = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[String]
-    val format = getArgValueOrDefault(args, PARAMETERS(7)).get.asInstanceOf[String]
     val command = getArgValueOrDefault(args, PARAMETERS(8)).get.asInstanceOf[String]
     val retry = getArgValueOrDefault(args, PARAMETERS(9)).get.asInstanceOf[Int]
     val parallelism = getArgValueOrDefault(args, PARAMETERS(10)).get.asInstanceOf[Int]


### PR DESCRIPTION


### Change Logs

[MINOR] hotfix in HdfsParquetImportProcedure for parquet parameter is not need to add

### Impact

none

### Risk level (write none, low medium or high below)

none

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
