### PR TITLE
[MINOR] Remove rocksdb version from m1 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2220,7 +2220,6 @@
       <id>m1-mac</id>
       <properties>
         <spark2.version>2.4.8</spark2.version>
-        <rocksdbjni.version>6.29.4.1</rocksdbjni.version>
       </properties>
       <activation>
         <os>


### PR DESCRIPTION
### Change Logs

https://github.com/apache/hudi/pull/9136 upgraded the `rocksdbjni.version` from 5.17.2 to 7.5.3 so this is no longer needed, and could actually cause issues in the future

### Impact

Prevent future issue for mac users

### Risk level (write none, low medium or high below)

none

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
