### PR TITLE
[HUDI-7036] Reduce the data amount collected on spark driver

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
@@ -61,13 +61,12 @@ public class HoodieRecordLocation implements Serializable, KryoSerializable {
       return false;
     }
     HoodieRecordLocation otherLoc = (HoodieRecordLocation) o;
-    return Objects.equals(instantTime, otherLoc.instantTime) && Objects.equals(fileId, otherLoc.fileId)
-        && Objects.equals(position, otherLoc.position);
+    return Objects.equals(instantTime, otherLoc.instantTime) && Objects.equals(fileId, otherLoc.fileId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(instantTime, fileId, position);
+    return Objects.hash(instantTime, fileId);
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

When building profile, the spark driver should only care data distribution on (partition_path, instant_time, file_id), instead of (partition_path, instant_time, file_id, record_position).

TESTS:
1. Before remove the record position from the comparison, the driver OOMed constantly.
2. After remove the record position from the comparision, both 500GB and 1TB query finished like a charm. 

### Impact

This fix removes some stability regression for large queries.

### Risk level (write none, low medium or high below)

Low.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
