### PR TITLE
[HUDI-7038] RunCompactionProcedure support limit parameter

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -46,7 +46,8 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
     ProcedureParameter.optional(2, "path", DataTypes.StringType),
     ProcedureParameter.optional(3, "timestamp", DataTypes.LongType),
     ProcedureParameter.optional(4, "options", DataTypes.StringType),
-    ProcedureParameter.optional(5, "instants", DataTypes.StringType)
+    ProcedureParameter.optional(5, "instants", DataTypes.StringType),
+    ProcedureParameter.optional(6, "limit", DataTypes.IntegerType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -71,6 +72,7 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
       confs = confs ++ HoodieCLIUtils.extractOptions(getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[String])
     }
     var specificInstants = getArgValueOrDefault(args, PARAMETERS(5))
+    val limit = getArgValueOrDefault(args, PARAMETERS(6))
 
     // For old version compatibility
     if (op.equals("run")) {
@@ -97,7 +99,7 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
       .toSeq.sortBy(f => f)
 
     var (filteredPendingCompactionInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
-      pendingCompactionInstants, specificInstants.asInstanceOf[Option[String]], Option(op))
+      pendingCompactionInstants, specificInstants.asInstanceOf[Option[String]], Option(op), limit.asInstanceOf[Option[Int]])
 
     var client: SparkRDDWriteClient[_] = null
     try {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestCompactionProcedure.scala
@@ -333,4 +333,51 @@ class TestCompactionProcedure extends HoodieSparkProcedureTestBase {
       }
     }
   }
+
+  test("Test Call run_clustering with limit parameter") {
+    withSQLConf("hoodie.compact.inline" -> "false", "hoodie.compact.inline.max.delta.commits" -> "1") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | tblproperties (
+             |  type = 'mor',
+             |  primaryKey = 'id',
+             |  preCombineField = 'ts'
+             | )
+             | location '${basePath}'
+       """.stripMargin)
+
+        val conf = new Configuration
+        val metaClient = HoodieTableMetaClient.builder.setConf(conf).setBasePath(basePath).build
+
+        assert(0 == metaClient.getActiveTimeline.getCompletedReplaceTimeline.getInstants.size())
+        assert(metaClient.getActiveTimeline.filterPendingReplaceTimeline().empty())
+
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+        spark.sql(s"update $tableName set name = 'a2' where id = 1")
+
+        spark.sql(s"call run_compaction(table => '$tableName', op => 'schedule')")
+
+        spark.sql(s"insert into $tableName values(2, 'b1', 20, 3000)")
+        spark.sql(s"update $tableName set name = 'b3' where id = 2")
+
+        spark.sql(s"call run_compaction(table => '$tableName', op => 'schedule')")
+        metaClient.reloadActiveTimeline();
+        assert(2 == metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size())
+
+        spark.sql(s"call run_compaction(table => '$tableName', op => 'execute', limit => 1)");
+
+        metaClient.reloadActiveTimeline();
+        assert(1 == metaClient.getActiveTimeline.filterPendingCompactionTimeline().getInstants.size())
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Change Logs

RunCompactionProcedure support limit parameter to execute plans in batches by `call run_compaction(table => '$tableName', op => 'execute', limit => 10)`. Limit parameter is optional and has no default value.

### Impact

none

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
