### PR TITLE
[HUDI-7045] fix evolution by using legacy ff for reader

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/NewHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/NewHoodieParquetFileFormat.scala
@@ -56,6 +56,8 @@ class NewHoodieParquetFileFormat(tableState: Broadcast[HoodieTableState],
                                  requiredFilters: Seq[Filter]
                                 ) extends ParquetFileFormat with SparkAdapterSupport {
 
+  private val legacyFF = sparkAdapter.createLegacyHoodieParquetFileFormat(true).get
+
   override def isSplitable(sparkSession: SparkSession,
                            options: Map[String, String],
                            path: Path): Boolean = {
@@ -74,9 +76,23 @@ class NewHoodieParquetFileFormat(tableState: Broadcast[HoodieTableState],
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
     if (!supportBatchCalled) {
       supportBatchCalled = true
-      supportBatchResult = !isMOR && super.supportBatch(sparkSession, schema)
+      supportBatchResult = !isMOR && legacyFF.supportBatch(sparkSession, schema)
     }
     supportBatchResult
+  }
+
+  private def wrapWithBatchConverter(reader: PartitionedFile => Iterator[InternalRow]): PartitionedFile => Iterator[InternalRow] = {
+    if (supportBatchCalled && !supportBatchResult) {
+      file: PartitionedFile => {
+        val iter = reader(file).asInstanceOf[Iterator[Any]]
+        iter.flatMap {
+          case r: InternalRow => Seq(r)
+          case b: ColumnarBatch => b.rowIterator().asScala
+        }
+      }
+    } else {
+      reader
+    }
   }
 
   override def buildReaderWithPartitionValues(sparkSession: SparkSession,
@@ -190,12 +206,12 @@ class NewHoodieParquetFileFormat(tableState: Broadcast[HoodieTableState],
     PartitionedFile => Iterator[InternalRow]) = {
 
     //file reader when you just read a hudi parquet file and don't do any merging
-    val baseFileReader = super.buildReaderWithPartitionValues(sparkSession, dataSchema, partitionSchema, requiredSchema,
+    val baseFileReader = legacyFF.buildReaderWithPartitionValues(sparkSession, dataSchema, partitionSchema, requiredSchema,
       filters ++ requiredFilters, options, new Configuration(hadoopConf))
 
     //file reader for reading a hudi base file that needs to be merged with log files
     val preMergeBaseFileReader = if (isMOR) {
-      super.buildReaderWithPartitionValues(sparkSession, dataSchema, StructType(Seq.empty),
+      legacyFF.buildReaderWithPartitionValues(sparkSession, dataSchema, StructType(Seq.empty),
         requiredSchemaWithMandatory, requiredFilters, options, new Configuration(hadoopConf))
     } else {
       _: PartitionedFile => Iterator.empty
@@ -214,11 +230,11 @@ class NewHoodieParquetFileFormat(tableState: Broadcast[HoodieTableState],
     val skeletonReader = if (needMetaCols && isBootstrap) {
       if (needDataCols || isMOR) {
         // no filter and no append
-        super.buildReaderWithPartitionValues(sparkSession, HoodieSparkUtils.getMetaSchema, StructType(Seq.empty),
+        legacyFF.buildReaderWithPartitionValues(sparkSession, HoodieSparkUtils.getMetaSchema, StructType(Seq.empty),
           requiredMeta, Seq.empty, options, new Configuration(hadoopConf))
       } else {
         // filter and append
-        super.buildReaderWithPartitionValues(sparkSession, HoodieSparkUtils.getMetaSchema, partitionSchema,
+        legacyFF.buildReaderWithPartitionValues(sparkSession, HoodieSparkUtils.getMetaSchema, partitionSchema,
           requiredMeta, filters, options, new Configuration(hadoopConf))
       }
     } else {
@@ -230,22 +246,25 @@ class NewHoodieParquetFileFormat(tableState: Broadcast[HoodieTableState],
       val dataSchemaWithoutMeta = StructType(dataSchema.fields.filterNot(sf => isMetaField(sf.name)))
       if (isMOR) {
         // no filter and no append
-        super.buildReaderWithPartitionValues(sparkSession, dataSchemaWithoutMeta, StructType(Seq.empty), requiredWithoutMeta,
+        legacyFF.buildReaderWithPartitionValues(sparkSession, dataSchemaWithoutMeta, StructType(Seq.empty), requiredWithoutMeta,
           Seq.empty, options, new Configuration(hadoopConf))
       } else if (needMetaCols) {
         // no filter but append
-        super.buildReaderWithPartitionValues(sparkSession, dataSchemaWithoutMeta, partitionSchema, requiredWithoutMeta,
+        legacyFF.buildReaderWithPartitionValues(sparkSession, dataSchemaWithoutMeta, partitionSchema, requiredWithoutMeta,
           Seq.empty, options, new Configuration(hadoopConf))
       } else {
         // filter and append
-        super.buildReaderWithPartitionValues(sparkSession, dataSchemaWithoutMeta, partitionSchema, requiredWithoutMeta,
+        legacyFF.buildReaderWithPartitionValues(sparkSession, dataSchemaWithoutMeta, partitionSchema, requiredWithoutMeta,
           filters ++ requiredFilters, options, new Configuration(hadoopConf))
       }
     } else {
       _: PartitionedFile => Iterator.empty
     }
 
-    (baseFileReader, preMergeBaseFileReader, skeletonReader, bootstrapBaseReader)
+   (wrapWithBatchConverter(baseFileReader),
+     wrapWithBatchConverter(preMergeBaseFileReader),
+     wrapWithBatchConverter(skeletonReader),
+     wrapWithBatchConverter(bootstrapBaseReader))
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Some of schema on write schema evolution happens inside the reader so we need to use legacy file format

### Impact

schema evolution works with the new reader and ff

### Risk level (write none, low medium or high below)

low

### Documentation Update

N/A

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
