### PR TITLE
[HUDI-7033] Fix read error for schema evolution + partition value ext…

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieDataSourceHelper.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieDataSourceHelper.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.sources.Filter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TestHoodieDataSourceHelper extends SparkAdapterSupport {
+
+  def checkCondition(filter: Option[Filter], outputSet: Set[String], expected: Any): Unit = {
+    val actual = HoodieDataSourceHelper.extractPredicatesWithinOutputSet(filter.get, outputSet)
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  def testExtractPredicatesWithinOutputSet() : Unit = {
+    val dataColsWithNoPartitionCols = Set("id", "extra_col")
+
+    val expr1 = sparkAdapter.translateFilter(expr("(region='reg2' and id = 1) or region='reg1'").expr)
+    checkCondition(expr1, dataColsWithNoPartitionCols, None)
+
+    val expr2 = sparkAdapter.translateFilter(expr("region='reg2' and id = 1").expr)
+    val expectedExpr2 = sparkAdapter.translateFilter(expr("id = 1").expr)
+    checkCondition(expr2, dataColsWithNoPartitionCols, expectedExpr2)
+
+    // not (region='reg2' and id = 1) -- BooleanSimplification --> not region='reg2' or not id = 1
+    val expr3 = sparkAdapter.translateFilter(expr("not region='reg2' or not id = 1").expr)
+    checkCondition(expr3, dataColsWithNoPartitionCols, None)
+
+    // not (region='reg2' or id = 1) -- BooleanSimplification --> not region='reg2' and not id = 1
+    val expr4 = sparkAdapter.translateFilter(expr("not region='reg2' and not id = 1").expr)
+    val expectedExpr4 = sparkAdapter.translateFilter(expr("not(id=1)").expr)
+    checkCondition(expr4, dataColsWithNoPartitionCols, expectedExpr4)
+  }
+
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestSpark3DDL.scala
@@ -1015,4 +1015,45 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
       }
     }
   }
+
+  test("Test extract partition values from path when schema evolution is enabled") {
+    withTable(generateTableName) { tableName =>
+      spark.sql(
+        s"""
+           |create table $tableName (
+           | id int,
+           | name string,
+           | ts bigint,
+           | region string,
+           | dt date
+           |) using hudi
+           |tblproperties (
+           | primaryKey = 'id',
+           | type = 'cow',
+           | preCombineField = 'ts'
+           |)
+           |partitioned by (region, dt)""".stripMargin)
+
+      withSQLConf("hoodie.datasource.read.extract.partition.values.from.path" -> "true",
+        "hoodie.schema.on.read.enable" -> "true") {
+        spark.sql(s"insert into $tableName partition (region='reg1', dt='2023-10-01') " +
+          s"select 1, 'name1', 1000")
+        checkAnswer(s"select id, name, ts, region, cast(dt as string) from $tableName where region='reg1'")(
+          Seq(1, "name1", 1000, "reg1", "2023-10-01")
+        )
+
+        // apply schema evolution and perform a read again
+        spark.sql(s"alter table $tableName add columns(price double)")
+        checkAnswer(s"select id, name, ts, region, cast(dt as string) from $tableName where region='reg1'")(
+          Seq(1, "name1", 1000, "reg1", "2023-10-01")
+        )
+
+        // ensure this won't be broken in the future
+        // BooleanSimplification is always applied when calling HoodieDataSourceHelper#getNonPartitionFilters
+        checkAnswer(s"select id, name, ts, region, cast(dt as string) from $tableName where not(region='reg2' or id=2)")(
+          Seq(1, "name1", 1000, "reg1", "2023-10-01")
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
…raction

After [HUDI-6960](https://issues.apache.org/jira/browse/HUDI-6960) is merged PR #9889, the `shouldExtractPartitionValuesFromPartitionPath` will correctly ignore partition columns in `requiredSchema`.


When using the configs below, there will be read errors.

```sql
hoodie.datasource.read.extract.partition.values.from.path = true 
hoodie.schema.on.read.enable = true 
```
 
The query schema will be pruned to **NOT** contain any partition columns.
 
When rebuilding parquet filters, file schema's columns are scanned against querySchema. However, Hudi files (file schema) might still contain partition columns. And when partition filters are being rebuilt with these file schema against query schema, it will lead to partition columns not being found.
 
```log
Caused by: java.lang.IllegalArgumentException: cannot found filter col name：region from querySchema: table {
 5: id: optional int
 6: name: optional string
 7: ts: optional long
}
at org.apache.hudi.internal.schema.utils.InternalSchemaUtils.reBuildFilterName(InternalSchemaUtils.java:180)
```

### Change Logs
Fixes schema evolution read error when partition values are extracted from path.
_Describe context and summary for this change. Highlight if any code was copied._

### Impact
None
_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
